### PR TITLE
Fix the search climbs query so it returns the same number as results …

### DIFF
--- a/app/components/search-drawer/search-form.tsx
+++ b/app/components/search-drawer/search-form.tsx
@@ -1,121 +1,146 @@
 import React from 'react';
-import { Form, Slider, InputNumber, Row, Col, Select, Input } from 'antd';
+import { Form, InputNumber, Row, Col, Select, Input } from 'antd';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import SearchClimbNameInput from './search-climb-name-input';
 
-interface SearchFormProps {}
-
-const SearchForm: React.FC<SearchFormProps> = () => {
+const SearchForm = () => {
   const { uiSearchParams, updateFilters } = useUISearchParams();
-
   const grades = TENSION_KILTER_GRADES;
 
+  const handleGradeChange = (type: 'min' | 'max', value: number | undefined) => {
+    if (type === 'min') {
+      updateFilters({ minGrade: value });
+    } else {
+      updateFilters({ maxGrade: value });
+    }
+  };
+
   return (
-    <>
-      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
-        <Form.Item label="Climb Name">
-          <SearchClimbNameInput />
-        </Form.Item>
-        <Form.Item label="Grade Range">
-          <Slider
-            range
-            min={grades[0].difficulty_id}
-            max={grades[grades.length - 1].difficulty_id}
-            value={[uiSearchParams.minGrade, uiSearchParams.maxGrade]}
-            marks={{
-              [uiSearchParams.minGrade]: {
-                style: { transform: 'translate(-5px, 0px);' }, // Push the label below the slider
-                label: grades.find(({ difficulty_id }) => difficulty_id === uiSearchParams.minGrade)?.difficulty_name,
-              },
-              [uiSearchParams.maxGrade]: {
-                style: { transform: 'translate(-5px, -30px)' }, // Push the label above the slider
-                label: grades.find(({ difficulty_id }) => difficulty_id === uiSearchParams.maxGrade)?.difficulty_name,
-              },
-            }}
-            onChange={(value) => updateFilters({ minGrade: value[0], maxGrade: value[1] })}
-            // tooltip={{
-            //   formatter: (value) => grades.find(({ difficulty_id }) => difficulty_id === value)?.difficulty_name,
-            // }}
-          />
-        </Form.Item>
+    <Form labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
+      <Form.Item label="Climb Name">
+        <SearchClimbNameInput />
+      </Form.Item>
 
-        <Form.Item label="Min Ascents">
-          <InputNumber
-            min={1}
-            value={uiSearchParams.minAscents}
-            onChange={(value) => updateFilters({ minAscents: value || 10 })}
-            style={{ width: '100%' }}
-          />
-        </Form.Item>
-
-        <Form.Item label="Sort By">
-          <Row gutter={8}>
-            <Col span={16}>
+      <Form.Item label="Grade Range">
+        <Row gutter={8}>
+          <Col span={12}>
+            <Form.Item label="Min" noStyle>
               <Select
-                value={uiSearchParams.sortBy}
-                onChange={(value) => updateFilters({ sortBy: value })}
+                value={uiSearchParams.minGrade || 0}
+                defaultValue={0}
+                onChange={(value) => handleGradeChange('min', value)}
                 style={{ width: '100%' }}
               >
-                <Select.Option value="ascents">Ascents</Select.Option>
-                <Select.Option value="difficulty">Difficulty</Select.Option>
-                <Select.Option value="name">Name</Select.Option>
-                <Select.Option value="quality">Quality</Select.Option>
+                <Select.Option value={0}>Any</Select.Option>
+                {grades.map((grade) => (
+                  <Select.Option key={grade.difficulty_id} value={grade.difficulty_id}>
+                    {grade.difficulty_name}
+                  </Select.Option>
+                ))}
               </Select>
-            </Col>
-            <Col span={8}>
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item label="Max" noStyle>
               <Select
-                value={uiSearchParams.sortOrder}
-                onChange={(value) => updateFilters({ sortOrder: value })}
+                value={uiSearchParams.maxGrade || 0}
+                defaultValue={0}
+                onChange={(value) => handleGradeChange('max', value)}
                 style={{ width: '100%' }}
               >
-                <Select.Option value="desc">Descending</Select.Option>
-                <Select.Option value="asc">Ascending</Select.Option>
+                <Select.Option value={0}>Any</Select.Option>
+                {grades.map((grade) => (
+                  <Select.Option key={grade.difficulty_id} value={grade.difficulty_id}>
+                    {grade.difficulty_name}
+                  </Select.Option>
+                ))}
               </Select>
-            </Col>
-          </Row>
-        </Form.Item>
+            </Form.Item>
+          </Col>
+        </Row>
+      </Form.Item>
 
-        <Form.Item label="Min Rating">
-          <InputNumber
-            min={1.0}
-            max={3.0}
-            step={0.1}
-            value={uiSearchParams.minRating}
-            onChange={(value) => updateFilters({ minRating: value || 1 })}
-            style={{ width: '100%' }}
-          />
-        </Form.Item>
+      <Form.Item label="Min Ascents">
+        <InputNumber
+          min={1}
+          value={uiSearchParams.minAscents}
+          onChange={(value) => updateFilters({ minAscents: value || undefined })}
+          style={{ width: '100%' }}
+          placeholder="Any"
+        />
+      </Form.Item>
 
-        <Form.Item label="Classics Only">
-          <Select
-            value={uiSearchParams.onlyClassics}
-            onChange={(value) => updateFilters({ onlyClassics: value })}
-            style={{ width: '100%' }}
-          >
-            <Select.Option value="0">No</Select.Option>
-            <Select.Option value="1">Yes</Select.Option>
-          </Select>
-        </Form.Item>
+      <Form.Item label="Sort By">
+        <Row gutter={8}>
+          <Col span={16}>
+            <Select
+              value={uiSearchParams.sortBy}
+              onChange={(value) => updateFilters({ sortBy: value })}
+              style={{ width: '100%' }}
+            >
+              <Select.Option value="ascents">Ascents</Select.Option>
+              <Select.Option value="difficulty">Difficulty</Select.Option>
+              <Select.Option value="name">Name</Select.Option>
+              <Select.Option value="quality">Quality</Select.Option>
+            </Select>
+          </Col>
+          <Col span={8}>
+            <Select
+              value={uiSearchParams.sortOrder}
+              onChange={(value) => updateFilters({ sortOrder: value })}
+              style={{ width: '100%' }}
+            >
+              <Select.Option value="desc">Descending</Select.Option>
+              <Select.Option value="asc">Ascending</Select.Option>
+            </Select>
+          </Col>
+        </Row>
+      </Form.Item>
 
-        <Form.Item label="Grade Accuracy">
-          <Select
-            value={uiSearchParams.gradeAccuracy}
-            onChange={(value) => updateFilters({ gradeAccuracy: value })}
-            style={{ width: '100%' }}
-          >
-            <Select.Option value={1}>Any</Select.Option>
-            <Select.Option value={0.2}>Somewhat Accurate (&lt;0.2)</Select.Option>
-            <Select.Option value={0.1}>Very Accurate (&lt;0.1)</Select.Option>
-            <Select.Option value={0.05}>Extremely Accurate (&lt;0.05)</Select.Option>
-          </Select>
-        </Form.Item>
+      <Form.Item label="Min Rating">
+        <InputNumber
+          min={1.0}
+          max={3.0}
+          step={0.1}
+          value={uiSearchParams.minRating}
+          onChange={(value) => updateFilters({ minRating: value || undefined })}
+          style={{ width: '100%' }}
+          placeholder="Any"
+        />
+      </Form.Item>
 
-        <Form.Item label="Setter Name">
-          <Input value={uiSearchParams.settername} onChange={(e) => updateFilters({ settername: e.target.value })} />
-        </Form.Item>
-      </Form>
-    </>
+      <Form.Item label="Classics Only">
+        <Select
+          value={uiSearchParams.onlyClassics}
+          onChange={(value) => updateFilters({ onlyClassics: value })}
+          style={{ width: '100%' }}
+        >
+          <Select.Option value="0">No</Select.Option>
+          <Select.Option value="1">Yes</Select.Option>
+        </Select>
+      </Form.Item>
+
+      <Form.Item label="Grade Accuracy">
+        <Select
+          value={uiSearchParams.gradeAccuracy}
+          onChange={(value) => updateFilters({ gradeAccuracy: value || undefined })}
+          style={{ width: '100%' }}
+        >
+          <Select.Option value={undefined}>Any</Select.Option>
+          <Select.Option value={0.2}>Somewhat Accurate (&lt;0.2)</Select.Option>
+          <Select.Option value={0.1}>Very Accurate (&lt;0.1)</Select.Option>
+          <Select.Option value={0.05}>Extremely Accurate (&lt;0.05)</Select.Option>
+        </Select>
+      </Form.Item>
+
+      <Form.Item label="Setter Name">
+        <Input 
+          value={uiSearchParams.settername} 
+          onChange={(e) => updateFilters({ settername: e.target.value })} 
+        />
+      </Form.Item>
+    </Form>
   );
 };
 

--- a/app/lib/db/db.ts
+++ b/app/lib/db/db.ts
@@ -11,5 +11,5 @@ if (process.env.VERCEL_ENV === 'development') {
 export * from '@vercel/postgres';
 
 export const dbz = drizzle({
-  logger: process.env.NODE_ENV === 'development'
+  logger: process.env.VERCEL_ENV === 'development',
 });

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -56,11 +56,11 @@ export type SetsResponse = {
 
 // Search Request Type
 export type SearchRequest = {
-  gradeAccuracy?: number;
-  maxGrade?: number;
-  minAscents?: number;
-  minGrade?: number;
-  minRating?: number;
+  gradeAccuracy: number;
+  maxGrade: number;
+  minAscents: number;
+  minGrade: number;
+  minRating: number;
   sortBy: 'ascents' | 'difficulty' | 'name' | 'quality';
   sortOrder: 'asc' | 'desc';
   name: string;

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -56,11 +56,11 @@ export type SetsResponse = {
 
 // Search Request Type
 export type SearchRequest = {
-  gradeAccuracy: number;
-  maxGrade: number;
-  minAscents: number;
-  minGrade: number;
-  minRating: number;
+  gradeAccuracy?: number;
+  maxGrade?: number;
+  minAscents?: number;
+  minGrade?: number;
+  minRating?: number;
   sortBy: 'ascents' | 'difficulty' | 'name' | 'quality';
   sortOrder: 'asc' | 'desc';
   name: string;

--- a/app/lib/url-utils.ts
+++ b/app/lib/url-utils.ts
@@ -37,26 +37,41 @@ export function parseBoardRouteParams<T extends BoardRouteParameters>(
   return parsedParams as T extends BoardRouteParametersWithUuid ? never : ParsedBoardRouteParameters;
 }
 
-export const searchParamsToUrlParams = (params: SearchRequestPagination): URLSearchParams => {
-  return new URLSearchParams({
-    gradeAccuracy: params.gradeAccuracy.toString(),
-    maxGrade: params.maxGrade.toString(),
-    minAscents: params.minAscents.toString(),
-    minGrade: params.minGrade.toString(),
-    minRating: params.minRating.toString(),
-    sortBy: params.sortBy,
-    sortOrder: params.sortOrder,
-    name: params.name,
-    onlyClassics: params.onlyClassics.toString(),
-    settername: params.settername,
-    setternameSuggestion: params.setternameSuggestion,
-    holds: params.holds,
-    mirroredHolds: params.mirroredHolds,
-    page: params.page.toString(),
-    pageSize: params.pageSize.toString(),
-  });
+export const searchParamsToUrlParams = ({ 
+ gradeAccuracy = DEFAULT_SEARCH_PARAMS.gradeAccuracy,
+ maxGrade = DEFAULT_SEARCH_PARAMS.maxGrade,
+ minGrade = DEFAULT_SEARCH_PARAMS.minGrade,
+ minAscents = DEFAULT_SEARCH_PARAMS.minAscents,
+ minRating = DEFAULT_SEARCH_PARAMS.minRating,
+ sortBy,
+ sortOrder, 
+ name,
+ onlyClassics,
+ settername,
+ setternameSuggestion,
+ holds,
+ mirroredHolds,
+ page,
+ pageSize
+}: SearchRequestPagination): URLSearchParams => {
+ return new URLSearchParams({
+   gradeAccuracy: gradeAccuracy.toString(),
+   maxGrade: maxGrade.toString(), 
+   minAscents: minAscents.toString(),
+   minGrade: minGrade.toString(),
+   minRating: minRating.toString(),
+   sortBy,
+   sortOrder,
+   name,
+   onlyClassics: onlyClassics.toString(),
+   settername,
+   setternameSuggestion,
+   holds,
+   mirroredHolds,
+   page: page.toString(),
+   pageSize: pageSize.toString(),
+ });
 };
-
 export const DEFAULT_SEARCH_PARAMS: SearchRequestPagination = {
   gradeAccuracy: 0,
   maxGrade: 0,

--- a/app/lib/url-utils.ts
+++ b/app/lib/url-utils.ts
@@ -58,9 +58,9 @@ export const searchParamsToUrlParams = (params: SearchRequestPagination): URLSea
 };
 
 export const DEFAULT_SEARCH_PARAMS: SearchRequestPagination = {
-  gradeAccuracy: 1,
-  maxGrade: 33,
-  minGrade: 1,
+  gradeAccuracy: 0,
+  maxGrade: 0,
+  minGrade: 0,
   minRating: 0,
   minAscents: 0,
   sortBy: 'ascents',


### PR DESCRIPTION
…as official

The boardsesh version of the query always had minimum ascents set to 1 and a bunch of other values. This commit removes those conditions from the query when there was no user input for those earch fields