### PR TITLE
feat: Add swipe navigation for mobile queue bar

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -19,12 +19,18 @@
   }
 }
 
-/* Swipe container for mobile navigation - carousel style */
+/* Swipe container for mobile navigation */
 .swipeContainer {
   touch-action: pan-y;
 }
 
-/* Individual carousel slides */
-.carouselSlide {
-  padding: 0 4px;
+/* Action backgrounds revealed on swipe (hidden on desktop) */
+.swipeAction {
+  z-index: 0;
+}
+
+@media (min-width: 768px) {
+  .swipeAction {
+    display: none !important;
+  }
 }

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -7,3 +7,50 @@
     cursor: default;
   }
 }
+
+/* Hide navigation buttons on mobile - use swipe instead */
+.navButtons {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .navButtons {
+    display: inline-flex;
+  }
+}
+
+/* Swipe container for mobile navigation */
+.swipeContainer {
+  width: 100%;
+  touch-action: pan-y;
+}
+
+/* Visual feedback during swipe */
+.swipeIndicator {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  transition: opacity 150ms ease, transform 150ms ease;
+  pointer-events: none;
+}
+
+.swipeIndicatorLeft {
+  left: 8px;
+}
+
+.swipeIndicatorRight {
+  right: 8px;
+}
+
+/* Hide swipe indicators on desktop */
+@media (min-width: 768px) {
+  .swipeIndicator {
+    display: none;
+  }
+}

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -19,38 +19,12 @@
   }
 }
 
-/* Swipe container for mobile navigation */
+/* Swipe container for mobile navigation - carousel style */
 .swipeContainer {
-  width: 100%;
   touch-action: pan-y;
 }
 
-/* Visual feedback during swipe */
-.swipeIndicator {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  transition: opacity 150ms ease, transform 150ms ease;
-  pointer-events: none;
-}
-
-.swipeIndicatorLeft {
-  left: 8px;
-}
-
-.swipeIndicatorRight {
-  right: 8px;
-}
-
-/* Hide swipe indicators on desktop */
-@media (min-width: 768px) {
-  .swipeIndicator {
-    display: none;
-  }
+/* Individual carousel slides */
+.carouselSlide {
+  padding: 0 4px;
 }

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -276,9 +276,6 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         styles={{
           body: {
             padding: '4px 12px 0px 12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
           },
         }}
         style={{
@@ -286,35 +283,36 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           borderRadius: 0,
           margin: 0,
           borderTop: `1px solid ${themeTokens.neutral[200]}`,
-          position: 'relative',
-          overflow: 'hidden',
         }}
       >
-        {/* Carousel container for swipe navigation */}
-        <div
-          {...swipeHandlers}
-          className={styles.swipeContainer}
-          style={{
-            display: 'flex',
-            width: '300%',
-            marginLeft: '-100%',
-            transform: `translateX(${swipeOffset}px)`,
-            transition: swipeOffset === 0 ? `transform ${themeTokens.transitions.fast}` : 'none',
-          }}
-        >
-          {/* Previous climb (left) */}
-          <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0, opacity: canSwipePrevious ? 1 : 0.3 }}>
-            {previousClimb ? renderClimbContent(previousClimb.climb, false) : renderClimbContent(null, false)}
-          </div>
+        {/* Overflow container to clip carousel */}
+        <div style={{ overflow: 'hidden', width: '100%', position: 'relative' }}>
+          {/* Carousel container for swipe navigation */}
+          <div
+            {...swipeHandlers}
+            className={styles.swipeContainer}
+            style={{
+              display: 'flex',
+              width: '300%',
+              marginLeft: '-100%',
+              transform: `translateX(${swipeOffset}px)`,
+              transition: swipeOffset === 0 ? `transform ${themeTokens.transitions.fast}` : 'none',
+            }}
+          >
+            {/* Previous climb (left) */}
+            <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0, opacity: canSwipePrevious ? 1 : 0.3 }}>
+              {previousClimb ? renderClimbContent(previousClimb.climb, false) : renderClimbContent(null, false)}
+            </div>
 
-          {/* Current climb (center) */}
-          <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0 }}>
-            {renderClimbContent(currentClimb, true)}
-          </div>
+            {/* Current climb (center) */}
+            <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0 }}>
+              {renderClimbContent(currentClimb, true)}
+            </div>
 
-          {/* Next climb (right) */}
-          <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0, opacity: canSwipeNext ? 1 : 0.3 }}>
-            {nextClimb ? renderClimbContent(nextClimb.climb, false) : renderClimbContent(null, false)}
+            {/* Next climb (right) */}
+            <div className={styles.carouselSlide} style={{ width: '33.333%', flexShrink: 0, opacity: canSwipeNext ? 1 : 0.3 }}>
+              {nextClimb ? renderClimbContent(nextClimb.climb, false) : renderClimbContent(null, false)}
+            </div>
           </div>
         </div>
       </Card>


### PR DESCRIPTION
Replace prev/next navigation buttons with swipe gestures on mobile:
- Swipe left to go to next climb in queue
- Swipe right to go to previous climb
- Visual indicators show during swipe with direction arrows
- Navigation buttons remain visible on desktop (>=768px)
- Follows existing swipe pattern from queue-list-item component