### PR TITLE
feat: Migrate Aurora ascents/bids to unified boardsesh_ticks table

### DIFF
--- a/packages/db/drizzle/0026_migrate_aurora_to_boardsesh_ticks.sql
+++ b/packages/db/drizzle/0026_migrate_aurora_to_boardsesh_ticks.sql
@@ -24,8 +24,8 @@ BEGIN
       ka.difficulty,
       COALESCE(ka.is_benchmark::boolean, false) AS is_benchmark,
       COALESCE(ka.comment, '') AS comment,
-      ka.climbed_at::timestamp::text AS climbed_at,
-      ka.created_at::timestamp::text AS created_at,
+      ka.climbed_at::timestamp AS climbed_at,
+      ka.created_at::timestamp AS created_at,
       'ascents'::aurora_table_type AS aurora_type,
       ka.uuid AS aurora_id
     FROM kilter_ascents ka
@@ -53,8 +53,8 @@ BEGIN
       NULL::integer AS difficulty,
       false AS is_benchmark,
       COALESCE(kb.comment, '') AS comment,
-      kb.climbed_at::timestamp::text AS climbed_at,
-      kb.created_at::timestamp::text AS created_at,
+      kb.climbed_at::timestamp AS climbed_at,
+      kb.created_at::timestamp AS created_at,
       'bids'::aurora_table_type AS aurora_type,
       kb.uuid AS aurora_id
     FROM kilter_bids kb
@@ -85,8 +85,8 @@ BEGIN
       ta.difficulty,
       COALESCE(ta.is_benchmark::boolean, false) AS is_benchmark,
       COALESCE(ta.comment, '') AS comment,
-      ta.climbed_at::timestamp::text AS climbed_at,
-      ta.created_at::timestamp::text AS created_at,
+      ta.climbed_at::timestamp AS climbed_at,
+      ta.created_at::timestamp AS created_at,
       'ascents'::aurora_table_type AS aurora_type,
       ta.uuid AS aurora_id
     FROM tension_ascents ta
@@ -114,8 +114,8 @@ BEGIN
       NULL::integer AS difficulty,
       false AS is_benchmark,
       COALESCE(tb.comment, '') AS comment,
-      tb.climbed_at::timestamp::text AS climbed_at,
-      tb.created_at::timestamp::text AS created_at,
+      tb.climbed_at::timestamp AS climbed_at,
+      tb.created_at::timestamp AS created_at,
       'bids'::aurora_table_type AS aurora_type,
       tb.uuid AS aurora_id
     FROM tension_bids tb
@@ -175,10 +175,10 @@ BEGIN
     comment,
     climbed_at,
     created_at,
-    NOW()::text, -- updated_at
+    NOW(), -- updated_at
     aurora_type,
     aurora_id,
-    NOW()::text  -- aurora_synced_at
+    NOW()  -- aurora_synced_at
   FROM all_ticks_to_migrate;
 
   -- Log migration count

