### PR TITLE
Fix hold filtering in climb search

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -54,6 +54,7 @@ export const climbQueries = {
       name: input.name,
       settername: input.setter && input.setter.length > 0 ? input.setter : undefined,
       onlyTallClimbs: input.onlyTallClimbs,
+      holdsFilter: input.holdsFilter as Record<string, 'ANY' | 'NOT'> | undefined,
       hideAttempted: input.hideAttempted,
       hideCompleted: input.hideCompleted,
       showOnlyAttempted: input.showOnlyAttempted,

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -154,6 +154,8 @@ export const typeDefs = /* GraphQL */ `
     setterId: Int
     onlyBenchmarks: Boolean
     onlyTallClimbs: Boolean
+    # Hold filters (JSON object: { "holdId": "ANY" | "NOT", ... })
+    holdsFilter: JSON
     # Personal progress filters (require auth)
     hideAttempted: Boolean
     hideCompleted: Boolean

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -130,6 +130,9 @@ export type ClimbSearchInput = {
   setter?: string[];
   setterId?: number;
   onlyBenchmarks?: boolean;
+  onlyTallClimbs?: boolean;
+  // Hold filters
+  holdsFilter?: Record<string, 'ANY' | 'NOT'>;
   // Personal progress filters
   hideAttempted?: boolean;
   hideCompleted?: boolean;

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -82,6 +82,15 @@ export const useQueueDataFetching = ({
         name: searchParams.name || undefined,
         setter: searchParams.settername && searchParams.settername.length > 0 ? searchParams.settername : undefined,
         onlyTallClimbs: searchParams.onlyTallClimbs || undefined,
+        // Convert holdsFilter to the format expected by GraphQL API
+        holdsFilter: searchParams.holdsFilter && Object.keys(searchParams.holdsFilter).length > 0
+          ? Object.fromEntries(
+              Object.entries(searchParams.holdsFilter).map(([key, value]) => [
+                key,
+                typeof value === 'string' ? value : value.state,
+              ]).filter(([, state]) => state === 'ANY' || state === 'NOT')
+            )
+          : undefined,
         hideAttempted: searchParams.hideAttempted || undefined,
         hideCompleted: searchParams.hideCompleted || undefined,
         showOnlyAttempted: searchParams.showOnlyAttempted || undefined,

--- a/packages/web/app/lib/graphql/operations/climb-search.ts
+++ b/packages/web/app/lib/graphql/operations/climb-search.ts
@@ -74,6 +74,7 @@ export interface ClimbSearchInputVariables {
     name?: string;
     setter?: string[];
     onlyTallClimbs?: boolean;
+    holdsFilter?: Record<string, 'ANY' | 'NOT'>;
     hideAttempted?: boolean;
     hideCompleted?: boolean;
     showOnlyAttempted?: boolean;


### PR DESCRIPTION
The 'Hold Filter' feature was not working because the holdsFilter parameter was missing from the GraphQL API layer after the migration from REST:
- Added holdsFilter field to GraphQL ClimbSearchInput schema
- Added holdsFilter to ClimbSearchInputVariables TypeScript type
- Added holdsFilter extraction in backend resolver
- Added holdsFilter conversion in use-queue-data-fetching hook
- Also added missing onlyTallClimbs field to shared-schema types.ts