### PR TITLE
feat: Add distributed state manager for multi-node WebSocket support

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -51,8 +51,15 @@ The party session system uses a GraphQL-over-WebSocket architecture with the fol
 │  │ RoomManager         │◄───┤ PubSub              │                     │
 │  │ - Session state     │    │ - Local dispatch    │                     │
 │  │ - Client tracking   │    │ - Redis pub/sub     │                     │
-│  │ - Leader election   │    └─────────────────────┘                     │
-│  └─────────┬───────────┘                                                 │
+│  └─────────┬───────────┘    └─────────────────────┘                     │
+│            │                                                             │
+│  ┌─────────▼─────────────────────────────────────────────────────────┐  │
+│  │ DistributedStateManager (multi-instance support)                   │  │
+│  │ - Cross-instance connection tracking                               │  │
+│  │ - Distributed leader election (Lua scripts)                        │  │
+│  │ - Session membership across instances                              │  │
+│  │ - Instance heartbeating & cleanup                                  │  │
+│  └─────────┬─────────────────────────────────────────────────────────┘  │
 │            │                                                             │
 │  ┌─────────▼───────────┐    ┌─────────────────────┐                     │
 │  │ RedisSessionStore   │    │ PostgreSQL          │                     │
@@ -179,25 +186,47 @@ sequenceDiagram
 
 ### Leader Election
 
-Leader election uses deterministic selection based on connection time:
+Leader election uses Redis-backed atomic operations for consistency across instances:
+
+**Single Instance Mode:**
+- First client to join becomes leader
+- On leader disconnect, earliest connected client is elected
+
+**Multi-Instance Mode (Distributed):**
+- Uses Lua scripts for atomic leader election
+- Leader stored in Redis: `boardsesh:session:{id}:leader`
+- Consistent across all backend instances
 
 ```mermaid
 sequenceDiagram
     participant U1 as User 1 (Leader)
-    participant U2 as User 2
+    participant U2 as User 2 (Instance 2)
     participant RM as RoomManager
+    participant DS as DistributedState
+    participant R as Redis
     participant PS as PubSub
 
     Note over U1,PS: User 1 is current leader
 
     U1->>RM: disconnect()
-    RM->>RM: wasLeader = true
-    RM->>RM: Sort remaining clients by connectedAt
-    RM->>RM: New leader = earliest connected
+    RM->>DS: leaveSession(connectionId, sessionId)
+    DS->>R: Execute ELECT_NEW_LEADER Lua script
+    R->>R: Find earliest connected member
+    R->>R: SET leader key atomically
+    R-->>DS: newLeaderId = U2
+    DS-->>RM: {newLeaderId: U2}
     RM->>PS: publishSessionEvent(LeaderChanged)
     PS->>U2: LeaderChanged{leaderId: U2}
 
-    Note over U2: User 2 is now leader
+    Note over U2: User 2 is now leader (on Instance 2)
+```
+
+**Lua Script Atomicity:**
+```lua
+-- ELECT_NEW_LEADER_SCRIPT
+-- Gets all session members, filters out leaving connection
+-- Sorts by connectedAt, picks earliest
+-- Atomically sets new leader
 ```
 
 ---
@@ -276,6 +305,36 @@ sequenceDiagram
 
 ## Multi-Instance Support
 
+The backend supports horizontal scaling with multiple instances behind a load balancer. **No sticky sessions are required** - any instance can handle any client.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Load Balancer                             │
+│              (No sticky sessions required)                       │
+└─────────────────────────────────────────────────────────────────┘
+           │                    │                    │
+    ┌──────▼───────┐    ┌──────▼───────┐    ┌──────▼───────┐
+    │  Instance A  │    │  Instance B  │    │  Instance C  │
+    │              │    │              │    │              │
+    │ DistState ───┼────┼──────────────┼────┼─── Redis ◄──┤
+    │  Manager     │    │              │    │              │
+    └──────────────┘    └──────────────┘    └──────────────┘
+```
+
+### DistributedStateManager
+
+The `DistributedStateManager` enables true horizontal scaling:
+
+| Feature | Description |
+|---------|-------------|
+| Connection Tracking | All connections visible across instances via Redis |
+| Session Membership | Aggregated user list from all instances |
+| Leader Election | Atomic Lua scripts ensure consistent leader |
+| Instance Heartbeat | 30s heartbeat detects dead instances |
+| Graceful Cleanup | Connections cleaned up on instance shutdown |
+
 ### Redis Pub/Sub for Cross-Instance Events
 
 ```mermaid
