### PR TITLE
fix: Add missing migrations to drizzle journal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,23 @@ npm run backend:dev
 - `npm run db:studio` - Open Drizzle Studio for database exploration
 - From packages/db: `npx drizzle-kit generate` - Generate new migrations
 
+### Creating Database Migrations
+
+**IMPORTANT**: Always use `npx drizzle-kit generate` from `packages/db/` to create new migrations. This command:
+1. Detects schema changes in `packages/db/src/schema/`
+2. Generates the SQL migration file in `packages/db/drizzle/`
+3. Automatically adds the migration to `packages/db/drizzle/meta/_journal.json`
+
+**Never manually create migration SQL files** without adding them to `_journal.json`. The journal tracks which migrations drizzle-kit should run - migrations missing from the journal will be silently skipped during deployment.
+
+```bash
+# From packages/db directory:
+npx drizzle-kit generate
+
+# Then apply locally to test:
+npm run db:migrate
+```
+
 ## Architecture Overview
 
 ### Routing Pattern

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -141,6 +141,20 @@
       "when": 1735516800000,
       "tag": "0025_fix_missing_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1735603200000,
+      "tag": "0026_migrate_aurora_to_boardsesh_ticks",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1735689600000,
+      "tag": "0027_add_sequence_column",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixed two migrations (`0026_migrate_aurora_to_boardsesh_ticks` and `0027_add_sequence_column`) that had SQL files but were missing from `_journal.json`, causing them to be silently skipped during Vercel deployments
- Added documentation to `CLAUDE.md` explaining the proper way to create database migrations to prevent this issue in the future

## Root Cause

The migrations were manually created without using `drizzle-kit generate`, so they never got registered in the journal. Drizzle-kit uses the journal to determine which migrations to run - without journal entries, the SQL files are ignored.

## Test plan

- [ ] Verify the PR deploys successfully on Vercel
- [ ] Check that migrations 0026 and 0027 are applied to the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)