### PR TITLE
Migrate to monorepo structure with graphql-ws foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,16 @@ jobs:
     
     - name: Run linting
       run: npm run lint
-    
-    - name: Run type checking
+
+    - name: Build shared-schema
+      run: npm run build
+      working-directory: packages/shared-schema
+
+    - name: Type check shared-schema
+      run: npx tsc --noEmit
+      working-directory: packages/shared-schema
+
+    - name: Run type checking (web)
       run: npx tsc --noEmit
       working-directory: packages/web
     

--- a/MIGRATION_TODO.md
+++ b/MIGRATION_TODO.md
@@ -14,13 +14,14 @@ This document tracks the remaining work to migrate from PeerJS/custom WebSocket 
 
 ## Remaining Work
 
-### Phase 1: Complete Shared Schema Package
+### Phase 1: Complete Shared Schema Package ✅
 
-The `packages/shared-schema/` has placeholder files. Need to verify types match existing codebase:
+The `packages/shared-schema/` has been verified and updated:
 
-- [ ] Verify `src/types.ts` matches `packages/web/app/lib/types.ts` (Climb type)
-- [ ] Verify `src/types.ts` matches `packages/web/app/components/queue-control/types.ts` (ClimbQueueItem)
-- [ ] Build the package: `npm run build --workspace=@boardsesh/shared-schema`
+- [x] Verify `src/types.ts` matches `packages/web/app/lib/types.ts` (Climb type) - **Identical**
+- [x] Verify `src/types.ts` matches `packages/web/app/components/queue-control/types.ts` (ClimbQueueItem) - **Added UserId type alias**
+- [x] Fixed `removeFromQueue` → `removeQueueItem` bug in operations.ts
+- [x] Build the package: `npm run build --workspace=@boardsesh/shared-schema`
 
 ### Phase 2: Daemon GraphQL Implementation
 

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -78,7 +78,7 @@ export const ADD_QUEUE_ITEM = `
 
 export const REMOVE_QUEUE_ITEM = `
   mutation RemoveQueueItem($uuid: ID!) {
-    removeFromQueue(uuid: $uuid)
+    removeQueueItem(uuid: $uuid)
   }
 `;
 

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -1,6 +1,8 @@
 // Shared TypeScript types for BoardSesh
 // These types are used by both the daemon and the web app
 
+export type UserId = string;
+
 export type LitUpHoldsMap = Record<string, string>;
 
 export type Climb = {
@@ -25,8 +27,8 @@ export type Climb = {
 export type ClimbQueueItem = {
   uuid: string;
   climb: Climb;
-  addedBy?: string;
-  tickedBy?: string[];
+  addedBy?: UserId;
+  tickedBy?: UserId[];
   suggested?: boolean;
 };
 


### PR DESCRIPTION
## Summary
This PR restructures the project as an NPM workspaces monorepo and lays the foundation for migrating from PeerJS to graphql-ws for party mode.

### Monorepo Structure
- `packages/web/` - Next.js web application
- `packages/daemon/` - WebSocket daemon for party mode
- `packages/shared-schema/` - Shared GraphQL schema and TypeScript types

### Key Changes
- Restructured project as NPM workspaces monorepo
- Added `@boardsesh/shared-schema` package with shared types and GraphQL operations
- Added `graphql` and `graphql-ws` dependencies to daemon and web packages
- Updated CI to build and typecheck shared-schema package
- Added migration TODO documentation tracking the graphql-ws refactor phases

### Phase 1 Complete
- Verified shared-schema types match web package definitions
- Added `UserId` type alias for user identification
- Fixed `removeQueueItem` mutation name in operations

## Test plan
- [x] `npm install` from root installs all workspace dependencies
- [x] `npm run build` builds all packages
- [x] `npm run dev` starts web development server
- [x] CI passes lint, typecheck, and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)