### PR TITLE
Sent user_id to user sync so that it doesnt pull all data all the time

### DIFF
--- a/app/lib/api-wrappers/aurora/types.ts
+++ b/app/lib/api-wrappers/aurora/types.ts
@@ -43,14 +43,8 @@ export interface SyncOptions {
   walls?: any[];
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   wallExpungements?: any[];
-  sharedSyncs?: Array<{
-    table_name: string;
-    last_synchronized_at: string;
-  }>;
-  userSyncs?: Array<{
-    table_name: string;
-    last_synchronized_at: string;
-  }>;
+  sharedSyncs?: Array<SyncData>;
+  userSyncs?: Array<UserSyncData>;
 }
 export interface ClimbStats {
   display_difficulty: number;
@@ -166,4 +160,12 @@ export interface ClimbStatSavedEvent {
 
 export type SaveAscentResponse = {
   events: (AscentSavedEvent | ClimbStatSavedEvent)[];
+};
+export type SyncData = {
+  table_name: string;
+  last_synchronized_at: string;
+};
+
+export type UserSyncData = SyncData & {
+  user_id: number;
 };


### PR DESCRIPTION
Turns out user_sync also requires a user_id in the the syncs synchronise array thing.

Submitted PR: https://github.com/lemeryfertitta/BoardLib/pull/51 to help document this requirement better (if only pythong had type safety)