### PR TITLE
Remove backendUrl query parameter

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -365,7 +365,6 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
         boardPath: pathname,
         createdAt: new Date().toISOString(),
         lastActivity: new Date().toISOString(),
-        backendUrl: backendUrl,
       });
 
       return newSessionId;
@@ -394,7 +393,6 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
         boardPath: pathname,
         createdAt: new Date().toISOString(),
         lastActivity: new Date().toISOString(),
-        backendUrl: backendUrl,
       });
     },
     [backendUrl, pathname, router, searchParams],

--- a/packages/web/app/components/setup-wizard/nearby-session-card.tsx
+++ b/packages/web/app/components/setup-wizard/nearby-session-card.tsx
@@ -23,7 +23,6 @@ type DiscoverableSession = {
 
 type NearbySessionCardProps = {
   session: DiscoverableSession;
-  backendUrl: string;
 };
 
 /**
@@ -49,14 +48,13 @@ function extractBoardName(boardPath: string): string {
   return 'Unknown Board';
 }
 
-const NearbySessionCard = ({ session, backendUrl }: NearbySessionCardProps) => {
+const NearbySessionCard = ({ session }: NearbySessionCardProps) => {
   const router = useRouter();
 
   const handleJoin = () => {
-    // Navigate to the board path with the session ID and backend URL
+    // Navigate to the board path with the session ID
     const url = new URL(session.boardPath, window.location.origin);
-    url.searchParams.set('backendUrl', backendUrl);
-    url.searchParams.set('sessionId', session.id);
+    url.searchParams.set('session', session.id);
     router.push(url.pathname + url.search);
   };
 

--- a/packages/web/app/components/setup-wizard/session-history-panel.tsx
+++ b/packages/web/app/components/setup-wizard/session-history-panel.tsx
@@ -16,11 +16,6 @@ type StoredSession = {
   createdAt: string;
   lastActivity: string;
   participantCount?: number;
-  backendUrl?: string;
-};
-
-type SessionHistoryPanelProps = {
-  backendUrl?: string;
 };
 
 /**
@@ -115,7 +110,7 @@ export async function saveSessionToHistory(session: StoredSession): Promise<void
   });
 }
 
-const SessionHistoryPanel = ({ backendUrl }: SessionHistoryPanelProps) => {
+const SessionHistoryPanel = () => {
   const router = useRouter();
   const [sessions, setSessions] = useState<StoredSession[]>([]);
   const [loading, setLoading] = useState(true);
@@ -129,10 +124,7 @@ const SessionHistoryPanel = ({ backendUrl }: SessionHistoryPanelProps) => {
 
   const handleResume = (session: StoredSession) => {
     const url = new URL(session.boardPath, window.location.origin);
-    if (session.backendUrl || backendUrl) {
-      url.searchParams.set('backendUrl', session.backendUrl || backendUrl || '');
-    }
-    url.searchParams.set('sessionId', session.id);
+    url.searchParams.set('session', session.id);
     router.push(url.pathname + url.search);
   };
 


### PR DESCRIPTION
The backendUrl was being passed as a URL query parameter when joining or resuming sessions. This was unnecessary since the app always uses the NEXT_PUBLIC_WS_URL environment variable for the backend URL.

This also fixes the continue session feature which was broken because the URL contained an encoded backendUrl parameter.

Changes:
- Remove backendUrl from URL query params in connection-settings-context
- Remove backendUrl from session history storage and resume logic
- Remove backendUrl prop from join-session-tab and nearby-session-card
- Clean up saveSessionToHistory calls to not include backendUrl
- Use environment variable directly instead of passing as prop