### PR TITLE
feat: Add heatmap flame button to create climb header

### DIFF
--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -99,6 +99,23 @@
   color: #6B7280;
 }
 
+/* Heatmap button next to title */
+.heatmapButton {
+  /* neutral-400 */
+  color: #9CA3AF;
+}
+
+.heatmapButton:hover {
+  /* neutral-500 */
+  color: #6B7280;
+}
+
+/* Opacity slider for heatmap */
+.opacitySlider {
+  width: 80px;
+  margin: 0;
+}
+
 /* Board container - fills remaining space like play view */
 .boardContainer {
   flex: 1;
@@ -175,6 +192,10 @@
 
   .climbTitleContainer {
     padding: 4px 8px;
+  }
+
+  .opacitySlider {
+    width: 60px;
   }
 }
 

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -130,6 +130,15 @@
   position: relative;
 }
 
+/* Wrapper for board and heatmap overlay - ensures overlay aligns with board */
+.boardWrapper {
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
 /* Settings overlay panel */
 .settingsPanel {
   position: absolute;

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -375,20 +375,22 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
 
         {/* Board section - fills remaining space like play view */}
         <div className={styles.boardContainer}>
-          <BoardRenderer
-            boardDetails={boardDetails}
-            litUpHoldsMap={litUpHoldsMap}
-            mirrored={false}
-            onHoldClick={handleHoldClick}
-            fillHeight
-          />
-          <CreateClimbHeatmapOverlay
-            boardDetails={boardDetails}
-            angle={angle}
-            litUpHoldsMap={litUpHoldsMap}
-            opacity={heatmapOpacity}
-            enabled={showHeatmap}
-          />
+          <div className={styles.boardWrapper}>
+            <BoardRenderer
+              boardDetails={boardDetails}
+              litUpHoldsMap={litUpHoldsMap}
+              mirrored={false}
+              onHoldClick={handleHoldClick}
+              fillHeight
+            />
+            <CreateClimbHeatmapOverlay
+              boardDetails={boardDetails}
+              angle={angle}
+              litUpHoldsMap={litUpHoldsMap}
+              opacity={heatmapOpacity}
+              enabled={showHeatmap}
+            />
+          </div>
 
           {/* Settings overlay panel */}
           {showSettingsPanel && (

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Input, Switch, Button, Typography, Tag, Alert, Flex } from 'antd';
+import { Input, Switch, Button, Typography, Tag, Alert, Flex, Slider, Tooltip } from 'antd';
 import type { InputRef } from 'antd';
-import { SettingOutlined, EditOutlined, CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import { SettingOutlined, EditOutlined, CheckOutlined, CloseOutlined, FireOutlined } from '@ant-design/icons';
 import { useRouter } from 'next/navigation';
 import { track } from '@vercel/analytics';
 import BoardRenderer from '../board-renderer/board-renderer';
@@ -15,7 +15,7 @@ import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import AuthModal from '../auth/auth-modal';
 import { useCreateClimbContext } from './create-climb-context';
-import { themeTokens } from '@/app/theme/theme-config';
+import CreateClimbHeatmapOverlay from './create-climb-heatmap-overlay';
 import styles from './create-climb-form.module.css';
 
 const { Text } = Typography;
@@ -63,6 +63,8 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
   const [isSaving, setIsSaving] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [pendingFormValues, setPendingFormValues] = useState<CreateClimbFormValues | null>(null);
+  const [showHeatmap, setShowHeatmap] = useState(false);
+  const [heatmapOpacity, setHeatmapOpacity] = useState(0.7);
 
   // Editable title state
   const [climbName, setClimbName] = useState(forkName ? `${forkName} fork` : '');
@@ -224,6 +226,15 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
     setShowSettingsPanel((prev) => !prev);
   }, []);
 
+  const handleToggleHeatmap = useCallback(() => {
+    setShowHeatmap((prev) => {
+      track(`Create Climb Heatmap ${!prev ? 'Shown' : 'Hidden'}`, {
+        boardLayout: boardDetails.layout_name || '',
+      });
+      return !prev;
+    });
+  }, [boardDetails.layout_name]);
+
   // Register actions with context for header to use
   useEffect(() => {
     if (createClimbContext) {
@@ -313,6 +324,16 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                     </Text>
                     <EditOutlined className={styles.editIcon} />
                   </div>
+                  <Tooltip title={showHeatmap ? 'Hide heatmap' : 'Show hold popularity heatmap'}>
+                    <Button
+                      type={showHeatmap ? 'primary' : 'text'}
+                      icon={<FireOutlined />}
+                      size="small"
+                      onClick={handleToggleHeatmap}
+                      danger={showHeatmap}
+                      className={styles.heatmapButton}
+                    />
+                  </Tooltip>
                   <Button
                     type="text"
                     icon={showSettingsPanel ? <CloseOutlined /> : <SettingOutlined />}
@@ -322,7 +343,7 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                   />
                 </Flex>
               )}
-              {/* Row 2: Draft toggle */}
+              {/* Row 2: Draft toggle and heatmap opacity */}
               <Flex gap={8} align="center">
                 <Text type="secondary" className={styles.draftLabel}>
                   Draft
@@ -332,6 +353,21 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
                   checked={isDraft}
                   onChange={setIsDraft}
                 />
+                {showHeatmap && (
+                  <>
+                    <Text type="secondary" className={styles.draftLabel}>
+                      Opacity
+                    </Text>
+                    <Slider
+                      min={0.1}
+                      max={1}
+                      step={0.1}
+                      value={heatmapOpacity}
+                      onChange={setHeatmapOpacity}
+                      className={styles.opacitySlider}
+                    />
+                  </>
+                )}
               </Flex>
             </Flex>
           </Flex>
@@ -345,6 +381,13 @@ export default function CreateClimbForm({ boardDetails, angle, forkFrames, forkN
             mirrored={false}
             onHoldClick={handleHoldClick}
             fillHeight
+          />
+          <CreateClimbHeatmapOverlay
+            boardDetails={boardDetails}
+            angle={angle}
+            litUpHoldsMap={litUpHoldsMap}
+            opacity={heatmapOpacity}
+            enabled={showHeatmap}
           />
 
           {/* Settings overlay panel */}

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { BoardDetails } from '@/app/lib/types';
+import { BoardDetails, SearchRequestPagination } from '@/app/lib/types';
 import { HeatmapData, LitUpHoldsMap, HoldState } from '../board-renderer/types';
 import { scaleLog } from 'd3-scale';
 import useHeatmapData from '../search-drawer/use-heatmap';
@@ -52,14 +52,20 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     return types;
   }, [litUpHoldsMap]);
 
-  // Fetch heatmap data - use empty filters to get all data
+  // Create filters that include the selected holds - this triggers refetch when holds change
+  const filters: SearchRequestPagination = useMemo(() => ({
+    ...DEFAULT_SEARCH_PARAMS,
+    holdsFilter: litUpHoldsMap,
+  }), [litUpHoldsMap]);
+
+  // Fetch heatmap data with holds filter
   const { data: heatmapData = [], loading } = useHeatmapData({
     boardName: boardDetails.board_name,
     layoutId: boardDetails.layout_id,
     sizeId: boardDetails.size_id,
     setIds: boardDetails.set_ids.join(','),
     angle,
-    filters: DEFAULT_SEARCH_PARAMS,
+    filters,
     enabled,
   });
 

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -9,6 +9,9 @@ import useHeatmapData from '../search-drawer/use-heatmap';
 const BLUR_RADIUS = 10;
 const HEAT_RADIUS_MULTIPLIER = 2;
 
+// Stable empty filters object to avoid re-fetching on every render
+const EMPTY_FILTERS = {} as SearchRequestPagination;
+
 // Color palette for heatmap
 const HEATMAP_COLORS = [
   '#4caf50', // Light green
@@ -58,7 +61,7 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     sizeId: boardDetails.size_id,
     setIds: boardDetails.set_ids.join(','),
     angle,
-    filters: {} as SearchRequestPagination,
+    filters: EMPTY_FILTERS,
     enabled,
   });
 

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -143,11 +143,6 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     };
   }, [heatmapData, litUpHoldsMap, getValue]);
 
