### PR TITLE
feat: Add persistent WebSocket connections across navigation

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -12,7 +12,7 @@ import BoardSeshHeader from '@/app/components/board-page/header';
 import { GraphQLQueueProvider } from '@/app/components/graphql-queue';
 import { ConnectionSettingsProvider } from '@/app/components/connection-manager/connection-settings-context';
 import { PartyProvider } from '@/app/components/party-manager/party-context';
-import PartyProfileWrapper from '@/app/components/party-manager/party-profile-wrapper';
+import { BoardSessionBridge } from '@/app/components/persistent-session';
 import { Metadata } from 'next';
 import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 
@@ -134,37 +134,37 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   return (
     <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column', padding: 0 }}>
-      <ConnectionSettingsProvider>
-        <PartyProfileWrapper>
+      <BoardSessionBridge boardDetails={boardDetails} parsedParams={parsedParams}>
+        <ConnectionSettingsProvider>
           <GraphQLQueueProvider parsedParams={parsedParams}>
             <PartyProvider>
-            <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
+              <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
-            <Content
-              id="content-for-scrollable"
-              style={{
-                flex: 1,
-                justifyContent: 'center',
-                alignItems: 'center',
-                overflowY: 'auto',
-                overflowX: 'hidden',
-                height: '80vh',
-                paddingLeft: '10px',
-                paddingRight: '10px',
-              }}
-            >
-              <Suspense fallback={<BoardPageSkeleton />}>
-                {children}
-              </Suspense>
-            </Content>
+              <Content
+                id="content-for-scrollable"
+                style={{
+                  flex: 1,
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  overflowY: 'auto',
+                  overflowX: 'hidden',
+                  height: '80vh',
+                  paddingLeft: '10px',
+                  paddingRight: '10px',
+                }}
+              >
+                <Suspense fallback={<BoardPageSkeleton />}>
+                  {children}
+                </Suspense>
+              </Content>
 
-            <Affix offsetBottom={0}>
-              <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
-            </Affix>
+              <Affix offsetBottom={0}>
+                <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
+              </Affix>
             </PartyProvider>
           </GraphQLQueueProvider>
-        </PartyProfileWrapper>
-      </ConnectionSettingsProvider>
+        </ConnectionSettingsProvider>
+      </BoardSessionBridge>
     </Layout>
   );
 }

--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useSearchParams, usePathname } from 'next/navigation';
+import { usePersistentSession } from './persistent-session-context';
+import { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
+
+interface BoardSessionBridgeProps {
+  boardDetails: BoardDetails;
+  parsedParams: ParsedBoardRouteParameters;
+  children: React.ReactNode;
+}
+
+/**
+ * Bridge component that connects the board layout to the persistent session.
+ * This component activates the session when mounted on a board page with a session param.
+ */
+const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
+  boardDetails,
+  parsedParams,
+  children,
+}) => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const sessionIdFromUrl = searchParams.get('session');
+
+  const { activeSession, activateSession, deactivateSession } = usePersistentSession();
+
+  // Activate session when we have a session param and board details
+  useEffect(() => {
+    if (sessionIdFromUrl && boardDetails) {
+      // Only activate if not already active for this session
+      if (activeSession?.sessionId !== sessionIdFromUrl || activeSession?.boardPath !== pathname) {
+        activateSession({
+          sessionId: sessionIdFromUrl,
+          boardPath: pathname,
+          boardDetails,
+          parsedParams,
+        });
+      }
+    } else if (!sessionIdFromUrl && activeSession?.boardPath === pathname) {
+      // If session was removed from URL while on this board, deactivate
+      deactivateSession();
+    }
+  }, [
+    sessionIdFromUrl,
+    pathname,
+    boardDetails,
+    parsedParams,
+    activeSession?.sessionId,
+    activeSession?.boardPath,
+    activateSession,
+    deactivateSession,
+  ]);
+
+  // Update board details if they change (e.g., angle change)
+  useEffect(() => {
+    if (activeSession?.sessionId === sessionIdFromUrl && activeSession?.boardPath !== pathname) {
+      // Board path changed but session is the same - update the session info
+      activateSession({
+        sessionId: sessionIdFromUrl!,
+        boardPath: pathname,
+        boardDetails,
+        parsedParams,
+      });
+    }
+  }, [pathname, parsedParams, boardDetails, activeSession, sessionIdFromUrl, activateSession]);
+
+  return <>{children}</>;
+};
+
+export default BoardSessionBridge;

