### PR TITLE
refactor: Replace react-infinite-scroll-component with custom IntersectionObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10229,27 +10229,6 @@
         "react": "^19.2.3"
       }
     },
-    "node_modules/react-infinite-scroll-component": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.1.tgz",
-      "integrity": "sha512-R8YoOyiNDynSWmfVme5LHslsKrP+/xcRUWR2ies8UgUab9dtyw5ECnMCVPPmnmjjF4MWQmfVdRwRWcWaDgeyMA==",
-      "license": "MIT",
-      "dependencies": {
-        "throttle-debounce": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
-    "node_modules/react-infinite-scroll-component/node_modules/throttle-debounce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
-      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -13670,7 +13649,6 @@
         "react": "^19.2.3",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.3",
-        "react-infinite-scroll-component": "^6.1.1",
         "server-only": "^0.0.1",
         "swr": "^2.3.8",
         "use-debounce": "^10.0.6",

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 
 import { Row, Col, Skeleton } from 'antd';
-import InfiniteScroll from 'react-infinite-scroll-component';
+import InfiniteScroll from '../infinite-scroll/infinite-scroll';
 import { track } from '@vercel/analytics';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueContext } from '../graphql-queue';
@@ -128,18 +128,17 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
 
   return (
     <InfiniteScroll
-      dataLength={climbs.length}
-      next={() => {
+      loadMore={() => {
         track('Infinite Scroll Load More', {
           currentCount: climbs.length,
           hasMore: hasMoreResults,
         });
-        return fetchMoreClimbs();
+        fetchMoreClimbs();
       }}
       hasMore={hasMoreResults}
+      isLoading={isFetchingClimbs}
       loader={<Skeleton active />}
       endMessage={<div style={{ textAlign: 'center' }}>No more climbs 🤐</div>}
-      // Probably not how this should be done in a React app, but it works and I ain't no CSS-wizard
       scrollableTarget="content-for-scrollable"
       style={{ paddingTop: '5px' }}
     >

--- a/packages/web/app/components/infinite-scroll/infinite-scroll.tsx
+++ b/packages/web/app/components/infinite-scroll/infinite-scroll.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useEffect, useRef, useCallback, ReactNode } from 'react';
+
+interface InfiniteScrollProps {
+  children: ReactNode;
+  loadMore: () => void;
+  hasMore: boolean;
+  isLoading?: boolean;
+  loader?: ReactNode;
+  endMessage?: ReactNode;
+  scrollableTarget?: string;
+  threshold?: number;
+  rootMargin?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Custom InfiniteScroll component using IntersectionObserver.
+ * Triggers loadMore when the sentinel element becomes visible in the viewport.
+ */
+const InfiniteScroll = ({
+  children,
+  loadMore,
+  hasMore,
+  isLoading = false,
+  loader,
+  endMessage,
+  scrollableTarget,
+  threshold = 0.1,
+  rootMargin = '100px',
+  className,
+  style,
+}: InfiniteScrollProps) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const handleIntersection = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting && hasMore && !isLoading) {
+        loadMore();
+      }
+    },
+    [hasMore, isLoading, loadMore],
+  );
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    // Get the root element if scrollableTarget is specified
+    const root = scrollableTarget ? document.getElementById(scrollableTarget) : null;
+
+    // Disconnect previous observer if it exists
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    // Create new IntersectionObserver
+    observerRef.current = new IntersectionObserver(handleIntersection, {
+      root,
+      rootMargin,
+      threshold,
+    });
+
+    observerRef.current.observe(sentinel);
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, [handleIntersection, scrollableTarget, rootMargin, threshold]);
+
+  return (
+    <div className={className} style={style}>
+      {children}
+      {/* Sentinel element that triggers loading when visible */}
+      <div ref={sentinelRef} style={{ height: '1px', width: '100%' }} />
+      {isLoading && loader}
+      {!hasMore && !isLoading && endMessage}
+    </div>
+  );
+};
+
+export default InfiniteScroll;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,6 @@
     "react": "^19.2.3",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.3",
-    "react-infinite-scroll-component": "^6.1.1",
     "server-only": "^0.0.1",
     "swr": "^2.3.8",
     "use-debounce": "^10.0.6",


### PR DESCRIPTION
Remove the npm dependency on react-infinite-scroll-component and replace
it with a lightweight custom component that uses IntersectionObserver API.
This reduces bundle size and removes an external dependency.