### PR TITLE
fix: Update BoardRenderer memo to compare litUpHoldsMap by reference

### DIFF
--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -49,10 +49,8 @@ const BoardRenderer = React.memo(
     if (prevProps.mirrored !== nextProps.mirrored) return false;
     if (prevProps.onHoldClick !== nextProps.onHoldClick) return false;
 
-    // Compare litUpHoldsMap presence (content comparison is handled by BoardLitupHolds memo)
-    const prevHasMap = !!prevProps.litUpHoldsMap;
-    const nextHasMap = !!nextProps.litUpHoldsMap;
-    if (prevHasMap !== nextHasMap) return false;
+    // Compare litUpHoldsMap by reference - different climbs have different map objects
+    if (prevProps.litUpHoldsMap !== nextProps.litUpHoldsMap) return false;
 
     // Compare boardDetails by key identifiers and dimensions
     if (prevProps.boardDetails !== nextProps.boardDetails) {


### PR DESCRIPTION
The previous comparison only checked if litUpHoldsMap was truthy, not
whether it had changed. This caused the queue bar preview to not update
when navigating to the next climb, since both the old and new climb had
a litUpHoldsMap present.