### PR TITLE
Improve loading spinner with radial sweep animation and image prefetching

### DIFF
--- a/app/components/board-renderer/board-heatmap.tsx
+++ b/app/components/board-renderer/board-heatmap.tsx
@@ -101,7 +101,7 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
     const centerY = (boardDetails.edge_top + boardDetails.edge_bottom) / 2;
 
     // Current sweep angle (0-360), advances each frame
-    const sweepAngle = (animationFrame * 3.6) % 360; // Full rotation over 100 frames
+    const sweepAngle = (animationFrame * 7.2) % 360; // Full rotation over 50 frames
     const sweepWidth = 60; // 60 degree sweep arc
 
     const holdsMap: LitUpHoldsMap = {};

--- a/app/components/board-renderer/board-heatmap.tsx
+++ b/app/components/board-renderer/board-heatmap.tsx
@@ -138,7 +138,7 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
 
     const animationInterval = setInterval(() => {
       setAnimationFrame((prev) => (prev + 1) % 100);
-    }, 150);
+    }, 80); // Faster rotation
 
     return () => clearInterval(animationInterval);
   }, [heatmapLoading]);

--- a/app/components/loading/animated-board-loading.tsx
+++ b/app/components/loading/animated-board-loading.tsx
@@ -89,7 +89,7 @@ const AnimatedBoardLoading: React.FC<AnimatedBoardLoadingProps> = ({ isVisible, 
 
     const animationInterval = setInterval(() => {
       setAnimationFrame(prev => (prev + 1) % 100);
-    }, 150); // Update every 150ms for smooth animation
+    }, 80); // Update every 80ms for faster rotation
 
     return () => clearInterval(animationInterval);
   }, [isVisible, boardDetails]);

--- a/app/components/loading/animated-board-loading.tsx
+++ b/app/components/loading/animated-board-loading.tsx
@@ -39,7 +39,7 @@ const AnimatedBoardLoading: React.FC<AnimatedBoardLoadingProps> = ({ isVisible, 
     const centerY = (boardDetails.edge_top + boardDetails.edge_bottom) / 2;
 
     // Current sweep angle (0-360), advances each frame
-    const sweepAngle = (animationFrame * 3.6) % 360; // Full rotation over 100 frames
+    const sweepAngle = (animationFrame * 7.2) % 360; // Full rotation over 50 frames
     const sweepWidth = 60; // 60 degree sweep arc
 
     const holdsMap: LitUpHoldsMap = {};

--- a/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/app/components/setup-wizard/consolidated-board-config.tsx
@@ -174,6 +174,24 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
     setSuggestedName(`${layoutName} ${sizeName}`);
   }, [selectedBoard, selectedLayout, selectedSize, layouts, sizes]);
 
+  // Prefetch images for common board configurations
+  useEffect(() => {
+    const prefetchImages = () => {
+      Object.values(boardConfigs.details).forEach((details) => {
+        if (!details) return;
+        Object.keys(details.images_to_holds).forEach((imageUrl) => {
+          const fullUrl = `/images/${details.board_name}/${imageUrl}`;
+          const link = document.createElement('link');
+          link.rel = 'prefetch';
+          link.href = fullUrl;
+          link.as = 'image';
+          document.head.appendChild(link);
+        });
+      });
+    };
+    prefetchImages();
+  }, [boardConfigs.details]);
+
   // Load configurations on mount
   useEffect(() => {
     const loadConfigurations = async () => {


### PR DESCRIPTION
## Summary
- Replace snake-like hold animation with radial sweep pattern that rotates like clock hands
- Holds now light up based on their angle from the board center, creating a spinner effect
- Add image prefetching for common board configurations on landing page to ensure images are loaded before spinner appears

## Test plan
- [ ] Load the landing page and verify images are being prefetched (check Network tab for prefetch requests)
- [ ] Click "Start Climbing" and verify the spinner shows a radial sweep pattern
- [ ] The sweep should rotate smoothly like clock hands, not jump around like before

🤖 Generated with [Claude Code](https://claude.com/claude-code)