### PR TITLE
refactor: Move Aurora logins to settings page with encrypted credentials

### DIFF
--- a/packages/web/app/api/internal/aurora-credentials/[board_type]/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/[board_type]/route.ts
@@ -1,0 +1,74 @@
+import { getServerSession } from "next-auth/next";
+import { NextResponse } from "next/server";
+import { getDb } from "@/app/lib/db/db";
+import * as schema from "@/app/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { authOptions } from "@/app/lib/auth/auth-options";
+import { decrypt } from "@/app/lib/crypto";
+
+interface RouteParams {
+  params: Promise<{ board_type: string }>;
+}
+
+/**
+ * GET - Get Aurora credentials for a specific board (for BoardProvider)
+ * Returns the decrypted token and user info needed for Aurora API calls
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { board_type } = await params;
+
+    if (!["kilter", "tension"].includes(board_type)) {
+      return NextResponse.json({ error: "Invalid board type" }, { status: 400 });
+    }
+
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({
+        authenticated: false,
+        token: null,
+        user_id: null,
+        username: null,
+      });
+    }
+
+    const db = getDb();
+
+    const credentials = await db
+      .select()
+      .from(schema.auroraCredentials)
+      .where(
+        and(
+          eq(schema.auroraCredentials.userId, session.user.id),
+          eq(schema.auroraCredentials.boardType, board_type)
+        )
+      )
+      .limit(1);
+
+    if (credentials.length === 0) {
+      return NextResponse.json({
+        authenticated: true,
+        token: null,
+        user_id: null,
+        username: null,
+      });
+    }
+
+    const credential = credentials[0];
+
+    // If the sync status is error or expired, the token might not be valid
+    // But we'll still return it and let the API calls fail gracefully
+
+    return NextResponse.json({
+      authenticated: true,
+      token: credential.auroraToken ? decrypt(credential.auroraToken) : null,
+      user_id: credential.auroraUserId,
+      username: decrypt(credential.encryptedUsername),
+      syncStatus: credential.syncStatus,
+    });
+  } catch (error) {
+    console.error("Failed to get Aurora credentials:", error);
+    return NextResponse.json({ error: "Failed to get credentials" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/internal/aurora-credentials/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/route.ts
@@ -1,0 +1,286 @@
+import { getServerSession } from "next-auth/next";
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/app/lib/db/db";
+import * as schema from "@/app/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import { authOptions } from "@/app/lib/auth/auth-options";
+import { encrypt, decrypt } from "@/app/lib/crypto";
+import AuroraClimbingClient from "@/app/lib/api-wrappers/aurora-rest-client/aurora-rest-client";
+import { syncUserData } from "@/app/lib/data-sync/aurora/user-sync";
+import { BoardName } from "@/app/lib/types";
+
+const saveCredentialsSchema = z.object({
+  boardType: z.enum(["kilter", "tension"]),
+  username: z.string().min(1, "Username is required"),
+  password: z.string().min(1, "Password is required"),
+});
+
+const deleteCredentialsSchema = z.object({
+  boardType: z.enum(["kilter", "tension"]),
+});
+
+export interface AuroraCredentialStatus {
+  boardType: string;
+  auroraUsername: string;
+  auroraUserId: number | null;
+  lastSyncAt: string | null;
+  syncStatus: string;
+  syncError: string | null;
+  createdAt: string;
+}
+
+/**
+ * GET - Get all Aurora credentials status for the logged-in user
+ */
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getDb();
+
+    const credentials = await db
+      .select()
+      .from(schema.auroraCredentials)
+      .where(eq(schema.auroraCredentials.userId, session.user.id));
+
+    // Return credentials without sensitive data
+    const credentialStatuses: AuroraCredentialStatus[] = credentials.map((cred) => ({
+      boardType: cred.boardType,
+      auroraUsername: decrypt(cred.encryptedUsername),
+      auroraUserId: cred.auroraUserId,
+      lastSyncAt: cred.lastSyncAt?.toISOString() ?? null,
+      syncStatus: cred.syncStatus,
+      syncError: cred.syncError,
+      createdAt: cred.createdAt.toISOString(),
+    }));
+
+    return NextResponse.json({ credentials: credentialStatuses });
+  } catch (error) {
+    console.error("Failed to get Aurora credentials:", error);
+    return NextResponse.json({ error: "Failed to get credentials" }, { status: 500 });
+  }
+}
+
+/**
+ * POST - Save Aurora credentials (login and store encrypted)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const validationResult = saveCredentialsSchema.safeParse(body);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { boardType, username, password } = validationResult.data;
+
+    // First, verify credentials by attempting login
+    const auroraClient = new AuroraClimbingClient({ boardName: boardType as BoardName });
+    let loginResponse;
+    try {
+      loginResponse = await auroraClient.signIn(username, password);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("401")) {
+        return NextResponse.json({ error: "Invalid Aurora credentials" }, { status: 401 });
+      }
+      throw error;
+    }
+
+    if (!loginResponse.token || !loginResponse.user_id) {
+      return NextResponse.json({ error: "Invalid login response from Aurora" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const now = new Date();
+
+    // Encrypt credentials
+    const encryptedUsername = encrypt(username);
+    const encryptedPassword = encrypt(password);
+    const encryptedToken = encrypt(loginResponse.token);
+
+    // Check if credentials already exist
+    const existing = await db
+      .select()
+      .from(schema.auroraCredentials)
+      .where(
+        and(
+          eq(schema.auroraCredentials.userId, session.user.id),
+          eq(schema.auroraCredentials.boardType, boardType)
+        )
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      // Update existing credentials
+      await db
+        .update(schema.auroraCredentials)
+        .set({
+          encryptedUsername,
+          encryptedPassword,
+          auroraUserId: loginResponse.user_id,
+          auroraToken: encryptedToken,
+          lastSyncAt: now,
+          syncStatus: "active",
+          syncError: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(schema.auroraCredentials.userId, session.user.id),
+            eq(schema.auroraCredentials.boardType, boardType)
+          )
+        );
+    } else {
+      // Insert new credentials
+      await db.insert(schema.auroraCredentials).values({
+        userId: session.user.id,
+        boardType,
+        encryptedUsername,
+        encryptedPassword,
+        auroraUserId: loginResponse.user_id,
+        auroraToken: encryptedToken,
+        lastSyncAt: now,
+        syncStatus: "active",
+        syncError: null,
+      });
+    }
+
+    // Also update/create user board mapping
+    const existingMapping = await db
+      .select()
+      .from(schema.userBoardMappings)
+      .where(
+        and(
+          eq(schema.userBoardMappings.userId, session.user.id),
+          eq(schema.userBoardMappings.boardType, boardType)
+        )
+      )
+      .limit(1);
+
+    if (existingMapping.length > 0) {
+      await db
+        .update(schema.userBoardMappings)
+        .set({
+          boardUserId: loginResponse.user_id,
+          boardUsername: username,
+          linkedAt: now,
+        })
+        .where(
+          and(
+            eq(schema.userBoardMappings.userId, session.user.id),
+            eq(schema.userBoardMappings.boardType, boardType)
+          )
+        );
+    } else {
+      await db.insert(schema.userBoardMappings).values({
+        userId: session.user.id,
+        boardType,
+        boardUserId: loginResponse.user_id,
+        boardUsername: username,
+      });
+    }
+
+    // Trigger sync in background
+    try {
+      await syncUserData(boardType as BoardName, loginResponse.token, loginResponse.user_id);
+    } catch (syncError) {
+      console.error("Sync error (non-blocking):", syncError);
+      // Update sync status to reflect error
+      await db
+        .update(schema.auroraCredentials)
+        .set({
+          syncStatus: "error",
+          syncError: syncError instanceof Error ? syncError.message : "Sync failed",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.auroraCredentials.userId, session.user.id),
+            eq(schema.auroraCredentials.boardType, boardType)
+          )
+        );
+    }
+
+    return NextResponse.json({
+      success: true,
+      credential: {
+        boardType,
+        auroraUsername: username,
+        auroraUserId: loginResponse.user_id,
+        lastSyncAt: now.toISOString(),
+        syncStatus: "active",
+        syncError: null,
+        createdAt: now.toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error("Failed to save Aurora credentials:", error);
+    return NextResponse.json({ error: "Failed to save credentials" }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE - Remove Aurora credentials for a specific board
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const validationResult = deleteCredentialsSchema.safeParse(body);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { boardType } = validationResult.data;
+    const db = getDb();
+
+    // Delete credentials
+    await db
+      .delete(schema.auroraCredentials)
+      .where(
+        and(
+          eq(schema.auroraCredentials.userId, session.user.id),
+          eq(schema.auroraCredentials.boardType, boardType)
+        )
+      );
+
+    // Also remove the board mapping
+    await db
+      .delete(schema.userBoardMappings)
+      .where(
+        and(
+          eq(schema.userBoardMappings.userId, session.user.id),
+          eq(schema.userBoardMappings.boardType, boardType)
+        )
+      );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete Aurora credentials:", error);
+    return NextResponse.json({ error: "Failed to delete credentials" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/internal/aurora-credentials/unsynced/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/unsynced/route.ts
@@ -1,0 +1,80 @@
+import { getServerSession } from "next-auth/next";
+import { NextResponse } from "next/server";
+import { sql } from "@/app/lib/db/db";
+import { authOptions } from "@/app/lib/auth/auth-options";
+
+export interface UnsyncedCounts {
+  kilter: {
+    ascents: number;
+    climbs: number;
+  };
+  tension: {
+    ascents: number;
+    climbs: number;
+  };
+}
+
+/**
+ * GET - Get count of unsynced items for the logged-in user's Aurora accounts
+ */
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Get user's Aurora account user IDs from credentials
+    const credentials = await sql`
+      SELECT board_type, aurora_user_id
+      FROM aurora_credentials
+      WHERE user_id = ${session.user.id} AND aurora_user_id IS NOT NULL
+    `;
+
+    const counts: UnsyncedCounts = {
+      kilter: { ascents: 0, climbs: 0 },
+      tension: { ascents: 0, climbs: 0 },
+    };
+
+    for (const cred of credentials) {
+      const boardType = cred.board_type as 'kilter' | 'tension';
+      const auroraUserId = cred.aurora_user_id;
+
+      if (boardType === 'kilter') {
+        // Count unsynced kilter ascents for this user
+        const ascentResult = await sql`
+          SELECT COUNT(*) as count FROM kilter_ascents
+          WHERE user_id = ${auroraUserId} AND synced = false
+        `;
+        counts.kilter.ascents = Number(ascentResult[0]?.count || 0);
+
+        // Count unsynced kilter climbs for this user
+        const climbResult = await sql`
+          SELECT COUNT(*) as count FROM kilter_climbs
+          WHERE setter_id = ${auroraUserId} AND synced = false
+        `;
+        counts.kilter.climbs = Number(climbResult[0]?.count || 0);
+      } else if (boardType === 'tension') {
+        // Count unsynced tension ascents for this user
+        const ascentResult = await sql`
+          SELECT COUNT(*) as count FROM tension_ascents
+          WHERE user_id = ${auroraUserId} AND synced = false
+        `;
+        counts.tension.ascents = Number(ascentResult[0]?.count || 0);
+
+        // Count unsynced tension climbs for this user
+        const climbResult = await sql`
+          SELECT COUNT(*) as count FROM tension_climbs
+          WHERE setter_id = ${auroraUserId} AND synced = false
+        `;
+        counts.tension.climbs = Number(climbResult[0]?.count || 0);
+      }
+    }
+
+    return NextResponse.json({ counts });
+  } catch (error) {
+    console.error("Failed to get unsynced counts:", error);
+    return NextResponse.json({ error: "Failed to get unsynced counts" }, { status: 500 });
+  }
+}

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -10,7 +10,6 @@ import SendClimbToBoardButton from '../board-bluetooth-control/send-climb-to-boa
 import { BoardDetails } from '@/app/lib/types';
 import { generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib/url-utils';
 import { ShareBoardButton } from './share-button';
-import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useQueueContext } from '../graphql-queue';
 import { UserOutlined, LogoutOutlined, LoginOutlined, PlusOutlined, MoreOutlined, SettingOutlined } from '@ant-design/icons';
 import AngleSelector from './angle-selector';
