### PR TITLE
fix: Preserve queue when creating or leaving party sessions

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useContext, createContext, ReactNode, useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useContext, createContext, ReactNode, useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
 import { useQueueReducer } from '../queue-control/reducer';
@@ -66,6 +66,14 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
   // Read sessionId from URL search params - party mode is opt-in
   const sessionIdFromUrl = searchParams.get('session');
   const [activeSessionId, setActiveSessionId] = useState<string | null>(sessionIdFromUrl);
+
+  // Ref to store the initial queue to sync when starting a new session
+  // This captures the queue state before the connection overwrites it with backend state
+  const pendingInitialQueueRef = useRef<{
+    queue: ClimbQueueItem[];
+    currentClimbQueueItem: ClimbQueueItem | null;
+    sessionId: string;
+  } | null>(null);
 
   // Sync activeSessionId with URL changes (e.g., when navigating to a shared link)
   useEffect(() => {
@@ -240,6 +248,33 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
     return unsubscribe;
   }, [isPersistentSessionActive, persistentSession, dispatch]);
 
+  // Sync pending initial queue after connecting to a new session
+  // This handles the case where user starts a session with existing queue items
+  useEffect(() => {
+    // Only run when we've just connected to a session
+    if (!isPersistentSessionActive || !persistentSession.hasConnected) return;
+
+    // Check if we have a pending initial queue for this session
+    const pending = pendingInitialQueueRef.current;
+    if (!pending || pending.sessionId !== sessionId) return;
+
+    // Only sync if we're the leader (creator of the session)
+    // Non-leaders should receive the queue from the session creator
+    if (!persistentSession.isLeader) {
+      pendingInitialQueueRef.current = null;
+      return;
+    }
+
+    // Clear the pending ref immediately to prevent duplicate syncs
+    pendingInitialQueueRef.current = null;
+
+    // Sync the initial queue to the server
+    // This will broadcast a FullSync event to all clients (including ourselves)
+    persistentSession.setQueue(pending.queue, pending.currentClimbQueueItem).catch((error) => {
+      console.error('[QueueContext] Failed to sync initial queue:', error);
+    });
+  }, [isPersistentSessionActive, persistentSession, sessionId]);
+
   // Use persistent session values when active
   const clientId = isPersistentSessionActive ? persistentSession.clientId : null;
   const isLeader = isPersistentSessionActive ? persistentSession.isLeader : false;
@@ -256,6 +291,18 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
 
       // Generate a new session ID
       const newSessionId = uuidv4();
+
+      // IMPORTANT: Capture the current queue BEFORE the connection is established.
+      // When we connect, the backend will return an empty queue (new session),
+      // which would overwrite our local queue. We store it here so we can sync it
+      // to the server after connecting.
+      if (state.queue.length > 0 || state.currentClimbQueueItem) {
+        pendingInitialQueueRef.current = {
+          queue: state.queue,
+          currentClimbQueueItem: state.currentClimbQueueItem,
+          sessionId: newSessionId,
+        };
+      }
 
       // Update URL with session parameter
       const params = new URLSearchParams(searchParams.toString());
@@ -277,7 +324,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
 
       return newSessionId;
     },
-    [backendUrl, pathname, router, searchParams],
+    [backendUrl, pathname, router, searchParams, state.queue, state.currentClimbQueueItem],
   );
 
   const joinSessionHandler = useCallback(

--- a/packages/web/app/components/queue-control/reducer.ts
+++ b/packages/web/app/components/queue-control/reducer.ts
@@ -41,20 +41,40 @@ export function queueReducer(state: QueueState, action: QueueAction): QueueState
         ...state,
         climbSearchParams: action.payload,
       };
-    case 'INITIAL_QUEUE_DATA':
+    case 'INITIAL_QUEUE_DATA': {
+      const newQueue = action.payload.queue;
+      let newCurrentClimbQueueItem = action.payload.currentClimbQueueItem ?? state.currentClimbQueueItem;
+
+      // Validate that current climb is in the queue
+      // If not, clear it to prevent inconsistent state
+      if (newCurrentClimbQueueItem && !newQueue.some(item => item.uuid === newCurrentClimbQueueItem?.uuid)) {
+        newCurrentClimbQueueItem = null;
+      }
+
       return {
         ...state,
-        queue: action.payload.queue,
-        currentClimbQueueItem: action.payload.currentClimbQueueItem ?? state.currentClimbQueueItem,
+        queue: newQueue,
+        currentClimbQueueItem: newCurrentClimbQueueItem,
         initialQueueDataReceivedFromPeers: true,
       };
+    }
 
-    case 'UPDATE_QUEUE':
+    case 'UPDATE_QUEUE': {
+      const newQueue = action.payload.queue;
+      let newCurrentClimbQueueItem = action.payload.currentClimbQueueItem ?? state.currentClimbQueueItem;
+
+      // Validate that current climb is in the queue
+      // If not, clear it to prevent inconsistent state
+      if (newCurrentClimbQueueItem && !newQueue.some(item => item.uuid === newCurrentClimbQueueItem?.uuid)) {
+        newCurrentClimbQueueItem = null;
+      }
+
       return {
         ...state,
-        queue: action.payload.queue,
-        currentClimbQueueItem: action.payload.currentClimbQueueItem ?? state.currentClimbQueueItem,
+        queue: newQueue,
+        currentClimbQueueItem: newCurrentClimbQueueItem,
       };
+    }
 
     case 'ADD_TO_QUEUE':
       return {


### PR DESCRIPTION
- Modified deactivateSession to not clear queue state, allowing queue
  to persist for local use after leaving party mode
- Added pendingInitialQueueRef to capture current queue before starting
  a new session, then sync it to the server after connecting
- Added validation in reducer and persistent-session-context to ensure
  currentClimbQueueItem is always in the queue, preventing inconsistent
  state where active climb is not in queue
- Clear currentClimbQueueItem when the item is removed from queue

This fixes the bug where queue was cleared when:
1. Creating a new party session (queue now syncs to server after connect)
2. Leaving a party session (queue now persists locally)
3. Edge cases where active climb was not in queue (now validated)