### PR TITLE
fix: Remove Ant Design 6 deprecation warnings

### DIFF
--- a/packages/web/app/components/climb-info/climb-info-button.tsx
+++ b/packages/web/app/components/climb-info/climb-info-button.tsx
@@ -11,7 +11,7 @@ const ClimbInfoButton = () => {
   return (
     <>
       <Button type="default" icon={<InfoCircleOutlined />} onClick={() => setIsOpen(true)} />
-      <Drawer title="Climb Info" placement="right" width={'80%'} open={isOpen} onClose={() => setIsOpen(false)}>
+      <Drawer title="Climb Info" placement="right" styles={{ wrapper: { width: '80%' } }} open={isOpen} onClose={() => setIsOpen(false)}>
         <ClimbInfo />
       </Drawer>
     </>

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -277,7 +277,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
             <Switch />
           </Form.Item>
 
-          <Space style={{ width: '100%' }} direction="vertical">
+          <Space style={{ width: '100%' }} orientation="vertical">
             <Button
               type="primary"
               htmlType="submit"

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Card, Rate, Tag, Typography, Space } from 'antd';
+import { Card, Rate, Tag, Typography, Space, Flex, Empty } from 'antd';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Climb } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
@@ -26,48 +26,48 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
 
   const showMirrorTag = boardName === 'tension';
 
+  if (climbAscents.length === 0) {
+    return <Empty description="No ascents logged for this climb" />;
+  }
+
   return (
-    <List
-      dataSource={climbAscents}
-      renderItem={(ascent) => (
-        <List.Item>
-          <Card style={{ width: '100%' }} size="small">
-            <Space direction="vertical" style={{ width: '100%' }}>
-              <Space wrap>
-                <Text strong>{dayjs(ascent.climbed_at).format('MMM D, YYYY h:mm A')}</Text>
-                {ascent.angle !== currentClimb.angle && (
-                  <>
-                    <Tag color="blue">{ascent.angle}°</Tag>
-                    {ascent.is_ascent ? (
-                      <CheckOutlined style={{ color: '#52c41a' }} />
-                    ) : (
-                      <CloseOutlined style={{ color: '#ff4d4f' }} />
-                    )}
-                  </>
-                )}
-                {showMirrorTag && ascent.is_mirror && <Tag color="purple">Mirrored</Tag>}
-              </Space>
-              {ascent.is_ascent && (
+    <Flex vertical gap={8}>
+      {climbAscents.map((ascent) => (
+        <Card key={`${ascent.climb_uuid}-${ascent.climbed_at}`} style={{ width: '100%' }} size="small">
+          <Space orientation="vertical" style={{ width: '100%' }}>
+            <Space wrap>
+              <Text strong>{dayjs(ascent.climbed_at).format('MMM D, YYYY h:mm A')}</Text>
+              {ascent.angle !== currentClimb.angle && (
                 <>
-                  <Space>
-                    <Rate disabled value={ascent.quality} count={3} style={{ fontSize: 14 }} />
-                  </Space>
+                  <Tag color="blue">{ascent.angle}°</Tag>
+                  {ascent.is_ascent ? (
+                    <CheckOutlined style={{ color: '#52c41a' }} />
+                  ) : (
+                    <CloseOutlined style={{ color: '#ff4d4f' }} />
+                  )}
                 </>
               )}
-              <Space>
-                <Text>Attempts: {ascent.tries}</Text>
-              </Space>
-
-              {ascent.comment && (
-                <Text type="secondary" style={{ whiteSpace: 'pre-wrap' }}>
-                  {ascent.comment}
-                </Text>
-              )}
+              {showMirrorTag && ascent.is_mirror && <Tag color="purple">Mirrored</Tag>}
             </Space>
-          </Card>
-        </List.Item>
-      )}
-      locale={{ emptyText: 'No ascents logged for this climb' }}
-    />
+            {ascent.is_ascent && (
+              <>
+                <Space>
+                  <Rate disabled value={ascent.quality} count={3} style={{ fontSize: 14 }} />
+                </Space>
+              </>
+            )}
+            <Space>
+              <Text>Attempts: {ascent.tries}</Text>
+            </Space>
+
+            {ascent.comment && (
+              <Text type="secondary" style={{ whiteSpace: 'pre-wrap' }}>
+                {ascent.comment}
+              </Text>
+            )}
+          </Space>
+        </Card>
+      ))}
+    </Flex>
   );
 };

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -104,7 +104,7 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
           userId={userId}
         />
       ) : (
-        <Drawer title="Login Required" placement="bottom" onClose={closeDrawer} open={drawerVisible} height="50%">
+        <Drawer title="Login Required" placement="bottom" onClose={closeDrawer} open={drawerVisible} styles={{ wrapper: { height: '50%' } }}>
           <LoginForm onLogin={handleLogin} isLoggingIn={isLoggingIn} />
         </Drawer>
       )}

