### PR TITLE
fix: Standardize branding to "Boardsesh" instead of "BoardSesh"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-BoardSesh is a monorepo containing a Next.js 15 application for controlling standardized interactive climbing training boards (Kilter, Tension, Decoy). It adds missing functionality to boards using Aurora Climbing's software, including queue management and real-time collaborative control.
+Boardsesh is a monorepo containing a Next.js 15 application for controlling standardized interactive climbing training boards (Kilter, Tension, Decoy). It adds missing functionality to boards using Aurora Climbing's software, including queue management and real-time collaborative control.
 
 ## Monorepo Structure
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,6 +1,6 @@
-# BoardSesh Backend
+# Boardsesh Backend
 
-WebSocket server for BoardSesh Party Mode. Provides reliable real-time synchronization for multi-user climbing queue management.
+WebSocket server for Boardsesh Party Mode. Provides reliable real-time synchronization for multi-user climbing queue management.
 
 ## Quick Start with Docker
 
@@ -55,7 +55,7 @@ For other devices on your network to connect:
    - macOS/Linux: `ifconfig` or `ip addr`
    - Windows: `ipconfig`
 
-2. Use the backend URL in BoardSesh: `ws://YOUR_IP:8080`
+2. Use the backend URL in Boardsesh: `ws://YOUR_IP:8080`
 
 Example: `ws://192.168.1.100:8080`
 
