### PR TITLE
feat: Add heart/favorite button for climbs with auth modal

### DIFF
--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -1,0 +1,155 @@
+import { getServerSession } from "next-auth/next";
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/app/lib/db/db";
+import * as schema from "@/app/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import { authOptions } from "@/app/lib/auth/auth-options";
+
+const favoriteSchema = z.object({
+  boardName: z.enum(["kilter", "tension", "decoy"]),
+  climbUuid: z.string().min(1),
+  angle: z.number().int(),
+});
+
+const checkFavoriteSchema = z.object({
+  boardName: z.enum(["kilter", "tension", "decoy"]),
+  climbUuids: z.array(z.string().min(1)),
+  angle: z.number().int(),
+});
+
+// POST: Toggle favorite (add or remove)
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const validationResult = favoriteSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { boardName, climbUuid, angle } = validationResult.data;
+    const db = getDb();
+
+    // Check if favorite already exists
+    const existing = await db
+      .select()
+      .from(schema.userFavorites)
+      .where(
+        and(
+          eq(schema.userFavorites.userId, session.user.id),
+          eq(schema.userFavorites.boardName, boardName),
+          eq(schema.userFavorites.climbUuid, climbUuid),
+          eq(schema.userFavorites.angle, angle)
+        )
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      // Remove favorite
+      await db
+        .delete(schema.userFavorites)
+        .where(
+          and(
+            eq(schema.userFavorites.userId, session.user.id),
+            eq(schema.userFavorites.boardName, boardName),
+            eq(schema.userFavorites.climbUuid, climbUuid),
+            eq(schema.userFavorites.angle, angle)
+          )
+        );
+      return NextResponse.json({ favorited: false });
+    } else {
+      // Add favorite
+      await db.insert(schema.userFavorites).values({
+        userId: session.user.id,
+        boardName,
+        climbUuid,
+        angle,
+      });
+      return NextResponse.json({ favorited: true });
+    }
+  } catch (error) {
+    console.error("Failed to toggle favorite:", error);
+    return NextResponse.json({ error: "Failed to toggle favorite" }, { status: 500 });
+  }
+}
+
+// GET: Check if climbs are favorited (batch check)
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      // Return empty favorites for non-authenticated users
+      return NextResponse.json({ favorites: [] });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const boardName = searchParams.get("boardName");
+    const climbUuidsParam = searchParams.get("climbUuids");
+    const angleParam = searchParams.get("angle");
+
+    if (!boardName || !climbUuidsParam || !angleParam) {
+      return NextResponse.json(
+        { error: "Missing required parameters" },
+        { status: 400 }
+      );
+    }
+
+    const climbUuids = climbUuidsParam.split(",");
+    const angle = parseInt(angleParam, 10);
+
+    if (isNaN(angle)) {
+      return NextResponse.json(
+        { error: "Invalid angle parameter" },
+        { status: 400 }
+      );
+    }
+
+    const validationResult = checkFavoriteSchema.safeParse({
+      boardName,
+      climbUuids,
+      angle,
+    });
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const db = getDb();
+
+    // Get all favorites for the user matching the given climbs
+    const favorites = await db
+      .select({ climbUuid: schema.userFavorites.climbUuid })
+      .from(schema.userFavorites)
+      .where(
+        and(
+          eq(schema.userFavorites.userId, session.user.id),
+          eq(schema.userFavorites.boardName, boardName),
+          eq(schema.userFavorites.angle, angle)
+        )
+      );
+
+    // Filter to only the requested climb UUIDs
+    const favoritedUuids = favorites
+      .map((f) => f.climbUuid)
+      .filter((uuid) => climbUuids.includes(uuid));
+
+    return NextResponse.json({ favorites: favoritedUuids });
+  } catch (error) {
+    console.error("Failed to check favorites:", error);
+    return NextResponse.json({ error: "Failed to check favorites" }, { status: 500 });
+  }
+}

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Modal, Form, Input, Button, Tabs, Typography, Divider, message, Space } from 'antd';
+import { UserOutlined, LockOutlined, MailOutlined, HeartFilled } from '@ant-design/icons';
+import { signIn } from 'next-auth/react';
+
+const { Text } = Typography;
+
+type AuthModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+  title?: string;
+  description?: string;
+};
+
+export default function AuthModal({
+  open,
+  onClose,
+  onSuccess,
+  title = "Sign in to continue",
+  description = "Create an account or sign in to save your favorites and more."
+}: AuthModalProps) {
+  const [loginForm] = Form.useForm();
+  const [registerForm] = Form.useForm();
+  const [loginLoading, setLoginLoading] = useState(false);
+  const [registerLoading, setRegisterLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState('login');
+
+  const handleLogin = async () => {
+    try {
+      const values = await loginForm.validateFields();
+      setLoginLoading(true);
+
+      const result = await signIn('credentials', {
+        email: values.email,
+        password: values.password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        message.error('Invalid email or password');
+      } else if (result?.ok) {
+        message.success('Logged in successfully');
+        loginForm.resetFields();
+        onClose();
+        onSuccess?.();
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+    } finally {
+      setLoginLoading(false);
+    }
+  };
+
+  const handleRegister = async () => {
+    try {
+      const values = await registerForm.validateFields();
+      setRegisterLoading(true);
+
+      const response = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: values.email,
+          password: values.password,
+          name: values.name,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        message.error(data.error || 'Registration failed');
+        return;
+      }
+
+      message.success('Account created! Logging you in...');
+
+      const loginResult = await signIn('credentials', {
+        email: values.email,
+        password: values.password,
+        redirect: false,
+      });
+
+      if (loginResult?.ok) {
+        registerForm.resetFields();
+        onClose();
+        onSuccess?.();
+      } else {
+        setActiveTab('login');
+        loginForm.setFieldValue('email', values.email);
+        message.info('Please log in with your new account');
+      }
+    } catch (error) {
+      console.error('Registration error:', error);
+      message.error('Registration failed. Please try again.');
+    } finally {
+      setRegisterLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    loginForm.resetFields();
+    registerForm.resetFields();
+    onClose();
+  };
+
+  const tabItems = [
+    {
+      key: 'login',
+      label: 'Login',
+      children: (
+        <Form form={loginForm} layout="vertical" onFinish={handleLogin}>
+          <Form.Item
+            name="email"
+            label="Email"
+            rules={[
+              { required: true, message: 'Please enter your email' },
+              { type: 'email', message: 'Please enter a valid email' },
+            ]}
+          >
+            <Input prefix={<MailOutlined />} placeholder="your@email.com" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            name="password"
+            label="Password"
+            rules={[{ required: true, message: 'Please enter your password' }]}
+          >
+            <Input.Password prefix={<LockOutlined />} placeholder="Password" size="large" />
+          </Form.Item>
+
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button type="primary" htmlType="submit" loading={loginLoading} block size="large">
+              Login
+            </Button>
+          </Form.Item>
+        </Form>
+      ),
+    },
+    {
+      key: 'register',
+      label: 'Create Account',
+      children: (
+        <Form form={registerForm} layout="vertical" onFinish={handleRegister}>
+          <Form.Item
+            name="name"
+            label="Name"
+            rules={[{ max: 100, message: 'Name must be less than 100 characters' }]}
+          >
+            <Input prefix={<UserOutlined />} placeholder="Your name (optional)" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            name="email"
+            label="Email"
+            rules={[
+              { required: true, message: 'Please enter your email' },
+              { type: 'email', message: 'Please enter a valid email' },
+            ]}
+          >
+            <Input prefix={<MailOutlined />} placeholder="your@email.com" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            name="password"
+            label="Password"
+            rules={[
+              { required: true, message: 'Please enter a password' },
+              { min: 8, message: 'Password must be at least 8 characters' },
+            ]}
+          >
+            <Input.Password prefix={<LockOutlined />} placeholder="Password (min 8 characters)" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            name="confirmPassword"
+            label="Confirm Password"
+            dependencies={['password']}
+            rules={[
+              { required: true, message: 'Please confirm your password' },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('password') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('Passwords do not match'));
+                },
+              }),
+            ]}
+          >
+            <Input.Password prefix={<LockOutlined />} placeholder="Confirm password" size="large" />
+          </Form.Item>
+
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button type="primary" htmlType="submit" loading={registerLoading} block size="large">
+              Create Account
+            </Button>
+          </Form.Item>
+        </Form>
+      ),
+    },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleCancel}
+      footer={null}
+      width={400}
+      centered
+    >
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Space direction="vertical" style={{ width: '100%', textAlign: 'center' }}>
+          <HeartFilled style={{ fontSize: 32, color: '#ff4d4f' }} />
+          <Text strong style={{ fontSize: 18 }}>{title}</Text>
+          <Text type="secondary">{description}</Text>
+        </Space>
+
+        <Tabs activeKey={activeTab} onChange={setActiveTab} items={tabItems} centered />
+
+        <Divider style={{ margin: '8px 0' }}>
+          <Text type="secondary">or</Text>
+        </Divider>
+
+        <Button
+          block
+          size="large"
+          onClick={() => signIn('google')}
+          icon={
+            <svg viewBox="0 0 24 24" width="16" height="16" style={{ marginRight: 8 }}>
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+          }
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          disabled
+        >
+          Continue with Google (Coming soon)
+        </Button>
+      </Space>
+    </Modal>
+  );
+}

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useState } from 'react';
+import { HeartOutlined, HeartFilled } from '@ant-design/icons';
+import { message, Tooltip } from 'antd';
+import { track } from '@vercel/analytics';
+import { useFavorite } from './use-favorite';
+import { BoardName } from '@/app/lib/types';
+import AuthModal from '../auth/auth-modal';
+
+type FavoriteButtonProps = {
+  boardName: BoardName;
+  climbUuid: string;
+  climbName?: string;
+  angle: number;
+  className?: string;
+  showLabel?: boolean;
+  size?: 'small' | 'default';
+};
+
+export default function FavoriteButton({
+  boardName,
+  climbUuid,
+  climbName,
+  angle,
+  className,
+  showLabel = false,
+  size = 'default',
+}: FavoriteButtonProps) {
+  const { isFavorited, isLoading, toggleFavorite, isAuthenticated } = useFavorite({
+    boardName,
+    climbUuid,
+    angle,
+  });
+
+  const [showAuthModal, setShowAuthModal] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (!isAuthenticated) {
+      setShowAuthModal(true);
+      return;
+    }
+
+    try {
+      const newState = await toggleFavorite();
+
+      track('Favorite Toggle', {
+        boardName,
+        climbUuid,
+        action: newState ? 'favorited' : 'unfavorited',
+      });
+
+      message.success(newState ? 'Added to favorites' : 'Removed from favorites');
+    } catch {
+      message.error('Failed to update favorite');
+    }
+  };
+
+  const handleAuthSuccess = () => {
+    // After successful auth, trigger the favorite action
+    toggleFavorite()
+      .then((newState) => {
+        track('Favorite Toggle', {
+          boardName,
+          climbUuid,
+          action: newState ? 'favorited' : 'unfavorited',
+        });
+        message.success('Added to favorites');
+      })
+      .catch(() => {
+        message.error('Failed to add to favorites');
+      });
+  };
+
+  const iconStyle: React.CSSProperties = {
+    fontSize: size === 'small' ? 14 : 16,
+    color: isFavorited ? '#ff4d4f' : 'inherit',
+    cursor: isLoading ? 'wait' : 'pointer',
+    transition: 'color 0.2s, transform 0.2s',
+  };
+
+  const Icon = isFavorited ? HeartFilled : HeartOutlined;
+
+  const content = (
+    <>
+      <Icon style={iconStyle} />
+      {showLabel && <span style={{ marginLeft: 8 }}>{isFavorited ? 'Favorited' : 'Favorite'}</span>}
+    </>
+  );
+
+  return (
+    <>
+      <Tooltip title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}>
+        <span
+          onClick={handleClick}
+          className={className}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            cursor: isLoading ? 'wait' : 'pointer',
+          }}
+          role="button"
+          aria-label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          {content}
+        </span>
+      </Tooltip>
+
+      <AuthModal
+        open={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        onSuccess={handleAuthSuccess}
+        title="Sign in to save favorites"
+        description={climbName ? `Sign in to save "${climbName}" to your favorites.` : 'Sign in to save climbs to your favorites.'}
+      />
+    </>
+  );
+}

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -98,8 +98,11 @@ export default function FavoriteButton({
           onClick={handleClick}
           className={className}
           style={{
-            display: 'inline-flex',
+            display: 'flex',
             alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
             cursor: isLoading ? 'wait' : 'pointer',
           }}
           role="button"

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -98,11 +98,8 @@ export default function FavoriteButton({
           onClick={handleClick}
           className={className}
           style={{
-            display: 'flex',
+            display: 'inline-flex',
             alignItems: 'center',
-            justifyContent: 'center',
-            width: '100%',
-            height: '100%',
             cursor: isLoading ? 'wait' : 'pointer',
           }}
           role="button"

--- a/packages/web/app/components/climb-actions/index.ts
+++ b/packages/web/app/components/climb-actions/index.ts
@@ -1,0 +1,3 @@
+export { default as FavoriteButton } from './favorite-button';
+export { default as QueueButton } from './queue-button';
+export { useFavorite, useFavoritesBatch } from './use-favorite';

--- a/packages/web/app/components/climb-actions/queue-button.tsx
+++ b/packages/web/app/components/climb-actions/queue-button.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { PlusCircleOutlined, CheckCircleOutlined } from '@ant-design/icons';
+import { Tooltip } from 'antd';
+import { track } from '@vercel/analytics';
+import { useQueueContext } from '../graphql-queue';
+import { Climb, BoardDetails } from '@/app/lib/types';
+
+type QueueButtonProps = {
+  climb: Climb;
+  boardDetails: BoardDetails;
+  showLabel?: boolean;
+  size?: 'small' | 'default';
+  className?: string;
+};
+
+export default function QueueButton({
+  climb,
+  boardDetails,
+  showLabel = false,
+  size = 'default',
+  className,
+}: QueueButtonProps) {
+  const { addToQueue, queue } = useQueueContext();
+  const [recentlyAdded, setRecentlyAdded] = useState(false);
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (addToQueue && !recentlyAdded) {
+      addToQueue(climb);
+
+      track('Add to Queue', {
+        boardLayout: boardDetails.layout_name || '',
+        queueLength: queue.length + 1,
+      });
+
+      setRecentlyAdded(true);
+
+      setTimeout(() => {
+        setRecentlyAdded(false);
+      }, 5000);
+    }
+  }, [addToQueue, recentlyAdded, climb, boardDetails.layout_name, queue.length]);
+
+  const iconStyle: React.CSSProperties = {
+    fontSize: size === 'small' ? 14 : 16,
+    color: recentlyAdded ? '#52c41a' : 'inherit',
+    cursor: recentlyAdded ? 'not-allowed' : 'pointer',
+  };
+
+  const Icon = recentlyAdded ? CheckCircleOutlined : PlusCircleOutlined;
+  const label = recentlyAdded ? 'Added' : 'Queue';
+
+  return (
+    <Tooltip title={recentlyAdded ? 'Added to queue' : 'Add to queue'}>
+      <span
+        onClick={handleClick}
+        className={className}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          cursor: recentlyAdded ? 'not-allowed' : 'pointer',
+        }}
+        role="button"
+        aria-label={recentlyAdded ? 'Added to queue' : 'Add to queue'}
+      >
+        <Icon style={iconStyle} />
+        {showLabel && <span style={{ marginLeft: 8 }}>{label}</span>}
+      </span>
+    </Tooltip>
+  );
+}

