### PR TITLE
fix: Prevent party mode current climb flickering on selection

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -105,6 +105,7 @@ export const GraphQLQueueProvider = ({ parsedParams, children }: GraphQLQueueCon
   }, [profile?.id, username, avatarUrl]);
 
   // Subscribe to queue events from persistent session
+  // Note: Initial sync is handled by the FullSync event sent by persistent-session-context on join
   useEffect(() => {
     if (!isPersistentSessionActive) return;
 
@@ -164,20 +165,6 @@ export const GraphQLQueueProvider = ({ parsedParams, children }: GraphQLQueueCon
 
     return unsubscribe;
   }, [isPersistentSessionActive, persistentSession, dispatch]);
-
-  // Sync local state with persistent session state on mount/reconnect
-  useEffect(() => {
-    if (isPersistentSessionActive && persistentSession.hasConnected) {
-      // Sync queue state from persistent session
-      dispatch({
-        type: 'INITIAL_QUEUE_DATA',
-        payload: {
-          queue: persistentSession.queue,
-          currentClimbQueueItem: persistentSession.currentClimbQueueItem,
-        },
-      });
-    }
-  }, [isPersistentSessionActive, persistentSession.hasConnected, persistentSession.queue, persistentSession.currentClimbQueueItem, dispatch]);
 
   // Use persistent session values when active
   const clientId = isPersistentSessionActive ? persistentSession.clientId : null;

--- a/packages/web/app/components/queue-control/reducer.ts
+++ b/packages/web/app/components/queue-control/reducer.ts
@@ -146,13 +146,19 @@ export function queueReducer(state: QueueState, action: QueueAction): QueueState
 
     case 'DELTA_UPDATE_CURRENT_CLIMB': {
       const { item, shouldAddToQueue } = action.payload;
+
+      // Skip if this is the same item (deduplication for optimistic updates)
+      if (item && state.currentClimbQueueItem?.uuid === item.uuid) {
+        return state;
+      }
+
       let newQueue = state.queue;
-      
+
       // Add to queue if requested and item doesn't exist
       if (item && shouldAddToQueue && !state.queue.find(qItem => qItem.uuid === item.uuid)) {
         newQueue = [...state.queue, item];
       }
-      
+
       return {
         ...state,
         queue: newQueue,


### PR DESCRIPTION
## Summary
Fixes two issues causing flickering and duplicate WebSocket connections in party mode:

### Fix 1: Prevent duplicate state updates in reducer
- Adds deduplication check to `DELTA_UPDATE_CURRENT_CLIMB` reducer action
- Skips redundant state updates when the subscription confirms a climb already set via optimistic update

### Fix 2: Prevent duplicate WebSocket connections
- **activateSession()**: Skip state update if sessionId and boardPath are already the same (prevents reconnection when only object references change)
- **Connection effect**: Wait for auth to finish loading before connecting, and use refs for username/avatarUrl/wsAuthToken to prevent re-runs when these async values load

## Root Causes

### Flickering Issue
The UI flickered because setting a climb triggered two state updates:
1. Optimistic update via `SET_CURRENT_CLIMB` (immediate)
2. Subscription update via `DELTA_UPDATE_CURRENT_CLIMB` (when server confirms)

### Duplicate Connections Issue
Multiple WebSocket connections were created because:
1. `activateSession()` created new state objects even when sessionId/boardPath were unchanged
2. The connection effect re-ran when `wsAuthToken`, `username`, or `avatarUrl` loaded async

## Files Changed
- `packages/web/app/components/queue-control/reducer.ts` - Added deduplication check
- `packages/web/app/components/persistent-session/persistent-session-context.tsx` - Fixed duplicate connections

## Test plan
- [ ] Open party mode with 2+ clients
- [ ] Verify only ONE WebSocket connection is created per client
- [ ] Add multiple climbs to queue  
- [ ] Click on different queue items to set as current
- [ ] Verify no flickering occurs
- [ ] Verify both clients stay in sync
- [ ] Change search filters - verify no reconnection/duplicate connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)