### PR TITLE
fix: Persist queue state across navigation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,100 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'packages/web/**'
+      - 'packages/shared-schema/**'
+      - 'packages/db/**'
+      - '.github/workflows/e2e-tests.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'packages/web/**'
+      - 'packages/shared-schema/**'
+      - 'packages/db/**'
+      - '.github/workflows/e2e-tests.yml'
+
+jobs:
+  e2e:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: boardsesh_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci --legacy-peer-deps
+
+    - name: Build shared-schema
+      run: npm run build --workspace=@boardsesh/shared-schema
+
+    - name: Build db package
+      run: npm run build --workspace=@boardsesh/db
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
+      working-directory: packages/web
+
+    - name: Build web application
+      run: npm run build --workspace=@boardsesh/web
+      env:
+        # Provide minimal env vars needed for build
+        NEXTAUTH_SECRET: test-secret-for-ci
+        NEXTAUTH_URL: http://localhost:3000
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+
+    - name: Run database migrations
+      run: npx drizzle-kit migrate
+      working-directory: packages/web
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+
+    - name: Start server and run E2E tests
+      run: |
+        npm run start --workspace=@boardsesh/web &
+        npx wait-on http://localhost:3000 --timeout 60000
+        npm run test:e2e --workspace=@boardsesh/web
+      env:
+        PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+        NEXTAUTH_SECRET: test-secret-for-ci
+        NEXTAUTH_URL: http://localhost:3000
+
+    - name: Upload Playwright Report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: packages/web/playwright-report/
+        retention-days: 7
+
+    - name: Upload Playwright Screenshots
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-screenshots
+        path: packages/web/test-results/
+        retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -3871,6 +3871,22 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rc-component/async-validator": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
@@ -5935,7 +5951,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6544,7 +6560,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7343,7 +7359,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8086,7 +8102,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -8419,6 +8435,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8612,6 +8675,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8631,6 +8695,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -8754,7 +8819,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -8847,6 +8912,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -9246,7 +9312,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -9269,12 +9335,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9286,12 +9352,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9303,12 +9369,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9320,12 +9386,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9337,12 +9403,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9354,12 +9420,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9371,12 +9437,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9388,12 +9454,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9405,12 +9471,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9422,12 +9488,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9439,12 +9505,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9456,12 +9522,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9473,12 +9539,12 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9490,12 +9556,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9507,12 +9573,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9524,12 +9590,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9541,12 +9607,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9558,12 +9624,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9575,12 +9641,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9592,12 +9658,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9609,12 +9675,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9626,12 +9692,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9643,12 +9709,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9660,12 +9726,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9677,12 +9743,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9694,12 +9760,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9708,7 +9774,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10863,6 +10929,7 @@
         "zod": "^4.2.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -136,7 +136,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
     <Layout style={{ height: '100dvh', display: 'flex', flexDirection: 'column', padding: 0 }}>
       <BoardSessionBridge boardDetails={boardDetails} parsedParams={parsedParams}>
         <ConnectionSettingsProvider>
-          <GraphQLQueueProvider parsedParams={parsedParams}>
+          <GraphQLQueueProvider parsedParams={parsedParams} boardDetails={boardDetails}>
             <PartyProvider>
               <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -1,8 +1,8 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 import { Flex, Button, Dropdown, MenuProps } from 'antd';
 import { Header } from 'antd/es/layout/layout';
-import { useSession, signIn, signOut } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import SearchButton from '../search-drawer/search-button';
 import SearchClimbNameInput from '../search-drawer/search-climb-name-input';
 import { UISearchParamsProvider } from '../queue-control/ui-searchparams-provider';
@@ -16,6 +16,7 @@ import AngleSelector from './angle-selector';
 import Logo from '../brand/logo';
 import styles from './header.module.css';
 import Link from 'next/link';
+import { AuthModal } from '../auth/auth-modal';
 
 type BoardSeshHeaderProps = {
   boardDetails: BoardDetails;
@@ -24,6 +25,7 @@ type BoardSeshHeaderProps = {
 export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeaderProps) {
   const { data: session } = useSession();
   const { currentClimb } = useQueueContext();
+  const [showAuthModal, setShowAuthModal] = useState(false);
 
   const handleSignOut = () => {
     signOut();
@@ -76,7 +78,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
       key: 'login',
       icon: <LoginOutlined />,
       label: 'Login',
-      onClick: () => signIn(),
+      onClick: () => setShowAuthModal(true),
     }] : []),
   ];
   return (
@@ -135,7 +137,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                 <Button
                   icon={<LoginOutlined />}
                   type="text"
-                  onClick={() => signIn()}
+                  onClick={() => setShowAuthModal(true)}
                 >
                   Login
                 </Button>
@@ -153,6 +155,13 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
           </Flex>
         </Flex>
       </UISearchParamsProvider>
+
+      <AuthModal
+        open={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        title="Sign in to Boardsesh"
+        description="Sign in to access all features including saving favorites, tracking ascents, and more."
+      />
     </Header>
   );
 }

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -16,7 +16,7 @@ import AngleSelector from './angle-selector';
 import Logo from '../brand/logo';
 import styles from './header.module.css';
 import Link from 'next/link';
-import { AuthModal } from '../auth/auth-modal';
+import AuthModal from '../auth/auth-modal';
 
 type BoardSeshHeaderProps = {
   boardDetails: BoardDetails;

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -13,9 +13,10 @@ import {
 } from '@ant-design/icons';
 import { Button, Input, Drawer, QRCode, Flex, message, Typography, Badge, Switch, Tabs, Space } from 'antd';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { signIn, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useQueueContext } from '../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
+import { AuthModal } from '../auth/auth-modal';
 
 const { Text } = Typography;
 
@@ -52,6 +53,7 @@ export const ShareBoardButton = () => {
   const [isStartingSession, setIsStartingSession] = useState(false);
   const [joinSessionId, setJoinSessionId] = useState('');
   const [discoverable, setDiscoverable] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
 
   const isLoggedIn = authStatus === 'authenticated';
 
@@ -82,7 +84,7 @@ export const ShareBoardButton = () => {
 
   const handleStartSession = async () => {
     if (!isLoggedIn) {
-      signIn();
+      setShowAuthModal(true);
       return;
     }
 
@@ -209,7 +211,7 @@ export const ShareBoardButton = () => {
                               }}
                             >
                               <Text>Sign in to start a party session</Text>
-                              <Button type="primary" size="small" icon={<LoginOutlined />} onClick={() => signIn()}>
+                              <Button type="primary" size="small" icon={<LoginOutlined />} onClick={() => setShowAuthModal(true)}>
                                 Sign in
                               </Button>
                             </Flex>
@@ -378,7 +380,7 @@ export const ShareBoardButton = () => {
                       <Text type="secondary" style={{ fontSize: '13px' }}>
                         Sign in to customize your username
                       </Text>
-                      <Button type="link" size="small" icon={<LoginOutlined />} onClick={() => signIn()}>
+                      <Button type="link" size="small" icon={<LoginOutlined />} onClick={() => setShowAuthModal(true)}>
                         Sign in
                       </Button>
                     </Flex>
@@ -407,6 +409,13 @@ export const ShareBoardButton = () => {
           )}
         </Flex>
       </Drawer>
+
+      <AuthModal
+        open={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        title="Sign in to start party mode"
+        description="Create an account or sign in to start a party session and climb with others."
+      />
     </>
   );
 };

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -16,7 +16,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useQueueContext } from '../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
-import { AuthModal } from '../auth/auth-modal';
+import AuthModal from '../auth/auth-modal';
 
 const { Text } = Typography;
 

--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -49,28 +49,30 @@ const ClimbCard = React.memo(
     );
 
     return (
-      <Card
-        title={cardTitle}
-        size="small"
-        style={{
-          borderColor: selected ? themeTokens.colors.primary : undefined,
-        }}
-        styles={{
-          header: { paddingTop: 8, paddingBottom: 6 },
-          body: {
-            padding: 6,
-            backgroundColor: selected ? themeTokens.semantic.selectedLight : undefined,
-          },
-        }}
-        actions={actions || (climb ? ClimbActions.asCardActions({
-          climb,
-          boardDetails,
-          angle: climb.angle,
-          exclude: ['tick', 'openInApp', 'mirror', 'share', 'addToList'],
-        }) : [])}
-      >
-        {cover}
-      </Card>
+      <div data-testid="climb-card">
+        <Card
+          title={cardTitle}
+          size="small"
+          style={{
+            borderColor: selected ? themeTokens.colors.primary : undefined,
+          }}
+          styles={{
+            header: { paddingTop: 8, paddingBottom: 6 },
+            body: {
+              padding: 6,
+              backgroundColor: selected ? themeTokens.semantic.selectedLight : undefined,
+            },
+          }}
+          actions={actions || (climb ? ClimbActions.asCardActions({
+            climb,
+            boardDetails,
+            angle: climb.angle,
+            exclude: ['tick', 'openInApp', 'mirror', 'share', 'addToList'],
+          }) : [])}
+        >
+          {cover}
+        </Card>
+      </div>
     );
   },
   (prevProps, nextProps) => {

--- a/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
+++ b/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Badge, Button, Tooltip, Typography } from 'antd';
-import { CloseOutlined, TeamOutlined } from '@ant-design/icons';
+import { Badge, Button, Modal, Tooltip, Typography } from 'antd';
+import { CloseOutlined, TeamOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { usePersistentSession, useIsOnBoardRoute } from './persistent-session-context';
 import BoardRenderer from '../board-renderer/board-renderer';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
@@ -13,6 +13,7 @@ const { Text } = Typography;
 const FloatingSessionThumbnail: React.FC = () => {
   const router = useRouter();
   const isOnBoardRoute = useIsOnBoardRoute();
+  const [showClearConfirmation, setShowClearConfirmation] = useState(false);
   const {
     activeSession,
     currentClimbQueueItem,
@@ -20,10 +21,19 @@ const FloatingSessionThumbnail: React.FC = () => {
     hasConnected,
     isConnecting,
     deactivateSession,
+    // Local queue state
+    localQueue,
+    localCurrentClimbQueueItem,
+    localBoardPath,
+    localBoardDetails,
+    clearLocalQueue,
   } = usePersistentSession();
 
-  // Don't show if no active session
-  if (!activeSession) {
+  // Determine if we have a local queue to show
+  const hasLocalQueue = !activeSession && localBoardPath && (localQueue.length > 0 || localCurrentClimbQueueItem);
+
+  // Don't show if no active session AND no local queue
+  if (!activeSession && !hasLocalQueue) {
     return null;
   }
 
@@ -32,146 +42,202 @@ const FloatingSessionThumbnail: React.FC = () => {
     return null;
   }
 
-  const { boardDetails, parsedParams, sessionId } = activeSession;
-  const currentClimb = currentClimbQueueItem?.climb;
+  // Determine which mode we're in and get appropriate values
+  const isPartyMode = !!activeSession;
 
-  // Construct the URL to navigate back to the board
-  const boardUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-    ? `${constructClimbListWithSlugs(
-        boardDetails.board_name,
-        boardDetails.layout_name,
-        boardDetails.size_name,
-        boardDetails.size_description,
-        boardDetails.set_names,
-        parsedParams.angle,
-      )}?session=${sessionId}`
-    : `${activeSession.boardPath}?session=${sessionId}`;
+  // Get board details and current climb based on mode
+  const boardDetails = isPartyMode ? activeSession.boardDetails : localBoardDetails;
+  const currentClimb = isPartyMode ? currentClimbQueueItem?.climb : localCurrentClimbQueueItem?.climb;
+  const queueLength = isPartyMode ? 0 : localQueue.length; // We don't track queue length for party mode in this context
+
+  // Build navigation URL
+  let boardUrl: string;
+  if (isPartyMode) {
+    const { parsedParams, sessionId } = activeSession;
+    boardUrl = boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
+      ? `${constructClimbListWithSlugs(
+          boardDetails.board_name,
+          boardDetails.layout_name,
+          boardDetails.size_name,
+          boardDetails.size_description,
+          boardDetails.set_names,
+          parsedParams.angle,
+        )}?session=${sessionId}`
+      : `${activeSession.boardPath}?session=${sessionId}`;
+  } else {
+    // Local mode - just navigate to the board path
+    boardUrl = localBoardPath || '/';
+  }
 
   const handleNavigateBack = () => {
     router.push(boardUrl);
   };
 
-  const handleLeaveSession = (e: React.MouseEvent) => {
+  const handleClose = (e: React.MouseEvent) => {
     e.stopPropagation();
-    deactivateSession();
+    if (isPartyMode) {
+      // For party mode, leave session directly
+      deactivateSession();
+    } else {
+      // For local mode, show confirmation
+      setShowClearConfirmation(true);
+    }
+  };
+
+  const handleConfirmClear = () => {
+    clearLocalQueue();
+    setShowClearConfirmation(false);
+  };
+
+  const handleCancelClear = () => {
+    setShowClearConfirmation(false);
   };
 
   const connectionStatus = isConnecting ? 'connecting' : hasConnected ? 'connected' : 'disconnected';
   const statusColor = connectionStatus === 'connected' ? 'green' : connectionStatus === 'connecting' ? 'orange' : 'red';
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: 16,
-        right: 16,
-        zIndex: 1000,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-end',
-        gap: 8,
-      }}
-    >
-      {/* Session info card */}
+    <>
       <div
