### PR TITLE
fix: Disable tooltips on touch devices to fix mobile tap-to-action issue

### DIFF
--- a/packages/web/app/components/climb-actions/action-tooltip.tsx
+++ b/packages/web/app/components/climb-actions/action-tooltip.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Tooltip, TooltipProps } from 'antd';
+
+/**
+ * A tooltip wrapper for action buttons that disables tooltips on touch devices.
+ *
+ * On touch devices (mobile), the default Tooltip behavior intercepts the first tap
+ * to show the tooltip, requiring a second tap to actually trigger the action.
+ * This component disables the tooltip trigger on touch devices so clicks work immediately.
+ */
+export function ActionTooltip({ children, ...props }: TooltipProps) {
+  // Use CSS media query to detect touch devices
+  // hover: none means the device doesn't have hover capability (touch device)
+  const [isTouchDevice, setIsTouchDevice] = React.useState(false);
+
+  React.useEffect(() => {
+    // Check if device has no hover capability (touch device)
+    const mediaQuery = window.matchMedia('(hover: none)');
+    setIsTouchDevice(mediaQuery.matches);
+
+    const handler = (e: MediaQueryListEvent) => setIsTouchDevice(e.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, []);
+
+  // On touch devices, render children without tooltip wrapper
+  // This ensures taps immediately trigger the action
+  if (isTouchDevice) {
+    return <>{children}</>;
+  }
+
+  return <Tooltip {...props}>{children}</Tooltip>;
+}
+
+export default ActionTooltip;

--- a/packages/web/app/components/climb-actions/actions/add-to-list-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/add-to-list-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Button, Tooltip, message } from 'antd';
+import { Button, message } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import { useSession } from 'next-auth/react';
 import { track } from '@vercel/analytics';
@@ -60,11 +61,11 @@ export function AddToListAction({
   // Icon mode - for Card actions
   const iconElement = (
     <>
-      <Tooltip title={label}>
+      <ActionTooltip title={label}>
         <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
           {icon}
         </span>
-      </Tooltip>
+      </ActionTooltip>
       {authModalElement}
     </>
   );

--- a/packages/web/app/components/climb-actions/actions/favorite-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/favorite-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { HeartOutlined, HeartFilled } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
@@ -91,11 +92,11 @@ export function FavoriteAction({
   // Icon mode - for Card actions
   const iconElement = (
     <>
-      <Tooltip title={label}>
+      <ActionTooltip title={label}>
         <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
           {icon}
         </span>
-      </Tooltip>
+      </ActionTooltip>
       {authModalElement}
     </>
   );

--- a/packages/web/app/components/climb-actions/actions/fork-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/fork-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { ForkOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { track } from '@vercel/analytics';
@@ -49,11 +50,11 @@ export function ForkAction({
 
   // Icon mode - for Card actions
   const iconElement = url ? (
-    <Tooltip title="Fork this climb">
+    <ActionTooltip title="Fork this climb">
       <Link href={url} onClick={handleClick} className={className}>
         {icon}
       </Link>
-    </Tooltip>
+    </ActionTooltip>
   ) : null;
 
   // Button mode

--- a/packages/web/app/components/climb-actions/actions/mirror-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/mirror-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { SwapOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
@@ -50,11 +51,11 @@ export function MirrorAction({
 
   // Icon mode - for Card actions
   const iconElement = canMirror ? (
-    <Tooltip title={isMirrored ? 'Mirrored (click to reset)' : 'Mirror climb'}>
+    <ActionTooltip title={isMirrored ? 'Mirrored (click to reset)' : 'Mirror climb'}>
       <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
         {icon}
       </span>
-    </Tooltip>
+    </ActionTooltip>
   ) : null;
 
   // Button mode

--- a/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { AppstoreOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
@@ -45,11 +46,11 @@ export function OpenInAppAction({
 
   // Icon mode - for Card actions
   const iconElement = (
-    <Tooltip title={label}>
+    <ActionTooltip title={label}>
       <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
         {icon}
       </span>
-    </Tooltip>
+    </ActionTooltip>
   );
 
   // Button mode

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Button, Tooltip, Popover, List, Input, Form, Space, Typography, Badge, ColorPicker, message } from 'antd';
+import { Button, Popover, List, Input, Form, Space, Typography, Badge, ColorPicker, message } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { TagOutlined, PlusOutlined, CheckOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
@@ -275,11 +276,11 @@ export function PlaylistAction({
         onOpenChange={setPopoverOpen}
         placement="bottomLeft"
       >
-        <Tooltip title={label}>
+        <ActionTooltip title={label}>
           <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
             {icon}
           </span>
-        </Tooltip>
+        </ActionTooltip>
       </Popover>
       {authModalElement}
     </>

--- a/packages/web/app/components/climb-actions/actions/queue-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/queue-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { PlusCircleOutlined, CheckCircleOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
@@ -54,7 +55,7 @@ export function QueueAction({
 
   // Icon mode - for Card actions
   const iconElement = (
-    <Tooltip title={recentlyAdded ? 'Added to queue' : 'Add to queue'}>
+    <ActionTooltip title={recentlyAdded ? 'Added to queue' : 'Add to queue'}>
       <span
         onClick={handleClick}
         style={{ cursor: recentlyAdded ? 'not-allowed' : 'pointer' }}
@@ -62,7 +63,7 @@ export function QueueAction({
       >
         {icon}
       </span>
-    </Tooltip>
+    </ActionTooltip>
   );
 
   // Button mode

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Button, Tooltip, message } from 'antd';
+import { Button, message } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { ShareAltOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
@@ -98,11 +99,11 @@ export function ShareAction({
 
   // Icon mode - for Card actions
   const iconElement = (
-    <Tooltip title={label}>
+    <ActionTooltip title={label}>
       <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
         {icon}
       </span>
-    </Tooltip>
+    </ActionTooltip>
   );
 
   // Button mode

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useCallback, useMemo } from 'react';
-import { Button, Tooltip, Badge, Drawer, Typography, Space } from 'antd';
+import { Button, Badge, Drawer, Typography, Space } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { CheckOutlined, LoginOutlined } from '@ant-design/icons';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
@@ -109,13 +110,13 @@ export function TickAction({
   // Icon mode - for Card actions
   const iconElement = (
     <>
-      <Tooltip title={label}>
+      <ActionTooltip title={label}>
         <Badge count={badgeCount} size="small" color={badgeColor} overflowCount={99} showZero={false}>
           <span onClick={handleClick} style={{ cursor: 'pointer' }} className={className}>
             {icon}
           </span>
         </Badge>
-      </Tooltip>
+      </ActionTooltip>
       {drawers}
     </>
   );

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button } from 'antd';
+import { ActionTooltip } from '../action-tooltip';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { track } from '@vercel/analytics';
@@ -61,11 +62,11 @@ export function ViewDetailsAction({
 
   // Icon mode - for Card actions
   const iconElement = (
-    <Tooltip title={label}>
+    <ActionTooltip title={label}>
       <Link href={url} onClick={handleClick} className={className}>
         {icon}
       </Link>
-    </Tooltip>
+    </ActionTooltip>
   );
 
   // Button mode


### PR DESCRIPTION
On mobile devices, AntD Tooltip intercepts the first tap to show the tooltip,
requiring a second tap to trigger the action. This creates a poor mobile UX.

Introduced ActionTooltip component that uses CSS media query (hover: none) to
detect touch devices and renders children without tooltip wrapper on mobile.