### PR TITLE
Use the BoardProvider username as the peer username

### DIFF
--- a/app/components/board-page/share-button.tsx
+++ b/app/components/board-page/share-button.tsx
@@ -5,6 +5,7 @@ import { TeamOutlined, CopyOutlined, CrownFilled, LoadingOutlined } from '@ant-d
 import { Button, Input, Drawer, QRCode, Flex, message, Typography, Badge } from 'antd';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { usePeerContext } from '../connection-manager/peer-context';
+import { usePartyContext } from '../party-manager/party-context';
 // import { usePartyContext } from '../party-manager/party-context';
 
 const { Text } = Typography;
@@ -21,6 +22,8 @@ const getShareUrl = (pathname: string, searchParams: URLSearchParams, peerId: st
 
 export const ShareBoardButton = () => {
   const { peerId, isConnecting, hasConnected, connections, hostId } = usePeerContext();
+  const { connectedUsers, userName } = usePartyContext();
+
   // const { connectedUsers } = usePartyContext();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -66,7 +69,7 @@ export const ShareBoardButton = () => {
       </Badge>
       <Drawer title="Party Mode" placement="top" onClose={handleClose} open={isDrawerOpen} height="70vh">
         <Flex gap="middle" vertical>
-          {connections.length > 0 && (
+          {connectedUsers.length > 0 && (
             <Flex vertical gap="small">
               <Text strong>Connected Users:</Text>
               <Flex
@@ -91,7 +94,7 @@ export const ShareBoardButton = () => {
                 >
                   <Flex gap="small" align="center">
                     {/* <Avatar size="small" icon={<UserOutlined />} src={user.avatar} /> */}
-                    <Text style={{ fontSize: '14px' }}>{peerId} (you)</Text>
+                    <Text style={{ fontSize: '14px' }}>{userName} (you)</Text>
                   </Flex>
                   {/* {true === false && (
                       <CrownFilled
@@ -102,9 +105,9 @@ export const ShareBoardButton = () => {
                       />
                     )} */}
                 </Flex>
-                {connections.map((conn) => (
+                {connectedUsers.map((conn) => (
                   <Flex
-                    key={conn.connection.peer}
+                    key={conn.id}
                     justify="space-between"
                     align="center"
                     style={{
@@ -116,7 +119,7 @@ export const ShareBoardButton = () => {
                   >
                     <Flex gap="small" align="center">
                       {/* <Avatar size="small" icon={<UserOutlined />} src={user.avatar} /> */}
-                      <Text style={{ fontSize: '14px' }}>{conn.connection.peer}</Text>
+                      <Text style={{ fontSize: '14px' }}>{conn.username || conn.id}</Text>
                     </Flex>
                     {conn.isHost && (
                       <CrownFilled

--- a/app/components/queue-control/queue-context.tsx
+++ b/app/components/queue-control/queue-context.tsx
@@ -10,7 +10,7 @@ import { useQueueDataFetching } from './hooks/use-queue-data-fetching';
 import { QueueContextType, ClimbQueueItem, UserName } from './types';
 import { urlParamsToSearchParams } from '@/app/lib/url-utils';
 import { Climb, ParsedBoardRouteParameters } from '@/app/lib/types';
-import { PeerData } from '../connection-manager/types';
+import { ReceivedPeerData } from '../connection-manager/types';
 
 type QueueContextProps = {
   parsedParams: ParsedBoardRouteParameters;
@@ -34,9 +34,7 @@ export const QueueProvider = ({ parsedParams, children }: QueueContextProps) => 
 
   // Set up queue update handler
   const handlePeerData = useCallback(
-    (data: PeerData) => {
-      console.log(`${new Date().getTime()} Queue context received: ${data.type} from: ${data.source}`);
-
+    (data: ReceivedPeerData) => {
       switch (data.type) {
         case 'new-connection':
           sendData(

--- a/app/components/queue-control/tick-button.tsx
+++ b/app/components/queue-control/tick-button.tsx
@@ -6,7 +6,7 @@ import Button from 'antd/es/button';
 import Badge from 'antd/es/badge';
 import { CheckOutlined } from '@ant-design/icons';
 
-export const TickButton = ({ currentClimb, angle }: { angle: Angle, currentClimb: Climb | null }) => {
+export const TickButton = ({ currentClimb, angle }: { angle: Angle; currentClimb: Climb | null }) => {
   const { logbook } = useBoardProvider();
   return (
     <Badge


### PR DESCRIPTION
If the user is logged in we can use the username of their BoardProvider to communicate who they are to the other party members