--- a/packages/web/app/components/climb-actions/use-favorite.ts
+++ b/packages/web/app/components/climb-actions/use-favorite.ts
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import { BoardName } from '@/app/lib/types';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+};
+
+type UseFavoriteOptions = {
+  boardName: BoardName;
+  climbUuid: string;
+  angle: number;
+};
+
+type UseFavoriteReturn = {
+  isFavorited: boolean;
+  isLoading: boolean;
+  toggleFavorite: () => Promise<boolean>;
+  isAuthenticated: boolean;
+};
+
+export function useFavorite({
+  boardName,
+  climbUuid,
+  angle,
+}: UseFavoriteOptions): UseFavoriteReturn {
+  const { status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+  const [isToggling, setIsToggling] = useState(false);
+
+  // Build the SWR key only if authenticated
+  const swrKey = isAuthenticated
+    ? `/api/internal/favorites?boardName=${boardName}&climbUuids=${climbUuid}&angle=${angle}`
+    : null;
+
+  const { data, mutate, isLoading: isLoadingFavorite } = useSWR<{ favorites: string[] }>(
+    swrKey,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 5000,
+    }
+  );
+
+  const isFavorited = data?.favorites?.includes(climbUuid) ?? false;
+
+  const toggleFavorite = useCallback(async (): Promise<boolean> => {
+    if (!isAuthenticated) {
+      return false;
+    }
+
+    setIsToggling(true);
+
+    try {
+      // Optimistic update
+      const newFavorited = !isFavorited;
+      mutate(
+        {
+          favorites: newFavorited
+            ? [...(data?.favorites || []), climbUuid]
+            : (data?.favorites || []).filter((id) => id !== climbUuid),
+        },
+        false
+      );
+
+      const response = await fetch('/api/internal/favorites', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          boardName,
+          climbUuid,
+          angle,
+        }),
+      });
+
+      if (!response.ok) {
+        // Revert optimistic update on error
+        mutate();
+        throw new Error('Failed to toggle favorite');
+      }
+
+      const result = await response.json();
+
+      // Revalidate to ensure we have the correct state
+      mutate();
+
+      return result.favorited;
+    } catch (error) {
+      console.error('Error toggling favorite:', error);
+      throw error;
+    } finally {
+      setIsToggling(false);
+    }
+  }, [isAuthenticated, isFavorited, mutate, data, boardName, climbUuid, angle]);
+
+  return {
+    isFavorited,
+    isLoading: isLoadingFavorite || isToggling || status === 'loading',
+    toggleFavorite,
+    isAuthenticated,
+  };
+}
+
+// Hook for batch checking favorites (useful for climb lists)
+type UseFavoritesBatchOptions = {
+  boardName: BoardName;
+  climbUuids: string[];
+  angle: number;
+};
+
+type UseFavoritesBatchReturn = {
+  favorites: Set<string>;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  refetch: () => void;
+};
+
+export function useFavoritesBatch({
+  boardName,
+  climbUuids,
+  angle,
+}: UseFavoritesBatchOptions): UseFavoritesBatchReturn {
+  const { status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+
+  // Build the SWR key only if authenticated and we have climb UUIDs
+  const swrKey =
+    isAuthenticated && climbUuids.length > 0
+      ? `/api/internal/favorites?boardName=${boardName}&climbUuids=${climbUuids.join(',')}&angle=${angle}`
+      : null;
+
+  const { data, isLoading, mutate } = useSWR<{ favorites: string[] }>(
+    swrKey,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 5000,
+    }
+  );
+
+  return {
+    favorites: new Set(data?.favorites || []),
+    isLoading: isLoading || status === 'loading',
+    isAuthenticated,
+    refetch: () => mutate(),
+  };
+}

