### PR TITLE
Fix classic symbol display on climb list

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -63,7 +63,12 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   }
 
   const hasGrade = climb.difficulty && climb.quality_average && climb.quality_average !== '0';
-  const isBenchmark = climb.benchmark_difficulty !== null && climb.benchmark_difficulty !== undefined;
+  // A climb is a benchmark/classic if benchmark_difficulty has a meaningful value (not null, undefined, empty, or "0")
+  const isBenchmark =
+    climb.benchmark_difficulty !== null &&
+    climb.benchmark_difficulty !== undefined &&
+    climb.benchmark_difficulty !== '' &&
+    climb.benchmark_difficulty !== '0';
 
   // Extract V grade from difficulty string (e.g., "6a/V3" -> "V3", "V5" -> "V5")
   const getVGrade = (difficulty: string): string | null => {


### PR DESCRIPTION
The classic/benchmark indicator (© icon) was showing on all climbs because the check only verified that benchmark_difficulty was not null/undefined. For non-benchmark climbs, the database returns 0 which was converted to "0" string and passed the check.

Fixed by also checking that benchmark_difficulty is not an empty string or "0".