### PR TITLE
refactor: Align create climb layout with play view

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/layout.tsx
@@ -1,0 +1,5 @@
+import { CreateClimbProvider } from '@/app/components/create-climb/create-climb-context';
+
+export default function CreateClimbLayout({ children }: { children: React.ReactNode }) {
+  return <CreateClimbProvider>{children}</CreateClimbProvider>;
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/layout.tsx
@@ -3,3 +3,5 @@ import { CreateClimbProvider } from '@/app/components/create-climb/create-climb-
 export default function CreateClimbLayout({ children }: { children: React.ReactNode }) {
   return <CreateClimbProvider>{children}</CreateClimbProvider>;
 }
+
+CreateClimbLayout.displayName = 'CreateClimbLayout';

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -9,6 +9,9 @@ import SearchButton from '../search-drawer/search-button';
 import SearchClimbNameInput from '../search-drawer/search-climb-name-input';
 import { UISearchParamsProvider } from '../queue-control/ui-searchparams-provider';
 import { BoardDetails } from '@/app/lib/types';
+import { useCreateClimbContext } from '../create-climb/create-climb-context';
+import { ExperimentOutlined } from '@ant-design/icons';
+import { themeTokens } from '@/app/theme/theme-config';
 
 // Dynamically import bluetooth component to reduce initial bundle size
 // LED placement data (~50KB) is only loaded when bluetooth is actually used
@@ -48,6 +51,7 @@ function usePageMode(): PageMode {
 export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeaderProps) {
   const { data: session } = useSession();
   const { currentClimb } = useQueueContext();
+  const createClimbContext = useCreateClimbContext();
   const [showAuthModal, setShowAuthModal] = useState(false);
   const pageMode = usePageMode();
   const searchParams = useSearchParams();
@@ -199,46 +203,66 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
 
           {/* Right Section */}
           <Flex gap={4} align="center">
-            {angle !== undefined && <AngleSelector boardName={boardDetails.board_name} currentAngle={angle} currentClimb={currentClimb} />}
-
-            {/* Desktop: show Create Climb button */}
-            {createClimbUrl && (
-              <div className={styles.desktopOnly}>
-                <Link href={createClimbUrl}>
-                  <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
-                </Link>
-              </div>
-            )}
-
-            <ShareBoardButton />
-            <SendClimbToBoardButton boardDetails={boardDetails} />
-
-            {/* Desktop: User menu or login button */}
-            <div className={styles.desktopOnly}>
-              {session?.user ? (
-                <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
-                  <Button icon={<UserOutlined />} type="text">
-                    {session.user.name || session.user.email}
-                  </Button>
-                </Dropdown>
-              ) : (
-                <Button
-                  icon={<LoginOutlined />}
-                  type="text"
-                  onClick={() => setShowAuthModal(true)}
-                >
-                  Login
+            {/* Create mode: Show cancel and publish buttons */}
+            {pageMode === 'create' && createClimbContext ? (
+              <>
+                <Button onClick={createClimbContext.onCancel} disabled={createClimbContext.isPublishing}>
+                  Cancel
                 </Button>
-              )}
-            </div>
+                <ExperimentOutlined style={{ color: themeTokens.colors.primary }} title="Beta Feature" />
+                <Button
+                  type="primary"
+                  onClick={createClimbContext.onPublish}
+                  loading={createClimbContext.isPublishing}
+                  disabled={!createClimbContext.canPublish || createClimbContext.isPublishing}
+                >
+                  {createClimbContext.isPublishing ? 'Publishing...' : 'Publish'}
+                </Button>
+              </>
+            ) : (
+              <>
+                {angle !== undefined && <AngleSelector boardName={boardDetails.board_name} currentAngle={angle} currentClimb={currentClimb} />}
 
-            {/* Mobile: meatball menu for Create Climb and Login */}
-            {mobileMenuItems.length > 0 && (
-              <div className={styles.mobileMenuButton}>
-                <Dropdown menu={{ items: mobileMenuItems }} placement="bottomRight" trigger={['click']}>
-                  <Button icon={<MoreOutlined />} type="default" />
-                </Dropdown>
-              </div>
+                {/* Desktop: show Create Climb button */}
+                {createClimbUrl && (
+                  <div className={styles.desktopOnly}>
+                    <Link href={createClimbUrl}>
+                      <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
+                    </Link>
+                  </div>
+                )}
+
+                <ShareBoardButton />
+                <SendClimbToBoardButton boardDetails={boardDetails} />
+
+                {/* Desktop: User menu or login button */}
+                <div className={styles.desktopOnly}>
+                  {session?.user ? (
+                    <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
+                      <Button icon={<UserOutlined />} type="text">
+                        {session.user.name || session.user.email}
+                      </Button>
+                    </Dropdown>
+                  ) : (
+                    <Button
+                      icon={<LoginOutlined />}
+                      type="text"
+                      onClick={() => setShowAuthModal(true)}
+                    >
+                      Login
+                    </Button>
+                  )}
+                </div>
+
+                {/* Mobile: meatball menu for Create Climb and Login */}
+                {mobileMenuItems.length > 0 && (
+                  <div className={styles.mobileMenuButton}>
+                    <Dropdown menu={{ items: mobileMenuItems }} placement="bottomRight" trigger={['click']}>
+                      <Button icon={<MoreOutlined />} type="default" />
+                    </Dropdown>
+                  </div>
+                )}
+              </>
             )}
           </Flex>
         </Flex>

--- a/packages/web/app/components/create-climb/create-climb-context.tsx
+++ b/packages/web/app/components/create-climb/create-climb-context.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+interface CreateClimbContextValue {
+  // State
+  canPublish: boolean;
+  isPublishing: boolean;
+  // Actions
+  onPublish: () => void;
+  onCancel: () => void;
+  // Registration (called by form to set up the actions)
+  registerActions: (actions: { onPublish: () => void; onCancel: () => void }) => void;
+  setCanPublish: (can: boolean) => void;
+  setIsPublishing: (is: boolean) => void;
+}
+
+const CreateClimbContext = createContext<CreateClimbContextValue | null>(null);
+
+export function CreateClimbProvider({ children }: { children: ReactNode }) {
+  const [canPublish, setCanPublish] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [actions, setActions] = useState<{ onPublish: () => void; onCancel: () => void }>({
+    onPublish: () => {},
+    onCancel: () => {},
+  });
+
+  const registerActions = useCallback((newActions: { onPublish: () => void; onCancel: () => void }) => {
+    setActions(newActions);
+  }, []);
+
+  return (
+    <CreateClimbContext.Provider
+      value={{
+        canPublish,
+        isPublishing,
+        onPublish: actions.onPublish,
+        onCancel: actions.onCancel,
+        registerActions,
+        setCanPublish,
+        setIsPublishing,
+      }}
+    >
+      {children}
+    </CreateClimbContext.Provider>
+  );
+}
+
+export function useCreateClimbContext() {
+  const context = useContext(CreateClimbContext);
+  return context;
+}

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -6,6 +6,7 @@
   flex-direction: column;
   overflow: hidden;
   touch-action: pan-y pinch-zoom;
+  background-color: var(--semantic-background, #F9FAFB);
 }
 
 /* Auth alert styling */
@@ -28,6 +29,7 @@
 .climbTitleContainer {
   width: 100%;
   flex-shrink: 0;
+  padding: 4px 12px;
 }
 
 /* Editable title styling */
@@ -47,6 +49,39 @@
 .editableTitle:focus {
   outline: none;
   background-color: rgba(0, 0, 0, 0.04);
+}
+
+/* Title wrapper for flex content */
+.titleWrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Title input when editing */
+.titleInput {
+  flex: 1;
+}
+
+/* Title text styling */
+.titleText {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Edit icon next to title */
+.editIcon {
+  font-size: 12px;
+  color: #9CA3AF;
+  margin-left: 4px;
+}
+
+/* Draft label */
+.draftLabel {
+  font-size: 12px;
+  font-weight: 400;
 }
 
 /* Board container - fills remaining space like play view */
@@ -84,6 +119,10 @@
   .holdCountsBar {
     padding: 6px 8px;
     gap: 6px;
+  }
+
+  .climbTitleContainer {
+    padding: 4px 8px;
   }
 }
 

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -8,17 +8,6 @@
   touch-action: pan-y pinch-zoom;
 }
 
-/* Header bar with cancel and publish buttons */
-.headerBar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 12px;
-  flex-shrink: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-  background-color: #fff;
-}
-
 /* Auth alert styling */
 .authAlert {
   margin: 8px 12px;
@@ -88,10 +77,6 @@
 
 /* Mobile adjustments */
 @media (max-width: 767px) {
-  .headerBar {
-    padding: 6px 8px;
-  }
-
   .authAlert {
     margin: 6px 8px;
   }

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -6,6 +6,7 @@
   flex-direction: column;
   overflow: hidden;
   touch-action: pan-y pinch-zoom;
+  /* semantic.background = neutral-50 */
   background-color: var(--semantic-background, #F9FAFB);
 }
 
@@ -43,12 +44,14 @@
 }
 
 .editableTitle:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  /* semantic.selectedLight */
+  background-color: rgba(6, 182, 212, 0.08);
 }
 
 .editableTitle:focus {
   outline: none;
-  background-color: rgba(0, 0, 0, 0.04);
+  /* semantic.selectedLight */
+  background-color: rgba(6, 182, 212, 0.08);
 }
 
 /* Title wrapper for flex content */
@@ -74,6 +77,7 @@
 /* Edit icon next to title */
 .editIcon {
   font-size: 12px;
+  /* neutral-400 */
   color: #9CA3AF;
   margin-left: 4px;
 }
@@ -86,10 +90,12 @@
 
 /* Settings button next to title */
 .settingsButton {
+  /* neutral-400 */
   color: #9CA3AF;
 }
 
 .settingsButton:hover {
+  /* neutral-500 */
   color: #6B7280;
 }
 
@@ -115,6 +121,7 @@
   right: 0;
   bottom: 0;
   padding: 12px;
+  /* semantic.surfaceOverlay */
   background-color: rgba(255, 255, 255, 0.95);
   overflow: auto;
   z-index: 10;
@@ -149,7 +156,9 @@
   justify-content: center;
   padding: 8px 12px;
   flex-shrink: 0;
-  background-color: #fff;
+  /* semantic.surface */
+  background-color: #FFFFFF;
+  /* neutral-100 with low opacity */
   border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,119 +1,111 @@
-/* Create Climb Form Styles */
+/* Create Climb Form Styles - matches play view layout */
 
 .pageContainer {
-  padding: 16px;
-  min-height: 100vh;
-  background-color: #F9FAFB;
-  max-width: 1200px;
-  margin: 0 auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  touch-action: pan-y pinch-zoom;
 }
 
-/* Board section - white card container */
-.boardSection {
-  background-color: #FFFFFF;
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 16px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+/* Header bar with cancel and publish buttons */
+.headerBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  flex-shrink: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  background-color: #fff;
 }
 
-/* Hold counts row */
-.holdCounts {
+/* Auth alert styling */
+.authAlert {
+  margin: 8px 12px;
+  flex-shrink: 0;
+}
+
+/* Content wrapper - matches play view */
+.contentWrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  min-height: 0;
+}
+
+/* Title container - same position as play view */
+.climbTitleContainer {
+  width: 100%;
+  flex-shrink: 0;
+}
+
+/* Editable title styling */
+.editableTitle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.editableTitle:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.editableTitle:focus {
+  outline: none;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+/* Board container - fills remaining space like play view */
+.boardContainer {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0;
+  min-height: 0;
+  max-height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+/* Hold counts bar at bottom */
+.holdCountsBar {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: 16px;
-}
-
-/* Form section - white card container */
-.formSection {
-  background-color: #FFFFFF;
-  border-radius: 12px;
-  padding: 16px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-}
-
-.formContent {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* Button group at bottom of form */
-.buttonGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 8px;
-}
-
-/* Beta banner */
-.betaBanner {
-  margin-bottom: 16px;
-}
-
-/* Auth alert */
-.authAlert {
-  margin-bottom: 16px;
+  justify-content: center;
+  padding: 8px 12px;
+  flex-shrink: 0;
+  background-color: #fff;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 /* Mobile adjustments */
 @media (max-width: 767px) {
-  .pageContainer {
-    padding: 12px;
+  .headerBar {
+    padding: 6px 8px;
   }
 
-  .boardSection,
-  .formSection {
-    padding: 12px;
-    border-radius: 8px;
-    margin-bottom: 12px;
+  .authAlert {
+    margin: 6px 8px;
   }
 
-  .formSection {
-    margin-bottom: 0;
-  }
-
-  .holdCounts {
-    margin-top: 12px;
-  }
-
-  .betaBanner {
-    margin-bottom: 12px;
+  .holdCountsBar {
+    padding: 6px 8px;
+    gap: 6px;
   }
 }
 
-/* Desktop layout */
-@media (min-width: 992px) {
-  .pageContainer {
-    padding: 24px;
-  }
-
-  .boardSection,
-  .formSection {
-    padding: 20px;
-  }
-
-  .contentWrapper {
-    display: flex;
-    gap: 24px;
-  }
-
-  .boardSection {
-    flex: 2;
-    margin-bottom: 0;
-  }
-
-  .formSection {
-    flex: 1;
-    max-width: 400px;
-    position: sticky;
-    top: 24px;
-    align-self: flex-start;
-  }
-
-  .buttonGroup {
-    margin-top: 16px;
+/* Desktop adjustments */
+@media (min-width: 768px) {
+  .boardContainer {
+    max-width: 600px;
+    margin: 0 auto;
   }
 }

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -84,6 +84,15 @@
   font-weight: 400;
 }
 
+/* Settings button next to title */
+.settingsButton {
+  color: #9CA3AF;
+}
+
+.settingsButton:hover {
+  color: #6B7280;
+}
+
 /* Board container - fills remaining space like play view */
 .boardContainer {
   flex: 1;
@@ -95,6 +104,40 @@
   max-height: 100%;
   width: 100%;
   overflow: hidden;
+  position: relative;
+}
+
+/* Settings overlay panel */
+.settingsPanel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 12px;
+  background-color: rgba(255, 255, 255, 0.95);
+  overflow: auto;
+  z-index: 10;
+}
+
+.settingsPanelHeader {
+  margin-bottom: 12px;
+}
+
+.settingsPanelContent {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settingsField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settingsLabel {
+  font-size: 12px;
 }
 
 /* Hold counts bar at bottom */

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -14,7 +14,6 @@ import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import AuthModal from '../auth/auth-modal';
 import { useCreateClimbContext } from './create-climb-context';
-import { themeTokens } from '@/app/theme/theme-config';
 import styles from './create-climb-form.module.css';
 
 const { Text } = Typography;
@@ -105,10 +104,12 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
   }, [climbName]);
 
   const handleSaveTitle = useCallback(() => {
-    if (editingName.trim()) {
-      setClimbName(editingName.trim());
+    const trimmedName = editingName.trim();
+    if (trimmedName) {
+      setClimbName(trimmedName);
     }
     setIsEditingTitle(false);
+    setEditingName('');
   }, [editingName]);
 
   const handleCancelEditTitle = useCallback(() => {
@@ -244,7 +245,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
   }, [createClimbContext, isSaving]);
 
   return (
-    <div className={styles.pageContainer} style={{ backgroundColor: themeTokens.semantic.background }}>
+    <div className={styles.pageContainer}>
       {/* Auth alerts */}
       {!isAuthenticated && (
         <Alert
@@ -279,15 +280,10 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
       {/* Main Content - matches play view layout */}
       <div className={styles.contentWrapper}>
         {/* Title section - same position as play view */}
-        <div
-          className={styles.climbTitleContainer}
-          style={{
-            padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[3]}px`,
-          }}
-        >
+        <div className={styles.climbTitleContainer}>
           <Flex gap={12} align="center">
             {/* Left side: Editable Name and draft toggle stacked */}
-            <Flex vertical gap={0} style={{ flex: 1, minWidth: 0 }}>
+            <Flex vertical gap={0} className={styles.titleWrapper}>
               {/* Row 1: Editable Title */}
               {isEditingTitle ? (
                 <Flex gap={4} align="center">
@@ -300,7 +296,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                     maxLength={100}
                     placeholder="Enter climb name"
                     size="small"
-                    style={{ flex: 1 }}
+                    className={styles.titleInput}
                   />
                   <Button
                     type="text"
@@ -323,35 +319,15 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                   tabIndex={0}
                   onKeyDown={(e) => e.key === 'Enter' && handleStartEditTitle()}
                 >
-                  <Text
-                    style={{
-                      fontSize: themeTokens.typography.fontSize.sm,
-                      fontWeight: themeTokens.typography.fontWeight.bold,
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
+                  <Text className={styles.titleText}>
                     {climbName || 'Tap to name your climb'}
                   </Text>
-                  <EditOutlined
-                    style={{
-                      fontSize: themeTokens.typography.fontSize.xs,
-                      color: themeTokens.neutral[400],
-                      marginLeft: 4,
-                    }}
-                  />
+                  <EditOutlined className={styles.editIcon} />
                 </div>
               )}
               {/* Row 2: Draft toggle */}
               <Flex gap={8} align="center">
-                <Text
-                  type="secondary"
-                  style={{
-                    fontSize: themeTokens.typography.fontSize.xs,
-                    fontWeight: themeTokens.typography.fontWeight.normal,
-                  }}
-                >
+                <Text type="secondary" className={styles.draftLabel}>
                   Draft
                 </Text>
                 <Switch

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -14,9 +14,11 @@ import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import AuthModal from '../auth/auth-modal';
 import { useCreateClimbContext } from './create-climb-context';
+import { themeTokens } from '@/app/theme/theme-config';
 import styles from './create-climb-form.module.css';
 
 const { Text } = Typography;
+const { TextArea } = Input;
 
 interface CreateClimbFormValues {
   name: string;
@@ -67,6 +69,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
   const [isDraft, setIsDraft] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editingName, setEditingName] = useState('');
+  const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   // Send frames to board whenever litUpHoldsMap changes and we're connected
@@ -218,8 +221,11 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
     router.push(listUrl);
   }, [boardDetails, angle, router]);
 
-  const boardNameCapitalized = boardDetails.board_name.charAt(0).toUpperCase() + boardDetails.board_name.slice(1);
   const canSave = isAuthenticated && hasAuroraCredentials && isValid && climbName.trim().length > 0;
+
+  const handleToggleSettings = useCallback(() => {
+    setShowSettingsPanel((prev) => !prev);
+  }, []);
 
   // Register actions with context for header to use
   useEffect(() => {
@@ -262,21 +268,6 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
         />
       )}
 
-      {isAuthenticated && !hasAuroraCredentials && (
-        <Alert
-          message={`Link your ${boardNameCapitalized} account`}
-          description={`Link your ${boardNameCapitalized} Board account in Settings to save climbs.`}
-          type="warning"
-          showIcon
-          className={styles.authAlert}
-          action={
-            <Button size="small" icon={<SettingOutlined />} onClick={() => router.push('/settings')}>
-              Settings
-            </Button>
-          }
-        />
-      )}
-
       {/* Main Content - matches play view layout */}
       <div className={styles.contentWrapper}>
         {/* Title section - same position as play view */}
@@ -312,18 +303,27 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                   />
                 </Flex>
               ) : (
-                <div
-                  className={styles.editableTitle}
-                  onClick={handleStartEditTitle}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => e.key === 'Enter' && handleStartEditTitle()}
-                >
-                  <Text className={styles.titleText}>
-                    {climbName || 'Tap to name your climb'}
-                  </Text>
-                  <EditOutlined className={styles.editIcon} />
-                </div>
+                <Flex gap={4} align="center">
+                  <div
+                    className={styles.editableTitle}
+                    onClick={handleStartEditTitle}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => e.key === 'Enter' && handleStartEditTitle()}
+                  >
+                    <Text className={styles.titleText}>
+                      {climbName || 'Tap to name your climb'}
+                    </Text>
+                    <EditOutlined className={styles.editIcon} />
+                  </div>
+                  <Button
+                    type="text"
+                    icon={showSettingsPanel ? <CloseOutlined /> : <SettingOutlined />}
+                    size="small"
+                    onClick={handleToggleSettings}
+                    className={styles.settingsButton}
+                  />
+                </Flex>
               )}
               {/* Row 2: Draft toggle */}
               <Flex gap={8} align="center">
@@ -349,6 +349,33 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
             onHoldClick={handleHoldClick}
             fillHeight
           />
+
+          {/* Settings overlay panel */}
+          {showSettingsPanel && (
+            <div
+              className={styles.settingsPanel}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className={styles.settingsPanelHeader}>
+                <Text strong>Climb Settings</Text>
+              </div>
+              <div className={styles.settingsPanelContent}>
+                <div className={styles.settingsField}>
+                  <Text type="secondary" className={styles.settingsLabel}>
+                    Description (optional)
+                  </Text>
+                  <TextArea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Add beta or notes about your climb..."
+                    rows={3}
+                    maxLength={500}
+                    showCount
+                  />
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Hold counts bar at bottom */}

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -226,7 +226,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
           Cancel
         </Button>
         <Flex gap={8} align="center">
-          <ExperimentOutlined style={{ color: themeTokens.colors.info }} title="Beta Feature" />
+          <ExperimentOutlined style={{ color: themeTokens.colors.primary }} title="Beta Feature" />
           <Button
             type="primary"
             onClick={handlePublish}

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -383,11 +383,9 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
           <Tag color={startingCount > 0 ? 'green' : 'default'}>Starting: {startingCount}/2</Tag>
           <Tag color={finishCount > 0 ? 'magenta' : 'default'}>Finish: {finishCount}/2</Tag>
           <Tag color={totalHolds > 0 ? 'blue' : 'default'}>Total: {totalHolds}</Tag>
-          {totalHolds > 0 && (
-            <Button size="small" onClick={resetHolds}>
-              Clear All
-            </Button>
-          )}
+          <Button size="small" onClick={resetHolds} disabled={totalHolds === 0}>
+            Clear All
+          </Button>
         </div>
       </div>
 


### PR DESCRIPTION
- Restructure layout to match play view (title at top, board fills space)
- Add editable title that shows as clickable text, becomes input on tap
- Move draft toggle to second header line below title
- Move publish button to header bar with cancel button
- Update CSS to use flexbox layout matching play view styling