-        onClick={handleNavigateBack}
         style={{
-          background: 'var(--ant-color-bg-elevated, #1f1f1f)',
-          borderRadius: 12,
-          padding: 12,
-          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
-          cursor: 'pointer',
-          border: '1px solid var(--ant-color-border, #303030)',
-          maxWidth: 200,
-          transition: 'transform 0.2s, box-shadow 0.2s',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'scale(1.02)';
-          e.currentTarget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.4)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'scale(1)';
-          e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.3)';
+          position: 'fixed',
+          bottom: 16,
+          right: 16,
+          zIndex: 1000,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 8,
         }}
       >
-        {/* Header with close button */}
+        {/* Session info card */}
         <div
+          onClick={handleNavigateBack}
           style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 8,
+            background: 'var(--ant-color-bg-elevated, #1f1f1f)',
+            borderRadius: 12,
+            padding: 12,
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+            cursor: 'pointer',
+            border: '1px solid var(--ant-color-border, #303030)',
+            maxWidth: 200,
+            transition: 'transform 0.2s, box-shadow 0.2s',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = 'scale(1.02)';
+            e.currentTarget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.4)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = 'scale(1)';
+            e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.3)';
           }}
         >
-          <Tooltip title={`${users.length} user${users.length !== 1 ? 's' : ''} connected`}>
-            <Badge
-              count={users.length}
-              size="small"
-              style={{ backgroundColor: statusColor }}
+          {/* Header with close button */}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 8,
+            }}
+          >
+            {isPartyMode ? (
+              <Tooltip title={`${users.length} user${users.length !== 1 ? 's' : ''} connected`}>
+                <Badge
+                  count={users.length}
+                  size="small"
+                  style={{ backgroundColor: statusColor }}
+                >
+                  <TeamOutlined style={{ fontSize: 16, color: 'var(--ant-color-text-secondary)' }} />
+                </Badge>
+              </Tooltip>
+            ) : (
+              <Tooltip title={`${queueLength} climb${queueLength !== 1 ? 's' : ''} in queue`}>
+                <Badge
+                  count={queueLength}
+                  size="small"
+                  style={{ backgroundColor: 'var(--ant-color-primary)' }}
+                >
+                  <UnorderedListOutlined style={{ fontSize: 16, color: 'var(--ant-color-text-secondary)' }} />
+                </Badge>
+              </Tooltip>
+            )}
+            <Tooltip title={isPartyMode ? 'Leave session' : 'Clear queue'}>
+              <Button
+                type="text"
+                size="small"
+                icon={<CloseOutlined />}
+                onClick={handleClose}
+                style={{ color: 'var(--ant-color-text-secondary)' }}
+              />
+            </Tooltip>
+          </div>
+
+          {/* Board thumbnail */}
+          {boardDetails && (
+            <div
+              style={{
+                width: 120,
+                height: 'auto',
+                marginBottom: 8,
+                borderRadius: 8,
+                overflow: 'hidden',
+                background: 'var(--ant-color-bg-container, #141414)',
+              }}
             >
-              <TeamOutlined style={{ fontSize: 16, color: 'var(--ant-color-text-secondary)' }} />
-            </Badge>
-          </Tooltip>
-          <Tooltip title="Leave session">
-            <Button
-              type="text"
-              size="small"
-              icon={<CloseOutlined />}
-              onClick={handleLeaveSession}
-              style={{ color: 'var(--ant-color-text-secondary)' }}
-            />
-          </Tooltip>
+              <BoardRenderer
+                boardDetails={boardDetails}
+                litUpHoldsMap={currentClimb?.litUpHoldsMap}
+                mirrored={!!currentClimb?.mirrored}
+                thumbnail
+              />
+            </div>
+          )}
+
+          {/* Climb name */}
+          <Text
+            style={{
+              fontSize: 12,
+              color: 'var(--ant-color-text)',
+              display: 'block',
+              textAlign: 'center',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '100%',
+            }}
+          >
+            {currentClimb?.name || 'No climb selected'}
+          </Text>
+
+          {/* Tap to return hint */}
+          <Text
+            type="secondary"
+            style={{
+              fontSize: 10,
+              display: 'block',
+              textAlign: 'center',
+              marginTop: 4,
+            }}
+          >
+            Tap to return
+          </Text>
         </div>
