### PR TITLE
feat: Reduce queue bar height for better board visibility

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -157,9 +157,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
             </Content>
 
             <Affix offsetBottom={0}>
-              <div style={{ width: '100%', backgroundColor: '#fff', boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.15)' }}>
-                <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
-              </div>
+              <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
             </Affix>
             </PartyProvider>
           </GraphQLQueueProvider>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropsWithChildren } from 'react';
-import { Layout } from 'antd';
+import { Affix, Layout } from 'antd';
 import { ParsedBoardRouteParameters, BoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { parseBoardRouteParams, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
@@ -156,7 +156,9 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               {children}
             </Content>
 
-            <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
+            <Affix offsetBottom={0}>
+              <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
+            </Affix>
             </PartyProvider>
           </GraphQLQueueProvider>
         </PartyProfileWrapper>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -132,7 +132,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
   const [boardDetails] = await Promise.all([getBoardDetails(parsedParams)]);
 
   return (
-    <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column' }}>
+    <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column', padding: 0 }}>
       <ConnectionSettingsProvider>
         <PartyProfileWrapper>
           <GraphQLQueueProvider parsedParams={parsedParams}>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropsWithChildren } from 'react';
-import { Affix, Layout } from 'antd';
+import { Layout } from 'antd';
 import { ParsedBoardRouteParameters, BoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { parseBoardRouteParams, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
@@ -156,9 +156,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               {children}
             </Content>
 
-            <Affix offsetBottom={0}>
-              <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
-            </Affix>
+            <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
             </PartyProvider>
           </GraphQLQueueProvider>
         </PartyProfileWrapper>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -52,7 +52,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
       <Card
         styles={{
           body: {
-            padding: '8px 12px',
+            padding: '4px 12px',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
@@ -62,7 +62,6 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           width: '100%',
           boxShadow: themeTokens.shadows.lg,
           borderRadius: 0,
-          borderTop: `1px solid ${themeTokens.neutral[200]}`,
         }}
       >
         <Row justify="space-between" align="middle" style={{ width: '100%' }}>
@@ -126,7 +125,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           </Col>
 
           {/* Button cluster */}
-          <Col xs={9} style={{ textAlign: 'right', paddingRight: '10px' }}>
+          <Col xs={9} style={{ textAlign: 'right' }}>
             <Space>
               {boardDetails.supportsMirroring ? (
                 <Button

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -53,7 +53,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         bordered={false}
         styles={{
           body: {
-            padding: '2px 12px',
+            padding: '4px 12px 0px 12px',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -47,7 +47,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   };
 
   return (
-    <>
+    <div style={{ flexShrink: 0, width: '100%' }}>
       {/* Main Control Bar */}
       <Card
         bordered={false}
@@ -166,7 +166,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
       >
         <QueueList boardDetails={boardDetails} onClimbNavigate={() => setIsQueueOpen(false)} />
       </Drawer>
-    </>
+    </div>
   );
 };
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -63,6 +63,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           width: '100%',
           boxShadow: themeTokens.shadows.lg,
           borderRadius: 0,
+          margin: 0,
         }}
       >
         <Row justify="space-between" align="middle" style={{ width: '100%' }}>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -47,7 +47,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   };
 
   return (
-    <div style={{ flexShrink: 0, width: '100%' }}>
+    <div style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
       {/* Main Control Bar */}
       <Card
         bordered={false}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -53,7 +53,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         bordered={false}
         styles={{
           body: {
-            padding: '4px 12px',
+            padding: '2px 12px',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
@@ -61,9 +61,9 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         }}
         style={{
           width: '100%',
-          boxShadow: themeTokens.shadows.lg,
           borderRadius: 0,
           margin: 0,
+          borderTop: `1px solid ${themeTokens.neutral[200]}`,
         }}
       >
         <Row justify="space-between" align="middle" style={{ width: '100%' }}>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -50,6 +50,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
     <>
       {/* Main Control Bar */}
       <Card
+        bordered={false}
         styles={{
           body: {
             padding: '4px 12px',


### PR DESCRIPTION
- Reduce vertical padding from 8px to 4px
- Remove redundant wrapper div with duplicate shadow
- Remove border-top that created extra visual line
- Remove unnecessary right padding on button cluster