### PR TITLE
fix: Reduce excessive /api/auth/session requests

### DIFF
--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -9,5 +9,13 @@ interface SessionProviderWrapperProps {
 }
 
 export default function SessionProviderWrapper({ children }: SessionProviderWrapperProps) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider
+      refetchOnWindowFocus={false}
+      refetchWhenOffline={false}
+      refetchInterval={5 * 60}
+    >
+      {children}
+    </SessionProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- Disable `refetchOnWindowFocus` to prevent session API calls when switching tabs
- Disable `refetchWhenOffline` to prevent calls when coming back online
- Add 5-minute `refetchInterval` to periodically check for expired sessions

This addresses the excessive `/api/auth/session` requests observed during development caused by NextAuth's default behavior of refetching on every window focus event.

## Test plan
- [ ] Verify session endpoint is only called on initial page load and every 5 minutes
- [ ] Verify switching tabs no longer triggers session requests
- [ ] Verify session expiration is still detected within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)