### PR TITLE
fix: Remove hardcoded WebSocket URL from .env.local

### DIFF
--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -16,5 +16,7 @@ IRON_SESSION_PASSWORD={ "1": "68cJgCDE39gaXwi8LTVW4WioyhGxwcAd" }
 NEXTAUTH_SECRET=68cJgCDE39gaXwi8LTVW4WioyhGxwcAd
 NEXTAUTH_URL=http://localhost:3000
 
-# Local backend WebSocket URL
-NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
+# Backend WebSocket URL
+# For local development, uncomment the line below:
+# NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
+# For production, set this via your deployment platform's environment variables (e.g., Vercel)


### PR DESCRIPTION
NEXT_PUBLIC_* environment variables are inlined at build time in Next.js.
Having the localhost URL hardcoded in .env.local meant production builds
would ignore any runtime environment variable for NEXT_PUBLIC_WS_URL.

Now production deployments can properly set the WebSocket URL via their
platform's environment variables (e.g., Vercel dashboard).