### PR TITLE
fix: Improve loading experience with proper page-ready signaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2804,14 +2804,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/@petamoriken/float16": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
-      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@rc-component/async-validator": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
@@ -4195,7 +4187,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4755,7 +4747,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5411,20 +5403,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5646,70 +5624,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gel": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gel/-/gel-2.2.0.tgz",
-      "integrity": "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@petamoriken/float16": "^3.8.7",
-        "debug": "^4.3.4",
-        "env-paths": "^3.0.0",
-        "semver": "^7.6.2",
-        "shell-quote": "^1.8.1",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "gel": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/gel/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/gel/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gel/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/gensync": {
@@ -6562,7 +6476,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -7167,6 +7081,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7186,6 +7101,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -7405,6 +7321,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -7494,20 +7411,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -7909,7 +7812,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -7932,12 +7835,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7949,12 +7852,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7966,12 +7869,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7983,12 +7886,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8000,12 +7903,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8017,12 +7920,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8034,12 +7937,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8051,12 +7954,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8068,12 +7971,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8085,12 +7988,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8102,12 +8005,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8119,12 +8022,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8136,12 +8039,12 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8153,12 +8056,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8170,12 +8073,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8187,12 +8090,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8204,12 +8107,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8221,12 +8124,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8238,12 +8141,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8255,12 +8158,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8272,12 +8175,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8289,12 +8192,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8306,12 +8209,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8323,12 +8226,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8340,12 +8243,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8357,12 +8260,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8371,7 +8274,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -129,8 +129,8 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   const { board_name, angle } = parsedParams;
 
-  // Fetch the climbs and board details server-side
-  const [boardDetails] = await Promise.all([getBoardDetails(parsedParams)]);
+  // Fetch the board details server-side
+  const boardDetails = await getBoardDetails(parsedParams);
 
   return (
     <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column', padding: 0 }}>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { PropsWithChildren } from 'react';
 import { Affix, Layout } from 'antd';
 import { ParsedBoardRouteParameters, BoardRouteParameters, BoardDetails } from '@/app/lib/types';
@@ -14,6 +14,7 @@ import { ConnectionSettingsProvider } from '@/app/components/connection-manager/
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import PartyProfileWrapper from '@/app/components/party-manager/party-profile-wrapper';
 import { Metadata } from 'next';
+import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 
 /**
  * Generates a user-friendly page title from board details.
@@ -152,7 +153,9 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                 paddingRight: '10px',
               }}
             >
-              {children}
+              <Suspense fallback={<BoardPageSkeleton />}>
+                {children}
+              </Suspense>
             </Content>
 
             <Affix offsetBottom={0}>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -11,6 +11,7 @@ import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import ClimbsList from '@/app/components/board-page/climbs-list';
 import { searchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
 import { getBoardDetails } from '@/app/lib/data/queries';
+import PageReadySignal from '@/app/components/loading/page-ready-signal';
 
 export default async function DynamicResultsPage(props: {
   params: Promise<BoardRouteParametersWithUuid>;
@@ -86,6 +87,7 @@ export default async function DynamicResultsPage(props: {
   return (
     <>
       <ClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={fetchedResults.climbs} />
+      <PageReadySignal />
     </>
   );
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -102,7 +102,7 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
 
     if (hasNumericParams || isUuidOnly(params.climb_uuid)) {
       // Need to redirect to new slug-based URL
-      const [currentClimb] = await Promise.all([getClimb(parsedParams)]);
+      const currentClimb = await getClimb(parsedParams);
 
       // Get the names for slug generation
       const layouts = await import('@/app/lib/data/queries').then((m) => m.getLayouts(parsedParams.board_name));

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -22,6 +22,7 @@ import { kilterBetaLinks, tensionBetaLinks } from '@/app/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import styles from './climb-view.module.css';
+import PageReadySignal from '@/app/components/loading/page-ready-signal';
 
 export async function generateMetadata(props: { params: Promise<BoardRouteParametersWithUuid> }): Promise<Metadata> {
   const params = await props.params;
@@ -191,27 +192,30 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
     );
 
     return (
-      <div className={styles.pageContainer}>
-        {/* Actions Section */}
-        <div className={styles.actionsSection}>
-          <ClimbViewActions
-            climb={climbWithProcessedData}
-            boardDetails={boardDetails}
-            auroraAppUrl={auroraAppUrl}
-            angle={parsedParams.angle}
-          />
-        </div>
+      <>
+        <div className={styles.pageContainer}>
+          {/* Actions Section */}
+          <div className={styles.actionsSection}>
+            <ClimbViewActions
+              climb={climbWithProcessedData}
+              boardDetails={boardDetails}
+              auroraAppUrl={auroraAppUrl}
+              angle={parsedParams.angle}
+            />
+          </div>
 