--- a/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
+++ b/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Badge, Button, Tooltip, Typography } from 'antd';
+import { CloseOutlined, TeamOutlined } from '@ant-design/icons';
+import { usePersistentSession, useIsOnBoardRoute } from './persistent-session-context';
+import BoardRenderer from '../board-renderer/board-renderer';
+import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+
+const { Text } = Typography;
+
+const FloatingSessionThumbnail: React.FC = () => {
+  const router = useRouter();
+  const isOnBoardRoute = useIsOnBoardRoute();
+  const {
+    activeSession,
+    currentClimbQueueItem,
+    users,
+    hasConnected,
+    isConnecting,
+    deactivateSession,
+  } = usePersistentSession();
+
+  // Don't show if no active session
+  if (!activeSession) {
+    return null;
+  }
+
+  // Don't show on board routes (including setup wizard)
+  if (isOnBoardRoute) {
+    return null;
+  }
+
+  const { boardDetails, parsedParams, sessionId } = activeSession;
+  const currentClimb = currentClimbQueueItem?.climb;
+
+  // Construct the URL to navigate back to the board
+  const boardUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
+    ? `${constructClimbListWithSlugs(
+        boardDetails.board_name,
+        boardDetails.layout_name,
+        boardDetails.size_name,
+        boardDetails.size_description,
+        boardDetails.set_names,
+        parsedParams.angle,
+      )}?session=${sessionId}`
+    : `${activeSession.boardPath}?session=${sessionId}`;
+
+  const handleNavigateBack = () => {
+    router.push(boardUrl);
+  };
+
+  const handleLeaveSession = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    deactivateSession();
+  };
+
+  const connectionStatus = isConnecting ? 'connecting' : hasConnected ? 'connected' : 'disconnected';
+  const statusColor = connectionStatus === 'connected' ? 'green' : connectionStatus === 'connecting' ? 'orange' : 'red';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 16,
+        right: 16,
+        zIndex: 1000,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+        gap: 8,
+      }}
+    >
+      {/* Session info card */}
+      <div
+        onClick={handleNavigateBack}
+        style={{
+          background: 'var(--ant-color-bg-elevated, #1f1f1f)',
+          borderRadius: 12,
+          padding: 12,
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+          cursor: 'pointer',
+          border: '1px solid var(--ant-color-border, #303030)',
+          maxWidth: 200,
+          transition: 'transform 0.2s, box-shadow 0.2s',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.transform = 'scale(1.02)';
+          e.currentTarget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.4)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.transform = 'scale(1)';
+          e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.3)';
+        }}
+      >
+        {/* Header with close button */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 8,
+          }}
+        >
+          <Tooltip title={`${users.length} user${users.length !== 1 ? 's' : ''} connected`}>
+            <Badge
+              count={users.length}
+              size="small"
+              style={{ backgroundColor: statusColor }}
+            >
+              <TeamOutlined style={{ fontSize: 16, color: 'var(--ant-color-text-secondary)' }} />
+            </Badge>
+          </Tooltip>
+          <Tooltip title="Leave session">
+            <Button
+              type="text"
+              size="small"
+              icon={<CloseOutlined />}
+              onClick={handleLeaveSession}
+              style={{ color: 'var(--ant-color-text-secondary)' }}
+            />
+          </Tooltip>
+        </div>
+
+        {/* Board thumbnail */}
+        <div
+          style={{
+            width: 120,
+            height: 'auto',
+            marginBottom: 8,
+            borderRadius: 8,
+            overflow: 'hidden',
+            background: 'var(--ant-color-bg-container, #141414)',
+          }}
+        >
+          <BoardRenderer
+            boardDetails={boardDetails}
+            litUpHoldsMap={currentClimb?.litUpHoldsMap}
+            mirrored={!!currentClimb?.mirrored}
+            thumbnail
+          />
+        </div>
+
+        {/* Climb name */}
+        <Text
+          style={{
+            fontSize: 12,
+            color: 'var(--ant-color-text)',
+            display: 'block',
+            textAlign: 'center',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '100%',
+          }}
+        >
+          {currentClimb?.name || 'No climb selected'}
+        </Text>
+
+        {/* Tap to return hint */}
+        <Text
+          type="secondary"
+          style={{
+            fontSize: 10,
+            display: 'block',
+            textAlign: 'center',
+            marginTop: 4,
+          }}
+        >
+          Tap to return
+        </Text>
+      </div>
+    </div>
+  );
+};
+
+export default FloatingSessionThumbnail;

