### PR TITLE
feat: Add GraphQL queries for board configuration and climb search

### DIFF
--- a/packages/backend/MIGRATION_PLAN.md
+++ b/packages/backend/MIGRATION_PLAN.md
@@ -45,7 +45,7 @@ Node.js HTTP Server
 
 ---
 
-## Phase 2: REST API Reimplementation (TODO)
+## Phase 2: REST API Reimplementation (IN PROGRESS)
 
 Reimplement Next.js REST APIs as GraphQL queries/mutations. Only endpoints that query our database - Aurora proxy routes stay in Next.js.
 
@@ -53,8 +53,11 @@ Reimplement Next.js REST APIs as GraphQL queries/mutations. Only endpoints that 
 
 | REST Endpoint | GraphQL Operation | Status |
 |---------------|-------------------|--------|
-| `GET /api/v1/grades/[board_name]` | `Query.grades(boardName: String!)` | TODO |
-| `GET /api/v1/angles/[board_name]/[layout_id]` | `Query.angles(boardName: String!, layoutId: Int!)` | TODO |
+| `GET /api/v1/grades/[board_name]` | `Query.grades(boardName: String!)` | ✅ DONE |
+| `GET /api/v1/angles/[board_name]/[layout_id]` | `Query.angles(boardName: String!, layoutId: Int!)` | ✅ DONE |
+| N/A | `Query.layouts(boardName: String!)` | ✅ DONE |
+| N/A | `Query.sizes(boardName: String!, layoutId: Int!)` | ✅ DONE |
+| N/A | `Query.sets(boardName: String!, layoutId: Int!, sizeId: Int!)` | ✅ DONE |
 | `GET /api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/details` | `Query.boardDetails(...)` | TODO |
 
 **Source files:**
@@ -66,8 +69,8 @@ Reimplement Next.js REST APIs as GraphQL queries/mutations. Only endpoints that 
 
 | REST Endpoint | GraphQL Operation | Status |
 |---------------|-------------------|--------|
-| `GET /api/v1/[board_name]/.../search` | `Query.searchClimbs(input: ClimbSearchInput!)` | TODO |
-| `GET /api/v1/[board_name]/.../[climb_uuid]` | `Query.climb(...)` | TODO |
+| `GET /api/v1/[board_name]/.../search` | `Query.searchClimbs(input: ClimbSearchInput!)` | ✅ DONE |
+| `GET /api/v1/[board_name]/.../[climb_uuid]` | `Query.climb(...)` | ✅ DONE |
 
 **Medium Priority:**
 
@@ -120,9 +123,13 @@ Reimplement Next.js REST APIs as GraphQL queries/mutations. Only endpoints that 
 
 ---
 
-## Phase 3: Type Sharing (TODO)
+## Phase 3: Type Sharing (PARTIAL)
 
 Add new GraphQL types to `packages/shared-schema/src/schema.ts` and corresponding TypeScript types to `packages/shared-schema/src/types.ts`.
+
+### Implemented Types
+- `Grade`, `BoardAngle`, `Layout`, `Size`, `Set` - Board configuration types
+- `ClimbSearchInput`, `ClimbSearchResult` - Climb search types
 
 ### New Types Needed
 
@@ -176,10 +183,11 @@ type Favorite { climbUuid: String!, angle: Int! }
 - [x] Verify WebSocket subscriptions work
 - [x] Remove Express dependency
 
-### Milestone 2: Core Queries (High Priority)
-- [ ] Add new types to shared-schema
-- [ ] Implement `grades`, `angles`, `boardDetails` queries
-- [ ] Implement `searchClimbs`, `climb` queries
+### Milestone 2: Core Queries (High Priority) - IN PROGRESS
+- [x] Add new types to shared-schema
+- [x] Implement `grades`, `angles`, `layouts`, `sizes`, `sets` queries
+- [x] Implement `searchClimbs`, `climb` queries
+- [ ] Implement `boardDetails` query (complex - requires hold/LED data)
 - [ ] Implement `profile` query and `updateProfile` mutation
 - [ ] Implement `auroraCredentials` queries/mutations
 

