### PR TITLE
refactor: Align create climb UI with rest of app

### DIFF
--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -8,25 +8,6 @@
   margin: 0 auto;
 }
 
-/* Header section - white card container */
-.headerSection {
-  background-color: #FFFFFF;
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 16px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-}
-
-.headerContent {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.headerTitle {
-  margin: 0 !important;
-}
-
 /* Board section - white card container */
 .boardSection {
   background-color: #FFFFFF;
@@ -34,11 +15,6 @@
   padding: 16px;
   margin-bottom: 16px;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-}
-
-.boardInstructions {
-  display: block;
-  margin-bottom: 12px;
 }
 
 /* Hold counts row */
@@ -89,7 +65,6 @@
     padding: 12px;
   }
 
-  .headerSection,
   .boardSection,
   .formSection {
     padding: 12px;
@@ -116,7 +91,6 @@
     padding: 24px;
   }
 
-  .headerSection,
   .boardSection,
   .formSection {
     padding: 20px;

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,0 +1,146 @@
+/* Create Climb Form Styles */
+
+.pageContainer {
+  padding: 16px;
+  min-height: 100vh;
+  background-color: #F9FAFB;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Header section - white card container */
+.headerSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.headerContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerTitle {
+  margin: 0 !important;
+}
+
+/* Board section - white card container */
+.boardSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.boardInstructions {
+  display: block;
+  margin-bottom: 12px;
+}
+
+/* Hold counts row */
+.holdCounts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 16px;
+}
+
+/* Form section - white card container */
+.formSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.formContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Button group at bottom of form */
+.buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+/* Beta banner */
+.betaBanner {
+  margin-bottom: 16px;
+}
+
+/* Modal content */
+.modalDescription {
+  display: block;
+  margin-bottom: 16px;
+}
+
+/* Mobile adjustments */
+@media (max-width: 767px) {
+  .pageContainer {
+    padding: 12px;
+  }
+
+  .headerSection,
+  .boardSection,
+  .formSection {
+    padding: 12px;
+    border-radius: 8px;
+    margin-bottom: 12px;
+  }
+
+  .formSection {
+    margin-bottom: 0;
+  }
+
+  .holdCounts {
+    margin-top: 12px;
+  }
+
+  .betaBanner {
+    margin-bottom: 12px;
+  }
+}
+
+/* Desktop layout */
+@media (min-width: 992px) {
+  .pageContainer {
+    padding: 24px;
+  }
+
+  .headerSection,
+  .boardSection,
+  .formSection {
+    padding: 20px;
+  }
+
+  .contentWrapper {
+    display: flex;
+    gap: 24px;
+  }
+
+  .boardSection {
+    flex: 2;
+    margin-bottom: 0;
+  }
+
+  .formSection {
+    flex: 1;
+    max-width: 400px;
+    position: sticky;
+    top: 24px;
+    align-self: flex-start;
+  }
+
+  .buttonGroup {
+    margin-top: 16px;
+  }
+}

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Form, Input, Switch, Button, Typography, Flex, Space, Tag, Modal, Alert } from 'antd';
+import { Form, Input, Switch, Button, Typography, Tag, Modal, Alert } from 'antd';
 import { BulbOutlined, BulbFilled, ExperimentOutlined } from '@ant-design/icons';
 import { useRouter } from 'next/navigation';
 import { track } from '@vercel/analytics';
@@ -13,6 +13,7 @@ import { BoardDetails } from '@/app/lib/types';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import '../board-bluetooth-control/send-climb-to-board-button.css';
+import styles from './create-climb-form.module.css';
 
 const { TextArea } = Input;
 const { Title, Text } = Typography;