-  // Don't render if not enabled or still loading
-  if (!enabled || loading) {
-    return null;
-  }
-
   // Guard against missing data
   if (!holdsData || holdsData.length === 0) {
     return null;
@@ -156,6 +151,9 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
   // Use unique filter IDs to avoid conflicts with other SVGs on the page
   const blurFilterId = 'create-climb-heatmap-blur';
   const sharpFilterId = 'create-climb-heatmap-sharp';
+
+  // Always render the SVG container to prevent layout shifts, but hide content when not enabled or loading
+  const showContent = enabled && !loading;
 
   return (
     <svg
@@ -168,7 +166,8 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
         width: '100%',
         height: '100%',
         pointerEvents: 'none',
-        opacity,
+        opacity: showContent ? opacity : 0,
+        visibility: showContent ? 'visible' : 'hidden',
       }}
     >
       <defs>

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { BoardDetails } from '@/app/lib/types';
+import { HeatmapData, LitUpHoldsMap, HoldState } from '../board-renderer/types';
+import { scaleLog } from 'd3-scale';
+import useHeatmapData from '../search-drawer/use-heatmap';
+
+const BLUR_RADIUS = 10;
+const HEAT_RADIUS_MULTIPLIER = 2;
+
+// Color palette for heatmap
+const HEATMAP_COLORS = [
+  '#4caf50', // Light green
+  '#8bc34a', // Lime green
+  '#cddc39', // Lime
+  '#ffeb3b', // Yellow
+  '#ffc107', // Amber
+  '#ff9800', // Orange
+  '#ff7043', // Deep Orange
+  '#ff5722', // Darker Orange
+  '#f44336', // Light Red
+  '#d32f2f', // Deep Red
+];
+
+interface CreateClimbHeatmapOverlayProps {
+  boardDetails: BoardDetails;
+  angle: number;
+  litUpHoldsMap: LitUpHoldsMap;
+  opacity: number;
+  enabled: boolean;
+}
+
+const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
+  boardDetails,
+  angle,
+  litUpHoldsMap,
+  opacity,
+  enabled,
+}) => {
+  const { boardWidth, boardHeight, holdsData } = boardDetails;
+
+  // Determine which hold types are currently selected to auto-select heatmap mode
+  const selectedHoldTypes = useMemo(() => {
+    const types = new Set<HoldState>();
+    Object.values(litUpHoldsMap).forEach((hold) => {
+      if (hold.state !== 'OFF') {
+        types.add(hold.state);
+      }
+    });
+    return types;
+  }, [litUpHoldsMap]);
+
+  // Fetch heatmap data
+  const { data: heatmapData = [], loading } = useHeatmapData({
+    boardName: boardDetails.board_name,
+    layoutId: boardDetails.layout_id,
+    sizeId: boardDetails.size_id,
+    setIds: boardDetails.set_ids.join(','),
+    angle,
+    filters: {}, // No additional filters
+    enabled,
+  });
+
+  const heatmapMap = useMemo(
+    () => new Map(heatmapData?.map((data) => [data.holdId, data]) || []),
+    [heatmapData],
+  );
+
+  // Get value based on the selected hold types
+  const getValue = (data: HeatmapData | undefined): number => {
+    if (!data) return 0;
+
+    // If specific hold types are selected, sum up their usage
+    if (selectedHoldTypes.size > 0) {
+      let total = 0;
+      if (selectedHoldTypes.has('STARTING')) total += data.startingUses;
+      if (selectedHoldTypes.has('HAND')) total += data.handUses;
+      if (selectedHoldTypes.has('FOOT')) total += data.footUses;
+      if (selectedHoldTypes.has('FINISH')) total += data.finishUses;
+      return total || data.totalUses; // Fallback to total if no specific types
+    }
+
+    // Default to total uses
+    return data.totalUses;
+  };
+
+  // Create color and opacity scales
+  const { colorScale, opacityScale } = useMemo(() => {
+    const values = heatmapData
+      .filter((data) => !litUpHoldsMap?.[data.holdId])
+      .map((data) => getValue(data))
+      .filter((val) => val && val >= 1)
+      .sort((a, b) => a - b);
+
+    if (values.length === 0) {
+      return {
+        colorScale: () => 'transparent',
+        opacityScale: () => 0,
+      };
+    }
+
+    const min = Math.max(1, values[0]);
+    const max = values[values.length - 1];
+
+    // Use log scale for better distribution
+    const logScale = scaleLog()
+      .domain([min, max])
+      .range([0, HEATMAP_COLORS.length - 1])
+      .clamp(true);
+
+    return {
+      colorScale: (value: number) => {
+        if (!value || value < 1) return 'transparent';
+        const index = Math.floor(logScale(value));
+        return HEATMAP_COLORS[index];
+      },
+      opacityScale: (value: number) => {
+        if (!value || value < 1) return 0;
+        return Math.max(0.3, Math.min(0.8, logScale(value) / HEATMAP_COLORS.length));
+      },
+    };
+  }, [heatmapData, litUpHoldsMap, selectedHoldTypes]);
+
+  if (!enabled || loading) {
+    return null;
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${boardWidth} ${boardHeight}`}
+      preserveAspectRatio="xMidYMid meet"
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        opacity,
+      }}
+    >
+      <defs>
+        <filter id="create-climb-blur">
+          <feGaussianBlur stdDeviation={BLUR_RADIUS} />
+        </filter>
+        <filter id="create-climb-blur-sharp">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="20" />
+        </filter>
+      </defs>
+
+      {/* Blurred background layer */}
+      <g filter="url(#create-climb-blur)">
+        {holdsData.map((hold) => {
+          // Skip holds that are already selected
+          if (litUpHoldsMap[hold.id]) return null;
+
+          const data = heatmapMap.get(hold.id);
+          const value = getValue(data);
+
+          if (value === 0 || value < 1) return null;
+
+          return (
+            <circle
+              key={`heat-blur-${hold.id}`}
+              cx={hold.cx}
+              cy={hold.cy}
+              r={hold.r * HEAT_RADIUS_MULTIPLIER}
+              fill={colorScale(value)}
+              opacity={opacityScale(value) * 0.5}
+            />
+          );
+        })}
+      </g>
+
+      {/* Sharp circles */}
+      {holdsData.map((hold) => {
+        // Skip holds that are already selected
+        if (litUpHoldsMap[hold.id]) return null;
+
+        const data = heatmapMap.get(hold.id);
+        const value = getValue(data);
+
+        if (value < 1) return null;
+
+        return (
+          <circle
+            key={`heat-sharp-${hold.id}`}
+            cx={hold.cx}
+            cy={hold.cy}
+            r={hold.r}
+            fill={colorScale(value)}
+            opacity={opacityScale(value)}
+            filter="url(#create-climb-blur-sharp)"
+          />
+        );
+      })}
+    </svg>
+  );
+};
+
+export default CreateClimbHeatmapOverlay;

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { BoardDetails, SearchRequestPagination } from '@/app/lib/types';
+import { BoardDetails } from '@/app/lib/types';
 import { HeatmapData, LitUpHoldsMap, HoldState } from '../board-renderer/types';
 import { scaleLog } from 'd3-scale';
 import useHeatmapData from '../search-drawer/use-heatmap';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 
 const BLUR_RADIUS = 10;
 const HEAT_RADIUS_MULTIPLIER = 2;
-
-// Stable empty filters object to avoid re-fetching on every render
-const EMPTY_FILTERS = {} as SearchRequestPagination;
 
 // Color palette for heatmap
 const HEATMAP_COLORS = [
@@ -61,7 +59,7 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     sizeId: boardDetails.size_id,
     setIds: boardDetails.set_ids.join(','),
     angle,
-    filters: EMPTY_FILTERS,
+    filters: DEFAULT_SEARCH_PARAMS,
     enabled,
   });
 

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { BoardDetails } from '@/app/lib/types';
+import { BoardDetails, SearchRequestPagination } from '@/app/lib/types';
 import { HeatmapData, LitUpHoldsMap, HoldState } from '../board-renderer/types';
 import { scaleLog } from 'd3-scale';
 import useHeatmapData from '../search-drawer/use-heatmap';
@@ -51,14 +51,14 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     return types;
   }, [litUpHoldsMap]);
 
-  // Fetch heatmap data
+  // Fetch heatmap data - use empty filters to get all data
   const { data: heatmapData = [], loading } = useHeatmapData({
     boardName: boardDetails.board_name,
     layoutId: boardDetails.layout_id,
     sizeId: boardDetails.size_id,
     setIds: boardDetails.set_ids.join(','),
     angle,
-    filters: {}, // No additional filters
+    filters: {} as SearchRequestPagination,
     enabled,
   });
 

--- a/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
+++ b/packages/web/app/components/create-climb/create-climb-heatmap-overlay.tsx
@@ -127,9 +127,19 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
     };
   }, [heatmapData, litUpHoldsMap, getValue]);
 
+  // Don't render if not enabled or still loading
   if (!enabled || loading) {
     return null;
   }
+
+  // Guard against missing data
+  if (!holdsData || holdsData.length === 0) {
+    return null;
+  }
+
+  // Use unique filter IDs to avoid conflicts with other SVGs on the page
+  const blurFilterId = 'create-climb-heatmap-blur';
+  const sharpFilterId = 'create-climb-heatmap-sharp';
 
   return (
     <svg
@@ -146,16 +156,16 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
       }}
     >
       <defs>
-        <filter id="create-climb-blur">
+        <filter id={blurFilterId}>
           <feGaussianBlur stdDeviation={BLUR_RADIUS} />
         </filter>
-        <filter id="create-climb-blur-sharp">
+        <filter id={sharpFilterId}>
           <feGaussianBlur in="SourceGraphic" stdDeviation="20" />
         </filter>
       </defs>
 
       {/* Blurred background layer */}
-      <g filter="url(#create-climb-blur)">
+      <g filter={`url(#${blurFilterId})`}>
         {holdsData.map((hold) => {
           // Skip holds that are already selected
           if (litUpHoldsMap[hold.id]) return null;
@@ -196,7 +206,7 @@ const CreateClimbHeatmapOverlay: React.FC<CreateClimbHeatmapOverlayProps> = ({
             r={hold.r}
             fill={colorScale(value)}
             opacity={opacityScale(value)}
-            filter="url(#create-climb-blur-sharp)"
+            filter={`url(#${sharpFilterId})`}
           />
         );
       })}

--- a/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
+++ b/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
@@ -3,6 +3,7 @@ import { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/t
 import { TableSet } from '@/lib/db/queries/util/table-select';
 import { getTableName } from '@/app/lib/data-sync/aurora/getTableName';
 import { SizeEdges } from '@/app/lib/__generated__/product-sizes-data';
+import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 
 /**
  * Creates a shared filtering object that can be used by both search climbs and heatmap queries
@@ -19,6 +20,10 @@ export const createClimbFilters = (
   sizeEdges: SizeEdges,
   userId?: number,
 ) => {
+  // Defense in depth: validate board_name before using in SQL queries
+  if (!SUPPORTED_BOARDS.includes(params.board_name)) {
+    throw new Error(`Invalid board name: ${params.board_name}`);
+  }
   // Process hold filters
   // holdsFilter can have values like:
   // - 'ANY': hold must be present in the climb

--- a/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
+++ b/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
@@ -20,13 +20,27 @@ export const createClimbFilters = (
   userId?: number,
 ) => {
   // Process hold filters
-  const holdsToFilter = Object.entries(searchParams.holdsFilter || {}).map(([key, state]) => [
-    key.replace('hold_', ''),
-    state,
-  ]);
+  // holdsFilter can have values like:
+  // - 'ANY': hold must be present in the climb
+  // - 'NOT': hold must NOT be present in the climb
+  // - { state: 'STARTING' | 'HAND' | 'FOOT' | 'FINISH' }: hold must be present with that specific state
+  // - 'STARTING' | 'HAND' | 'FOOT' | 'FINISH': (after URL parsing) same as above
+  const holdsToFilter = Object.entries(searchParams.holdsFilter || {}).map(([key, stateOrValue]) => {
+    const holdId = key.replace('hold_', '');
+    // Handle both object form { state: 'STARTING' } and string form 'STARTING' (after URL parsing)
+    const state = typeof stateOrValue === 'object' && stateOrValue !== null
+      ? (stateOrValue as { state: string }).state
+      : stateOrValue;
+    return [holdId, state] as const;
+  });
 
   const anyHolds = holdsToFilter.filter(([, value]) => value === 'ANY').map(([key]) => Number(key));
   const notHolds = holdsToFilter.filter(([, value]) => value === 'NOT').map(([key]) => Number(key));
+
+  // Hold state filters - hold must be present with specific state (STARTING, HAND, FOOT, FINISH)
+  const holdStateFilters = holdsToFilter
+    .filter(([, value]) => ['STARTING', 'HAND', 'FOOT', 'FINISH'].includes(value as string))
+    .map(([key, state]) => ({ holdId: Number(key), state: state as string }));
 
   // Base conditions for filtering climbs that don't reference the product sizes table
   const baseConditions: SQL[] = [
@@ -89,6 +103,17 @@ export const createClimbFilters = (
     ...anyHolds.map((holdId) => like(tables.climbs.frames, `%${holdId}r%`)),
     ...notHolds.map((holdId) => notLike(tables.climbs.frames, `%${holdId}r%`)),
   ];
+
+  // State-specific hold conditions - use climb_holds table to filter by hold_id AND hold_state
+  const climbHoldsTable = getTableName(params.board_name, 'climb_holds');
+  const holdStateConditions: SQL[] = holdStateFilters.map(({ holdId, state }) =>
+    sql`EXISTS (
+      SELECT 1 FROM ${sql.identifier(climbHoldsTable)} ch
+      WHERE ch.climb_uuid = ${tables.climbs.uuid}
+      AND ch.hold_id = ${holdId}
+      AND ch.hold_state = ${state}
+    )`
+  );
 
   // Tall climbs filter condition
   // Only applies for Kilter Homewall (layout_id = 8) on the largest size
@@ -213,7 +238,7 @@ export const createClimbFilters = (
 
   return {
     // Helper function to get all climb filtering conditions
-    getClimbWhereConditions: () => [...baseConditions, ...nameCondition, ...setterNameCondition, ...holdConditions, ...tallClimbsConditions, ...personalProgressConditions],
+    getClimbWhereConditions: () => [...baseConditions, ...nameCondition, ...setterNameCondition, ...holdConditions, ...holdStateConditions, ...tallClimbsConditions, ...personalProgressConditions],
 
     // Size-specific conditions
     getSizeConditions: () => sizeConditions,
@@ -245,10 +270,12 @@ export const createClimbFilters = (
     nameCondition,
     setterNameCondition,
     holdConditions,
+    holdStateConditions,
     tallClimbsConditions,
     sizeConditions,
     personalProgressConditions,
     anyHolds,
     notHolds,
+    holdStateFilters,
   };
 };


### PR DESCRIPTION
- Add flame button floated to the right of the title that toggles heatmap visibility
- Create CreateClimbHeatmapOverlay component that renders heatmap over the climb board
- Heatmap displays hold popularity based on currently selected hold types (starting, hand, foot, finish)
- Add opacity slider control when heatmap is visible
- Use existing heatmap API and color scheme for consistent visualization