--- a/packages/web/app/components/climb-card/climb-card-actions.tsx
+++ b/packages/web/app/components/climb-card/climb-card-actions.tsx
@@ -2,18 +2,17 @@
 import React, { useState } from 'react';
 import { useQueueContext } from '../graphql-queue';
 import { BoardDetails, Climb } from '@/app/lib/types';
-import { PlusCircleOutlined, HeartOutlined, InfoCircleOutlined, CheckCircleOutlined, ForkOutlined } from '@ant-design/icons';
+import { PlusCircleOutlined, InfoCircleOutlined, CheckCircleOutlined, ForkOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, constructCreateClimbUrl } from '@/app/lib/url-utils';
 import { track } from '@vercel/analytics';
-import { message } from 'antd';
-
-// import TickClimbButton from '@/c/tick-climb/tick-climb-button';
+import { FavoriteButton } from '../climb-actions';
 
 type ClimbCardActionsProps = {
   climb?: Climb;
   boardDetails: BoardDetails;
 };
+
 const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
   const { addToQueue, queue } = useQueueContext();
   const [recentlyAdded, setRecentlyAdded] = useState(false);
@@ -40,8 +39,6 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
   };
 
   const actions: (React.JSX.Element | null)[] = [
-    // <SettingOutlined key="setting" />,
-    // <TickClimbButton key="tickclimbbutton" />,
     <Link
       key="infocircle"
       href={
@@ -99,7 +96,14 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
         <ForkOutlined />
       </Link>
     ) : null,
-    <HeartOutlined key="heart" onClick={() => message.info('TODO: Implement')} />,
+    <FavoriteButton
+      key="heart"
+      boardName={boardDetails.board_name}
+      climbUuid={climb.uuid}
+      climbName={climb.name}
+      angle={climb.angle}
+      size="small"
+    />,
     recentlyAdded ? (
       <CheckCircleOutlined
         key="edit"

--- a/packages/web/app/components/climb-card/climb-card-actions.tsx
+++ b/packages/web/app/components/climb-card/climb-card-actions.tsx
@@ -90,7 +90,7 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
 
   const HeartIcon = isFavorited ? HeartFilled : HeartOutlined;
 
-  const actions: (React.JSX.Element | null)[] = [
+  const actions: React.JSX.Element[] = [
     <Link
       key="infocircle"
       href={
@@ -125,52 +125,36 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
     >
       <InfoCircleOutlined />
     </Link>,
-    boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names ? (
-      <Link
-        key="fork"
-        href={constructCreateClimbUrl(
-          boardDetails.board_name,
-          boardDetails.layout_name,
-          boardDetails.size_name,
-          boardDetails.size_description,
-          boardDetails.set_names,
-          climb.angle,
-          { frames: climb.frames, name: climb.name },
-        )}
-        onClick={() => {
-          track('Climb Forked', {
-            boardLayout: boardDetails.layout_name || '',
-            originalClimb: climb.uuid,
-          });
-        }}
-        title="Fork this climb"
-      >
-        <ForkOutlined />
-      </Link>
-    ) : null,
-    <HeartIcon
-      key="heart"
-      onClick={handleFavorite}
-      style={{ color: isFavorited ? '#ff4d4f' : 'inherit' }}
-    />,
-    recentlyAdded ? (
-      <CheckCircleOutlined
-        key="edit"
-        onClick={handleAddToQueue}
-        style={{ color: '#52c41a', cursor: 'not-allowed' }}
+    ...(boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
+      ? [
+          <Link
+            key="fork"
+            href={constructCreateClimbUrl(
+              boardDetails.board_name,
+              boardDetails.layout_name,
+              boardDetails.size_name,
+              boardDetails.size_description,
+              boardDetails.set_names,
+              climb.angle,
+              { frames: climb.frames, name: climb.name },
+            )}
+            onClick={() => {
+              track('Climb Forked', {
+                boardLayout: boardDetails.layout_name || '',
+                originalClimb: climb.uuid,
+              });
+            }}
+            title="Fork this climb"
+          >
+            <ForkOutlined />
+          </Link>,
+        ]
+      : []),
+    <React.Fragment key="heart">
+      <HeartIcon
+        onClick={handleFavorite}
+        style={{ color: isFavorited ? '#ff4d4f' : 'inherit' }}
       />
-    ) : (
-      <PlusCircleOutlined
-        key="edit"
-        onClick={handleAddToQueue}
-        style={{ color: 'inherit', cursor: 'pointer' }}
-      />
-    ),
-  ];
-
-  return (
-    <>
-      {actions.filter((action): action is React.JSX.Element => action !== null)}
       <AuthModal
         open={showAuthModal}
         onClose={() => setShowAuthModal(false)}
@@ -178,8 +162,23 @@ const ClimbCardActions = ({ climb, boardDetails }: ClimbCardActionsProps) => {
         title="Sign in to save favorites"
         description={`Sign in to save "${climb.name}" to your favorites.`}
       />
-    </>
-  );
+    </React.Fragment>,
+    recentlyAdded ? (
+      <CheckCircleOutlined
+        key="queue"
+        onClick={handleAddToQueue}
+        style={{ color: '#52c41a', cursor: 'not-allowed' }}
+      />
+    ) : (
+      <PlusCircleOutlined
+        key="queue"
+        onClick={handleAddToQueue}
+        style={{ color: 'inherit', cursor: 'pointer' }}
+      />
+    ),
+  ];
+
+  return actions;
 };
 
 export default ClimbCardActions;

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Button, Space, message, Dropdown } from 'antd';
+import { Button, Space, Dropdown, message } from 'antd';
 import {
   HeartOutlined,
   HeartFilled,
@@ -86,25 +86,33 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
         climbUuid: climb.uuid,
         action: newState ? 'favorited' : 'unfavorited',
       });
-      message.success(newState ? 'Added to favorites' : 'Removed from favorites');
     } catch {
-      message.error('Failed to update favorite');
+      // Silently fail
     }
   };
 