--- a/packages/db/drizzle/0026_migrate_aurora_to_boardsesh_ticks.sql
+++ b/packages/db/drizzle/0026_migrate_aurora_to_boardsesh_ticks.sql
@@ -1,0 +1,187 @@
+-- Migration: Migrate Aurora ascents/bids to boardsesh_ticks
+-- This migration is idempotent and only migrates users with NextAuth accounts
+
+-- Migrate historical Aurora data to unified boardsesh_ticks table
+DO $$
+DECLARE
+  migrated_count integer;
+BEGIN
+  -- Migrate Kilter Ascents (Flash/Send)
+  WITH kilter_ascents_to_migrate AS (
+    SELECT
+      gen_random_uuid()::text AS uuid,
+      ac.user_id AS user_id,
+      'kilter' AS board_type,
+      ka.climb_uuid,
+      ka.angle,
+      COALESCE(ka.is_mirror, false) AS is_mirror,
+      CASE
+        WHEN ka.attempt_id = 1 THEN 'flash'::tick_status
+        ELSE 'send'::tick_status
+      END AS status,
+      COALESCE(ka.bid_count, 1) AS attempt_count,
+      ROUND((ka.quality / 3.0) * 5)::integer AS quality,
+      ka.difficulty,
+      COALESCE(ka.is_benchmark::boolean, false) AS is_benchmark,
+      COALESCE(ka.comment, '') AS comment,
+      ka.climbed_at::timestamp::text AS climbed_at,
+      ka.created_at::timestamp::text AS created_at,
+      'ascents'::aurora_table_type AS aurora_type,
+      ka.uuid AS aurora_id
+    FROM kilter_ascents ka
+    INNER JOIN aurora_credentials ac
+      ON ac.aurora_user_id = ka.user_id
+      AND ac.board_type = 'kilter'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM boardsesh_ticks bt
+      WHERE bt.aurora_id = ka.uuid
+    )
+  ),
+
+  -- Migrate Kilter Bids (Attempts)
+  kilter_bids_to_migrate AS (
+    SELECT
+      gen_random_uuid()::text AS uuid,
+      ac.user_id AS user_id,
+      'kilter' AS board_type,
+      kb.climb_uuid,
+      kb.angle,
+      COALESCE(kb.is_mirror, false) AS is_mirror,
+      'attempt'::tick_status AS status,
+      COALESCE(kb.bid_count, 1) AS attempt_count,
+      NULL::integer AS quality,
+      NULL::integer AS difficulty,
+      false AS is_benchmark,
+      COALESCE(kb.comment, '') AS comment,
+      kb.climbed_at::timestamp::text AS climbed_at,
+      kb.created_at::timestamp::text AS created_at,
+      'bids'::aurora_table_type AS aurora_type,
+      kb.uuid AS aurora_id
+    FROM kilter_bids kb
+    INNER JOIN aurora_credentials ac
+      ON ac.aurora_user_id = kb.user_id
+      AND ac.board_type = 'kilter'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM boardsesh_ticks bt
+      WHERE bt.aurora_id = kb.uuid
+    )
+  ),
+
+  -- Migrate Tension Ascents (Flash/Send)
+  tension_ascents_to_migrate AS (
+    SELECT
+      gen_random_uuid()::text AS uuid,
+      ac.user_id AS user_id,
+      'tension' AS board_type,
+      ta.climb_uuid,
+      ta.angle,
+      COALESCE(ta.is_mirror, false) AS is_mirror,
+      CASE
+        WHEN ta.attempt_id = 1 THEN 'flash'::tick_status
+        ELSE 'send'::tick_status
+      END AS status,
+      COALESCE(ta.bid_count, 1) AS attempt_count,
+      ROUND((ta.quality / 3.0) * 5)::integer AS quality,
+      ta.difficulty,
+      COALESCE(ta.is_benchmark::boolean, false) AS is_benchmark,
+      COALESCE(ta.comment, '') AS comment,
+      ta.climbed_at::timestamp::text AS climbed_at,
+      ta.created_at::timestamp::text AS created_at,
+      'ascents'::aurora_table_type AS aurora_type,
+      ta.uuid AS aurora_id
+    FROM tension_ascents ta
+    INNER JOIN aurora_credentials ac
+      ON ac.aurora_user_id = ta.user_id
+      AND ac.board_type = 'tension'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM boardsesh_ticks bt
+      WHERE bt.aurora_id = ta.uuid
+    )
+  ),
+
+  -- Migrate Tension Bids (Attempts)
+  tension_bids_to_migrate AS (
+    SELECT
+      gen_random_uuid()::text AS uuid,
+      ac.user_id AS user_id,
+      'tension' AS board_type,
+      tb.climb_uuid,
+      tb.angle,
+      COALESCE(tb.is_mirror, false) AS is_mirror,
+      'attempt'::tick_status AS status,
+      COALESCE(tb.bid_count, 1) AS attempt_count,
+      NULL::integer AS quality,
+      NULL::integer AS difficulty,
+      false AS is_benchmark,
+      COALESCE(tb.comment, '') AS comment,
+      tb.climbed_at::timestamp::text AS climbed_at,
+      tb.created_at::timestamp::text AS created_at,
+      'bids'::aurora_table_type AS aurora_type,
+      tb.uuid AS aurora_id
+    FROM tension_bids tb
+    INNER JOIN aurora_credentials ac
+      ON ac.aurora_user_id = tb.user_id
+      AND ac.board_type = 'tension'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM boardsesh_ticks bt
+      WHERE bt.aurora_id = tb.uuid
+    )
+  ),
+
+  -- Union all migrations
+  all_ticks_to_migrate AS (
+    SELECT * FROM kilter_ascents_to_migrate
+    UNION ALL
+    SELECT * FROM kilter_bids_to_migrate
+    UNION ALL
+    SELECT * FROM tension_ascents_to_migrate
+    UNION ALL
+    SELECT * FROM tension_bids_to_migrate
+  )
+
+  -- Insert into boardsesh_ticks
+  INSERT INTO boardsesh_ticks (
+    uuid,
+    user_id,
+    board_type,
+    climb_uuid,
+    angle,
+    is_mirror,
+    status,
+    attempt_count,
+    quality,
+    difficulty,
+    is_benchmark,
+    comment,
+    climbed_at,
+    created_at,
+    updated_at,
+    aurora_type,
+    aurora_id,
+    aurora_synced_at
+  )
+  SELECT
+    uuid,
+    user_id,
+    board_type,
+    climb_uuid,
+    angle,
+    is_mirror,
+    status,
+    attempt_count,
+    quality,
+    difficulty,
+    is_benchmark,
+    comment,
+    climbed_at,
+    created_at,
+    NOW()::text, -- updated_at
+    aurora_type,
+    aurora_id,
+    NOW()::text  -- aurora_synced_at
+  FROM all_ticks_to_migrate;
+
+  -- Log migration count
+  GET DIAGNOSTICS migrated_count = ROW_COUNT;
+  RAISE NOTICE 'Migrated % historical ticks from Aurora to boardsesh_ticks', migrated_count;
+END $$;

