### PR TITLE
Add heatmap feature to create climb screen

### DIFF
--- a/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
+++ b/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
@@ -1,4 +1,4 @@
-import { getHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap';
+import { getHoldHeatmapData, HoldsWithStateFilter } from '@/app/lib/db/queries/climbs/holds-heatmap';
 import { getSession } from '@/app/lib/session';
 import { BoardRouteParameters, ErrorResponse, SearchRequestPagination } from '@/app/lib/types';
 import { urlParamsToSearchParams } from '@/app/lib/url-utils';
@@ -60,8 +60,19 @@ export async function GET(
       userId = session.userId;
     }
 
+    // Parse holdsWithState filter if provided (JSON stringified object)
+    let holdsWithState: HoldsWithStateFilter | undefined;
+    const holdsWithStateParam = query.get('holdsWithState');
+    if (holdsWithStateParam) {
+      try {
+        holdsWithState = JSON.parse(holdsWithStateParam);
+      } catch {
+        console.warn('Invalid holdsWithState parameter, ignoring');
+      }
+    }
+
     // Get the heatmap data using the query function
-    const holdStats = await getHoldHeatmapData(parsedParams, searchParams, userId);
+    const holdStats = await getHoldHeatmapData(parsedParams, searchParams, userId, holdsWithState);
 
     // Return response
     return NextResponse.json({

--- a/app/components/board-renderer/board-heatmap.tsx
+++ b/app/components/board-renderer/board-heatmap.tsx
@@ -318,7 +318,7 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({
           </div>
         )}
         <svg
-          viewBox={`0 0 ${boardWidth} ${boardHeight + LEGEND_HEIGHT}`}
+          viewBox={`0 0 ${boardWidth} ${boardHeight + (showHeatmap && !heatmapLoading ? LEGEND_HEIGHT : 0)}`}
           preserveAspectRatio="xMidYMid meet"
           className="w-full h-auto max-h-[55vh]"
         >

--- a/app/components/board-renderer/board-heatmap.tsx
+++ b/app/components/board-renderer/board-heatmap.tsx
@@ -5,12 +5,14 @@ import { BoardDetails } from '@/app/lib/types';
 import { HeatmapData } from './types';
 import { LitUpHoldsMap } from './types';
 import { scaleLog } from 'd3-scale';
-import useHeatmapData from '../search-drawer/use-heatmap';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
+import useHeatmapData, { HoldsWithStateFilter } from '../search-drawer/use-heatmap';
+import { usePathname } from 'next/navigation';
+import { useUISearchParamsOptional } from '@/app/components/queue-control/ui-searchparams-provider';
 import { Button, Select, Form, Switch } from 'antd';
 import { track } from '@vercel/analytics';
 import BoardRenderer from './board-renderer';
+import { SearchRequestPagination } from '@/app/lib/types';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 
 const LEGEND_HEIGHT = 96; // Increased from 80
 const BLUR_RADIUS = 10; // Increased blur radius
@@ -41,6 +43,9 @@ interface BoardHeatmapProps {
   boardDetails: BoardDetails;
   litUpHoldsMap?: LitUpHoldsMap;
   onHoldClick?: (holdId: number) => void;
+  holdsWithState?: HoldsWithStateFilter; // Filter for create climb heatmap
+  angle?: number; // Optional angle override (used by create climb)
+  filters?: SearchRequestPagination; // Optional filters override (used by create climb)
 }
 
 // Define the color mode type including user-specific modes
@@ -55,17 +60,30 @@ type ColorMode =
   | 'userAscents'
   | 'userAttempts';
 
-const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap, onHoldClick }) => {
+const BoardHeatmap: React.FC<BoardHeatmapProps> = ({
+  boardDetails,
+  litUpHoldsMap,
+  onHoldClick,
+  holdsWithState,
+  angle: angleProp,
+  filters: filtersProp,
+}) => {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const { uiSearchParams } = useUISearchParams();
+
+  // Use uiSearchParams context if available and no filters prop provided
+  const uiSearchParamsContext = useUISearchParamsOptional();
+  const uiSearchParams = uiSearchParamsContext?.uiSearchParams;
 
   const [colorMode, setColorMode] = useState<ColorMode>('ascents');
   const [showNumbers, setShowNumbers] = useState(false);
   const [showHeatmap, setShowHeatmap] = useState(false);
 
-  // Get angle from pathname - derived directly without needing state
-  const angle = useMemo(() => getAngleFromPath(pathname), [pathname]);
+  // Get angle from pathname if not provided as prop
+  const angleFromPath = useMemo(() => getAngleFromPath(pathname), [pathname]);
+  const angle = angleProp ?? angleFromPath;
+
+  // Use provided filters or fall back to uiSearchParams (context may not be available in create climb screen)
+  const filters = filtersProp ?? uiSearchParams ?? DEFAULT_SEARCH_PARAMS;
 
   // Only fetch heatmap data when heatmap is enabled
   const { data: heatmapData = [], loading: heatmapLoading } = useHeatmapData({
@@ -74,8 +92,9 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
     sizeId: boardDetails.size_id,
     setIds: boardDetails.set_ids.join(','),
     angle,
-    filters: uiSearchParams,
+    filters,
     enabled: showHeatmap,
+    holdsWithState,
   });
 
   const [threshold, setThreshold] = useState(1);

--- a/app/components/queue-control/ui-searchparams-provider.tsx
+++ b/app/components/queue-control/ui-searchparams-provider.tsx
@@ -86,3 +86,8 @@ export const useUISearchParams = () => {
   }
   return context;
 };
+
+// Optional version that returns null if not in context (for components that can work without it)
+export const useUISearchParamsOptional = () => {
+  return useContext(UISearchParamsContext);
+};

--- a/app/components/search-drawer/use-heatmap.tsx
+++ b/app/components/search-drawer/use-heatmap.tsx
@@ -35,6 +35,10 @@ export default function useHeatmapData({
   const [error, setError] = useState<Error | null>(null);
   const { token, user_id } = useBoardProvider();
 
+  // Serialize objects for stable comparison in useEffect
+  const holdsWithStateKey = holdsWithState ? JSON.stringify(holdsWithState) : '';
+  const filtersKey = JSON.stringify(filters);
+
   useEffect(() => {
     // Don't fetch if not enabled
     if (!enabled) {
@@ -97,7 +101,8 @@ export default function useHeatmapData({
     return () => {
       cancelled = true;
     };
-  }, [boardName, layoutId, sizeId, setIds, angle, filters, token, user_id, enabled, holdsWithState]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardName, layoutId, sizeId, setIds, angle, filtersKey, token, user_id, enabled, holdsWithStateKey]);
 
   return { data: heatmapData, loading, error };
 }

--- a/app/components/search-drawer/use-heatmap.tsx
+++ b/app/components/search-drawer/use-heatmap.tsx
@@ -4,6 +4,11 @@ import { HeatmapData } from '../board-renderer/types';
 import { searchParamsToUrlParams } from '@/app/lib/url-utils';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 
+// Filter type for holds with their states (used in create climb heatmap)
+export interface HoldsWithStateFilter {
+  [holdId: string]: string; // holdId -> HoldState (STARTING, HAND, FOOT, FINISH)
+}
+
 interface UseHeatmapDataProps {
   boardName: BoardName;
   layoutId: number;
@@ -12,6 +17,7 @@ interface UseHeatmapDataProps {
   angle: number;
   filters: SearchRequestPagination;
   enabled?: boolean;
+  holdsWithState?: HoldsWithStateFilter; // Optional filter for create climb heatmap
 }
 
 export default function useHeatmapData({
@@ -22,6 +28,7 @@ export default function useHeatmapData({
   angle,
   filters,
   enabled = true,
+  holdsWithState,
 }: UseHeatmapDataProps) {
   const [heatmapData, setHeatmapData] = useState<HeatmapData[]>([]);
   const [loading, setLoading] = useState(false);
@@ -49,8 +56,16 @@ export default function useHeatmapData({
           headers['x-user-id'] = user_id.toString();
         }
 
+        // Build URL with query params
+        const urlParams = searchParamsToUrlParams(filters);
+
+        // Add holdsWithState filter if provided and has entries
+        if (holdsWithState && Object.keys(holdsWithState).length > 0) {
+          urlParams.set('holdsWithState', JSON.stringify(holdsWithState));
+        }
+
         const response = await fetch(
-          `/api/v1/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/heatmap?${searchParamsToUrlParams(filters).toString()}`,
+          `/api/v1/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/heatmap?${urlParams.toString()}`,
           { headers },
         );
 
@@ -82,7 +97,7 @@ export default function useHeatmapData({
     return () => {
       cancelled = true;
     };
-  }, [boardName, layoutId, sizeId, setIds, angle, filters, token, user_id, enabled]);
+  }, [boardName, layoutId, sizeId, setIds, angle, filters, token, user_id, enabled, holdsWithState]);
 
   return { data: heatmapData, loading, error };
 }


### PR DESCRIPTION
## Summary
- Adds a heatmap overlay to the create climb screen that filters by selected holds
- Heatmap shows statistics only for climbs containing ALL selected holds in their exact states (STARTING, HAND, FOOT, FINISH)
- Helps route setters understand which holds are commonly used together with their selected holds

## Changes
- Add `holdsWithState` filter to heatmap API endpoint and database query
- Update `BoardHeatmap` component to accept filter props for use outside search context
- Integrate `BoardHeatmap` into `CreateClimbForm` replacing `BoardRenderer`
- Add `useUISearchParamsOptional` hook for components that can work outside the search params context

## Test plan
- [ ] Navigate to create climb screen
- [ ] Select some holds with different states (starting, hand, foot, finish)
- [ ] Toggle the "Show Heatmap" button
- [ ] Verify heatmap loads and shows statistics filtered by selected holds
- [ ] Verify heatmap updates as you add/remove holds
- [ ] Verify existing heatmap in search drawer still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)