### PR TITLE
Add board layout differentiation to grade ascents

### DIFF
--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -251,6 +251,7 @@ export const typeDefs = /* GraphQL */ `
     auroraType: String
     auroraId: String
     auroraSyncedAt: String
+    layoutId: Int
   }
 
   input SaveTickInput {

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -224,6 +224,7 @@ export type Tick = {
   auroraType: string | null;
   auroraId: string | null;
   auroraSyncedAt: string | null;
+  layoutId: number | null;
 };
 
 export type SaveTickInput = {

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -49,6 +49,7 @@ export const GET_USER_TICKS = gql`
       auroraType
       auroraId
       auroraSyncedAt
+      layoutId
     }
   }
 `;


### PR DESCRIPTION
Updates the profile page "Ascents by Grade" chart to group ascents by board layout instead of just board type. Now shows separate datasets for:
- Kilter Original
- Kilter Homewall
- Tension Classic
- Tension 2 Mirror
- Tension 2 Spray

Changes:
- Add layoutId field to Tick GraphQL type and TypeScript type
- Update backend resolver to join with climbs table to get layoutId
- Add layout name mapping and color scheme
- Update chart aggregation to group by layout