### PR TITLE
feat: Add Instagram profile URL support

### DIFF
--- a/packages/db/drizzle/0028_add_instagram_url.sql
+++ b/packages/db/drizzle/0028_add_instagram_url.sql
@@ -1,0 +1,2 @@
+-- Add Instagram URL column to user_profiles table
+ALTER TABLE "user_profiles" ADD COLUMN "instagram_url" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1735689600000,
       "tag": "0027_add_sequence_column",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1735776000000,
+      "tag": "0028_add_instagram_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth/credentials.ts
+++ b/packages/db/src/schema/auth/credentials.ts
@@ -25,6 +25,7 @@ export const userProfiles = pgTable("user_profiles", {
     .references(() => users.id, { onDelete: "cascade" }),
   displayName: text("display_name"), // Custom display name (optional, falls back to users.name)
   avatarUrl: text("avatar_url"), // URL to avatar image (S3 or external)
+  instagramUrl: text("instagram_url"), // Instagram profile URL (optional)
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/packages/web/app/api/internal/profile/[userId]/route.ts
+++ b/packages/web/app/api/internal/profile/[userId]/route.ts
@@ -59,6 +59,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         ? {
             displayName: profile.displayName,
             avatarUrl: profile.avatarUrl,
+            instagramUrl: profile.instagramUrl,
           }
         : null,
       credentials,

--- a/packages/web/app/api/internal/profile/route.ts
+++ b/packages/web/app/api/internal/profile/route.ts
@@ -9,6 +9,7 @@ import { authOptions } from "@/app/lib/auth/auth-options";
 const updateProfileSchema = z.object({
   displayName: z.string().max(100, "Display name must be less than 100 characters").optional().nullable(),
   avatarUrl: z.string().url("Invalid avatar URL").optional().nullable(),
+  instagramUrl: z.string().url("Invalid Instagram URL").optional().nullable(),
 });
 
 export async function GET() {
@@ -51,6 +52,7 @@ export async function GET() {
         ? {
             displayName: profile.displayName,
             avatarUrl: profile.avatarUrl,
+            instagramUrl: profile.instagramUrl,
           }
         : null,
     });
@@ -79,7 +81,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const { displayName, avatarUrl } = validationResult.data;
+    const { displayName, avatarUrl, instagramUrl } = validationResult.data;
     const db = getDb();
 
     // Check if profile exists
@@ -98,6 +100,7 @@ export async function PUT(request: NextRequest) {
         .set({
           displayName: displayName ?? null,
           avatarUrl: avatarUrl ?? null,
+          instagramUrl: instagramUrl ?? null,
           updatedAt: now,
         })
         .where(eq(schema.userProfiles.userId, session.user.id));
@@ -107,6 +110,7 @@ export async function PUT(request: NextRequest) {
         userId: session.user.id,
         displayName: displayName ?? null,
         avatarUrl: avatarUrl ?? null,
+        instagramUrl: instagramUrl ?? null,
       });
     }
 

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -14,7 +14,7 @@ import {
   DatePicker,
   message,
 } from 'antd';
-import { UserOutlined } from '@ant-design/icons';
+import { UserOutlined, InstagramOutlined } from '@ant-design/icons';
 import { useSession } from 'next-auth/react';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
@@ -52,6 +52,7 @@ interface UserProfile {
   profile: {
     displayName: string | null;
     avatarUrl: string | null;
+    instagramUrl: string | null;
   } | null;
 }
 
@@ -543,6 +544,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
 
   const displayName = profile?.profile?.displayName || profile?.name || 'Crusher';
   const avatarUrl = profile?.profile?.avatarUrl || profile?.image;
+  const instagramUrl = profile?.profile?.instagramUrl;
 
   // Board options are now available for all users (no Aurora credentials required)
   const boardOptions = BOARD_TYPES.map((boardType) => ({
@@ -587,6 +589,17 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
               </Title>
               {isOwnProfile && (
                 <Text type="secondary">{profile?.email}</Text>
+              )}
+              {instagramUrl && (
+                <a
+                  href={instagramUrl.startsWith('http') ? instagramUrl : `https://${instagramUrl}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.instagramLink}
+                >
+                  <InstagramOutlined className={styles.instagramIcon} />
+                  <span>{instagramUrl.replace(/^https?:\/\/(www\.)?instagram\.com\//, '@').replace(/\/$/, '')}</span>
+                </a>
               )}
             </div>
           </div>

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -60,6 +60,26 @@
   margin: 0 !important;
 }
 
+.instagramLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px; /* spacing between icon and text */
+  color: #E1306C; /* Instagram brand color */
+  font-size: 14px;
+  margin-top: 4px;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.instagramLink:hover {
+  opacity: 0.8;
+  text-decoration: none;
+}
+
+.instagramIcon {
+  font-size: 16px;
+}
+
 .statsCard {
   margin-bottom: 24px; /* spacing.6 */
 }

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -15,7 +15,7 @@ import {
   message,
   Spin,
 } from 'antd';
-import { UserOutlined, UploadOutlined, LoadingOutlined } from '@ant-design/icons';
+import { UserOutlined, UploadOutlined, LoadingOutlined, InstagramOutlined } from '@ant-design/icons';
 import type { UploadFile, UploadProps } from 'antd/es/upload/interface';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
@@ -59,6 +59,7 @@ interface UserProfile {
   profile: {
     displayName: string | null;
     avatarUrl: string | null;
+    instagramUrl: string | null;
   } | null;
 }
 
@@ -108,6 +109,7 @@ export default function SettingsPageContent() {
       setProfile(data);
       form.setFieldsValue({
         displayName: data.profile?.displayName || data.name || '',
+        instagramUrl: data.profile?.instagramUrl || '',
       });
       setPreviewUrl(data.profile?.avatarUrl || data.image || undefined);
     } catch (error) {
@@ -220,6 +222,7 @@ export default function SettingsPageContent() {
         body: JSON.stringify({
           displayName: values.displayName?.trim() || null,
           avatarUrl,
+          instagramUrl: values.instagramUrl?.trim() || null,
         }),
       });
 
@@ -318,6 +321,22 @@ export default function SettingsPageContent() {
               rules={[{ max: 100, message: 'Display name must be less than 100 characters' }]}
             >
               <Input placeholder="Enter your display name" prefix={<UserOutlined />} maxLength={100} />
+            </Form.Item>
+
+            <Form.Item
+              name="instagramUrl"
+              label="Instagram Profile"
+              rules={[
+                {
+                  pattern: /^(https?:\/\/)?(www\.)?instagram\.com\/[a-zA-Z0-9._]+\/?$/,
+                  message: 'Please enter a valid Instagram profile URL',
+                },
+              ]}
+            >
+              <Input
+                placeholder="https://instagram.com/username"
+                prefix={<InstagramOutlined />}
+              />
             </Form.Item>
 
             <Divider />


### PR DESCRIPTION
- Add instagramUrl field to userProfiles database schema
- Create migration 0028 to add instagram_url column
- Update profile API endpoints (GET/PUT) to handle instagramUrl
- Add Instagram URL input field to settings page with validation
- Display Instagram link with icon on public profile page