-  const handleAuthSuccess = () => {
-    toggleFavorite()
-      .then((newState) => {
+  const handleAuthSuccess = async () => {
+    // Call API directly since session state may not have updated yet
+    try {
+      const response = await fetch('/api/internal/favorites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          boardName: boardDetails.board_name,
+          climbUuid: climb.uuid,
+          angle,
+        }),
+      });
+      if (response.ok) {
         track('Favorite Toggle', {
           boardName: boardDetails.board_name,
           climbUuid: climb.uuid,
-          action: newState ? 'favorited' : 'unfavorited',
+          action: 'favorited',
         });
-        message.success('Added to favorites');
-      })
-      .catch(() => {
-        message.error('Failed to add to favorites');
-      });
+      }
+    } catch {
+      // Silently fail
+    }
   };
 
   const handleAddToList = () => {

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Button, Space, message, Dropdown } from 'antd';
 import {
   HeartOutlined,
+  HeartFilled,
   PlusCircleOutlined,
   CheckCircleOutlined,
   AppstoreOutlined,
@@ -17,6 +18,9 @@ import { Climb, BoardDetails } from '@/app/lib/types';
 import type { MenuProps } from 'antd';
 import styles from './climb-view-actions.module.css';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import { useFavorite } from '../climb-actions';
+import { track } from '@vercel/analytics';
+import AuthModal from '../auth/auth-modal';
 
 type ClimbViewActionsProps = {
   climb: Climb;
@@ -26,10 +30,17 @@ type ClimbViewActionsProps = {
 };
 
 const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbViewActionsProps) => {
-  const { addToQueue, queue } = useQueueContext();
+  const { addToQueue } = useQueueContext();
   const [recentlyAdded, setRecentlyAdded] = useState(false);
   const [canGoBack, setCanGoBack] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
   const router = useRouter();
+
+  const { isFavorited, isLoading: isFavoriteLoading, toggleFavorite, isAuthenticated } = useFavorite({
+    boardName: boardDetails.board_name,
+    climbUuid: climb.uuid,
+    angle,
+  });
 
   useEffect(() => {
     // Check if we can go back and if the previous page was on Boardsesh
@@ -62,8 +73,38 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
     }
   };
 
-  const handleFavourite = () => {
-    message.info('TODO: Implement favourite functionality');
+  const handleFavorite = async () => {
+    if (!isAuthenticated) {
+      setShowAuthModal(true);
+      return;
+    }
+
+    try {
+      const newState = await toggleFavorite();
+      track('Favorite Toggle', {
+        boardName: boardDetails.board_name,
+        climbUuid: climb.uuid,
+        action: newState ? 'favorited' : 'unfavorited',
+      });
+      message.success(newState ? 'Added to favorites' : 'Removed from favorites');
+    } catch {
+      message.error('Failed to update favorite');
+    }
+  };
+
+  const handleAuthSuccess = () => {
+    toggleFavorite()
+      .then((newState) => {
+        track('Favorite Toggle', {
+          boardName: boardDetails.board_name,
+          climbUuid: climb.uuid,
+          action: newState ? 'favorited' : 'unfavorited',
+        });
+        message.success('Added to favorites');
+      })
+      .catch(() => {
+        message.error('Failed to add to favorites');
+      });
   };
 
   const handleAddToList = () => {
@@ -117,75 +158,34 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
     },
   ];
 
+  const FavoriteIcon = isFavorited ? HeartFilled : HeartOutlined;
+  const favoriteIconStyle = isFavorited ? { color: '#ff4d4f' } : undefined;
+
   return (
-    <div className={styles.container}>
-      {/* Mobile view: Show back button + key actions + overflow menu */}
-      <div className={styles.mobileActions}>
-        <div className={styles.mobileLeft}>
-          {canGoBack ? (
-            <Button icon={<ArrowLeftOutlined />} onClick={handleBackClick}>
-              Back
-            </Button>
-          ) : (
-            <Link href={getBackToListUrl()}>
-              <Button icon={<ArrowLeftOutlined />}>
+    <>
+      <div className={styles.container}>
+        {/* Mobile view: Show back button + key actions + overflow menu */}
+        <div className={styles.mobileActions}>
+          <div className={styles.mobileLeft}>
+            {canGoBack ? (
+              <Button icon={<ArrowLeftOutlined />} onClick={handleBackClick}>
                 Back
               </Button>
-            </Link>
-          )}
-        </div>
+            ) : (
+              <Link href={getBackToListUrl()}>
+                <Button icon={<ArrowLeftOutlined />}>
+                  Back
+                </Button>
+              </Link>
+            )}
+          </div>
 
-        <div className={styles.mobileRight}>
-          <Button icon={<HeartOutlined />} onClick={handleFavourite} />
-
-          {recentlyAdded ? (
+          <div className={styles.mobileRight}>
             <Button
-              icon={<CheckCircleOutlined />}
-              onClick={handleAddToQueue}
-              disabled
-              className={styles.inQueueButton}
-            >
-              Added
-            </Button>
-          ) : (
-            <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue}>
-              Queue
-            </Button>
-          )}
-
-          <Dropdown menu={{ items: menuItems }} placement="bottomRight" trigger={['click']}>
-            <Button icon={<MoreOutlined />} />
-          </Dropdown>
-        </div>
-      </div>
-
-      {/* Desktop view: Show all buttons */}
-      <div className={styles.desktopActions}>
-        {canGoBack ? (
-          <Button icon={<ArrowLeftOutlined />} className={styles.backButton} onClick={handleBackClick}>
-            Back to List
-          </Button>
-        ) : (
-          <Link href={getBackToListUrl()}>
-            <Button icon={<ArrowLeftOutlined />} className={styles.backButton}>
-              Back to List
-            </Button>
-          </Link>
-        )}
-
-        <div className={styles.actionButtons}>
-          <Space wrap>
-            <Button icon={<HeartOutlined />} onClick={handleFavourite}>
-              Favourite
-            </Button>
-
-            <Button icon={<PlusCircleOutlined />} onClick={handleAddToList}>
-              Add to List
-            </Button>
-
-            <Button icon={<CheckCircleOutlined />} onClick={handleTick}>
-              Tick
-            </Button>
+              icon={<FavoriteIcon style={favoriteIconStyle} />}
+              onClick={handleFavorite}
+              loading={isFavoriteLoading}
+            />
 
             {recentlyAdded ? (
               <Button
@@ -194,21 +194,83 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
                 disabled
                 className={styles.inQueueButton}
               >
-                Added to Queue
+                Added
               </Button>
             ) : (
               <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue}>
-                Add to Queue
+                Queue
               </Button>
             )}
 
-            <Button icon={<AppstoreOutlined />} href={auroraAppUrl} target="_blank" rel="noopener">
-              Open in App
+            <Dropdown menu={{ items: menuItems }} placement="bottomRight" trigger={['click']}>
+              <Button icon={<MoreOutlined />} />
+            </Dropdown>
+          </div>
+        </div>
+
+        {/* Desktop view: Show all buttons */}
+        <div className={styles.desktopActions}>
+          {canGoBack ? (
+            <Button icon={<ArrowLeftOutlined />} className={styles.backButton} onClick={handleBackClick}>
+              Back to List
             </Button>
-          </Space>
+          ) : (
+            <Link href={getBackToListUrl()}>
+              <Button icon={<ArrowLeftOutlined />} className={styles.backButton}>
+                Back to List
+              </Button>
+            </Link>
+          )}
+
+          <div className={styles.actionButtons}>
+            <Space wrap>
+              <Button
+                icon={<FavoriteIcon style={favoriteIconStyle} />}
+                onClick={handleFavorite}
+                loading={isFavoriteLoading}
+              >
+                {isFavorited ? 'Favorited' : 'Favorite'}
+              </Button>
+
+              <Button icon={<PlusCircleOutlined />} onClick={handleAddToList}>
+                Add to List
+              </Button>
+
+              <Button icon={<CheckCircleOutlined />} onClick={handleTick}>
+                Tick
+              </Button>
+
+              {recentlyAdded ? (
+                <Button
+                  icon={<CheckCircleOutlined />}
+                  onClick={handleAddToQueue}
+                  disabled
+                  className={styles.inQueueButton}
+                >
+                  Added to Queue
+                </Button>
+              ) : (
+                <Button icon={<PlusCircleOutlined />} onClick={handleAddToQueue}>
+                  Add to Queue
+                </Button>
+              )}
+
+              <Button icon={<AppstoreOutlined />} href={auroraAppUrl} target="_blank" rel="noopener">
+                Open in App
+              </Button>
+            </Space>
+          </div>
         </div>
       </div>
-    </div>
+
+      <AuthModal
+        open={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        onSuccess={handleAuthSuccess}
+        title="Sign in to save favorites"
+        description={`Sign in to save "${climb.name}" to your favorites.`}
+      />
+    </>
   );
 };
 

