### PR TITLE
Fix login state not updating buttons immediately

### DIFF
--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -12,7 +12,7 @@ const { Content, Header } = Layout;
 const { Title, Text } = Typography;
 
 export default function AuthPageContent() {
-  const { status } = useSession();
+  const { status, update: updateSession } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') || '/';
@@ -56,6 +56,8 @@ export default function AuthPageContent() {
       if (result?.error) {
         message.error('Invalid email or password');
       } else if (result?.ok) {
+        // Force session refresh so all components get the updated auth state
+        await updateSession();
         message.success('Logged in successfully');
         router.push(callbackUrl);
       }
@@ -101,6 +103,8 @@ export default function AuthPageContent() {
       });
 
       if (loginResult?.ok) {
+        // Force session refresh so all components get the updated auth state
+        await updateSession();
         router.push(callbackUrl);
       } else {
         // If auto-login fails, switch to login tab

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { Modal, Form, Input, Button, Tabs, Typography, Divider, message, Space } from 'antd';
 import { UserOutlined, LockOutlined, MailOutlined, HeartFilled } from '@ant-design/icons';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 
 const { Text } = Typography;
 
@@ -22,6 +22,7 @@ export default function AuthModal({
   title = "Sign in to continue",
   description = "Create an account or sign in to save your favorites and more."
 }: AuthModalProps) {
+  const { update: updateSession } = useSession();
   const [loginForm] = Form.useForm();
   const [registerForm] = Form.useForm();
   const [loginLoading, setLoginLoading] = useState(false);
@@ -42,6 +43,8 @@ export default function AuthModal({
       if (result?.error) {
         message.error('Invalid email or password');
       } else if (result?.ok) {
+        // Force session refresh so all components get the updated auth state
+        await updateSession();
         message.success('Logged in successfully');
         loginForm.resetFields();
         onClose();
@@ -87,6 +90,8 @@ export default function AuthModal({
       });
 
       if (loginResult?.ok) {
+        // Force session refresh so all components get the updated auth state
+        await updateSession();
         registerForm.resetFields();
         onClose();
         onSuccess?.();


### PR DESCRIPTION
When using signIn with redirect: false, the session cookie is set but the useSession hook doesn't automatically refetch. Call updateSession() after successful login to ensure all components using isAuthenticated re-render with the correct auth state without requiring a page refresh.