### PR TITLE
fix: Proxy avatar images from S3 instead of requiring public access

### DIFF
--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -236,8 +236,10 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
 
           // Upload to S3
           const s3Key = `avatars/${userId}.${ext}`;
-          const result = await uploadToS3(fileBuffer, s3Key, mimeType);
-          avatarUrl = result.url;
+          await uploadToS3(fileBuffer, s3Key, mimeType);
+          // Return backend-relative URL instead of direct S3 URL
+          // This allows the backend to proxy the image, avoiding S3 public access requirements
+          avatarUrl = `/static/avatars/${userId}.${ext}`;
         } else {
           // Delete any existing avatars for this user (all extensions) from local storage
           await deleteExistingAvatars(userId);


### PR DESCRIPTION
S3-compatible services like Railway Object Storage often don't support
public ACLs or public bucket access. This change:

1. Avatar upload now returns a backend-relative URL (/static/avatars/...)
   instead of a direct S3 URL
2. Static handler proxies images from S3 instead of redirecting
3. Added getFromS3() function to stream objects from S3

This allows avatars to render correctly even when the S3 bucket is
private, as the backend fetches from S3 with credentials and streams
to the client.