### PR TITLE
Add fork climb button to climb info screen

### DIFF
--- a/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
+++ b/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
@@ -11,8 +11,13 @@ export const metadata: Metadata = {
   description: 'Create a new climb on your climbing board',
 };
 
-export default async function CreateClimbPage(props: { params: Promise<BoardRouteParameters> }) {
-  const params = await props.params;
+interface CreateClimbPageProps {
+  params: Promise<BoardRouteParameters>;
+  searchParams: Promise<{ forkFrames?: string; forkName?: string }>;
+}
+
+export default async function CreateClimbPage(props: CreateClimbPageProps) {
+  const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
 
   // Check if any parameters are in numeric format (old URLs)
   const hasNumericParams = [params.layout_id, params.size_id, params.set_ids].some((param) =>
@@ -29,5 +34,12 @@ export default async function CreateClimbPage(props: { params: Promise<BoardRout
 
   const boardDetails = await getBoardDetails(parsedParams);
 
-  return <CreateClimbForm boardDetails={boardDetails} angle={parsedParams.angle} />;
+  return (
+    <CreateClimbForm
+      boardDetails={boardDetails}
+      angle={parsedParams.angle}
+      forkFrames={searchParams.forkFrames}
+      forkName={searchParams.forkName}
+    />
+  );
 }

--- a/app/components/climb-card/climb-card-actions.tsx
+++ b/app/components/climb-card/climb-card-actions.tsx
@@ -2,9 +2,9 @@
 import React, { useState } from 'react';
 import { useQueueContext } from '../queue-control/queue-context';
 import { BoardDetails, Climb } from '@/app/lib/types';
-import { PlusCircleOutlined, HeartOutlined, InfoCircleOutlined, CheckCircleOutlined } from '@ant-design/icons';
+import { PlusCircleOutlined, HeartOutlined, InfoCircleOutlined, CheckCircleOutlined, ForkOutlined } from '@ant-design/icons';
 import Link from 'next/link';
-import { constructClimbViewUrl, constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, constructCreateClimbUrl } from '@/app/lib/url-utils';
 import { track } from '@vercel/analytics';
 import { message } from 'antd';
 
@@ -44,7 +44,7 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
     }
   };
 
-  return [
+  const actions: (React.JSX.Element | null)[] = [
     // <SettingOutlined key="setting" />,
     // <TickClimbButton key="tickclimbbutton" />,
     <Link
@@ -81,6 +81,29 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
     >
       <InfoCircleOutlined />
     </Link>,
+    boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names ? (
+      <Link
+        key="fork"
+        href={constructCreateClimbUrl(
+          boardDetails.board_name,
+          boardDetails.layout_name,
+          boardDetails.size_name,
+          boardDetails.size_description,
+          boardDetails.set_names,
+          climb.angle,
+          { frames: climb.frames, name: climb.name },
+        )}
+        onClick={() => {
+          track('Climb Forked', {
+            boardLayout: boardDetails.layout_name || '',
+            originalClimb: climb.uuid,
+          });
+        }}
+        title="Fork this climb"
+      >
+        <ForkOutlined />
+      </Link>
+    ) : null,
     <HeartOutlined key="heart" onClick={() => message.info('TODO: Implement')} />,
     isAlreadyInQueue ? (
       <CheckCircleOutlined
@@ -96,6 +119,8 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
       />
     ),
   ];
+
+  return actions.filter((action): action is React.JSX.Element => action !== null);
 };
 
 export default ClimbCardActions;

--- a/app/components/create-climb/use-create-climb.ts
+++ b/app/components/create-climb/use-create-climb.ts
@@ -23,8 +23,12 @@ const STATE_TO_CODE: Record<BoardName, Partial<Record<HoldState, HoldCode>>> = {
   },
 };
 
-export function useCreateClimb(boardName: BoardName) {
-  const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>({});
+interface UseCreateClimbOptions {
+  initialHoldsMap?: LitUpHoldsMap;
+}
+
+export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOptions) {
+  const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>(options?.initialHoldsMap ?? {});
 
   // Derived state: count holds by type
   const startingCount = useMemo(

--- a/app/lib/url-utils.ts
+++ b/app/lib/url-utils.ts
@@ -421,3 +421,29 @@ export const isNumericId = (value: string): boolean => {
 export const isSlugFormat = (value: string): boolean => {
   return !isNumericId(value);
 };
+
+// Construct URL for creating a new climb (with optional fork params)
+export const constructCreateClimbUrl = (
+  board_name: string,
+  layoutName: string,
+  sizeName: string,
+  sizeDescription: string | undefined,
+  setNames: string[],
+  angle: number,
+  forkParams?: { frames: string; name: string },
+) => {
+  const layoutSlug = generateLayoutSlug(layoutName);
+  const sizeSlug = generateSizeSlug(sizeName, sizeDescription);
+  const setSlug = generateSetSlug(setNames);
+  const baseUrl = `/${board_name}/${layoutSlug}/${sizeSlug}/${setSlug}/${angle}/create`;
+
+  if (forkParams) {
+    const params = new URLSearchParams({
+      forkFrames: forkParams.frames,
+      forkName: forkParams.name,
+    });
+    return `${baseUrl}?${params.toString()}`;
+  }
+
+  return baseUrl;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,6 +362,19 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@atlaskit/feature-gate-js-client/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@atlaskit/icon": {
       "version": "29.0.0",
       "resolved": "https://registry.npmjs.org/@atlaskit/icon/-/icon-29.0.0.tgz",
@@ -550,6 +563,71 @@
       }
     },
     "node_modules/@auth/core": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.3.tgz",
+      "integrity": "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@panva/hkdf": "^1.1.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.6.0",
+        "jose": "^5.1.3",
+        "oauth4webapi": "^2.10.4",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/core/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@auth/core/node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@auth/drizzle-adapter": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.11.1.tgz",
+      "integrity": "sha512-cQTvDZqsyF7RPhDm/B6SvqdVP9EzQhy3oM4Muu7fjjmSYFLbSR203E6dH631ZHSKDn2b4WZkfMnjPDzRsPSAeA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.1"
+      }
+    },
+    "node_modules/@auth/drizzle-adapter/node_modules/@auth/core": {
       "version": "0.41.1",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
       "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
@@ -578,13 +656,31 @@
         }
       }
     },
