### PR TITLE
feat: Show Boardsesh text next to logo on desktop, hide on mobile

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -73,7 +73,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
         <Flex justify="space-between" align="center" style={{ width: '100%' }} gap={8}>
           {/* Logo - Fixed to left */}
           <Flex align="center">
-            <Logo size="sm" showText={false} />
+            <Logo size="sm" showText={true} hideTextOnMobile={true} />
           </Flex>
 
           {/* Center Section - Mobile only */}

--- a/packages/web/app/components/brand/logo.module.css
+++ b/packages/web/app/components/brand/logo.module.css
@@ -1,0 +1,21 @@
+.logoContainer {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.logoText {
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.hideTextOnMobile {
+  display: inline;
+}
+
+@media (max-width: 768px) {
+  .hideTextOnMobile {
+    display: none;
+  }
+}

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -3,10 +3,12 @@
 import React from 'react';
 import Link from 'next/link';
 import { themeTokens } from '@/app/theme/theme-config';
+import styles from './logo.module.css';
 
 type LogoProps = {
   size?: 'sm' | 'md' | 'lg';
   showText?: boolean;
+  hideTextOnMobile?: boolean;
   linkToHome?: boolean;
 };
 
@@ -16,18 +18,13 @@ const sizes = {
   lg: { icon: 36, fontSize: 20, gap: 10 },
 };
 
-export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) => {
+export const Logo = ({ size = 'md', showText = true, hideTextOnMobile = false, linkToHome = true }: LogoProps) => {
   const { icon, fontSize, gap } = sizes[size];
 
   const logoContent = (
     <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap,
-        textDecoration: 'none',
-        color: 'inherit',
-      }}
+      className={styles.logoContainer}
+      style={{ gap }}
     >
       <svg
         width={icon}
@@ -56,12 +53,11 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
       </svg>
       {showText && (
         <span
+          className={`${styles.logoText} ${hideTextOnMobile ? styles.hideTextOnMobile : ''}`}
           style={{
             fontSize,
             fontWeight: themeTokens.typography.fontWeight.bold,
             color: themeTokens.neutral[800],
-            letterSpacing: '-0.02em',
-            lineHeight: 1,
           }}
         >
           Boardsesh


### PR DESCRIPTION
Add responsive text visibility to the Logo component using CSS media queries. The header now displays the "Boardsesh" text next to the logo icon on desktop screens (>768px) and hides it on mobile for better space usage.