### PR TITLE
Fix PeerJS party mode by properly separating WebSocket and PeerJS modes

### DIFF
--- a/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -12,7 +12,7 @@ import QueueControlBar from '@/app/components/queue-control/queue-control-bar';
 import { getBoardDetails } from '@/app/lib/data/queries';
 import BoardSeshHeader from '@/app/components/board-page/header';
 import { QueueProvider } from '@/app/components/queue-control/queue-context';
-import { PeerProvider } from '@/app/components/connection-manager/peer-context';
+import { ConnectionProviderWrapper } from '@/app/components/connection-manager/connection-provider-wrapper';
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 
 interface BoardLayoutProps {
@@ -82,7 +82,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
     <>
       <title>{`Boardsesh on ${board_name} - Layout ${layout_id}`}</title>
       <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column' }}>
-        <PeerProvider>
+        <ConnectionProviderWrapper>
           <QueueProvider parsedParams={parsedParams}>
             <PartyProvider>
               <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
@@ -111,7 +111,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               </Affix>
             </PartyProvider>
           </QueueProvider>
-        </PeerProvider>
+        </ConnectionProviderWrapper>
       </Layout>
     </>
   );

--- a/app/components/board-page/share-button.tsx
+++ b/app/components/board-page/share-button.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { TeamOutlined, CopyOutlined, CrownFilled, LoadingOutlined } from '@ant-design/icons';
 import { Button, Input, Drawer, QRCode, Flex, message, Typography, Badge } from 'antd';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { usePeerContext } from '../connection-manager/peer-context';
+import { useConnection } from '../connection-manager/use-connection';
 import { usePartyContext } from '../party-manager/party-context';
 // import { usePartyContext } from '../party-manager/party-context';
 
@@ -21,7 +21,7 @@ const getShareUrl = (pathname: string, searchParams: URLSearchParams, peerId: st
 };
 
 export const ShareBoardButton = () => {
-  const { peerId, isConnecting, hasConnected, connections, hostId } = usePeerContext();
+  const { peerId, isConnecting, hasConnected, connections, hostId } = useConnection();
   const { connectedUsers, userName } = usePartyContext();
   const searchParams = useSearchParams();
   const pathname = usePathname();

--- a/app/components/connection-manager/connection-provider-wrapper.tsx
+++ b/app/components/connection-manager/connection-provider-wrapper.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { useSearchParams } from 'next/navigation';
+import { PeerProvider } from './peer-context';
+import { WebSocketProvider } from './websocket-context';
+
+export const ConnectionProviderWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const searchParams = useSearchParams();
+  const controllerUrl = searchParams.get('controllerUrl');
+  const isControllerMode = !!controllerUrl;
+
+  // Use WebSocket for controller mode, PeerJS for party mode
+  if (isControllerMode) {
+    return (
+      <WebSocketProvider>
+        {children}
+      </WebSocketProvider>
+    );
+  }
+
+  return (
+    <PeerProvider>
+      {children}
+    </PeerProvider>
+  );
+};

--- a/app/components/connection-manager/peer-context.tsx
+++ b/app/components/connection-manager/peer-context.tsx
@@ -15,7 +15,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { peerReducer, initialPeerState } from './reducer';
 
-const PeerContext = createContext<PeerContextType | undefined>(undefined);
+export const PeerContext = createContext<PeerContextType | undefined>(undefined);
 let peerInstance: Peer | undefined;
 let heartbeatInterval: NodeJS.Timeout | undefined;
 let healthCheckInterval: NodeJS.Timeout | undefined;

--- a/app/components/connection-manager/use-connection.ts
+++ b/app/components/connection-manager/use-connection.ts
@@ -15,10 +15,9 @@ export const useConnection = (): PeerContextType => {
   const controllerUrl = searchParams.get('controllerUrl');
   const isControllerMode = !!controllerUrl;
 
-  const peerContext = useContext(PeerContext);
-  const wsContext = useContext(WebSocketContext);
-
+  // Only try to use the context that should be available
   if (isControllerMode) {
+    const wsContext = useContext(WebSocketContext);
     if (!wsContext) {
       throw new Error('useConnection must be used within a WebSocketProvider when in controller mode');
     }
@@ -37,11 +36,11 @@ export const useConnection = (): PeerContextType => {
       subscribeToData: wsContext.subscribeToData,
       connectToPeer: () => {}, // No-op in WebSocket mode
     };
+  } else {
+    const peerContext = useContext(PeerContext);
+    if (!peerContext) {
+      throw new Error('useConnection must be used within a PeerProvider when in party mode');
+    }
+    return peerContext;
   }
-
-  if (!peerContext) {
-    throw new Error('useConnection must be used within a PeerProvider when in party mode');
-  }
-
-  return peerContext;
 };

