### PR TITLE
Add full-page loading overlay to board selector

### DIFF
--- a/app/components/loading/full-page-loading-overlay.tsx
+++ b/app/components/loading/full-page-loading-overlay.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Spin, Typography } from 'antd';
+
+const { Text } = Typography;
+
+const loadingMessages = [
+  "Setting up your board...",
+  "Configuring climb routes...",
+  "Preparing the wall...",
+  "Loading hold sets...",
+  "Almost ready to climb...",
+  "Warming up the LEDs...",
+  "Syncing board configuration...",
+  "Calibrating difficulty grades...",
+  "Getting your climbing groove on...",
+  "Checking route conditions...",
+];
+
+interface FullPageLoadingOverlayProps {
+  isVisible: boolean;
+}
+
+const FullPageLoadingOverlay: React.FC<FullPageLoadingOverlayProps> = ({ isVisible }) => {
+  const [currentMessage, setCurrentMessage] = useState(loadingMessages[0]);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    let messageIndex = 0;
+    const interval = setInterval(() => {
+      messageIndex = (messageIndex + 1) % loadingMessages.length;
+      setCurrentMessage(loadingMessages[messageIndex]);
+    }, 2500);
+
+    return () => clearInterval(interval);
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        zIndex: 9999,
+        gap: '24px',
+      }}
+    >
+      <Spin size="large" />
+      <Text
+        style={{
+          color: 'white',
+          fontSize: '16px',
+          textAlign: 'center',
+          opacity: 0.9,
+          maxWidth: '300px',
+          lineHeight: 1.4,
+        }}
+      >
+        {currentMessage}
+      </Text>
+    </div>
+  );
+};
+
+export default FullPageLoadingOverlay;

--- a/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/app/components/setup-wizard/consolidated-board-config.tsx
@@ -12,6 +12,7 @@ import BoardConfigPreview from './board-config-preview';
 import BoardConfigLivePreview from './board-config-live-preview';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
+import FullPageLoadingOverlay from '../loading/full-page-loading-overlay';
 
 const { Option } = Select;
 const { Title, Text } = Typography;
@@ -377,7 +378,9 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
   const isFormComplete = selectedBoard && selectedLayout && selectedSize && selectedSets.length > 0;
 
   return (
-    <div style={{ padding: '24px', maxWidth: '600px', margin: '0 auto' }}>
+    <>
+      <FullPageLoadingOverlay isVisible={isStartingClimbing} />
+      <div style={{ padding: '24px', maxWidth: '600px', margin: '0 auto' }}>
       <Card>
         <Title level={1} style={{ textAlign: 'center', marginBottom: '8px' }}>
           BoardSesh
@@ -576,6 +579,7 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
         )}
       </Card>
     </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
• Add full-page loading overlay when users click "Start climbing" in board selector
• Show rotating fun status messages similar to Claude Code's loading experience
• Improve UX during the board loading delay between clicking "Start climbing" and reaching the board page

## Changes
• Created `FullPageLoadingOverlay` component with semi-transparent background and spinner
• Added 10+ fun climbing-themed loading messages that rotate every 2.5 seconds
• Integrated overlay into board selector to show when `isStartingClimbing` state is true
• Uses Ant Design Spin component for consistency with existing UI

## Test plan
- [x] Component renders correctly when loading state is active
- [x] Messages rotate properly every 2.5 seconds
- [x] Overlay covers full screen with proper z-index
- [x] Component disappears when loading completes
- [x] ESLint passes with no warnings
- [x] TypeScript build succeeds
- [x] Responsive design works on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)