### PR TITLE
Fix WebSocket daemon initial queue sync on session join

### DIFF
--- a/app/components/queue-control/queue-context.tsx
+++ b/app/components/queue-control/queue-context.tsx
@@ -59,11 +59,18 @@ export const QueueProvider = ({ parsedParams, children }: QueueContextProps) => 
           );
           break;
         case 'initial-queue-data':
+          console.log('[QueueContext] Received initial-queue-data:', {
+            source: data.source,
+            hostId,
+            queueLength: data.queue?.length ?? 0,
+            currentClimb: data.currentClimbQueueItem?.climb?.name ?? null,
+          });
           // Accept data from the host OR from the daemon (which is authoritative in daemon mode)
           if (hostId !== data.source && data.source !== 'daemon') {
-            console.log(`Ignoring queue data from ${data.source} since it's not the host(${hostId}) or daemon.`);
+            console.log(`[QueueContext] Ignoring queue data from ${data.source} since it's not the host(${hostId}) or daemon.`);
             return;
           }
+          console.log('[QueueContext] Applying initial queue data');
           dispatch({
             type: 'INITIAL_QUEUE_DATA',
             payload: {

--- a/daemon/src/handlers/message.ts
+++ b/daemon/src/handlers/message.ts
@@ -184,5 +184,9 @@ async function handleQueueOperation(
       break;
   }
 
+  console.log(`[Daemon] Persisting queue state for session ${client.sessionId}:`, {
+    queueLength: queue?.length ?? 0,
+    currentClimb: currentClimbQueueItem?.climb?.name ?? null,
+  });
   await roomManager.updateQueueState(client.sessionId, queue, currentClimbQueueItem);
 }

--- a/daemon/src/handlers/room.ts
+++ b/daemon/src/handlers/room.ts
@@ -42,6 +42,12 @@ export async function handleJoinSession(
       currentClimbQueueItem: result.currentClimbQueueItem,
       isLeader: result.isLeader,
     };
+    console.log(`[Daemon] Sending session-joined to ${result.clientId}:`, {
+      sessionId: message.sessionId,
+      queueLength: result.queue?.length ?? 0,
+      currentClimb: result.currentClimbQueueItem?.climb?.name ?? null,
+      isLeader: result.isLeader,
+    });
     sendToClient(ws, sessionJoinedMessage);
 
     // Notify other clients about the new user

--- a/daemon/src/services/room-manager.ts
+++ b/daemon/src/services/room-manager.ts
@@ -263,9 +263,14 @@ class RoomManager {
       .limit(1);
 
     if (result.length === 0) {
+      console.log(`[RoomManager] getQueueState(${sessionId}): No data found in DB`);
       return { queue: [], currentClimbQueueItem: null };
     }
 
+    console.log(`[RoomManager] getQueueState(${sessionId}):`, {
+      queueLength: result[0].queue?.length ?? 0,
+      currentClimb: result[0].currentClimbQueueItem?.climb?.name ?? null,
+    });
     return {
       queue: result[0].queue,
       currentClimbQueueItem: result[0].currentClimbQueueItem,


### PR DESCRIPTION
The issue was a race condition where the session-joined message could be
processed before the QueueContext had registered its subscription handler.

Changes:
- Store initial queue data in a ref when session-joined is received
- Replay pending initial data to new subscribers when they register
- Always send initial-queue-data notification (even when empty) to ensure
  the QueueContext can set initialQueueDataReceivedFromPeers flag
- Clear pending data on disconnect, session end, and connection close