### PR TITLE
chore(db): Drop redundant indexes and cleanup orphaned records

### DIFF
--- a/packages/web/drizzle/0021_drop_redundant_indexes.sql
+++ b/packages/web/drizzle/0021_drop_redundant_indexes.sql
@@ -1,0 +1,27 @@
+-- Drop redundant indexes on tension_climb_holds
+-- These indexes are redundant with existing indexes and waste ~224 MB of storage
+
+-- This index is redundant with idx_tension_climb_holds_main
+-- _main: (climb_uuid, hold_id) INCLUDE (hold_state) - 123 MB
+-- _enhanced: (climb_uuid, hold_id, hold_state) - 122 MB (redundant)
+DROP INDEX IF EXISTS idx_tension_climb_holds_enhanced;
+
+-- This index was manually created and isn't used by any queries
+-- The tension_climb_holds_search_idx (hold_id, hold_state) serves the same purpose
+DROP INDEX IF EXISTS idx_tension_climb_holds_states;
+
+-- Also clean up orphaned records in climb_holds tables
+-- These are holds referencing climbs that no longer exist
+DELETE FROM kilter_climb_holds
+WHERE NOT EXISTS (
+    SELECT 1 FROM kilter_climbs WHERE uuid = kilter_climb_holds.climb_uuid
+);
+
+DELETE FROM tension_climb_holds
+WHERE NOT EXISTS (
+    SELECT 1 FROM tension_climbs WHERE uuid = tension_climb_holds.climb_uuid
+);
+
+-- Update statistics after cleanup
+ANALYZE tension_climb_holds;
+ANALYZE kilter_climb_holds;

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1766699828855,
       "tag": "0018_perpetual_cerise",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1735398000000,
+      "tag": "0021_drop_redundant_indexes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Database cleanup to reduce storage usage on Neon (~244 MB savings):

- Drop `idx_tension_climb_holds_enhanced` (~122 MB) - redundant with `idx_tension_climb_holds_main`
- Drop `idx_tension_climb_holds_states` (~102 MB) - manually created, not used by any queries
- Clean up orphaned `climb_holds` records (~60k rows referencing deleted climbs)

## Background

Investigation showed the database had grown to ~2.8 GB. Analysis revealed:
- `climb_holds` tables: 1.8 GB (64% of DB) with oversized indexes
- Redundant indexes on `tension_climb_holds` serving the same query patterns
- Orphaned records from climbs that were deleted but holds weren't cascaded

## Test plan

- [ ] Run migration on staging first
- [ ] Verify heatmap queries still work correctly after index removal
- [ ] Check database size reduction in Neon dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)