--- a/packages/backend/src/db/tables.ts
+++ b/packages/backend/src/db/tables.ts
@@ -1,0 +1,91 @@
+// Table selection utility for backend
+// Similar to packages/web/app/lib/db/queries/util/table-select.ts
+import {
+  kilterClimbs,
+  kilterClimbStats,
+  kilterDifficultyGrades,
+  kilterProductSizes,
+  kilterLayouts,
+  kilterSets,
+  kilterProductSizesLayoutsSets,
+  kilterHoles,
+  kilterPlacements,
+  kilterLeds,
+  kilterProducts,
+  tensionClimbs,
+  tensionClimbStats,
+  tensionDifficultyGrades,
+  tensionProductSizes,
+  tensionLayouts,
+  tensionSets,
+  tensionProductSizesLayoutsSets,
+  tensionHoles,
+  tensionPlacements,
+  tensionLeds,
+  tensionProducts,
+} from '@boardsesh/db/schema';
+
+export type BoardName = 'kilter' | 'tension';
+
+// Define the table structure
+export type TableSet = {
+  climbs: typeof kilterClimbs | typeof tensionClimbs;
+  climbStats: typeof kilterClimbStats | typeof tensionClimbStats;
+  difficultyGrades: typeof kilterDifficultyGrades | typeof tensionDifficultyGrades;
+  productSizes: typeof kilterProductSizes | typeof tensionProductSizes;
+  layouts: typeof kilterLayouts | typeof tensionLayouts;
+  sets: typeof kilterSets | typeof tensionSets;
+  productSizesLayoutsSets: typeof kilterProductSizesLayoutsSets | typeof tensionProductSizesLayoutsSets;
+  holes: typeof kilterHoles | typeof tensionHoles;
+  placements: typeof kilterPlacements | typeof tensionPlacements;
+  leds: typeof kilterLeds | typeof tensionLeds;
+  products: typeof kilterProducts | typeof tensionProducts;
+};
+
+// Create a complete mapping of all tables
+const BOARD_TABLES: Record<BoardName, TableSet> = {
+  kilter: {
+    climbs: kilterClimbs,
+    climbStats: kilterClimbStats,
+    difficultyGrades: kilterDifficultyGrades,
+    productSizes: kilterProductSizes,
+    layouts: kilterLayouts,
+    sets: kilterSets,
+    productSizesLayoutsSets: kilterProductSizesLayoutsSets,
+    holes: kilterHoles,
+    placements: kilterPlacements,
+    leds: kilterLeds,
+    products: kilterProducts,
+  },
+  tension: {
+    climbs: tensionClimbs,
+    climbStats: tensionClimbStats,
+    difficultyGrades: tensionDifficultyGrades,
+    productSizes: tensionProductSizes,
+    layouts: tensionLayouts,
+    sets: tensionSets,
+    productSizesLayoutsSets: tensionProductSizesLayoutsSets,
+    holes: tensionHoles,
+    placements: tensionPlacements,
+    leds: tensionLeds,
+    products: tensionProducts,
+  },
+} as const;
+
+/**
+ * Get all tables for a specific board
+ * @param boardName The board (kilter or tension)
+ * @returns All tables for the specified board
+ */
+export function getBoardTables(boardName: BoardName): TableSet {
+  return BOARD_TABLES[boardName];
+}
+
+/**
+ * Helper function to check if a board name is valid
+ * @param boardName The name to check
+ * @returns True if the board name is valid
+ */
+export function isValidBoardName(boardName: string): boardName is BoardName {
+  return boardName === 'kilter' || boardName === 'tension';
+}

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -115,12 +115,85 @@ export const typeDefs = /* GraphQL */ `
     discoverable: Boolean!
   }
 
+  # Board Configuration Types
+  type Grade {
+    difficultyId: Int!
+    difficultyName: String!
+  }
+
+  type BoardAngle {
+    angle: Int!
+  }
+
+  type Layout {
+    id: Int!
+    name: String!
+  }
+
+  type Size {
+    id: Int!
+    name: String!
+    description: String!
+  }
+
+  type Set {
+    id: Int!
+    name: String!
+  }
+
+  # Climb Search Types
+  input ClimbSearchInput {
+    boardName: String!
+    layoutId: Int!
+    sizeId: Int!
+    setIds: [Int!]!
+    angle: Int!
+    # Pagination
+    page: Int
+    pageSize: Int
+    # Filters
+    minGrade: Int
+    maxGrade: Int
+    minAscents: Int
+    minRating: Int
+    gradeAccuracy: Int
+    name: String
+    settername: [String!]
+    onlyClassics: Boolean
+    onlyTallClimbs: Boolean
+    # Sort
+    sortBy: String
+    sortOrder: String
+    # Progress filters (requires userId)
+    hideAttempted: Boolean
+    hideCompleted: Boolean
+    showOnlyAttempted: Boolean
+    showOnlyCompleted: Boolean
+  }
+
+  type ClimbSearchResult {
+    climbs: [Climb!]!
+    totalCount: Int!
+    hasMore: Boolean!
+  }
+
   type Query {
     session(sessionId: ID!): Session
     # Find discoverable sessions near a location
     nearbySessions(latitude: Float!, longitude: Float!, radiusMeters: Float): [DiscoverableSession!]!
     # Get current user's recent sessions (requires auth context)
     mySessions: [DiscoverableSession!]!
+
+    # Board Configuration Queries
+    grades(boardName: String!): [Grade!]!
+    angles(boardName: String!, layoutId: Int!): [BoardAngle!]!
+    layouts(boardName: String!): [Layout!]!
+    sizes(boardName: String!, layoutId: Int!): [Size!]!
+    sets(boardName: String!, layoutId: Int!, sizeId: Int!): [Set!]!
+
+    # Climb Queries
+    searchClimbs(input: ClimbSearchInput!): ClimbSearchResult!
+    climb(boardName: String!, layoutId: Int!, sizeId: Int!, setIds: [Int!]!, angle: Int!, climbUuid: ID!): Climb
   }
 
   type Mutation {

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -123,3 +123,67 @@ export type ConnectionContext = {
   userId?: string;
   isAuthenticated?: boolean;
 };
+
+// Board Configuration Types
+export type BoardName = 'kilter' | 'tension';
+
+export type Grade = {
+  difficultyId: number;
+  difficultyName: string;
+};
+
+export type BoardAngle = {
+  angle: number;
+};
+
+export type Layout = {
+  id: number;
+  name: string;
+};
+
+export type Size = {
+  id: number;
+  name: string;
+  description: string;
+};
+
+export type Set = {
+  id: number;
+  name: string;
+};
+
+// Climb Search Types
+export type ClimbSearchInput = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+  angle: number;
+  // Pagination
+  page?: number;
+  pageSize?: number;
+  // Filters
+  minGrade?: number;
+  maxGrade?: number;
+  minAscents?: number;
+  minRating?: number;
+  gradeAccuracy?: number;
+  name?: string;
+  settername?: string[];
+  onlyClassics?: boolean;
+  onlyTallClimbs?: boolean;
+  // Sort
+  sortBy?: string;
+  sortOrder?: string;
+  // Progress filters
+  hideAttempted?: boolean;
+  hideCompleted?: boolean;
+  showOnlyAttempted?: boolean;
+  showOnlyCompleted?: boolean;
+};
+
+export type ClimbSearchResult = {
+  climbs: Climb[];
+  totalCount: number;
+  hasMore: boolean;
+};


### PR DESCRIPTION
Implements Phase 2 of the REST API to GraphQL migration:

Schema additions (shared-schema):
- Grade, BoardAngle, Layout, Size, Set types for board configuration
- ClimbSearchInput and ClimbSearchResult types for climb search

Backend queries:
- grades(boardName) - Fetch difficulty grades for a board
- angles(boardName, layoutId) - Fetch available angles for a layout
- layouts(boardName) - Fetch layouts for a board
- sizes(boardName, layoutId) - Fetch sizes for a layout
- sets(boardName, layoutId, sizeId) - Fetch sets for a size
- searchClimbs(input) - Search climbs with filters and pagination
- climb(...) - Fetch a single climb by UUID

New backend utilities:
- src/db/tables.ts - Board-aware table selection utility

This is part of the incremental migration from Next.js REST APIs to
GraphQL, enabling the backend to serve data directly from the database.