### PR TITLE
Fix initial queue state not syncing to new users in daemon mode

### DIFF
--- a/app/components/connection-manager/types.ts
+++ b/app/components/connection-manager/types.ts
@@ -54,6 +54,7 @@ export interface PeerContextType {
   currentLeader: PeerId;
   isLeader: boolean;
   initiateLeaderElection: () => void;
+  requestQueueState?: () => void;
 }
 
 export type PeerProviderProps = {
@@ -69,6 +70,16 @@ interface PeerDataBase {
 // Specific message types
 interface RequestUpdateQueueData {
   type: 'request-update-queue';
+}
+
+interface RequestQueueStateData {
+  type: 'request-queue-state';
+}
+
+interface QueueStateResponseData {
+  type: 'queue-state-response';
+  queue: ClimbQueue;
+  currentClimbQueueItem: ClimbQueueItem | null;
 }
 
 interface UpdateQueueData {
@@ -166,6 +177,8 @@ interface ReconnectCoordinationData {
 // Union type of all possible message types
 export type PeerData =
   | RequestUpdateQueueData
+  | RequestQueueStateData
+  | QueueStateResponseData
   | UpdateQueueData
   | BroadcastOtherPeersData
   | NewConnectionData
@@ -195,12 +208,14 @@ export function isPeerData(data: unknown): data is ReceivedPeerData {
   // Validate based on type
   switch (msg.type) {
     case 'request-update-queue':
+    case 'request-queue-state':
     case 'new-connection':
       return true; // No additional required fields
     case 'send-peer-info':
       return !!msg.username;
     case 'initial-queue-data':
     case 'update-queue':
+    case 'queue-state-response':
       return 'queue' in msg && 'currentClimbQueueItem' in msg;
     case 'broadcast-other-peers':
       return Array.isArray(msg.peers);

--- a/daemon/src/types/messages.ts
+++ b/daemon/src/types/messages.ts
@@ -100,6 +100,10 @@ export interface HeartbeatMessage {
   timestamp: number;
 }
 
+export interface RequestQueueStateMessage {
+  type: 'request-queue-state';
+}
+
 // ============= Daemon -> Client Messages =============
 
 export interface SessionJoinedMessage {
@@ -145,6 +149,12 @@ export interface SessionEndedMessage {
   newPath?: string;
 }
 
+export interface QueueStateResponseMessage {
+  type: 'queue-state-response';
+  queue: ClimbQueueItem[];
+  currentClimbQueueItem: ClimbQueueItem | null;
+}
+
 // Union types
 export type ClientMessage =
   | JoinSessionMessage
@@ -157,7 +167,8 @@ export type ClientMessage =
   | UpdateCurrentClimbMessage
   | MirrorCurrentClimbMessage
   | ReplaceQueueItemMessage
-  | HeartbeatMessage;
+  | HeartbeatMessage
+  | RequestQueueStateMessage;
 
 export type DaemonMessage =
   | SessionJoinedMessage
@@ -173,7 +184,8 @@ export type DaemonMessage =
   | UpdateQueueMessage
   | UpdateCurrentClimbMessage
   | MirrorCurrentClimbMessage
-  | ReplaceQueueItemMessage;
+  | ReplaceQueueItemMessage
+  | QueueStateResponseMessage;
 
 // Type guards
 export function isClientMessage(data: unknown): data is ClientMessage {
@@ -193,6 +205,7 @@ export function isClientMessage(data: unknown): data is ClientMessage {
     'mirror-current-climb',
     'replace-queue-item',
     'heartbeat',
+    'request-queue-state',
   ];
 
   return validTypes.includes(msg.type);


### PR DESCRIPTION
## Summary

- Fixes race condition where `session-joined` arrived before `QueueProvider` subscribed, causing new users to miss initial queue state
- Fixes issue where queue changes were being reverted due to stale initial data being replayed on re-subscription
- Adds `request-queue-state` message type for explicit queue state requests (enables future re-sync on reconnection)

## Changes

**Daemon:**
- Add `RequestQueueStateMessage` and `QueueStateResponseMessage` types
- Add `handleRequestQueueState` handler in room.ts
- Route `request-queue-state` messages in message.ts

**Client:**
- Store initial queue data in DaemonContext and provide to late subscribers
- Use refs in QueueProvider to stabilize `handlePeerData` callback (prevents re-subscription on queue changes)
- Add `hasReceivedInitialData` flag to prevent replaying initial data multiple times
- Fix reconnection loop by using refs for callbacks in `connect()`

## Test plan

- [ ] Start daemon and create a session with User A
- [ ] Add items to the queue with User A
- [ ] Have User B join the session
- [ ] Verify User B sees the existing queue items immediately
- [ ] Verify queue changes sync correctly between users
- [ ] Verify queue changes are not reverted after making them

🤖 Generated with [Claude Code](https://claude.com/claude-code)