### PR TITLE
fix: Fix queue sync validation errors in party mode

### DIFF
--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -65,13 +65,13 @@ export const ClimbInputSchema = z.object({
   ascensionist_count: z.number().min(0),
   difficulty: z.string().max(50),
   quality_average: z.string().max(20),
-  stars: z.number().min(0).max(5),
+  stars: z.number().min(0).max(15),
   difficulty_error: z.string().max(50),
   litUpHoldsMap: z.record(z.any()), // JSON object
-  mirrored: z.boolean().optional(),
+  mirrored: z.boolean().nullish(),
   benchmark_difficulty: z.string().max(50).nullable().optional(),
-  userAscents: z.number().min(0).optional(),
-  userAttempts: z.number().min(0).optional(),
+  userAscents: z.number().min(0).nullish(),
+  userAttempts: z.number().min(0).nullish(),
 });
 
 /**
@@ -91,7 +91,7 @@ export const ClimbQueueItemSchema = z.object({
   climb: ClimbInputSchema,
   addedBy: z.string().max(100).optional(),
   addedByUser: QueueItemUserSchema.optional(),
-  tickedBy: z.array(z.string()).max(100).optional(),
+  tickedBy: z.array(z.string()).max(100).nullish(),
   suggested: z.boolean().optional(),
 });
 

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -551,7 +551,7 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
         query: SET_QUEUE,
         variables: {
           queue: newQueue.map(toClimbQueueItemInput),
-          currentClimbQueueItem: newCurrentClimbQueueItem ? toClimbQueueItemInput(newCurrentClimbQueueItem) : null,
+          currentClimbQueueItem: newCurrentClimbQueueItem ? toClimbQueueItemInput(newCurrentClimbQueueItem) : undefined,
         },
       });
     },


### PR DESCRIPTION
## Summary
- Fixed `stars` field validation to allow max 15 (was incorrectly set to 5, but stars = quality_average * 5)
- Changed optional fields (`mirrored`, `userAscents`, `userAttempts`, `tickedBy`) to use `.nullish()` instead of `.optional()` to accept `null` values from frontend
- Fixed frontend to send `undefined` instead of `null` for absent `currentClimbQueueItem`

## Problem
When dragging/dropping items in the queue list, the `setQueue` mutation was being rejected by the backend with validation errors like:
- "Number must be less than or equal to 5" (stars field)
- "Expected boolean, received null" (mirrored field)
- "Expected number, received null" (userAscents/userAttempts)
- "Expected array, received null" (tickedBy)

This caused queue reordering to not sync to other connected browsers in party mode.

## Test plan
- [ ] Start backend and web dev servers
- [ ] Open two browsers connected to the same party session
- [ ] Add some climbs to the queue
- [ ] Drag and drop a queue item in browser A
- [ ] Verify browser B receives the queue update in real-time
- [ ] Verify no validation errors in WebSocket messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)