### PR TITLE
feat: Redesign logo with "BS" letters in 90s cyan/pink style

### DIFF
--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -16,9 +16,9 @@ const KILTER_PINK = '#FF00FF'; // Finish hold color
 const BG_COLOR = '#0a0a14'; // Dark background
 
 const sizes = {
-  sm: { icon: 28, fontSize: 14, gap: 6 },
-  md: { icon: 34, fontSize: 16, gap: 8 },
-  lg: { icon: 44, fontSize: 20, gap: 10 },
+  sm: { icon: 32, fontSize: 14, gap: 6 },
+  md: { icon: 40, fontSize: 16, gap: 8 },
+  lg: { icon: 52, fontSize: 20, gap: 10 },
 };
 
 // Pixel art letter definitions (each letter on a grid)

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -13,6 +13,7 @@ type LogoProps = {
 // 90s vibe colors from Kilter board holds
 const KILTER_CYAN = '#00FFFF'; // Hand hold color
 const KILTER_PINK = '#FF00FF'; // Finish hold color
+const BG_COLOR = '#0a0a14'; // Dark background
 
 const sizes = {
   sm: { icon: 28, fontSize: 14, gap: 6 },
@@ -20,8 +21,68 @@ const sizes = {
   lg: { icon: 44, fontSize: 20, gap: 10 },
 };
 
+// Pixel art letter definitions (each letter on a grid)
+// B letter - 7 wide x 9 tall pixels
+const B_PIXELS = [
+  [1, 1, 1, 1, 1, 1, 0],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 0, 1, 1],
+  [1, 1, 1, 1, 1, 1, 0],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 0, 1, 1],
+  [1, 1, 0, 0, 0, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 0],
+];
+
+// S letter - 7 wide x 9 tall pixels
+const S_PIXELS = [
+  [0, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 0, 0, 0, 0, 0],
+  [1, 1, 1, 1, 1, 1, 0],
+  [0, 1, 1, 1, 1, 1, 1],
+  [0, 0, 0, 0, 0, 1, 1],
+  [0, 0, 0, 0, 0, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 0],
+];
+
+const PixelLetter = ({
+  pixels,
+  startX,
+  startY,
+  pixelSize,
+  fill,
+}: {
+  pixels: number[][];
+  startX: number;
+  startY: number;
+  pixelSize: number;
+  fill: string;
+}) => (
+  <>
+    {pixels.map((row, y) =>
+      row.map((pixel, x) =>
+        pixel ? (
+          <rect
+            key={`${x}-${y}`}
+            x={startX + x * pixelSize}
+            y={startY + y * pixelSize}
+            width={pixelSize}
+            height={pixelSize}
+            fill={fill}
+          />
+        ) : null,
+      ),
+    )}
+  </>
+);
+
 export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) => {
   const { icon, fontSize, gap } = sizes[size];
+  const pixelSize = 3;
+  const shadowOffset = 2;
 
   const logoContent = (
     <div
@@ -41,91 +102,20 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Boardsesh logo"
       >
-        <defs>
-          {/* Gradient for 90s vibe */}
-          <linearGradient id="bs-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor={KILTER_CYAN} />
-            <stop offset="100%" stopColor={KILTER_PINK} />
-          </linearGradient>
-          <linearGradient id="bs-gradient-reverse" x1="100%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor={KILTER_PINK} />
-            <stop offset="100%" stopColor={KILTER_CYAN} />
-          </linearGradient>
-        </defs>
+        {/* Background */}
+        <rect x="0" y="0" width="48" height="48" rx="4" fill={BG_COLOR} />
 
-        {/* Background with rounded corners */}
-        <rect x="2" y="2" width="44" height="44" rx="6" fill="#0d0d1a" />
+        {/* Pink shadow layer for B */}
+        <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* Diagonal stripes background - 90s pattern */}
-        <g clipPath="url(#bg-clip)">
-          <clipPath id="bg-clip">
-            <rect x="2" y="2" width="44" height="44" rx="6" />
-          </clipPath>
-          <line x1="0" y1="48" x2="16" y2="0" stroke={KILTER_CYAN} strokeWidth="1" opacity="0.15" />
-          <line x1="16" y1="48" x2="32" y2="0" stroke={KILTER_PINK} strokeWidth="1" opacity="0.15" />
-          <line x1="32" y1="48" x2="48" y2="0" stroke={KILTER_CYAN} strokeWidth="1" opacity="0.15" />
-        </g>
+        {/* Pink shadow layer for S */}
+        <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* Geometric accent shapes */}
-        <polygon points="2,2 14,2 2,14" fill={KILTER_CYAN} opacity="0.8" />
-        <polygon points="46,46 34,46 46,34" fill={KILTER_PINK} opacity="0.8" />
+        {/* Cyan B letter */}
+        <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
 