--- a/packages/web/app/components/persistent-session/index.ts
+++ b/packages/web/app/components/persistent-session/index.ts
@@ -1,0 +1,11 @@
+export {
+  PersistentSessionProvider,
+  usePersistentSession,
+  useIsOnBoardRoute,
+  type PersistentSessionContextType,
+  type ActiveSessionInfo,
+  type Session,
+} from './persistent-session-context';
+
+export { default as FloatingSessionThumbnail } from './floating-session-thumbnail';
+export { default as BoardSessionBridge } from './board-session-bridge';

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -1,0 +1,581 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { usePathname } from 'next/navigation'; // Used by useIsOnBoardRoute
+import { createGraphQLClient, execute, subscribe, Client } from '../graphql-queue/graphql-client';
+import {
+  JOIN_SESSION,
+  LEAVE_SESSION,
+  ADD_QUEUE_ITEM,
+  REMOVE_QUEUE_ITEM,
+  SET_CURRENT_CLIMB,
+  MIRROR_CURRENT_CLIMB,
+  SET_QUEUE,
+  SESSION_UPDATES,
+  QUEUE_UPDATES,
+  SessionUser,
+  ClientQueueEvent,
+  SessionEvent,
+  QueueState,
+} from '@boardsesh/shared-schema';
+import { ClimbQueueItem as LocalClimbQueueItem } from '../queue-control/types';
+import { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { usePartyProfile } from '../party-manager/party-profile-context';
+
+const DEBUG = process.env.NODE_ENV === 'development';
+
+// Default backend URL from environment variable
+const DEFAULT_BACKEND_URL = process.env.NEXT_PUBLIC_WS_URL || null;
+
+// Board names to check if we're on a board route
+const BOARD_NAMES = ['kilter', 'tension', 'decoy'];
+
+// Session type matching the GraphQL response
+export interface Session {
+  id: string;
+  boardPath: string;
+  users: SessionUser[];
+  queueState: QueueState;
+  isLeader: boolean;
+  clientId: string;
+}
+
+// Active session info stored at root level
+export interface ActiveSessionInfo {
+  sessionId: string;
+  boardPath: string;
+  boardDetails: BoardDetails;
+  parsedParams: ParsedBoardRouteParameters;
+}
+
+// Convert local ClimbQueueItem to GraphQL input format
+function toClimbQueueItemInput(item: LocalClimbQueueItem) {
+  return {
+    uuid: item.uuid,
+    climb: {
+      uuid: item.climb.uuid,
+      setter_username: item.climb.setter_username,
+      name: item.climb.name,
+      description: item.climb.description || '',
+      frames: item.climb.frames,
+      angle: item.climb.angle,
+      ascensionist_count: item.climb.ascensionist_count,
+      difficulty: item.climb.difficulty,
+      quality_average: item.climb.quality_average,
+      stars: item.climb.stars,
+      difficulty_error: item.climb.difficulty_error,
+      litUpHoldsMap: item.climb.litUpHoldsMap,
+      mirrored: item.climb.mirrored,
+      benchmark_difficulty: item.climb.benchmark_difficulty,
+      userAscents: item.climb.userAscents,
+      userAttempts: item.climb.userAttempts,
+    },
+    addedBy: item.addedBy,
+    addedByUser: item.addedByUser
+      ? {
+          id: item.addedByUser.id,
+          username: item.addedByUser.username,
+          avatarUrl: item.addedByUser.avatarUrl,
+        }
+      : undefined,
+    tickedBy: item.tickedBy,
+    suggested: item.suggested,
+  };
+}
+
+export interface PersistentSessionContextType {
+  // Active session info
+  activeSession: ActiveSessionInfo | null;
+
+  // Session state
+  session: Session | null;
+  isConnecting: boolean;
+  hasConnected: boolean;
+  error: Error | null;
+
+  // Session data
+  clientId: string | null;
+  isLeader: boolean;
+  users: SessionUser[];
+
+  // Queue state synced from backend
+  currentClimbQueueItem: LocalClimbQueueItem | null;
+  queue: LocalClimbQueueItem[];
+
+  // Session lifecycle
+  activateSession: (info: ActiveSessionInfo) => void;
+  deactivateSession: () => void;
+
+  // Mutation functions
+  addQueueItem: (item: LocalClimbQueueItem, position?: number) => Promise<void>;
+  removeQueueItem: (uuid: string) => Promise<void>;
+  setCurrentClimb: (item: LocalClimbQueueItem | null, shouldAddToQueue?: boolean) => Promise<void>;
+  mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
+  setQueue: (queue: LocalClimbQueueItem[], currentClimbQueueItem?: LocalClimbQueueItem | null) => Promise<void>;
+
+  // Event subscription for board-level components
+  subscribeToQueueEvents: (callback: (event: ClientQueueEvent) => void) => () => void;
+  subscribeToSessionEvents: (callback: (event: SessionEvent) => void) => () => void;
+}
+
+const PersistentSessionContext = createContext<PersistentSessionContextType | undefined>(undefined);
+
+export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { token: wsAuthToken } = useWsAuthToken();
+  const { username, avatarUrl } = usePartyProfile();
+
+  // Active session info
+  const [activeSession, setActiveSession] = useState<ActiveSessionInfo | null>(null);
+
+  // Connection state
+  const [client, setClient] = useState<Client | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [hasConnected, setHasConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Queue state synced from backend
+  const [currentClimbQueueItem, setCurrentClimbQueueItem] = useState<LocalClimbQueueItem | null>(null);
+  const [queue, setQueueState] = useState<LocalClimbQueueItem[]>([]);
+
+  // Refs for cleanup and callbacks
+  const queueUnsubscribeRef = useRef<(() => void) | null>(null);
+  const sessionUnsubscribeRef = useRef<(() => void) | null>(null);
+  const sessionRef = useRef<Session | null>(null);
+  const isReconnectingRef = useRef(false);
+  const activeSessionRef = useRef<ActiveSessionInfo | null>(null);
+
+  // Event subscribers
+  const queueEventSubscribersRef = useRef<Set<(event: ClientQueueEvent) => void>>(new Set());
+  const sessionEventSubscribersRef = useRef<Set<(event: SessionEvent) => void>>(new Set());
+
+  // Keep refs in sync
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    activeSessionRef.current = activeSession;
+  }, [activeSession]);
+
+  // Notify queue event subscribers
+  const notifyQueueSubscribers = useCallback((event: ClientQueueEvent) => {
+    queueEventSubscribersRef.current.forEach((callback) => callback(event));
+  }, []);
+
+  // Notify session event subscribers
+  const notifySessionSubscribers = useCallback((event: SessionEvent) => {
+    sessionEventSubscribersRef.current.forEach((callback) => callback(event));
+  }, []);
+
+  // Handle queue events internally
+  const handleQueueEvent = useCallback((event: ClientQueueEvent) => {
+    switch (event.__typename) {
+      case 'FullSync':
+        setQueueState(event.state.queue as LocalClimbQueueItem[]);
+        setCurrentClimbQueueItem(event.state.currentClimbQueueItem as LocalClimbQueueItem | null);
+        break;
+      case 'QueueItemAdded':
+        setQueueState((prev) => {
+          const newQueue = [...prev];
+          if (event.position !== undefined && event.position >= 0) {
+            newQueue.splice(event.position, 0, event.addedItem as LocalClimbQueueItem);
+          } else {
+            newQueue.push(event.addedItem as LocalClimbQueueItem);
+          }
+          return newQueue;
+        });
+        break;
+      case 'QueueItemRemoved':
+        setQueueState((prev) => prev.filter((item) => item.uuid !== event.uuid));
+        break;
+      case 'QueueReordered':
+        setQueueState((prev) => {
+          const newQueue = [...prev];
+          const [item] = newQueue.splice(event.oldIndex, 1);
+          newQueue.splice(event.newIndex, 0, item);
+          return newQueue;
+        });
+        break;
+      case 'CurrentClimbChanged':
+        setCurrentClimbQueueItem(event.currentItem as LocalClimbQueueItem | null);
+        break;
+      case 'ClimbMirrored':
+        setCurrentClimbQueueItem((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            climb: {
+              ...prev.climb,
+              mirrored: event.mirrored,
+            },
+          };
+        });
+        break;
+    }
+
+    // Notify external subscribers
+    notifyQueueSubscribers(event);
+  }, [notifyQueueSubscribers]);
+
+  // Handle session events internally
+  const handleSessionEvent = useCallback((event: SessionEvent) => {
+    setSession((prev) => {
+      if (!prev) return prev;
+
+      switch (event.__typename) {
+        case 'UserJoined':
+          return {
+            ...prev,
+            users: [...prev.users, event.user],
+          };
+        case 'UserLeft':
+          return {
+            ...prev,
+            users: prev.users.filter((u) => u.id !== event.userId),
+          };
+        case 'LeaderChanged':
+          return {
+            ...prev,
+            isLeader: event.leaderId === prev.clientId,
+            users: prev.users.map((u) => ({
+              ...u,
+              isLeader: u.id === event.leaderId,
+            })),
+          };
+        case 'SessionEnded':
+          if (DEBUG) console.log('[PersistentSession] Session ended:', event.reason);
+          return prev;
+        default:
+          return prev;
+      }
+    });
+
+    // Notify external subscribers
+    notifySessionSubscribers(event);
+  }, [notifySessionSubscribers]);
+
+  // Connect to session when activeSession changes
+  useEffect(() => {
+    if (!activeSession) {
+      if (DEBUG) console.log('[PersistentSession] No active session, skipping connection');
+      return;
+    }
+
+    const { sessionId, boardPath } = activeSession;
+    const backendUrl = DEFAULT_BACKEND_URL;
+
+    if (!backendUrl) {
+      if (DEBUG) console.log('[PersistentSession] No backend URL configured');
+      return;
+    }
+
+    let mounted = true;
+    let graphqlClient: Client | null = null;
+
+    async function joinSession(clientToUse: Client): Promise<Session | null> {
+      if (DEBUG) console.log('[PersistentSession] Calling joinSession mutation...');
+      try {
+        const response = await execute<{ joinSession: Session }>(clientToUse, {
+          query: JOIN_SESSION,
+          variables: { sessionId, boardPath, username, avatarUrl },
+        });
+        return response.joinSession;
+      } catch (err) {
+        console.error('[PersistentSession] JoinSession failed:', err);
+        return null;
+      }
+    }
+
+    async function handleReconnect() {
+      if (!mounted || !graphqlClient) return;
+      if (isReconnectingRef.current) {
+        if (DEBUG) console.log('[PersistentSession] Reconnection already in progress');
+        return;
+      }
+
+      isReconnectingRef.current = true;
+      try {
+        if (DEBUG) console.log('[PersistentSession] Reconnecting...');
+        const sessionData = await joinSession(graphqlClient);
+        if (sessionData && mounted) {
+          setSession(sessionData);
+          if (DEBUG) console.log('[PersistentSession] Reconnected, clientId:', sessionData.clientId);
+        }
+      } finally {
+        isReconnectingRef.current = false;
+      }
+    }
+
+    async function connect() {
+      if (DEBUG) console.log('[PersistentSession] Connecting to session:', sessionId);
+      setIsConnecting(true);
+      setError(null);
+
+      try {
+        graphqlClient = createGraphQLClient({
+          url: backendUrl!,
+          authToken: wsAuthToken,
+          onReconnect: handleReconnect,
+        });
+
+        if (!mounted) {
+          graphqlClient.dispose();
+          return;
+        }
+
+        setClient(graphqlClient);
+
+        const sessionData = await joinSession(graphqlClient);
+
+        if (!mounted) {
+          graphqlClient.dispose();
+          return;
+        }
+
+        if (!sessionData) {
+          throw new Error('Failed to join session');
+        }
+
+        if (DEBUG) console.log('[PersistentSession] Joined session, clientId:', sessionData.clientId);
+
+        setSession(sessionData);
+        setHasConnected(true);
+        setIsConnecting(false);
+
+        // Send initial queue state
+        if (sessionData.queueState) {
+          handleQueueEvent({
+            __typename: 'FullSync',
+            state: sessionData.queueState,
+          });
+        }
+
+        // Subscribe to queue updates
+        queueUnsubscribeRef.current = subscribe<{ queueUpdates: ClientQueueEvent }>(
+          graphqlClient,
+          { query: QUEUE_UPDATES, variables: { sessionId } },
+          {
+            next: (data) => {
+              if (data.queueUpdates) {
+                handleQueueEvent(data.queueUpdates);
+              }
+            },
+            error: (err) => {
+              console.error('[PersistentSession] Queue subscription error:', err);
+              if (mounted) {
+                setError(err instanceof Error ? err : new Error(String(err)));
+              }
+            },
+            complete: () => {
+              if (DEBUG) console.log('[PersistentSession] Queue subscription completed');
+            },
+          },
+        );
+
+        // Subscribe to session updates
+        sessionUnsubscribeRef.current = subscribe<{ sessionUpdates: SessionEvent }>(
+          graphqlClient,
+          { query: SESSION_UPDATES, variables: { sessionId } },
+          {
+            next: (data) => {
+              if (data.sessionUpdates) {
+                handleSessionEvent(data.sessionUpdates);
+              }
+            },
+            error: (err) => {
+              console.error('[PersistentSession] Session subscription error:', err);
+            },
+            complete: () => {
+              if (DEBUG) console.log('[PersistentSession] Session subscription completed');
+            },
+          },
+        );
+      } catch (err) {
+        console.error('[PersistentSession] Connection failed:', err);
+        if (mounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsConnecting(false);
+        }
+        if (graphqlClient) {
+          graphqlClient.dispose();
+        }
+      }
+    }
+
+    connect();
+
+    return () => {
+      if (DEBUG) console.log('[PersistentSession] Cleaning up connection');
+      mounted = false;
+
+      queueUnsubscribeRef.current?.();
+      sessionUnsubscribeRef.current?.();
+
+      if (graphqlClient) {
+        if (sessionRef.current) {
+          execute(graphqlClient, { query: LEAVE_SESSION }).catch(() => {});
+        }
+        graphqlClient.dispose();
+      }
+
+      setClient(null);
+      setSession(null);
+      setHasConnected(false);
+      setIsConnecting(false);
+    };
+  }, [activeSession, username, avatarUrl, wsAuthToken, handleQueueEvent, handleSessionEvent]);
+
+  // Session lifecycle functions
+  const activateSession = useCallback((info: ActiveSessionInfo) => {
+    if (DEBUG) console.log('[PersistentSession] Activating session:', info.sessionId);
+    setActiveSession(info);
+  }, []);
+
+  const deactivateSession = useCallback(() => {
+    if (DEBUG) console.log('[PersistentSession] Deactivating session');
+    setActiveSession(null);
+    setQueueState([]);
+    setCurrentClimbQueueItem(null);
+  }, []);
+
+  // Mutation functions
+  const addQueueItem = useCallback(
+    async (item: LocalClimbQueueItem, position?: number) => {
+      if (!client || !session) throw new Error('Not connected to session');
+      await execute(client, {
+        query: ADD_QUEUE_ITEM,
+        variables: { item: toClimbQueueItemInput(item), position },
+      });
+    },
+    [client, session],
+  );
+
+  const removeQueueItem = useCallback(
+    async (uuid: string) => {
+      if (!client || !session) throw new Error('Not connected to session');
+      await execute(client, {
+        query: REMOVE_QUEUE_ITEM,
+        variables: { uuid },
+      });
+    },
+    [client, session],
+  );
+
+  const setCurrentClimbMutation = useCallback(
+    async (item: LocalClimbQueueItem | null, shouldAddToQueue?: boolean) => {
+      if (!client || !session) throw new Error('Not connected to session');
+      await execute(client, {
+        query: SET_CURRENT_CLIMB,
+        variables: {
+          item: item ? toClimbQueueItemInput(item) : null,
+          shouldAddToQueue,
+        },
+      });
+    },
+    [client, session],
+  );
+
+  const mirrorCurrentClimbMutation = useCallback(
+    async (mirrored: boolean) => {
+      if (!client || !session) throw new Error('Not connected to session');
+      await execute(client, {
+        query: MIRROR_CURRENT_CLIMB,
+        variables: { mirrored },
+      });
+    },
+    [client, session],
+  );
+
+  const setQueueMutation = useCallback(
+    async (newQueue: LocalClimbQueueItem[], newCurrentClimbQueueItem?: LocalClimbQueueItem | null) => {
+      if (!client || !session) throw new Error('Not connected to session');
+      await execute(client, {
+        query: SET_QUEUE,
+        variables: {
+          queue: newQueue.map(toClimbQueueItemInput),
+          currentClimbQueueItem: newCurrentClimbQueueItem ? toClimbQueueItemInput(newCurrentClimbQueueItem) : null,
+        },
+      });
+    },
+    [client, session],
+  );
+
+  // Event subscription functions
+  const subscribeToQueueEvents = useCallback((callback: (event: ClientQueueEvent) => void) => {
+    queueEventSubscribersRef.current.add(callback);
+    return () => {
+      queueEventSubscribersRef.current.delete(callback);
+    };
+  }, []);
+
+  const subscribeToSessionEvents = useCallback((callback: (event: SessionEvent) => void) => {
+    sessionEventSubscribersRef.current.add(callback);
+    return () => {
+      sessionEventSubscribersRef.current.delete(callback);
+    };
+  }, []);
+
+  const value = useMemo<PersistentSessionContextType>(
+    () => ({
+      activeSession,
+      session,
+      isConnecting,
+      hasConnected,
+      error,
+      clientId: session?.clientId ?? null,
+      isLeader: session?.isLeader ?? false,
+      users: session?.users ?? [],
+      currentClimbQueueItem,
+      queue,
+      activateSession,
+      deactivateSession,
+      addQueueItem,
+      removeQueueItem,
+      setCurrentClimb: setCurrentClimbMutation,
+      mirrorCurrentClimb: mirrorCurrentClimbMutation,
+      setQueue: setQueueMutation,
+      subscribeToQueueEvents,
+      subscribeToSessionEvents,
+    }),
+    [
+      activeSession,
+      session,
+      isConnecting,
+      hasConnected,
+      error,
+      currentClimbQueueItem,
+      queue,
+      activateSession,
+      deactivateSession,
+      addQueueItem,
+      removeQueueItem,
+      setCurrentClimbMutation,
+      mirrorCurrentClimbMutation,
+      setQueueMutation,
+      subscribeToQueueEvents,
+      subscribeToSessionEvents,
+    ],
+  );
+
+  return (
+    <PersistentSessionContext.Provider value={value}>
+      {children}
+    </PersistentSessionContext.Provider>
+  );
+};
+
+export function usePersistentSession() {
+  const context = useContext(PersistentSessionContext);
+  if (!context) {
+    throw new Error('usePersistentSession must be used within a PersistentSessionProvider');
+  }
+  return context;
+}
+
+// Helper hook to check if we're on a board route
+export function useIsOnBoardRoute() {
+  const pathname = usePathname();
+  return BOARD_NAMES.some((board) => pathname.startsWith(`/${board}/`));
+}

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import { PartyProfileProvider } from '../party-manager/party-profile-context';
+import { PersistentSessionProvider, FloatingSessionThumbnail } from '../persistent-session';
+
+interface PersistentSessionWrapperProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Root-level wrapper that provides:
+ * 1. PartyProfileProvider - user profile from IndexedDB and NextAuth session
+ * 2. PersistentSessionProvider - WebSocket connection management that persists across navigation
+ * 3. FloatingSessionThumbnail - shows current session when navigated away from board
+ */
+export default function PersistentSessionWrapper({ children }: PersistentSessionWrapperProps) {
+  return (
+    <PartyProfileProvider>
+      <PersistentSessionProvider>
+        <FloatingSessionThumbnail />
+        {children}
+      </PersistentSessionProvider>
+    </PartyProfileProvider>
+  );
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import SessionProviderWrapper from './components/providers/session-provider';
 import QueryClientProvider from './components/providers/query-client-provider';
 import { NavigationLoadingProvider } from './components/providers/navigation-loading-provider';
+import PersistentSessionWrapper from './components/providers/persistent-session-wrapper';
 import { antdTheme } from './theme/antd-theme';
 import './components/index.css';
 
@@ -23,7 +24,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <AntdRegistry>
               <ConfigProvider theme={antdTheme}>
                 <App>
-                  <NavigationLoadingProvider>{children}</NavigationLoadingProvider>
+                  <PersistentSessionWrapper>
+                    <NavigationLoadingProvider>{children}</NavigationLoadingProvider>
+                  </PersistentSessionWrapper>
                 </App>
               </ConfigProvider>
             </AntdRegistry>


### PR DESCRIPTION
## Summary

- Move WebSocket connection management to root layout level for persistence
- Add `PersistentSessionProvider` that maintains connection when navigating away from board pages
- Add floating thumbnail (bottom-right) showing current climb when on non-board pages (e.g., settings)
- Refactor `GraphQLQueueProvider` to delegate to persistent session

## Problem

Previously, navigating to `/settings` or other non-board pages would unmount the `GraphQLQueueProvider`, destroying the WebSocket connection. Returning to the board required reconnecting, and multiple connections could appear in the network panel.

## Solution

- **Root-level session management**: Connection state is now managed at root layout level via `PersistentSessionProvider`
- **Lazy connection**: Only connects when a session is activated (user joins party mode)
- **Floating thumbnail**: When navigating away from board, a small thumbnail shows in bottom-right corner with:
  - Current climb preview
  - User count
  - Click to return to board
  - Leave session button

## Test plan

- [ ] Join a party mode session on a board
- [ ] Navigate to settings - verify thumbnail appears in bottom-right
- [ ] Click thumbnail - verify navigation back to board with session preserved
- [ ] Verify only 1 WebSocket connection in network panel
- [ ] Leave session via thumbnail button - verify connection closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)