### PR TITLE
fix: Fix queue drag-drop sync validation errors in party mode

### DIFF
--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -6,6 +6,11 @@ import { z } from 'zod';
 export const UUIDSchema = z.string().uuid('Invalid UUID format');
 
 /**
+ * External UUID schema for Aurora API climb UUIDs (non-standard format without dashes)
+ */
+export const ExternalUUIDSchema = z.string().min(1, 'UUID cannot be empty').max(50, 'UUID too long');
+
+/**
  * Session ID validation schema
  */
 export const SessionIdSchema = UUIDSchema;
@@ -56,7 +61,7 @@ export const CreateSessionInputSchema = z.object({
  * Climb validation schema (simplified for input)
  */
 export const ClimbInputSchema = z.object({
-  uuid: UUIDSchema,
+  uuid: ExternalUUIDSchema, // Aurora API uses non-standard UUID format (no dashes)
   setter_username: z.string().max(100),
   name: z.string().max(200),
   description: z.string().max(2000),
@@ -80,7 +85,7 @@ export const ClimbInputSchema = z.object({
 export const QueueItemUserSchema = z.object({
   id: z.string().max(100),
   username: z.string().max(100),
-  avatarUrl: z.string().max(500).optional(),
+  avatarUrl: z.string().max(500).nullish(), // Can be null or undefined
 });
 
 /**


### PR DESCRIPTION
## Summary
- Fix validation errors when dragging/reordering climbs in the queue list during party mode
- The `setQueue` mutation was rejecting valid data due to overly strict UUID validation and null handling

## Root Cause
Two validation issues in `packages/backend/src/validation/schemas.ts`:
1. **Climb UUIDs**: Aurora API returns UUIDs as 32 hex chars without dashes (e.g., `765B981977014517A10E5E3D0828696D`), but `z.string().uuid()` requires RFC 4122 format with dashes
2. **avatarUrl**: Frontend sends `null` but `.optional()` only allows `undefined`

## Changes
- Add `ExternalUUIDSchema` for Aurora API climb UUIDs (lenient string validation)
- Update `ClimbInputSchema.uuid` to use the lenient schema
- Change `QueueItemUserSchema.avatarUrl` from `.optional()` to `.nullish()`

## Test plan
- [ ] Start backend and web dev servers
- [ ] Create a party session with 2+ climbs in queue
- [ ] Drag to reorder a climb
- [ ] Verify no WebSocket validation errors occur
- [ ] Verify other clients see the reordered queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)