@@ -24,12 +23,10 @@ type BoardSeshHeaderProps = {
 };
 export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeaderProps) {
   const { data: session } = useSession();
-  const { logout } = useBoardProvider();
   const { currentClimb } = useQueueContext();
 
   const handleSignOut = () => {
     signOut();
-    logout(); // Also logout from board provider
   };
 
   const userMenuItems: MenuProps['items'] = [

--- a/packages/web/app/components/board-provider/board-provider-context.tsx
+++ b/packages/web/app/components/board-provider/board-provider-context.tsx
@@ -1,48 +1,11 @@
 'use client';
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { BoardName, ClimbUuid } from '@/app/lib/types';
-import { IDBPDatabase, openDB } from 'idb';
 import { AscentSavedEvent, LogbookEntry, SaveAscentResponse, SaveClimbOptions } from '@/app/lib/api-wrappers/aurora/types';
 import { SaveAscentOptions } from '@/app/lib/api-wrappers/aurora/types';
 import { generateUuid } from '@/app/lib/api-wrappers/aurora/util';
-import { supported_boards } from '../board-renderer/types';
 import { message } from 'antd';
-
-const DB_NAME = 'boardsesh_v2';
-const DB_VERSION = 5;
-
-const initDB = async () => {
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      // Simply create any missing stores
-      supported_boards.forEach((boardName) => {
-        if (!db.objectStoreNames.contains(boardName)) {
-          db.createObjectStore(boardName);
-        }
-      });
-    },
-  });
-  return db;
-};
-
-const loadAuthState = async (db: IDBPDatabase, board_name: BoardName): Promise<AuthState | null> => {
-  try {
-    const authState = await db.get(board_name, 'auth');
-    return authState || null;
-  } catch (error) {
-    console.error('Failed to load auth state:', error);
-    return null;
-  }
-};
-
-const saveAuthState = async (db: IDBPDatabase, board_name: BoardName, value: AuthState): Promise<void> => {
-  try {
-    await db.put(board_name, value, 'auth');
-  } catch (error) {
-    console.error('Failed to save auth state:', error);
-    throw error;
-  }
-};
+import { useSession } from 'next-auth/react';
 
 interface AuthState {
   token: string | null;
@@ -58,11 +21,10 @@ export interface SaveClimbResponse {
 interface BoardContextType {
   boardName: BoardName;
   isAuthenticated: boolean;
+  hasAuroraCredentials: boolean;
   token: string | null;
   user_id: number | null;
   username: string | null;
-  login: (board: BoardName, username: string, password: string) => Promise<void>;
-  logout: () => Promise<void>;
   isLoading: boolean;
   error: string | null;
   isInitialized: boolean;
@@ -75,131 +37,82 @@ interface BoardContextType {
 const BoardContext = createContext<BoardContextType | undefined>(undefined);
 
 export function BoardProvider({ boardName, children }: { boardName: BoardName; children: React.ReactNode }) {
+  const { data: session, status: sessionStatus } = useSession();
   const [authState, setAuthState] = useState<AuthState>({
     token: null,
     user_id: null,
     username: null,
     board: null,
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
-  const [db, setDb] = useState<IDBPDatabase | null>(null);
   const [logbook, setLogbook] = useState<LogbookEntry[]>([]);
   const [currentClimbUuids, setCurrentClimbUuids] = useState<ClimbUuid[]>([]);
 
-  // Load saved auth state on mount
+  // Fetch Aurora credentials when session changes
   useEffect(() => {
     let mounted = true;
 
-    const initializeAuth = async () => {
+    const fetchAuroraCredentials = async () => {
+      // Only fetch if user is authenticated with NextAuth
+      if (sessionStatus === 'loading') {
+        return;
+      }
+
+      if (sessionStatus !== 'authenticated' || !session?.user?.id) {
+        setAuthState({
+          token: null,
+          user_id: null,
+          username: null,
+          board: null,
+        });
+        setIsLoading(false);
+        setIsInitialized(true);
+        return;
+      }
+
       try {
-        const database = await initDB();
+        setIsLoading(true);
+        const response = await fetch(`/api/internal/aurora-credentials/${boardName}`);
+
         if (!mounted) return;
 
-        setDb(database);
-
-        const savedState = await loadAuthState(database, boardName);
-        if (!mounted) return;
-
-        if (savedState) {
-          setAuthState(savedState);
+        if (response.ok) {
+          const data = await response.json();
+          setAuthState({
+            token: data.token,
+            user_id: data.user_id,
+            username: data.username,
+            board: boardName,
+          });
+        } else {
+          setAuthState({
+            token: null,
+            user_id: null,
+            username: null,
+            board: null,
+          });
         }
-      } catch (error) {
-        console.error('Failed to initialize auth:', error);
+      } catch (err) {
+        console.error('Failed to fetch Aurora credentials:', err);
         if (mounted) {
-          setError('Failed to initialize authentication system');
+          setError('Failed to load Aurora credentials');
         }
       } finally {
         if (mounted) {
+          setIsLoading(false);
           setIsInitialized(true);
         }
       }
     };
 
-    initializeAuth();
+    fetchAuroraCredentials();
 
     return () => {
       mounted = false;
     };
-  }, [boardName]);
-
-  useEffect(() => {
-    const syncUserData = async () => {
-      if (!authState.token || !authState.user_id || !boardName) {
-        return;
-      }
-
-      try {
-        // await fetch(`/api/v1/${boardName}/proxy/user-sync`, {
-        //   method: 'POST',
-        //   headers: {
-        //     'Content-Type': 'application/json',
-        //   },
-        //   body: JSON.stringify({
-        //     board_name: boardName,
-        //   }),
-        // });
-      } catch (error) {
-        console.error('Failed to sync user data:', error);
-        // Don't surface this error to the user since it's a background sync
-      }
-    };
-
-    if (authState.token && boardName && authState.user_id) {
-      syncUserData();
-    }
-  }, [authState.token, authState.user_id, boardName]);
-
-  const login = async (board: BoardName, username: string, password: string) => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const response = await fetch(`/api/v1/${board}/proxy/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ username, password }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Login failed');
-      }
-
-      const newAuthState = {
-        token: data.token,
-        user_id: data.user_id,
-        username: username,
-        board,
-      };
-
-      // Update state
-      setAuthState(newAuthState);
-
-      // Persist to IndexedDB - use the board parameter from login, not from context
-      if (db) {
-        try {
-          await saveAuthState(db, board, newAuthState);
-        } catch (error) {
-          console.error('Failed to persist auth state:', error);
-          message.warning('Login successful but failed to save session');
-        }
-      } else {
-        console.error('Database not initialized');
-        message.warning('Login successful but session may not persist');
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'An error occurred during login';
-      setError(errorMessage);
-      throw error;
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  }, [boardName, session?.user?.id, sessionStatus]);
 
   const getLogbook = useCallback(async (climbUuids: ClimbUuid[]) => {
     try {
@@ -347,21 +260,12 @@ export function BoardProvider({ boardName, children }: { boardName: BoardName; c
     }
   };
 
-  const logout = async () => {
-    setAuthState({
-      token: null,
-      user_id: null,
-      username: null,
-      board: null,
-    });
-  };
   const value = {
-    isAuthenticated: !!authState.token,
+    isAuthenticated: sessionStatus === 'authenticated',
+    hasAuroraCredentials: !!authState.token && !!authState.user_id,
     token: authState.token,
     user_id: authState.user_id,
     username: authState.username,
-    login,
-    logout,
     isLoading,
     error,
     isInitialized,

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -53,9 +53,8 @@
   margin-bottom: 16px;
 }
 
-/* Modal content */
-.modalDescription {
-  display: block;
+/* Auth alert */
+.authAlert {
   margin-bottom: 16px;
 }
 

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -120,11 +120,10 @@ describe('useQueueDataFetching', () => {
 
     mockUseBoardProvider.mockReturnValue({
       isAuthenticated: true,
+      hasAuroraCredentials: true,
       token: 'mock-token',
       user_id: 123,
       username: 'testuser',
-      login: vi.fn(),
-      logout: vi.fn(),
       isLoading: false,
       error: null,
       isInitialized: true,

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -50,3 +50,7 @@
   display: block;
   margin-bottom: 16px;
 }
+
+.unsyncedAlert {
+  margin-top: 12px;
+}

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -1,0 +1,52 @@
+.sectionDescription {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.cardsContainer {
+  width: 100%;
+}
+
+.credentialCard {
+  width: 100%;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.notConnectedText {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.credentialInfo {
+  margin-bottom: 16px;
+}
+
+.infoRow {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.errorRow {
+  margin-top: 8px;
+  padding: 8px;
+  background-color: #fff1f0;
+  border-radius: 4px;
+}
+
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+}
+
+.modalDescription {
+  display: block;
+  margin-bottom: 16px;
+}

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Card,
+  Button,
+  Form,
+  Input,
+  Typography,
+  Space,
+  Modal,
+  message,
+  Spin,
+  Tag,
+  Popconfirm,
+} from 'antd';
+import {
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
+  ClockCircleOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  SyncOutlined,
+} from '@ant-design/icons';
+import type { AuroraCredentialStatus } from '@/app/api/internal/aurora-credentials/route';
+import styles from './aurora-credentials-section.module.css';
+
+const { Text, Title } = Typography;
+
+interface BoardCredentialCardProps {
+  boardType: 'kilter' | 'tension';
+  credential: AuroraCredentialStatus | null;
+  onAdd: () => void;
+  onRemove: () => void;
+  isRemoving: boolean;
+}
+
+function BoardCredentialCard({
+  boardType,
+  credential,
+  onAdd,
+  onRemove,
+  isRemoving,
+}: BoardCredentialCardProps) {
+  const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
+
+  const getSyncStatusTag = () => {
+    if (!credential) return null;
+
+    switch (credential.syncStatus) {
+      case 'active':
+        return (
+          <Tag icon={<CheckCircleOutlined />} color="success">
+            Connected
+          </Tag>
+        );
+      case 'error':
+        return (
+          <Tag icon={<ExclamationCircleOutlined />} color="error">
+            Error
+          </Tag>
+        );
+      case 'expired':
+        return (
+          <Tag icon={<ClockCircleOutlined />} color="warning">
+            Expired
+          </Tag>
+        );
+      default:
+        return (
+          <Tag icon={<SyncOutlined spin />} color="processing">
+            Syncing
+          </Tag>
+        );
+    }
+  };
+
+  const formatLastSync = (dateString: string | null) => {
+    if (!dateString) return 'Never';
+    const date = new Date(dateString);
+    return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+  };
+
+  if (!credential) {
+    return (
+      <Card className={styles.credentialCard}>
+        <div className={styles.cardHeader}>
+          <Title level={5} style={{ margin: 0 }}>
+            {boardName} Board
+          </Title>
+        </div>
+        <Text type="secondary" className={styles.notConnectedText}>
+          Not connected. Link your {boardName} account to sync your logbook and ascents.
+        </Text>
+        <Button type="primary" icon={<PlusOutlined />} onClick={onAdd} block>
+          Link {boardName} Account
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={styles.credentialCard}>
+      <div className={styles.cardHeader}>
+        <Title level={5} style={{ margin: 0 }}>
+          {boardName} Board
+        </Title>
+        {getSyncStatusTag()}
+      </div>
+      <div className={styles.credentialInfo}>
+        <div className={styles.infoRow}>
+          <Text type="secondary">Username:</Text>
+          <Text strong>{credential.auroraUsername}</Text>
+        </div>
+        <div className={styles.infoRow}>
+          <Text type="secondary">Last synced:</Text>
+          <Text>{formatLastSync(credential.lastSyncAt)}</Text>
+        </div>
+        {credential.syncError && (
+          <div className={styles.errorRow}>
+            <Text type="danger">{credential.syncError}</Text>
+          </div>
+        )}
+      </div>
+      <Popconfirm
+        title="Remove account link"
+        description={`Are you sure you want to unlink your ${boardName} account?`}
+        onConfirm={onRemove}
+        okText="Yes, unlink"
+        cancelText="Cancel"
+        okButtonProps={{ danger: true }}
+      >
+        <Button danger icon={<DeleteOutlined />} loading={isRemoving} block>
+          Unlink Account
+        </Button>
+      </Popconfirm>
+    </Card>
+  );
+}
+
+export default function AuroraCredentialsSection() {
+  const [credentials, setCredentials] = useState<AuroraCredentialStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedBoard, setSelectedBoard] = useState<'kilter' | 'tension'>('kilter');
+  const [isSaving, setIsSaving] = useState(false);
+  const [removingBoard, setRemovingBoard] = useState<string | null>(null);
+  const [form] = Form.useForm();
+
+  const fetchCredentials = async () => {
+    try {
+      const response = await fetch('/api/internal/aurora-credentials');
+      if (response.ok) {
+        const data = await response.json();
+        setCredentials(data.credentials);
+      }
+    } catch (error) {
+      console.error('Failed to fetch credentials:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCredentials();
+  }, []);
+
+  const handleAddClick = (boardType: 'kilter' | 'tension') => {
+    setSelectedBoard(boardType);
+    form.resetFields();
+    setIsModalOpen(true);
+  };
+
+  const handleModalCancel = () => {
+    setIsModalOpen(false);
+    form.resetFields();
+  };
+
+  const handleSaveCredentials = async (values: { username: string; password: string }) => {
+    setIsSaving(true);
+    try {
+      const response = await fetch('/api/internal/aurora-credentials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          boardType: selectedBoard,
+          username: values.username,
+          password: values.password,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to save credentials');
+      }
+
+      message.success(`${selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} account linked successfully`);
+      setIsModalOpen(false);
+      form.resetFields();
+      fetchCredentials();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'Failed to link account');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRemove = async (boardType: 'kilter' | 'tension') => {
+    setRemovingBoard(boardType);
+    try {
+      const response = await fetch('/api/internal/aurora-credentials', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ boardType }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to remove credentials');
+      }
+
+      message.success('Account unlinked successfully');
+      fetchCredentials();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'Failed to unlink account');
+    } finally {
+      setRemovingBoard(null);
+    }
+  };
+
+  const getCredentialForBoard = (boardType: 'kilter' | 'tension') => {
+    return credentials.find((c) => c.boardType === boardType) || null;
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <div className={styles.loadingContainer}>
+          <Spin />
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <Title level={5}>Board Accounts</Title>
+        <Text type="secondary" className={styles.sectionDescription}>
+          Link your Kilter and Tension board accounts to sync your logbook, track ascents, and save
+          new climbs.
+        </Text>
+
+        <Space direction="vertical" size="middle" className={styles.cardsContainer}>
+          <BoardCredentialCard
+            boardType="kilter"
+            credential={getCredentialForBoard('kilter')}
+            onAdd={() => handleAddClick('kilter')}
+            onRemove={() => handleRemove('kilter')}
+            isRemoving={removingBoard === 'kilter'}
+          />
+          <BoardCredentialCard
+            boardType="tension"
+            credential={getCredentialForBoard('tension')}
+            onAdd={() => handleAddClick('tension')}
+            onRemove={() => handleRemove('tension')}
+            isRemoving={removingBoard === 'tension'}
+          />
+        </Space>
+      </Card>
+
+      <Modal
+        title={`Link ${selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} Account`}
+        open={isModalOpen}
+        onCancel={handleModalCancel}
+        footer={null}
+        destroyOnClose
+      >
+        <Text type="secondary" className={styles.modalDescription}>
+          Enter your {selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} Board
+          username and password. Your credentials are encrypted and securely stored.
+        </Text>
+        <Form form={form} layout="vertical" onFinish={handleSaveCredentials}>
+          <Form.Item
+            name="username"
+            label="Username"
+            rules={[{ required: true, message: 'Please enter your username' }]}
+          >
+            <Input placeholder="Enter your username" />
+          </Form.Item>
+
+          <Form.Item
+            name="password"
+            label="Password"
+            rules={[{ required: true, message: 'Please enter your password' }]}
+          >
+            <Input.Password placeholder="Enter your password" />
+          </Form.Item>
+
+          <Button type="primary" htmlType="submit" loading={isSaving} block>
+            {isSaving ? 'Linking...' : 'Link Account'}
+          </Button>
+        </Form>
+      </Modal>
+    </>
+  );
+}

--- a/packages/web/app/components/setup-wizard/layout-selection.tsx
+++ b/packages/web/app/components/setup-wizard/layout-selection.tsx
@@ -1,21 +1,16 @@
 'use client';
 import React, { useState } from 'react';
-import { Button, Form, Select, Typography, Input, Divider } from 'antd';
+import { Button, Form, Select, Typography } from 'antd';
 import { useRouter } from 'next/navigation';
 import { LayoutRow } from '@/app/lib/data/queries';
-import { useBoardProvider } from '../board-provider/board-provider-context';
 import { BoardName } from '@/app/lib/types';
 
 const { Option } = Select;
-const { Title, Text } = Typography;
+const { Title } = Typography;
 
-const LayoutSelection = ({ layouts = [], boardName }: { layouts: LayoutRow[]; boardName: BoardName }) => {
+const LayoutSelection = ({ layouts = [] }: { layouts: LayoutRow[]; boardName: BoardName }) => {
   const router = useRouter();
-  const { login, isAuthenticated } = useBoardProvider();
   const [selectedLayout, setSelectedLayout] = useState<number>();
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
 
   const onLayoutChange = (value: number) => {
     setSelectedLayout(value);
@@ -23,19 +18,6 @@ const LayoutSelection = ({ layouts = [], boardName }: { layouts: LayoutRow[]; bo
 
   const handleNext = () => {
     router.push(`${window.location.pathname}/${selectedLayout}`);
-  };
-
-  const handleLogin = async () => {
-    if (!username || !password) return;
-
-    setIsLoggingIn(true);
-    try {
-      await login(boardName, username, password);
-    } catch (error) {
-      console.error('Login failed:', error);
-    } finally {
-      setIsLoggingIn(false);
-    }
   };
 
   return (
@@ -51,34 +33,6 @@ const LayoutSelection = ({ layouts = [], boardName }: { layouts: LayoutRow[]; bo
             ))}
           </Select>
         </Form.Item>
-
-        <Divider>
-          <Text type="secondary">Optional Login</Text>
-        </Divider>
-
-        {isAuthenticated ? (
-          <div style={{ marginBottom: '16px' }}>
-            <Text type="success">Logged in to {boardName} board</Text>
-          </div>
-        ) : (
-          <div>
-            <Form.Item label="Username" tooltip="Your board account username">
-              <Input placeholder="Enter username" value={username} onChange={(e) => setUsername(e.target.value)} />
-            </Form.Item>
-
-            <Form.Item label="Password" tooltip="Your board account password">
-              <Input.Password
-                placeholder="Enter password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </Form.Item>
-
-            <Button type="default" block loading={isLoggingIn} onClick={handleLogin}>
-              {isLoggingIn ? 'Logging in...' : 'Login (Optional)'}
-            </Button>
-          </div>
-        )}
 
         <Button type="primary" block style={{ marginTop: '16px' }} onClick={handleNext} disabled={!selectedLayout}>
           Next

--- a/packages/web/app/lib/api-wrappers/aurora/saveAscent.ts
+++ b/packages/web/app/lib/api-wrappers/aurora/saveAscent.ts
@@ -4,6 +4,104 @@ import dayjs from 'dayjs';
 import { sql } from '@/app/lib/db/db';
 import { getTableName } from '../../data-sync/aurora/getTableName';
 
+interface AuroraSyncResult {
+  success: boolean;
+  ascent?: Ascent;
+  error?: string;
+}
+
+/**
+ * Attempts to save an ascent to the Aurora API
+ * Returns the result without throwing - caller decides how to handle errors
+ */
+async function syncAscentToAurora(
+  board: BoardName,
+  token: string,
+  requestData: {
+    user_id: number;
+    uuid: string;
+    climb_uuid: string;
+    angle: number;
+    difficulty: number;
+    is_mirror: number;
+    attempt_id: number;
+    bid_count: number;
+    quality: number;
+    is_benchmark: number;
+    comment: string;
+    climbed_at: string;
+  }
+): Promise<AuroraSyncResult> {
+  try {
+    // Build URL-encoded form data - Aurora expects this format!
+    const requestBody = new URLSearchParams();
+    Object.entries(requestData).forEach(([key, value]) => {
+      requestBody.append(key, String(value));
+    });
+
+    // Use the web host endpoint with POST method
+    const url = `${WEB_HOSTS[board]}/ascents/save`;
+    console.log(`Saving ascent to Aurora: ${url}`);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'Kilter%20Board/202 CFNetwork/1568.100.1 Darwin/24.0.0',
+        Cookie: `token=${token}`,
+      },
+      body: requestBody.toString(),
+    });
+
+    console.log(`Save ascent response status: ${response.status}`);
+
+    if (!response.ok) {
+      const responseClone = response.clone();
+      let errorData;
+      try {
+        errorData = await response.json();
+      } catch {
+        try {
+          errorData = await responseClone.text();
+        } catch {
+          errorData = 'Could not read error response';
+        }
+      }
+      return {
+        success: false,
+        error: `HTTP ${response.status}: ${JSON.stringify(errorData)}`,
+      };
+    }
+
+    // Handle potentially empty response body
+    const responseText = await response.text();
+    if (!responseText || responseText.trim() === '') {
+      return {
+        success: false,
+        error: 'Empty response from Aurora API',
+      };
+    }
+
+    const responseData = JSON.parse(responseText) as { ascents?: Ascent[] };
+    if (!responseData.ascents || responseData.ascents.length === 0) {
+      return {
+        success: false,
+        error: 'No ascent data in Aurora response',
+      };
+    }
+
+    return {
+      success: true,
+      ascent: responseData.ascents[0],
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error during Aurora sync',
+    };
+  }
+}
+
 export async function saveAscent(
   board: BoardName,
   token: string,
@@ -11,6 +109,7 @@ export async function saveAscent(
 ): Promise<SaveAscentResponse> {
   // Convert the ISO date to the required format "YYYY-MM-DD HH:mm:ss"
   const formattedDate = dayjs(options.climbed_at).format('YYYY-MM-DD HH:mm:ss');
+  const createdAt = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
   // Match Kilter Board v3.6.4 payload structure exactly
   const requestData = {
@@ -20,7 +119,7 @@ export async function saveAscent(
     angle: options.angle,
     difficulty: options.difficulty,
     is_mirror: options.is_mirror ? 1 : 0,
-    attempt_id: options.attempt_id || options.bid_count, // Use attempt_id if available, fallback to bid_count
+    attempt_id: options.attempt_id || options.bid_count,
     bid_count: options.bid_count,
     quality: options.quality,
     is_benchmark: options.is_benchmark ? 1 : 0,
@@ -28,83 +127,31 @@ export async function saveAscent(
     climbed_at: formattedDate,
   };
 
-  // Build URL-encoded form data - Aurora expects this format!
-  const requestBody = new URLSearchParams();
-  Object.entries(requestData).forEach(([key, value]) => {
-    requestBody.append(key, String(value));
-  });
+  // Try to sync to Aurora API first
+  const auroraResult = await syncAscentToAurora(board, token, requestData);
 
-  // Use the web host endpoint with POST method
-  const url = `${WEB_HOSTS[board]}/ascents/save`;
-  console.log(`Saving ascent to: ${url}`);
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': 'Kilter%20Board/202 CFNetwork/1568.100.1 Darwin/24.0.0',
-      Cookie: `token=${token}`,
-    },
-    body: requestBody.toString(),
-  });
-
-  console.log(`Save ascent response status: ${response.status}`);
-  console.log(`Save ascent response headers:`, Object.fromEntries(response.headers.entries()));
-
-  if (!response.ok) {
-    const responseClone = response.clone();
-    let errorData;
-    try {
-      errorData = await response.json();
-    } catch {
-      try {
-        errorData = await responseClone.text();
-      } catch {
-        errorData = 'Could not read error response';
-      }
-    }
-    console.error('Error response:', {
-      status: response.status,
-      statusText: response.statusText,
-      errors: errorData,
-    });
-    throw new Error(`HTTP error! status: ${response.status}, details: ${JSON.stringify(errorData)}`);
+  if (!auroraResult.success) {
+    console.warn(`Aurora sync failed for ascent ${options.uuid}: ${auroraResult.error}`);
   }
 
-  // Handle potentially empty response body
-  let responseData: unknown;
-  try {
-    const responseText = await response.text();
-    console.log(`Save ascent response body: ${responseText}`);
-
-    if (!responseText || responseText.trim() === '') {
-      throw new Error('Empty response from API');
-    }
-    responseData = JSON.parse(responseText);
-  } catch (parseError) {
-    console.error('Failed to parse response:', parseError);
-    throw new Error(`Failed to parse API response: ${parseError}`);
-  }
-
-  // Handle the new response format
-  const typedResponse = responseData as { ascents?: Ascent[] };
-  if (!typedResponse.ascents || typedResponse.ascents.length === 0) {
-    throw new Error('No ascent data in response');
-  }
-
-  const savedAscent = typedResponse.ascents[0];
-
-  // Insert into the intermediate database
-  const fullTableName = getTableName(board, 'ascents'); // Replace with your actual table name
+  // Always save to local database, regardless of Aurora success
+  const fullTableName = getTableName(board, 'ascents');
+  const synced = auroraResult.success;
+  const syncError = auroraResult.success ? null : auroraResult.error;
+  const finalCreatedAt = auroraResult.ascent?.created_at || createdAt;
 
   await sql`
     INSERT INTO ${sql.unsafe(fullTableName)} (
-      uuid, climb_uuid, angle, is_mirror, user_id, attempt_id, 
-      bid_count, quality, difficulty, is_benchmark, comment, 
-      climbed_at, created_at
+      uuid, climb_uuid, angle, is_mirror, user_id, attempt_id,
+      bid_count, quality, difficulty, is_benchmark, comment,
+      climbed_at, created_at, synced, sync_error
     )
     VALUES (
-      ${requestData.uuid}, ${requestData.climb_uuid}, ${requestData.angle}, ${requestData.is_mirror}, ${requestData.user_id}, ${requestData.attempt_id || requestData.bid_count}, ${requestData.bid_count}, ${requestData.quality}, ${requestData.difficulty}, ${requestData.is_benchmark ? 1 : 0}, ${requestData.comment || ''}, ${requestData.climbed_at}, ${savedAscent.created_at}
+      ${requestData.uuid}, ${requestData.climb_uuid}, ${requestData.angle},
+      ${requestData.is_mirror}, ${requestData.user_id}, ${requestData.attempt_id},
+      ${requestData.bid_count}, ${requestData.quality}, ${requestData.difficulty},
+      ${requestData.is_benchmark}, ${requestData.comment || ''},
+      ${requestData.climbed_at}, ${finalCreatedAt}, ${synced}, ${syncError}
     )
     ON CONFLICT (uuid) DO UPDATE SET
       climb_uuid = EXCLUDED.climb_uuid,
@@ -116,15 +163,37 @@ export async function saveAscent(
       difficulty = EXCLUDED.difficulty,
       is_benchmark = EXCLUDED.is_benchmark,
       comment = EXCLUDED.comment,
-      climbed_at = EXCLUDED.climbed_at
+      climbed_at = EXCLUDED.climbed_at,
+      synced = EXCLUDED.synced,
+      sync_error = EXCLUDED.sync_error
   `;
 
-  // Return response in the expected format
+  // Create a local ascent object for the response
+  const localAscent: Ascent = auroraResult.ascent || {
+    uuid: options.uuid,
+    user_id: options.user_id,
+    climb_uuid: options.climb_uuid,
+    angle: options.angle,
+    is_mirror: options.is_mirror,
+    attempt_id: requestData.attempt_id,
+    bid_count: options.bid_count,
+    quality: options.quality,
+    difficulty: options.difficulty,
+    is_benchmark: options.is_benchmark,
+    is_listed: true,
+    wall_uuid: null,
+    comment: options.comment,
+    climbed_at: formattedDate,
+    created_at: finalCreatedAt,
+    updated_at: finalCreatedAt,
+  };
+
+  // Return response in the expected format - always success from client perspective
   return {
     events: [
       {
         _type: 'ascent_saved' as const,
-        ascent: savedAscent,
+        ascent: localAscent,
       },
     ],
   };

--- a/packages/web/app/lib/api-wrappers/aurora/saveClimb.ts
+++ b/packages/web/app/lib/api-wrappers/aurora/saveClimb.ts
@@ -1,21 +1,120 @@
 import { BoardName } from '../../types';
 import { API_HOSTS, SaveClimbOptions } from './types';
 import { generateUuid } from './util';
+import { sql } from '@/app/lib/db/db';
+import { getTableName } from '../../data-sync/aurora/getTableName';
+import dayjs from 'dayjs';
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export async function saveClimb(board: BoardName, token: string, options: SaveClimbOptions): Promise<any> {
+interface AuroraSyncResult {
+  success: boolean;
+  climb?: {
+    uuid: string;
+    created_at?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  };
+  error?: string;
+}
+
+/**
+ * Attempts to save a climb to the Aurora API
+ * Returns the result without throwing - caller decides how to handle errors
+ */
+async function syncClimbToAurora(
+  board: BoardName,
+  token: string,
+  uuid: string,
+  options: SaveClimbOptions
+): Promise<AuroraSyncResult> {
+  try {
+    const response = await fetch(`${API_HOSTS[board]}/v2/climbs/${uuid}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        uuid,
+        ...options,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unknown error');
+      return {
+        success: false,
+        error: `HTTP ${response.status}: ${errorText}`,
+      };
+    }
+
+    const data = await response.json();
+    return {
+      success: true,
+      climb: data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error during Aurora sync',
+    };
+  }
+}
+
+export interface SaveClimbResponse {
+  uuid: string;
+  synced: boolean;
+}
+
+export async function saveClimb(
+  board: BoardName,
+  token: string,
+  options: SaveClimbOptions
+): Promise<SaveClimbResponse> {
   const uuid = generateUuid();
-  const response = await fetch(`${API_HOSTS[board]}/v2/climbs/${uuid}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      uuid,
-      ...options,
-    }),
-  });
-  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  return response.json();
+  const createdAt = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+  // Try to sync to Aurora API first
+  const auroraResult = await syncClimbToAurora(board, token, uuid, options);
+
+  if (!auroraResult.success) {
+    console.warn(`Aurora sync failed for climb ${uuid}: ${auroraResult.error}`);
+  }
+
+  // Always save to local database, regardless of Aurora success
+  const fullTableName = getTableName(board, 'climbs');
+  const synced = auroraResult.success;
+  const syncError = auroraResult.success ? null : auroraResult.error;
+  const finalCreatedAt = auroraResult.climb?.created_at || createdAt;
+
+  await sql`
+    INSERT INTO ${sql.unsafe(fullTableName)} (
+      uuid, layout_id, setter_id, name, description, angle,
+      frames_count, frames_pace, frames, is_draft, is_listed,
+      created_at, synced, sync_error
+    )
+    VALUES (
+      ${uuid}, ${options.layout_id}, ${options.setter_id}, ${options.name},
+      ${options.description || ''}, ${options.angle}, ${options.frames_count || 1},
+      ${options.frames_pace || 0}, ${options.frames}, ${options.is_draft},
+      ${false}, ${finalCreatedAt}, ${synced}, ${syncError}
+    )
+    ON CONFLICT (uuid) DO UPDATE SET
+      layout_id = EXCLUDED.layout_id,
+      setter_id = EXCLUDED.setter_id,
+      name = EXCLUDED.name,
+      description = EXCLUDED.description,
+      angle = EXCLUDED.angle,
+      frames_count = EXCLUDED.frames_count,
+      frames_pace = EXCLUDED.frames_pace,
+      frames = EXCLUDED.frames,
+      is_draft = EXCLUDED.is_draft,
+      synced = EXCLUDED.synced,
+      sync_error = EXCLUDED.sync_error
+  `;
+
+  // Return response - always success from client perspective
+  return {
+    uuid,
+    synced: auroraResult.success,
+  };
 }

--- a/packages/web/app/lib/crypto.ts
+++ b/packages/web/app/lib/crypto.ts
@@ -1,0 +1,65 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const TAG_LENGTH = 16;
+const SALT_LENGTH = 32;
+const KEY_LENGTH = 32;
+
+function getEncryptionKey(): Buffer {
+  const secret = process.env.AURORA_CREDENTIALS_SECRET;
+  if (!secret) {
+    throw new Error('AURORA_CREDENTIALS_SECRET environment variable is not set');
+  }
+  // Use PBKDF2 to derive a consistent key from the secret
+  return crypto.pbkdf2Sync(secret, 'aurora-credentials-salt', 100000, KEY_LENGTH, 'sha256');
+}
+
+/**
+ * Encrypts a string using AES-256-GCM
+ * @param text - The plaintext to encrypt
+ * @returns Base64-encoded encrypted string with IV and auth tag
+ */
+export function encrypt(text: string): string {
+  const key = getEncryptionKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+
+  const authTag = cipher.getAuthTag();
+
+  // Combine IV + authTag + encrypted data
+  const combined = Buffer.concat([
+    iv,
+    authTag,
+    Buffer.from(encrypted, 'hex')
+  ]);
+
+  return combined.toString('base64');
+}
+
+/**
+ * Decrypts an AES-256-GCM encrypted string
+ * @param encryptedText - Base64-encoded encrypted string with IV and auth tag
+ * @returns The decrypted plaintext
+ */
+export function decrypt(encryptedText: string): string {
+  const key = getEncryptionKey();
+  const combined = Buffer.from(encryptedText, 'base64');
+
+  // Extract IV, authTag, and encrypted data
+  const iv = combined.subarray(0, IV_LENGTH);
+  const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
+  const encrypted = combined.subarray(IV_LENGTH + TAG_LENGTH);
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(encrypted.toString('hex'), 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}

--- a/packages/web/app/lib/db/schema.ts
+++ b/packages/web/app/lib/db/schema.ts
@@ -184,6 +184,8 @@ export const kilterBids = pgTable(
     comment: text().default(''),
     climbedAt: text('climbed_at'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => [
     foreignKey({
@@ -294,6 +296,8 @@ export const kilterClimbs = pgTable(
     isDraft: boolean('is_draft').default(false),
     isListed: boolean('is_listed'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => ({
     // Indexes
@@ -464,6 +468,8 @@ export const tensionBids = pgTable(
     comment: text().default(''),
     climbedAt: text('climbed_at'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => [
     foreignKey({
@@ -544,6 +550,8 @@ export const tensionClimbs = pgTable(
     isDraft: boolean('is_draft').default(false),
     isListed: boolean('is_listed'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => ({
     // Indexes
@@ -811,6 +819,8 @@ export const kilterAscents = pgTable(
     comment: text().default(''),
     climbedAt: text('climbed_at'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => [
     foreignKey({
@@ -914,6 +924,8 @@ export const tensionAscents = pgTable(
     comment: text().default(''),
     climbedAt: text('climbed_at'),
     createdAt: text('created_at'),
+    synced: boolean('synced').default(true).notNull(),
+    syncError: text('sync_error'),
   },
   (table) => [
     foreignKey({

--- a/packages/web/app/lib/db/schema.ts
+++ b/packages/web/app/lib/db/schema.ts
@@ -1214,3 +1214,33 @@ export const userFavorites = pgTable(
     ),
   })
 );
+
+// Aurora credentials for Kilter/Tension board accounts (encrypted)
+export const auroraCredentials = pgTable(
+  "aurora_credentials",
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    boardType: text("board_type").notNull(), // 'kilter', 'tension'
+    encryptedUsername: text("encrypted_username").notNull(),
+    encryptedPassword: text("encrypted_password").notNull(),
+    auroraUserId: integer("aurora_user_id"), // Aurora board user ID after successful login
+    auroraToken: text("aurora_token"), // Session token (encrypted)
+    lastSyncAt: timestamp("last_sync_at"), // Last successful sync
+    syncStatus: text("sync_status").default("pending").notNull(), // 'pending', 'active', 'error', 'expired'
+    syncError: text("sync_error"), // Error message if sync failed
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    // Ensure unique credential per board type for each user
+    uniqueUserBoardCredential: uniqueIndex("unique_user_board_credential").on(
+      table.userId,
+      table.boardType
+    ),
+    // Index for efficient lookup by user
+    userCredentialsIdx: index("aurora_credentials_user_idx").on(table.userId),
+  })
+);

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -20,6 +20,7 @@ import type { UploadFile, UploadProps } from 'antd/es/upload/interface';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Logo from '@/app/components/brand/logo';
+import AuroraCredentialsSection from '@/app/components/settings/aurora-credentials-section';
 
 const { Content, Header } = Layout;
 const { Title, Text } = Typography;
@@ -291,6 +292,10 @@ export default function SettingsPageContent() {
             </Form.Item>
           </Form>
         </Card>
+
+        <Divider />
+
+        <AuroraCredentialsSection />
       </Content>
     </Layout>
   );

--- a/packages/web/drizzle/0019_aurora_credentials.sql
+++ b/packages/web/drizzle/0019_aurora_credentials.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "aurora_credentials" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"board_type" text NOT NULL,
+	"encrypted_username" text NOT NULL,
+	"encrypted_password" text NOT NULL,
+	"aurora_user_id" integer,
+	"aurora_token" text,
+	"last_sync_at" timestamp,
+	"sync_status" text DEFAULT 'pending' NOT NULL,
+	"sync_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "aurora_credentials" ADD CONSTRAINT "aurora_credentials_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_user_board_credential" ON "aurora_credentials" USING btree ("user_id","board_type");--> statement-breakpoint
+CREATE INDEX "aurora_credentials_user_idx" ON "aurora_credentials" USING btree ("user_id");

--- a/packages/web/drizzle/0020_add_synced_columns.sql
+++ b/packages/web/drizzle/0020_add_synced_columns.sql
@@ -1,0 +1,40 @@
+-- Add synced columns to ascent and climb tables for tracking Aurora sync status
+-- Default to true for existing data (assumed to be synced from Aurora)
+
+-- Kilter ascents
+ALTER TABLE "kilter_ascents" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "kilter_ascents" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Tension ascents
+ALTER TABLE "tension_ascents" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "tension_ascents" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Kilter bids
+ALTER TABLE "kilter_bids" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "kilter_bids" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Tension bids
+ALTER TABLE "tension_bids" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "tension_bids" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Kilter climbs
+ALTER TABLE "kilter_climbs" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "kilter_climbs" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Tension climbs
+ALTER TABLE "tension_climbs" ADD COLUMN IF NOT EXISTS "synced" boolean DEFAULT true NOT NULL;
+ALTER TABLE "tension_climbs" ADD COLUMN IF NOT EXISTS "sync_error" text;
+--> statement-breakpoint
+
+-- Create indexes for efficient lookup of unsynced items
+CREATE INDEX IF NOT EXISTS "kilter_ascents_synced_idx" ON "kilter_ascents" ("synced") WHERE "synced" = false;
+CREATE INDEX IF NOT EXISTS "tension_ascents_synced_idx" ON "tension_ascents" ("synced") WHERE "synced" = false;
+CREATE INDEX IF NOT EXISTS "kilter_bids_synced_idx" ON "kilter_bids" ("synced") WHERE "synced" = false;
+CREATE INDEX IF NOT EXISTS "tension_bids_synced_idx" ON "tension_bids" ("synced") WHERE "synced" = false;
+CREATE INDEX IF NOT EXISTS "kilter_climbs_synced_idx" ON "kilter_climbs" ("synced") WHERE "synced" = false;
+CREATE INDEX IF NOT EXISTS "tension_climbs_synced_idx" ON "tension_climbs" ("synced") WHERE "synced" = false;


### PR DESCRIPTION
- Add aurora_credentials table with encrypted username/password storage
- Create API endpoints for Aurora credential management (CRUD operations)
- Add Aurora credentials section to settings page with sync status cards
- Update BoardProvider to fetch credentials from database via NextAuth session
- Remove login/logout functions from BoardProvider (now handled in settings)
- Update search form to show NextAuth login banner instead of Aurora login
- Update create-climb form to check for linked Aurora account
- Update tick-button to use new auth flow
- Remove optional login from layout-selection wizard