### PR TITLE
optimize tick icons

### DIFF
--- a/app/components/queue-control/queue-control-bar.tsx
+++ b/app/components/queue-control/queue-control-bar.tsx
@@ -58,7 +58,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
               <div
                 style={{
                   display: 'flex',
-                  alignItems: 'center',
+                  alignItems: 'baseline',
                   justifyContent: 'center',
                   gap: '4px',
                 }}

--- a/app/components/queue-control/queue-list-item.tsx
+++ b/app/components/queue-control/queue-list-item.tsx
@@ -51,6 +51,7 @@ export const AscentStatus = ({ climbUuid }: { climbUuid: ClimbUuid }) => {
             style={{
               position: 'absolute',
               transform: 'scaleX(-1)',
+              left: '2px',
             }}
           >
             <CheckOutlined style={{ color: '#52c41a' }} />


### PR DESCRIPTION
optimizing display of tick icons to remove the vertical offset and create some horizontal distance (otherwise icons look too ugly)
<img width="223" alt="image" src="https://github.com/user-attachments/assets/bc7f0b09-1250-4fbe-8122-96bf61fcae19">