@@ -297,6 +356,26 @@ sequenceDiagram
     I2->>C2: QueueItemAdded event
 
     I1->>C1: QueueItemAdded event
+```
+
+### Cross-Instance Session Membership Validation
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant I1 as Instance 1
+    participant DS as DistributedState
+    participant R as Redis
+
+    C->>I1: Subscribe to session (via Instance 1)
+    I1->>I1: Check local context
+    Note over I1: Not found locally
+
+    I1->>DS: isConnectionInSession(connId, sessionId)
+    DS->>R: HGET connection data
+    R-->>DS: {sessionId: "session-123"}
+    DS-->>I1: true (valid member)
+    I1->>C: Subscription authorized
 ```
 
 ### Channel Naming Convention
@@ -541,14 +620,29 @@ sequenceDiagram
 
 ### Key Redis Data Structures
 
+**Session State (RedisSessionStore):**
 ```
-boardsesh:session:{id}              # Hash - session data
-boardsesh:session:{id}:users        # Hash - connected users
+boardsesh:session:{id}              # Hash - session data (queue, version, etc.)
+boardsesh:session:{id}:users        # Hash - connected users (legacy)
 boardsesh:session:{id}:events       # List - event buffer (delta sync)
 boardsesh:session:active            # Set - active session IDs
 boardsesh:session:recent            # Sorted Set - recent sessions (by time)
-boardsesh:queue:{id}                # Pub/Sub channel - queue events
-boardsesh:lock:session:restore:{id} # String - distributed lock
+boardsesh:lock:session:restore:{id} # String - distributed lock (10s TTL)
+```
+
+**Distributed State (DistributedStateManager):**
+```
+boardsesh:conn:{connectionId}       # Hash - connection data (instanceId, sessionId, username, etc.)
+boardsesh:session:{id}:members      # Set - connection IDs in session (cross-instance)
+boardsesh:session:{id}:leader       # String - leader connection ID
+boardsesh:instance:{id}:conns       # Set - connections owned by instance
+boardsesh:instance:{id}:heartbeat   # String - instance heartbeat timestamp (60s TTL)
+```
+
+**Pub/Sub Channels:**
+```
+boardsesh:queue:{sessionId}         # Queue events (add, remove, reorder, etc.)
+boardsesh:session:{sessionId}       # Session events (join, leave, leader change)
 ```
 
 ### Graceful Shutdown
@@ -557,19 +651,33 @@ boardsesh:lock:session:restore:{id} # String - distributed lock
 sequenceDiagram
     participant P as Process
     participant RM as RoomManager
+    participant DS as DistributedState
     participant R as Redis
     participant PG as PostgreSQL
     participant WS as WebSocket
 
     P->>P: SIGTERM received
-    P->>RM: flushPendingWrites()
+    P->>RM: shutdown()
+    RM->>RM: flushPendingWrites()
 
     loop For each pending session
         RM->>RM: Clear debounce timer
         RM->>PG: Write queue state
     end
 
-    RM-->>P: Writes flushed
+    RM->>DS: stop()
+    DS->>DS: Stop heartbeat interval
+
+    loop For each connection on this instance
+        DS->>R: Remove connection data
+        DS->>R: Remove from session members
+        DS->>R: Elect new leader if needed
+    end
+
+    DS->>R: Remove instance tracking keys
+    DS-->>RM: Cleanup complete
+
+    RM-->>P: Shutdown complete
 
     P->>WS: Close all connections
     WS->>WS: Send close frame (1000)
@@ -604,6 +712,10 @@ sequenceDiagram
 | Event buffer TTL | 5 min | Old events cleanup |
 | Hash verification | 60s | State drift detection |
 | Subscription queue | 1000 | Max pending events |
+| Connection TTL | 1 hour | Distributed connection expiry |
+| Instance heartbeat | 30s | Heartbeat update interval |
+| Instance heartbeat TTL | 60s | Dead instance detection |
+| Session members TTL | 4 hours | Matches session TTL |
 
 ---
 
