### PR TITLE
feat: Expand search bar to full width on focus with collapsible header

### DIFF
--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -10,6 +10,14 @@
   display: none;
 }
 
+.hideOnMobileExpanded {
+  display: flex;
+}
+
+.showOnMobileExpanded {
+  display: none;
+}
+
 .header {
   touch-action: manipulation;
 }
@@ -30,6 +38,14 @@
   }
 
   .mobileMenuButton {
+    display: flex;
+  }
+
+  .hideOnMobileExpanded {
+    display: none;
+  }
+
+  .showOnMobileExpanded {
     display: flex;
   }
 }

--- a/packages/web/app/components/search-drawer/search-climb-name-input.tsx
+++ b/packages/web/app/components/search-drawer/search-climb-name-input.tsx
@@ -1,15 +1,24 @@
 'use client';
 
-import React from 'react';
-import { Input } from 'antd';
+import React, { useRef } from 'react';
+import { Input, InputRef } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
 
-const SearchClimbNameInput = () => {
+interface SearchClimbNameInputProps {
+  onFocus?: () => void;
+  onBlur?: () => void;
+  inputRef?: React.RefObject<InputRef | null>;
+}
+
+const SearchClimbNameInput = ({ onFocus, onBlur, inputRef }: SearchClimbNameInputProps) => {
   const { uiSearchParams, updateFilters } = useUISearchParams();
+  const localRef = useRef<InputRef>(null);
+  const ref = inputRef || localRef;
 
   return (
     <Input
+      ref={ref}
       placeholder="Search by climb name..."
       prefix={<SearchOutlined style={{ color: '#9CA3AF' }} />}
       allowClear
@@ -19,6 +28,8 @@ const SearchClimbNameInput = () => {
         });
       }}
       value={uiSearchParams.name}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 };


### PR DESCRIPTION
When the search input is focused on mobile:
- The search bar expands to take full width
- Logo and right section buttons are hidden
- Ellipsis menu appears with all actions (Create Climb, Login/Logout)
- Close button replaces the search filter button to collapse back

Changes:
- Add focus/blur handlers to SearchClimbNameInput
- Track expanded state in header
- Add CSS classes for mobile-only visibility toggling