--- a/packages/web/app/components/party-manager/party-profile-modal.tsx
+++ b/packages/web/app/components/party-manager/party-profile-modal.tsx
@@ -158,7 +158,7 @@ const PartyProfileModal: React.FC<PartyProfileModalProps> = ({ open, onClose, is
 
         {isBackendMode && backendUrl && (
           <Form.Item label="Avatar (optional)">
-            <Space direction="vertical" align="center" style={{ width: '100%' }}>
+            <Space orientation="vertical" align="center" style={{ width: '100%' }}>
               <Avatar size={80} src={previewUrl} icon={<UserOutlined />} />
               <Space>
                 <Upload {...uploadProps}>

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { List, Row, Col, Typography, Avatar, Tooltip } from 'antd';
-import { HolderOutlined, CheckOutlined, CloseOutlined, UserOutlined } from '@ant-design/icons';
+import { Row, Col, Typography, Avatar, Tooltip, Flex } from 'antd';
+import { HolderOutlined, CheckOutlined, CloseOutlined, UserOutlined, CopyrightOutlined } from '@ant-design/icons';
 import { BoardDetails, ClimbUuid } from '@/app/lib/types';
 import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { DragHandleButton } from '@atlaskit/pragmatic-drag-and-drop-react-accessibility/drag-handle-button';
@@ -12,7 +12,6 @@ import { ClimbQueueItem } from './types';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import { CopyrightOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
 
 const { Text } = Typography;
@@ -125,8 +124,12 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
 
   return (
     <div ref={itemRef}>
-      <List.Item
+      <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: '12px 0',
+          borderBottom: `1px solid ${themeTokens.neutral[200]}`,
           backgroundColor: isCurrent
             ? themeTokens.semantic.selected
             : isHistory
@@ -158,38 +161,36 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
             />
           </Col>
           <Col xs={item.addedByUser ? 12 : 14} sm={item.addedByUser ? 14 : 16}>
-            <List.Item.Meta
-              title={
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <Text
-                    style={{
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      fontWeight: 'bold',
-                    }}
-                  >
-                    {item.climb?.name}
-                  </Text>
-                  <AscentStatus climbUuid={item.climb?.uuid} />
-                </div>
-              }
-              description={
+            <Flex vertical gap={4}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 <Text
-                  type={isHistory ? 'secondary' : undefined}
                   style={{
                     whiteSpace: 'nowrap',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
+                    fontWeight: 'bold',
                   }}
                 >
-                  {item.climb?.difficulty && item.climb?.quality_average
-                    ? `${item.climb?.difficulty} ${item.climb?.quality_average}★ @ ${item.climb?.angle}°`
-                    : `project @ ${item.climb?.angle}°`}
-                  {item.climb?.benchmark_difficulty && <CopyrightOutlined style={{ marginLeft: 4 }} />}
+                  {item.climb?.name}
                 </Text>
-              }
-            />
+                <AscentStatus climbUuid={item.climb?.uuid} />
+              </div>
+              <Text
+                type={isHistory ? 'secondary' : undefined}
+                style={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  fontSize: '14px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {item.climb?.difficulty && item.climb?.quality_average
+                  ? `${item.climb?.difficulty} ${item.climb?.quality_average}★ @ ${item.climb?.angle}°`
+                  : `project @ ${item.climb?.angle}°`}
+                {item.climb?.benchmark_difficulty && <CopyrightOutlined style={{ marginLeft: 4 }} />}
+              </Text>
+            </Flex>
           </Col>
           {item.addedByUser && (
             <Col xs={2} sm={2}>
@@ -203,7 +204,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
           </Col>
         </Row>
         {closestEdge && <DropIndicator edge={closestEdge} gap="1px" />}
-      </List.Item>
+      </div>
     </div>
   );
 };

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect } from 'react';
-import { List, Divider, Row, Col, Typography, Button } from 'antd';
+import { Divider, Row, Col, Typography, Button, Flex } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { useQueueContext } from '../graphql-queue';
 import { Climb, BoardDetails } from '@/app/lib/types';
@@ -9,6 +9,7 @@ import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
 import QueueListItem from './queue-list-item';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
+import { themeTokens } from '@/app/theme/theme-config';
 
 const { Text } = Typography;
 
@@ -61,11 +62,14 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
     return cleanup; // Cleanup listener on component unmount
   }, [queue, setQueue]);
 
+  const suggestedClimbs = (climbSearchResults || []).filter(
+    (item) => !queue.find((queueItem) => queueItem.climb?.uuid === item.uuid),
+  );
+
   return (
     <>
-      <List
-        dataSource={queue}
-        renderItem={(climbQueueItem, index) => {
+      <Flex vertical>
+        {queue.map((climbQueueItem, index) => {
           const isCurrent = currentClimbQueueItem?.uuid === climbQueueItem.uuid;
           const isHistory =
             queue.findIndex((item) => item.uuid === currentClimbQueueItem?.uuid) >
@@ -84,17 +88,22 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
               onClimbNavigate={onClimbNavigate}
             />
           );
-        }}
-      />
+        })}
+      </Flex>
       {!viewOnlyMode && (
         <>
           <Divider>Suggested Items</Divider>
-          <List
-            dataSource={(climbSearchResults || []).filter(
-              (item) => !queue.find((queueItem) => queueItem.climb?.uuid === item.uuid),
-            )}
-            renderItem={(climb: Climb) => (
-              <List.Item>
+          <Flex vertical>
+            {suggestedClimbs.map((climb: Climb) => (
+              <div
+                key={climb.uuid}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '12px 0',
+                  borderBottom: `1px solid ${themeTokens.neutral[200]}`,
+                }}
+              >
                 <Row style={{ width: '100%' }} gutter={[8, 8]} align="middle" wrap={false}>
                   <Col xs={2} sm={1}>
                     {/* Empty space to maintain layout consistency */}
@@ -108,28 +117,24 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
                     />
                   </Col>
                   <Col xs={14} sm={16}>
-                    <List.Item.Meta
-                      title={
-                        <Text ellipsis strong>
-                          {climb.name}
-                        </Text>
-                      }
-                      description={
-                        <Text type="secondary" ellipsis>
-                          {climb.difficulty && climb.quality_average
-                            ? `${climb.difficulty} ${climb.quality_average}★ @ ${climb.angle}°`
-                            : `project @ ${climb.angle}°`}
-                        </Text>
-                      }
-                    />
+                    <Flex vertical gap={4}>
+                      <Text ellipsis strong>
+                        {climb.name}
+                      </Text>
+                      <Text type="secondary" ellipsis style={{ fontSize: '14px' }}>
+                        {climb.difficulty && climb.quality_average
+                          ? `${climb.difficulty} ${climb.quality_average}★ @ ${climb.angle}°`
+                          : `project @ ${climb.angle}°`}
+                      </Text>
+                    </Flex>
                   </Col>
                   <Col xs={3} sm={2}>
                     <Button type="default" icon={<PlusOutlined />} onClick={() => addToQueue(climb)} />
                   </Col>
                 </Row>
-              </List.Item>
-            )}
-          />
+              </div>
+            ))}
+          </Flex>
         </>
       )}
     </>

--- a/packages/web/app/components/setup-wizard/board-config-preview.tsx
+++ b/packages/web/app/components/setup-wizard/board-config-preview.tsx
@@ -139,10 +139,10 @@ export default function BoardConfigPreview({ config, onDelete, boardConfigs, isE
           style={{ minWidth: 0 }}
           extra={isEditMode ? <Button type="text" icon={<DeleteOutlined />} onClick={handleDelete} danger size="small" /> : undefined}
         >
-          <Space direction="vertical" size="small" align="center">
+          <Space orientation="vertical" size="small" align="center">
             <Text type="secondary">Preview unavailable</Text>
             <Text strong>{config.name}</Text>
-            <Space direction="vertical" size={2}>
+            <Space orientation="vertical" size={2}>
               <Tag>{layoutName}</Tag>
               <Space size={2}>
                 <Tag>{sizeName}</Tag>
@@ -175,7 +175,7 @@ export default function BoardConfigPreview({ config, onDelete, boardConfigs, isE
         <Card.Meta
           title={<Text strong>{config.name}</Text>}
           description={
-            <Space direction="vertical" size={2}>
+            <Space orientation="vertical" size={2}>
               <Tag>{layoutName}</Tag>
               <Space size={2}>
                 <Tag>{sizeName}</Tag>


### PR DESCRIPTION
- Replace Space `direction` prop with `orientation` in:
  - board-config-preview.tsx
  - create-climb-form.tsx
  - logbook-view.tsx
  - party-profile-modal.tsx

- Replace Drawer `width`/`height` props with `styles.wrapper` in:
  - climb-info-button.tsx
  - tick-button.tsx

- Replace deprecated List component with Flex/Card pattern in:
  - logbook-view.tsx
  - queue-list.tsx
  - queue-list-item.tsx