### PR TITLE
fix: Improve WebSocket persistence reliability and prevent memory leaks

### DIFF
--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -27,9 +27,11 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
   const { activeSession, activateSession } = usePersistentSession();
 
   // Activate session when we have a session param and board details
+  // This handles both initial session joins (via shared link) and updates when
+  // board details change (e.g., angle change) while staying in the same session
   useEffect(() => {
     if (sessionIdFromUrl && boardDetails) {
-      // Activate session when URL has session param (joining via shared link)
+      // Activate when: joining a new session OR board path changed (e.g., angle change)
       if (activeSession?.sessionId !== sessionIdFromUrl || activeSession?.boardPath !== pathname) {
         activateSession({
           sessionId: sessionIdFromUrl,
@@ -50,19 +52,6 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
     activeSession?.boardPath,
     activateSession,
   ]);
-
-  // Update board details if they change (e.g., angle change)
-  useEffect(() => {
-    if (activeSession?.sessionId === sessionIdFromUrl && activeSession?.boardPath !== pathname) {
-      // Board path changed but session is the same - update the session info
-      activateSession({
-        sessionId: sessionIdFromUrl!,
-        boardPath: pathname,
-        boardDetails,
-        parsedParams,
-      });
-    }
-  }, [pathname, parsedParams, boardDetails, activeSession, sessionIdFromUrl, activateSession]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
- Add exponential backoff with jitter (1s→30s) for GraphQL client reconnection
  to prevent hammering the server on failures and avoid thundering herd
- Replace mutable mounted variable with useRef in persistent-session-context
  for safer async callback handling in React concurrent mode
- Clean up subscription refs on error/complete to prevent resource leaks
- Consolidate duplicate useEffects in board-session-bridge that could cause
  unnecessary double session activations