### PR TITLE
fix: Reduce header border shadow from 3px blur to crisp 1px line

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -150,7 +150,6 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                 height: '80vh',
                 paddingLeft: '10px',
                 paddingRight: '10px',
-                paddingTop: '10px',
               }}
             >
               {children}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -141,6 +141,7 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
       endMessage={<div style={{ textAlign: 'center' }}>No more climbs 🤐</div>}
       // Probably not how this should be done in a React app, but it works and I ain't no CSS-wizard
       scrollableTarget="content-for-scrollable"
+      style={{ paddingTop: '10px' }}
     >
       <Row gutter={[16, 16]}>
         {climbs.map((climb) => (

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -135,6 +135,23 @@ html {
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
 }
 
+/* Queue bar shadow utility */
+.queue-bar-shadow {
+  position: relative;
+  z-index: 10;
+}
+
+.queue-bar-shadow::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -4px;
+  height: 4px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.06), transparent);
+  pointer-events: none;
+}
+
 /* Drawer transitions - Ant Design already handles this, but we customize the easing */
 .ant-drawer .ant-drawer-content-wrapper {
   transition: transform 0.3s cubic-bezier(0.23, 1, 0.32, 1);

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -115,7 +115,7 @@ html {
 /* Header shadow utility */
 .header-shadow {
   border-bottom: 2px solid #E5E7EB;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -114,13 +114,8 @@ html {
 
 /* Header shadow utility */
 .header-shadow {
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.12);
-  border-bottom: none;
-}
-
-/* Remove any default Ant Design header border */
-.ant-layout-header {
-  border-bottom: none;
+  box-shadow: none;
+  border-bottom: 1px solid #E5E7EB;
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -115,6 +115,12 @@ html {
 /* Header shadow utility */
 .header-shadow {
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+  border-bottom: none;
+}
+
+/* Remove any default Ant Design header border */
+.ant-layout-header {
+  border-bottom: none;
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -114,8 +114,10 @@ html {
 
 /* Header shadow utility */
 .header-shadow {
-  border-bottom: 2px solid #E5E7EB;
+  border-bottom: 1px solid #E5E7EB;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+  position: relative;
+  z-index: 10;
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -114,7 +114,7 @@ html {
 
 /* Header shadow utility */
 .header-shadow {
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.12);
   border-bottom: none;
 }
 

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -114,7 +114,7 @@ html {
 
 /* Header shadow utility */
 .header-shadow {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -115,9 +115,19 @@ html {
 /* Header shadow utility */
 .header-shadow {
   border-bottom: 1px solid #E5E7EB;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
   position: relative;
   z-index: 10;
+}
+
+.header-shadow::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 4px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.06), transparent);
+  pointer-events: none;
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -114,8 +114,8 @@ html {
 
 /* Header shadow utility */
 .header-shadow {
-  box-shadow: none;
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 2px solid #E5E7EB;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
 }
 
 /* Bottom bar shadow utility */

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -63,7 +63,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           width: '100%',
           borderRadius: 0,
           margin: 0,
-          borderTop: `2px solid ${themeTokens.neutral[200]}`,
+          borderTop: `1px solid ${themeTokens.neutral[200]}`,
         }}
       >
         <Row justify="space-between" align="middle" style={{ width: '100%' }}>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -47,7 +47,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   };
 
   return (
-    <div style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
+    <div className="queue-bar-shadow" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
       {/* Main Control Bar */}
       <Card
         bordered={false}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -63,7 +63,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           width: '100%',
           borderRadius: 0,
           margin: 0,
-          borderTop: `1px solid ${themeTokens.neutral[200]}`,
+          borderTop: `2px solid ${themeTokens.neutral[200]}`,
         }}
       >
         <Row justify="space-between" align="middle" style={{ width: '100%' }}>


### PR DESCRIPTION
Changed header-shadow from blurry 3px shadow to a thin 1px solid line
for a cleaner visual appearance that doesn't overlay content.