### PR TITLE
feat: Add OpenGraph metadata with OG image to play page

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { BoardRouteParametersWithUuid, ParsedBoardRouteParameters } from '@/app/lib/types';
-import { parseBoardRouteParams, extractUuidFromSlug } from '@/app/lib/url-utils';
+import { BoardRouteParametersWithUuid } from '@/app/lib/types';
+import { parseBoardRouteParams, extractUuidFromSlug, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { getBoardDetails } from '@/app/lib/__generated__/product-sizes-data';
 import { getClimb } from '@/app/lib/data/queries';
@@ -17,13 +17,61 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
 
     const climbName = currentClimb.name || `${boardDetails.board_name} Climb`;
     const climbGrade = currentClimb.difficulty || 'Unknown Grade';
+    const setter = currentClimb.setter_username || 'Unknown Setter';
+    const description = `${climbName} - ${climbGrade} by ${setter}. Quality: ${currentClimb.quality_average || 0}/5. Ascents: ${currentClimb.ascensionist_count || 0}`;
+
+    // Construct the play URL for OG
+    const playUrl =
+      boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
+        ? constructPlayUrlWithSlugs(
+            parsedParams.board_name,
+            boardDetails.layout_name,
+            boardDetails.size_name,
+            boardDetails.size_description,
+            boardDetails.set_names,
+            parsedParams.angle,
+            parsedParams.climb_uuid,
+            currentClimb.name,
+          )
+        : `/${parsedParams.board_name}/${parsedParams.layout_id}/${parsedParams.size_id}/${parsedParams.set_ids.join(',')}/${parsedParams.angle}/play/${parsedParams.climb_uuid}`;
+
+    // Generate OG image URL - use parsed numeric IDs for better performance
+    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
+    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
+    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
+    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
+    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
+    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
 
     return {
       title: `${climbName} - ${climbGrade} | Play Mode | Boardsesh`,
+      description,
+      openGraph: {
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        type: 'website',
+        url: playUrl,
+        images: [
+          {
+            url: ogImageUrl.toString(),
+            width: 1200,
+            height: 630,
+            alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        images: [ogImageUrl.toString()],
+      },
     };
   } catch {
     return {
       title: 'Play Mode | Boardsesh',
+      description: 'Play climbing routes in fullscreen mode',
     };
   }
 }


### PR DESCRIPTION
Add rich social embed support for play page URLs matching the climb view page. This includes:
- Full OpenGraph metadata (title, description, image, URL)
- Twitter card support (summary_large_image)
- Dynamic OG image generation using the existing /api/og/climb endpoint
- Description with climb name, grade, setter, quality rating, and ascent count