### PR TITLE
Fix queue drag and drop index calculation when moving items forward

### DIFF
--- a/app/components/queue-control/queue-list.tsx
+++ b/app/components/queue-control/queue-list.tsx
@@ -41,7 +41,12 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
         if (isNaN(sourceIndex) || isNaN(targetIndex)) return;
 
         const edge = extractClosestEdge(target.data);
-        const finalIndex = edge === 'bottom' ? targetIndex + 1 : targetIndex;
+        let finalIndex = edge === 'bottom' ? targetIndex + 1 : targetIndex;
+        
+        // Adjust for the fact that removing the source item shifts indices
+        if (sourceIndex < finalIndex) {
+          finalIndex = finalIndex - 1;
+        }
 
         const newQueue = reorder({
           list: queue,


### PR DESCRIPTION
## Summary
- Fixes off-by-one error when dragging queue items forward (from lower to higher index)
- Adjusts finalIndex calculation to account for index shift when source item is removed

## Problem
When dragging an item forward in the queue, the drop position was incorrect. For example:
- Dragging item at index 0 to drop between items 2-3 
- Would incorrectly place it after item 3 instead of between items 2-3

This was the same issue reported in #140.

## Solution
Added logic to adjust the finalIndex when `sourceIndex < finalIndex` to compensate for the removed source item.

## Test plan
- [x] Test dragging items backward in queue (should work as before)
- [x] Test dragging items forward in queue (should now place correctly)
- [x] Test dragging to top and bottom edges of target items

Fixes #140

🤖 Generated with [Claude Code](https://claude.ai/code)