### PR TITLE
fix: Remove isLoaded blocking check to restore SSR for climb list

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -55,7 +55,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
   const [state, dispatch] = useQueueReducer(initialSearchParams);
 
   // Get backend URL from settings
-  const { backendUrl, isLoaded } = useConnectionSettings();
+  const { backendUrl } = useConnectionSettings();
 
   // Get party profile for user ID, and username/avatarUrl from NextAuth session
   const { profile, username, avatarUrl } = usePartyProfile();
@@ -572,11 +572,6 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
       endSession,
     ],
   );
-
-  // Don't render until connection settings are loaded
-  if (!isLoaded) {
-    return null;
-  }
 
   // Wrap children with FavoritesProvider to pass hoisted favorites data
   const wrappedChildren = (


### PR DESCRIPTION
The GraphQLQueueProvider was returning null during SSR because isLoaded
only becomes true after a client-side useEffect runs. This prevented the
climb list from being server-side rendered, causing a blank page until
client-side hydration completed.

The fix removes the blocking check, allowing the provider to render its
children during SSR. The climb list will correctly use initialClimbs
from the server until the first client-side fetch completes.