--- a/packages/web/app/lib/db/schema.ts
+++ b/packages/web/app/lib/db/schema.ts
@@ -1182,3 +1182,35 @@ export const userProfiles = pgTable("user_profiles", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
+
+// User favorites for saved/hearted climbs
+export const userFavorites = pgTable(
+  "user_favorites",
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    boardName: text("board_name").notNull(), // 'kilter', 'tension', 'decoy'
+    climbUuid: text("climb_uuid").notNull(),
+    angle: integer("angle").notNull(), // The angle at which the climb was favorited
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    // Ensure unique favorite per user per climb per angle
+    uniqueFavorite: uniqueIndex("unique_user_favorite").on(
+      table.userId,
+      table.boardName,
+      table.climbUuid,
+      table.angle
+    ),
+    // Index for efficient lookup by user
+    userFavoritesIdx: index("user_favorites_user_idx").on(table.userId),
+    // Index for checking if a climb is favorited
+    climbFavoriteIdx: index("user_favorites_climb_idx").on(
+      table.boardName,
+      table.climbUuid,
+      table.angle
+    ),
+  })
+);

--- a/packages/web/drizzle/0018_perpetual_cerise.sql
+++ b/packages/web/drizzle/0018_perpetual_cerise.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "user_favorites" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"board_name" text NOT NULL,
+	"climb_uuid" text NOT NULL,
+	"angle" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_user_favorite" ON "user_favorites" USING btree ("user_id","board_name","climb_uuid","angle");--> statement-breakpoint
+CREATE INDEX "user_favorites_user_idx" ON "user_favorites" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_favorites_climb_idx" ON "user_favorites" USING btree ("board_name","climb_uuid","angle");