-
-        {/* Board thumbnail */}
-        <div
-          style={{
-            width: 120,
-            height: 'auto',
-            marginBottom: 8,
-            borderRadius: 8,
-            overflow: 'hidden',
-            background: 'var(--ant-color-bg-container, #141414)',
-          }}
-        >
-          <BoardRenderer
-            boardDetails={boardDetails}
-            litUpHoldsMap={currentClimb?.litUpHoldsMap}
-            mirrored={!!currentClimb?.mirrored}
-            thumbnail
-          />
-        </div>
-
-        {/* Climb name */}
-        <Text
-          style={{
-            fontSize: 12,
-            color: 'var(--ant-color-text)',
-            display: 'block',
-            textAlign: 'center',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            maxWidth: '100%',
-          }}
-        >
-          {currentClimb?.name || 'No climb selected'}
-        </Text>
-
-        {/* Tap to return hint */}
-        <Text
-          type="secondary"
-          style={{
-            fontSize: 10,
-            display: 'block',
-            textAlign: 'center',
-            marginTop: 4,
-          }}
-        >
-          Tap to return
-        </Text>
       </div>
-    </div>
+
+      {/* Confirmation modal for clearing local queue */}
+      <Modal
+        title="Clear queue?"
+        open={showClearConfirmation}
+        onOk={handleConfirmClear}
+        onCancel={handleCancelClear}
+        okText="Clear"
+        cancelText="Cancel"
+        okButtonProps={{ danger: true }}
+      >
+        <p>Are you sure you want to clear your queue? This will remove all {queueLength} climb{queueLength !== 1 ? 's' : ''} from your queue.</p>
+      </Modal>
+    </>
   );
 };
 

