### PR TITLE
fix: Improve SSR cache key generation for climb search

### DIFF
--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -39,15 +39,37 @@ async function executeGraphQLInternal<T = unknown, V extends Variables = Variabl
 }
 
 /**
+ * Recursively sort object keys for consistent JSON serialization
+ */
+function sortObjectKeys<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys) as T;
+  }
+
+  const sortedObj: Record<string, unknown> = {};
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+
+  for (const key of keys) {
+    sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+
+  return sortedObj as T;
+}
+
+/**
  * Create a stable cache key from GraphQL variables
- * Sorts object keys to ensure consistent key generation
+ * Recursively sorts all object keys to ensure consistent key generation
  */
 function createCacheKeyFromVariables(variables: Variables | undefined): string[] {
   if (!variables) return ['no-variables'];
 
-  // Create a stable JSON representation by sorting keys
-  const sortedJson = JSON.stringify(variables, Object.keys(variables).sort());
-  return [sortedJson];
+  // Recursively sort all keys for stable JSON representation
+  const sortedVariables = sortObjectKeys(variables);
+  return [JSON.stringify(sortedVariables)];
 }
 
 /**
@@ -81,24 +103,72 @@ export function createCachedGraphQLQuery<T = unknown, V extends Variables = Vari
 }
 
 /**
+ * Search input type for climb search queries
+ */
+interface ClimbSearchInput {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+  page?: number;
+  pageSize?: number;
+  gradeAccuracy?: string;
+  minGrade?: number;
+  maxGrade?: number;
+  minAscents?: number;
+  sortBy?: string;
+  sortOrder?: string;
+  name?: string;
+  setter?: string | string[];
+}
+
+/**
  * Pre-configured cached query for climb search
  *
  * @param document - GraphQL query document
- * @param variables - Query variables
+ * @param variables - Query variables containing { input: ClimbSearchInput }
  * @param isDefaultSearch - Whether this is a default/unfiltered search (caches longer)
  */
 export async function cachedSearchClimbs<T = unknown>(
   document: RequestDocument,
-  variables: Variables,
+  variables: { input: ClimbSearchInput },
   isDefaultSearch: boolean = false,
 ): Promise<T> {
   const revalidate = isDefaultSearch
     ? CACHE_DURATION_DEFAULT_SEARCH
     : CACHE_DURATION_FILTERED_SEARCH;
 
+  const { input } = variables;
+
+  // Build explicit cache key with board identifiers as separate segments
+  // This ensures cache hits/misses are correctly differentiated by board configuration
+  const cacheKey = [
+    'graphql',
+    'climb-search',
+    input.boardName,
+    String(input.layoutId),
+    String(input.sizeId),
+    input.setIds,
+    String(input.angle),
+    // Include filter params as a sorted JSON string
+    JSON.stringify(sortObjectKeys({
+      page: input.page,
+      pageSize: input.pageSize,
+      gradeAccuracy: input.gradeAccuracy,
+      minGrade: input.minGrade,
+      maxGrade: input.maxGrade,
+      minAscents: input.minAscents,
+      sortBy: input.sortBy,
+      sortOrder: input.sortOrder,
+      name: input.name,
+      setter: input.setter,
+    })),
+  ];
+
   const cachedFn = unstable_cache(
     async () => executeGraphQLInternal<T>(document, variables),
-    ['graphql', 'climb-search', ...createCacheKeyFromVariables(variables)],
+    cacheKey,
     {
       revalidate,
       tags: ['climb-search'],


### PR DESCRIPTION
The cache key was not properly differentiating between different board
configurations because the JSON.stringify only sorted top-level keys,
not nested object keys. This caused cached results from one board/layout
to be incorrectly served for other board/layout combinations.

Changes:
- Add sortObjectKeys() to recursively sort all object keys for stable
  JSON serialization
- Build explicit cache key with board identifiers (boardName, layoutId,
  sizeId, setIds, angle) as separate segments
- Add ClimbSearchInput type for better type safety
- Keep filter params (page, pageSize, grades, etc.) as a separate
  sorted JSON string in the cache key