### PR TITLE
fix: Display custom uploaded avatars in the UI

### DIFF
--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -94,6 +94,7 @@ export async function uploadToS3(
       Body: buffer,
       ContentType: contentType,
       CacheControl: 'public, max-age=31536000, immutable',
+      ACL: 'public-read',
     })
   );
 


### PR DESCRIPTION
Two issues were preventing uploaded avatars from displaying:

1. S3 uploads were private by default - added ACL: 'public-read' to
   make uploaded avatars publicly accessible

2. PartyProfileContext was only using session?.user?.image (OAuth
   provider image) instead of the custom avatar from userProfiles.
   Updated the context to fetch and prefer custom profile data
   (avatarUrl and displayName) over the NextAuth session defaults.