### PR TITLE
Remove host query parameter from party modal

### DIFF
--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -20,16 +20,13 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 const { Text } = Typography;
 
-const getShareUrl = (pathname: string, searchParams: URLSearchParams, backendUrl: string | null) => {
+const getShareUrl = (pathname: string, searchParams: URLSearchParams) => {
   try {
     const params = new URLSearchParams(searchParams.toString());
-    // Remove existing connection params
+    // Remove legacy connection params (no longer needed with environment-based backend URL)
     params.delete('hostId');
     params.delete('backendUrl');
 
-    if (backendUrl) {
-      params.set('backendUrl', backendUrl);
-    }
     return `${window.location.origin}${pathname}?${params.toString()}`;
   } catch {
     return '';
@@ -60,7 +57,7 @@ export const ShareBoardButton = () => {
   const isConnecting = !!(isBackendMode && !hasConnected);
   const isConnected = !!(isBackendMode && hasConnected);
 
-  const shareUrl = getShareUrl(pathname, searchParams, backendUrl);
+  const shareUrl = getShareUrl(pathname, searchParams);
 
   const copyToClipboard = () => {
     navigator.clipboard

--- a/packages/web/app/components/setup-wizard/join-session-tab.tsx
+++ b/packages/web/app/components/setup-wizard/join-session-tab.tsx
@@ -189,7 +189,6 @@ const JoinSessionTab = ({ backendUrl }: JoinSessionTabProps) => {
           <NearbySessionCard
             key={session.id}
             session={session}
-            backendUrl={backendUrl}
           />
         ))}
       </div>

--- a/packages/web/app/components/setup-wizard/nearby-session-card.tsx
+++ b/packages/web/app/components/setup-wizard/nearby-session-card.tsx
@@ -23,7 +23,6 @@ type DiscoverableSession = {
 
 type NearbySessionCardProps = {
   session: DiscoverableSession;
-  backendUrl: string;
 };
 
 /**
@@ -49,13 +48,12 @@ function extractBoardName(boardPath: string): string {
   return 'Unknown Board';
 }
 
-const NearbySessionCard = ({ session, backendUrl }: NearbySessionCardProps) => {
+const NearbySessionCard = ({ session }: NearbySessionCardProps) => {
   const router = useRouter();
 
   const handleJoin = () => {
-    // Navigate to the board path with the session ID and backend URL
+    // Navigate to the board path with the session ID
     const url = new URL(session.boardPath, window.location.origin);
-    url.searchParams.set('backendUrl', backendUrl);
     url.searchParams.set('sessionId', session.id);
     router.push(url.pathname + url.search);
   };

--- a/packages/web/app/components/setup-wizard/session-history-panel.tsx
+++ b/packages/web/app/components/setup-wizard/session-history-panel.tsx
@@ -19,10 +19,6 @@ type StoredSession = {
   backendUrl?: string;
 };
 
-type SessionHistoryPanelProps = {
-  backendUrl?: string;
-};
-
 /**
  * Format relative time for display
  */
@@ -115,7 +111,7 @@ export async function saveSessionToHistory(session: StoredSession): Promise<void
   });
 }
 
-const SessionHistoryPanel = ({ backendUrl }: SessionHistoryPanelProps) => {
+const SessionHistoryPanel = () => {
   const router = useRouter();
   const [sessions, setSessions] = useState<StoredSession[]>([]);
   const [loading, setLoading] = useState(true);
@@ -129,9 +125,6 @@ const SessionHistoryPanel = ({ backendUrl }: SessionHistoryPanelProps) => {
 
   const handleResume = (session: StoredSession) => {
     const url = new URL(session.boardPath, window.location.origin);
-    if (session.backendUrl || backendUrl) {
-      url.searchParams.set('backendUrl', session.backendUrl || backendUrl || '');
-    }
     url.searchParams.set('sessionId', session.id);
     router.push(url.pathname + url.search);
   };


### PR DESCRIPTION
The GraphQL backend no longer requires the host in query parameters. The backend URL is now derived from the NEXT_PUBLIC_WS_URL environment variable. This change removes backendUrl from:
- Share URL generation in party mode
- Session resume navigation
- Join session navigation

Legacy backendUrl query params are still read for backward compatibility.