### PR TITLE
feat: Make party mode opt-in with user-owned sessions

### DIFF
--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -127,6 +127,31 @@ export const SET_QUEUE = `
   }
 `;
 
+export const CREATE_SESSION = `
+  mutation CreateSession($input: CreateSessionInput!) {
+    createSession(input: $input) {
+      id
+      boardPath
+      clientId
+      isLeader
+      users {
+        id
+        username
+        isLeader
+        avatarUrl
+      }
+      queueState {
+        queue {
+          ${QUEUE_ITEM_FIELDS}
+        }
+        currentClimbQueueItem {
+          ${QUEUE_ITEM_FIELDS}
+        }
+      }
+    }
+  }
+`;
+
 // Subscriptions
 export const SESSION_UPDATES = `
   subscription SessionUpdates($sessionId: ID!) {


### PR DESCRIPTION
## Summary

- **Party mode is now opt-in**: Users browse without a session until they explicitly start or join one
- **User-owned sessions**: Each logged-in user gets their own unique session ID (UUID) instead of sharing based on URL path
- **Shareable sessions**: Sessions can be joined via QR code, shareable link, or pasting a session ID
- **Discoverability toggle**: Users can optionally make their session discoverable via GPS

**Built on top of `fix_sockets_attempt2` branch** which includes comprehensive security hardening.

## Changes

### QueueContext.tsx
- Session ID now read from `?session=` URL parameter instead of derived from pathname
- Added `startSession()`, `joinSession()`, and `endSession()` methods to context
- Only connects to backend when a session is active
- Saves sessions to IndexedDB history for resumption

### ShareBoardButton
- Transformed into dual-purpose component:
  - **No session**: Shows tabs for "Start Session" (login required) and "Join Session"
  - **Session active**: Shows connected users, QR code, share URL, and "Leave" button
- Added discoverability toggle when creating sessions
- Button shows as primary (blue) when session is active

### shared-schema/operations.ts
- Added `CREATE_SESSION` GraphQL mutation operation

## Test plan

- [ ] Navigate to a board page - should NOT auto-join a session
- [ ] Click party mode button - should show Start/Join tabs
- [ ] Try to start session without login - should prompt to sign in
- [ ] Start session when logged in - should connect and show QR code
- [ ] Copy share URL and open in another browser - should join same session
- [ ] Click "Leave" button - should disconnect and remove ?session from URL
- [ ] Join session by pasting URL/ID - should connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)