### PR TITLE
feat: Change profile chart from stacked to grouped bars

### DIFF
--- a/packages/web/app/crusher/[user_id]/profile-stats-charts.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-stats-charts.tsx
@@ -65,14 +65,14 @@ const optionsAggregated = {
   },
   scales: {
     x: {
-      stacked: true,
+      stacked: false,
       title: {
         display: true,
         text: 'Grade',
       },
     },
     y: {
-      stacked: true,
+      stacked: false,
       title: {
         display: true,
         text: 'Ascents',


### PR DESCRIPTION
Update the first chart on the profile page (Ascents by Grade) to use
grouped bar display instead of stacked bars for better readability.