@@ -616,8 +728,10 @@ sequenceDiagram
 - `packages/backend/src/pubsub/redis-adapter.ts` - Redis pub/sub adapter
 - `packages/backend/src/services/room-manager.ts` - Session & queue management
 - `packages/backend/src/services/redis-session-store.ts` - Redis session persistence
+- `packages/backend/src/services/distributed-state.ts` - Multi-instance state management
 - `packages/backend/src/graphql/resolvers/queue/` - Queue mutations & subscriptions
 - `packages/backend/src/graphql/resolvers/sessions/` - Session mutations & subscriptions
+- `packages/backend/src/graphql/resolvers/shared/helpers.ts` - Cross-instance auth validation
 
 ### Frontend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3875,7 +3875,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.57.0"
@@ -5951,7 +5951,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6560,7 +6560,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7359,7 +7359,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8114,7 +8114,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -8451,7 +8451,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.57.0"
@@ -8470,7 +8470,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8687,7 +8687,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8707,7 +8706,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -8840,7 +8838,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -8933,7 +8931,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -9333,7 +9330,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -9356,12 +9353,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9373,12 +9370,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9390,12 +9387,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9407,12 +9404,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9424,12 +9421,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9441,12 +9438,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9458,12 +9455,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9475,12 +9472,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9492,12 +9489,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9509,12 +9506,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9526,12 +9523,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9543,12 +9540,12 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9560,12 +9557,12 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9577,12 +9574,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9594,12 +9591,12 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9611,12 +9608,12 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9628,12 +9625,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9645,12 +9642,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9662,12 +9659,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9679,12 +9676,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9696,12 +9693,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9713,12 +9710,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9730,12 +9727,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9747,12 +9744,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9764,12 +9761,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9781,12 +9778,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9795,7 +9792,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/backend/src/__tests__/distributed-state.test.ts
+++ b/packages/backend/src/__tests__/distributed-state.test.ts
@@ -19,10 +19,14 @@ describe('DistributedStateManager', () => {
   });
 
   beforeEach(async () => {
-    // Clean up any existing test keys
-    const keys = await redis.keys('boardsesh:*');
-    if (keys.length > 0) {
-      await redis.del(...keys);
+    // Clean up any existing test keys with try-catch for robustness
+    try {
+      const keys = await redis.keys('boardsesh:*');
+      if (keys.length > 0) {
+        await redis.del(...keys);
+      }
+    } catch (err) {
+      console.warn('Failed to clean up test keys:', err);
     }
     manager = new DistributedStateManager(redis, 'test-instance-1');
   });
@@ -293,10 +297,14 @@ describe('DistributedStateManager - Multi-Instance', () => {
   });
 
   beforeEach(async () => {
-    // Clean up any existing test keys
-    const keys = await redis1.keys('boardsesh:*');
-    if (keys.length > 0) {
-      await redis1.del(...keys);
+    // Clean up any existing test keys with try-catch for robustness
+    try {
+      const keys = await redis1.keys('boardsesh:*');
+      if (keys.length > 0) {
+        await redis1.del(...keys);
+      }
+    } catch (err) {
+      console.warn('Failed to clean up test keys:', err);
     }
     manager1 = new DistributedStateManager(redis1, 'instance-1');
     manager2 = new DistributedStateManager(redis2, 'instance-2');
@@ -451,9 +459,14 @@ describe('DistributedStateManager - Edge Cases', () => {
   });
 
   beforeEach(async () => {
-    const keys = await redis.keys('boardsesh:*');
-    if (keys.length > 0) {
-      await redis.del(...keys);
+    // Clean up any existing test keys with try-catch for robustness
+    try {
+      const keys = await redis.keys('boardsesh:*');
+      if (keys.length > 0) {
+        await redis.del(...keys);
+      }
+    } catch (err) {
+      console.warn('Failed to clean up test keys:', err);
     }
     manager = new DistributedStateManager(redis, 'edge-instance');
   });

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -169,7 +169,7 @@ const registerAndJoinSession = async (
   boardPath: string,
   username: string
 ) => {
-  roomManager.registerClient(clientId);
+  await roomManager.registerClient(clientId);
   return roomManager.joinSession(clientId, sessionId, boardPath, username);
 };
 

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -300,7 +300,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
 
       // Verify all joined successfully
       expect(results).toHaveLength(3);
-      const users = roomManager.getSessionUsers(sessionId);
+      const users = await roomManager.getSessionUsers(sessionId);
       expect(users).toHaveLength(3);
     });
   });

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -13,7 +13,7 @@ export const sessionQueries = {
     // Validate session ID
     validateInput(SessionIdSchema, sessionId, 'sessionId');
 
-    const users = roomManager.getSessionUsers(sessionId);
+    const users = await roomManager.getSessionUsers(sessionId);
     if (users.length === 0) return null;
 
     const queueState = await roomManager.getQueueState(sessionId);

--- a/packages/backend/src/services/distributed-state.ts
+++ b/packages/backend/src/services/distributed-state.ts
@@ -1,0 +1,581 @@
+import type Redis from 'ioredis';
+import { v4 as uuidv4 } from 'uuid';
+import type { SessionUser } from '@boardsesh/shared-schema';
+
+/**
+ * Connection data stored in Redis for cross-instance visibility.
+ */
+export interface DistributedConnection {
+  connectionId: string;
+  instanceId: string;
+  sessionId: string | null;
+  userId: string | null;
+  username: string;
+  avatarUrl: string | null;
+  isLeader: boolean;
+  connectedAt: number; // Unix timestamp ms
+}
+
+/**
+ * Redis key prefixes for distributed state.
+ */
+const KEYS = {
+  // Hash: connectionId -> connection data
+  connection: (connectionId: string) => `boardsesh:conn:${connectionId}`,
+  // Set: sessionId -> set of connectionIds
+  sessionMembers: (sessionId: string) => `boardsesh:session:${sessionId}:members`,
+  // String: sessionId -> connectionId of leader
+  sessionLeader: (sessionId: string) => `boardsesh:session:${sessionId}:leader`,
+  // Set: instanceId -> set of connectionIds owned by this instance
+  instanceConnections: (instanceId: string) => `boardsesh:instance:${instanceId}:conns`,
+  // String: instanceId -> heartbeat timestamp
+  instanceHeartbeat: (instanceId: string) => `boardsesh:instance:${instanceId}:heartbeat`,
+} as const;
+
+/**
+ * TTL values in seconds.
+ */
+const TTL = {
+  connection: 60 * 60, // 1 hour - refreshed on activity
+  instanceHeartbeat: 60, // 1 minute - refreshed every 30s
+  sessionMembership: 4 * 60 * 60, // 4 hours - matches session TTL
+} as const;
+
+/**
+ * Lua script for atomic leader election.
+ * Returns: 1 if leader was set, 0 if leader already exists
+ */
+const LEADER_ELECTION_SCRIPT = `
+  local leaderKey = KEYS[1]
+  local connectionId = ARGV[1]
+  local connectedAt = ARGV[2]
+
+  -- Check if leader already exists
+  local currentLeader = redis.call('GET', leaderKey)
+  if currentLeader then
+    return 0
+  end
+
+  -- Set this connection as leader
+  redis.call('SET', leaderKey, connectionId)
+  return 1
+`;
+
+/**
+ * Lua script for atomic leader transfer.
+ * Only transfers leadership if current leader matches expected.
+ * Returns: 1 if transferred, 0 if not
+ */
+const LEADER_TRANSFER_SCRIPT = `
+  local leaderKey = KEYS[1]
+  local expectedLeader = ARGV[1]
+  local newLeader = ARGV[2]
+
+  local currentLeader = redis.call('GET', leaderKey)
+  if currentLeader ~= expectedLeader then
+    return 0
+  end
+
+  if newLeader == '' then
+    redis.call('DEL', leaderKey)
+  else
+    redis.call('SET', leaderKey, newLeader)
+  end
+  return 1
+`;
+
+/**
+ * Lua script to elect new leader from session members.
+ * Picks the member with the earliest connectedAt timestamp.
+ * Returns: connectionId of new leader, or nil if no members
+ */
+const ELECT_NEW_LEADER_SCRIPT = `
+  local sessionMembersKey = KEYS[1]
+  local leaderKey = KEYS[2]
+  local leavingConnectionId = ARGV[1]
+
+  -- Get all members except the leaving one
+  local members = redis.call('SMEMBERS', sessionMembersKey)
+  local candidates = {}
+
+  for _, memberId in ipairs(members) do
+    if memberId ~= leavingConnectionId then
+      local connKey = 'boardsesh:conn:' .. memberId
+      local connectedAt = redis.call('HGET', connKey, 'connectedAt')
+      if connectedAt then
+        table.insert(candidates, {memberId, tonumber(connectedAt)})
+      end
+    end
+  end
+
+  -- No candidates left
+  if #candidates == 0 then
+    redis.call('DEL', leaderKey)
+    return nil
+  end
+
+  -- Sort by connectedAt (earliest first)
+  table.sort(candidates, function(a, b) return a[2] < b[2] end)
+
+  local newLeaderId = candidates[1][1]
+
+  -- Set new leader
+  redis.call('SET', leaderKey, newLeaderId)
+
+  -- Update isLeader flag on the connection
+  local connKey = 'boardsesh:conn:' .. newLeaderId
+  redis.call('HSET', connKey, 'isLeader', 'true')
+
+  return newLeaderId
+`;
+
+/**
+ * DistributedStateManager provides cross-instance state management for:
+ * - Connection tracking
+ * - Session membership
+ * - Leader election
+ *
+ * This enables true horizontal scaling without sticky sessions.
+ */
+export class DistributedStateManager {
+  private readonly instanceId: string;
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly redis: Redis,
+    instanceId?: string
+  ) {
+    this.instanceId = instanceId || uuidv4();
+  }
+
+  /**
+   * Get this instance's unique ID.
+   */
+  getInstanceId(): string {
+    return this.instanceId;
+  }
+
+  /**
+   * Start the heartbeat and cleanup background tasks.
+   */
+  start(): void {
+    if (this.heartbeatInterval) {
+      return;
+    }
+
+    // Update heartbeat every 30 seconds
+    this.heartbeatInterval = setInterval(() => {
+      this.updateHeartbeat().catch((err) => {
+        console.error('[DistributedState] Heartbeat update failed:', err);
+      });
+    }, 30_000);
+
+    // Initial heartbeat
+    this.updateHeartbeat().catch((err) => {
+      console.error('[DistributedState] Initial heartbeat failed:', err);
+    });
+
+    console.log(`[DistributedState] Started with instance ID: ${this.instanceId.slice(0, 8)}`);
+  }
+
+  /**
+   * Stop background tasks and clean up instance state.
+   */
+  async stop(): Promise<void> {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+
+    // Clean up all connections for this instance
+    await this.cleanupInstanceConnections();
+
+    console.log(`[DistributedState] Stopped instance: ${this.instanceId.slice(0, 8)}`);
+  }
+
+  /**
+   * Register a new connection in distributed state.
+   */
+  async registerConnection(
+    connectionId: string,
+    username: string,
+    userId?: string | null,
+    avatarUrl?: string | null
+  ): Promise<void> {
+    const connection: DistributedConnection = {
+      connectionId,
+      instanceId: this.instanceId,
+      sessionId: null,
+      userId: userId || null,
+      username,
+      avatarUrl: avatarUrl || null,
+      isLeader: false,
+      connectedAt: Date.now(),
+    };
+
+    const multi = this.redis.multi();
+
+    // Store connection data
+    multi.hmset(KEYS.connection(connectionId), this.connectionToHash(connection));
+    multi.expire(KEYS.connection(connectionId), TTL.connection);
+
+    // Track connection under this instance
+    multi.sadd(KEYS.instanceConnections(this.instanceId), connectionId);
+
+    await multi.exec();
+
+    console.log(`[DistributedState] Registered connection: ${connectionId.slice(0, 8)} on instance: ${this.instanceId.slice(0, 8)}`);
+  }
+
+  /**
+   * Remove a connection from distributed state.
+   */
+  async removeConnection(connectionId: string): Promise<{ sessionId: string | null; wasLeader: boolean }> {
+    // Get current connection state
+    const connection = await this.getConnection(connectionId);
+    if (!connection) {
+      return { sessionId: null, wasLeader: false };
+    }
+
+    const sessionId = connection.sessionId;
+    const wasLeader = connection.isLeader;
+
+    const multi = this.redis.multi();
+
+    // Remove connection data
+    multi.del(KEYS.connection(connectionId));
+
+    // Remove from instance tracking
+    multi.srem(KEYS.instanceConnections(this.instanceId), connectionId);
+
+    // Remove from session if member
+    if (sessionId) {
+      multi.srem(KEYS.sessionMembers(sessionId), connectionId);
+    }
+
+    await multi.exec();
+
+    console.log(`[DistributedState] Removed connection: ${connectionId.slice(0, 8)}`);
+
+    return { sessionId, wasLeader };
+  }
+
+  /**
+   * Get connection data from Redis.
+   */
+  async getConnection(connectionId: string): Promise<DistributedConnection | null> {
+    const data = await this.redis.hgetall(KEYS.connection(connectionId));
+    if (!data || !data.connectionId) {
+      return null;
+    }
+    return this.hashToConnection(data);
+  }
+
+  /**
+   * Check if a connection exists and belongs to a specific session.
+   */
+  async isConnectionInSession(connectionId: string, sessionId: string): Promise<boolean> {
+    const connection = await this.getConnection(connectionId);
+    return connection !== null && connection.sessionId === sessionId;
+  }
+
+  /**
+   * Join a session. Handles leader election for first member.
+   * Returns whether this connection became leader.
+   */
+  async joinSession(
+    connectionId: string,
+    sessionId: string,
+    username?: string,
+    avatarUrl?: string | null
+  ): Promise<{ isLeader: boolean }> {
+    // Update connection with session info
+    const updates: Record<string, string> = {
+      sessionId,
+    };
+    if (username) {
+      updates.username = username;
+    }
+    if (avatarUrl !== undefined) {
+      updates.avatarUrl = avatarUrl || '';
+    }
+
+    const multi = this.redis.multi();
+
+    // Update connection
+    multi.hmset(KEYS.connection(connectionId), updates);
+    multi.expire(KEYS.connection(connectionId), TTL.connection);
+
+    // Add to session members
+    multi.sadd(KEYS.sessionMembers(sessionId), connectionId);
+    multi.expire(KEYS.sessionMembers(sessionId), TTL.sessionMembership);
+
+    await multi.exec();
+
+    // Try to become leader (atomic operation)
+    const connection = await this.getConnection(connectionId);
+    const connectedAt = connection?.connectedAt || Date.now();
+
+    const becameLeader = await this.redis.eval(
+      LEADER_ELECTION_SCRIPT,
+      1,
+      KEYS.sessionLeader(sessionId),
+      connectionId,
+      connectedAt.toString()
+    ) as number;
+
+    if (becameLeader === 1) {
+      // Update connection to mark as leader
+      await this.redis.hset(KEYS.connection(connectionId), 'isLeader', 'true');
+      console.log(`[DistributedState] Connection ${connectionId.slice(0, 8)} became leader of session ${sessionId.slice(0, 8)}`);
+    }
+
+    return { isLeader: becameLeader === 1 };
+  }
+
+  /**
+   * Leave a session. Handles leader election if leaving member was leader.
+   * Returns the new leader's connectionId if leadership changed.
+   */
+  async leaveSession(connectionId: string, sessionId: string): Promise<{ newLeaderId: string | null }> {
+    const connection = await this.getConnection(connectionId);
+    const wasLeader = connection?.isLeader || false;
+
+    const multi = this.redis.multi();
+
+    // Update connection
+    multi.hmset(KEYS.connection(connectionId), {
+      sessionId: '',
+      isLeader: 'false',
+    });
+
+    // Remove from session members
+    multi.srem(KEYS.sessionMembers(sessionId), connectionId);
+
+    await multi.exec();
+
+    // If was leader, elect new leader
+    let newLeaderId: string | null = null;
+    if (wasLeader) {
+      newLeaderId = await this.redis.eval(
+        ELECT_NEW_LEADER_SCRIPT,
+        2,
+        KEYS.sessionMembers(sessionId),
+        KEYS.sessionLeader(sessionId),
+        connectionId
+      ) as string | null;
+
+      if (newLeaderId) {
+        console.log(`[DistributedState] Elected new leader: ${newLeaderId.slice(0, 8)} for session ${sessionId.slice(0, 8)}`);
+      }
+    }
+
+    return { newLeaderId };
+  }
+
+  /**
+   * Get all members of a session as SessionUser objects.
+   * This aggregates data from all instances.
+   */
+  async getSessionMembers(sessionId: string): Promise<SessionUser[]> {
+    const memberIds = await this.redis.smembers(KEYS.sessionMembers(sessionId));
+
+    if (memberIds.length === 0) {
+      return [];
+    }
+
+    // Batch fetch all connection data
+    const pipeline = this.redis.pipeline();
+    for (const memberId of memberIds) {
+      pipeline.hgetall(KEYS.connection(memberId));
+    }
+
+    const results = await pipeline.exec();
+    const users: SessionUser[] = [];
+
+    if (results) {
+      for (let i = 0; i < results.length; i++) {
+        const [err, data] = results[i] as [Error | null, Record<string, string>];
+        if (!err && data && data.connectionId) {
+          const connection = this.hashToConnection(data);
+          users.push({
+            id: connection.connectionId,
+            username: connection.username,
+            isLeader: connection.isLeader,
+            avatarUrl: connection.avatarUrl || undefined,
+          });
+        }
+      }
+    }
+
+    return users;
+  }
+
+  /**
+   * Get the current leader of a session.
+   */
+  async getSessionLeader(sessionId: string): Promise<string | null> {
+    return this.redis.get(KEYS.sessionLeader(sessionId));
+  }
+
+  /**
+   * Get count of members in a session.
+   */
+  async getSessionMemberCount(sessionId: string): Promise<number> {
+    return this.redis.scard(KEYS.sessionMembers(sessionId));
+  }
+
+  /**
+   * Update connection username.
+   */
+  async updateUsername(connectionId: string, username: string, avatarUrl?: string): Promise<void> {
+    const updates: Record<string, string> = { username };
+    if (avatarUrl !== undefined) {
+      updates.avatarUrl = avatarUrl || '';
+    }
+    await this.redis.hmset(KEYS.connection(connectionId), updates);
+  }
+
+  /**
+   * Refresh connection TTL (call periodically for active connections).
+   */
+  async refreshConnection(connectionId: string): Promise<void> {
+    await this.redis.expire(KEYS.connection(connectionId), TTL.connection);
+  }
+
+  /**
+   * Check if session has any members.
+   */
+  async hasSessionMembers(sessionId: string): Promise<boolean> {
+    const count = await this.redis.scard(KEYS.sessionMembers(sessionId));
+    return count > 0;
+  }
+
+  /**
+   * Clean up session state when it becomes empty.
+   */
+  async cleanupEmptySession(sessionId: string): Promise<void> {
+    const multi = this.redis.multi();
+    multi.del(KEYS.sessionMembers(sessionId));
+    multi.del(KEYS.sessionLeader(sessionId));
+    await multi.exec();
+
+    console.log(`[DistributedState] Cleaned up empty session: ${sessionId.slice(0, 8)}`);
+  }
+
+  /**
+   * Update instance heartbeat.
+   */
+  private async updateHeartbeat(): Promise<void> {
+    await this.redis.setex(
+      KEYS.instanceHeartbeat(this.instanceId),
+      TTL.instanceHeartbeat,
+      Date.now().toString()
+    );
+  }
+
+  /**
+   * Clean up all connections belonging to this instance.
+   * Called on graceful shutdown.
+   */
+  private async cleanupInstanceConnections(): Promise<void> {
+    const connectionIds = await this.redis.smembers(KEYS.instanceConnections(this.instanceId));
+
+    for (const connectionId of connectionIds) {
+      const { sessionId, wasLeader } = await this.removeConnection(connectionId);
+
+      // Handle leader election if needed
+      if (sessionId && wasLeader) {
+        await this.redis.eval(
+          ELECT_NEW_LEADER_SCRIPT,
+          2,
+          KEYS.sessionMembers(sessionId),
+          KEYS.sessionLeader(sessionId),
+          connectionId
+        );
+      }
+    }
+
+    // Remove instance tracking keys
+    const multi = this.redis.multi();
+    multi.del(KEYS.instanceConnections(this.instanceId));
+    multi.del(KEYS.instanceHeartbeat(this.instanceId));
+    await multi.exec();
+
+    console.log(`[DistributedState] Cleaned up ${connectionIds.length} connections for instance: ${this.instanceId.slice(0, 8)}`);
+  }
+
+  /**
+   * Convert connection object to Redis hash fields.
+   */
+  private connectionToHash(conn: DistributedConnection): Record<string, string> {
+    return {
+      connectionId: conn.connectionId,
+      instanceId: conn.instanceId,
+      sessionId: conn.sessionId || '',
+      userId: conn.userId || '',
+      username: conn.username,
+      avatarUrl: conn.avatarUrl || '',
+      isLeader: conn.isLeader ? 'true' : 'false',
+      connectedAt: conn.connectedAt.toString(),
+    };
+  }
+
+  /**
+   * Convert Redis hash fields to connection object.
+   */
+  private hashToConnection(hash: Record<string, string>): DistributedConnection {
+    return {
+      connectionId: hash.connectionId,
+      instanceId: hash.instanceId,
+      sessionId: hash.sessionId || null,
+      userId: hash.userId || null,
+      username: hash.username,
+      avatarUrl: hash.avatarUrl || null,
+      isLeader: hash.isLeader === 'true',
+      connectedAt: parseInt(hash.connectedAt, 10) || Date.now(),
+    };
+  }
+}
+
+// Singleton instance - initialized when Redis is available
+let distributedStateManager: DistributedStateManager | null = null;
+
+/**
+ * Initialize the distributed state manager.
+ * Call this during server startup when Redis is available.
+ */
+export function initializeDistributedState(redis: Redis, instanceId?: string): DistributedStateManager {
+  if (distributedStateManager) {
+    console.warn('[DistributedState] Already initialized, returning existing instance');
+    return distributedStateManager;
+  }
+
+  distributedStateManager = new DistributedStateManager(redis, instanceId);
+  return distributedStateManager;
+}
+
+/**
+ * Get the distributed state manager instance.
+ * Returns null if not initialized (single-instance mode).
+ */
+export function getDistributedState(): DistributedStateManager | null {
+  return distributedStateManager;
+}
+
+/**
+ * Check if distributed state is enabled (Redis available).
+ */
+export function isDistributedStateEnabled(): boolean {
+  return distributedStateManager !== null;
+}
+
+/**
+ * Shutdown the distributed state manager.
+ */
+export async function shutdownDistributedState(): Promise<void> {
+  if (distributedStateManager) {
+    await distributedStateManager.stop();
+    distributedStateManager = null;
+  }
+}

--- a/packages/backend/src/services/room-manager.ts
+++ b/packages/backend/src/services/room-manager.ts
@@ -431,7 +431,19 @@ class RoomManager {
       }
     }
 