--- a/app/components/connection-manager/use-connection.ts
+++ b/app/components/connection-manager/use-connection.ts
@@ -15,9 +15,12 @@ export const useConnection = (): PeerContextType => {
   const controllerUrl = searchParams.get('controllerUrl');
   const isControllerMode = !!controllerUrl;
 
-  // Only try to use the context that should be available
+  // Always call hooks at the top level (React hooks rules)
+  const peerContext = useContext(PeerContext);
+  const wsContext = useContext(WebSocketContext);
+
+  // Choose which context to use based on mode
   if (isControllerMode) {
-    const wsContext = useContext(WebSocketContext);
     if (!wsContext) {
       throw new Error('useConnection must be used within a WebSocketProvider when in controller mode');
     }
@@ -37,7 +40,6 @@ export const useConnection = (): PeerContextType => {
       connectToPeer: () => {}, // No-op in WebSocket mode
     };
   } else {
-    const peerContext = useContext(PeerContext);
     if (!peerContext) {
       throw new Error('useConnection must be used within a PeerProvider when in party mode');
     }

--- a/app/components/connection-manager/use-connection.ts
+++ b/app/components/connection-manager/use-connection.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useContext } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { PeerContext } from './peer-context';
+import { WebSocketContext } from './websocket-context';
+import { PeerContextType } from './types';
+
+/**
+ * Hook that returns the appropriate connection context (WebSocket or PeerJS)
+ * based on whether we're in controller mode or party mode
+ */
+export const useConnection = (): PeerContextType => {
+  const searchParams = useSearchParams();
+  const controllerUrl = searchParams.get('controllerUrl');
+  const isControllerMode = !!controllerUrl;
+
+  const peerContext = useContext(PeerContext);
+  const wsContext = useContext(WebSocketContext);
+
+  if (isControllerMode) {
+    if (!wsContext) {
+      throw new Error('useConnection must be used within a WebSocketProvider when in controller mode');
+    }
+    
+    // Adapt WebSocket context to match PeerContextType interface
+    return {
+      peerId: 'boardsesh-client',
+      hostId: wsContext.controllerId,
+      isConnecting: !wsContext.isConnected,
+      hasConnected: wsContext.isConnected,
+      connections: [], // WebSocket mode doesn't have peer connections
+      currentLeader: wsContext.controllerId,
+      isLeader: false, // Controller is always the leader
+      initiateLeaderElection: () => {}, // No-op in WebSocket mode
+      sendData: wsContext.sendData,
+      subscribeToData: wsContext.subscribeToData,
+      connectToPeer: () => {}, // No-op in WebSocket mode
+    };
+  }
+
+  if (!peerContext) {
+    throw new Error('useConnection must be used within a PeerProvider when in party mode');
+  }
+
+  return peerContext;
+};

--- a/app/components/connection-manager/websocket-context.tsx
+++ b/app/components/connection-manager/websocket-context.tsx
@@ -13,7 +13,7 @@ interface WebSocketContextType {
   subscribeToData: (callback: (data: ReceivedPeerData) => void) => () => void;
 }
 
-const WebSocketContext = createContext<WebSocketContextType | undefined>(undefined);
+export const WebSocketContext = createContext<WebSocketContextType | undefined>(undefined);
 
 type DataHandler = {
   id: string;

--- a/app/components/party-manager/party-context.tsx
+++ b/app/components/party-manager/party-context.tsx
@@ -2,7 +2,7 @@
 
 import React, { useContext, createContext, useEffect, useCallback, useState, useMemo } from 'react';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import { usePeerContext } from '../connection-manager/peer-context';
+import { useConnection } from '../connection-manager/use-connection';
 import { ReceivedPeerData, SendPeerInfo } from '../connection-manager/types';
 
 type ConnectedUser = {
@@ -22,7 +22,7 @@ type WebSocketData = Pick<SendPeerInfo, 'username'>;
 const PartyContext = createContext<PartyContextType | undefined>(undefined);
 
 export const PartyProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { sendData, peerId, subscribeToData, connections } = usePeerContext();
+  const { sendData, peerId, subscribeToData, connections } = useConnection();
   const { username: boardUsername } = useBoardProvider();
 
   const username = boardUsername || '';


### PR DESCRIPTION
## Summary
- Fixes PeerJS party mode not working after WebSocket support was added
- Introduces proper separation between WebSocket (controller mode) and PeerJS (party mode) connections
- Ensures the two connection types never run simultaneously to prevent conflicts

## Technical Changes
- **ConnectionProviderWrapper**: New wrapper component that conditionally renders either `WebSocketProvider` or `PeerProvider` based on the presence of `controllerUrl` query parameter
- **useConnection hook**: Unified interface that adapts WebSocket context to match PeerJS context interface when in controller mode
- **Mode detection**: Uses `controllerUrl` search parameter to determine connection mode - WebSocket for controller mode, PeerJS for party mode
- **Context separation**: Each mode now runs in complete isolation with its own provider and context

## Test plan
- [ ] Test party mode (PeerJS) functionality without `controllerUrl` parameter
- [ ] Test controller mode (WebSocket) functionality with `controllerUrl` parameter
- [ ] Verify no conflicts occur between the two modes
- [ ] Test mode switching by adding/removing the `controllerUrl` parameter
- [ ] Verify existing queue synchronization works in both modes

🤖 Generated with [Claude Code](https://claude.ai/code)