### PR TITLE
fix: Ensure infinite scroll properly loads more climb results

### DIFF
--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -61,7 +61,7 @@ export const useQueueDataFetching = ({
     initialSize: searchParams.page ? searchParams.page + 1 : 1,
   });
 
-  const hasMoreResults = data && data[0] && size * PAGE_LIMIT < data[0].totalCount;
+  const hasMoreResults = Boolean(data && data[0] && size * PAGE_LIMIT < data[0].totalCount);
   const totalSearchResultCount = (data && data[0] && data[0].totalCount) || null;
 
   const climbSearchResults = useMemo(
@@ -102,7 +102,7 @@ export const useQueueDataFetching = ({
   }, [climbSearchResults, hasDoneFirstFetch, setHasDoneFirstFetch]);
 
   const fetchMoreClimbs = useCallback(() => {
-    setSize((oldSize) => {
+    return setSize((oldSize) => {
       const newParams = { ...searchParams, page: oldSize + 1 };
       history.replaceState(null, '', `${window.location.pathname}?${searchParamsToUrlParams(newParams).toString()}`);
       return oldSize + 1;

--- a/packages/web/app/components/queue-control/types.ts
+++ b/packages/web/app/components/queue-control/types.ts
@@ -74,7 +74,7 @@ export interface QueueContextType {
   setCurrentClimbQueueItem: (item: ClimbQueueItem) => void;
   setClimbSearchParams: (params: SearchRequestPagination) => void;
   mirrorClimb: () => void;
-  fetchMoreClimbs: () => void;
+  fetchMoreClimbs: () => Promise<unknown>;
   getNextClimbQueueItem: () => ClimbQueueItem | null;
   getPreviousClimbQueueItem: () => ClimbQueueItem | null;
   setQueue: (queue: ClimbQueueItem[]) => void;


### PR DESCRIPTION
- Convert hasMoreResults to always return a boolean instead of potentially undefined, which could cause InfiniteScroll's hasMore prop to behave incorrectly
- Return the Promise from setSize in fetchMoreClimbs to allow proper coordination with the InfiniteScroll component
- Update fetchMoreClimbs type signature to reflect Promise return