### PR TITLE
Remove unused database tables to clean up schema

### DIFF
--- a/app/lib/db/queries/util/table-select.ts
+++ b/app/lib/db/queries/util/table-select.ts
@@ -10,7 +10,6 @@ import {
   kilterAscents,
   kilterBids,
   kilterClimbStatsHistory,
-  kilterClimbCacheFields,
   tensionClimbs,
   tensionClimbStats,
   tensionDifficultyGrades,
@@ -21,7 +20,6 @@ import {
   tensionAscents,
   tensionBids,
   tensionClimbStatsHistory,
-  tensionClimbCacheFields,
   kilterAttempts,
   tensionAttempts,
   tensionProducts,
@@ -36,8 +34,6 @@ import {
   tensionBetaLinks,
   kilterWalls,
   tensionWalls,
-  kilterWallsSets,
-  tensionWallsSets,
   kilterTags,
   tensionTags,
 } from '@/lib/db/schema';
@@ -56,7 +52,6 @@ export type TableSet = {
   ascents: typeof kilterAscents | typeof tensionAscents;
   bids: typeof kilterBids | typeof tensionBids;
   climbStatsHistory: typeof kilterClimbStatsHistory | typeof tensionClimbStatsHistory;
-  climbCacheFields: typeof kilterClimbCacheFields | typeof tensionClimbCacheFields;
   attempts: typeof kilterAttempts | typeof tensionAttempts;
   products: typeof kilterProducts | typeof tensionProducts;
   userSyncs: typeof kilterUserSyncs | typeof tensionUserSyncs;
@@ -64,7 +59,6 @@ export type TableSet = {
   climbHolds: typeof kilterClimbHolds | typeof tensionClimbHolds;
   betaLinks: typeof kilterBetaLinks | typeof tensionBetaLinks;
   walls: typeof kilterWalls | typeof tensionWalls;
-  wallsSets: typeof kilterWallsSets | typeof tensionWallsSets;
   tags: typeof kilterTags | typeof tensionTags;
 };
 
@@ -81,7 +75,6 @@ const BOARD_TABLES: Record<BoardName, TableSet> = {
     ascents: kilterAscents,
     bids: kilterBids,
     climbStatsHistory: kilterClimbStatsHistory,
-    climbCacheFields: kilterClimbCacheFields,
     attempts: kilterAttempts,
     products: kilterProducts,
     userSyncs: kilterUserSyncs,
@@ -89,7 +82,6 @@ const BOARD_TABLES: Record<BoardName, TableSet> = {
     climbHolds: kilterClimbHolds,
     betaLinks: kilterBetaLinks,
     walls: kilterWalls,
-    wallsSets: kilterWallsSets,
     tags: kilterTags,
   },
   tension: {
@@ -103,7 +95,6 @@ const BOARD_TABLES: Record<BoardName, TableSet> = {
     ascents: tensionAscents,
     bids: tensionBids,
     climbStatsHistory: tensionClimbStatsHistory,
-    climbCacheFields: tensionClimbCacheFields,
     attempts: tensionAttempts,
     products: tensionProducts,
     userSyncs: tensionUserSyncs,
@@ -111,7 +102,6 @@ const BOARD_TABLES: Record<BoardName, TableSet> = {
     climbHolds: tensionClimbHolds,
     betaLinks: tensionBetaLinks,
     walls: tensionWalls,
-    wallsSets: tensionWallsSets,
     tags: tensionTags,
   },
 } as const;

--- a/app/lib/db/relations.ts
+++ b/app/lib/db/relations.ts
@@ -1,11 +1,9 @@
 import { relations } from 'drizzle-orm/relations';
 import {
   kilterClimbs,
-  kilterClimbCacheFields,
   kilterProducts,
   kilterLayouts,
   tensionClimbs,
-  tensionClimbCacheFields,
   kilterHoles,
   kilterLeds,
   kilterProductSizes,
@@ -34,10 +32,6 @@ import {
   tensionAttempts,
   tensionAscents,
   tensionDifficultyGrades,
-  kilterProductsAngles,
-  kilterWallsSets,
-  tensionWallsSets,
-  tensionProductsAngles,
   kilterUserSyncs,
   tensionUserSyncs,
   kilterBetaLinks,
@@ -62,15 +56,8 @@ export const kilterClimbStatsRelations = relations(kilterClimbStats, ({ one }) =
   }),
 }));
 
-export const kilterClimbCacheFieldsRelations = relations(kilterClimbCacheFields, ({ one }) => ({
-  kilterClimb: one(kilterClimbs, {
-    fields: [kilterClimbCacheFields.climbUuid],
-    references: [kilterClimbs.uuid],
-  }),
-}));
 
 export const kilterClimbsRelations = relations(kilterClimbs, ({ one, many }) => ({
-  kilterClimbCacheFields: many(kilterClimbCacheFields),
   kilterBids: many(kilterBids),
   kilterLayout: one(kilterLayouts, {
     fields: [kilterClimbs.layoutId],
@@ -97,18 +84,10 @@ export const kilterProductsRelations = relations(kilterProducts, ({ many }) => (
   kilterHoles: many(kilterHoles),
   kilterPlacementRoles: many(kilterPlacementRoles),
   kilterWalls: many(kilterWalls),
-  kilterProductsAngles: many(kilterProductsAngles),
 }));
 
-export const tensionClimbCacheFieldsRelations = relations(tensionClimbCacheFields, ({ one }) => ({
-  tensionClimb: one(tensionClimbs, {
-    fields: [tensionClimbCacheFields.climbUuid],
-    references: [tensionClimbs.uuid],
-  }),
-}));
 
 export const tensionClimbsRelations = relations(tensionClimbs, ({ one, many }) => ({
-  tensionClimbCacheFields: many(tensionClimbCacheFields),
   tensionBids: many(tensionBids),
   tensionLayout: one(tensionLayouts, {
     fields: [tensionClimbs.layoutId],
@@ -196,7 +175,6 @@ export const kilterPlacementsRelations = relations(kilterPlacements, ({ one }) =
 export const kilterSetsRelations = relations(kilterSets, ({ many }) => ({
   kilterPlacements: many(kilterPlacements),
   kilterProductSizesLayoutsSets: many(kilterProductSizesLayoutsSets),
-  kilterWallsSets: many(kilterWallsSets),
 }));
 
 export const kilterProductSizesLayoutsSetsRelations = relations(kilterProductSizesLayoutsSets, ({ one }) => ({
@@ -214,7 +192,7 @@ export const kilterProductSizesLayoutsSetsRelations = relations(kilterProductSiz
   }),
 }));
 
-export const kilterWallsRelations = relations(kilterWalls, ({ one, many }) => ({
+export const kilterWallsRelations = relations(kilterWalls, ({ one }) => ({
   kilterLayout: one(kilterLayouts, {
     fields: [kilterWalls.layoutId],
     references: [kilterLayouts.id],
@@ -231,7 +209,6 @@ export const kilterWallsRelations = relations(kilterWalls, ({ one, many }) => ({
     fields: [kilterWalls.userId],
     references: [kilterUsers.id],
   }),
-  kilterWallsSets: many(kilterWallsSets),
 }));
 
 export const tensionBidsRelations = relations(tensionBids, ({ one }) => ({
@@ -275,7 +252,6 @@ export const tensionProductsRelations = relations(tensionProducts, ({ many }) =>
   tensionLayouts: many(tensionLayouts),
   tensionProductSizes: many(tensionProductSizes),
   tensionWalls: many(tensionWalls),
-  tensionProductsAngles: many(tensionProductsAngles),
 }));
 
 export const tensionLayoutsRelations = relations(tensionLayouts, ({ one, many }) => ({
@@ -319,7 +295,6 @@ export const tensionPlacementRolesRelations = relations(tensionPlacementRoles, (
 export const tensionSetsRelations = relations(tensionSets, ({ many }) => ({
   tensionPlacements: many(tensionPlacements),
   tensionProductSizesLayoutsSets: many(tensionProductSizesLayoutsSets),
-  tensionWallsSets: many(tensionWallsSets),
 }));
 
 export const tensionLedsRelations = relations(tensionLeds, ({ one }) => ({
@@ -385,7 +360,7 @@ export const kilterDifficultyGradesRelations = relations(kilterDifficultyGrades,
   kilterAscents: many(kilterAscents),
 }));
 
-export const tensionWallsRelations = relations(tensionWalls, ({ one, many }) => ({
+export const tensionWallsRelations = relations(tensionWalls, ({ one }) => ({
   tensionLayout: one(tensionLayouts, {
     fields: [tensionWalls.layoutId],
     references: [tensionLayouts.id],
@@ -402,7 +377,6 @@ export const tensionWallsRelations = relations(tensionWalls, ({ one, many }) => 
     fields: [tensionWalls.userId],
     references: [tensionUsers.id],
   }),
-  tensionWallsSets: many(tensionWallsSets),
 }));
 
 export const tensionAscentsRelations = relations(tensionAscents, ({ one }) => ({
@@ -432,41 +406,9 @@ export const tensionDifficultyGradesRelations = relations(tensionDifficultyGrade
   tensionAscents: many(tensionAscents),
 }));
 
-export const kilterProductsAnglesRelations = relations(kilterProductsAngles, ({ one }) => ({
-  kilterProduct: one(kilterProducts, {
-    fields: [kilterProductsAngles.productId],
-    references: [kilterProducts.id],
-  }),
-}));
 
-export const kilterWallsSetsRelations = relations(kilterWallsSets, ({ one }) => ({
-  kilterSet: one(kilterSets, {
-    fields: [kilterWallsSets.setId],
-    references: [kilterSets.id],
-  }),
-  kilterWall: one(kilterWalls, {
-    fields: [kilterWallsSets.wallUuid],
-    references: [kilterWalls.uuid],
-  }),
-}));
 
-export const tensionWallsSetsRelations = relations(tensionWallsSets, ({ one }) => ({
-  tensionSet: one(tensionSets, {
-    fields: [tensionWallsSets.setId],
-    references: [tensionSets.id],
-  }),
-  tensionWall: one(tensionWalls, {
-    fields: [tensionWallsSets.wallUuid],
-    references: [tensionWalls.uuid],
-  }),
-}));
 
-export const tensionProductsAnglesRelations = relations(tensionProductsAngles, ({ one }) => ({
-  tensionProduct: one(tensionProducts, {
-    fields: [tensionProductsAngles.productId],
-    references: [tensionProducts.id],
-  }),
-}));
 
 export const kilterUserSyncsRelations = relations(kilterUserSyncs, ({ one }) => ({
   kilterUser: one(kilterUsers, {

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -12,25 +12,6 @@ import {
   index,
 } from 'drizzle-orm/pg-core';
 
-export const kilterClimbCacheFields = pgTable(
-  'kilter_climb_cache_fields',
-  {
-    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
-    climbUuid: text('climb_uuid'),
-    ascensionistCount: integer('ascensionist_count'),
-    displayDifficulty: doublePrecision('display_difficulty'),
-    qualityAverage: doublePrecision('quality_average'),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.climbUuid],
-      foreignColumns: [kilterClimbs.uuid],
-      name: 'climb_cache_fields_climb_uuid_fkey1',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const kilterAttempts = pgTable('kilter_attempts', {
   id: integer().primaryKey().notNull(),
@@ -38,10 +19,6 @@ export const kilterAttempts = pgTable('kilter_attempts', {
   name: text(),
 });
 
-export const kilterClimbRandomPositions = pgTable('kilter_climb_random_positions', {
-  climbUuid: text('climb_uuid').primaryKey().notNull(),
-  position: integer(),
-});
 
 export const kilterLayouts = pgTable(
   'kilter_layouts',
@@ -66,9 +43,6 @@ export const kilterLayouts = pgTable(
   ],
 );
 
-export const kilterAndroidMetadata = pgTable('kilter_android_metadata', {
-  locale: text(),
-});
 
 export const kilterCircuits = pgTable('kilter_circuits', {
   uuid: text().primaryKey().notNull(),
@@ -115,25 +89,6 @@ export const tensionClimbStatsHistory = pgTable('tension_climb_stats_history', {
   createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
 });
 
-export const tensionClimbCacheFields = pgTable(
-  'tension_climb_cache_fields',
-  {
-    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
-    climbUuid: text('climb_uuid'),
-    ascensionistCount: integer('ascensionist_count'),
-    displayDifficulty: doublePrecision('display_difficulty'),
-    qualityAverage: doublePrecision('quality_average'),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.climbUuid],
-      foreignColumns: [tensionClimbs.uuid],
-      name: 'climb_cache_fields_climb_uuid_fkey',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const kilterLeds = pgTable(
   'kilter_leds',
@@ -219,14 +174,6 @@ export const kilterProductSizes = pgTable(
   ],
 );
 
-export const kilterKits = pgTable('kilter_kits', {
-  serialNumber: text('serial_number').primaryKey().notNull(),
-  name: text(),
-  isAutoconnect: boolean('is_autoconnect'),
-  isListed: boolean('is_listed'),
-  createdAt: text('created_at'),
-  updatedAt: text('updated_at'),
-});
 
 export const kilterBids = pgTable(
   'kilter_bids',
@@ -281,27 +228,6 @@ export const kilterHoles = pgTable(
   ],
 );
 
-export const kilterPlacementRoles = pgTable(
-  'kilter_placement_roles',
-  {
-    id: integer().primaryKey().notNull(),
-    productId: integer('product_id'),
-    position: integer(),
-    name: text(),
-    fullName: text('full_name'),
-    ledColor: text('led_color'),
-    screenColor: text('screen_color'),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.productId],
-      foreignColumns: [kilterProducts.id],
-      name: 'placement_roles_product_id_fkey1',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const kilterDifficultyGrades = pgTable('kilter_difficulty_grades', {
   difficulty: integer().primaryKey().notNull(),
@@ -440,6 +366,13 @@ export const kilterUsers = pgTable('kilter_users', {
   createdAt: text('created_at'),
 });
 
+
+export const kilterSets = pgTable('kilter_sets', {
+  id: integer().primaryKey().notNull(),
+  name: text(),
+  hsm: integer(),
+});
+
 export const kilterProducts = pgTable('kilter_products', {
   id: integer().primaryKey().notNull(),
   name: text(),
@@ -449,11 +382,27 @@ export const kilterProducts = pgTable('kilter_products', {
   maxCountInFrame: integer('max_count_in_frame'),
 });
 
-export const kilterSets = pgTable('kilter_sets', {
-  id: integer().primaryKey().notNull(),
-  name: text(),
-  hsm: integer(),
-});
+export const kilterPlacementRoles = pgTable(
+  'kilter_placement_roles',
+  {
+    id: integer().primaryKey().notNull(),
+    productId: integer('product_id'),
+    position: integer(),
+    name: text(),
+    fullName: text('full_name'),
+    ledColor: text('led_color'),
+    screenColor: text('screen_color'),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.productId],
+      foreignColumns: [kilterProducts.id],
+      name: 'placement_roles_product_id_fkey1',
+    })
+      .onUpdate('cascade')
+      .onDelete('cascade'),
+  ],
+);
 
 export const kilterWalls = pgTable(
   'kilter_walls',
@@ -502,9 +451,6 @@ export const kilterWalls = pgTable(
   ],
 );
 
-export const tensionAndroidMetadata = pgTable('tension_android_metadata', {
-  locale: text(),
-});
 
 export const tensionAttempts = pgTable('tension_attempts', {
   id: integer().primaryKey().notNull(),
@@ -583,19 +529,7 @@ export const tensionCircuits = pgTable('tension_circuits', {
   updatedAt: text('updated_at'),
 });
 
-export const tensionKits = pgTable('tension_kits', {
-  serialNumber: text('serial_number').primaryKey().notNull(),
-  name: text(),
-  isAutoconnect: boolean('is_autoconnect'),
-  isListed: boolean('is_listed'),
-  createdAt: text('created_at'),
-  updatedAt: text('updated_at'),
-});
 
-export const tensionClimbRandomPositions = pgTable('tension_climb_random_positions', {
-  climbUuid: text('climb_uuid').primaryKey().notNull(),
-  position: integer(),
-});
 
 export const tensionClimbs = pgTable(
   'tension_climbs',
@@ -682,6 +616,37 @@ export const tensionSets = pgTable('tension_sets', {
   hsm: integer(),
 });
 
+export const tensionProducts = pgTable('tension_products', {
+  id: integer().primaryKey().notNull(),
+  name: text(),
+  isListed: boolean('is_listed'),
+  password: text(),
+  minCountInFrame: integer('min_count_in_frame'),
+  maxCountInFrame: integer('max_count_in_frame'),
+});
+
+export const tensionPlacementRoles = pgTable(
+  'tension_placement_roles',
+  {
+    id: integer().primaryKey().notNull(),
+    productId: integer('product_id'),
+    position: integer(),
+    name: text(),
+    fullName: text('full_name'),
+    ledColor: text('led_color'),
+    screenColor: text('screen_color'),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.productId],
+      foreignColumns: [tensionProducts.id],
+      name: 'placement_roles_product_id_fkey',
+    })
+      .onUpdate('cascade')
+      .onDelete('cascade'),
+  ],
+);
+
 export const tensionPlacements = pgTable(
   'tension_placements',
   {
@@ -723,27 +688,6 @@ export const tensionPlacements = pgTable(
   ],
 );
 
-export const tensionPlacementRoles = pgTable(
-  'tension_placement_roles',
-  {
-    id: integer().primaryKey().notNull(),
-    productId: integer('product_id'),
-    position: integer(),
-    name: text(),
-    fullName: text('full_name'),
-    ledColor: text('led_color'),
-    screenColor: text('screen_color'),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.productId],
-      foreignColumns: [tensionProducts.id],
-      name: 'placement_roles_product_id_fkey',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const tensionLeds = pgTable(
   'tension_leds',
@@ -956,14 +900,6 @@ export const tensionWalls = pgTable(
   ],
 );
 
-export const tensionProducts = pgTable('tension_products', {
-  id: integer().primaryKey().notNull(),
-  name: text(),
-  isListed: boolean('is_listed'),
-  password: text(),
-  minCountInFrame: integer('min_count_in_frame'),
-  maxCountInFrame: integer('max_count_in_frame'),
-});
 
 export const tensionDifficultyGrades = pgTable('tension_difficulty_grades', {
   difficulty: integer().primaryKey().notNull(),
@@ -1027,88 +963,10 @@ export const tensionUsers = pgTable('tension_users', {
   createdAt: text('created_at'),
 });
 
-export const kilterProductsAngles = pgTable(
-  'kilter_products_angles',
-  {
-    productId: integer('product_id').notNull(),
-    angle: integer().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.productId],
-      foreignColumns: [kilterProducts.id],
-      name: 'products_angles_product_id_fkey1',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
-export const kilterWallsSets = pgTable(
-  'kilter_walls_sets',
-  {
-    wallUuid: text('wall_uuid').notNull(),
-    setId: integer('set_id').notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.setId],
-      foreignColumns: [kilterSets.id],
-      name: 'walls_sets_set_id_fkey1',
-    })
-      .onUpdate('cascade')
-      .onDelete('restrict'),
-    foreignKey({
-      columns: [table.wallUuid],
-      foreignColumns: [kilterWalls.uuid],
-      name: 'walls_sets_wall_uuid_fkey1',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
-export const kilterUserPermissions = pgTable(
-  'kilter_user_permissions',
-  {
-    userId: integer('user_id').notNull(),
-    name: text().notNull(),
-  },
-  () => [],
-);
 
-export const tensionUserPermissions = pgTable(
-  'tension_user_permissions',
-  {
-    userId: integer('user_id').notNull(),
-    name: text().notNull(),
-  },
-  () => [],
-);
 
-export const tensionWallsSets = pgTable(
-  'tension_walls_sets',
-  {
-    wallUuid: text('wall_uuid').notNull(),
-    setId: integer('set_id').notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.setId],
-      foreignColumns: [tensionSets.id],
-      name: 'walls_sets_set_id_fkey',
-    })
-      .onUpdate('cascade')
-      .onDelete('restrict'),
-    foreignKey({
-      columns: [table.wallUuid],
-      foreignColumns: [tensionWalls.uuid],
-      name: 'walls_sets_wall_uuid_fkey',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const kilterCircuitsClimbs = pgTable(
   'kilter_circuits_climbs',
@@ -1120,22 +978,6 @@ export const kilterCircuitsClimbs = pgTable(
   () => [],
 );
 
-export const tensionProductsAngles = pgTable(
-  'tension_products_angles',
-  {
-    productId: integer('product_id').notNull(),
-    angle: integer().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.productId],
-      foreignColumns: [tensionProducts.id],
-      name: 'products_angles_product_id_fkey',
-    })
-      .onUpdate('cascade')
-      .onDelete('cascade'),
-  ],
-);
 
 export const kilterUserSyncs = pgTable(
   'kilter_user_syncs',

--- a/drizzle/0015_majestic_carmella_unuscione.sql
+++ b/drizzle/0015_majestic_carmella_unuscione.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS "kilter_android_metadata" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_climb_cache_fields" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_climb_random_positions" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_kits" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_products_angles" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_user_permissions" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "kilter_walls_sets" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_android_metadata" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_climb_cache_fields" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_climb_random_positions" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_kits" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_products_angles" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_user_permissions" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "tension_walls_sets" CASCADE;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,3674 @@
+{
+  "id": "adf48b70-c4d6-4836-9278-e1355abee657",
+  "prevId": "9c689779-3005-49b1-b4af-1cf1c8a97fcb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.kilter_ascents": {
+      "name": "kilter_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey1": {
+          "name": "ascents_attempt_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey1": {
+          "name": "ascents_climb_uuid_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey1": {
+          "name": "ascents_difficulty_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey1": {
+          "name": "ascents_user_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_attempts": {
+      "name": "kilter_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_beta_links": {
+      "name": "kilter_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey1": {
+          "name": "beta_links_climb_uuid_fkey1",
+          "tableFrom": "kilter_beta_links",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_bids": {
+      "name": "kilter_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey1": {
+          "name": "bids_climb_uuid_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey1": {
+          "name": "bids_user_id_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits": {
+      "name": "kilter_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits_climbs": {
+      "name": "kilter_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_holds": {
+      "name": "kilter_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kilter_climb_holds_search_idx": {
+          "name": "kilter_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "kilter_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats": {
+      "name": "kilter_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_stats_pk": {
+          "name": "kilter_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats_history": {
+      "name": "kilter_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climbs": {
+      "name": "kilter_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kilter_climbs_layout_filter_idx": {
+          "name": "kilter_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kilter_climbs_edges_idx": {
+          "name": "kilter_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey1": {
+          "name": "climbs_layout_id_fkey1",
+          "tableFrom": "kilter_climbs",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_difficulty_grades": {
+      "name": "kilter_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_holes": {
+      "name": "kilter_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_product_id_fkey1": {
+          "name": "holes_product_id_fkey1",
+          "tableFrom": "kilter_holes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_layouts": {
+      "name": "kilter_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey1": {
+          "name": "layouts_product_id_fkey1",
+          "tableFrom": "kilter_layouts",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_leds": {
+      "name": "kilter_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey1": {
+          "name": "leds_hole_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey1": {
+          "name": "leds_product_size_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placement_roles": {
+      "name": "kilter_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey1": {
+          "name": "placement_roles_product_id_fkey1",
+          "tableFrom": "kilter_placement_roles",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placements": {
+      "name": "kilter_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey1": {
+          "name": "placements_default_placement_role_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey1": {
+          "name": "placements_hole_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey1": {
+          "name": "placements_layout_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey1": {
+          "name": "placements_set_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes": {
+      "name": "kilter_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey1": {
+          "name": "product_sizes_product_id_fkey1",
+          "tableFrom": "kilter_product_sizes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes_layouts_sets": {
+      "name": "kilter_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey1": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey1": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey1": {
+          "name": "product_sizes_layouts_sets_set_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_products": {
+      "name": "kilter_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_sets": {
+      "name": "kilter_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_shared_syncs": {
+      "name": "kilter_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_tags": {
+      "name": "kilter_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_user_syncs": {
+      "name": "kilter_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey1": {
+          "name": "user_syncs_user_id_fkey1",
+          "tableFrom": "kilter_user_syncs",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kilter_user_sync_pk": {
+          "name": "kilter_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_users": {
+      "name": "kilter_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_walls": {
+      "name": "kilter_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey1": {
+          "name": "walls_layout_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey1": {
+          "name": "walls_product_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey1": {
+          "name": "walls_product_size_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey1": {
+          "name": "walls_user_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_ascents": {
+      "name": "tension_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey": {
+          "name": "ascents_attempt_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey": {
+          "name": "ascents_climb_uuid_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey": {
+          "name": "ascents_difficulty_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey": {
+          "name": "ascents_user_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_attempts": {
+      "name": "tension_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_beta_links": {
+      "name": "tension_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey": {
+          "name": "beta_links_climb_uuid_fkey",
+          "tableFrom": "tension_beta_links",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_bids": {
+      "name": "tension_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey": {
+          "name": "bids_climb_uuid_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey": {
+          "name": "bids_user_id_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits": {
+      "name": "tension_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits_climbs": {
+      "name": "tension_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_holds": {
+      "name": "tension_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tension_climb_holds_search_idx": {
+          "name": "tension_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "tension_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats": {
+      "name": "tension_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_stats_pk": {
+          "name": "tension_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats_history": {
+      "name": "tension_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climbs": {
+      "name": "tension_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tension_climbs_layout_filter_idx": {
+          "name": "tension_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tension_climbs_edges_idx": {
+          "name": "tension_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey": {
+          "name": "climbs_layout_id_fkey",
+          "tableFrom": "tension_climbs",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_difficulty_grades": {
+      "name": "tension_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_holes": {
+      "name": "tension_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_mirrored_hole_id_fkey": {
+          "name": "holes_mirrored_hole_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "mirrored_hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "holes_product_id_fkey": {
+          "name": "holes_product_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_layouts": {
+      "name": "tension_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey": {
+          "name": "layouts_product_id_fkey",
+          "tableFrom": "tension_layouts",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_leds": {
+      "name": "tension_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey": {
+          "name": "leds_hole_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey": {
+          "name": "leds_product_size_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placement_roles": {
+      "name": "tension_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey": {
+          "name": "placement_roles_product_id_fkey",
+          "tableFrom": "tension_placement_roles",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placements": {
+      "name": "tension_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey": {
+          "name": "placements_default_placement_role_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey": {
+          "name": "placements_hole_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey": {
+          "name": "placements_layout_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey": {
+          "name": "placements_set_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes": {
+      "name": "tension_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey": {
+          "name": "product_sizes_product_id_fkey",
+          "tableFrom": "tension_product_sizes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes_layouts_sets": {
+      "name": "tension_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey": {
+          "name": "product_sizes_layouts_sets_set_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_products": {
+      "name": "tension_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_sets": {
+      "name": "tension_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_shared_syncs": {
+      "name": "tension_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_tags": {
+      "name": "tension_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_user_syncs": {
+      "name": "tension_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey": {
+          "name": "user_syncs_user_id_fkey",
+          "tableFrom": "tension_user_syncs",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tension_user_sync_pk": {
+          "name": "tension_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_users": {
+      "name": "tension_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_walls": {
+      "name": "tension_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey": {
+          "name": "walls_layout_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey": {
+          "name": "walls_product_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey": {
+          "name": "walls_product_size_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey": {
+          "name": "walls_user_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1741938194000,
       "tag": "0014_add_missing_primary_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1752459287070,
+      "tag": "0015_majestic_carmella_unuscione",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove 14 unused database tables to improve schema maintainability
- Reduce total tables from 64 to 50 (22% reduction)
- Keep circuits and tags tables for future implementation
- Update all related imports and relations

## Removed Tables
**14 tables dropped** (7 kilter + 7 tension variants):
- `*_android_metadata` - Android-specific metadata
- `*_climb_cache_fields` - Redundant cached statistics  
- `*_climb_random_positions` - Random positioning feature
- `*_kits` - Hardware kit tracking
- `*_products_angles` - Product angle definitions
- `*_user_permissions` - Unused permission system
- `*_walls_sets` - Junction table for wall configurations

## Changes Made
- ✅ Created migration script with `IF EXISTS` for safe execution
- ✅ Removed table definitions from `schema.ts`
- ✅ Updated imports in `table-select.ts`
- ✅ Cleaned up relations in `relations.ts`
- ✅ Applied migration to development database

## Test Plan
- [x] Database migration runs successfully
- [x] Build completes without errors
- [x] Schema validation passes (no additional migrations needed)
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)