### PR TITLE
fix: Add missing onlyTallClimbs parameter to GraphQL search API

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -53,6 +53,7 @@ export const climbQueries = {
       sortOrder: input.sortOrder ?? 'desc',
       name: input.name,
       settername: input.setter && input.setter.length > 0 ? input.setter : undefined,
+      onlyTallClimbs: input.onlyTallClimbs,
       hideAttempted: input.hideAttempted,
       hideCompleted: input.hideCompleted,
       showOnlyAttempted: input.showOnlyAttempted,

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -153,6 +153,7 @@ export const typeDefs = /* GraphQL */ `
     setter: [String!]
     setterId: Int
     onlyBenchmarks: Boolean
+    onlyTallClimbs: Boolean
     # Personal progress filters (require auth)
     hideAttempted: Boolean
     hideCompleted: Boolean

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -81,6 +81,7 @@ export const useQueueDataFetching = ({
         sortOrder: searchParams.sortOrder || 'desc',
         name: searchParams.name || undefined,
         setter: searchParams.settername && searchParams.settername.length > 0 ? searchParams.settername : undefined,
+        onlyTallClimbs: searchParams.onlyTallClimbs || undefined,
         hideAttempted: searchParams.hideAttempted || undefined,
         hideCompleted: searchParams.hideCompleted || undefined,
         showOnlyAttempted: searchParams.showOnlyAttempted || undefined,

--- a/packages/web/app/lib/graphql/operations/climb-search.ts
+++ b/packages/web/app/lib/graphql/operations/climb-search.ts
@@ -73,6 +73,7 @@ export interface ClimbSearchInputVariables {
     sortOrder?: string;
     name?: string;
     setter?: string[];
+    onlyTallClimbs?: boolean;
     hideAttempted?: boolean;
     hideCompleted?: boolean;
     showOnlyAttempted?: boolean;


### PR DESCRIPTION
The "Tall Climbs Only" filter for Kilter Homewall was not working because the onlyTallClimbs parameter was missing from:
- GraphQL ClimbSearchInput schema
- Backend resolver's searchParams object
- Client-side ClimbSearchInputVariables type
- use-queue-data-fetching hook's input object

This fix adds the parameter at all four levels so the filter is properly passed from the UI through to the database query.