### PR TITLE
fix: Default hasMoreResults to true until data is loaded

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -126,6 +126,21 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
     }
   }, [page, hasDoneFirstFetch, isFetchingClimbs]); // Depend on the page query parameter
 
+  // Auto-trigger load when content doesn't fill the scroll container
+  // This handles the case where initial climbs don't fill the viewport
+  useEffect(() => {
+    if (!hasMoreResults || isFetchingClimbs) return;
+
+    const scrollContainer = document.getElementById('content-for-scrollable');
+    if (!scrollContainer) return;
+
+    // Check if content doesn't fill the container (no scrollbar needed)
+    const needsMoreContent = scrollContainer.scrollHeight <= scrollContainer.clientHeight;
+    if (needsMoreContent) {
+      fetchMoreClimbs();
+    }
+  }, [hasMoreResults, isFetchingClimbs, climbs.length, fetchMoreClimbs]);
+
   return (
     <InfiniteScroll
       dataLength={climbs.length}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -126,6 +126,30 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
     }
   }, [page, hasDoneFirstFetch, isFetchingClimbs]); // Depend on the page query parameter
 
+  // Auto-trigger load when content doesn't fill the scroll container
+  const wasFetchingRef = useRef(isFetchingClimbs);
+
+  useEffect(() => {
+    const wasFetching = wasFetchingRef.current;
+    wasFetchingRef.current = isFetchingClimbs;
+
+    // Only check when fetch just completed (was fetching, now not)
+    // OR on initial mount when not fetching
+    const fetchJustCompleted = wasFetching && !isFetchingClimbs;
+    const isInitialCheck = !wasFetching && !isFetchingClimbs && climbs.length > 0;
+
+    if (!hasMoreResults || isFetchingClimbs) return;
+    if (!fetchJustCompleted && !isInitialCheck) return;
+
+    const scrollContainer = document.getElementById('content-for-scrollable');
+    if (!scrollContainer) return;
+
+    const needsMoreContent = scrollContainer.scrollHeight <= scrollContainer.clientHeight;
+    if (needsMoreContent) {
+      fetchMoreClimbs();
+    }
+  }, [hasMoreResults, isFetchingClimbs, climbs.length, fetchMoreClimbs]);
+
   return (
     <InfiniteScroll
       dataLength={climbs.length}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -126,21 +126,6 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
     }
   }, [page, hasDoneFirstFetch, isFetchingClimbs]); // Depend on the page query parameter
 
-  // Auto-trigger load when content doesn't fill the scroll container
-  // This handles the case where initial climbs don't fill the viewport
-  useEffect(() => {
-    if (!hasMoreResults || isFetchingClimbs) return;
-
-    const scrollContainer = document.getElementById('content-for-scrollable');
-    if (!scrollContainer) return;
-
-    // Check if content doesn't fill the container (no scrollbar needed)
-    const needsMoreContent = scrollContainer.scrollHeight <= scrollContainer.clientHeight;
-    if (needsMoreContent) {
-      fetchMoreClimbs();
-    }
-  }, [hasMoreResults, isFetchingClimbs, climbs.length, fetchMoreClimbs]);
-
   return (
     <InfiniteScroll
       dataLength={climbs.length}

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -19,11 +19,13 @@ html, body {
 }
 
 /* Prevent horizontal scroll on layout components */
-.ant-layout,
-.ant-layout-content {
+.ant-layout {
   max-width: 100%;
   overflow-x: hidden;
 }
+
+/* Note: .ant-layout-content overflow is controlled by inline styles on #content-for-scrollable
+   to enable proper infinite scroll detection. Do not set overflow here. */
 
 /* Prevent double-tap zoom globally while preserving pinch-to-zoom */
 html {

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -63,7 +63,9 @@ export const useQueueDataFetching = ({
 
   // When data exists, calculate normally. Otherwise default to true while loading
   // (so infinite scroll works during SSR hydration), or false after loading completes with no data
-  const hasMoreResults = data?.[0] ? size * PAGE_LIMIT < data[0].totalCount : isFetchingClimbs;
+  const hasMoreResults = data?.[0]?.totalCount !== undefined
+    ? size * PAGE_LIMIT < data[0].totalCount
+    : Boolean(isFetchingClimbs);
   const totalSearchResultCount = (data && data[0] && data[0].totalCount) || null;
 
   const climbSearchResults = useMemo(

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -61,7 +61,9 @@ export const useQueueDataFetching = ({
     initialSize: searchParams.page ? searchParams.page + 1 : 1,
   });
 
-  const hasMoreResults = data && data[0] && size * PAGE_LIMIT < data[0].totalCount;
+  // When data exists, calculate normally. Otherwise default to true while loading
+  // (so infinite scroll works during SSR hydration), or false after loading completes with no data
+  const hasMoreResults = data?.[0] ? size * PAGE_LIMIT < data[0].totalCount : isFetchingClimbs;
   const totalSearchResultCount = (data && data[0] && data[0].totalCount) || null;
 
   const climbSearchResults = useMemo(


### PR DESCRIPTION
The infinite scroll trigger was broken because hasMoreResults returned
undefined (falsy) when SWR data hadn't loaded yet. This prevented the
InfiniteScroll component from triggering the next fetch.

When using SSR initialClimbs, the client-side SWR fetch hasn't completed
yet, so hasMoreResults was undefined. Now it defaults to true until
we have actual data to determine the correct value.