-    // Always clean up local state to prevent memory leaks
+    // Clean up local state to prevent memory leaks
+    const client = this.clients.get(connectionId);
+    if (client?.sessionId) {
+      // Remove from session membership set
+      const sessionSet = this.sessions.get(client.sessionId);
+      if (sessionSet) {
+        sessionSet.delete(connectionId);
+        // Clean up empty session sets to prevent memory buildup
+        if (sessionSet.size === 0) {
+          this.sessions.delete(client.sessionId);
+        }
+      }
+    }
     this.clients.delete(connectionId);
 
     return { distributedStateCleanedUp };

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -79,7 +79,7 @@ export function setupWebSocketServer(httpServer: HttpServer): WebSocketServer {
 
         // Create context on initial connection with auth info
         const context = createContext(undefined, isAuthenticated, authenticatedUserId);
-        roomManager.registerClient(context.connectionId);
+        await roomManager.registerClient(context.connectionId);
         console.log(`Client connected: ${context.connectionId} (authenticated: ${isAuthenticated})`);
 
         // Store context in ctx.extra for access in other hooks
@@ -139,7 +139,7 @@ export function setupWebSocketServer(httpServer: HttpServer): WebSocketServer {
             }
           }
 
-          roomManager.removeClient(context.connectionId);
+          await roomManager.removeClient(context.connectionId);
           removeContext(context.connectionId);
         }
       },


### PR DESCRIPTION
Implements DistributedStateManager service to enable horizontal scaling
without sticky sessions:

- Redis-backed connection tracking across instances
- Distributed user list aggregation from all instances
- Atomic leader election using Lua scripts
- Cross-instance session membership validation

Key changes:
- New DistributedStateManager service with comprehensive test coverage
- RoomManager integration for seamless multi-instance support
- Updated requireSessionMember helper for cross-instance auth
- getSessionUsers now async to support distributed queries

This enables running multiple backend nodes behind a load balancer
without requiring sticky sessions. Leader election is coordinated
via Redis, and user lists are aggregated across all instances.