### PR TITLE
fix: Remove queue success message and reset add button after 5s

### DIFF
--- a/packages/web/app/components/climb-card/climb-card-actions.tsx
+++ b/packages/web/app/components/climb-card/climb-card-actions.tsx
@@ -16,31 +16,26 @@ type ClimbCardActionsProps = {
 };
 const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
   const { addToQueue, queue } = useQueueContext();
-  const [isDuplicate, setDuplicateTimer] = useState(false);
+  const [recentlyAdded, setRecentlyAdded] = useState(false);
 
   if (!climb) {
     return [];
   }
 
-  const isAlreadyInQueue = queue.some((item) => item.climb?.uuid === climb.uuid);
-
   const handleAddToQueue = () => {
-    if (addToQueue && !isDuplicate) {
+    if (addToQueue && !recentlyAdded) {
       addToQueue(climb);
-
-      const climbName = climb.name || '';
-      message.info(`Successfully added ${climbName} to the queue`);
 
       track('Add to Queue', {
         boardLayout: boardDetails.layout_name || '',
         queueLength: queue.length + 1,
       });
 
-      setDuplicateTimer(true);
+      setRecentlyAdded(true);
 
       setTimeout(() => {
-        setDuplicateTimer(false);
-      }, 3000);
+        setRecentlyAdded(false);
+      }, 5000);
     }
   };
 
@@ -105,17 +100,17 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
       </Link>
     ) : null,
     <HeartOutlined key="heart" onClick={() => message.info('TODO: Implement')} />,
-    isAlreadyInQueue ? (
+    recentlyAdded ? (
       <CheckCircleOutlined
         key="edit"
         onClick={handleAddToQueue}
-        style={{ color: '#52c41a', cursor: isDuplicate ? 'not-allowed' : 'pointer' }}
+        style={{ color: '#52c41a', cursor: 'not-allowed' }}
       />
     ) : (
       <PlusCircleOutlined
         key="edit"
         onClick={handleAddToQueue}
-        style={{ color: 'inherit', cursor: isDuplicate ? 'not-allowed' : 'pointer' }}
+        style={{ color: 'inherit', cursor: 'pointer' }}
       />
     ),
   ];

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -27,11 +27,9 @@ type ClimbViewActionsProps = {
 
 const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbViewActionsProps) => {
   const { addToQueue, queue } = useQueueContext();
-  const [isDuplicate, setDuplicateTimer] = useState(false);
+  const [recentlyAdded, setRecentlyAdded] = useState(false);
   const [canGoBack, setCanGoBack] = useState(false);
   const router = useRouter();
-
-  const isAlreadyInQueue = queue.some((item) => item.climb?.uuid === climb.uuid);
 
   useEffect(() => {
     // Check if we can go back and if the previous page was on Boardsesh
@@ -53,17 +51,14 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
   }, []);
 
   const handleAddToQueue = () => {
-    if (addToQueue && !isDuplicate) {
+    if (addToQueue && !recentlyAdded) {
       addToQueue(climb);
 
-      const climbName = climb.name || '';
-      message.info(`Successfully added ${climbName} to the queue`);
-
-      setDuplicateTimer(true);
+      setRecentlyAdded(true);
 
       setTimeout(() => {
-        setDuplicateTimer(false);
-      }, 3000);
+        setRecentlyAdded(false);
+      }, 5000);
     }
   };
 
@@ -143,17 +138,17 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
         <div className={styles.mobileRight}>
           <Button icon={<HeartOutlined />} onClick={handleFavourite} />
 
-          {isAlreadyInQueue ? (
+          {recentlyAdded ? (
             <Button
               icon={<CheckCircleOutlined />}
               onClick={handleAddToQueue}
-              disabled={isDuplicate}
+              disabled
               className={styles.inQueueButton}
             >
-              In Queue
+              Added
             </Button>
           ) : (
-            <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue} disabled={isDuplicate}>
+            <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue}>
               Queue
             </Button>
           )}
@@ -192,17 +187,17 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
               Tick
             </Button>
 
-            {isAlreadyInQueue ? (
+            {recentlyAdded ? (
               <Button
                 icon={<CheckCircleOutlined />}
                 onClick={handleAddToQueue}
-                disabled={isDuplicate}
+                disabled
                 className={styles.inQueueButton}
               >
-                In Queue
+                Added to Queue
               </Button>
             ) : (
-              <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue} disabled={isDuplicate}>
+              <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue}>
                 Add to Queue
               </Button>
             )}


### PR DESCRIPTION
- Remove the "Successfully added to queue" toast notification
- Change icon back to add button after 5 seconds instead of
  permanently showing the green check
- Rename isDuplicate to recentlyAdded for clarity