@@ -70,7 +70,7 @@ Internet
     ↓
 Traefik (TLS termination, Let's Encrypt)
     ↓ (ws://backend:8080)
-BoardSesh Backend
+Boardsesh Backend
     ↓
 PostgreSQL
 ```

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boardsesh-backend",
   "version": "1.0.0",
-  "description": "WebSocket backend for BoardSesh Party Mode",
+  "description": "WebSocket backend for Boardsesh Party Mode",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,7 +6,7 @@ const { wss, httpServer } = startServer();
 
 // Handle graceful shutdown
 function shutdown() {
-  console.log('\nShutting down BoardSesh Daemon...');
+  console.log('\nShutting down Boardsesh Daemon...');
 
   // Close WebSocket server (stops accepting new connections)
   wss.close(() => {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -178,7 +178,7 @@ export function startServer(): { wss: WebSocketServer; httpServer: ReturnType<ty
     path: '/graphql',
   });
 
-  console.log(`BoardSesh Backend starting on port ${PORT}...`);
+  console.log(`Boardsesh Backend starting on port ${PORT}...`);
 
   // Use graphql-ws server
   useServer<Record<string, unknown>, CustomExtra>(
@@ -259,7 +259,7 @@ export function startServer(): { wss: WebSocketServer; httpServer: ReturnType<ty
 
   // Start HTTP server (WebSocket server is attached to it)
   httpServer.listen(PORT, () => {
-    console.log(`BoardSesh Backend is running on port ${PORT}`);
+    console.log(`Boardsesh Backend is running on port ${PORT}`);
     console.log(`  GraphQL WS: ws://0.0.0.0:${PORT}/graphql`);
     console.log(`  Health check: http://0.0.0.0:${PORT}/health`);
     console.log(`  Join session: http://0.0.0.0:${PORT}/join`);

--- a/packages/shared-schema/package.json
+++ b/packages/shared-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boardsesh/shared-schema",
   "version": "1.0.0",
-  "description": "Shared GraphQL schema and types for BoardSesh",
+  "description": "Shared GraphQL schema and types for Boardsesh",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -1,4 +1,4 @@
-// GraphQL Operations for BoardSesh Queue Client
+// GraphQL Operations for Boardsesh Queue Client
 // These operations are used by the web app to communicate with the backend
 
 // Fragment for reusable climb fields

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -1,4 +1,4 @@
-// GraphQL Schema for BoardSesh Queue Synchronization
+// GraphQL Schema for Boardsesh Queue Synchronization
 // This schema is shared between the backend server and client
 
 export const typeDefs = /* GraphQL */ `

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -1,4 +1,4 @@
-// Shared TypeScript types for BoardSesh
+// Shared TypeScript types for Boardsesh
 // These types are used by both the backend and the web app
 
 export type UserId = string;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
@@ -7,7 +7,7 @@ import CreateClimbForm from '@/app/components/create-climb/create-climb-form';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Create Climb | BoardSesh',
+  title: 'Create Climb | Boardsesh',
   description: 'Create a new climb on your climbing board',
 };
 

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -17,7 +17,7 @@ import { Metadata } from 'next';
 
 /**
  * Generates a user-friendly page title from board details.
- * Example output: "Kilter Original 12x12 | BoardSesh"
+ * Example output: "Kilter Original 12x12 | Boardsesh"
  */
 function generateBoardTitle(boardDetails: BoardDetails): string {
   const parts: string[] = [];
@@ -51,7 +51,7 @@ function generateBoardTitle(boardDetails: BoardDetails): string {
     parts.push(boardDetails.size_description);
   }
 
-  return `${parts.join(' ')} | BoardSesh`;
+  return `${parts.join(' ')} | Boardsesh`;
 }
 
 export async function generateMetadata(props: { params: Promise<BoardRouteParameters> }): Promise<Metadata> {
@@ -80,7 +80,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     // Fallback title if metadata generation fails
     const boardName = params.board_name.charAt(0).toUpperCase() + params.board_name.slice(1);
     return {
-      title: `${boardName} | BoardSesh`,
+      title: `${boardName} | Boardsesh`,
     };
   }
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
 
     return {
-      title: `${climbName} - ${climbGrade} | BoardSesh`,
+      title: `${climbName} - ${climbGrade} | Boardsesh`,
       description,
       openGraph: {
         title: `${climbName} - ${climbGrade}`,
@@ -71,7 +71,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     };
   } catch {
     return {
-      title: 'Climb View | BoardSesh',
+      title: 'Climb View | Boardsesh',
       description: 'View climb details and beta videos',
     };
   }

--- a/packages/web/app/components/board-page/backend-setup-panel.tsx
+++ b/packages/web/app/components/board-page/backend-setup-panel.tsx
@@ -56,8 +56,8 @@ export const BackendSetupPanel: React.FC<BackendSetupPanelProps> = ({
       <Alert
         type="info"
         showIcon
-        message="BoardSesh Backend Required"
-        description="To use Backend mode for more reliable connections, you need to run the BoardSesh backend on your local network."
+        message="Boardsesh Backend Required"
+        description="To use Backend mode for more reliable connections, you need to run the Boardsesh backend on your local network."
       />
 
       <Flex vertical gap="small">

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -35,7 +35,7 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         viewBox="0 0 48 48"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        aria-label="BoardSesh logo"
+        aria-label="Boardsesh logo"
       >
         {/* Board background with rounded corners */}
         <rect x="2" y="2" width="44" height="44" rx="8" fill={themeTokens.colors.primary} />
@@ -64,7 +64,7 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
             lineHeight: 1,
           }}
         >
-          BoardSesh
+          Boardsesh
         </span>
       )}
     </div>

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -34,7 +34,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
   const isAlreadyInQueue = queue.some((item) => item.climb?.uuid === climb.uuid);
 
   useEffect(() => {
-    // Check if we can go back and if the previous page was on BoardSesh
+    // Check if we can go back and if the previous page was on Boardsesh
     const checkCanGoBack = () => {
       if (typeof window !== 'undefined') {
         // Check if there's history to go back to

--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -28,7 +28,7 @@ export interface ExtendedClient extends Client {
 }
 
 /**
- * Creates a GraphQL-WS client for connecting to the BoardSesh backend
+ * Creates a GraphQL-WS client for connecting to the Boardsesh backend
  */
 export function createGraphQLClient(
   url: string,

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -1,4 +1,4 @@
-/* BoardSesh Global Styles */
+/* Boardsesh Global Styles */
 
 /* Base styles */
 body {

--- a/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
@@ -602,7 +602,7 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
               disabled={!isFormComplete}
             >
               Use this board configuration as default
-              <Tooltip title="When this option is selected, navigating to BoardSesh will always load this board configuration immediately">
+              <Tooltip title="When this option is selected, navigating to Boardsesh will always load this board configuration immediately">
                 <InfoCircleOutlined style={{ marginLeft: '4px', color: '#1890ff' }} />
               </Tooltip>
             </Checkbox>

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -1,4 +1,4 @@
-// Design tokens for BoardSesh
+// Design tokens for Boardsesh
 // This file defines the design system used throughout the application
 
 export const themeTokens = {

--- a/packages/web/board-controller/.dockerignore
+++ b/packages/web/board-controller/.dockerignore
@@ -36,7 +36,7 @@ docker-compose.yml
 .git/
 .gitignore
 
-# Static frontend files (we redirect to BoardSesh now)
+# Static frontend files (we redirect to Boardsesh now)
 static/
 
 # Data directory (mounted as volume)

--- a/packages/web/board-controller/README.md
+++ b/packages/web/board-controller/README.md
@@ -1,14 +1,14 @@
 # Board Controller
 
-A Python WebSocket server that enables persistent queue management and collaborative control for Kilter/Tension climbing boards. Integrates with BoardSesh.com to provide synchronized queue state across multiple devices and apps.
+A Python WebSocket server that enables persistent queue management and collaborative control for Kilter/Tension climbing boards. Integrates with Boardsesh.com to provide synchronized queue state across multiple devices and apps.
 
 ## Features
 
 - **Single Entry Point**: One command starts everything
 - **Bluetooth Support**: Accepts commands from Kilter/Tension mobile apps (optional)
-- **WebSocket Integration**: Real-time synchronization with BoardSesh.com
+- **WebSocket Integration**: Real-time synchronization with Boardsesh.com
 - **Queue Persistence**: SQLite database maintains queue state across restarts
-- **Auto-redirect**: localhost:8000 automatically redirects to BoardSesh with controller integration
+- **Auto-redirect**: localhost:8000 automatically redirects to Boardsesh with controller integration
 - **Multi-device Support**: Control queue from both web browser and mobile apps simultaneously
 
 ## Quick Start
@@ -48,10 +48,10 @@ python main.py --port 8080
 
 1. Run `python main.py`
 2. Open http://localhost:8000 in your browser
-3. You'll be automatically redirected to BoardSesh with controller integration
-4. The controller takes over queue management from BoardSesh
+3. You'll be automatically redirected to Boardsesh with controller integration
+4. The controller takes over queue management from Boardsesh
 5. Add climbs to the queue - they persist across browser refreshes
-6. Use both BoardSesh web interface and Kilter/Tension mobile apps
+6. Use both Boardsesh web interface and Kilter/Tension mobile apps
 
 ## Architecture
 
@@ -72,7 +72,7 @@ python main.py --port 8080
 
 ### WebSocket Protocol
 
-Key message types between BoardSesh and controller:
+Key message types between Boardsesh and controller:
 
 ```json
 // Initial handshake from controller
@@ -126,7 +126,7 @@ uvicorn main:BoardController().app --reload --port 8000
 SQLite database is created automatically with tables:
 - `sessions` - Controller sessions
 - `queue_items` - Queue persistence
-- `climb_cache` - BoardSesh API cache
+- `climb_cache` - Boardsesh API cache
 
 ## Configuration
 
@@ -148,7 +148,7 @@ These environment variables control the default board configuration for the redi
 
 **How to Find Your Board Configuration:**
 
-The easiest way to determine your board's configuration is to look at your BoardSesh URL when you navigate to your specific board setup. The URL follows this pattern:
+The easiest way to determine your board's configuration is to look at your Boardsesh URL when you navigate to your specific board setup. The URL follows this pattern:
 
 ```
 https://www.boardsesh.com/{board_name}/{layout}/{size}/{set}/{angle}/list
@@ -183,7 +183,7 @@ For example:
   - `plastic_wood` (both hold types combined)
 - **Angles**: `0`, `5`, `10`, `15`, `20`, `25`, `30`, `35`, `40`, `45`, `50`, `55`, `60`, `65`, `70`
 
-**Note**: The exact available options depend on your specific board configuration and what hold sets you have installed. Visit BoardSesh.com and navigate to your board to see the exact URL parameters for your setup.
+**Note**: The exact available options depend on your specific board configuration and what hold sets you have installed. Visit Boardsesh.com and navigate to your board to see the exact URL parameters for your setup.
 
 **Example configurations:**
 ```bash
@@ -356,18 +356,18 @@ docker run -p 8000:8000 -v ./data:/app/data board-controller \
   python main.py --no-bluetooth --host 0.0.0.0
 ```
 
-## Integration with BoardSesh
+## Integration with Boardsesh
 
-The controller is designed to seamlessly integrate with BoardSesh.com:
+The controller is designed to seamlessly integrate with Boardsesh.com:
 
-1. **Detection**: BoardSesh detects `controllerUrl` parameter in URL
+1. **Detection**: Boardsesh detects `controllerUrl` parameter in URL
 2. **Connection**: Establishes WebSocket connection to controller
 3. **Takeover**: Controller becomes the source of truth for queue state
 4. **Synchronization**: All queue changes sync through controller
-5. **Fallback**: If controller disconnects, BoardSesh falls back to PeerJS
+5. **Fallback**: If controller disconnects, Boardsesh falls back to PeerJS
 
 This allows users to control their climbing board through:
-- BoardSesh web interface
+- Boardsesh web interface
 - Kilter/Tension mobile apps
 - Controller web interface
 

--- a/packages/web/board-controller/generate_cert.py
+++ b/packages/web/board-controller/generate_cert.py
@@ -27,7 +27,7 @@ def generate_certificate(hostname="localhost", ip_address=None):
         x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
         x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
         x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
-        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "BoardSesh Controller"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Boardsesh Controller"),
         x509.NameAttribute(NameOID.COMMON_NAME, hostname),
     ])
     

--- a/packages/web/board-controller/main.py
+++ b/packages/web/board-controller/main.py
@@ -603,7 +603,7 @@ class BoardController:
                 "bluetoothEnabled": self.bluetooth_manager.bluetooth_enabled
             }
         
-        # Root endpoint - redirect to BoardSesh with controller URL
+        # Root endpoint - redirect to Boardsesh with controller URL
         @self.app.get("/")
         async def root(request: Request):
             from fastapi.responses import RedirectResponse
@@ -628,7 +628,7 @@ class BoardController:
             
             return RedirectResponse(url=boardsesh_url, status_code=302)
         
-        # No static files needed - we redirect to BoardSesh
+        # No static files needed - we redirect to Boardsesh
     
     async def _handle_websocket_message(self, data: dict, websocket: WebSocket):
         """Handle incoming WebSocket messages"""
@@ -645,14 +645,14 @@ class BoardController:
             }, websocket)
         
         elif msg_type == "controller-takeover":
-            # BoardSesh is acknowledging controller takeover
+            # Boardsesh is acknowledging controller takeover
             await self.ws_manager.broadcast({
                 "type": "controller-active",
                 "sessionId": self.session_id
             })
         
         elif msg_type in ["add-queue-item", "remove-queue-item", "update-current-climb"]:
-            # Queue operations from BoardSesh
+            # Queue operations from Boardsesh
             # Update database and broadcast to other connections
             if msg_type == "add-queue-item":
                 item_data = data.get("item", {})
@@ -780,7 +780,7 @@ def auto_generate_ssl_cert():
             x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "CA"),
             x509.NameAttribute(NameOID.LOCALITY_NAME, "Local"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "BoardSesh Controller"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Boardsesh Controller"),
             x509.NameAttribute(NameOID.COMMON_NAME, "localhost"),
         ])
         

--- a/packages/web/board-controller/requirements.txt
+++ b/packages/web/board-controller/requirements.txt
@@ -9,7 +9,7 @@ python-multipart==0.0.18
 # Database
 aiosqlite==0.20.0
 
-# HTTP client for BoardSesh API
+# HTTP client for Boardsesh API
 httpx==0.27.2
 
 # QR code generation

--- a/packages/web/db/setup-development-db.sh
+++ b/packages/web/db/setup-development-db.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "🚀 Starting BoardSesh development database setup..."
+echo "🚀 Starting Boardsesh development database setup..."
 
 # Check if this is a fresh setup or just running migrations
 FRESH_SETUP=false
@@ -124,4 +124,4 @@ echo "🔄 Step 8/8: Running drizzle migrations..."
 npx drizzle-kit migrate
 echo "   ✅ Drizzle migrations completed!"
 
-echo "✨ BoardSesh development database is ready!" 
+echo "✨ Boardsesh development database is ready!" 

--- a/packages/web/setup-dev.sh
+++ b/packages/web/setup-dev.sh
@@ -17,8 +17,8 @@ CHECK="✅"
 WARNING="⚠️"
 ERROR="❌"
 
-echo -e "${BLUE}${ROCKET} Welcome to BoardSesh Development Setup!${NC}"
-echo -e "This script will set up everything you need to contribute to BoardSesh."
+echo -e "${BLUE}${ROCKET} Welcome to Boardsesh Development Setup!${NC}"
+echo -e "This script will set up everything you need to contribute to Boardsesh."
 echo ""
 
 # Function to check if command exists


### PR DESCRIPTION
Consistent branding across documentation, comments, page titles, and user-facing text. Code identifiers (e.g., BoardSeshHeader component) remain unchanged as they follow CamelCase convention.