### PR TITLE
fix: Style active ClimbCard with white header and lighter body

### DIFF
--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -53,10 +53,15 @@ const ClimbCard = React.memo(
         title={cardTitle}
         size="small"
         style={{
-          backgroundColor: selected ? themeTokens.semantic.selected : themeTokens.semantic.surface,
           borderColor: selected ? themeTokens.colors.primary : undefined,
         }}
-        styles={{ header: { paddingTop: 8, paddingBottom: 6 }, body: { padding: 6 } }}
+        styles={{
+          header: { paddingTop: 8, paddingBottom: 6 },
+          body: {
+            padding: 6,
+            backgroundColor: selected ? themeTokens.semantic.selectedLight : undefined,
+          },
+        }}
         actions={actions || (climb ? ClimbActions.asCardActions({
           climb,
           boardDetails,

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -35,6 +35,7 @@ export const themeTokens = {
   // Semantic colors
   semantic: {
     selected: '#ECFEFF', // Cyan-50 - lighter cyan
+    selectedLight: 'rgba(6, 182, 212, 0.08)', // Very light cyan for subtle highlights
     selectedBorder: '#06B6D4', // Cyan-500 - matches primary
     background: '#F9FAFB',
     surface: '#FFFFFF',


### PR DESCRIPTION
- Keep header white when card is selected/active
- Apply lighter selected background only to card body
- Add new selectedLight theme token for subtle highlights