--- a/packages/web/drizzle/meta/0018_snapshot.json
+++ b/packages/web/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,4275 @@
+{
+  "id": "799aa0b6-c7c7-4ad2-8bb1-ad1e3b408807",
+  "prevId": "476c56f4-a744-409b-a589-fdacd9fc3d58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_ascents": {
+      "name": "kilter_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey1": {
+          "name": "ascents_attempt_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey1": {
+          "name": "ascents_climb_uuid_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey1": {
+          "name": "ascents_difficulty_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey1": {
+          "name": "ascents_user_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_attempts": {
+      "name": "kilter_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_beta_links": {
+      "name": "kilter_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey1": {
+          "name": "beta_links_climb_uuid_fkey1",
+          "tableFrom": "kilter_beta_links",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_bids": {
+      "name": "kilter_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey1": {
+          "name": "bids_climb_uuid_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey1": {
+          "name": "bids_user_id_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits": {
+      "name": "kilter_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits_climbs": {
+      "name": "kilter_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_holds": {
+      "name": "kilter_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kilter_climb_holds_search_idx": {
+          "name": "kilter_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "kilter_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats": {
+      "name": "kilter_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_stats_pk": {
+          "name": "kilter_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats_history": {
+      "name": "kilter_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climbs": {
+      "name": "kilter_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kilter_climbs_layout_filter_idx": {
+          "name": "kilter_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kilter_climbs_edges_idx": {
+          "name": "kilter_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey1": {
+          "name": "climbs_layout_id_fkey1",
+          "tableFrom": "kilter_climbs",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_difficulty_grades": {
+      "name": "kilter_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_holes": {
+      "name": "kilter_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_product_id_fkey1": {
+          "name": "holes_product_id_fkey1",
+          "tableFrom": "kilter_holes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_layouts": {
+      "name": "kilter_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey1": {
+          "name": "layouts_product_id_fkey1",
+          "tableFrom": "kilter_layouts",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_leds": {
+      "name": "kilter_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey1": {
+          "name": "leds_hole_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey1": {
+          "name": "leds_product_size_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placement_roles": {
+      "name": "kilter_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey1": {
+          "name": "placement_roles_product_id_fkey1",
+          "tableFrom": "kilter_placement_roles",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placements": {
+      "name": "kilter_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey1": {
+          "name": "placements_default_placement_role_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey1": {
+          "name": "placements_hole_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey1": {
+          "name": "placements_layout_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey1": {
+          "name": "placements_set_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes": {
+      "name": "kilter_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey1": {
+          "name": "product_sizes_product_id_fkey1",
+          "tableFrom": "kilter_product_sizes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes_layouts_sets": {
+      "name": "kilter_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey1": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey1": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey1": {
+          "name": "product_sizes_layouts_sets_set_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_products": {
+      "name": "kilter_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_sets": {
+      "name": "kilter_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_shared_syncs": {
+      "name": "kilter_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_tags": {
+      "name": "kilter_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_user_syncs": {
+      "name": "kilter_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey1": {
+          "name": "user_syncs_user_id_fkey1",
+          "tableFrom": "kilter_user_syncs",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kilter_user_sync_pk": {
+          "name": "kilter_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_users": {
+      "name": "kilter_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_walls": {
+      "name": "kilter_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey1": {
+          "name": "walls_layout_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey1": {
+          "name": "walls_product_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey1": {
+          "name": "walls_product_size_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey1": {
+          "name": "walls_user_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_ascents": {
+      "name": "tension_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey": {
+          "name": "ascents_attempt_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey": {
+          "name": "ascents_climb_uuid_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey": {
+          "name": "ascents_difficulty_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey": {
+          "name": "ascents_user_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_attempts": {
+      "name": "tension_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_beta_links": {
+      "name": "tension_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey": {
+          "name": "beta_links_climb_uuid_fkey",
+          "tableFrom": "tension_beta_links",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_bids": {
+      "name": "tension_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey": {
+          "name": "bids_climb_uuid_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey": {
+          "name": "bids_user_id_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits": {
+      "name": "tension_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits_climbs": {
+      "name": "tension_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_holds": {
+      "name": "tension_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tension_climb_holds_search_idx": {
+          "name": "tension_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "tension_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats": {
+      "name": "tension_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_stats_pk": {
+          "name": "tension_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats_history": {
+      "name": "tension_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climbs": {
+      "name": "tension_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tension_climbs_layout_filter_idx": {
+          "name": "tension_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tension_climbs_edges_idx": {
+          "name": "tension_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey": {
+          "name": "climbs_layout_id_fkey",
+          "tableFrom": "tension_climbs",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_difficulty_grades": {
+      "name": "tension_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_holes": {
+      "name": "tension_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_mirrored_hole_id_fkey": {
+          "name": "holes_mirrored_hole_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "mirrored_hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "holes_product_id_fkey": {
+          "name": "holes_product_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_layouts": {
+      "name": "tension_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey": {
+          "name": "layouts_product_id_fkey",
+          "tableFrom": "tension_layouts",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_leds": {
+      "name": "tension_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey": {
+          "name": "leds_hole_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey": {
+          "name": "leds_product_size_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placement_roles": {
+      "name": "tension_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey": {
+          "name": "placement_roles_product_id_fkey",
+          "tableFrom": "tension_placement_roles",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placements": {
+      "name": "tension_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey": {
+          "name": "placements_default_placement_role_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey": {
+          "name": "placements_hole_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey": {
+          "name": "placements_layout_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey": {
+          "name": "placements_set_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes": {
+      "name": "tension_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey": {
+          "name": "product_sizes_product_id_fkey",
+          "tableFrom": "tension_product_sizes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes_layouts_sets": {
+      "name": "tension_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey": {
+          "name": "product_sizes_layouts_sets_set_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_products": {
+      "name": "tension_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_sets": {
+      "name": "tension_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_shared_syncs": {
+      "name": "tension_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_tags": {
+      "name": "tension_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_user_syncs": {
+      "name": "tension_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey": {
+          "name": "user_syncs_user_id_fkey",
+          "tableFrom": "tension_user_syncs",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tension_user_sync_pk": {
+          "name": "tension_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_users": {
+      "name": "tension_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_walls": {
+      "name": "tension_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey": {
+          "name": "walls_layout_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey": {
+          "name": "walls_product_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey": {
+          "name": "walls_product_size_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey": {
+          "name": "walls_user_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1766697469058,
       "tag": "0017_puzzling_mikhail_rasputin",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1766699828855,
+      "tag": "0018_perpetual_cerise",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
- Add userFavorites table to database schema with proper indexes
- Create API endpoint for toggle favorite (POST) and batch check (GET)
- Create reusable FavoriteButton component with auth modal integration
- Create useFavorite and useFavoritesBatch hooks for state management
- Create AuthModal component for login/register prompts when not authenticated
- Update ClimbCardActions to use new FavoriteButton component
- Update ClimbViewActions to use useFavorite hook with proper button integration
- Add database migration for user_favorites table

When a non-logged-in user clicks the heart button, they see a login/register
modal. After successful authentication, the favorite action completes automatically.