### PR TITLE
fix: Prevent party mode session disconnect when changing search filters

### DIFF
--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -24,12 +24,12 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
   const pathname = usePathname();
   const sessionIdFromUrl = searchParams.get('session');
 
-  const { activeSession, activateSession, deactivateSession } = usePersistentSession();
+  const { activeSession, activateSession } = usePersistentSession();
 
   // Activate session when we have a session param and board details
   useEffect(() => {
     if (sessionIdFromUrl && boardDetails) {
-      // Only activate if not already active for this session
+      // Activate session when URL has session param (joining via shared link)
       if (activeSession?.sessionId !== sessionIdFromUrl || activeSession?.boardPath !== pathname) {
         activateSession({
           sessionId: sessionIdFromUrl,
@@ -38,10 +38,9 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
           parsedParams,
         });
       }
-    } else if (!sessionIdFromUrl && activeSession?.boardPath === pathname) {
-      // If session was removed from URL while on this board, deactivate
-      deactivateSession();
     }
+    // Don't deactivate when URL param is missing - only explicit endSession() should disconnect
+    // The session connection persists even if URL param is temporarily removed
   }, [
     sessionIdFromUrl,
     pathname,
@@ -50,7 +49,6 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
     activeSession?.sessionId,
     activeSession?.boardPath,
     activateSession,
-    deactivateSession,
   ]);
 
   // Update board details if they change (e.g., angle change)


### PR DESCRIPTION
## Summary
- Fixed bug where party mode session would disconnect when changing search filters
- Session param is now preserved when filter URL is updated
- Session connection persists even if URL param is accidentally removed
- Session param is auto-restored to URL if it goes missing

## Root Cause
`setClimbSearchParams` in `QueueContext.tsx` was creating a new URL using only filter parameters, dropping the `session` parameter. This triggered `BoardSessionBridge` to call `deactivateSession()`.

## Changes
| File | Change |
|------|--------|
| `QueueContext.tsx` | Preserve session param when updating filters, don't clear `activeSessionId` on URL changes, restore session param if missing |
| `board-session-bridge.tsx` | Only activate sessions from URL, don't deactivate on URL changes |

## Test plan
- [ ] Start a party mode session
- [ ] Apply various search filters (grade, name, setter, etc.)
- [ ] Verify session remains connected
- [ ] Verify session param stays in URL
- [ ] Manually remove session param from URL - verify session stays connected and param is restored
- [ ] Click "End Session" - verify session disconnects properly
- [ ] Join session via shared link - verify it still works
- [ ] Refresh page with session param - verify reconnection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)