### PR TITLE
fix: Add suggested items to queue when sent in party mode

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -242,7 +242,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
             type: 'DELTA_UPDATE_CURRENT_CLIMB',
             payload: {
               item: event.currentItem as ClimbQueueItem | null,
-              shouldAddToQueue: false,
+              shouldAddToQueue: (event.currentItem as ClimbQueueItem | null)?.suggested ?? false,
               isServerEvent: true,
               eventClientId: event.clientId || undefined,
               myClientId: persistentSession.clientId || undefined,


### PR DESCRIPTION
When handling CurrentClimbChanged events from the server, the shouldAddToQueue flag was hardcoded to false. This caused other clients in a party session to not add suggested items to their queue when another client sent them.

The fix uses the item's suggested flag to determine whether to add the item to the queue, matching the behavior of the sending client's optimistic update.