### PR TITLE
fix: Reduce top padding on board config screen to 10px

### DIFF
--- a/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
@@ -439,9 +439,13 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
       <AnimatedBoardLoading isVisible={isStartingClimbing} boardDetails={loadingBoardDetails} />
       <div
         style={{
-          padding: `10px ${themeTokens.spacing[6]} ${themeTokens.spacing[6]}`,
+          padding: `10px ${themeTokens.spacing[6]} 20vh`,
           maxWidth: '600px',
           margin: '0 auto',
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
         }}
       >
         <Card style={{ boxShadow: themeTokens.shadows.lg }}>

--- a/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
@@ -439,13 +439,9 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
       <AnimatedBoardLoading isVisible={isStartingClimbing} boardDetails={loadingBoardDetails} />
       <div
         style={{
-          padding: themeTokens.spacing[6],
+          padding: `10px ${themeTokens.spacing[6]} ${themeTokens.spacing[6]}`,
           maxWidth: '600px',
           margin: '0 auto',
-          minHeight: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
         }}
       >
         <Card style={{ boxShadow: themeTokens.shadows.lg }}>


### PR DESCRIPTION
Remove vertical centering and full viewport height from the board
configuration container, replacing with a simple 10px top padding.