### PR TITLE
Add meatball menu for mobile header actions

### DIFF
--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -103,7 +103,7 @@ export default function AngleSelector({ boardName, currentAngle, currentClimb }:
 
   return (
     <>
-      <Button type="default" onClick={() => setIsDrawerOpen(true)} style={{ minWidth: '45px', padding: '4px 8px' }}>
+      <Button type="default" onClick={() => setIsDrawerOpen(true)} style={{ minWidth: '38px', padding: '4px 6px' }}>
         {currentAngle}°
       </Button>
 

--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -10,6 +10,16 @@
   display: none;
 }
 
+.header {
+  touch-action: manipulation;
+}
+
+.header button,
+.header a,
+.header input {
+  touch-action: manipulation;
+}
+
 @media (max-width: 768px) {
   .mobileOnly {
     display: block;

--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -2,8 +2,24 @@
   display: none;
 }
 
+.desktopOnly {
+  display: flex;
+}
+
+.mobileMenuButton {
+  display: none;
+}
+
 @media (max-width: 768px) {
   .mobileOnly {
     display: block;
+  }
+
+  .desktopOnly {
+    display: none;
+  }
+
+  .mobileMenuButton {
+    display: flex;
   }
 }

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -128,7 +128,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
             {mobileMenuItems.length > 0 && (
               <div className={styles.mobileMenuButton}>
                 <Dropdown menu={{ items: mobileMenuItems }} placement="bottomRight" trigger={['click']}>
-                  <Button icon={<MoreOutlined />} type="text" />
+                  <Button icon={<MoreOutlined />} type="default" />
                 </Dropdown>
               </div>
             )}

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -60,6 +60,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
   ];
   return (
     <Header
+      className={styles.header}
       style={{
         background: '#fff',
         height: '8dvh',

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-import { Flex, Button, Dropdown, MenuProps, Grid } from 'antd';
+import { Flex, Button, Dropdown, MenuProps } from 'antd';
 import { Header } from 'antd/es/layout/layout';
 import Title from 'antd/es/typography/Title';
 import Link from 'next/link';
@@ -14,7 +14,7 @@ import { generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib
 import { ShareBoardButton } from './share-button';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useQueueContext } from '../graphql-queue';
-import { UserOutlined, LogoutOutlined, LoginOutlined, PlusOutlined } from '@ant-design/icons';
+import { UserOutlined, LogoutOutlined, LoginOutlined, PlusOutlined, MoreOutlined } from '@ant-design/icons';
 import AngleSelector from './angle-selector';
 import styles from './header.module.css';
 
@@ -23,8 +23,6 @@ type BoardSeshHeaderProps = {
   angle?: number;
 };
 export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeaderProps) {
-  const { useBreakpoint } = Grid;
-  const screens = useBreakpoint();
   const { data: session } = useSession();
   const { logout } = useBoardProvider();
   const { currentClimb } = useQueueContext();
@@ -41,6 +39,24 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
       label: 'Logout',
       onClick: handleSignOut,
     },
+  ];
+
+  const createClimbUrl = angle !== undefined && boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
+    ? `/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name)}/${generateSetSlug(boardDetails.set_names)}/${angle}/create`
+    : null;
+
+  const mobileMenuItems: MenuProps['items'] = [
+    ...(createClimbUrl ? [{
+      key: 'create-climb',
+      icon: <PlusOutlined />,
+      label: <Link href={createClimbUrl}>Create Climb</Link>,
+    }] : []),
+    ...(!session?.user ? [{
+      key: 'login',
+      icon: <LoginOutlined />,
+      label: 'Login',
+      onClick: () => signIn(),
+    }] : []),
   ];
   return (
     <Header
@@ -63,7 +79,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
           </Flex>
 
           {/* Center Section - Mobile only */}
-          <Flex justify="center" gap={2} style={{ flex: 1, maxWidth: '200px' }}>
+          <Flex justify="center" gap={2} style={{ flex: 1 }}>
             <div className={styles.mobileOnly} style={{ flex: 1 }}>
               <SearchClimbNameInput />
             </div>
@@ -75,15 +91,20 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
           {/* Right Section */}
           <Flex gap={4} align="center">
             {angle !== undefined && <AngleSelector boardName={boardDetails.board_name} currentAngle={angle} currentClimb={currentClimb} />}
-            {angle !== undefined && boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names && (
-              <Link
-                href={`/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name)}/${generateSetSlug(boardDetails.set_names)}/${angle}/create`}
-              >
-                <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
-              </Link>
+
+            {/* Desktop: show Create Climb button */}
+            {createClimbUrl && (
+              <div className={styles.desktopOnly}>
+                <Link href={createClimbUrl}>
+                  <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
+                </Link>
+              </div>
             )}
+
             <ShareBoardButton />
             <SendClimbToBoardButton boardDetails={boardDetails} />
+
+            {/* User menu or login button */}
             {session?.user ? (
               <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
                 <Button icon={<UserOutlined />} type="text">
@@ -91,14 +112,24 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                 </Button>
               </Dropdown>
             ) : (
-              <Button 
-                icon={<LoginOutlined />} 
-                type="text" 
-                onClick={() => signIn()}
-                size={screens.xs ? 'small' : 'middle'}
-              >
-                {screens.xs ? '' : 'Login'}
-              </Button>
+              <div className={styles.desktopOnly}>
+                <Button
+                  icon={<LoginOutlined />}
+                  type="text"
+                  onClick={() => signIn()}
+                >
+                  Login
+                </Button>
+              </div>
+            )}
+
+            {/* Mobile: meatball menu for Create Climb and Login */}
+            {mobileMenuItems.length > 0 && (
+              <div className={styles.mobileMenuButton}>
+                <Dropdown menu={{ items: mobileMenuItems }} placement="bottomRight" trigger={['click']}>
+                  <Button icon={<MoreOutlined />} type="text" />
+                </Dropdown>
+              </div>
             )}
           </Flex>
         </Flex>


### PR DESCRIPTION
- Create Climb and Login buttons now appear in a meatball menu (three dots)
  on mobile devices for a cleaner header layout
- The meatball menu only appears when there are actions to show (no login
  button when user is already logged in)
- Remove Grid.useBreakpoint() in favor of CSS media queries
- Make angle selector slightly narrower (38px vs 45px)
- Remove maxWidth constraint on search input to fill available space