### PR TITLE
refactor: Redesign ClimbCard title with large V grade on right

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -126,11 +126,11 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
   const largeGradeElement = vGrade && (
     <Text
+      type="secondary"
       style={{
         fontSize: 28,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
-        color: themeTokens.neutral[500],
       }}
     >
       {vGrade}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -126,11 +126,11 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
   const largeGradeElement = vGrade && (
     <Text
-      type="secondary"
       style={{
         fontSize: 28,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
+        color: 'var(--ant-color-text-secondary)',
       }}
     >
       {vGrade}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -73,15 +73,6 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       }
     : {};
 
-  const renderQualityText = () => {
-    if (hasGrade) {
-      const baseText = `${climb.quality_average}★`;
-      return showAngle ? `${baseText} @ ${climb.angle}°` : baseText;
-    }
-    const projectText = showAngle ? `project @ ${climb.angle}°` : 'project';
-    return <span style={{ fontStyle: 'italic' }}>{projectText}</span>;
-  };
-
   const renderDifficultyText = () => {
     if (hasGrade) {
       const baseText = `${climb.difficulty} ${climb.quality_average}★`;
@@ -122,19 +113,6 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       }}
     >
       {renderDifficultyText()}
-    </Text>
-  );
-
-  const qualityElement = (
-    <Text
-      type="secondary"
-      style={{
-        fontSize: themeTokens.typography.fontSize.xs,
-        fontWeight: themeTokens.typography.fontWeight.normal,
-        ...textOverflowStyles,
-      }}
-    >
-      {renderQualityText()}
     </Text>
   );
 

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -144,7 +144,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         fontSize: 28,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
-        color: themeTokens.colors.textSecondary,
+        color: themeTokens.neutral[500],
       }}
     >
       {climb.difficulty}
@@ -165,21 +165,39 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   );
 
   if (layout === 'horizontal') {
+    const secondLineContent = [];
+    if (hasGrade) {
+      secondLineContent.push(`${climb.quality_average}★`);
+    }
+    if (showSetterInfo && climb.setter_username) {
+      secondLineContent.push(`${climb.setter_username}`);
+    }
+    if (climb.ascensionist_count !== undefined) {
+      secondLineContent.push(`${climb.ascensionist_count} ascents`);
+    }
+
     return (
       <Flex gap={12} align="center" className={className}>
-        {/* Left side: Name, quality, and setter stacked */}
+        {/* Left side: Name and quality/setter stacked */}
         <Flex vertical gap={0} style={{ flex: 1, minWidth: 0 }}>
           {/* Row 1: Name with addon */}
           <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
             {nameElement}
             {nameAddon}
           </div>
-          {/* Row 2: Quality/stars */}
-          {qualityElement}
-          {/* Row 3 (optional): Setter info */}
-          {setterElement}
+          {/* Row 2: Quality, setter, ascents */}
+          <Text
+            type="secondary"
+            style={{
+              fontSize: themeTokens.typography.fontSize.xs,
+              fontWeight: themeTokens.typography.fontWeight.normal,
+              ...textOverflowStyles,
+            }}
+          >
+            {secondLineContent.length > 0 ? secondLineContent.join(' · ') : <span style={{ fontStyle: 'italic' }}>project</span>}
+          </Text>
         </Flex>
-        {/* Right side: Large V grade spanning all rows */}
+        {/* Right side: Large V grade spanning both rows */}
         {largeGradeElement}
       </Flex>
     );

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -65,6 +65,14 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   const hasGrade = climb.difficulty && climb.quality_average && climb.quality_average !== '0';
   const isBenchmark = climb.benchmark_difficulty !== null && climb.benchmark_difficulty !== undefined;
 
+  // Extract V grade from difficulty string (e.g., "6a/V3" -> "V3", "V5" -> "V5")
+  const getVGrade = (difficulty: string): string | null => {
+    const vGradeMatch = difficulty.match(/V\d+/i);
+    return vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
+  };
+
+  const vGrade = climb.difficulty ? getVGrade(climb.difficulty) : null;
+
   const textOverflowStyles = ellipsis
     ? {
         whiteSpace: 'nowrap' as const,
@@ -116,7 +124,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     </Text>
   );
 
-  const largeGradeElement = climb.difficulty && (
+  const largeGradeElement = vGrade && (
     <Text
       style={{
         fontSize: 28,
@@ -125,7 +133,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         color: themeTokens.neutral[500],
       }}
     >
-      {climb.difficulty}
+      {vGrade}
     </Text>
   );
 
@@ -145,7 +153,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   if (layout === 'horizontal') {
     const secondLineContent = [];
     if (hasGrade) {
-      secondLineContent.push(`${climb.quality_average}★`);
+      secondLineContent.push(`${climb.difficulty} ${climb.quality_average}★`);
     }
     if (showSetterInfo && climb.setter_username) {
       secondLineContent.push(`${climb.setter_username}`);

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -73,6 +73,15 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       }
     : {};
 
+  const renderQualityText = () => {
+    if (hasGrade) {
+      const baseText = `${climb.quality_average}★`;
+      return showAngle ? `${baseText} @ ${climb.angle}°` : baseText;
+    }
+    const projectText = showAngle ? `project @ ${climb.angle}°` : 'project';
+    return <span style={{ fontStyle: 'italic' }}>{projectText}</span>;
+  };
+
   const renderDifficultyText = () => {
     if (hasGrade) {
       const baseText = `${climb.difficulty} ${climb.quality_average}★`;
@@ -116,6 +125,32 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     </Text>
   );
 
+  const qualityElement = (
+    <Text
+      type="secondary"
+      style={{
+        fontSize: themeTokens.typography.fontSize.xs,
+        fontWeight: themeTokens.typography.fontWeight.normal,
+        ...textOverflowStyles,
+      }}
+    >
+      {renderQualityText()}
+    </Text>
+  );
+
+  const largeGradeElement = climb.difficulty && (
+    <Text
+      style={{
+        fontSize: 28,
+        fontWeight: themeTokens.typography.fontWeight.bold,
+        lineHeight: 1,
+        color: themeTokens.colors.textSecondary,
+      }}
+    >
+      {climb.difficulty}
+    </Text>
+  );
+
   const setterElement = showSetterInfo && climb.setter_username && (
     <Text
       type="secondary"
@@ -131,17 +166,21 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
   if (layout === 'horizontal') {
     return (
-      <Flex vertical gap={0} className={className}>
-        {/* Row 1: Name (left) with addon, Grade (right) */}
-        <Flex justify="space-between" align="center">
+      <Flex gap={12} align="center" className={className}>
+        {/* Left side: Name, quality, and setter stacked */}
+        <Flex vertical gap={0} style={{ flex: 1, minWidth: 0 }}>
+          {/* Row 1: Name with addon */}
           <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
             {nameElement}
             {nameAddon}
           </div>
-          {gradeElement}
+          {/* Row 2: Quality/stars */}
+          {qualityElement}
+          {/* Row 3 (optional): Setter info */}
+          {setterElement}
         </Flex>
-        {/* Row 2 (optional): Setter info */}
-        {setterElement}
+        {/* Right side: Large V grade spanning all rows */}
+        {largeGradeElement}
       </Flex>
     );
   }


### PR DESCRIPTION
Move quality/stars to second line and add a large V grade element
floated to the right that spans the full height of the title section.