### PR TITLE
feat: Add custom playlists for organizing climbs

### DIFF
--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -10,6 +10,8 @@ import { climbQueries } from './climbs/queries.js';
 import { climbFieldResolvers } from './climbs/field-resolvers.js';
 import { favoriteQueries } from './favorites/queries.js';
 import { favoriteMutations } from './favorites/mutations.js';
+import { playlistQueries } from './playlists/queries.js';
+import { playlistMutations } from './playlists/mutations.js';
 import { sessionQueries } from './sessions/queries.js';
 import { sessionMutations } from './sessions/mutations.js';
 import { sessionSubscriptions } from './sessions/subscriptions.js';
@@ -30,6 +32,7 @@ export const resolvers = {
     ...tickQueries,
     ...userQueries,
     ...favoriteQueries,
+    ...playlistQueries,
   },
 
   Mutation: {
@@ -38,6 +41,7 @@ export const resolvers = {
     ...tickMutations,
     ...userMutations,
     ...favoriteMutations,
+    ...playlistMutations,
   },
 
   Subscription: {

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -1,0 +1,338 @@
+import { eq, and, sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client.js';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, validateInput } from '../shared/helpers.js';
+import {
+  CreatePlaylistInputSchema,
+  UpdatePlaylistInputSchema,
+  AddClimbToPlaylistInputSchema,
+  RemoveClimbFromPlaylistInputSchema,
+} from '../../../validation/schemas.js';
+
+export const playlistMutations = {
+  /**
+   * Create a new playlist with the authenticated user as owner
+   */
+  createPlaylist: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<unknown> => {
+    requireAuthenticated(ctx);
+    const validatedInput = validateInput(CreatePlaylistInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+    const uuid = uuidv4();
+    const now = new Date();
+
+    // Create playlist
+    const [playlist] = await db
+      .insert(dbSchema.playlists)
+      .values({
+        uuid,
+        boardType: validatedInput.boardType,
+        layoutId: validatedInput.layoutId,
+        name: validatedInput.name,
+        description: validatedInput.description || null,
+        isPublic: false, // Always private initially
+        color: validatedInput.color || null,
+        icon: validatedInput.icon || null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    // Create ownership
+    await db.insert(dbSchema.playlistOwnership).values({
+      playlistId: playlist.id,
+      userId,
+      role: 'owner',
+      createdAt: now,
+    });
+
+    return {
+      id: playlist.id.toString(),
+      uuid: playlist.uuid,
+      boardType: playlist.boardType,
+      layoutId: playlist.layoutId,
+      name: playlist.name,
+      description: playlist.description,
+      isPublic: playlist.isPublic,
+      color: playlist.color,
+      icon: playlist.icon,
+      createdAt: playlist.createdAt.toISOString(),
+      updatedAt: playlist.updatedAt.toISOString(),
+      climbCount: 0,
+      userRole: 'owner',
+    };
+  },
+
+  /**
+   * Update an existing playlist (requires owner role)
+   */
+  updatePlaylist: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<unknown> => {
+    requireAuthenticated(ctx);
+    const validatedInput = validateInput(UpdatePlaylistInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Check ownership
+    const ownership = await db
+      .select()
+      .from(dbSchema.playlistOwnership)
+      .innerJoin(
+        dbSchema.playlists,
+        eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner')
+        )
+      )
+      .limit(1);
+
+    if (ownership.length === 0) {
+      throw new Error('Playlist not found or you do not have permission to edit it');
+    }
+
+    const playlistId = ownership[0].playlists.id;
+
+    // Build update object (only update provided fields)
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+
+    if (validatedInput.name !== undefined) updateData.name = validatedInput.name;
+    if (validatedInput.description !== undefined) updateData.description = validatedInput.description;
+    if (validatedInput.isPublic !== undefined) updateData.isPublic = validatedInput.isPublic;
+    if (validatedInput.color !== undefined) updateData.color = validatedInput.color;
+    if (validatedInput.icon !== undefined) updateData.icon = validatedInput.icon;
+
+    // Update playlist
+    const [updated] = await db
+      .update(dbSchema.playlists)
+      .set(updateData)
+      .where(eq(dbSchema.playlists.id, playlistId))
+      .returning();
+
+    // Get climb count
+    const climbCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(dbSchema.playlistClimbs)
+      .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+      .limit(1);
+
+    return {
+      id: updated.id.toString(),
+      uuid: updated.uuid,
+      boardType: updated.boardType,
+      layoutId: updated.layoutId,
+      name: updated.name,
+      description: updated.description,
+      isPublic: updated.isPublic,
+      color: updated.color,
+      icon: updated.icon,
+      createdAt: updated.createdAt.toISOString(),
+      updatedAt: updated.updatedAt.toISOString(),
+      climbCount: climbCount[0]?.count || 0,
+      userRole: 'owner',
+    };
+  },
+
+  /**
+   * Delete a playlist (requires owner role)
+   */
+  deletePlaylist: async (
+    _: unknown,
+    { playlistId }: { playlistId: string },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+
+    const userId = ctx.userId!;
+
+    // Check ownership
+    const ownership = await db
+      .select({ id: dbSchema.playlists.id })
+      .from(dbSchema.playlistOwnership)
+      .innerJoin(
+        dbSchema.playlists,
+        eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner')
+        )
+      )
+      .limit(1);
+
+    if (ownership.length === 0) {
+      throw new Error('Playlist not found or you do not have permission to delete it');
+    }
+
+    // Delete playlist (cascade will handle ownership and climbs)
+    await db.delete(dbSchema.playlists).where(eq(dbSchema.playlists.id, ownership[0].id));
+
+    return true;
+  },
+
+  /**
+   * Add a climb to a playlist
+   */
+  addClimbToPlaylist: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<unknown> => {
+    requireAuthenticated(ctx);
+    const validatedInput = validateInput(AddClimbToPlaylistInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Check ownership/access
+    const ownership = await db
+      .select({ id: dbSchema.playlists.id })
+      .from(dbSchema.playlistOwnership)
+      .innerJoin(
+        dbSchema.playlists,
+        eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (ownership.length === 0) {
+      throw new Error('Playlist not found or you do not have permission to edit it');
+    }
+
+    const playlistId = ownership[0].id;
+
+    // Check if climb already exists in playlist
+    const existing = await db
+      .select()
+      .from(dbSchema.playlistClimbs)
+      .where(
+        and(
+          eq(dbSchema.playlistClimbs.playlistId, playlistId),
+          eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid)
+        )
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      // Already in playlist - return existing
+      return {
+        id: existing[0].id.toString(),
+        playlistId: validatedInput.playlistId,
+        climbUuid: existing[0].climbUuid,
+        angle: existing[0].angle,
+        position: existing[0].position,
+        addedAt: existing[0].addedAt.toISOString(),
+      };
+    }
+
+    // Get max position
+    const maxPosition = await db
+      .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
+      .from(dbSchema.playlistClimbs)
+      .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+      .limit(1);
+
+    const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
+
+    // Add climb to playlist
+    const [playlistClimb] = await db
+      .insert(dbSchema.playlistClimbs)
+      .values({
+        playlistId,
+        climbUuid: validatedInput.climbUuid,
+        angle: validatedInput.angle,
+        position: nextPosition,
+        addedAt: new Date(),
+      })
+      .returning();
+
+    // Update playlist updatedAt
+    await db
+      .update(dbSchema.playlists)
+      .set({ updatedAt: new Date() })
+      .where(eq(dbSchema.playlists.id, playlistId));
+
+    return {
+      id: playlistClimb.id.toString(),
+      playlistId: validatedInput.playlistId,
+      climbUuid: playlistClimb.climbUuid,
+      angle: playlistClimb.angle,
+      position: playlistClimb.position,
+      addedAt: playlistClimb.addedAt.toISOString(),
+    };
+  },
+
+  /**
+   * Remove a climb from a playlist
+   */
+  removeClimbFromPlaylist: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    const validatedInput = validateInput(RemoveClimbFromPlaylistInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Check ownership/access
+    const ownership = await db
+      .select({ id: dbSchema.playlists.id })
+      .from(dbSchema.playlistOwnership)
+      .innerJoin(
+        dbSchema.playlists,
+        eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (ownership.length === 0) {
+      throw new Error('Playlist not found or you do not have permission to edit it');
+    }
+
+    const playlistId = ownership[0].id;
+
+    // Remove climb from playlist
+    await db
+      .delete(dbSchema.playlistClimbs)
+      .where(
+        and(
+          eq(dbSchema.playlistClimbs.playlistId, playlistId),
+          eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid)
+        )
+      );
+
+    // Update playlist updatedAt
+    await db
+      .update(dbSchema.playlists)
+      .set({ updatedAt: new Date() })
+      .where(eq(dbSchema.playlists.id, playlistId));
+
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/playlists/queries.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries.ts
@@ -1,0 +1,197 @@
+import { eq, and, inArray, desc, sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client.js';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, validateInput } from '../shared/helpers.js';
+import {
+  GetUserPlaylistsInputSchema,
+  GetPlaylistsForClimbInputSchema,
+} from '../../../validation/schemas.js';
+
+export const playlistQueries = {
+  /**
+   * Get all playlists owned by the authenticated user for a specific board and layout
+   */
+  userPlaylists: async (
+    _: unknown,
+    { input }: { input: { boardType: string; layoutId: number } },
+    ctx: ConnectionContext
+  ): Promise<unknown[]> => {
+    requireAuthenticated(ctx);
+    validateInput(GetUserPlaylistsInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Get user's playlists with climb counts
+    const userPlaylists = await db
+      .select({
+        id: dbSchema.playlists.id,
+        uuid: dbSchema.playlists.uuid,
+        boardType: dbSchema.playlists.boardType,
+        layoutId: dbSchema.playlists.layoutId,
+        name: dbSchema.playlists.name,
+        description: dbSchema.playlists.description,
+        isPublic: dbSchema.playlists.isPublic,
+        color: dbSchema.playlists.color,
+        icon: dbSchema.playlists.icon,
+        createdAt: dbSchema.playlists.createdAt,
+        updatedAt: dbSchema.playlists.updatedAt,
+        role: dbSchema.playlistOwnership.role,
+      })
+      .from(dbSchema.playlists)
+      .innerJoin(
+        dbSchema.playlistOwnership,
+        eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlists.boardType, input.boardType),
+          eq(dbSchema.playlists.layoutId, input.layoutId)
+        )
+      )
+      .orderBy(desc(dbSchema.playlists.updatedAt));
+
+    // Get climb counts for each playlist
+    const playlistIds = userPlaylists.map(p => p.id);
+
+    const climbCounts =
+      playlistIds.length > 0
+        ? await db
+            .select({
+              playlistId: dbSchema.playlistClimbs.playlistId,
+              count: sql<number>`count(*)::int`,
+            })
+            .from(dbSchema.playlistClimbs)
+            .where(inArray(dbSchema.playlistClimbs.playlistId, playlistIds))
+            .groupBy(dbSchema.playlistClimbs.playlistId)
+        : [];
+
+    const countMap = new Map(climbCounts.map(c => [c.playlistId.toString(), c.count]));
+
+    return userPlaylists.map(p => ({
+      id: p.id.toString(),
+      uuid: p.uuid,
+      boardType: p.boardType,
+      layoutId: p.layoutId,
+      name: p.name,
+      description: p.description,
+      isPublic: p.isPublic,
+      color: p.color,
+      icon: p.icon,
+      createdAt: p.createdAt.toISOString(),
+      updatedAt: p.updatedAt.toISOString(),
+      climbCount: countMap.get(p.id.toString()) || 0,
+      userRole: p.role,
+    }));
+  },
+
+  /**
+   * Get a specific playlist by ID (requires ownership)
+   */
+  playlist: async (
+    _: unknown,
+    { playlistId }: { playlistId: string },
+    ctx: ConnectionContext
+  ): Promise<unknown | null> => {
+    requireAuthenticated(ctx);
+
+    const userId = ctx.userId!;
+
+    // Get playlist with ownership check
+    const result = await db
+      .select({
+        id: dbSchema.playlists.id,
+        uuid: dbSchema.playlists.uuid,
+        boardType: dbSchema.playlists.boardType,
+        layoutId: dbSchema.playlists.layoutId,
+        name: dbSchema.playlists.name,
+        description: dbSchema.playlists.description,
+        isPublic: dbSchema.playlists.isPublic,
+        color: dbSchema.playlists.color,
+        icon: dbSchema.playlists.icon,
+        createdAt: dbSchema.playlists.createdAt,
+        updatedAt: dbSchema.playlists.updatedAt,
+        role: dbSchema.playlistOwnership.role,
+      })
+      .from(dbSchema.playlists)
+      .innerJoin(
+        dbSchema.playlistOwnership,
+        eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (result.length === 0) return null;
+
+    const playlist = result[0];
+
+    // Get climb count
+    const climbCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(dbSchema.playlistClimbs)
+      .where(eq(dbSchema.playlistClimbs.playlistId, playlist.id))
+      .limit(1);
+
+    return {
+      id: playlist.id.toString(),
+      uuid: playlist.uuid,
+      boardType: playlist.boardType,
+      layoutId: playlist.layoutId,
+      name: playlist.name,
+      description: playlist.description,
+      isPublic: playlist.isPublic,
+      color: playlist.color,
+      icon: playlist.icon,
+      createdAt: playlist.createdAt.toISOString(),
+      updatedAt: playlist.updatedAt.toISOString(),
+      climbCount: climbCount[0]?.count || 0,
+      userRole: playlist.role,
+    };
+  },
+
+  /**
+   * Get all playlist IDs that contain a specific climb for the authenticated user
+   */
+  playlistsForClimb: async (
+    _: unknown,
+    { input }: { input: { boardType: string; layoutId: number; climbUuid: string } },
+    ctx: ConnectionContext
+  ): Promise<string[]> => {
+    if (!ctx.isAuthenticated || !ctx.userId) {
+      return [];
+    }
+
+    validateInput(GetPlaylistsForClimbInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Get playlists containing this climb (only user's playlists)
+    const results = await db
+      .select({ playlistId: dbSchema.playlistClimbs.playlistId })
+      .from(dbSchema.playlistClimbs)
+      .innerJoin(
+        dbSchema.playlists,
+        eq(dbSchema.playlists.id, dbSchema.playlistClimbs.playlistId)
+      )
+      .innerJoin(
+        dbSchema.playlistOwnership,
+        eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlistClimbs.climbUuid, input.climbUuid),
+          eq(dbSchema.playlists.boardType, input.boardType),
+          eq(dbSchema.playlists.layoutId, input.layoutId),
+          eq(dbSchema.playlistOwnership.userId, userId)
+        )
+      );
+
+    return results.map(r => r.playlistId.toString());
+  },
+};

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -285,3 +285,66 @@ export const GetTicksInputSchema = z.object({
   boardType: BoardNameSchema,
   climbUuids: z.array(ExternalUUIDSchema).optional(),
 });
+
+/**
+ * Playlist validation schemas
+ */
+export const PlaylistNameSchema = z
+  .string()
+  .min(1, 'Playlist name cannot be empty')
+  .max(100, 'Playlist name too long');
+
+export const PlaylistDescriptionSchema = z
+  .string()
+  .max(500, 'Playlist description too long')
+  .optional();
+
+export const PlaylistColorSchema = z
+  .string()
+  .regex(/^#[0-9A-Fa-f]{6}$/, 'Invalid color format (must be hex)')
+  .optional();
+
+export const PlaylistIconSchema = z
+  .string()
+  .max(50, 'Icon name too long')
+  .optional();
+
+export const CreatePlaylistInputSchema = z.object({
+  boardType: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+  name: PlaylistNameSchema,
+  description: PlaylistDescriptionSchema,
+  color: PlaylistColorSchema,
+  icon: PlaylistIconSchema,
+});
+
+export const UpdatePlaylistInputSchema = z.object({
+  playlistId: z.string().min(1),
+  name: PlaylistNameSchema.optional(),
+  description: PlaylistDescriptionSchema,
+  isPublic: z.boolean().optional(),
+  color: PlaylistColorSchema,
+  icon: PlaylistIconSchema,
+});
+
+export const AddClimbToPlaylistInputSchema = z.object({
+  playlistId: z.string().min(1),
+  climbUuid: ExternalUUIDSchema,
+  angle: z.number().int().min(0).max(90),
+});
+
+export const RemoveClimbFromPlaylistInputSchema = z.object({
+  playlistId: z.string().min(1),
+  climbUuid: ExternalUUIDSchema,
+});
+
+export const GetUserPlaylistsInputSchema = z.object({
+  boardType: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+});
+
+export const GetPlaylistsForClimbInputSchema = z.object({
+  boardType: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+  climbUuid: ExternalUUIDSchema,
+});

--- a/packages/db/drizzle/0024_add_playlists.sql
+++ b/packages/db/drizzle/0024_add_playlists.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "playlists" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"uuid" text NOT NULL,
+	"board_type" text NOT NULL,
+	"layout_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"color" text,
+	"icon" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "playlists_uuid_unique" UNIQUE("uuid")
+);
+--> statement-breakpoint
+CREATE TABLE "playlist_climbs" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"playlist_id" bigint NOT NULL,
+	"climb_uuid" text NOT NULL,
+	"angle" integer NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	"added_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "playlist_ownership" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"playlist_id" bigint NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text DEFAULT 'owner' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "playlist_climbs" ADD CONSTRAINT "playlist_climbs_playlist_id_playlists_id_fk" FOREIGN KEY ("playlist_id") REFERENCES "public"."playlists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "playlist_ownership" ADD CONSTRAINT "playlist_ownership_playlist_id_playlists_id_fk" FOREIGN KEY ("playlist_id") REFERENCES "public"."playlists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "playlist_ownership" ADD CONSTRAINT "playlist_ownership_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_playlist_climb" ON "playlist_climbs" USING btree ("playlist_id","climb_uuid");--> statement-breakpoint
+CREATE INDEX "playlist_climbs_climb_idx" ON "playlist_climbs" USING btree ("climb_uuid");--> statement-breakpoint
+CREATE INDEX "playlist_climbs_position_idx" ON "playlist_climbs" USING btree ("playlist_id","position");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_playlist_ownership" ON "playlist_ownership" USING btree ("playlist_id","user_id");--> statement-breakpoint
+CREATE INDEX "playlist_ownership_user_idx" ON "playlist_ownership" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "playlists_board_layout_idx" ON "playlists" USING btree ("board_type","layout_id");--> statement-breakpoint
+CREATE INDEX "playlists_uuid_idx" ON "playlists" USING btree ("uuid");

--- a/packages/db/drizzle/meta/0023_snapshot.json
+++ b/packages/db/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,5465 @@
+{
+  "id": "6058f9a0-6cb9-4401-b246-2dee25d10567",
+  "prevId": "799aa0b6-c7c7-4ad2-8bb1-ad1e3b408807",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.kilter_ascents": {
+      "name": "kilter_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey1": {
+          "name": "ascents_attempt_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey1": {
+          "name": "ascents_climb_uuid_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey1": {
+          "name": "ascents_difficulty_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey1": {
+          "name": "ascents_user_id_fkey1",
+          "tableFrom": "kilter_ascents",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_attempts": {
+      "name": "kilter_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_beta_links": {
+      "name": "kilter_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey1": {
+          "name": "beta_links_climb_uuid_fkey1",
+          "tableFrom": "kilter_beta_links",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_bids": {
+      "name": "kilter_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey1": {
+          "name": "bids_climb_uuid_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey1": {
+          "name": "bids_user_id_fkey1",
+          "tableFrom": "kilter_bids",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits": {
+      "name": "kilter_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_circuits_climbs": {
+      "name": "kilter_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_holds": {
+      "name": "kilter_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kilter_climb_holds_search_idx": {
+          "name": "kilter_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "kilter_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats": {
+      "name": "kilter_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kilter_climb_stats_pk": {
+          "name": "kilter_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climb_stats_history": {
+      "name": "kilter_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_climbs": {
+      "name": "kilter_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kilter_climbs_layout_filter_idx": {
+          "name": "kilter_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kilter_climbs_edges_idx": {
+          "name": "kilter_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey1": {
+          "name": "climbs_layout_id_fkey1",
+          "tableFrom": "kilter_climbs",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_difficulty_grades": {
+      "name": "kilter_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_holes": {
+      "name": "kilter_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_product_id_fkey1": {
+          "name": "holes_product_id_fkey1",
+          "tableFrom": "kilter_holes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_layouts": {
+      "name": "kilter_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey1": {
+          "name": "layouts_product_id_fkey1",
+          "tableFrom": "kilter_layouts",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_leds": {
+      "name": "kilter_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey1": {
+          "name": "leds_hole_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey1": {
+          "name": "leds_product_size_id_fkey1",
+          "tableFrom": "kilter_leds",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placement_roles": {
+      "name": "kilter_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey1": {
+          "name": "placement_roles_product_id_fkey1",
+          "tableFrom": "kilter_placement_roles",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_placements": {
+      "name": "kilter_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey1": {
+          "name": "placements_default_placement_role_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey1": {
+          "name": "placements_hole_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey1": {
+          "name": "placements_layout_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey1": {
+          "name": "placements_set_id_fkey1",
+          "tableFrom": "kilter_placements",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes": {
+      "name": "kilter_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey1": {
+          "name": "product_sizes_product_id_fkey1",
+          "tableFrom": "kilter_product_sizes",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_product_sizes_layouts_sets": {
+      "name": "kilter_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey1": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey1": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey1": {
+          "name": "product_sizes_layouts_sets_set_id_fkey1",
+          "tableFrom": "kilter_product_sizes_layouts_sets",
+          "tableTo": "kilter_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_products": {
+      "name": "kilter_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_sets": {
+      "name": "kilter_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_shared_syncs": {
+      "name": "kilter_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_tags": {
+      "name": "kilter_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_user_syncs": {
+      "name": "kilter_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey1": {
+          "name": "user_syncs_user_id_fkey1",
+          "tableFrom": "kilter_user_syncs",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kilter_user_sync_pk": {
+          "name": "kilter_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_users": {
+      "name": "kilter_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilter_walls": {
+      "name": "kilter_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey1": {
+          "name": "walls_layout_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey1": {
+          "name": "walls_product_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey1": {
+          "name": "walls_product_size_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey1": {
+          "name": "walls_user_id_fkey1",
+          "tableFrom": "kilter_walls",
+          "tableTo": "kilter_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_ascents": {
+      "name": "tension_ascents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ascents_attempt_id_fkey": {
+          "name": "ascents_attempt_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_climb_uuid_fkey": {
+          "name": "ascents_climb_uuid_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_difficulty_fkey": {
+          "name": "ascents_difficulty_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_difficulty_grades",
+          "columnsFrom": [
+            "difficulty"
+          ],
+          "columnsTo": [
+            "difficulty"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ascents_user_id_fkey": {
+          "name": "ascents_user_id_fkey",
+          "tableFrom": "tension_ascents",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_attempts": {
+      "name": "tension_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_beta_links": {
+      "name": "tension_beta_links",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beta_links_climb_uuid_fkey": {
+          "name": "beta_links_climb_uuid_fkey",
+          "tableFrom": "tension_beta_links",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_bids": {
+      "name": "tension_bids",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bid_count": {
+          "name": "bid_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_climb_uuid_fkey": {
+          "name": "bids_climb_uuid_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "bids_user_id_fkey": {
+          "name": "bids_user_id_fkey",
+          "tableFrom": "tension_bids",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits": {
+      "name": "tension_circuits",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_circuits_climbs": {
+      "name": "tension_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_holds": {
+      "name": "tension_climb_holds",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tension_climb_holds_search_idx": {
+          "name": "tension_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_holds_climb_uuid_hold_id_pk": {
+          "name": "tension_climb_holds_climb_uuid_hold_id_pk",
+          "columns": [
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats": {
+      "name": "tension_climb_stats",
+      "schema": "",
+      "columns": {
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tension_climb_stats_pk": {
+          "name": "tension_climb_stats_pk",
+          "columns": [
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climb_stats_history": {
+      "name": "tension_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_climbs": {
+      "name": "tension_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tension_climbs_layout_filter_idx": {
+          "name": "tension_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tension_climbs_edges_idx": {
+          "name": "tension_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climbs_layout_id_fkey": {
+          "name": "climbs_layout_id_fkey",
+          "tableFrom": "tension_climbs",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_difficulty_grades": {
+      "name": "tension_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_holes": {
+      "name": "tension_holes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "holes_mirrored_hole_id_fkey": {
+          "name": "holes_mirrored_hole_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "mirrored_hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "holes_product_id_fkey": {
+          "name": "holes_product_id_fkey",
+          "tableFrom": "tension_holes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_layouts": {
+      "name": "tension_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layouts_product_id_fkey": {
+          "name": "layouts_product_id_fkey",
+          "tableFrom": "tension_layouts",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_leds": {
+      "name": "tension_leds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leds_hole_id_fkey": {
+          "name": "leds_hole_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "leds_product_size_id_fkey": {
+          "name": "leds_product_size_id_fkey",
+          "tableFrom": "tension_leds",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placement_roles": {
+      "name": "tension_placement_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_roles_product_id_fkey": {
+          "name": "placement_roles_product_id_fkey",
+          "tableFrom": "tension_placement_roles",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_placements": {
+      "name": "tension_placements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placements_default_placement_role_id_fkey": {
+          "name": "placements_default_placement_role_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_placement_roles",
+          "columnsFrom": [
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "placements_hole_id_fkey": {
+          "name": "placements_hole_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_holes",
+          "columnsFrom": [
+            "hole_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_layout_id_fkey": {
+          "name": "placements_layout_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "placements_set_id_fkey": {
+          "name": "placements_set_id_fkey",
+          "tableFrom": "tension_placements",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes": {
+      "name": "tension_product_sizes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_product_id_fkey": {
+          "name": "product_sizes_product_id_fkey",
+          "tableFrom": "tension_product_sizes",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_product_sizes_layouts_sets": {
+      "name": "tension_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_sizes_layouts_sets_layout_id_fkey": {
+          "name": "product_sizes_layouts_sets_layout_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_product_size_id_fkey": {
+          "name": "product_sizes_layouts_sets_product_size_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "product_sizes_layouts_sets_set_id_fkey": {
+          "name": "product_sizes_layouts_sets_set_id_fkey",
+          "tableFrom": "tension_product_sizes_layouts_sets",
+          "tableTo": "tension_sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_products": {
+      "name": "tension_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_sets": {
+      "name": "tension_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_shared_syncs": {
+      "name": "tension_shared_syncs",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_tags": {
+      "name": "tension_tags",
+      "schema": "",
+      "columns": {
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_user_syncs": {
+      "name": "tension_user_syncs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_syncs_user_id_fkey": {
+          "name": "user_syncs_user_id_fkey",
+          "tableFrom": "tension_user_syncs",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tension_user_sync_pk": {
+          "name": "tension_user_sync_pk",
+          "columns": [
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_users": {
+      "name": "tension_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tension_walls": {
+      "name": "tension_walls",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "walls_layout_id_fkey": {
+          "name": "walls_layout_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_id_fkey": {
+          "name": "walls_product_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_product_size_id_fkey": {
+          "name": "walls_product_size_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_product_sizes",
+          "columnsFrom": [
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "walls_user_id_fkey": {
+          "name": "walls_user_id_fkey",
+          "tableFrom": "tension_walls",
+          "tableTo": "tension_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlistId": {
+          "name": "playlistId",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlistId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlistId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlistId_playlists_id_fk": {
+          "name": "playlist_climbs_playlistId_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlistId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlistId": {
+          "name": "playlistId",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlistId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlistId_playlists_id_fk": {
+          "name": "playlist_ownership_playlistId_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlistId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1766703000000,
       "tag": "0022_add_session_status",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1767055200000,
+      "tag": "0024_add_playlists",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/index.ts
+++ b/packages/db/src/schema/app/index.ts
@@ -1,3 +1,4 @@
 export * from './sessions.js';
 export * from './favorites.js';
 export * from './ascents.js';
+export * from './playlists.js';

--- a/packages/db/src/schema/app/playlists.ts
+++ b/packages/db/src/schema/app/playlists.ts
@@ -1,0 +1,119 @@
+import {
+  pgTable,
+  bigserial,
+  text,
+  integer,
+  boolean,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { users } from '../auth/users.js';
+
+/**
+ * Playlists - User-created collections of climbs
+ * Scoped to boardType + layoutId (can contain climbs from different sizes)
+ */
+export const playlists = pgTable(
+  'playlists',
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    uuid: text('uuid').notNull().unique(),
+    boardType: text('board_type').notNull(), // 'kilter' | 'tension'
+    layoutId: integer('layout_id').notNull(),
+
+    // Metadata
+    name: text('name').notNull(),
+    description: text('description'),
+    isPublic: boolean('is_public').default(false).notNull(),
+    color: text('color'), // Hex color (e.g., '#06B6D4')
+    icon: text('icon'), // Ant Design icon name (e.g., 'StarOutlined')
+
+    // Timestamps
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    // Index for efficient lookup by board + layout
+    boardLayoutIdx: index('playlists_board_layout_idx').on(
+      table.boardType,
+      table.layoutId
+    ),
+    // Index for UUID lookups
+    uuidIdx: index('playlists_uuid_idx').on(table.uuid),
+  })
+);
+
+/**
+ * Playlist Climbs - Junction table for climbs in playlists
+ */
+export const playlistClimbs = pgTable(
+  'playlist_climbs',
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    playlistId: bigserial({ mode: 'bigint' })
+      .notNull()
+      .references(() => playlists.id, { onDelete: 'cascade' }),
+    climbUuid: text('climb_uuid').notNull(), // Aurora climb UUID
+    angle: integer('angle').notNull(),
+
+    // Position for manual ordering within playlist
+    position: integer('position').notNull().default(0),
+
+    // Timestamps
+    addedAt: timestamp('added_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    // Ensure unique climb per playlist
+    uniquePlaylistClimb: uniqueIndex('unique_playlist_climb').on(
+      table.playlistId,
+      table.climbUuid
+    ),
+    // Index for efficient lookup of playlists containing a climb
+    climbIdx: index('playlist_climbs_climb_idx').on(table.climbUuid),
+    // Index for ordered retrieval
+    playlistPositionIdx: index('playlist_climbs_position_idx').on(
+      table.playlistId,
+      table.position
+    ),
+  })
+);
+
+/**
+ * Playlist Ownership - Separate ownership for future collaboration
+ */
+export const playlistOwnership = pgTable(
+  'playlist_ownership',
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    playlistId: bigserial({ mode: 'bigint' })
+      .notNull()
+      .references(() => playlists.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+
+    // Role for future collaboration features
+    role: text('role').notNull().default('owner'), // 'owner' | 'editor' | 'viewer'
+
+    // Timestamps
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    // Ensure unique user-playlist ownership
+    uniqueOwnership: uniqueIndex('unique_playlist_ownership').on(
+      table.playlistId,
+      table.userId
+    ),
+    // Index for efficient user playlist queries
+    userIdx: index('playlist_ownership_user_idx').on(table.userId),
+  })
+);
+
+// Type exports for use in application code
+export type Playlist = typeof playlists.$inferSelect;
+export type NewPlaylist = typeof playlists.$inferInsert;
+export type PlaylistClimb = typeof playlistClimbs.$inferSelect;
+export type NewPlaylistClimb = typeof playlistClimbs.$inferInsert;
+export type PlaylistOwnership = typeof playlistOwnership.$inferSelect;
+export type NewPlaylistOwnership = typeof playlistOwnership.$inferInsert;

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -270,6 +270,75 @@ export const typeDefs = /* GraphQL */ `
     climbUuids: [String!]
   }
 
+  # ============================================
+  # Playlist Types
+  # ============================================
+
+  type Playlist {
+    id: ID!
+    uuid: ID!
+    boardType: String!
+    layoutId: Int!
+    name: String!
+    description: String
+    isPublic: Boolean!
+    color: String
+    icon: String
+    createdAt: String!
+    updatedAt: String!
+    climbCount: Int!
+    userRole: String
+  }
+
+  type PlaylistClimb {
+    id: ID!
+    playlistId: ID!
+    climbUuid: String!
+    angle: Int!
+    position: Int!
+    addedAt: String!
+  }
+
+  input CreatePlaylistInput {
+    boardType: String!
+    layoutId: Int!
+    name: String!
+    description: String
+    color: String
+    icon: String
+  }
+
+  input UpdatePlaylistInput {
+    playlistId: ID!
+    name: String
+    description: String
+    isPublic: Boolean
+    color: String
+    icon: String
+  }
+
+  input AddClimbToPlaylistInput {
+    playlistId: ID!
+    climbUuid: String!
+    angle: Int!
+  }
+
+  input RemoveClimbFromPlaylistInput {
+    playlistId: ID!
+    climbUuid: String!
+  }
+
+  input GetUserPlaylistsInput {
+    boardType: String!
+    layoutId: Int!
+  }
+
+  input GetPlaylistsForClimbInput {
+    boardType: String!
+    layoutId: Int!
+    climbUuid: String!
+  }
+
   type Query {
     session(sessionId: ID!): Session
     # Find discoverable sessions near a location
@@ -328,6 +397,17 @@ export const typeDefs = /* GraphQL */ `
     ticks(input: GetTicksInput!): [Tick!]!
     # Get public ticks for a specific user
     userTicks(userId: ID!, boardType: String!): [Tick!]!
+
+    # ============================================
+    # Playlist Queries (require auth)
+    # ============================================
+
+    # Get current user's playlists for a board+layout
+    userPlaylists(input: GetUserPlaylistsInput!): [Playlist!]!
+    # Get a specific playlist by ID (checks ownership/access)
+    playlist(playlistId: ID!): Playlist
+    # Get playlists that contain a specific climb
+    playlistsForClimb(input: GetPlaylistsForClimbInput!): [ID!]!
   }
 
   type Mutation {
@@ -375,6 +455,21 @@ export const typeDefs = /* GraphQL */ `
 
     # Save a new tick (local ascent tracking)
     saveTick(input: SaveTickInput!): Tick!
+
+    # ============================================
+    # Playlist Mutations (require auth)
+    # ============================================
+
+    # Create a new playlist
+    createPlaylist(input: CreatePlaylistInput!): Playlist!
+    # Update playlist metadata
+    updatePlaylist(input: UpdatePlaylistInput!): Playlist!
+    # Delete a playlist (only owner can delete)
+    deletePlaylist(playlistId: ID!): Boolean!
+    # Add a climb to a playlist
+    addClimbToPlaylist(input: AddClimbToPlaylistInput!): PlaylistClimb!
+    # Remove a climb from a playlist
+    removeClimbFromPlaylist(input: RemoveClimbFromPlaylistInput!): Boolean!
   }
 
   type Subscription {

--- a/packages/web/app/components/climb-actions/actions/index.ts
+++ b/packages/web/app/components/climb-actions/actions/index.ts
@@ -7,3 +7,4 @@ export { OpenInAppAction } from './open-in-app-action';
 export { MirrorAction } from './mirror-action';
 export { ShareAction } from './share-action';
 export { AddToListAction } from './add-to-list-action';
+export { PlaylistAction } from './playlist-action';

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Button, Tooltip, Popover, List, Input, Form, Space, Typography, Badge, ColorPicker, message } from 'antd';
+import { TagOutlined, PlusOutlined, CheckOutlined } from '@ant-design/icons';
+import { track } from '@vercel/analytics';
+import type { ClimbActionProps, ClimbActionResult } from '../types';
+import { usePlaylists } from '../use-playlists';
+import AuthModal from '../../auth/auth-modal';
+import type { Playlist } from '../playlists-batch-context';
+import type { Color } from 'antd/es/color-picker';
+
+const { Text } = Typography;
+
+export function PlaylistAction({
+  climb,
+  boardDetails,
+  angle,
+  viewMode,
+  size = 'default',
+  showLabel,
+  disabled,
+  className,
+  onComplete,
+}: ClimbActionProps): ClimbActionResult {
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [form] = Form.useForm();
+  const [creatingPlaylist, setCreatingPlaylist] = useState(false);
+
+  const {
+    playlists,
+    playlistsContainingClimb,
+    addToPlaylist,
+    removeFromPlaylist,
+    createPlaylist,
+    isAuthenticated,
+    isLoading,
+    refreshPlaylists,
+  } = usePlaylists({
+    climbUuid: climb.uuid,
+    angle,
+  });
+
+  const handleClick = useCallback(
+    (e?: React.MouseEvent) => {
+      e?.stopPropagation();
+      e?.preventDefault();
+
+      if (!isAuthenticated) {
+        setShowAuthModal(true);
+        return;
+      }
+
+      setPopoverOpen(true);
+      onComplete?.();
+    },
+    [isAuthenticated, onComplete]
+  );
+
+  const handleTogglePlaylist = useCallback(
+    async (playlistId: string, isInPlaylist: boolean) => {
+      try {
+        if (isInPlaylist) {
+          await removeFromPlaylist(playlistId);
+          message.success('Removed from playlist');
+          track('Remove from Playlist', {
+            boardName: boardDetails.board_name,
+            climbUuid: climb.uuid,
+            playlistId,
+          });
+        } else {
+          await addToPlaylist(playlistId);
+          message.success('Added to playlist');
+          track('Add to Playlist', {
+            boardName: boardDetails.board_name,
+            climbUuid: climb.uuid,
+            playlistId,
+          });
+        }
+        await refreshPlaylists();
+      } catch (error) {
+        message.error(isInPlaylist ? 'Failed to remove from playlist' : 'Failed to add to playlist');
+        console.error('Playlist toggle error:', error);
+      }
+    },
+    [addToPlaylist, removeFromPlaylist, refreshPlaylists, boardDetails.board_name, climb.uuid]
+  );
+
+  const handleCreatePlaylist = useCallback(async () => {
+    try {
+      const values = await form.validateFields();
+      setCreatingPlaylist(true);
+
+      // Extract hex color from ColorPicker value
+      let colorHex: string | undefined;
+      if (values.color) {
+        if (typeof values.color === 'string') {
+          colorHex = values.color;
+        } else if (typeof values.color === 'object' && 'toHexString' in values.color) {
+          colorHex = (values.color as Color).toHexString();
+        }
+      }
+
+      const newPlaylist = await createPlaylist(values.name, values.description, colorHex, undefined);
+
+      // Automatically add current climb to new playlist
+      await addToPlaylist(newPlaylist.id);
+
+      message.success(`Created playlist "${values.name}"`);
+      track('Create Playlist', {
+        boardName: boardDetails.board_name,
+        playlistName: values.name,
+      });
+
+      form.resetFields();
+      setShowCreateForm(false);
+      await refreshPlaylists();
+    } catch (error) {
+      if (error instanceof Error && 'errorFields' in error) {
+        // Form validation error - don't show message
+        return;
+      }
+      message.error('Failed to create playlist');
+      console.error('Create playlist error:', error);
+    } finally {
+      setCreatingPlaylist(false);
+    }
+  }, [form, createPlaylist, addToPlaylist, refreshPlaylists, boardDetails.board_name]);
+
+  const popoverContent = (
+    <div style={{ width: 300, maxHeight: 400, overflow: 'auto' }}>
+      {playlists.length === 0 && !showCreateForm ? (
+        <Space direction="vertical" style={{ width: '100%', textAlign: 'center', padding: 16 }}>
+          <Text type="secondary">No playlists yet</Text>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => setShowCreateForm(true)}
+            block
+          >
+            Create Your First Playlist
+          </Button>
+        </Space>
+      ) : (
+        <>
+          {!showCreateForm && (
+            <>
+              <List
+                dataSource={playlists}
+                loading={isLoading}
+                renderItem={(playlist: Playlist) => {
+                  const isInPlaylist = playlistsContainingClimb.has(playlist.id);
+                  return (
+                    <List.Item
+                      style={{
+                        padding: '8px 16px',
+                        cursor: 'pointer',
+                        borderLeft: playlist.color ? `4px solid ${playlist.color}` : undefined,
+                      }}
+                      onClick={() => handleTogglePlaylist(playlist.id, isInPlaylist)}
+                    >
+                      <Space style={{ width: '100%', justifyContent: 'space-between' }}>
+                        <Space direction="vertical" size={0}>
+                          <Text strong>{playlist.name}</Text>
+                          {playlist.description && (
+                            <Text type="secondary" style={{ fontSize: 12 }}>
+                              {playlist.description}
+                            </Text>
+                          )}
+                          <Text type="secondary" style={{ fontSize: 12 }}>
+                            {playlist.climbCount} {playlist.climbCount === 1 ? 'climb' : 'climbs'}
+                          </Text>
+                        </Space>
+                        {isInPlaylist && (
+                          <CheckOutlined style={{ color: '#52c41a', fontSize: 16 }} />
+                        )}
+                      </Space>
+                    </List.Item>
+                  );
+                }}
+              />
+              <div style={{ padding: '8px 16px', borderTop: '1px solid #f0f0f0' }}>
+                <Button
+                  type="dashed"
+                  icon={<PlusOutlined />}
+                  onClick={() => setShowCreateForm(true)}
+                  block
+                >
+                  Create New Playlist
+                </Button>
+              </div>
+            </>
+          )}
+
+          {showCreateForm && (
+            <div style={{ padding: 16 }}>
+              <Form form={form} layout="vertical">
+                <Form.Item
+                  name="name"
+                  label="Playlist Name"
+                  rules={[
+                    { required: true, message: 'Please enter a playlist name' },
+                    { max: 100, message: 'Name too long' },
+                  ]}
+                >
+                  <Input placeholder="e.g., Hard Crimps" autoFocus />
+                </Form.Item>
+                <Form.Item
+                  name="description"
+                  label="Description (optional)"
+                  rules={[{ max: 500, message: 'Description too long' }]}
+                >
+                  <Input.TextArea
+                    placeholder="Optional description..."
+                    rows={2}
+                    maxLength={500}
+                  />
+                </Form.Item>
+                <Form.Item name="color" label="Color (optional)">
+                  <ColorPicker format="hex" showText />
+                </Form.Item>
+              </Form>
+              <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
+                <Button
+                  onClick={() => {
+                    setShowCreateForm(false);
+                    form.resetFields();
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button type="primary" onClick={handleCreatePlaylist} loading={creatingPlaylist}>
+                  Create
+                </Button>
+              </Space>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  const label = 'Add to Playlist';
+  const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
+  const iconSize = size === 'small' ? 14 : size === 'large' ? 20 : 16;
+
+  const inPlaylistCount = playlistsContainingClimb.size;
+  const icon =
+    inPlaylistCount > 0 ? (
+      <Badge count={inPlaylistCount} size="small" offset={[-2, 2]}>
+        <TagOutlined style={{ fontSize: iconSize }} />
+      </Badge>
+    ) : (
+      <TagOutlined style={{ fontSize: iconSize }} />
+    );
+
+  const authModalElement = (
+    <AuthModal
+      open={showAuthModal}
+      onClose={() => setShowAuthModal(false)}
+      onSuccess={() => setShowAuthModal(false)}
+      title="Sign in to create playlists"
+      description="Sign in to organize your climbs into custom playlists."
+    />
+  );
+
+  // Icon mode - for Card actions
+  const iconElement = (
+    <>
+      <Popover
+        content={popoverContent}
+        title="Add to Playlist"
+        trigger="click"
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        placement="bottomLeft"
+      >
+        <Tooltip title={label}>
+          <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
+            {icon}
+          </span>
+        </Tooltip>
+      </Popover>
+      {authModalElement}
+    </>
+  );
+
+  // Button mode
+  const buttonElement = (
+    <>
+      <Popover
+        content={popoverContent}
+        title="Add to Playlist"
+        trigger="click"
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        placement="bottomLeft"
+      >
+        <Button
+          icon={icon}
+          onClick={handleClick}
+          size={size === 'large' ? 'large' : size === 'small' ? 'small' : 'middle'}
+          disabled={disabled}
+          className={className}
+        >
+          {shouldShowLabel && label}
+        </Button>
+      </Popover>
+      {authModalElement}
+    </>
+  );
+
+  // Menu item for dropdown
+  const menuItem = {
+    key: 'playlist',
+    label: inPlaylistCount > 0 ? `${label} (${inPlaylistCount})` : label,
+    icon: <TagOutlined />,
+    onClick: () => handleClick(),
+  };
+
+  let element: React.ReactNode;
+  switch (viewMode) {
+    case 'icon':
+      element = iconElement;
+      break;
+    case 'button':
+    case 'compact':
+      element = buttonElement;
+      break;
+    case 'dropdown':
+      element = authModalElement; // Need to render modals even in dropdown mode
+      break;
+    default:
+      element = iconElement;
+  }
+
+  return {
+    element,
+    menuItem,
+    key: 'playlist',
+    available: true,
+  };
+}
+
+export default PlaylistAction;

--- a/packages/web/app/components/climb-actions/climb-actions.tsx
+++ b/packages/web/app/components/climb-actions/climb-actions.tsx
@@ -21,6 +21,7 @@ import {
   MirrorAction,
   ShareAction,
   AddToListAction,
+  PlaylistAction,
 } from './actions';
 import styles from './climb-actions.module.css';
 
@@ -43,6 +44,7 @@ const ACTION_COMPONENTS: Record<
   mirror: MirrorAction,
   share: ShareAction,
   addToList: AddToListAction,
+  playlist: PlaylistAction,
 };
 
 export function ClimbActions({

--- a/packages/web/app/components/climb-actions/playlists-batch-context.tsx
+++ b/packages/web/app/components/climb-actions/playlists-batch-context.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { createContext, useContext, useMemo } from 'react';
+
+export interface Playlist {
+  id: string;
+  uuid: string;
+  boardType: string;
+  layoutId: number;
+  name: string;
+  description?: string;
+  isPublic: boolean;
+  color?: string;
+  icon?: string;
+  createdAt: string;
+  updatedAt: string;
+  climbCount: number;
+  userRole?: string;
+}
+
+interface PlaylistsContextValue {
+  // List of user's playlists for this board+layout
+  playlists: Playlist[];
+  // Check if a climb is in specific playlists (returns playlist IDs)
+  getPlaylistsForClimb: (climbUuid: string) => Set<string>;
+  // Add climb to playlist
+  addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
+  // Remove climb from playlist
+  removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
+  // Create new playlist
+  createPlaylist: (
+    name: string,
+    description?: string,
+    color?: string,
+    icon?: string
+  ) => Promise<Playlist>;
+  // Loading state
+  isLoading: boolean;
+  // Is authenticated
+  isAuthenticated: boolean;
+  // Refresh playlists
+  refreshPlaylists: () => Promise<void>;
+}
+
+export const PlaylistsContext = createContext<PlaylistsContextValue | null>(null);
+
+interface PlaylistsProviderProps {
+  playlists: Playlist[];
+  playlistMemberships: Map<string, Set<string>>; // climbUuid -> Set<playlistId>
+  addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
+  removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
+  createPlaylist: (
+    name: string,
+    description?: string,
+    color?: string,
+    icon?: string
+  ) => Promise<Playlist>;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  refreshPlaylists: () => Promise<void>;
+  children: React.ReactNode;
+}
+
+/**
+ * Provider that passes hoisted playlist data to child components.
+ * Similar to FavoritesProvider pattern.
+ */
+export function PlaylistsProvider({
+  playlists,
+  playlistMemberships,
+  addToPlaylist,
+  removeFromPlaylist,
+  createPlaylist,
+  isLoading,
+  isAuthenticated,
+  refreshPlaylists,
+  children,
+}: PlaylistsProviderProps) {
+  const getPlaylistsForClimb = useMemo(
+    () => (climbUuid: string) => {
+      return playlistMemberships.get(climbUuid) || new Set<string>();
+    },
+    [playlistMemberships]
+  );
+
+  const value = useMemo<PlaylistsContextValue>(
+    () => ({
+      playlists,
+      getPlaylistsForClimb,
+      addToPlaylist,
+      removeFromPlaylist,
+      createPlaylist,
+      isLoading,
+      isAuthenticated,
+      refreshPlaylists,
+    }),
+    [
+      playlists,
+      getPlaylistsForClimb,
+      addToPlaylist,
+      removeFromPlaylist,
+      createPlaylist,
+      isLoading,
+      isAuthenticated,
+      refreshPlaylists,
+    ]
+  );
+
+  return <PlaylistsContext.Provider value={value}>{children}</PlaylistsContext.Provider>;
+}
+
+/**
+ * Hook to access playlists data from context.
+ * Must be used within a PlaylistsProvider.
+ */
+export function usePlaylistsContext(): PlaylistsContextValue {
+  const context = useContext(PlaylistsContext);
+  if (!context) {
+    throw new Error('usePlaylistsContext must be used within a PlaylistsProvider');
+  }
+  return context;
+}

--- a/packages/web/app/components/climb-actions/types.ts
+++ b/packages/web/app/components/climb-actions/types.ts
@@ -13,7 +13,8 @@ export type ClimbActionType =
   | 'openInApp'
   | 'mirror'
   | 'share'
-  | 'addToList';
+  | 'addToList'
+  | 'playlist';
 
 /**
  * View modes for rendering climb actions
@@ -133,6 +134,7 @@ export const DEFAULT_ACTION_ORDER: ClimbActionType[] = [
   'tick',
   'share',
   'addToList',
+  'playlist',
   'openInApp',
   'mirror',
 ];
@@ -140,7 +142,7 @@ export const DEFAULT_ACTION_ORDER: ClimbActionType[] = [
 /**
  * Actions that require authentication
  */
-export const AUTH_REQUIRED_ACTIONS: ClimbActionType[] = ['favorite', 'addToList'];
+export const AUTH_REQUIRED_ACTIONS: ClimbActionType[] = ['favorite', 'addToList', 'playlist'];
 
 /**
  * Actions that require Aurora credentials

--- a/packages/web/app/components/climb-actions/use-playlists.ts
+++ b/packages/web/app/components/climb-actions/use-playlists.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePlaylistsContext, type Playlist } from './playlists-batch-context';
+
+type UsePlaylistsOptions = {
+  climbUuid: string;
+  angle: number;
+};
+
+type UsePlaylistsReturn = {
+  playlists: Playlist[];
+  playlistsContainingClimb: Set<string>;
+  addToPlaylist: (playlistId: string) => Promise<void>;
+  removeFromPlaylist: (playlistId: string) => Promise<void>;
+  createPlaylist: (
+    name: string,
+    description?: string,
+    color?: string,
+    icon?: string
+  ) => Promise<Playlist>;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  refreshPlaylists: () => Promise<void>;
+};
+
+/**
+ * Hook to manage playlist operations for a specific climb.
+ */
+export function usePlaylists({ climbUuid, angle }: UsePlaylistsOptions): UsePlaylistsReturn {
+  const {
+    playlists,
+    getPlaylistsForClimb,
+    addToPlaylist: addToPlaylistContext,
+    removeFromPlaylist: removeFromPlaylistContext,
+    createPlaylist: createPlaylistContext,
+    isLoading,
+    isAuthenticated,
+    refreshPlaylists,
+  } = usePlaylistsContext();
+
+  const playlistsContainingClimb = getPlaylistsForClimb(climbUuid);
+
+  const addToPlaylist = useCallback(
+    async (playlistId: string): Promise<void> => {
+      return addToPlaylistContext(playlistId, climbUuid, angle);
+    },
+    [addToPlaylistContext, climbUuid, angle]
+  );
+
+  const removeFromPlaylist = useCallback(
+    async (playlistId: string): Promise<void> => {
+      return removeFromPlaylistContext(playlistId, climbUuid);
+    },
+    [removeFromPlaylistContext, climbUuid]
+  );
+
+  return {
+    playlists,
+    playlistsContainingClimb,
+    addToPlaylist,
+    removeFromPlaylist,
+    createPlaylist: createPlaylistContext,
+    isLoading,
+    isAuthenticated,
+    refreshPlaylists,
+  };
+}

--- a/packages/web/app/lib/graphql/operations/index.ts
+++ b/packages/web/app/lib/graphql/operations/index.ts
@@ -1,3 +1,4 @@
 export * from './climb-search';
 export * from './favorites';
 export * from './ticks';
+export * from './playlists';

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -1,0 +1,224 @@
+import { gql } from 'graphql-request';
+
+// Fragment for playlist fields
+export const PLAYLIST_FIELDS = gql`
+  fragment PlaylistFields on Playlist {
+    id
+    uuid
+    boardType
+    layoutId
+    name
+    description
+    isPublic
+    color
+    icon
+    createdAt
+    updatedAt
+    climbCount
+    userRole
+  }
+`;
+
+// Get user's playlists for a board+layout
+export const GET_USER_PLAYLISTS = gql`
+  ${PLAYLIST_FIELDS}
+  query GetUserPlaylists($input: GetUserPlaylistsInput!) {
+    userPlaylists(input: $input) {
+      ...PlaylistFields
+    }
+  }
+`;
+
+// Get playlist by ID
+export const GET_PLAYLIST = gql`
+  ${PLAYLIST_FIELDS}
+  query GetPlaylist($playlistId: ID!) {
+    playlist(playlistId: $playlistId) {
+      ...PlaylistFields
+    }
+  }
+`;
+
+// Get playlists containing a climb (returns playlist IDs)
+export const GET_PLAYLISTS_FOR_CLIMB = gql`
+  query GetPlaylistsForClimb($input: GetPlaylistsForClimbInput!) {
+    playlistsForClimb(input: $input)
+  }
+`;
+
+// Create new playlist
+export const CREATE_PLAYLIST = gql`
+  ${PLAYLIST_FIELDS}
+  mutation CreatePlaylist($input: CreatePlaylistInput!) {
+    createPlaylist(input: $input) {
+      ...PlaylistFields
+    }
+  }
+`;
+
+// Update playlist
+export const UPDATE_PLAYLIST = gql`
+  ${PLAYLIST_FIELDS}
+  mutation UpdatePlaylist($input: UpdatePlaylistInput!) {
+    updatePlaylist(input: $input) {
+      ...PlaylistFields
+    }
+  }
+`;
+
+// Delete playlist
+export const DELETE_PLAYLIST = gql`
+  mutation DeletePlaylist($playlistId: ID!) {
+    deletePlaylist(playlistId: $playlistId)
+  }
+`;
+
+// Add climb to playlist
+export const ADD_CLIMB_TO_PLAYLIST = gql`
+  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {
+    addClimbToPlaylist(input: $input) {
+      id
+      playlistId
+      climbUuid
+      angle
+      position
+      addedAt
+    }
+  }
+`;
+
+// Remove climb from playlist
+export const REMOVE_CLIMB_FROM_PLAYLIST = gql`
+  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {
+    removeClimbFromPlaylist(input: $input)
+  }
+`;
+
+// TypeScript types for operations
+
+export interface Playlist {
+  id: string;
+  uuid: string;
+  boardType: string;
+  layoutId: number;
+  name: string;
+  description?: string;
+  isPublic: boolean;
+  color?: string;
+  icon?: string;
+  createdAt: string;
+  updatedAt: string;
+  climbCount: number;
+  userRole?: string;
+}
+
+export interface GetUserPlaylistsInput {
+  boardType: string;
+  layoutId: number;
+}
+
+export interface GetUserPlaylistsQueryVariables {
+  input: GetUserPlaylistsInput;
+}
+
+export interface GetUserPlaylistsQueryResponse {
+  userPlaylists: Playlist[];
+}
+
+export interface GetPlaylistQueryVariables {
+  playlistId: string;
+}
+
+export interface GetPlaylistQueryResponse {
+  playlist: Playlist | null;
+}
+
+export interface GetPlaylistsForClimbInput {
+  boardType: string;
+  layoutId: number;
+  climbUuid: string;
+}
+
+export interface GetPlaylistsForClimbQueryVariables {
+  input: GetPlaylistsForClimbInput;
+}
+
+export interface GetPlaylistsForClimbQueryResponse {
+  playlistsForClimb: string[];
+}
+
+export interface CreatePlaylistInput {
+  boardType: string;
+  layoutId: number;
+  name: string;
+  description?: string;
+  color?: string;
+  icon?: string;
+}
+
+export interface CreatePlaylistMutationVariables {
+  input: CreatePlaylistInput;
+}
+
+export interface CreatePlaylistMutationResponse {
+  createPlaylist: Playlist;
+}
+
+export interface UpdatePlaylistInput {
+  playlistId: string;
+  name?: string;
+  description?: string;
+  isPublic?: boolean;
+  color?: string;
+  icon?: string;
+}
+
+export interface UpdatePlaylistMutationVariables {
+  input: UpdatePlaylistInput;
+}
+
+export interface UpdatePlaylistMutationResponse {
+  updatePlaylist: Playlist;
+}
+
+export interface DeletePlaylistMutationVariables {
+  playlistId: string;
+}
+
+export interface DeletePlaylistMutationResponse {
+  deletePlaylist: boolean;
+}
+
+export interface AddClimbToPlaylistInput {
+  playlistId: string;
+  climbUuid: string;
+  angle: number;
+}
+
+export interface AddClimbToPlaylistMutationVariables {
+  input: AddClimbToPlaylistInput;
+}
+
+export interface AddClimbToPlaylistMutationResponse {
+  addClimbToPlaylist: {
+    id: string;
+    playlistId: string;
+    climbUuid: string;
+    angle: number;
+    position: number;
+    addedAt: string;
+  };
+}
+
+export interface RemoveClimbFromPlaylistInput {
+  playlistId: string;
+  climbUuid: string;
+}
+
+export interface RemoveClimbFromPlaylistMutationVariables {
+  input: RemoveClimbFromPlaylistInput;
+}
+
+export interface RemoveClimbFromPlaylistMutationResponse {
+  removeClimbFromPlaylist: boolean;
+}


### PR DESCRIPTION
## Summary

This PR implements a custom playlist feature that allows users to organize climbs into personalized collections. Key features include:

- **Label icon action** on climb cards that opens a popover menu for playlist management
- **Add/remove climbs** from playlists with one click
- **Create new playlists** with name, description, and color customization
- **Full GraphQL backend** with proper authentication and data validation
- **Scoped to board + layout** - playlists can contain climbs from different sizes within the same layout
- **Batch loading** for optimal performance following existing favorites pattern
- **Badge indicator** showing count of playlists containing each climb
- **Auto-add feature** - when creating a playlist from a climb card, automatically adds that climb
- **Separate ownership table** prepared for future multi-user collaboration

## Technical Implementation

**Backend:**
- 3 new database tables: `playlists`, `playlist_climbs`, `playlist_ownership`
- 3 GraphQL queries: `userPlaylists`, `playlist`, `playlistsForClimb`
- 5 GraphQL mutations: `createPlaylist`, `updatePlaylist`, `deletePlaylist`, `addClimbToPlaylist`, `removeClimbFromPlaylist`
- Zod validation schemas for all operations
- Proper authentication checks using `requireAuthenticated`

**Frontend:**
- New `PlaylistAction` component with Popover UI (Ant Design)
- `PlaylistsProvider` context following favorites batch loading pattern
- `usePlaylists` hook for component-level usage
- Integrated into existing climb actions system
- Uses `useWsAuthToken` for authentication (not NextAuth session directly)

## Test Plan

- [ ] Sign in and verify playlist icon appears on climb cards
- [ ] Click playlist icon and verify popover opens with empty state
- [ ] Create a new playlist with name, description, and color
- [ ] Verify playlist appears in list
- [ ] Add climb to playlist and verify checkmark appears
- [ ] Remove climb from playlist and verify checkmark disappears
- [ ] Verify badge count updates correctly when climb is in multiple playlists
- [ ] Create another playlist from a different climb card
- [ ] Verify both playlists are available on all climb cards (for same board+layout)
- [ ] Test with different board types (Kilter, Tension)
- [ ] Test with different sizes on same layout
- [ ] Verify authentication modal appears when not signed in
- [ ] Test GraphQL operations in playground
- [ ] Verify database migrations applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)