### PR TITLE
feat: Add reusable ClimbTitle component for consistent climb info styling

### DIFF
--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -2,16 +2,12 @@
 
 import React from 'react';
 import Card from 'antd/es/card';
-import Flex from 'antd/es/flex';
-import Typography from 'antd/es/typography';
-import { CopyrightOutlined } from '@ant-design/icons';
 
 import ClimbCardCover from './climb-card-cover';
+import ClimbTitle from './climb-title';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbCardActions from './climb-card-actions';
 import { themeTokens } from '@/app/theme/theme-config';
-
-const { Text } = Typography;
 
 type ClimbCardProps = {
   climb?: Climb;
@@ -26,30 +22,7 @@ const ClimbCard = ({ climb, boardDetails, onCoverClick, selected, actions }: Cli
   const cover = <ClimbCardCover climb={climb} boardDetails={boardDetails} onClick={onCoverClick} />;
 
   const cardTitle = climb ? (
-    <Flex vertical gap={0}>
-      {/* Row 1: Name, Benchmark | Difficulty, Quality */}
-      <Flex justify="space-between" align="center">
-        <Text strong style={{ fontSize: themeTokens.typography.fontSize.sm }}>
-          {climb.name}
-          {climb.benchmark_difficulty !== null && (
-            <CopyrightOutlined style={{ marginLeft: 4, fontSize: themeTokens.typography.fontSize.xs, color: themeTokens.colors.primary }} />
-          )}
-        </Text>
-        <Text strong type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
-          {climb.difficulty && climb.quality_average && climb.quality_average !== '0' ? (
-            `${climb.difficulty} ★${climb.quality_average}`
-          ) : (
-            <Text italic type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
-              project
-            </Text>
-          )}
-        </Text>
-      </Flex>
-      {/* Row 2: Setter and ascent count */}
-      <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.xs, fontWeight: themeTokens.typography.fontWeight.normal }}>
-        By {climb.setter_username} - {climb.ascensionist_count} ascents
-      </Text>
-    </Flex>
+    <ClimbTitle climb={climb} layout="horizontal" showSetterInfo />
   ) : (
     'Loading...'
   );

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -31,6 +31,8 @@ type ClimbTitleProps = {
   className?: string;
   /** Layout mode: 'stacked' (default) puts grade below name, 'horizontal' puts grade beside name */
   layout?: 'stacked' | 'horizontal';
+  /** Center the content (useful for QueueControlBar) */
+  centered?: boolean;
 };
 
 /**
@@ -45,6 +47,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   ellipsis = true,
   className,
   layout = 'stacked',
+  centered = false,
 }) => {
   if (!climb) {
     return (
@@ -144,7 +147,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   }
 
   return (
-    <Flex vertical gap={2} className={className}>
+    <Flex vertical gap={2} className={className} align={centered ? 'center' : 'flex-start'}>
       {/* Row 1: Name with optional benchmark icon and addon (e.g., AscentStatus) */}
       <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
         {nameElement}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -108,6 +108,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       type="secondary"
       style={{
         fontSize: themeTokens.typography.fontSize.xs,
+        fontWeight: themeTokens.typography.fontWeight.normal,
         color: themeTokens.neutral[500],
         ...textOverflowStyles,
       }}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import React from 'react';