@@ -198,35 +199,38 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
   };
 
   return (
-    <div style={{ padding: '16px' }}>
+    <div className={styles.pageContainer}>
       <Alert
         message="Beta Feature"
         type="info"
         showIcon
         icon={<ExperimentOutlined />}
-        style={{ marginBottom: '16px' }}
+        className={styles.betaBanner}
         banner
       />
 
-      <Flex justify="space-between" align="center" style={{ marginBottom: '16px' }}>
-        <Title level={4} style={{ margin: 0 }}>
-          {forkName ? 'Fork Climb' : 'Create New Climb'}
-        </Title>
-        <Button
-          type="default"
-          icon={isConnected ? <BulbFilled className="connect-button-glow" /> : <BulbOutlined />}
-          onClick={handleBluetoothConnect}
-          loading={bluetoothLoading}
-          title={isConnected ? 'Connected to board' : 'Connect to board for live preview'}
-        >
-          {isConnected ? 'Connected' : 'Connect Board'}
-        </Button>
-      </Flex>
+      {/* Header Section */}
+      <div className={styles.headerSection}>
+        <div className={styles.headerContent}>
+          <Title level={4} className={styles.headerTitle}>
+            {forkName ? 'Fork Climb' : 'Create New Climb'}
+          </Title>
+          <Button
+            type="default"
+            icon={isConnected ? <BulbFilled className="connect-button-glow" /> : <BulbOutlined />}
+            onClick={handleBluetoothConnect}
+            loading={bluetoothLoading}
+            title={isConnected ? 'Connected to board' : 'Connect to board for live preview'}
+          >
+            {isConnected ? 'Connected' : 'Connect Board'}
+          </Button>
+        </div>
+      </div>
 
-      <Flex vertical gap={16}>
-        {/* Board with clickable holds */}
-        <div>
-          <Text type="secondary" style={{ display: 'block', marginBottom: '8px' }}>
+      <div className={styles.contentWrapper}>
+        {/* Board Section */}
+        <div className={styles.boardSection}>
+          <Text type="secondary" className={styles.boardInstructions}>
             Tap holds to set their type. Tap again to cycle through types.
             {isConnected && ' Changes are shown live on the board.'}
           </Text>
@@ -236,65 +240,68 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
             mirrored={false}
             onHoldClick={handleHoldClick}
           />
+
+          {/* Hold counts */}
+          <div className={styles.holdCounts}>
+            <Tag color={startingCount > 0 ? 'green' : 'default'}>Starting: {startingCount}/2</Tag>
+            <Tag color={finishCount > 0 ? 'magenta' : 'default'}>Finish: {finishCount}/2</Tag>
+            <Tag color={totalHolds > 0 ? 'blue' : 'default'}>Total holds: {totalHolds}</Tag>
+            {totalHolds > 0 && (
+              <Button size="small" onClick={resetHolds}>
+                Clear All
+              </Button>
+            )}
+          </div>
         </div>
 
-        {/* Hold counts */}
-        <Flex gap={8} wrap="wrap" align="center">
-          <Tag color={startingCount > 0 ? 'green' : 'default'}>Starting: {startingCount}/2</Tag>
-          <Tag color={finishCount > 0 ? 'magenta' : 'default'}>Finish: {finishCount}/2</Tag>
-          <Tag color={totalHolds > 0 ? 'blue' : 'default'}>Total holds: {totalHolds}</Tag>
-          {totalHolds > 0 && (
-            <Button size="small" onClick={resetHolds}>
-              Clear All
-            </Button>
-          )}
-        </Flex>
-
-        {/* Form */}
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={handleSubmit}
-          initialValues={{
-            name: forkName ? `${forkName} fork` : '',
-            description: '',
-            isDraft: false,
-          }}
-        >
-          <Form.Item
-            name="name"
-            label="Climb Name"
-            rules={[{ required: true, message: 'Please enter a name for your climb' }]}
+        {/* Form Section */}
+        <div className={styles.formSection}>
+          <Form
+            form={form}
+            layout="vertical"
+            onFinish={handleSubmit}
+            initialValues={{
+              name: forkName ? `${forkName} fork` : '',
+              description: '',
+              isDraft: false,
+            }}
+            className={styles.formContent}
           >
-            <Input placeholder="Enter climb name" maxLength={100} />
-          </Form.Item>
-
-          <Form.Item name="description" label="Description">
-            <TextArea placeholder="Optional description or beta" rows={3} maxLength={500} />
-          </Form.Item>
-
-          <Form.Item name="isDraft" label="Save as Draft" valuePropName="checked">
-            <Switch />
-          </Form.Item>
-
-          <Space style={{ width: '100%' }} orientation="vertical">
-            <Button
-              type="primary"
-              htmlType="submit"
-              loading={isSaving}
-              disabled={!isValid || isSaving}
-              block
-              size="large"
+            <Form.Item
+              name="name"
+              label="Climb Name"
+              rules={[{ required: true, message: 'Please enter a name for your climb' }]}
             >
-              {isSaving ? 'Saving...' : 'Save Climb'}
-            </Button>
+              <Input placeholder="Enter climb name" maxLength={100} />
+            </Form.Item>
 
-            <Button block size="large" onClick={handleCancel} disabled={isSaving}>
-              Cancel
-            </Button>
-          </Space>
-        </Form>
-      </Flex>
+            <Form.Item name="description" label="Description">
+              <TextArea placeholder="Optional description or beta" rows={3} maxLength={500} />
+            </Form.Item>
+
+            <Form.Item name="isDraft" label="Save as Draft" valuePropName="checked">
+              <Switch />
+            </Form.Item>
+
+            <div className={styles.buttonGroup}>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={isSaving}
+                disabled={!isValid || isSaving}
+                block
+                size="large"
+              >
+                {isSaving ? 'Saving...' : 'Save Climb'}
+              </Button>
+
+              <Button block size="large" onClick={handleCancel} disabled={isSaving}>
+                Cancel
+              </Button>
+            </div>
+          </Form>
+        </div>
+      </div>
 
       {/* Aurora Login Modal */}
       <Modal
@@ -304,7 +311,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
         footer={null}
         destroyOnClose
       >
-        <Text type="secondary" style={{ display: 'block', marginBottom: '16px' }}>
+        <Text type="secondary" className={styles.modalDescription}>
           Please log in with your {boardDetails.board_name.charAt(0).toUpperCase() + boardDetails.board_name.slice(1)}{' '}
           Board account to save your climb.
         </Text>

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Form, Input, Switch, Button, Typography, Tag, Modal, Alert } from 'antd';
-import { BulbOutlined, BulbFilled, ExperimentOutlined } from '@ant-design/icons';
+import { ExperimentOutlined } from '@ant-design/icons';
 import { useRouter } from 'next/navigation';
 import { track } from '@vercel/analytics';
 import BoardRenderer from '../board-renderer/board-renderer';
