### PR TITLE
feat: Cache default heatmap responses for 30 days

### DIFF
--- a/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
+++ b/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
@@ -1,10 +1,81 @@
-import { getHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap';
+import { getHoldHeatmapData, HoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap';
 import { getSession } from '@/app/lib/session';
-import { BoardRouteParameters, ErrorResponse, SearchRequestPagination } from '@/app/lib/types';
+import { BoardRouteParameters, ErrorResponse, ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
 import { urlParamsToSearchParams } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { cookies } from 'next/headers';
+import { unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
+
+/**
+ * Cache duration for heatmap queries (in seconds)
+ * Anonymous heatmap queries are cached for 30 days since aggregate data doesn't change meaningfully
+ */
+const CACHE_DURATION_HEATMAP = 30 * 24 * 60 * 60; // 30 days
+
+/**
+ * Recursively sort object keys for consistent JSON serialization
+ */
+function sortObjectKeys<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys) as T;
+  }
+
+  const sortedObj: Record<string, unknown> = {};
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+
+  for (const key of keys) {
+    sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+
+  return sortedObj as T;
+}
+
+/**
+ * Cached version of getHoldHeatmapData
+ * Only used for anonymous requests - user-specific data is not cached
+ */
+async function cachedGetHoldHeatmapData(
+  params: ParsedBoardRouteParameters,
+  searchParams: SearchRequestPagination,
+): Promise<HoldHeatmapData[]> {
+  // Build explicit cache key with board identifiers as separate segments
+  // This ensures cache hits/misses are correctly differentiated by board configuration
+  const cacheKey = [
+    'heatmap',
+    params.board_name,
+    String(params.layout_id),
+    String(params.size_id),
+    params.set_ids.join(','),
+    String(params.angle),
+    // Include filter params as a sorted JSON string
+    JSON.stringify(sortObjectKeys({
+      gradeAccuracy: searchParams.gradeAccuracy,
+      minGrade: searchParams.minGrade,
+      maxGrade: searchParams.maxGrade,
+      minAscents: searchParams.minAscents,
+      sortBy: searchParams.sortBy,
+      sortOrder: searchParams.sortOrder,
+      name: searchParams.name,
+      settername: searchParams.settername,
+    })),
+  ];
+
+  const cachedFn = unstable_cache(
+    async () => getHoldHeatmapData(params, searchParams, undefined),
+    cacheKey,
+    {
+      revalidate: CACHE_DURATION_HEATMAP,
+      tags: ['heatmap'],
+    }
+  );
+
+  return cachedFn();
+}
 
 export interface HoldHeatmapResponse {
   holdStats: Array<{
@@ -60,8 +131,11 @@ export async function GET(
       userId = session.userId;
     }
 
-    // Get the heatmap data using the query function
-    const holdStats = await getHoldHeatmapData(parsedParams, searchParams, userId);
+    // Get the heatmap data - use cached version for anonymous requests only
+    // User-specific data is not cached to ensure fresh personal progress data
+    const holdStats = userId
+      ? await getHoldHeatmapData(parsedParams, searchParams, userId)
+      : await cachedGetHoldHeatmapData(parsedParams, searchParams);
 
     // Return response
     return NextResponse.json({

--- a/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
+++ b/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
@@ -3,6 +3,7 @@ import { getSession } from '@/app/lib/session';
 import { BoardRouteParameters, ErrorResponse, ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
 import { urlParamsToSearchParams } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
+import { sortObjectKeys } from '@/app/lib/cache-utils';
 import { cookies } from 'next/headers';
 import { unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
@@ -12,28 +13,6 @@ import { NextResponse } from 'next/server';
  * Anonymous heatmap queries are cached for 30 days since aggregate data doesn't change meaningfully
  */
 const CACHE_DURATION_HEATMAP = 30 * 24 * 60 * 60; // 30 days
-
-/**
- * Recursively sort object keys for consistent JSON serialization
- */
-function sortObjectKeys<T>(obj: T): T {
-  if (obj === null || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map(sortObjectKeys) as T;
-  }
-
-  const sortedObj: Record<string, unknown> = {};
-  const keys = Object.keys(obj as Record<string, unknown>).sort();
-
-  for (const key of keys) {
-    sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
-  }
-
-  return sortedObj as T;
-}
 
 /**
  * Cached version of getHoldHeatmapData
@@ -58,10 +37,14 @@ async function cachedGetHoldHeatmapData(
       minGrade: searchParams.minGrade,
       maxGrade: searchParams.maxGrade,
       minAscents: searchParams.minAscents,
+      minRating: searchParams.minRating,
       sortBy: searchParams.sortBy,
       sortOrder: searchParams.sortOrder,
       name: searchParams.name,
       settername: searchParams.settername,
+      onlyClassics: searchParams.onlyClassics,
+      onlyTallClimbs: searchParams.onlyTallClimbs,
+      holdsFilter: searchParams.holdsFilter,
     })),
   ];
 

--- a/packages/web/app/lib/cache-utils.ts
+++ b/packages/web/app/lib/cache-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Recursively sort object keys for consistent JSON serialization in cache keys
+ * This ensures that objects with the same properties in different orders
+ * produce the same cache key string
+ */
+export function sortObjectKeys<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys) as T;
+  }
+
+  const sortedObj: Record<string, unknown> = {};
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+
+  for (const key of keys) {
+    sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+
+  return sortedObj as T;
+}

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { unstable_cache } from 'next/cache';
 import { GraphQLClient, RequestDocument, Variables } from 'graphql-request';
+import { sortObjectKeys } from '@/app/lib/cache-utils';
 
 /**
  * Cache durations for climb search queries (in seconds)
@@ -36,28 +37,6 @@ async function executeGraphQLInternal<T = unknown, V extends Variables = Variabl
   });
 
   return client.request<T>(document, variables);
-}
-
-/**
- * Recursively sort object keys for consistent JSON serialization
- */
-function sortObjectKeys<T>(obj: T): T {
-  if (obj === null || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map(sortObjectKeys) as T;
-  }
-
-  const sortedObj: Record<string, unknown> = {};
-  const keys = Object.keys(obj as Record<string, unknown>).sort();
-
-  for (const key of keys) {
-    sortedObj[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
-  }
-
-  return sortedObj as T;
 }
 
 /**


### PR DESCRIPTION
Add caching to the heatmap API endpoint using Next.js unstable_cache, following the same pattern as the climb list caching. Default heatmap responses (no filters, no user authentication) are cached for 30 days using a cache key that includes board configuration parameters.