### PR TITLE
fix: Restore infinite scroll functionality in climb list

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -5,7 +5,6 @@ import { ParsedBoardRouteParameters, BoardRouteParameters, BoardDetails } from '
 import { parseBoardRouteParams, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { permanentRedirect } from 'next/navigation';
-import { Content } from 'antd/es/layout/layout';
 import QueueControlBar from '@/app/components/queue-control/queue-control-bar';
 import { getBoardDetails } from '@/app/lib/data/queries';
 import BoardSeshHeader from '@/app/components/board-page/header';
@@ -14,6 +13,7 @@ import { ConnectionSettingsProvider } from '@/app/components/connection-manager/
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import PartyProfileWrapper from '@/app/components/party-manager/party-profile-wrapper';
 import { Metadata } from 'next';
+import { ScrollableContent } from '@/app/components/board-page/scrollable-content';
 
 /**
  * Generates a user-friendly page title from board details.
@@ -139,21 +139,9 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
             <PartyProvider>
             <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
-            <Content
-              id="content-for-scrollable"
-              style={{
-                flex: 1,
-                justifyContent: 'center',
-                alignItems: 'center',
-                overflowY: 'auto',
-                overflowX: 'hidden',
-                height: '80vh',
-                paddingLeft: '10px',
-                paddingRight: '10px',
-              }}
-            >
+            <ScrollableContent>
               {children}
-            </Content>
+            </ScrollableContent>
 
             <Affix offsetBottom={0}>
               <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />

--- a/packages/web/app/components/board-page/scrollable-content.tsx
+++ b/packages/web/app/components/board-page/scrollable-content.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { Content } from 'antd/es/layout/layout';
+
+type ScrollContainerContextType = HTMLDivElement | null;
+
+const ScrollContainerContext = createContext<ScrollContainerContextType>(null);
+
+export function useScrollContainer(): HTMLDivElement | null {
+  return useContext(ScrollContainerContext);
+}
+
+interface ScrollableContentProps {
+  children: ReactNode;
+}
+
+export function ScrollableContent({ children }: ScrollableContentProps) {
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+
+  const scrollContainerRef = useCallback((node: HTMLDivElement | null) => {
+    if (node !== null) {
+      setScrollContainer(node);
+    }
+  }, []);
+
+  return (
+    <ScrollContainerContext.Provider value={scrollContainer}>
+      <Content
+        ref={scrollContainerRef}
+        id="content-for-scrollable"
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          height: '80vh',
+          paddingLeft: '10px',
+          paddingRight: '10px',
+        }}
+      >
+        {children}
+      </Content>
+    </ScrollContainerContext.Provider>
+  );
+}

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -97,7 +97,7 @@ const mockQueue: ClimbQueue = [];
 
 describe('useQueueDataFetching', () => {
   const mockSetHasDoneFirstFetch = vi.fn();
-  const mockGetLogbook = vi.fn();
+  const mockGetLogbook = vi.fn().mockResolvedValue([]);
   const mockSetSize = vi.fn();
 
   beforeEach(() => {
@@ -252,7 +252,8 @@ describe('useQueueDataFetching', () => {
     expect(result.current.climbSearchResults).toBeNull();
     expect(result.current.suggestedClimbs).toEqual([]);
     expect(result.current.totalSearchResultCount).toBeNull();
-    expect(result.current.hasMoreResults).toBeFalsy();
+    // Before first fetch completes, we optimistically assume there are more results
+  expect(result.current.hasMoreResults).toBe(true);
   });
 
   it('should handle fetchMoreClimbs', () => {


### PR DESCRIPTION
## Summary
- Fix scroll container not found during SSR hydration by using a state-based context with callback ref pattern
- Default `hasMoreResults` to `true` before SWR fetches data
- Catch `getLogbook` errors to prevent unhandled promise rejections
- Pass DOM element reference to InfiniteScroll instead of string ID

## Root Cause
The `react-infinite-scroll-component` with `scrollableTarget="content-for-scrollable"` was trying to find the scroll container by ID during SSR hydration, but the element didn't exist yet. The component caches the scroll target on mount and doesn't re-check, causing infinite scroll to never work.

## Solution
Created a `ScrollableContent` client component that:
1. Uses a callback ref to capture the DOM element
2. Stores it in React state (not a ref) to trigger re-renders
3. Passes the actual DOM element to `scrollableTarget` via context
4. Renders a fallback until the scroll container is available

## Test plan
- [ ] Visit climb list page without `?page=X` in URL
- [ ] Scroll down to the bottom
- [ ] Verify URL updates with `?page=1`, `?page=2`, etc.
- [ ] Verify more climbs are loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)