+import { Flex, Typography } from 'antd';
+import { CopyrightOutlined } from '@ant-design/icons';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const { Text } = Typography;
+
+export type ClimbTitleData = {
+  name?: string;
+  difficulty?: string | null;
+  quality_average?: string | null;
+  benchmark_difficulty?: string | null;
+  angle?: number | string;
+  setter_username?: string;
+  ascensionist_count?: number;
+};
+
+type ClimbTitleProps = {
+  climb?: ClimbTitleData | null;
+  /** Show angle after difficulty/quality */
+  showAngle?: boolean;
+  /** Show setter and ascent count */
+  showSetterInfo?: boolean;
+  /** Custom element to render after the name (e.g., AscentStatus) */
+  nameAddon?: React.ReactNode;
+  /** Use ellipsis for text overflow */
+  ellipsis?: boolean;
+  /** Additional className for the container */
+  className?: string;
+  /** Layout mode: 'stacked' (default) puts grade below name, 'horizontal' puts grade beside name */
+  layout?: 'stacked' | 'horizontal';
+};
+
+/**
+ * Reusable component for displaying climb title and info consistently across the app.
+ * Used in ClimbCard, QueueControlBar, QueueListItem, and suggested items.
+ */
+const ClimbTitle: React.FC<ClimbTitleProps> = ({
+  climb,
+  showAngle = false,
+  showSetterInfo = false,
+  nameAddon,
+  ellipsis = true,
+  className,
+  layout = 'stacked',
+}) => {
+  if (!climb) {
+    return (
+      <Text
+        style={{
+          fontSize: themeTokens.typography.fontSize.sm,
+          fontWeight: themeTokens.typography.fontWeight.bold,
+        }}
+      >
+        No climb selected
+      </Text>
+    );
+  }
+
+  const hasGrade = climb.difficulty && climb.quality_average && climb.quality_average !== '0';
+  const isBenchmark = climb.benchmark_difficulty !== null && climb.benchmark_difficulty !== undefined;
+
+  const textOverflowStyles = ellipsis
+    ? {
+        whiteSpace: 'nowrap' as const,
+        overflow: 'hidden' as const,
+        textOverflow: 'ellipsis' as const,
+      }
+    : {};
+
+  const renderDifficultyText = () => {
+    if (hasGrade) {
+      const baseText = `${climb.difficulty} ${climb.quality_average}★`;
+      return showAngle ? `${baseText} @ ${climb.angle}°` : baseText;
+    }
+    const projectText = showAngle ? `project @ ${climb.angle}°` : 'project';
+    return <span style={{ fontStyle: 'italic' }}>{projectText}</span>;
+  };
+
+  const nameElement = (
+    <Text
+      style={{
+        fontSize: themeTokens.typography.fontSize.sm,
+        fontWeight: themeTokens.typography.fontWeight.bold,
+        ...textOverflowStyles,
+      }}
+    >
+      {climb.name}
+      {isBenchmark && (
+        <CopyrightOutlined
+          style={{
+            marginLeft: 4,
+            fontSize: themeTokens.typography.fontSize.xs,
+            color: themeTokens.colors.primary,
+          }}
+        />
+      )}
+    </Text>
+  );
+
+  const gradeElement = (
+    <Text
+      type="secondary"
+      style={{
+        fontSize: themeTokens.typography.fontSize.xs,
+        color: themeTokens.neutral[500],
+        ...textOverflowStyles,
+      }}
+    >
+      {renderDifficultyText()}
+    </Text>
+  );
+
+  const setterElement = showSetterInfo && climb.setter_username && (
+    <Text
+      type="secondary"
+      style={{
+        fontSize: themeTokens.typography.fontSize.xs,
+        fontWeight: themeTokens.typography.fontWeight.normal,
+        ...textOverflowStyles,
+      }}
+    >
+      By {climb.setter_username} - {climb.ascensionist_count ?? 0} ascents
+    </Text>
+  );
+
+  if (layout === 'horizontal') {
+    return (
+      <Flex vertical gap={0} className={className}>
+        {/* Row 1: Name (left) with addon, Grade (right) */}
+        <Flex justify="space-between" align="center">
+          <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
+            {nameElement}
+            {nameAddon}
+          </div>
+          {gradeElement}
+        </Flex>
+        {/* Row 2 (optional): Setter info */}
+        {setterElement}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex vertical gap={2} className={className}>
+      {/* Row 1: Name with optional benchmark icon and addon (e.g., AscentStatus) */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
+        {nameElement}
+        {nameAddon}
+      </div>
+      {/* Row 2: Difficulty/Quality and optional Angle */}
+      {gradeElement}
+      {/* Row 3 (optional): Setter info */}
+      {setterElement}
+    </Flex>
+  );
+};
+
+export default ClimbTitle;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -83,6 +83,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
               <ClimbTitle
                 climb={currentClimb}
                 showAngle
+                centered
                 nameAddon={currentClimb?.name && <AscentStatus climbUuid={currentClimb.uuid} />}
               />
             </div>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useState } from 'react';
-import { Button, Typography, Row, Col, Card, Drawer, Space } from 'antd';
+import { Button, Row, Col, Card, Drawer, Space } from 'antd';
 import { SyncOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { useQueueContext } from '../graphql-queue';
@@ -11,12 +11,10 @@ import { BoardName, BoardDetails, Angle } from '@/app/lib/types';
 import QueueList from './queue-list';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
+import ClimbTitle from '../climb-card/climb-title';
 import { AscentStatus } from './queue-list-item';
-import { CopyrightOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './queue-control-bar.module.css';
-
-const { Title, Text } = Typography;
 
 export interface QueueControlBar {
   boardDetails: BoardDetails;
@@ -82,47 +80,11 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           {/* Clickable main body for opening the queue */}
           <Col xs={11} style={{ textAlign: 'center' }}>
             <div onClick={toggleQueueDrawer} className={`${styles.queueToggle} ${isListPage ? styles.listPage : ''}`}>
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'baseline',
-                  justifyContent: 'center',
-                  gap: '4px',
-                }}
-              >
-                <Title
-                  level={5}
-                  style={{
-                    marginBottom: 0,
-                    fontSize: '14px',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                  }}
-                >
-                  {currentClimb && currentClimb.name ? currentClimb.name : 'No climb selected'}
-                </Title>
-                {currentClimb && currentClimb.name && <AscentStatus climbUuid={currentClimb.uuid} />}
-              </div>
-              <Text
-                style={{
-                  fontSize: '12px',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {currentClimb ? (
-                  <>
-                    {currentClimb.difficulty && currentClimb.quality_average ? (
-                      `${currentClimb.difficulty} ${currentClimb.quality_average}★ @ ${currentClimb.angle}°`
-                    ) : (
-                      <span style={{ fontWeight: 400, fontStyle: 'italic' }}>project @ {currentClimb.angle}°</span>
-                    )}
-                    {currentClimb.benchmark_difficulty && <CopyrightOutlined style={{ marginLeft: 4 }} />}
-                  </>
-                ) : null}
-              </Text>
+              <ClimbTitle
+                climb={currentClimb}
+                showAngle
+                nameAddon={currentClimb?.name && <AscentStatus climbUuid={currentClimb.uuid} />}
+              />
             </div>
           </Col>
 

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -163,6 +163,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
             <ClimbTitle
               climb={item.climb}
               showAngle
+              centered
               nameAddon={<AscentStatus climbUuid={item.climb?.uuid} />}
             />
           </Col>

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Row, Col, Typography, Avatar, Tooltip, Flex } from 'antd';
-import { HolderOutlined, CheckOutlined, CloseOutlined, UserOutlined, CopyrightOutlined } from '@ant-design/icons';
+import { Row, Col, Avatar, Tooltip } from 'antd';
+import { HolderOutlined, CheckOutlined, CloseOutlined, UserOutlined } from '@ant-design/icons';
 import { BoardDetails, ClimbUuid } from '@/app/lib/types';
 import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { DragHandleButton } from '@atlaskit/pragmatic-drag-and-drop-react-accessibility/drag-handle-button';
@@ -11,10 +11,9 @@ import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import { ClimbQueueItem } from './types';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
+import ClimbTitle from '../climb-card/climb-title';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
-
-const { Text } = Typography;
 
 type QueueListItemProps = {
   item: ClimbQueueItem;
@@ -161,36 +160,11 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
             />
           </Col>
           <Col xs={item.addedByUser ? 12 : 14} sm={item.addedByUser ? 14 : 16}>
-            <Flex vertical gap={4}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <Text
-                  style={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    fontWeight: 'bold',
-                  }}
-                >
-                  {item.climb?.name}
-                </Text>
-                <AscentStatus climbUuid={item.climb?.uuid} />
-              </div>
-              <Text
-                type={isHistory ? 'secondary' : undefined}
-                style={{
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  fontSize: '14px',
-                  color: themeTokens.neutral[500],
-                }}
-              >
-                {item.climb?.difficulty && item.climb?.quality_average
-                  ? `${item.climb?.difficulty} ${item.climb?.quality_average}★ @ ${item.climb?.angle}°`
-                  : `project @ ${item.climb?.angle}°`}
-                {item.climb?.benchmark_difficulty && <CopyrightOutlined style={{ marginLeft: 4 }} />}
-              </Text>
-            </Flex>
+            <ClimbTitle
+              climb={item.climb}
+              showAngle
+              nameAddon={<AscentStatus climbUuid={item.climb?.uuid} />}
+            />
           </Col>
           {item.addedByUser && (
             <Col xs={2} sm={2}>

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect } from 'react';
-import { Divider, Row, Col, Typography, Button, Flex } from 'antd';
+import { Divider, Row, Col, Button, Flex } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { useQueueContext } from '../graphql-queue';
 import { Climb, BoardDetails } from '@/app/lib/types';
@@ -9,9 +9,8 @@ import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
 import QueueListItem from './queue-list-item';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
+import ClimbTitle from '../climb-card/climb-title';
 import { themeTokens } from '@/app/theme/theme-config';
-
-const { Text } = Typography;
 
 type QueueListProps = {
   boardDetails: BoardDetails;
@@ -117,16 +116,7 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
                     />
                   </Col>
                   <Col xs={14} sm={16}>
-                    <Flex vertical gap={4}>
-                      <Text ellipsis strong>
-                        {climb.name}
-                      </Text>
-                      <Text type="secondary" ellipsis style={{ fontSize: '14px' }}>
-                        {climb.difficulty && climb.quality_average
-                          ? `${climb.difficulty} ${climb.quality_average}★ @ ${climb.angle}°`
-                          : `project @ ${climb.angle}°`}
-                      </Text>
-                    </Flex>
+                    <ClimbTitle climb={climb} showAngle />
                   </Col>
                   <Col xs={3} sm={2}>
                     <Button type="default" icon={<PlusOutlined />} onClick={() => addToQueue(climb)} />

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -116,7 +116,7 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
                     />
                   </Col>
                   <Col xs={14} sm={16}>
-                    <ClimbTitle climb={climb} showAngle />
+                    <ClimbTitle climb={climb} showAngle centered />
                   </Col>
                   <Col xs={3} sm={2}>
                     <Button type="default" icon={<PlusOutlined />} onClick={() => addToQueue(climb)} />


### PR DESCRIPTION
Create a new ClimbTitle component that standardizes how climb information
(name, grade, quality, angle, benchmark indicator) is displayed across
ClimbCard, QueueControlBar, QueueListItem, and suggested items. This
eliminates duplicate styling code and ensures visual consistency.

The component supports both horizontal (used in ClimbCard header) and
stacked (used in queue items) layouts, with optional setter info and
angle display.