### PR TITLE
fix: Improve WebSocket persistence reliability and prevent memory leaks

### DIFF
--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -5,6 +5,11 @@ export type { Client };
 const DEBUG = process.env.NODE_ENV === 'development';
 const MUTATION_TIMEOUT_MS = 30_000; // 30 second timeout for mutations
 
+// Exponential backoff configuration for reconnection
+const INITIAL_RETRY_DELAY_MS = 1000; // Start with 1 second
+const MAX_RETRY_DELAY_MS = 30_000; // Cap at 30 seconds
+const BACKOFF_MULTIPLIER = 2; // Double the delay each retry
+
 let clientCounter = 0;
 
 // Cache for parsed operation names to avoid regex on every call
@@ -61,8 +66,17 @@ export function createGraphQLClient(
 
   const client = createClient({
     url,
-    retryAttempts: 5,
+    retryAttempts: 10, // More attempts with exponential backoff
     shouldRetry: () => true,
+    // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
+    retryWait: async (retryCount) => {
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, retryCount),
+        MAX_RETRY_DELAY_MS,
+      );
+      if (DEBUG) console.log(`[GraphQL] Client #${clientId} retry #${retryCount + 1}, waiting ${delay}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    },
     // Lazy connection - only connects when first subscription/mutation is made
     lazy: true,
     // Keep alive to detect disconnections

--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -26,10 +26,15 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
 
   const { activeSession, activateSession } = usePersistentSession();
 
-  // Activate session when we have a session param and board details
+  // Activate or update session when we have a session param and board details
+  // This effect handles:
+  // 1. Initial session activation when joining via shared link
+  // 2. Updates when pathname changes (e.g., angle change) while session remains active
   useEffect(() => {
     if (sessionIdFromUrl && boardDetails) {
-      // Activate session when URL has session param (joining via shared link)
+      // Activate session when URL has session param and either:
+      // - Session ID changed
+      // - Board path changed (e.g., navigating to different angle)
       if (activeSession?.sessionId !== sessionIdFromUrl || activeSession?.boardPath !== pathname) {
         activateSession({
           sessionId: sessionIdFromUrl,
@@ -50,19 +55,6 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
     activeSession?.boardPath,
     activateSession,
   ]);
-
-  // Update board details if they change (e.g., angle change)
-  useEffect(() => {
-    if (activeSession?.sessionId === sessionIdFromUrl && activeSession?.boardPath !== pathname) {
-      // Board path changed but session is the same - update the session info
-      activateSession({
-        sessionId: sessionIdFromUrl!,
-        boardPath: pathname,
-        boardDetails,
-        parsedParams,
-      });
-    }
-  }, [pathname, parsedParams, boardDetails, activeSession, sessionIdFromUrl, activateSession]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
- Use ref for mounted flag in persistent-session-context to safely prevent
  reconnect callbacks from executing after unmount
- Clean up subscription refs on error/complete to prevent resource leaks
- Remove duplicate useEffect in board-session-bridge that could cause
  double session activations
- Add exponential backoff (1s->30s) for GraphQL client reconnection
  to prevent hammering the server on failures