-        {/* Main Content */}
-        <div className={styles.contentWrapper}>
-          <div className={styles.climbSection}>
-            <ClimbCard climb={climbWithProcessedData} boardDetails={boardDetails} actions={[]} />
-          </div>
-          <div className={styles.betaSection}>
-            <BetaVideos betaLinks={betaLinks} />
+          {/* Main Content */}
+          <div className={styles.contentWrapper}>
+            <div className={styles.climbSection}>
+              <ClimbCard climb={climbWithProcessedData} boardDetails={boardDetails} actions={[]} />
+            </div>
+            <div className={styles.betaSection}>
+              <BetaVideos betaLinks={betaLinks} />
+            </div>
           </div>
         </div>
-      </div>
+        <PageReadySignal />
+      </>
     );
   } catch (error) {
     console.error('Error fetching results or climb:', error);

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -1,10 +1,9 @@
-'use client';
-
 import React from 'react';
 import Row from 'antd/es/row';
 import Col from 'antd/es/col';
 import Flex from 'antd/es/flex';
 import Card from 'antd/es/card';
+import Skeleton from 'antd/es/skeleton';
 import { InfoCircleOutlined, ForkOutlined, HeartOutlined, PlusCircleOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -14,58 +13,33 @@ import { themeTokens } from '@/app/theme/theme-config';
 const ClimbCardTitleSkeleton = () => (
   <Flex gap={12} align="center">
     {/* Left side: Name and info stacked */}
-    <Flex vertical gap={2} style={{ flex: 1, minWidth: 0 }}>
-      {/* Name placeholder */}
-      <div
-        style={{
-          height: 14,
-          width: '60%',
-          backgroundColor: 'var(--ant-color-fill-secondary)',
-          borderRadius: 4,
-        }}
-      />
-      {/* Quality/setter placeholder */}
-      <div
-        style={{
-          height: 12,
-          width: '80%',
-          backgroundColor: 'var(--ant-color-fill-tertiary)',
-          borderRadius: 4,
-        }}
-      />
+    <Flex vertical gap={4} style={{ flex: 1, minWidth: 0 }}>
+      <Skeleton.Input active size="small" style={{ width: '60%', minWidth: 80 }} />
+      <Skeleton.Input active size="small" style={{ width: '80%', minWidth: 100, height: 14 }} />
     </Flex>
     {/* Right side: V grade placeholder */}
-    <div
-      style={{
-        width: 32,
-        height: 32,
-        backgroundColor: 'var(--ant-color-fill-secondary)',
-        borderRadius: 4,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    />
+    <Skeleton.Avatar active shape="square" size={32} />
   </Flex>
 );
 
 /**
- * Skeleton that mimics the BoardRenderer - just a placeholder area
+ * Skeleton that mimics the BoardRenderer - square placeholder for the board image
  */
 const BoardRendererSkeleton = () => (
-  <div
+  <Skeleton.Node
+    active
     style={{
       width: '100%',
-      aspectRatio: '1 / 1.1',
-      backgroundColor: 'var(--ant-color-fill-quaternary)',
-      borderRadius: 4,
+      height: 0,
+      paddingBottom: '110%', // Matches aspectRatio 1/1.1
     }}
-  />
+  >
+    <span />
+  </Skeleton.Node>
 );
 
 /**
- * Skeleton loading UI for the board page, matching the ClimbsList grid layout.
- * Uses the same Card structure as ClimbCard with muted action icons.
+ * Skeleton loading UI for ClimbCard, matching the card structure with muted action icons.
  */
 const ClimbCardSkeleton = () => (
   <Card
@@ -89,6 +63,9 @@ const ClimbCardSkeleton = () => (
   </Card>
 );
 
+/**
+ * Skeleton loading UI for the board page, matching the ClimbsList grid layout.
+ */
 const BoardPageSkeleton = () => {
   return (
     <Row gutter={[8, 8]}>

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -1,5 +1,10 @@
+'use client';
+
 import React from 'react';
-import { Row, Col, Skeleton, Card } from 'antd';
+import Row from 'antd/es/row';
+import Col from 'antd/es/col';
+import Skeleton from 'antd/es/skeleton';
+import Card from 'antd/es/card';
 
 /**
  * Skeleton loading UI for the board page, matching the ClimbsList grid layout.

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Row, Col, Skeleton, Card } from 'antd';
+
+/**
+ * Skeleton loading UI for the board page, matching the ClimbsList grid layout.
+ * Used as a fallback for Suspense boundaries.
+ */
+const ClimbCardSkeleton = () => (
+  <Card
+    size="small"
+    styles={{ header: { paddingTop: 8, paddingBottom: 6 }, body: { padding: 6 } }}
+    title={<Skeleton.Input active size="small" style={{ width: 200 }} />}
+  >
+    <Skeleton.Image active style={{ width: '100%', height: 200 }} />
+  </Card>
+);
+
+const BoardPageSkeleton = () => {
+  return (
+    <Row gutter={[8, 8]}>
+      {Array.from({ length: 10 }, (_, i) => (
+        <Col xs={24} lg={12} xl={12} key={i}>
+          <ClimbCardSkeleton />
+        </Col>
+      ))}
+    </Row>
+  );
+};
+
+export default BoardPageSkeleton;

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Row from 'antd/es/row';
 import Col from 'antd/es/col';

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -25,15 +25,16 @@ const ClimbCardTitleSkeleton = () => (
 );
 
 /**
- * Skeleton that mimics the BoardRenderer - square placeholder for the board image
+ * Skeleton that mimics the BoardRenderer - placeholder for the board image.
+ * Uses minHeight to approximate the actual BoardRenderer which has maxHeight: 55vh.
  */
 const BoardRendererSkeleton = () => (
   <Skeleton.Node
     active
     style={{
       width: '100%',
-      height: 0,
-      paddingBottom: '110%', // Matches aspectRatio 1/1.1
+      minHeight: '40vh',
+      aspectRatio: '1 / 1.1',
     }}
   >
     <span />

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -3,8 +3,108 @@
 import React from 'react';
 import Row from 'antd/es/row';
 import Col from 'antd/es/col';
-import Skeleton from 'antd/es/skeleton';
+import Flex from 'antd/es/flex';
 import Card from 'antd/es/card';
+import { themeTokens } from '@/app/theme/theme-config';
+
+/**
+ * Skeleton that mimics the ClimbCard title structure (horizontal layout with V grade)
+ */
+const ClimbCardTitleSkeleton = () => (
+  <Flex gap={12} align="center">
+    {/* Left side: Name and info stacked */}
+    <Flex vertical gap={4} style={{ flex: 1, minWidth: 0 }}>
+      {/* Name placeholder */}
+      <div
+        style={{
+          height: 16,
+          width: '70%',
+          backgroundColor: 'var(--ant-color-fill-tertiary)',
+          borderRadius: 4,
+        }}
+      />
+      {/* Quality/setter placeholder */}
+      <div
+        style={{
+          height: 12,
+          width: '50%',
+          backgroundColor: 'var(--ant-color-fill-quaternary)',
+          borderRadius: 4,
+        }}
+      />
+    </Flex>
+    {/* Right side: V grade placeholder */}
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        backgroundColor: 'var(--ant-color-fill-tertiary)',
+        borderRadius: 6,
+      }}
+    />
+  </Flex>
+);
+
+/**
+ * Skeleton that mimics the BoardRenderer with board background and hold circles
+ */
+const BoardRendererSkeleton = () => (
+  <div
+    style={{
+      width: '100%',
+      aspectRatio: '1 / 1.2',
+      backgroundColor: 'var(--ant-color-fill-quaternary)',
+      borderRadius: 4,
+      position: 'relative',
+      overflow: 'hidden',
+    }}
+  >
+    {/* Simulated hold circles scattered on the board */}
+    {[
+      { top: '15%', left: '30%', size: 16 },
+      { top: '25%', left: '60%', size: 14 },
+      { top: '35%', left: '45%', size: 18 },
+      { top: '45%', left: '25%', size: 14 },
+      { top: '55%', left: '70%', size: 16 },
+      { top: '65%', left: '40%', size: 14 },
+      { top: '75%', left: '55%', size: 18 },
+      { top: '85%', left: '35%', size: 16 },
+    ].map((hold, i) => (
+      <div
+        key={i}
+        style={{
+          position: 'absolute',
+          top: hold.top,
+          left: hold.left,
+          width: hold.size,
+          height: hold.size,
+          borderRadius: '50%',
+          border: '3px solid var(--ant-color-fill-secondary)',
+          opacity: 0.6,
+        }}
+      />
+    ))}
+  </div>
+);
+
+/**
+ * Card action button placeholders
+ */
+const CardActionsSkeleton = () => (
+  <Flex justify="space-around" style={{ padding: '8px 0' }}>
+    {[1, 2, 3, 4].map((i) => (
+      <div
+        key={i}
+        style={{
+          width: 20,
+          height: 20,
+          backgroundColor: 'var(--ant-color-fill-tertiary)',
+          borderRadius: 4,
+        }}
+      />
+    ))}
+  </Flex>
+);
 
 /**
  * Skeleton loading UI for the board page, matching the ClimbsList grid layout.
@@ -13,10 +113,18 @@ import Card from 'antd/es/card';
 const ClimbCardSkeleton = () => (
   <Card
     size="small"
-    styles={{ header: { paddingTop: 8, paddingBottom: 6 }, body: { padding: 6 } }}
-    title={<Skeleton.Input active size="small" style={{ width: 200 }} />}
+    style={{
+      backgroundColor: themeTokens.semantic.surface,
+    }}
+    styles={{
+      header: { paddingTop: 8, paddingBottom: 6 },
+      body: { padding: 6 },
+      actions: { borderTop: '1px solid var(--ant-color-border-secondary)' },
+    }}
+    title={<ClimbCardTitleSkeleton />}
+    actions={[<CardActionsSkeleton key="actions" />]}
   >
-    <Skeleton.Image active style={{ width: '100%', height: 200 }} />
+    <BoardRendererSkeleton />
   </Card>
 );
 

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -5,6 +5,7 @@ import Row from 'antd/es/row';
 import Col from 'antd/es/col';
 import Flex from 'antd/es/flex';
 import Card from 'antd/es/card';
+import { InfoCircleOutlined, ForkOutlined, HeartOutlined, PlusCircleOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
 
 /**
@@ -13,13 +14,13 @@ import { themeTokens } from '@/app/theme/theme-config';
 const ClimbCardTitleSkeleton = () => (
   <Flex gap={12} align="center">
     {/* Left side: Name and info stacked */}
-    <Flex vertical gap={4} style={{ flex: 1, minWidth: 0 }}>
+    <Flex vertical gap={2} style={{ flex: 1, minWidth: 0 }}>
       {/* Name placeholder */}
       <div
         style={{
-          height: 16,
-          width: '70%',
-          backgroundColor: 'var(--ant-color-fill-tertiary)',
+          height: 14,
+          width: '60%',
+          backgroundColor: 'var(--ant-color-fill-secondary)',
           borderRadius: 4,
         }}
       />
@@ -27,8 +28,8 @@ const ClimbCardTitleSkeleton = () => (
       <div
         style={{
           height: 12,
-          width: '50%',
-          backgroundColor: 'var(--ant-color-fill-quaternary)',
+          width: '80%',
+          backgroundColor: 'var(--ant-color-fill-tertiary)',
           borderRadius: 4,
         }}
       />
@@ -36,79 +37,35 @@ const ClimbCardTitleSkeleton = () => (
     {/* Right side: V grade placeholder */}
     <div
       style={{
-        width: 36,
-        height: 36,
-        backgroundColor: 'var(--ant-color-fill-tertiary)',
-        borderRadius: 6,
+        width: 32,
+        height: 32,
+        backgroundColor: 'var(--ant-color-fill-secondary)',
+        borderRadius: 4,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
       }}
     />
   </Flex>
 );
 
 /**
- * Skeleton that mimics the BoardRenderer with board background and hold circles
+ * Skeleton that mimics the BoardRenderer - just a placeholder area
  */
 const BoardRendererSkeleton = () => (
   <div
     style={{
       width: '100%',
-      aspectRatio: '1 / 1.2',
+      aspectRatio: '1 / 1.1',
       backgroundColor: 'var(--ant-color-fill-quaternary)',
       borderRadius: 4,
-      position: 'relative',
-      overflow: 'hidden',
     }}
-  >
-    {/* Simulated hold circles scattered on the board */}
-    {[
-      { top: '15%', left: '30%', size: 16 },
-      { top: '25%', left: '60%', size: 14 },
-      { top: '35%', left: '45%', size: 18 },
-      { top: '45%', left: '25%', size: 14 },
-      { top: '55%', left: '70%', size: 16 },
-      { top: '65%', left: '40%', size: 14 },
-      { top: '75%', left: '55%', size: 18 },
-      { top: '85%', left: '35%', size: 16 },
-    ].map((hold, i) => (
-      <div
-        key={i}
-        style={{
-          position: 'absolute',
-          top: hold.top,
-          left: hold.left,
-          width: hold.size,
-          height: hold.size,
-          borderRadius: '50%',
-          border: '3px solid var(--ant-color-fill-secondary)',
-          opacity: 0.6,
-        }}
-      />
-    ))}
-  </div>
-);
-
-/**
- * Card action button placeholders
- */
-const CardActionsSkeleton = () => (
-  <Flex justify="space-around" style={{ padding: '8px 0' }}>
-    {[1, 2, 3, 4].map((i) => (
-      <div
-        key={i}
-        style={{
-          width: 20,
-          height: 20,
-          backgroundColor: 'var(--ant-color-fill-tertiary)',
-          borderRadius: 4,
-        }}
-      />
-    ))}
-  </Flex>
+  />
 );
 
 /**
  * Skeleton loading UI for the board page, matching the ClimbsList grid layout.
- * Used as a fallback for Suspense boundaries.
+ * Uses the same Card structure as ClimbCard with muted action icons.
  */
 const ClimbCardSkeleton = () => (
   <Card
@@ -119,10 +76,14 @@ const ClimbCardSkeleton = () => (
     styles={{
       header: { paddingTop: 8, paddingBottom: 6 },
       body: { padding: 6 },
-      actions: { borderTop: '1px solid var(--ant-color-border-secondary)' },
     }}
     title={<ClimbCardTitleSkeleton />}
-    actions={[<CardActionsSkeleton key="actions" />]}
+    actions={[
+      <InfoCircleOutlined key="info" style={{ color: 'var(--ant-color-text-quaternary)' }} />,
+      <ForkOutlined key="fork" style={{ color: 'var(--ant-color-text-quaternary)' }} />,
+      <HeartOutlined key="heart" style={{ color: 'var(--ant-color-text-quaternary)' }} />,
+      <PlusCircleOutlined key="plus" style={{ color: 'var(--ant-color-text-quaternary)' }} />,
+    ]}
   >
     <BoardRendererSkeleton />
   </Card>

--- a/packages/web/app/components/board-renderer/board-litup-holds.tsx
+++ b/packages/web/app/components/board-renderer/board-litup-holds.tsx
@@ -16,8 +16,9 @@ const areLitUpHoldsMapsEqual = (prev: LitUpHoldsMap, next: LitUpHoldsMap): boole
   if (prevKeys.length !== nextKeys.length) return false;
 
   for (const key of prevKeys) {
-    const prevHold = prev[key];
-    const nextHold = next[key];
+    const numKey = Number(key);
+    const prevHold = prev[numKey];
+    const nextHold = next[numKey];
     if (!nextHold) return false;
     if (prevHold.state !== nextHold.state || prevHold.color !== nextHold.color) {
       return false;

--- a/packages/web/app/components/board-renderer/board-litup-holds.tsx
+++ b/packages/web/app/components/board-renderer/board-litup-holds.tsx
@@ -9,49 +9,74 @@ interface BoardLitupHoldsProps {
   onHoldClick?: (holdId: number) => void;
 }
 
-const BoardLitupHolds: React.FC<BoardLitupHoldsProps> = ({
-  holdsData,
-  litUpHoldsMap,
-  mirrored,
-  thumbnail,
-  onHoldClick,
-}) => {
-  if (!holdsData) return null;
+const areLitUpHoldsMapsEqual = (prev: LitUpHoldsMap, next: LitUpHoldsMap): boolean => {
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(next);
 
-  return (
-    <>
-      {holdsData.map((hold) => {
-        const isLitUp = litUpHoldsMap[hold.id]?.state && litUpHoldsMap[hold.id].state !== 'OFF';
-        const color = isLitUp ? litUpHoldsMap[hold.id].color : 'transparent';
+  if (prevKeys.length !== nextKeys.length) return false;
 
-        let renderHold = hold;
-        if (mirrored && hold.mirroredHoldId) {
-          const mirroredHold = holdsData.find(({ id }) => id === hold.mirroredHoldId);
-          if (!mirroredHold) {
-            throw new Error("Couldn't find mirrored hold");
-          }
-          renderHold = mirroredHold;
-        }
+  for (const key of prevKeys) {
+    const prevHold = prev[key];
+    const nextHold = next[key];
+    if (!nextHold) return false;
+    if (prevHold.state !== nextHold.state || prevHold.color !== nextHold.color) {
+      return false;
+    }
+  }
 
-        return (
-          <circle
-            key={renderHold.id}
-            id={`hold-${renderHold.id}`}
-            data-mirror-id={renderHold.mirroredHoldId || undefined}
-            cx={renderHold.cx}
-            cy={renderHold.cy}
-            r={renderHold.r}
-            stroke={color}
-            strokeWidth={thumbnail ? 8 : 6}
-            fillOpacity={thumbnail ? 1 : 0}
-            fill={thumbnail ? color : undefined}
-            style={{ cursor: onHoldClick ? 'pointer' : 'default' }}
-            onClick={onHoldClick ? () => onHoldClick(renderHold.id) : undefined}
-          />
-        );
-      })}
-    </>
-  );
+  return true;
 };
+
+const BoardLitupHolds = React.memo(
+  ({ holdsData, litUpHoldsMap, mirrored, thumbnail, onHoldClick }: BoardLitupHoldsProps) => {
+    if (!holdsData) return null;
+
+    return (
+      <>
+        {holdsData.map((hold) => {
+          const isLitUp = litUpHoldsMap[hold.id]?.state && litUpHoldsMap[hold.id].state !== 'OFF';
+          const color = isLitUp ? litUpHoldsMap[hold.id].color : 'transparent';
+
+          let renderHold = hold;
+          if (mirrored && hold.mirroredHoldId) {
+            const mirroredHold = holdsData.find(({ id }) => id === hold.mirroredHoldId);
+            if (!mirroredHold) {
+              throw new Error("Couldn't find mirrored hold");
+            }
+            renderHold = mirroredHold;
+          }
+
+          return (
+            <circle
+              key={renderHold.id}
+              id={`hold-${renderHold.id}`}
+              data-mirror-id={renderHold.mirroredHoldId || undefined}
+              cx={renderHold.cx}
+              cy={renderHold.cy}
+              r={renderHold.r}
+              stroke={color}
+              strokeWidth={thumbnail ? 8 : 6}
+              fillOpacity={thumbnail ? 1 : 0}
+              fill={thumbnail ? color : undefined}
+              style={{ cursor: onHoldClick ? 'pointer' : 'default' }}
+              onClick={onHoldClick ? () => onHoldClick(renderHold.id) : undefined}
+            />
+          );
+        })}
+      </>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.holdsData === nextProps.holdsData &&
+      prevProps.mirrored === nextProps.mirrored &&
+      prevProps.thumbnail === nextProps.thumbnail &&
+      prevProps.onHoldClick === nextProps.onHoldClick &&
+      areLitUpHoldsMapsEqual(prevProps.litUpHoldsMap, nextProps.litUpHoldsMap)
+    );
+  },
+);
+
+BoardLitupHolds.displayName = 'BoardLitupHolds';
 
 export default BoardLitupHolds;

--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -12,33 +12,37 @@ export type BoardProps = {
   onHoldClick?: (holdId: number) => void;
 };
 
-const BoardRenderer = ({ boardDetails, thumbnail, litUpHoldsMap, mirrored, onHoldClick }: BoardProps) => {
-  const { boardWidth, boardHeight, holdsData } = boardDetails;
+const BoardRenderer = React.memo(
+  ({ boardDetails, thumbnail, litUpHoldsMap, mirrored, onHoldClick }: BoardProps) => {
+    const { boardWidth, boardHeight, holdsData } = boardDetails;
 
-  return (
-    <svg
-      viewBox={`0 0 ${boardWidth} ${boardHeight}`}
-      preserveAspectRatio="xMidYMid meet" // Ensures aspect ratio is maintained
-      style={{
-        width: '100%',
-        height: 'auto',
-        display: 'block',
-        maxHeight: thumbnail ? '10vh' : '55vh', // TODO: Find better size
-      }} // Ensures scaling
-    >
-      {Object.keys(boardDetails.images_to_holds).map((imageUrl) => (
-        <image key={imageUrl} href={getImageUrl(imageUrl, boardDetails.board_name)} width="100%" height="100%" />
-      ))}
-      {litUpHoldsMap && (
-        <BoardLitupHolds
-          onHoldClick={onHoldClick}
-          holdsData={holdsData}
-          litUpHoldsMap={litUpHoldsMap}
-          mirrored={mirrored}
-        />
-      )}
-    </svg>
-  );
-};
+    return (
+      <svg
+        viewBox={`0 0 ${boardWidth} ${boardHeight}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          width: '100%',
+          height: 'auto',
+          display: 'block',
+          maxHeight: thumbnail ? '10vh' : '55vh',
+        }}
+      >
+        {Object.keys(boardDetails.images_to_holds).map((imageUrl) => (
+          <image key={imageUrl} href={getImageUrl(imageUrl, boardDetails.board_name)} width="100%" height="100%" />
+        ))}
+        {litUpHoldsMap && (
+          <BoardLitupHolds
+            onHoldClick={onHoldClick}
+            holdsData={holdsData}
+            litUpHoldsMap={litUpHoldsMap}
+            mirrored={mirrored}
+          />
+        )}
+      </svg>
+    );
+  },
+);
+
+BoardRenderer.displayName = 'BoardRenderer';
 
 export default BoardRenderer;

--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -18,29 +18,42 @@ type ClimbCardProps = {
   actions?: React.JSX.Element[];
 };
 
-const ClimbCard = ({ climb, boardDetails, onCoverClick, selected, actions }: ClimbCardProps) => {
-  const cover = <ClimbCardCover climb={climb} boardDetails={boardDetails} onClick={onCoverClick} />;
+const ClimbCard = React.memo(
+  ({ climb, boardDetails, onCoverClick, selected, actions }: ClimbCardProps) => {
+    const cover = <ClimbCardCover climb={climb} boardDetails={boardDetails} onClick={onCoverClick} />;
 
-  const cardTitle = climb ? (
-    <ClimbTitle climb={climb} layout="horizontal" showSetterInfo />
-  ) : (
-    'Loading...'
-  );
+    const cardTitle = climb ? (
+      <ClimbTitle climb={climb} layout="horizontal" showSetterInfo />
+    ) : (
+      'Loading...'
+    );
 
-  return (
-    <Card
-      title={cardTitle}
-      size="small"
-      style={{
-        backgroundColor: selected ? themeTokens.semantic.selected : themeTokens.semantic.surface,
-        borderColor: selected ? themeTokens.colors.primary : undefined,
-      }}
-      styles={{ header: { paddingTop: 8, paddingBottom: 6 }, body: { padding: 6 } }}
-      actions={actions || ClimbCardActions({ climb, boardDetails })}
-    >
-      {cover}
-    </Card>
-  );
-};
+    return (
+      <Card
+        title={cardTitle}
+        size="small"
+        style={{
+          backgroundColor: selected ? themeTokens.semantic.selected : themeTokens.semantic.surface,
+          borderColor: selected ? themeTokens.colors.primary : undefined,
+        }}
+        styles={{ header: { paddingTop: 8, paddingBottom: 6 }, body: { padding: 6 } }}
+        actions={actions || ClimbCardActions({ climb, boardDetails })}
+      >
+        {cover}
+      </Card>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.climb?.uuid === nextProps.climb?.uuid &&
+      prevProps.selected === nextProps.selected &&
+      prevProps.boardDetails === nextProps.boardDetails &&
+      prevProps.onCoverClick === nextProps.onCoverClick &&
+      prevProps.actions === nextProps.actions
+    );
+  },
+);
+
+ClimbCard.displayName = 'ClimbCard';
 
 export default ClimbCard;

--- a/packages/web/app/components/loading/page-ready-signal.tsx
+++ b/packages/web/app/components/loading/page-ready-signal.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useNavigationLoading } from '../providers/navigation-loading-provider';
+
+/**
+ * A component that signals to the NavigationLoadingProvider that the page content
+ * has finished rendering. Place this at the end of your page component to hide
+ * the loading overlay once the page is ready.
+ */
+export default function PageReadySignal() {
+  const { signalPageReady } = useNavigationLoading();
+
+  useEffect(() => {
+    signalPageReady();
+  }, [signalPageReady]);
+
+  return null;
+}

--- a/packages/web/app/components/setup-wizard/board-config-live-preview.tsx
+++ b/packages/web/app/components/setup-wizard/board-config-live-preview.tsx
@@ -56,7 +56,6 @@ export default function BoardConfigLivePreview({
         let details = cachedDetails;
         if (!details) {
           try {
-            debugger;
             details = await fetchBoardDetails(safeBoardName, safeLayoutId, safeSizeId, setIds);
           } catch (error) {
             console.error('Failed to fetch board details:', error);


### PR DESCRIPTION
- Replace pathname-based loading hide with explicit page-ready signal
- Loading overlay now persists until page content is actually rendered
- Add 10-second safety timeout to prevent infinite loading states
- Add memoization to ClimbCard, BoardRenderer, and BoardLitupHolds
- Add Suspense boundary with skeleton fallback to board layout
- Create PageReadySignal component to signal when pages are ready

This fixes the "freeze" at the end of loading where the overlay would
disappear before the page content was rendered, causing a blank screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>