### PR TITLE
feat: Add Ascent/Attempt toggle to log ascent drawer

### DIFF
--- a/packages/web/app/components/logbook/log-ascent-drawer.tsx
+++ b/packages/web/app/components/logbook/log-ascent-drawer.tsx
@@ -22,7 +22,7 @@ export const LogAscentDrawer: React.FC<LogAscentDrawerProps> = ({
       placement="bottom"
       onClose={onClose}
       open={open}
-      height="90%"
+      height="100%"
     >
       {currentClimb && (
         <LogAscentForm


### PR DESCRIPTION
Add a segmented control at the top of the log ascent form that allows
users to choose between logging an "Ascent" (flash/send) or an "Attempt".
When "Attempt" is selected, the status is always set to "attempt"
regardless of the attempt count.