### PR TITLE
feat: Add stacked bar chart showing ascents by grade across boards

### DIFF
--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -64,6 +64,11 @@
   margin-bottom: 24px; /* spacing.6 */
 }
 
+.chartDescription {
+  display: block;
+  margin-bottom: 16px; /* spacing.4 */
+}
+
 .boardSelector {
   margin-bottom: 16px; /* spacing.4 */
 }

--- a/packages/web/app/crusher/[user_id]/profile-stats-charts.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-stats-charts.tsx
@@ -27,10 +27,60 @@ export interface ChartData {
 }
 
 interface ProfileStatsChartsProps {
+  chartDataAggregated?: ChartData | null;
   chartDataWeeklyBar: ChartData | null;
   chartDataBar: ChartData | null;
   chartDataPie: ChartData | null;
 }
+
+const optionsAggregated = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: true,
+      position: 'top' as const,
+    },
+    title: {
+      display: false,
+    },
+    tooltip: {
+      callbacks: {
+        label: function (context: TooltipItem<'bar'>) {
+          const label = context.dataset.label || '';
+          const value = (context.raw as number) || 0;
+          return value > 0 ? `${label}: ${value}` : '';
+        },
+        footer: function (tooltipItems: TooltipItem<'bar'>[]) {
+          let total = 0;
+          tooltipItems.forEach((tooltipItem) => {
+            total += (tooltipItem.raw as number) || 0;
+          });
+          return `Total: ${total}`;
+        },
+      },
+      mode: 'index' as const,
+      intersect: false,
+    },
+  },
+  scales: {
+    x: {
+      stacked: true,
+      title: {
+        display: true,
+        text: 'Grade',
+      },
+    },
+    y: {
+      stacked: true,
+      title: {
+        display: true,
+        text: 'Ascents',
+      },
+      beginAtZero: true,
+    },
+  },
+};
 
 const optionsBar = {
   responsive: true,
@@ -103,32 +153,42 @@ const optionsWeeklyBar = {
 };
 
 export default function ProfileStatsCharts({
+  chartDataAggregated,
   chartDataWeeklyBar,
   chartDataBar,
   chartDataPie,
 }: ProfileStatsChartsProps) {
   return (
     <>
+      {/* Aggregated Chart - Ascents by Grade stacked by Board */}
+      {chartDataAggregated && (
+        <div style={{ height: 350, marginBottom: 24 }}>
+          <Bar data={chartDataAggregated} options={optionsAggregated} />
+        </div>
+      )}
+
       {/* Weekly Chart */}
-      <div style={{ height: 400, marginBottom: 24 }}>
-        {chartDataWeeklyBar && (
+      {chartDataWeeklyBar && (
+        <div style={{ height: 400, marginBottom: 24 }}>
           <Bar data={chartDataWeeklyBar} options={optionsWeeklyBar} />
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Bottom Charts Row */}
-      <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
-        <div style={{ flex: 1, minWidth: 280, height: 300 }}>
-          {chartDataBar && (
-            <Bar data={chartDataBar} options={optionsBar} />
-          )}
+      {(chartDataBar || chartDataPie) && (
+        <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+          <div style={{ flex: 1, minWidth: 280, height: 300 }}>
+            {chartDataBar && (
+              <Bar data={chartDataBar} options={optionsBar} />
+            )}
+          </div>
+          <div style={{ flex: '0 0 280px', height: 300 }}>
+            {chartDataPie && (
+              <Pie data={chartDataPie} options={optionsPie} />
+            )}
+          </div>
         </div>
-        <div style={{ flex: '0 0 280px', height: 300 }}>
-          {chartDataPie && (
-            <Pie data={chartDataPie} options={optionsPie} />
-          )}
-        </div>
-      </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Add a new aggregated chart to the profile page that displays total
ascents by grade, stacked by board type (Kilter/Tension). The chart
includes time filters (Today, Week, Month, Year, All) and appears
as the first chart section on the profile page.

Changes:
- Fetch ticks for all boards in parallel for the aggregated view
- Generate stacked bar chart data with board-specific colors
- Add separate time filter controls for the aggregated chart
- Update ProfileStatsCharts to conditionally render the new chart