-    "node_modules/@auth/drizzle-adapter": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.11.1.tgz",
-      "integrity": "sha512-cQTvDZqsyF7RPhDm/B6SvqdVP9EzQhy3oM4Muu7fjjmSYFLbSR203E6dH631ZHSKDn2b4WZkfMnjPDzRsPSAeA==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.41.1"
+    "node_modules/@auth/drizzle-adapter/node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/drizzle-adapter/node_modules/oauth4webapi": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/drizzle-adapter/node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -601,7 +697,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.28.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -611,7 +706,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -640,12 +734,10 @@
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/json5": {
       "version": "2.2.3",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -656,7 +748,6 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -680,7 +771,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -695,7 +785,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -723,7 +812,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -763,7 +851,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -773,7 +860,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -1898,7 +1984,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3348,6 +3433,14 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "dev": true,
@@ -3412,7 +3505,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4398,7 +4491,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.25.1",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4433,7 +4525,7 @@
     },
     "node_modules/bufferutil": {
       "version": "4.0.9",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5138,7 +5230,6 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.183",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5394,7 +5485,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6153,7 +6243,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7013,10 +7102,12 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7229,7 +7320,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -7530,7 +7620,7 @@
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -7540,7 +7630,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/oauth": {
@@ -7550,10 +7639,12 @@
       "license": "MIT"
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
-      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8183,10 +8274,15 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -8349,7 +8445,6 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8369,7 +8464,6 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -8706,7 +8800,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -9551,7 +9644,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10031,7 +10123,6 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
Adds ability to fork an existing climb, opening the create climb screen
with all holds pre-selected and the name set to "[original name] fork".

- Add constructCreateClimbUrl helper for fork URL with params
- Update use-create-climb hook to accept initial holds map
- Update CreateClimbForm to handle fork params from URL search params
- Add Fork button with ForkOutlined icon to climb card actions