### PR TITLE
Fix Bluetooth connection by filtering on Aurora service UUID

### DIFF
--- a/app/components/board-bluetooth-control/bluetooth.ts
+++ b/app/components/board-bluetooth-control/bluetooth.ts
@@ -8,6 +8,9 @@ const PACKET_MIDDLE = 81;
 const PACKET_FIRST = 82;
 const PACKET_LAST = 83;
 const PACKET_ONLY = 84;
+// Aurora boards (Kilter, Tension, etc.) advertise this service UUID for discovery
+const AURORA_ADVERTISED_SERVICE_UUID = '4488b571-7806-4df6-bcff-a2897e4953ff';
+// Nordic UART Service UUID - used for actual communication
 const SERVICE_UUID = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const CHARACTERISTIC_UUID = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 
@@ -77,9 +80,11 @@ export const writeCharacteristicSeries = async (
   }
 };
 
-export const requestDevice = async (namePrefix: string) =>
+export const requestDevice = async () =>
   navigator.bluetooth.requestDevice({
-    filters: [{ namePrefix }],
+    // Filter by the Aurora advertised service UUID to find Kilter/Tension/Decoy boards
+    // Board names can be customized by users so namePrefix filtering doesn't work reliably
+    filters: [{ services: [AURORA_ADVERTISED_SERVICE_UUID] }],
     optionalServices: [SERVICE_UUID],
   });
 

--- a/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
+++ b/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
@@ -94,8 +94,7 @@ const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({ boardDe
     try {
       // Request Bluetooth connection if not already connected
       if (!bluetoothDeviceRef.current || !characteristicRef.current) {
-        const bluetoothboardname = boardDetails.board_name[0].toUpperCase() + boardDetails.board_name.slice(1);
-        const device = await requestDevice(bluetoothboardname);
+        const device = await requestDevice();
         const characteristic = await getCharacteristic(device);
 
         if (characteristic) {


### PR DESCRIPTION
The Bluetooth device picker wasn't finding boards because it was filtering
by device name prefix (e.g., "Kilter", "Tension"). However, Aurora boards
allow users to customize the board name, so the name might not start with
the expected prefix.

Changed to filter by the Aurora advertised service UUID
(4488b571-7806-4df6-bcff-a2897e4953ff) which all Kilter/Tension/Decoy
boards broadcast, regardless of their custom name.