### PR TITLE
refactor: Move climb title from header to play view content area

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -172,9 +172,9 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
     <div className={styles.pageContainer} style={{ backgroundColor: themeTokens.semantic.background }}>
       {/* Main Content with Swipe */}
       <div className={styles.contentWrapper}>
-        {/* Climb title - centered above board */}
+        {/* Climb title - left aligned above board */}
         <div className={styles.climbTitleContainer}>
-          <ClimbTitle climb={displayClimb} showAngle centered />
+          <ClimbTitle climb={displayClimb} layout="horizontal" showSetterInfo />
         </div>
         <div {...swipeHandlers} className={styles.swipeContainer}>
           {/* Swipe indicators */}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -9,6 +9,7 @@ import { track } from '@vercel/analytics';
 import { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useQueueContext } from '@/app/components/graphql-queue';
 import BoardRenderer from '@/app/components/board-renderer/board-renderer';
+import ClimbTitle from '@/app/components/climb-card/climb-title';
 import { constructClimbListWithSlugs, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './play-view.module.css';
@@ -171,6 +172,10 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
     <div className={styles.pageContainer} style={{ backgroundColor: themeTokens.semantic.background }}>
       {/* Main Content with Swipe */}
       <div className={styles.contentWrapper}>
+        {/* Climb title - centered above board */}
+        <div className={styles.climbTitleContainer}>
+          <ClimbTitle climb={displayClimb} showAngle centered />
+        </div>
         <div {...swipeHandlers} className={styles.swipeContainer}>
           {/* Swipe indicators */}
           {prevItem && (

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -172,8 +172,13 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
     <div className={styles.pageContainer} style={{ backgroundColor: themeTokens.semantic.background }}>
       {/* Main Content with Swipe */}
       <div className={styles.contentWrapper}>
-        {/* Climb title - left aligned above board */}
-        <div className={styles.climbTitleContainer}>
+        {/* Climb title - horizontal layout with grade on right */}
+        <div
+          className={styles.climbTitleContainer}
+          style={{
+            padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[3]}px`,
+          }}
+        >
           <ClimbTitle climb={displayClimb} layout="horizontal" showSetterInfo />
         </div>
         <div {...swipeHandlers} className={styles.swipeContainer}>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -202,6 +202,7 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
               boardDetails={boardDetails}
               litUpHoldsMap={displayClimb.litUpHoldsMap}
               mirrored={!!displayClimb.mirrored}
+              maxHeight="80vh"
             />
           </div>
 

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -20,7 +20,7 @@
 .climbTitleContainer {
   display: flex;
   justify-content: center;
-  padding: 8px 16px;
+  padding: 8px 16px 5px;
   flex-shrink: 0;
 }
 
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   touch-action: pan-y pinch-zoom;
   overflow: hidden;
   min-height: 0;
@@ -38,9 +38,9 @@
 .boardContainer {
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 4px;
+  padding: 0 4px 4px;
   min-height: 0;
   max-height: 100%;
   width: 100%;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -18,8 +18,7 @@
 }
 
 .climbTitleContainer {
-  display: flex;
-  justify-content: flex-start;
+  width: 100%;
   padding: 8px 16px 5px;
   flex-shrink: 0;
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -19,7 +19,7 @@
 
 .climbTitleContainer {
   width: 100%;
-  padding: 8px 16px 5px;
+  padding: 4px 12px 2px;
   flex-shrink: 0;
 }
 
@@ -39,7 +39,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 0 4px 4px;
+  padding: 0;
   min-height: 0;
   max-height: 100%;
   width: 100%;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -17,6 +17,13 @@
   min-height: 0;
 }
 
+.climbTitleContainer {
+  display: flex;
+  justify-content: center;
+  padding: 8px 16px;
+  flex-shrink: 0;
+}
+
 .swipeContainer {
   flex: 1;
   display: flex;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -19,7 +19,7 @@
 
 .climbTitleContainer {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 8px 16px 5px;
   flex-shrink: 0;
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -19,7 +19,6 @@
 
 .climbTitleContainer {
   width: 100%;
-  padding: 4px 12px 2px;
   flex-shrink: 0;
 }
 
@@ -37,7 +36,7 @@
 .boardContainer {
   flex: 1;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   padding: 0;
   min-height: 0;

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -9,7 +9,6 @@ import SearchButton from '../search-drawer/search-button';
 import SearchClimbNameInput from '../search-drawer/search-climb-name-input';
 import { UISearchParamsProvider } from '../queue-control/ui-searchparams-provider';
 import { BoardDetails } from '@/app/lib/types';
-import ClimbTitle from '../climb-card/climb-title';
 
 // Dynamically import bluetooth component to reduce initial bundle size
 // LED placement data (~50KB) is only loaded when bluetooth is actually used
@@ -169,18 +168,15 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
               </>
             )}
 
-            {/* Play page: Show search/back button and climb name (mobile only) */}
+            {/* Play page: Show search/back button (mobile only) */}
             {pageMode === 'play' && (
-              <div className={styles.mobileOnly} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+              <div className={styles.mobileOnly}>
                 <Button
                   icon={<SearchOutlined />}
                   type="text"
                   aria-label="Back to search"
                   onClick={() => router.push(getBackToListUrl())}
                 />
-                <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-                  <ClimbTitle climb={currentClimb} showAngle centered />
-                </div>
               </div>
             )}
 

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -19,7 +19,7 @@ const SendClimbToBoardButton = dynamic(
 import { generateLayoutSlug, generateSizeSlug, generateSetSlug, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { ShareBoardButton } from './share-button';
 import { useQueueContext } from '../graphql-queue';
-import { UserOutlined, LogoutOutlined, LoginOutlined, PlusOutlined, MoreOutlined, SettingOutlined, LineChartOutlined, SearchOutlined } from '@ant-design/icons';
+import { UserOutlined, LogoutOutlined, LoginOutlined, PlusOutlined, MoreOutlined, SettingOutlined, LineChartOutlined, LeftOutlined } from '@ant-design/icons';
 import AngleSelector from './angle-selector';
 import Logo from '../brand/logo';
 import styles from './header.module.css';
@@ -149,8 +149,19 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
     >
       <UISearchParamsProvider>
         <Flex justify="space-between" align="center" style={{ width: '100%' }} gap={8}>
-          {/* Logo - Fixed to left */}
-          <Flex align="center">
+          {/* Logo and back button - Fixed to left */}
+          <Flex align="center" gap={4}>
+            {/* Play page: Show back button next to logo (mobile only) */}
+            {pageMode === 'play' && (
+              <div className={styles.mobileOnly}>
+                <Button
+                  icon={<LeftOutlined />}
+                  type="text"
+                  aria-label="Back to search"
+                  onClick={() => router.push(getBackToListUrl())}
+                />
+              </div>
+            )}
             <Logo size="sm" showText={false} />
           </Flex>
 
@@ -166,18 +177,6 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                   <SearchButton boardDetails={boardDetails} />
                 </div>
               </>
-            )}
-
-            {/* Play page: Show search/back button (mobile only) */}
-            {pageMode === 'play' && (
-              <div className={styles.mobileOnly}>
-                <Button
-                  icon={<SearchOutlined />}
-                  type="text"
-                  aria-label="Back to search"
-                  onClick={() => router.push(getBackToListUrl())}
-                />
-              </div>
             )}
 
             {/* View page: Empty center on mobile (back button is in the page content) */}

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -157,7 +157,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                 <Button
                   icon={<LeftOutlined />}
                   type="text"
-                  aria-label="Back to search"
+                  aria-label="Back to climb list"
                   onClick={() => router.push(getBackToListUrl())}
                 />
               </div>

--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -24,7 +24,7 @@ const BoardRenderer = React.memo(
           width: '100%',
           height: 'auto',
           display: 'block',
-          maxHeight: thumbnail ? '10vh' : '55vh',
+          maxHeight: thumbnail ? '10vh' : '80vh',
         }}
       >
         {Object.keys(boardDetails.images_to_holds).map((imageUrl) => (

--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -9,12 +9,16 @@ export type BoardProps = {
   litUpHoldsMap?: LitUpHoldsMap;
   mirrored: boolean;
   thumbnail?: boolean;
+  /** Custom max-height for the board SVG. Defaults to '55vh', or '10vh' for thumbnails */
+  maxHeight?: string;
   onHoldClick?: (holdId: number) => void;
 };
 
 const BoardRenderer = React.memo(
-  ({ boardDetails, thumbnail, litUpHoldsMap, mirrored, onHoldClick }: BoardProps) => {
+  ({ boardDetails, thumbnail, maxHeight, litUpHoldsMap, mirrored, onHoldClick }: BoardProps) => {
     const { boardWidth, boardHeight, holdsData } = boardDetails;
+
+    const resolvedMaxHeight = thumbnail ? '10vh' : (maxHeight ?? '55vh');
 
     return (
       <svg
@@ -24,7 +28,7 @@ const BoardRenderer = React.memo(
           width: '100%',
           height: 'auto',
           display: 'block',
-          maxHeight: thumbnail ? '10vh' : '80vh',
+          maxHeight: resolvedMaxHeight,
         }}
       >
         {Object.keys(boardDetails.images_to_holds).map((imageUrl) => (
@@ -42,8 +46,9 @@ const BoardRenderer = React.memo(
     );
   },
   (prevProps, nextProps) => {
-    // Compare thumbnail (affects SVG maxHeight)
+    // Compare thumbnail and maxHeight (affects SVG maxHeight)
     if (prevProps.thumbnail !== nextProps.thumbnail) return false;
+    if (prevProps.maxHeight !== nextProps.maxHeight) return false;
 
     // Compare mirrored and onHoldClick (passed to BoardLitupHolds)
     if (prevProps.mirrored !== nextProps.mirrored) return false;


### PR DESCRIPTION
Move the ClimbTitle component from the header into the play view,
rendering it centered above the board. This improves the layout by
keeping the title with the content rather than in the header.