### PR TITLE
fix: Make grade and stars use same color as setter in ClimbTitle

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -109,7 +109,6 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       style={{
         fontSize: themeTokens.typography.fontSize.xs,
         fontWeight: themeTokens.typography.fontWeight.normal,
-        color: themeTokens.neutral[500],
         ...textOverflowStyles,
       }}
     >


### PR DESCRIPTION
Remove explicit neutral[500] color from gradeElement so it uses
the same secondary text color as the setter element, ensuring
consistent styling across all climb card metadata.