### PR TITLE
fix: disable tap-to-zoom on mobile while preserving pinch-to-zoom

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -5,8 +5,6 @@ import { ParsedBoardRouteParameters, BoardRouteParameters, BoardDetails } from '
 import { parseBoardRouteParams, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { permanentRedirect } from 'next/navigation';
-import '@/c/index.css';
-
 import { Content } from 'antd/es/layout/layout';
 import QueueControlBar from '@/app/components/queue-control/queue-control-bar';
 import { getBoardDetails } from '@/app/lib/data/queries';

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -4,11 +4,29 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
+/* Prevent double-tap zoom globally while preserving pinch-to-zoom */
+html {
+  touch-action: manipulation;
+}
+
+/* Ensure all interactive elements have minimum 16px font to prevent iOS auto-zoom on focus */
 @media (max-width: 768px) {
   input,
   textarea,
-  select {
+  select,
+  button,
+  .ant-select,
+  .ant-select-selector,
+  .ant-select-selection-item,
+  .ant-select-selection-search-input,
+  .ant-select-selection-placeholder,
+  .ant-input,
+  .ant-input-number,
+  .ant-input-number-input,
+  .ant-picker,
+  .ant-picker-input > input,
+  .ant-btn,
+  .ant-dropdown-trigger {
     font-size: 16px !important;
-    touch-action: manipulation;
   }
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -5,12 +5,13 @@ import { App } from 'antd';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import SessionProviderWrapper from './components/providers/session-provider';
+import './components/index.css';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </head>
       <body style={{ margin: 0 }}>
         <Analytics />


### PR DESCRIPTION
- Update viewport meta tag to allow pinch-to-zoom by removing
  maximum-scale and user-scalable restrictions
- Apply touch-action: manipulation globally to prevent double-tap zoom
- Ensure all form inputs and Ant Design components have 16px font size
  on mobile to prevent iOS auto-zoom on focus
- Move global CSS import to root layout so it applies to all pages
  including board selection screen