### PR TITLE
fix: Prevent party session reconnection when swiping between climbs

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -31,21 +31,40 @@ import {
 } from '@/app/lib/graphql/operations/playlists';
 
 /**
- * Extracts the base board path from a full pathname.
- * This removes dynamic segments like /play/[climb_uuid] or /list that change during navigation
- * but don't represent a change in board configuration.
+ * Extracts the base board configuration path from a full pathname.
+ * This removes dynamic segments that can change during a session:
+ * - /play/[climb_uuid] - viewing different climbs
+ * - /list, /create - different views
+ * - /{angle} - the board angle is adjustable during a session
+ *
+ * The base path represents the physical board setup: /{board}/{layout}/{size}/{sets}
  */
 function getBaseBoardPath(pathname: string): string {
-  const playMatch = pathname.match(/^(.+?)\/play\/[^/]+$/);
-  if (playMatch) return playMatch[1];
+  // First, strip off /play/[uuid], /list, or /create if present
+  let path = pathname;
 
-  const listMatch = pathname.match(/^(.+?)\/list$/);
-  if (listMatch) return listMatch[1];
+  const playMatch = path.match(/^(.+?)\/play\/[^/]+$/);
+  if (playMatch) {
+    path = playMatch[1];
+  } else {
+    const listMatch = path.match(/^(.+?)\/list$/);
+    if (listMatch) {
+      path = listMatch[1];
+    } else {
+      const createMatch = path.match(/^(.+?)\/create$/);
+      if (createMatch) {
+        path = createMatch[1];
+      }
+    }
+  }
 
-  const createMatch = pathname.match(/^(.+?)\/create$/);
-  if (createMatch) return createMatch[1];
+  // Strip off the angle (last segment, which is a number)
+  const angleMatch = path.match(/^(.+?)\/\d+$/);
+  if (angleMatch) {
+    return angleMatch[1];
+  }
 
-  return pathname;
+  return path;
 }
 
 // Extended context type with session management

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useQueueReducer } from '../queue-control/reducer';
 import { useQueueDataFetching } from '../queue-control/hooks/use-queue-data-fetching';
 import { QueueContextType, ClimbQueueItem, UserName, QueueItemUser } from '../queue-control/types';
-import { urlParamsToSearchParams, searchParamsToUrlParams } from '@/app/lib/url-utils';
+import { urlParamsToSearchParams, searchParamsToUrlParams, getBaseBoardPath } from '@/app/lib/url-utils';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useConnectionSettings } from '../connection-manager/connection-settings-context';
 import { usePartyProfile } from '../party-manager/party-profile-context';
@@ -29,43 +29,6 @@ import {
   type AddClimbToPlaylistMutationResponse,
   type RemoveClimbFromPlaylistMutationResponse,
 } from '@/app/lib/graphql/operations/playlists';
-
-/**
- * Extracts the base board configuration path from a full pathname.
- * This removes dynamic segments that can change during a session:
- * - /play/[climb_uuid] - viewing different climbs
- * - /list, /create - different views
- * - /{angle} - the board angle is adjustable during a session
- *
- * The base path represents the physical board setup: /{board}/{layout}/{size}/{sets}
- */
-function getBaseBoardPath(pathname: string): string {
-  // First, strip off /play/[uuid], /list, or /create if present
-  let path = pathname;
-
-  const playMatch = path.match(/^(.+?)\/play\/[^/]+$/);
-  if (playMatch) {
-    path = playMatch[1];
-  } else {
-    const listMatch = path.match(/^(.+?)\/list$/);
-    if (listMatch) {
-      path = listMatch[1];
-    } else {
-      const createMatch = path.match(/^(.+?)\/create$/);
-      if (createMatch) {
-        path = createMatch[1];
-      }
-    }
-  }
-
-  // Strip off the angle (last segment, which is a number)
-  const angleMatch = path.match(/^(.+?)\/\d+$/);
-  if (angleMatch) {
-    return angleMatch[1];
-  }
-
-  return path;
-}
 
 // Extended context type with session management
 export interface GraphQLQueueContextType extends QueueContextType {

--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -4,58 +4,12 @@ import React, { useEffect, useMemo } from 'react';
 import { useSearchParams, usePathname } from 'next/navigation';
 import { usePersistentSession } from './persistent-session-context';
 import { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
+import { getBaseBoardPath } from '@/app/lib/url-utils';
 
 interface BoardSessionBridgeProps {
   boardDetails: BoardDetails;
   parsedParams: ParsedBoardRouteParameters;
   children: React.ReactNode;
-}
-
-/**
- * Extracts the base board configuration path from a full pathname.
- * This removes dynamic segments that can change during a session:
- * - /play/[climb_uuid] - viewing different climbs
- * - /list, /create - different views
- * - /{angle} - the board angle is adjustable during a session
- *
- * The base path represents the physical board setup: /{board}/{layout}/{size}/{sets}
- *
- * Examples:
- *   /kilter/original/12x12/default/45/play/abc-123 -> /kilter/original/12x12/default
- *   /kilter/original/12x12/default/45/list -> /kilter/original/12x12/default
- *   /kilter/original/12x12/default/45 -> /kilter/original/12x12/default
- *   /kilter/original/12x12/default/50 -> /kilter/original/12x12/default
- */
-function getBaseBoardPath(pathname: string): string {
-  // URL structure: /{board}/{layout}/{size}/{sets}/{angle}[/play/uuid|/list|/create]
-  // We want to extract: /{board}/{layout}/{size}/{sets}
-
-  // First, strip off /play/[uuid], /list, or /create if present
-  let path = pathname;
-
-  const playMatch = path.match(/^(.+?)\/play\/[^/]+$/);
-  if (playMatch) {
-    path = playMatch[1];
-  } else {
-    const listMatch = path.match(/^(.+?)\/list$/);
-    if (listMatch) {
-      path = listMatch[1];
-    } else {
-      const createMatch = path.match(/^(.+?)\/create$/);
-      if (createMatch) {
-        path = createMatch[1];
-      }
-    }
-  }
-
-  // Now strip off the angle (last segment, which is a number)
-  // Path is now: /{board}/{layout}/{size}/{sets}/{angle}
-  const angleMatch = path.match(/^(.+?)\/\d+$/);
-  if (angleMatch) {
-    return angleMatch[1];
-  }
-
-  return path;
 }
 
 /**


### PR DESCRIPTION
When swiping between climbs in play view, the URL pathname changes from
/play/[uuid1] to /play/[uuid2]. This was triggering session reconnection
because BoardSessionBridge compared the full pathname with the stored
boardPath, which always differed.

Changes:
- Add getBaseBoardPath() to extract base board configuration path
  (strips /play/[uuid], /list, /create segments)
- Use baseBoardPath for session comparison in BoardSessionBridge
- Update QueueContext to use baseBoardPath for:
  - isPersistentSessionActive check
  - Local queue path comparisons

This ensures WebSocket connection remains stable during climb navigation
while still detecting actual board configuration changes (e.g., angle).