--- a/packages/web/app/api/internal/migrate-users-cron/route.ts
+++ b/packages/web/app/api/internal/migrate-users-cron/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server';
+import { migrateUserAuroraHistory } from '@/app/lib/data-sync/aurora/migrate-user-history';
+import { getPool } from '@/app/lib/db/db';
+import { drizzle } from 'drizzle-orm/neon-serverless';
+import { eq, sql } from 'drizzle-orm';
+import { BoardName } from '@/app/lib/types';
+import * as schema from '@/app/lib/db/schema';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300; // 5 minutes max
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+interface MigrationResult {
+  userId: string;
+  boardType: string;
+  migrated?: number;
+  error?: string;
+}
+
+export async function GET(request: Request) {
+  try {
+    // Auth check
+    const authHeader = request.headers.get('authorization');
+    if (process.env.VERCEL_ENV !== 'development' && authHeader !== `Bearer ${CRON_SECRET}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const pool = getPool();
+
+    // Find users with aurora_credentials but no migrated ticks
+    let unmigratedUsers;
+    {
+      const client = await pool.connect();
+      try {
+        const result = await client.query(`
+          SELECT DISTINCT
+            ac.user_id,
+            ac.board_type,
+            ac.aurora_user_id
+          FROM aurora_credentials ac
+          WHERE ac.sync_status = 'active'
+            AND NOT EXISTS (
+              SELECT 1 FROM boardsesh_ticks bt
+              WHERE bt.user_id = ac.user_id
+                AND bt.board_type = ac.board_type
+                AND bt.aurora_id IS NOT NULL
+            )
+          LIMIT 10
+        `);
+        unmigratedUsers = result.rows;
+      } finally {
+        client.release();
+      }
+    }
+
+    console.log(`[Migrate Users Cron] Found ${unmigratedUsers.length} users with unmigrated Aurora data`);
+
+    const results = {
+      total: unmigratedUsers.length,
+      successful: 0,
+      failed: 0,
+      totalMigrated: 0,
+      errors: [] as MigrationResult[],
+    };
+
+    // Migrate each user sequentially
+    for (const user of unmigratedUsers) {
+      try {
+        console.log(`[Migrate Users Cron] Migrating user ${user.user_id} (${user.board_type})`);
+
+        const result = await migrateUserAuroraHistory(
+          user.user_id,
+          user.board_type as BoardName,
+          user.aurora_user_id
+        );
+
+        results.successful++;
+        results.totalMigrated += result.migrated;
+
+        console.log(`[Migrate Users Cron] Successfully migrated ${result.migrated} ticks for user ${user.user_id}`);
+      } catch (error) {
+        results.failed++;
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.error(`[Migrate Users Cron] Failed to migrate user ${user.user_id}:`, errorMessage);
+
+        results.errors.push({
+          userId: user.user_id,
+          boardType: user.board_type,
+          error: errorMessage,
+        });
+
+        // Update sync status in aurora_credentials to reflect error
+        const client = await pool.connect();
+        try {
+          const db = drizzle(client);
+          await db
+            .update(schema.auroraCredentials)
+            .set({
+              syncStatus: 'error',
+              syncError: `Migration failed: ${errorMessage}`,
+              updatedAt: new Date(),
+            })
+            .where(
+              sql`${schema.auroraCredentials.userId} = ${user.user_id} AND ${schema.auroraCredentials.boardType} = ${user.board_type}`
+            );
+        } catch (updateError) {
+          console.error(`[Migrate Users Cron] Failed to update error status:`, updateError);
+        } finally {
+          client.release();
+        }
+      }
+    }
+
+    console.log(
+      `[Migrate Users Cron] Completed: ${results.successful}/${results.total} users, ${results.totalMigrated} ticks migrated`
+    );
+
+    return NextResponse.json(results);
+  } catch (error) {
+    console.error('[Migrate Users Cron] Fatal error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/app/api/internal/migrate-users-cron/route.ts
+++ b/packages/web/app/api/internal/migrate-users-cron/route.ts
@@ -20,9 +20,11 @@ interface MigrationResult {
 
 export async function GET(request: Request) {
   try {
-    // Auth check
+    // Auth check: skip in development only, require secret in all other environments
     const authHeader = request.headers.get('authorization');
-    if (process.env.VERCEL_ENV !== 'development' && authHeader !== `Bearer ${CRON_SECRET}`) {
+    const isDevelopment = process.env.VERCEL_ENV === 'development' || process.env.NODE_ENV === 'development';
+
+    if (!isDevelopment && authHeader !== `Bearer ${CRON_SECRET}`) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/packages/web/app/lib/data-sync/aurora/convert-quality.ts
+++ b/packages/web/app/lib/data-sync/aurora/convert-quality.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert Aurora quality (1-5) to Boardsesh quality (1-5)
+ * Formula: quality / 3.0 * 5
+ *
+ * Aurora uses a 1-3 scale (with some 4-5 values), while Boardsesh uses a 1-5 scale.
+ * This conversion scales the Aurora rating to match the Boardsesh scale.
+ */
+export function convertQuality(auroraQuality: number | null | undefined): number | null {
+  if (auroraQuality == null) return null;
+  return Math.round((auroraQuality / 3.0) * 5);
+}

--- a/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
+++ b/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
@@ -84,12 +84,12 @@ export async function migrateUserAuroraHistory(
         difficulty: Number(ascent.difficulty),
         isBenchmark: Boolean(ascent.isBenchmark || 0),
         comment: ascent.comment || '',
-        climbedAt: ascent.climbedAt,
-        createdAt: ascent.createdAt,
-        updatedAt: new Date().toISOString(),
+        climbedAt: new Date(ascent.climbedAt),
+        createdAt: new Date(ascent.createdAt),
+        updatedAt: new Date(),
         auroraType: 'ascents',
         auroraId: ascent.uuid,
-        auroraSyncedAt: new Date().toISOString(),
+        auroraSyncedAt: new Date(),
       });
 
       totalMigrated++;
@@ -116,12 +116,12 @@ export async function migrateUserAuroraHistory(
         difficulty: null,
         isBenchmark: false,
         comment: bid.comment || '',
-        climbedAt: bid.climbedAt,
-        createdAt: bid.createdAt,
-        updatedAt: new Date().toISOString(),
+        climbedAt: new Date(bid.climbedAt),
+        createdAt: new Date(bid.createdAt),
+        updatedAt: new Date(),
         auroraType: 'bids',
         auroraId: bid.uuid,
-        auroraSyncedAt: new Date().toISOString(),
+        auroraSyncedAt: new Date(),
       });
 
       totalMigrated++;

--- a/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
+++ b/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
@@ -84,12 +84,12 @@ export async function migrateUserAuroraHistory(
         difficulty: Number(ascent.difficulty),
         isBenchmark: Boolean(ascent.isBenchmark || 0),
         comment: ascent.comment || '',
-        climbedAt: new Date(ascent.climbedAt),
-        createdAt: new Date(ascent.createdAt),
-        updatedAt: new Date(),
+        climbedAt: new Date(ascent.climbedAt).toISOString(),
+        createdAt: new Date(ascent.createdAt).toISOString(),
+        updatedAt: new Date().toISOString(),
         auroraType: 'ascents',
         auroraId: ascent.uuid,
-        auroraSyncedAt: new Date(),
+        auroraSyncedAt: new Date().toISOString(),
       });
 
       totalMigrated++;
@@ -116,12 +116,12 @@ export async function migrateUserAuroraHistory(
         difficulty: null,
         isBenchmark: false,
         comment: bid.comment || '',
-        climbedAt: new Date(bid.climbedAt),
-        createdAt: new Date(bid.createdAt),
-        updatedAt: new Date(),
+        climbedAt: new Date(bid.climbedAt).toISOString(),
+        createdAt: new Date(bid.createdAt).toISOString(),
+        updatedAt: new Date().toISOString(),
         auroraType: 'bids',
         auroraId: bid.uuid,
-        auroraSyncedAt: new Date(),
+        auroraSyncedAt: new Date().toISOString(),
       });
 
       totalMigrated++;

--- a/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
+++ b/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
@@ -79,7 +79,7 @@ export async function migrateUserAuroraHistory(
         continue;
       }
 
-      const status = Number(ascent.attemptId) === 1 ? 'flash' : 'send';
+      const status = Number(ascent.attemptId) === 1 ? ('flash' as const) : ('send' as const);
       const convertedQuality = convertQuality(ascent.quality);
 
       ascentValues.push({

--- a/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
+++ b/packages/web/app/lib/data-sync/aurora/migrate-user-history.ts
@@ -1,0 +1,134 @@
+import { getPool } from '@/app/lib/db/db';
+import { BoardName } from '../../types';
+import { drizzle } from 'drizzle-orm/neon-serverless';
+import { NeonDatabase } from 'drizzle-orm/neon-serverless';
+import { getTable } from '../../db/queries/util/table-select';
+import { boardseshTicks } from '../../db/schema';
+import { randomUUID } from 'crypto';
+
+/**
+ * Convert Aurora quality (1-5) to Boardsesh quality (1-5)
+ * Formula: quality / 3.0 * 5
+ */
+function convertQuality(auroraQuality: number | null | undefined): number | null {
+  if (auroraQuality == null) return null;
+  return Math.round((auroraQuality / 3.0) * 5);
+}
+
+/**
+ * Migrate a single user's historical Aurora data to boardsesh_ticks
+ * This function is called when:
+ * 1. User adds Aurora credentials (user-triggered)
+ * 2. Background cron job finds unmigrated users (cron-triggered)
+ *
+ * @param nextAuthUserId - NextAuth user ID
+ * @param boardType - Board type ('kilter' or 'tension')
+ * @param auroraUserId - Aurora user ID
+ * @returns Object with migrated count
+ */
+export async function migrateUserAuroraHistory(
+  nextAuthUserId: string,
+  boardType: BoardName,
+  auroraUserId: number,
+): Promise<{ migrated: number }> {
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+    const db = drizzle(client);
+
+    let totalMigrated = 0;
+
+    // Check if user already has migrated data
+    const existingTicks = await db
+      .select({ count: boardseshTicks.id })
+      .from(boardseshTicks)
+      .where((bt) => bt.userId === nextAuthUserId && bt.boardType === boardType && bt.auroraId !== null)
+      .limit(1);
+
+    if (existingTicks.length > 0) {
+      console.log(`User ${nextAuthUserId} already has migrated data for ${boardType}, skipping`);
+      await client.query('COMMIT');
+      return { migrated: 0 };
+    }
+
+    // Migrate ascents (successful climbs)
+    const ascentsSchema = getTable('ascents', boardType);
+    const ascents = await db
+      .select()
+      .from(ascentsSchema)
+      .where((a) => a.userId === auroraUserId);
+
+    for (const ascent of ascents) {
+      const status = Number(ascent.attemptId) === 1 ? 'flash' : 'send';
+      const convertedQuality = convertQuality(ascent.quality);
+
+      await db.insert(boardseshTicks).values({
+        uuid: randomUUID(),
+        userId: nextAuthUserId,
+        boardType: boardType,
+        climbUuid: ascent.climbUuid,
+        angle: Number(ascent.angle),
+        isMirror: Boolean(ascent.isMirror),
+        status: status,
+        attemptCount: Number(ascent.bidCount || 1),
+        quality: convertedQuality,
+        difficulty: Number(ascent.difficulty),
+        isBenchmark: Boolean(ascent.isBenchmark || 0),
+        comment: ascent.comment || '',
+        climbedAt: ascent.climbedAt,
+        createdAt: ascent.createdAt,
+        updatedAt: new Date().toISOString(),
+        auroraType: 'ascents',
+        auroraId: ascent.uuid,
+        auroraSyncedAt: new Date().toISOString(),
+      });
+
+      totalMigrated++;
+    }
+
+    // Migrate bids (failed attempts)
+    const bidsSchema = getTable('bids', boardType);
+    const bids = await db
+      .select()
+      .from(bidsSchema)
+      .where((b) => b.userId === auroraUserId);
+
+    for (const bid of bids) {
+      await db.insert(boardseshTicks).values({
+        uuid: randomUUID(),
+        userId: nextAuthUserId,
+        boardType: boardType,
+        climbUuid: bid.climbUuid,
+        angle: Number(bid.angle),
+        isMirror: Boolean(bid.isMirror),
+        status: 'attempt',
+        attemptCount: Number(bid.bidCount || 1),
+        quality: null,
+        difficulty: null,
+        isBenchmark: false,
+        comment: bid.comment || '',
+        climbedAt: bid.climbedAt,
+        createdAt: bid.createdAt,
+        updatedAt: new Date().toISOString(),
+        auroraType: 'bids',
+        auroraId: bid.uuid,
+        auroraSyncedAt: new Date().toISOString(),
+      });
+
+      totalMigrated++;
+    }
+
+    await client.query('COMMIT');
+    console.log(`Migrated ${totalMigrated} historical ticks for user ${nextAuthUserId} on ${boardType}`);
+
+    return { migrated: totalMigrated };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('Failed to migrate user Aurora history:', error);
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -207,12 +207,12 @@ async function upsertTableData(
             difficulty: Number(item.difficulty),
             isBenchmark: Boolean(item.is_benchmark || 0),
             comment: item.comment || '',
-            climbedAt: item.climbed_at,
-            createdAt: item.created_at,
-            updatedAt: new Date().toISOString(),
+            climbedAt: new Date(item.climbed_at),
+            createdAt: new Date(item.created_at),
+            updatedAt: new Date(),
             auroraType: 'ascents',
             auroraId: item.uuid,
-            auroraSyncedAt: new Date().toISOString(),
+            auroraSyncedAt: new Date(),
           })
           .onConflictDoUpdate({
             target: boardseshTicks.auroraId,
@@ -226,9 +226,9 @@ async function upsertTableData(
               difficulty: Number(item.difficulty),
               isBenchmark: Boolean(item.is_benchmark || 0),
               comment: item.comment || '',
-              climbedAt: item.climbed_at,
-              updatedAt: new Date().toISOString(),
-              auroraSyncedAt: new Date().toISOString(),
+              climbedAt: new Date(item.climbed_at),
+              updatedAt: new Date(),
+              auroraSyncedAt: new Date(),
             },
           });
       }
@@ -280,12 +280,12 @@ async function upsertTableData(
             difficulty: null,
             isBenchmark: false,
             comment: item.comment || '',
-            climbedAt: item.climbed_at,
-            createdAt: item.created_at,
-            updatedAt: new Date().toISOString(),
+            climbedAt: new Date(item.climbed_at),
+            createdAt: new Date(item.created_at),
+            updatedAt: new Date(),
             auroraType: 'bids',
             auroraId: item.uuid,
-            auroraSyncedAt: new Date().toISOString(),
+            auroraSyncedAt: new Date(),
           })
           .onConflictDoUpdate({
             target: boardseshTicks.auroraId,
@@ -295,9 +295,9 @@ async function upsertTableData(
               isMirror: Boolean(item.is_mirror),
               attemptCount: Number(item.bid_count || 1),
               comment: item.comment || '',
-              climbedAt: item.climbed_at,
-              updatedAt: new Date().toISOString(),
-              auroraSyncedAt: new Date().toISOString(),
+              climbedAt: new Date(item.climbed_at),
+              updatedAt: new Date(),
+              auroraSyncedAt: new Date(),
             },
           });
       }

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -6,12 +6,41 @@ import { eq, and, inArray } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import { NeonDatabase } from 'drizzle-orm/neon-serverless';
 import { getTable } from '../../db/queries/util/table-select';
+import { boardseshTicks, auroraCredentials } from '../../db/schema';
+import { randomUUID } from 'crypto';
+
+/**
+ * Convert Aurora quality (1-5) to Boardsesh quality (1-5)
+ * Formula: quality / 3.0 * 5
+ */
+function convertQuality(auroraQuality: number | null | undefined): number | null {
+  if (auroraQuality == null) return null;
+  return Math.round((auroraQuality / 3.0) * 5);
+}
+
+/**
+ * Get NextAuth user ID from Aurora user ID
+ */
+async function getNextAuthUserId(
+  db: NeonDatabase<Record<string, never>>,
+  boardName: BoardName,
+  auroraUserId: number,
+): Promise<string | null> {
+  const result = await db
+    .select({ userId: auroraCredentials.userId })
+    .from(auroraCredentials)
+    .where(and(eq(auroraCredentials.boardType, boardName), eq(auroraCredentials.auroraUserId, auroraUserId)))
+    .limit(1);
+
+  return result[0]?.userId || null;
+}
 
 async function upsertTableData(
   db: NeonDatabase<Record<string, never>>,
   boardName: BoardName,
   tableName: string,
-  userId: number,
+  auroraUserId: number,
+  nextAuthUserId: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any[],
 ) {
@@ -45,7 +74,7 @@ async function upsertTableData(
           .insert(wallsSchema)
           .values({
             uuid: item.uuid,
-            userId: Number(userId),
+            userId: Number(auroraUserId),
             name: item.name,
             productId: Number(item.product_id),
             isAdjustable: Boolean(item.is_adjustable),
@@ -80,7 +109,7 @@ async function upsertTableData(
           .values({
             uuid: item.uuid,
             layoutId: Number(item.layout_id),
-            setterId: Number(userId),
+            setterId: Number(auroraUserId),
             setterUsername: item.setter_username || '',
             name: item.name || 'Untitled Draft',
             description: item.description || '',
@@ -101,7 +130,7 @@ async function upsertTableData(
             target: climbsSchema.uuid,
             set: {
               layoutId: Number(item.layout_id),
-              setterId: Number(userId),
+              setterId: Number(auroraUserId),
               setterUsername: item.setter_username || '',
               name: item.name || 'Untitled Draft',
               description: item.description || '',
@@ -125,6 +154,7 @@ async function upsertTableData(
     case 'ascents': {
       const ascentsSchema = getTable('ascents', boardName);
       for (const item of data) {
+        // Write to Aurora table
         await db
           .insert(ascentsSchema)
           .values({
@@ -132,7 +162,7 @@ async function upsertTableData(
             climbUuid: item.climb_uuid,
             angle: Number(item.angle),
             isMirror: Boolean(item.is_mirror),
-            userId: Number(userId),
+            userId: Number(auroraUserId),
             attemptId: Number(item.attempt_id),
             bidCount: Number(item.bid_count || 1),
             quality: Number(item.quality),
@@ -157,6 +187,50 @@ async function upsertTableData(
               climbedAt: item.climbed_at,
             },
           });
+
+        // Dual write to boardsesh_ticks
+        const status = Number(item.attempt_id) === 1 ? 'flash' : 'send';
+        const convertedQuality = convertQuality(item.quality);
+
+        await db
+          .insert(boardseshTicks)
+          .values({
+            uuid: randomUUID(),
+            userId: nextAuthUserId,
+            boardType: boardName,
+            climbUuid: item.climb_uuid,
+            angle: Number(item.angle),
+            isMirror: Boolean(item.is_mirror),
+            status: status,
+            attemptCount: Number(item.bid_count || 1),
+            quality: convertedQuality,
+            difficulty: Number(item.difficulty),
+            isBenchmark: Boolean(item.is_benchmark || 0),
+            comment: item.comment || '',
+            climbedAt: item.climbed_at,
+            createdAt: item.created_at,
+            updatedAt: new Date().toISOString(),
+            auroraType: 'ascents',
+            auroraId: item.uuid,
+            auroraSyncedAt: new Date().toISOString(),
+          })
+          .onConflictDoUpdate({
+            target: boardseshTicks.auroraId,
+            set: {
+              climbUuid: item.climb_uuid,
+              angle: Number(item.angle),
+              isMirror: Boolean(item.is_mirror),
+              status: status,
+              attemptCount: Number(item.bid_count || 1),
+              quality: convertedQuality,
+              difficulty: Number(item.difficulty),
+              isBenchmark: Boolean(item.is_benchmark || 0),
+              comment: item.comment || '',
+              climbedAt: item.climbed_at,
+              updatedAt: new Date().toISOString(),
+              auroraSyncedAt: new Date().toISOString(),
+            },
+          });
       }
       break;
     }
@@ -164,11 +238,12 @@ async function upsertTableData(
     case 'bids': {
       const bidsSchema = getTable('bids', boardName);
       for (const item of data) {
+        // Write to Aurora table
         await db
           .insert(bidsSchema)
           .values({
             uuid: item.uuid,
-            userId: Number(userId),
+            userId: Number(auroraUserId),
             climbUuid: item.climb_uuid,
             angle: Number(item.angle),
             isMirror: Boolean(item.is_mirror),
@@ -188,6 +263,43 @@ async function upsertTableData(
               climbedAt: item.climbed_at,
             },
           });
+
+        // Dual write to boardsesh_ticks
+        await db
+          .insert(boardseshTicks)
+          .values({
+            uuid: randomUUID(),
+            userId: nextAuthUserId,
+            boardType: boardName,
+            climbUuid: item.climb_uuid,
+            angle: Number(item.angle),
+            isMirror: Boolean(item.is_mirror),
+            status: 'attempt',
+            attemptCount: Number(item.bid_count || 1),
+            quality: null,
+            difficulty: null,
+            isBenchmark: false,
+            comment: item.comment || '',
+            climbedAt: item.climbed_at,
+            createdAt: item.created_at,
+            updatedAt: new Date().toISOString(),
+            auroraType: 'bids',
+            auroraId: item.uuid,
+            auroraSyncedAt: new Date().toISOString(),
+          })
+          .onConflictDoUpdate({
+            target: boardseshTicks.auroraId,
+            set: {
+              climbUuid: item.climb_uuid,
+              angle: Number(item.angle),
+              isMirror: Boolean(item.is_mirror),
+              attemptCount: Number(item.bid_count || 1),
+              comment: item.comment || '',
+              climbedAt: item.climbed_at,
+              updatedAt: new Date().toISOString(),
+              auroraSyncedAt: new Date().toISOString(),
+            },
+          });
       }
       break;
     }
@@ -204,7 +316,7 @@ async function upsertTableData(
           .where(
             and(
               eq(tagsSchema.entityUuid, item.entity_uuid),
-              eq(tagsSchema.userId, Number(userId)),
+              eq(tagsSchema.userId, Number(auroraUserId)),
               eq(tagsSchema.name, item.name),
             ),
           )
@@ -214,7 +326,7 @@ async function upsertTableData(
         if (result.length === 0) {
           await db.insert(tagsSchema).values({
             entityUuid: item.entity_uuid,
-            userId: Number(userId),
+            userId: Number(auroraUserId),
             name: item.name,
             isListed: Boolean(item.is_listed),
           });
@@ -233,7 +345,7 @@ async function upsertTableData(
             name: item.name,
             description: item.description,
             color: item.color,
-            userId: Number(userId),
+            userId: Number(auroraUserId),
             isPublic: Boolean(item.is_public),
             createdAt: item.created_at,
             updatedAt: item.updated_at,
@@ -368,12 +480,26 @@ export async function syncUserData(
         // Create a drizzle instance for this transaction
         const tx = drizzle(client);
 
+        // Get NextAuth user ID for dual write to boardsesh_ticks
+        const nextAuthUserId = await getNextAuthUserId(tx, board, userId);
+        if (!nextAuthUserId) {
+          console.warn(`No NextAuth user found for Aurora user ${userId} on ${board}, skipping ascents/bids sync`);
+          // We can still sync other tables (users, walls, etc.) that don't need NextAuth user ID
+        }
+
         // Process each table - data is directly under table names
         for (const tableName of tables) {
           console.log(`Syncing ${tableName} for user ${userId} (batch ${syncAttempts})`);
           if (syncResults[tableName] && Array.isArray(syncResults[tableName])) {
             const data = syncResults[tableName];
-            await upsertTableData(tx, board, tableName, userId, data);
+
+            // Skip ascents/bids if no NextAuth user (can't dual write)
+            if ((tableName === 'ascents' || tableName === 'bids') && !nextAuthUserId) {
+              console.warn(`Skipping ${tableName} sync for Aurora user ${userId} - no NextAuth mapping`);
+              continue;
+            }
+
+            await upsertTableData(tx, board, tableName, userId, nextAuthUserId || '', data);
 
             // Accumulate results
             if (!totalResults[tableName]) {

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -207,12 +207,12 @@ async function upsertTableData(
             difficulty: Number(item.difficulty),
             isBenchmark: Boolean(item.is_benchmark || 0),
             comment: item.comment || '',
-            climbedAt: new Date(item.climbed_at),
-            createdAt: new Date(item.created_at),
-            updatedAt: new Date(),
+            climbedAt: new Date(item.climbed_at).toISOString(),
+            createdAt: new Date(item.created_at).toISOString(),
+            updatedAt: new Date().toISOString(),
             auroraType: 'ascents',
             auroraId: item.uuid,
-            auroraSyncedAt: new Date(),
+            auroraSyncedAt: new Date().toISOString(),
           })
           .onConflictDoUpdate({
             target: boardseshTicks.auroraId,
@@ -226,9 +226,9 @@ async function upsertTableData(
               difficulty: Number(item.difficulty),
               isBenchmark: Boolean(item.is_benchmark || 0),
               comment: item.comment || '',
-              climbedAt: new Date(item.climbed_at),
-              updatedAt: new Date(),
-              auroraSyncedAt: new Date(),
+              climbedAt: new Date(item.climbed_at).toISOString(),
+              updatedAt: new Date().toISOString(),
+              auroraSyncedAt: new Date().toISOString(),
             },
           });
       }
@@ -280,12 +280,12 @@ async function upsertTableData(
             difficulty: null,
             isBenchmark: false,
             comment: item.comment || '',
-            climbedAt: new Date(item.climbed_at),
-            createdAt: new Date(item.created_at),
-            updatedAt: new Date(),
+            climbedAt: new Date(item.climbed_at).toISOString(),
+            createdAt: new Date(item.created_at).toISOString(),
+            updatedAt: new Date().toISOString(),
             auroraType: 'bids',
             auroraId: item.uuid,
-            auroraSyncedAt: new Date(),
+            auroraSyncedAt: new Date().toISOString(),
           })
           .onConflictDoUpdate({
             target: boardseshTicks.auroraId,
@@ -295,9 +295,9 @@ async function upsertTableData(
               isMirror: Boolean(item.is_mirror),
               attemptCount: Number(item.bid_count || 1),
               comment: item.comment || '',
-              climbedAt: new Date(item.climbed_at),
-              updatedAt: new Date(),
-              auroraSyncedAt: new Date(),
+              climbedAt: new Date(item.climbed_at).toISOString(),
+              updatedAt: new Date().toISOString(),
+              auroraSyncedAt: new Date().toISOString(),
             },
           });
       }

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/internal/user-sync-cron",
       "schedule": "0 */6 * * *"
+    },
+    {
+      "path": "/api/internal/migrate-users-cron",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive migration strategy to sync Aurora climb data (ascents and bids) to the new unified `boardsesh_ticks` table while maintaining backward compatibility with existing Aurora tables.

This PR enables:
- Unified storage for all climb attempts (successful and failed)
- Quality rating conversion from Aurora's scale to Boardsesh's 5-star system
- Automatic migration for new users linking Aurora credentials
- Background migration for existing users

## Changes

### New Files
- `packages/db/drizzle/0026_migrate_aurora_to_boardsesh_ticks.sql` - SQL migration to backfill existing Aurora data
- `packages/web/app/lib/data-sync/aurora/migrate-user-history.ts` - Reusable function for per-user historical data migration
- `packages/web/app/api/internal/migrate-users-cron/route.ts` - Background cron job to process unmigrated users

### Modified Files
- `packages/web/app/lib/data-sync/aurora/user-sync.ts` - Added dual-write strategy for ascents/bids to both Aurora tables and boardsesh_ticks
- `packages/web/app/api/internal/aurora-credentials/route.ts` - Trigger user migration when credentials are added
- `vercel.json` - Added daily migration cron job schedule (3 AM)

## Implementation Details

### Data Transformations
- **Quality Conversion**: `(aurora_quality / 3.0) * 5` to convert Aurora's 1-5 scale
- **Status Mapping**: 
  - Aurora ascents with `attempt_id = 1` → `status: 'flash'`
  - Aurora ascents with `attempt_id > 1` → `status: 'send'`
  - Aurora bids → `status: 'attempt'`
- **User Mapping**: Aurora user IDs mapped to NextAuth user IDs via `aurora_credentials` table

### Migration Strategy

Three migration paths ensure all users get their data:

1. **Initial SQL Migration**: One-time backfill for all existing users with Aurora credentials
2. **User-Triggered**: Automatic migration when users add/update Aurora credentials
3. **Background Cron**: Daily job (3 AM) processes up to 10 unmigrated users per run

### Dual-Write Pattern

The `user-sync.ts` code now writes to both:
- Aurora tables (`kilter_ascents`, `kilter_bids`, etc.) - for backward compatibility
- `boardsesh_ticks` - unified new table

All writes happen in the same transaction to ensure data integrity.

## Testing Strategy

### Pre-Migration Validation
```sql
-- Count records to be migrated
SELECT 'kilter_ascents' as source, COUNT(*) as total
FROM kilter_ascents ka
LEFT JOIN aurora_credentials ac ON ac.aurora_user_id = ka.user_id;
```

### Post-Migration Validation
```sql
-- Verify migration counts
SELECT aurora_type, board_type, COUNT(*) as migrated_count
FROM boardsesh_ticks
WHERE aurora_id IS NOT NULL
GROUP BY aurora_type, board_type;

-- Verify quality conversion
SELECT ka.quality as aurora_quality, bt.quality as boardsesh_quality
FROM kilter_ascents ka
INNER JOIN boardsesh_ticks bt ON bt.aurora_id = ka.uuid
LIMIT 10;
```

## Rollback Plan

If issues occur:
```sql
-- Rollback: Delete migrated records
DELETE FROM boardsesh_ticks WHERE aurora_id IS NOT NULL;
```

Sync code changes can be reverted via git. Aurora tables remain unchanged, ensuring no data loss.

## Edge Cases Handled

- ✅ Users without NextAuth accounts: Filtered out via INNER JOIN
- ✅ NULL quality values: Handled gracefully by conversion function
- ✅ Duplicate migrations: Prevented by idempotent design (WHERE NOT EXISTS checks)
- ✅ Transaction failures: Automatic rollback on any error
- ✅ Missing Aurora credentials: Sync skips ascents/bids gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)