--- a/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
+++ b/packages/web/app/components/persistent-session/floating-session-thumbnail.tsx
@@ -99,6 +99,7 @@ const FloatingSessionThumbnail: React.FC = () => {
   return (
     <>
       <div
+        data-testid="floating-session-thumbnail"
         style={{
           position: 'fixed',
           bottom: 16,

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -53,7 +53,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   };
 
   return (
-    <div className="queue-bar-shadow" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
+    <div className="queue-bar-shadow" data-testid="queue-control-bar" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
       {/* Main Control Bar */}
       <Card
         bordered={false}

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -122,7 +122,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
   }, [index, item.uuid]);
 
   return (
-    <div ref={itemRef}>
+    <div ref={itemRef} data-testid="queue-item">
       <div
         style={{
           display: 'flex',

--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 /**
  * E2E tests for queue persistence across navigation.
@@ -8,7 +8,7 @@ import { test, expect } from '@playwright/test';
  */
 
 // Helper to wait for the page to be ready
-async function waitForBoardPage(page: ReturnType<typeof test['page']>) {
+async function waitForBoardPage(page: Page) {
   // Wait for the queue control bar to be visible
   await page.waitForSelector('[data-testid="queue-control-bar"]', { timeout: 30000 }).catch(() => {
     // Fallback: wait for any content to load
@@ -17,7 +17,7 @@ async function waitForBoardPage(page: ReturnType<typeof test['page']>) {
 }
 
 // Helper to add a climb to the queue
-async function addClimbToQueue(page: ReturnType<typeof test['page']>) {
+async function addClimbToQueue(page: Page) {
   // Click on a climb card to add it to queue
   const climbCard = page.locator('[data-testid="climb-card"]').first();
   if (await climbCard.isVisible()) {

--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for queue persistence across navigation.
+ *
+ * These tests verify that the queue state is preserved when navigating
+ * away from the board page and back.
+ */
+
+// Helper to wait for the page to be ready
+async function waitForBoardPage(page: ReturnType<typeof test['page']>) {
+  // Wait for the queue control bar to be visible
+  await page.waitForSelector('[data-testid="queue-control-bar"]', { timeout: 30000 }).catch(() => {
+    // Fallback: wait for any content to load
+    return page.waitForLoadState('networkidle');
+  });
+}
+
+// Helper to add a climb to the queue
+async function addClimbToQueue(page: ReturnType<typeof test['page']>) {
+  // Click on a climb card to add it to queue
+  const climbCard = page.locator('[data-testid="climb-card"]').first();
+  if (await climbCard.isVisible()) {
+    await climbCard.click();
+    // Wait for the climb to be added
+    await page.waitForTimeout(500);
+  }
+}
+
+test.describe('Queue Persistence - Local Mode', () => {
+  // Use a known board configuration for testing
+  const boardUrl = '/kilter/kilter-board-original/12-x-12-commercial/1,72/40/list';
+
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the board page
+    await page.goto(boardUrl);
+    await waitForBoardPage(page);
+  });
+
+  test('queue should persist when navigating to settings and back', async ({ page }) => {
+    // Get initial queue state
+    const initialQueueCount = await page.locator('[data-testid="queue-item"]').count();
+
+    // Add a climb to the queue if none exist
+    if (initialQueueCount === 0) {
+      await addClimbToQueue(page);
+    }
+
+    // Verify queue has items
+    const queueCountBefore = await page.locator('[data-testid="queue-item"]').count();
+    expect(queueCountBefore).toBeGreaterThan(0);
+
+    // Navigate to settings
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    // Verify we're on settings page
+    await expect(page).toHaveURL(/\/settings/);
+
+    // Navigate back to the board
+    await page.goto(boardUrl);
+    await waitForBoardPage(page);
+
+    // Verify queue items are preserved
+    const queueCountAfter = await page.locator('[data-testid="queue-item"]').count();
+    expect(queueCountAfter).toBe(queueCountBefore);
+  });
+
+  test('floating thumbnail should appear when navigating away with queue items', async ({ page }) => {
+    // Add a climb to the queue
+    await addClimbToQueue(page);
+
+    // Verify queue has items
+    const queueCount = await page.locator('[data-testid="queue-item"]').count();
+    if (queueCount === 0) {
+      test.skip();
+      return;
+    }
+
+    // Navigate to settings (or any non-board page)
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    // Check for floating thumbnail
+    const thumbnail = page.locator('[data-testid="floating-session-thumbnail"]');
+    await expect(thumbnail).toBeVisible({ timeout: 5000 });
+  });
+
+  test('clicking floating thumbnail should navigate back to board', async ({ page }) => {
+    // Add a climb to the queue
+    await addClimbToQueue(page);
+
+    // Verify queue has items
+    const queueCount = await page.locator('[data-testid="queue-item"]').count();
+    if (queueCount === 0) {
+      test.skip();
+      return;
+    }
+
+    // Navigate to settings
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    // Click the floating thumbnail
+    const thumbnail = page.locator('[data-testid="floating-session-thumbnail"]');
+    if (await thumbnail.isVisible()) {
+      await thumbnail.click();
+
+      // Verify we're back on a board page
+      await expect(page).toHaveURL(/\/(kilter|tension|decoy)\//);
+    }
+  });
+
+  test('clearing queue via thumbnail should show confirmation', async ({ page }) => {
+    // Add a climb to the queue
+    await addClimbToQueue(page);
+
+    // Verify queue has items
+    const queueCount = await page.locator('[data-testid="queue-item"]').count();
+    if (queueCount === 0) {
+      test.skip();
+      return;
+    }
+
+    // Navigate to settings
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    // Find and click the close button on the thumbnail
+    const closeButton = page.locator('[data-testid="floating-session-thumbnail"] button').first();
+    if (await closeButton.isVisible()) {
+      await closeButton.click();
+
+      // Verify confirmation modal appears
+      const modal = page.locator('.ant-modal');
+      await expect(modal).toBeVisible({ timeout: 5000 });
+
+      // Verify modal has clear/cancel buttons
+      await expect(page.getByRole('button', { name: /clear/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: /cancel/i })).toBeVisible();
+    }
+  });
+
+  test('confirming queue clear should hide thumbnail', async ({ page }) => {
+    // Add a climb to the queue
+    await addClimbToQueue(page);
+
+    // Verify queue has items
+    const queueCount = await page.locator('[data-testid="queue-item"]').count();
+    if (queueCount === 0) {
+      test.skip();
+      return;
+    }
+
+    // Navigate to settings
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    // Find and click the close button on the thumbnail
+    const closeButton = page.locator('[data-testid="floating-session-thumbnail"] button').first();
+    if (await closeButton.isVisible()) {
+      await closeButton.click();
+
+      // Click the clear button in the confirmation modal
+      const clearButton = page.getByRole('button', { name: /clear/i });
+      if (await clearButton.isVisible()) {
+        await clearButton.click();
+
+        // Wait for modal to close
+        await page.waitForTimeout(500);
+
+        // Verify thumbnail is now hidden
+        const thumbnail = page.locator('[data-testid="floating-session-thumbnail"]');
+        await expect(thumbnail).not.toBeVisible();
+      }
+    }
+  });
+});
+
+test.describe('Queue Persistence - Board Switch', () => {
+  test('queue should clear when switching to different board configuration', async ({ page }) => {
+    const boardUrl1 = '/kilter/kilter-board-original/12-x-12-commercial/1,72/40/list';
+    const boardUrl2 = '/kilter/kilter-board-original/12-x-12-commercial/1,72/45/list'; // Different angle
+
+    // Navigate to first board
+    await page.goto(boardUrl1);
+    await waitForBoardPage(page);
+
+    // Add a climb to the queue
+    await addClimbToQueue(page);
+
+    // Get queue count
+    const queueCountOnBoard1 = await page.locator('[data-testid="queue-item"]').count();
+
+    // Navigate to different board configuration
+    await page.goto(boardUrl2);
+    await waitForBoardPage(page);
+
+    // Queue should be empty (cleared on board switch)
+    const queueCountOnBoard2 = await page.locator('[data-testid="queue-item"]').count();
+
+    // If we had items before, they should be cleared
+    if (queueCountOnBoard1 > 0) {
+      expect(queueCountOnBoard2).toBe(0);
+    }
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,10 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.3.0",
@@ -59,6 +62,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? 'github' : 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Uncomment to test on more browsers
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: process.env.CI
+    ? undefined // In CI, we expect the server to be started separately
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      },
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     env: {
       NODE_ENV: 'test',
     },
-    exclude: ['**/node_modules/**', '**/dist/**', 'backend/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'backend/**', 'e2e/**'],
     coverage: {
       provider: 'v8',
       include: ['app/**/*.{ts,tsx}'],


### PR DESCRIPTION
## Summary

- Fixes queue loss when navigating to settings and back (both party mode and local mode)
- Shows floating queue thumbnail for local (non-party) queues as well
- Adds confirmation modal before clearing local queue

## Changes

1. **Party Mode Queue Restoration**: Added effect to initialize reducer state from `persistentSession` when component remounts with active session

2. **Local Queue Persistence**: Added local queue state to `PersistentSessionContext` that persists at root level across navigation

3. **Queue Sync**: Added effects to sync queue changes to persistent session for local mode, and initialize from saved state on remount

4. **Updated Floating Thumbnail**: Shows for both party mode and local queues, with appropriate icons and confirmation for clearing

## Test plan

- [ ] Party mode: Navigate to settings and back - queue should persist
- [ ] Party mode: Click floating thumbnail to return - queue should persist
- [ ] Local mode: Add items to queue, navigate to settings and back - queue should persist
- [ ] Local mode: Floating thumbnail should appear when queue has items
- [ ] Local mode: Clicking thumbnail navigates back to board with queue intact
- [ ] Local mode: Clicking X on thumbnail shows confirmation modal
- [ ] Local mode: Confirming clear removes queue and hides thumbnail
- [ ] Switching from local to party mode should clear local queue
- [ ] Navigating to different board config clears local queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)