-        {/* "B" shadow layer - offset for 90s depth effect */}
-        <text
-          x="10"
-          y="36"
-          fontFamily="Impact, Arial Black, sans-serif"
-          fontSize="32"
-          fontWeight="900"
-          fill="#000"
-          opacity="0.5"
-        >
-          B
-        </text>
-
-        {/* "B" main letter */}
-        <text
-          x="8"
-          y="34"
-          fontFamily="Impact, Arial Black, sans-serif"
-          fontSize="32"
-          fontWeight="900"
-          fill={KILTER_CYAN}
-          stroke="#000"
-          strokeWidth="1"
-        >
-          B
-        </text>
-
-        {/* "S" shadow layer */}
-        <text
-          x="26"
-          y="38"
-          fontFamily="Impact, Arial Black, sans-serif"
-          fontSize="32"
-          fontWeight="900"
-          fill="#000"
-          opacity="0.5"
-        >
-          S
-        </text>
-
-        {/* "S" main letter - slightly overlapping B */}
-        <text
-          x="24"
-          y="36"
-          fontFamily="Impact, Arial Black, sans-serif"
-          fontSize="32"
-          fontWeight="900"
-          fill={KILTER_PINK}
-          stroke="#000"
-          strokeWidth="1"
-        >
-          S
-        </text>
-
-        {/* Bottom accent bar with gradient */}
-        <rect x="4" y="42" width="40" height="3" rx="1.5" fill="url(#bs-gradient)" />
+        {/* Cyan S letter */}
+        <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -13,7 +13,6 @@ type LogoProps = {
 // 90s vibe colors from Kilter board holds
 const KILTER_CYAN = '#00FFFF'; // Hand hold color
 const KILTER_PINK = '#FF00FF'; // Finish hold color
-const BG_COLOR = '#0a0a14'; // Dark background
 
 const sizes = {
   sm: { icon: 32, fontSize: 14, gap: 6 },
@@ -102,8 +101,8 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Boardsesh logo"
       >
-        {/* Background */}
-        <rect x="0" y="0" width="48" height="48" rx="4" fill={BG_COLOR} />
+        {/* Transparent background */}
+        <rect x="0" y="0" width="48" height="48" rx="4" fill="transparent" />
 
         {/* Pink shadow layer for B */}
         <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -104,21 +104,13 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         {/* Transparent background */}
         <rect x="0" y="0" width="48" height="48" rx="4" fill="transparent" />
 
-        {/* B letter - straight */}
-        <g>
-          {/* Pink shadow layer for B */}
-          <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
-          {/* Cyan B letter */}
-          <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
-        </g>
+        {/* Pink shadow layers */}
+        <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
+        <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* S letter - rotated -10 degrees for playfulness */}
-        <g transform="rotate(-10, 34.5, 19.5)">
-          {/* Pink shadow layer for S */}
-          <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
-          {/* Cyan S letter */}
-          <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
-        </g>
+        {/* Cyan letters */}
+        <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -104,17 +104,18 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         {/* Transparent background */}
         <rect x="0" y="0" width="48" height="48" rx="4" fill="transparent" />
 
-        {/* Rotated group for playfulness */}
-        <g transform="rotate(-20, 24, 24)">
+        {/* B letter - straight */}
+        <g>
           {/* Pink shadow layer for B */}
           <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
-
-          {/* Pink shadow layer for S */}
-          <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
-
           {/* Cyan B letter */}
           <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        </g>
 
+        {/* S letter - rotated -10 degrees for playfulness */}
+        <g transform="rotate(-10, 34.5, 19.5)">
+          {/* Pink shadow layer for S */}
+          <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
           {/* Cyan S letter */}
           <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
         </g>

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -15,9 +15,9 @@ const KILTER_CYAN = '#00FFFF'; // Hand hold color
 const KILTER_PINK = '#FF00FF'; // Finish hold color
 
 const sizes = {
-  sm: { icon: 24, fontSize: 14, gap: 6 },
-  md: { icon: 28, fontSize: 16, gap: 8 },
-  lg: { icon: 36, fontSize: 20, gap: 10 },
+  sm: { icon: 28, fontSize: 14, gap: 6 },
+  md: { icon: 34, fontSize: 16, gap: 8 },
+  lg: { icon: 44, fontSize: 20, gap: 10 },
 };
 
 export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) => {
@@ -47,47 +47,85 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
             <stop offset="0%" stopColor={KILTER_CYAN} />
             <stop offset="100%" stopColor={KILTER_PINK} />
           </linearGradient>
-          {/* Drop shadow filter */}
-          <filter id="bs-shadow" x="-20%" y="-20%" width="140%" height="140%">
-            <feDropShadow dx="1" dy="1" stdDeviation="0.5" floodColor="#000" floodOpacity="0.4" />
-          </filter>
+          <linearGradient id="bs-gradient-reverse" x1="100%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stopColor={KILTER_PINK} />
+            <stop offset="100%" stopColor={KILTER_CYAN} />
+          </linearGradient>
         </defs>
 
         {/* Background with rounded corners */}
-        <rect x="2" y="2" width="44" height="44" rx="8" fill="#1a1a2e" />
+        <rect x="2" y="2" width="44" height="44" rx="6" fill="#0d0d1a" />
 
-        {/* Decorative corner triangles - 90s geometric style */}
-        <polygon points="2,10 2,2 10,2" fill={KILTER_CYAN} opacity="0.6" />
-        <polygon points="46,38 46,46 38,46" fill={KILTER_PINK} opacity="0.6" />
+        {/* Diagonal stripes background - 90s pattern */}
+        <g clipPath="url(#bg-clip)">
+          <clipPath id="bg-clip">
+            <rect x="2" y="2" width="44" height="44" rx="6" />
+          </clipPath>
+          <line x1="0" y1="48" x2="16" y2="0" stroke={KILTER_CYAN} strokeWidth="1" opacity="0.15" />
+          <line x1="16" y1="48" x2="32" y2="0" stroke={KILTER_PINK} strokeWidth="1" opacity="0.15" />
+          <line x1="32" y1="48" x2="48" y2="0" stroke={KILTER_CYAN} strokeWidth="1" opacity="0.15" />
+        </g>
 
-        {/* Bold "B" letter - clean geometric style */}
+        {/* Geometric accent shapes */}
+        <polygon points="2,2 14,2 2,14" fill={KILTER_CYAN} opacity="0.8" />
+        <polygon points="46,46 34,46 46,34" fill={KILTER_PINK} opacity="0.8" />
+
+        {/* "B" shadow layer - offset for 90s depth effect */}
         <text
-          x="8"
-          y="35"
-          fontFamily="Arial Black, Arial, sans-serif"
-          fontSize="28"
+          x="10"
+          y="36"
+          fontFamily="Impact, Arial Black, sans-serif"
+          fontSize="32"
           fontWeight="900"
-          fill={KILTER_CYAN}
-          filter="url(#bs-shadow)"
+          fill="#000"
+          opacity="0.5"
         >
           B
         </text>
 
-        {/* Bold "S" letter - offset for depth effect */}
+        {/* "B" main letter */}
         <text
-          x="24"
-          y="35"
-          fontFamily="Arial Black, Arial, sans-serif"
-          fontSize="28"
+          x="8"
+          y="34"
+          fontFamily="Impact, Arial Black, sans-serif"
+          fontSize="32"
           fontWeight="900"
-          fill={KILTER_PINK}
-          filter="url(#bs-shadow)"
+          fill={KILTER_CYAN}
+          stroke="#000"
+          strokeWidth="1"
+        >
+          B
+        </text>
+
+        {/* "S" shadow layer */}
+        <text
+          x="26"
+          y="38"
+          fontFamily="Impact, Arial Black, sans-serif"
+          fontSize="32"
+          fontWeight="900"
+          fill="#000"
+          opacity="0.5"
         >
           S
         </text>
 
-        {/* Accent line - 90s style */}
-        <rect x="2" y="42" width="44" height="4" rx="2" fill="url(#bs-gradient)" />
+        {/* "S" main letter - slightly overlapping B */}
+        <text
+          x="24"
+          y="36"
+          fontFamily="Impact, Arial Black, sans-serif"
+          fontSize="32"
+          fontWeight="900"
+          fill={KILTER_PINK}
+          stroke="#000"
+          strokeWidth="1"
+        >
+          S
+        </text>
+
+        {/* Bottom accent bar with gradient */}
+        <rect x="4" y="42" width="40" height="3" rx="1.5" fill="url(#bs-gradient)" />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -104,17 +104,17 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         {/* Transparent background */}
         <rect x="0" y="0" width="48" height="48" rx="4" fill="transparent" />
 
-        {/* Pink shadow layer for B */}
-        <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
+        {/* Cyan shadow layer for B */}
+        <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_CYAN} />
 