@@ -12,11 +12,10 @@ import { useBoardBluetooth } from '../board-bluetooth-control/use-board-bluetoot
 import { BoardDetails } from '@/app/lib/types';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
-import '../board-bluetooth-control/send-climb-to-board-button.css';
 import styles from './create-climb-form.module.css';
 
 const { TextArea } = Input;
-const { Title, Text } = Typography;
+const { Text } = Typography;
 
 interface CreateClimbFormValues {
   name: string;
@@ -54,7 +53,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
     resetHolds: originalResetHolds,
   } = useCreateClimb(boardDetails.board_name, { initialHoldsMap });
 
-  const { isConnected, loading: bluetoothLoading, connect, sendFramesToBoard } = useBoardBluetooth({ boardDetails });
+  const { isConnected, sendFramesToBoard } = useBoardBluetooth({ boardDetails });
 
   const [form] = Form.useForm<CreateClimbFormValues>();
   const [loginForm] = Form.useForm<{ username: string; password: string }>();
@@ -88,12 +87,6 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
       sendFramesToBoard('');
     }
   }, [originalResetHolds, isConnected, sendFramesToBoard]);
-
-  // Handle Bluetooth connect button click
-  const handleBluetoothConnect = useCallback(async () => {
-    const frames = generateFramesString();
-    await connect(frames);
-  }, [connect, generateFramesString]);
 
   const doSaveClimb = async (values: CreateClimbFormValues) => {
     setIsSaving(true);
@@ -209,31 +202,9 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
         banner
       />
 
-      {/* Header Section */}
-      <div className={styles.headerSection}>
-        <div className={styles.headerContent}>
-          <Title level={4} className={styles.headerTitle}>
-            {forkName ? 'Fork Climb' : 'Create New Climb'}
-          </Title>
-          <Button
-            type="default"
-            icon={isConnected ? <BulbFilled className="connect-button-glow" /> : <BulbOutlined />}
-            onClick={handleBluetoothConnect}
-            loading={bluetoothLoading}
-            title={isConnected ? 'Connected to board' : 'Connect to board for live preview'}
-          >
-            {isConnected ? 'Connected' : 'Connect Board'}
-          </Button>
-        </div>
-      </div>
-
       <div className={styles.contentWrapper}>
         {/* Board Section */}
         <div className={styles.boardSection}>
-          <Text type="secondary" className={styles.boardInstructions}>
-            Tap holds to set their type. Tap again to cycle through types.
-            {isConnected && ' Changes are shown live on the board.'}
-          </Text>
           <BoardRenderer
             boardDetails={boardDetails}
             litUpHoldsMap={litUpHoldsMap}


### PR DESCRIPTION
- Create CSS module for create-climb-form to replace inline styles
- Match page structure with climb-view (pageContainer, white card sections)
- Add responsive media queries for mobile/tablet/desktop
- Improve desktop layout with side-by-side board and form sections
- Use consistent styling patterns from other pages