### PR TITLE
Debug and fix backend deployment errors

### DIFF
--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -148,6 +148,7 @@ const createTestClimb = (): ClimbQueueItem => ({
     difficulty_error: '0.5',
     litUpHoldsMap: {},
     mirrored: false,
+    benchmark_difficulty: null,
   },
   addedBy: 'test-user',
   tickedBy: [],

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -1,8 +1,10 @@
 // Re-export schema from @boardsesh/db with aliases for backward compatibility
 export {
   boardSessions as sessions,
+  boardSessions,
   boardSessionClients as sessionClients,
   boardSessionQueues as sessionQueues,
+  boardSessionQueues,
   type BoardSession as Session,
   type NewBoardSession as NewSession,
   type BoardSessionClient as SessionClient,

--- a/packages/backend/src/graphql/resolvers.ts
+++ b/packages/backend/src/graphql/resolvers.ts
@@ -312,17 +312,24 @@ const resolvers = {
       const sessions = await roomManager.getUserSessions(ctx.userId);
 
       // Convert Session to DiscoverableSession format
-      return sessions.map((s) => ({
-        id: s.id,
-        name: s.name,
-        boardPath: s.boardPath,
-        latitude: s.latitude || 0,
-        longitude: s.longitude || 0,
-        createdAt: s.createdAt,
-        createdByUserId: s.createdByUserId,
-        participantCount: roomManager.getSessionClients(s.id).length,
-        distance: 0, // Not applicable for own sessions
-      }));
+      const result: DiscoverableSession[] = [];
+      for (const s of sessions) {
+        const participantCount = roomManager.getSessionClients(s.id).length;
+        const isActive = await roomManager.isSessionActive(s.id);
+        result.push({
+          id: s.id,
+          name: s.name,
+          boardPath: s.boardPath,
+          latitude: s.latitude || 0,
+          longitude: s.longitude || 0,
+          createdAt: s.createdAt,
+          createdByUserId: s.createdByUserId,
+          participantCount,
+          distance: 0, // Not applicable for own sessions
+          isActive,
+        });
+      }
+      return result;
     },
 
     // ============================================

--- a/packages/backend/src/services/room-manager.ts
+++ b/packages/backend/src/services/room-manager.ts
@@ -278,6 +278,20 @@ class RoomManager {
     return session ? Array.from(session) : [];
   }
 
+  /**
+   * Check if a session is active (has connected users OR exists in Redis within TTL)
+   */
+  async isSessionActive(sessionId: string): Promise<boolean> {
+    const participantCount = this.sessions.get(sessionId)?.size || 0;
+    if (participantCount > 0) {
+      return true;
+    }
+    if (this.redisStore) {
+      return this.redisStore.exists(sessionId);
+    }
+    return false;
+  }
+
   async updateUsername(connectionId: string, username: string, avatarUrl?: string): Promise<void> {
     const client = this.clients.get(connectionId);
     if (client) {

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
- Export boardSessions and boardSessionQueues with both original and aliased names in db/schema.ts to support test imports
- Add missing benchmark_difficulty field to test Climb object
- Add isActive field to mySessions resolver by introducing isSessionActive helper method in room-manager
- Exclude __tests__ directory from tsconfig to prevent test file compilation errors during build