### PR TITLE
fix: Fix clear queue button in party mode

### DIFF
--- a/packages/backend/src/graphql/resolvers.ts
+++ b/packages/backend/src/graphql/resolvers.ts
@@ -648,6 +648,14 @@ const resolvers = {
       applyRateLimit(ctx, 30); // Lower limit for bulk operations
       const sessionId = requireSession(ctx);
 
+      // Only the party leader can clear the queue
+      if (queue.length === 0) {
+        const client = roomManager.getClient(ctx.connectionId);
+        if (!client?.isLeader) {
+          throw new Error('Only the party leader can clear the queue');
+        }
+      }
+
       // Validate queue size to prevent memory exhaustion
       validateInput(QueueArraySchema, queue, 'queue');
       if (currentClimbQueueItem) {

--- a/packages/web/app/components/graphql-queue/use-queue-session.ts
+++ b/packages/web/app/components/graphql-queue/use-queue-session.ts
@@ -32,37 +32,40 @@ export interface Session {
 }
 
 // Convert local ClimbQueueItem to GraphQL input format
+// Handles null/undefined values properly for Zod validation:
+// - Zod's .optional() allows undefined but NOT null
+// - Required fields need defaults for potentially null database values
 function toClimbQueueItemInput(item: LocalClimbQueueItem) {
   return {
     uuid: item.uuid,
     climb: {
       uuid: item.climb.uuid,
-      setter_username: item.climb.setter_username,
-      name: item.climb.name,
+      setter_username: item.climb.setter_username || '',
+      name: item.climb.name || '',
       description: item.climb.description || '',
-      frames: item.climb.frames,
-      angle: item.climb.angle,
-      ascensionist_count: item.climb.ascensionist_count,
-      difficulty: item.climb.difficulty,
-      quality_average: item.climb.quality_average,
-      stars: item.climb.stars,
-      difficulty_error: item.climb.difficulty_error,
-      litUpHoldsMap: item.climb.litUpHoldsMap,
-      mirrored: item.climb.mirrored,
+      frames: item.climb.frames || '',
+      angle: item.climb.angle ?? 0,
+      ascensionist_count: item.climb.ascensionist_count ?? 0,
+      difficulty: item.climb.difficulty || '',
+      quality_average: item.climb.quality_average || '',
+      stars: item.climb.stars ?? 0,
+      difficulty_error: item.climb.difficulty_error || '',
+      litUpHoldsMap: item.climb.litUpHoldsMap || {},
+      mirrored: item.climb.mirrored ?? undefined,
       benchmark_difficulty: item.climb.benchmark_difficulty,
-      userAscents: item.climb.userAscents,
-      userAttempts: item.climb.userAttempts,
+      userAscents: item.climb.userAscents ?? undefined,
+      userAttempts: item.climb.userAttempts ?? undefined,
     },
-    addedBy: item.addedBy,
+    addedBy: item.addedBy ?? undefined,
     addedByUser: item.addedByUser
       ? {
           id: item.addedByUser.id,
           username: item.addedByUser.username,
-          avatarUrl: item.addedByUser.avatarUrl,
+          avatarUrl: item.addedByUser.avatarUrl ?? undefined,
         }
       : undefined,
-    tickedBy: item.tickedBy,
-    suggested: item.suggested,
+    tickedBy: item.tickedBy ?? undefined,
+    suggested: item.suggested ?? undefined,
   };
 }
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -28,7 +28,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
 
   const isViewPage = pathname.includes('/view/');
   const isListPage = pathname.includes('/list');
-  const { currentClimb, mirrorClimb, queue, setQueue } = useQueueContext();
+  const { currentClimb, mirrorClimb, queue, setQueue, isLeader, isSessionActive } = useQueueContext();
 
   const handleClearQueue = () => {
     setQueue([]);
@@ -136,7 +136,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         onClose={toggleQueueDrawer}
         styles={{ body: { padding: 0 } }}
         extra={
-          queue.length > 0 && (
+          queue.length > 0 && (!isSessionActive || isLeader) && (
             <Popconfirm
               title="Clear queue"
               description="Are you sure you want to clear all items from the queue?"


### PR DESCRIPTION
## Summary

- Fix data validation error when clearing queue in party mode by properly handling null/undefined values in `toClimbQueueItemInput`
- Add leader check to clear queue button - only visible to party leader in party mode, still available to all users in local mode
- Add server-side enforcement - only party leader can clear the queue via `setQueue` mutation

## Problem

When clicking "Clear queue" in party mode, users got this error:
```
Invalid currentClimbQueueItem: Invalid UUID format, Number must be less than or equal to 5,
Expected boolean, received null, Expected number, received null, Expected string, received null,
Expected array, received null
```

## Root Cause

1. Zod's `.optional()` allows `undefined` but NOT `null`, causing validation failures when queue item data contained null values from the database
2. The clear queue button was visible to all users in party mode, but should only be available to the party leader

## Changes

1. **`use-queue-session.ts`**: Updated `toClimbQueueItemInput` to:
   - Provide defaults for required fields that might be null
   - Convert null to undefined for optional fields (mirrored, suggested, tickedBy, etc.)

2. **`queue-control-bar.tsx`**: Added leader check:
   - Show clear button if `queue.length > 0` AND (`not in party mode` OR `is the party leader`)

3. **`resolvers.ts`** (backend): Added server-side enforcement:
   - Only the party leader can clear the queue (when `queue.length === 0`)
   - Throws error "Only the party leader can clear the queue" for non-leaders

## Test plan

- [ ] In local mode (no party session): Clear queue button works as before
- [ ] In party mode as leader: Clear queue button is visible and works without validation errors
- [ ] In party mode as non-leader: Clear queue button is NOT visible
- [ ] Backend rejects clear queue requests from non-leaders with appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)