-        {/* Pink shadow layer for S */}
-        <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
+        {/* Cyan shadow layer for S */}
+        <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_CYAN} />
 
-        {/* Cyan B letter */}
-        <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        {/* Pink B letter */}
+        <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* Cyan S letter */}
-        <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        {/* Pink S letter */}
+        <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_PINK} />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -10,6 +10,10 @@ type LogoProps = {
   linkToHome?: boolean;
 };
 
+// 90s vibe colors from Kilter board holds
+const KILTER_CYAN = '#00FFFF'; // Hand hold color
+const KILTER_PINK = '#FF00FF'; // Finish hold color
+
 const sizes = {
   sm: { icon: 24, fontSize: 14, gap: 6 },
   md: { icon: 28, fontSize: 16, gap: 8 },
@@ -37,22 +41,53 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Boardsesh logo"
       >
-        {/* Board background with rounded corners */}
-        <rect x="2" y="2" width="44" height="44" rx="8" fill={themeTokens.colors.primary} />
+        <defs>
+          {/* Gradient for 90s vibe */}
+          <linearGradient id="bs-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor={KILTER_CYAN} />
+            <stop offset="100%" stopColor={KILTER_PINK} />
+          </linearGradient>
+          {/* Drop shadow filter */}
+          <filter id="bs-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="1" dy="1" stdDeviation="0.5" floodColor="#000" floodOpacity="0.4" />
+          </filter>
+        </defs>
 
-        {/* Climbing holds pattern - arranged like a real board */}
-        {/* Top row */}
-        <circle cx="14" cy="12" r="4" fill={themeTokens.semantic.selected} />
-        <circle cx="34" cy="14" r="3.5" fill={themeTokens.semantic.selected} />
+        {/* Background with rounded corners */}
+        <rect x="2" y="2" width="44" height="44" rx="8" fill="#1a1a2e" />
 
-        {/* Middle section */}
-        <circle cx="24" cy="22" r="5" fill={themeTokens.semantic.selected} />
-        <circle cx="10" cy="26" r="3" fill={themeTokens.semantic.selected} />
-        <circle cx="38" cy="28" r="3.5" fill={themeTokens.semantic.selected} />
+        {/* Decorative corner triangles - 90s geometric style */}
+        <polygon points="2,10 2,2 10,2" fill={KILTER_CYAN} opacity="0.6" />
+        <polygon points="46,38 46,46 38,46" fill={KILTER_PINK} opacity="0.6" />
 
-        {/* Bottom row */}
-        <circle cx="18" cy="38" r="4" fill={themeTokens.semantic.selected} />
-        <circle cx="32" cy="36" r="3" fill={themeTokens.semantic.selected} />
+        {/* Bold "B" letter - clean geometric style */}
+        <text
+          x="8"
+          y="35"
+          fontFamily="Arial Black, Arial, sans-serif"
+          fontSize="28"
+          fontWeight="900"
+          fill={KILTER_CYAN}
+          filter="url(#bs-shadow)"
+        >
+          B
+        </text>
+
+        {/* Bold "S" letter - offset for depth effect */}
+        <text
+          x="24"
+          y="35"
+          fontFamily="Arial Black, Arial, sans-serif"
+          fontSize="28"
+          fontWeight="900"
+          fill={KILTER_PINK}
+          filter="url(#bs-shadow)"
+        >
+          S
+        </text>
+
+        {/* Accent line - 90s style */}
+        <rect x="2" y="42" width="44" height="4" rx="2" fill="url(#bs-gradient)" />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -104,17 +104,20 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
         {/* Transparent background */}
         <rect x="0" y="0" width="48" height="48" rx="4" fill="transparent" />
 
-        {/* Cyan shadow layer for B */}
-        <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        {/* Rotated group for playfulness */}
+        <g transform="rotate(-20, 24, 24)">
+          {/* Pink shadow layer for B */}
+          <PixelLetter pixels={B_PIXELS} startX={3 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* Cyan shadow layer for S */}
-        <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_CYAN} />
+          {/* Pink shadow layer for S */}
+          <PixelLetter pixels={S_PIXELS} startX={24 + shadowOffset} startY={6 + shadowOffset} pixelSize={pixelSize} fill={KILTER_PINK} />
 
-        {/* Pink B letter */}
-        <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_PINK} />
+          {/* Cyan B letter */}
+          <PixelLetter pixels={B_PIXELS} startX={3} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
 
-        {/* Pink S letter */}
-        <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_PINK} />
+          {/* Cyan S letter */}
+          <PixelLetter pixels={S_PIXELS} startX={24} startY={6} pixelSize={pixelSize} fill={KILTER_CYAN} />
+        </g>
       </svg>
       {showText && (
         <span


### PR DESCRIPTION
Use Kilter board hold colors for a retro 90s vibe:
- Cyan (#00FFFF) for "B" - matches hand hold color
- Pink/Magenta (#FF00FF) for "S" - matches finish hold color
- Dark background with geometric corner accents
- Gradient accent bar at bottom