### PR TITLE
fix: Remove max-width constraint from .ant-row to fix asymmetric card spacing

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -20,8 +20,7 @@ html, body {
 
 /* Prevent horizontal scroll on layout components */
 .ant-layout,
-.ant-layout-content,
-.ant-row {
+.ant-layout-content {
   max-width: 100%;
   overflow-x: hidden;
 }


### PR DESCRIPTION
The global CSS rule applying max-width: 100% to .ant-row was breaking
Ant Design's Row gutter system. The Row uses negative margins (-8px each
side with gutter={[16, 16]}) to compensate for column padding, but the
max-width constraint was causing the browser to adjust the right margin
to balance the box model equation, resulting in 16px more grey space on
the right side of cards than on the left.