### PR TITLE
fix: Handle CORS preflight for avatar upload endpoint

### DIFF
--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -51,8 +51,8 @@ export async function startServer(): Promise<{ wss: WebSocketServer; httpServer:
         return;
       }
 
-      // Avatar upload endpoint
-      if (pathname === '/api/avatars' && req.method === 'POST') {
+      // Avatar upload endpoint (handle OPTIONS for CORS preflight)
+      if (pathname === '/api/avatars' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleAvatarUpload(req, res);
         return;
       }


### PR DESCRIPTION
The avatar upload endpoint only handled POST requests, causing OPTIONS
preflight requests to fall through to the 404 handler. This resulted in
CORS preflight failures, which manifested as "load failed" errors when
trying to upload avatars.