### PR TITLE
Add recent ascents feed to profile page

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -1,9 +1,9 @@
-import { eq, and, desc, inArray } from 'drizzle-orm';
+import { eq, and, desc, inArray, sql, count } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client.js';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers.js';
-import { GetTicksInputSchema, BoardNameSchema } from '../../../validation/schemas.js';
+import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas.js';
 
 // Helper to get the climbs table based on board type
 const getClimbsTable = (boardType: string) => {
@@ -188,5 +188,129 @@ export const tickQueries = {
       auroraSyncedAt: tick.auroraSyncedAt,
       layoutId: null,
     }));
+  },
+
+  /**
+   * Get ascent activity feed for a specific user (public query)
+   * Returns ticks with enriched climb data for display in a feed
+   */
+  userAscentsFeed: async (
+    _: unknown,
+    { userId, input }: { userId: string; input?: { limit?: number; offset?: number } }
+  ): Promise<{
+    items: unknown[];
+    totalCount: number;
+    hasMore: boolean;
+  }> => {
+    // Validate and set defaults
+    const validatedInput = validateInput(AscentFeedInputSchema, input || {}, 'input');
+    const limit = validatedInput.limit ?? 20;
+    const offset = validatedInput.offset ?? 0;
+
+    // Get total count of ticks for this user
+    const countResult = await db
+      .select({ count: count() })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.userId, userId));
+
+    const totalCount = Number(countResult[0]?.count || 0);
+
+    // Fetch ticks ordered by climbedAt, paginated
+    const ticks = await db
+      .select()
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.userId, userId))
+      .orderBy(desc(dbSchema.boardseshTicks.climbedAt))
+      .limit(limit)
+      .offset(offset);
+
+    // Enrich ticks with climb data
+    const items = await Promise.all(
+      ticks.map(async (tick) => {
+        // Get climb details based on board type
+        let climbName = 'Unknown Climb';
+        let setterUsername: string | null = null;
+        let layoutId: number | null = null;
+
+        if (tick.boardType === 'kilter') {
+          const climb = await db
+            .select({
+              name: dbSchema.kilterClimbs.name,
+              setterUsername: dbSchema.kilterClimbs.setterUsername,
+              layoutId: dbSchema.kilterClimbs.layoutId,
+            })
+            .from(dbSchema.kilterClimbs)
+            .where(eq(dbSchema.kilterClimbs.uuid, tick.climbUuid))
+            .limit(1);
+
+          if (climb[0]) {
+            climbName = climb[0].name || 'Unnamed Climb';
+            setterUsername = climb[0].setterUsername;
+            layoutId = climb[0].layoutId;
+          }
+        } else if (tick.boardType === 'tension') {
+          const climb = await db
+            .select({
+              name: dbSchema.tensionClimbs.name,
+              setterUsername: dbSchema.tensionClimbs.setterUsername,
+              layoutId: dbSchema.tensionClimbs.layoutId,
+            })
+            .from(dbSchema.tensionClimbs)
+            .where(eq(dbSchema.tensionClimbs.uuid, tick.climbUuid))
+            .limit(1);
+
+          if (climb[0]) {
+            climbName = climb[0].name || 'Unnamed Climb';
+            setterUsername = climb[0].setterUsername;
+            layoutId = climb[0].layoutId;
+          }
+        }
+
+        // Get difficulty name if available
+        let difficultyName: string | null = null;
+        if (tick.difficulty !== null) {
+          if (tick.boardType === 'kilter') {
+            const grade = await db
+              .select({ boulderName: dbSchema.kilterDifficultyGrades.boulderName })
+              .from(dbSchema.kilterDifficultyGrades)
+              .where(eq(dbSchema.kilterDifficultyGrades.difficulty, tick.difficulty))
+              .limit(1);
+            difficultyName = grade[0]?.boulderName || null;
+          } else if (tick.boardType === 'tension') {
+            const grade = await db
+              .select({ boulderName: dbSchema.tensionDifficultyGrades.boulderName })
+              .from(dbSchema.tensionDifficultyGrades)
+              .where(eq(dbSchema.tensionDifficultyGrades.difficulty, tick.difficulty))
+              .limit(1);
+            difficultyName = grade[0]?.boulderName || null;
+          }
+        }
+
+        return {
+          uuid: tick.uuid,
+          climbUuid: tick.climbUuid,
+          climbName,
+          setterUsername,
+          boardType: tick.boardType,
+          layoutId,
+          angle: tick.angle,
+          isMirror: tick.isMirror,
+          status: tick.status,
+          attemptCount: tick.attemptCount,
+          quality: tick.quality,
+          difficulty: tick.difficulty,
+          difficultyName,
+          isBenchmark: tick.isBenchmark,
+          comment: tick.comment || '',
+          climbedAt: tick.climbedAt,
+        };
+      })
+    );
+
+    return {
+      items,
+      totalCount,
+      hasMore: offset + items.length < totalCount,
+    };
   },
 };

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -290,6 +290,14 @@ export const GetTicksInputSchema = z.object({
 });
 
 /**
+ * Ascent feed input validation schema
+ */
+export const AscentFeedInputSchema = z.object({
+  limit: z.number().int().min(1).max(50).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+});
+
+/**
  * Playlist validation schemas
  */
 export const PlaylistNameSchema = z

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -284,6 +284,41 @@ export const typeDefs = /* GraphQL */ `
   }
 
   # ============================================
+  # Activity Feed Types
+  # ============================================
+
+  # A feed item representing a climb ascent with enriched data
+  type AscentFeedItem {
+    uuid: ID!
+    climbUuid: String!
+    climbName: String!
+    setterUsername: String
+    boardType: String!
+    layoutId: Int
+    angle: Int!
+    isMirror: Boolean!
+    status: TickStatus!
+    attemptCount: Int!
+    quality: Int
+    difficulty: Int
+    difficultyName: String
+    isBenchmark: Boolean!
+    comment: String!
+    climbedAt: String!
+  }
+
+  type AscentFeedResult {
+    items: [AscentFeedItem!]!
+    totalCount: Int!
+    hasMore: Boolean!
+  }
+
+  input AscentFeedInput {
+    limit: Int
+    offset: Int
+  }
+
+  # ============================================
   # Playlist Types
   # ============================================
 
@@ -412,6 +447,8 @@ export const typeDefs = /* GraphQL */ `
     ticks(input: GetTicksInput!): [Tick!]!
     # Get public ticks for a specific user
     userTicks(userId: ID!, boardType: String!): [Tick!]!
+    # Get public ascent activity feed for a specific user (all boards, with climb details)
+    userAscentsFeed(userId: ID!, input: AscentFeedInput): AscentFeedResult!
 
     # ============================================
     # Playlist Queries (require auth)

--- a/packages/web/app/components/activity-feed/ascents-feed.module.css
+++ b/packages/web/app/components/activity-feed/ascents-feed.module.css
@@ -1,0 +1,81 @@
+/*
+ * Ascents Feed styles
+ * Values match themeTokens from @/app/theme/theme-config.ts
+ * spacing: 1=4px, 2=8px, 3=12px, 4=16px, 5=20px, 6=24px, 8=32px
+ */
+
+.feed {
+  width: 100%;
+}
+
+.feedItem {
+  transition: box-shadow 0.2s ease;
+}
+
+.feedItem:hover {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+
+.statusTag {
+  font-weight: 500;
+}
+
+.climbName {
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.timeAgo {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.boardType {
+  font-size: 12px;
+}
+
+.attempts {
+  font-size: 12px;
+}
+
+.rating {
+  font-size: 12px;
+}
+
+.setter {
+  font-size: 12px;
+  font-style: italic;
+}
+
+.comment {
+  font-size: 13px;
+  background: var(--neutral-50, #F9FAFB);
+  padding: 8px 12px; /* spacing.2 spacing.3 */
+  border-radius: 4px; /* borderRadius.sm */
+  margin-top: 4px;
+  white-space: pre-wrap;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0; /* spacing.12 */
+}
+
+.loadMoreContainer {
+  margin-top: 16px; /* spacing.4 */
+  padding: 8px 0; /* spacing.2 */
+}
+
+@media (max-width: 768px) {
+  .climbName {
+    max-width: 150px;
+  }
+
+  .feedItem {
+    padding: 8px; /* spacing.2 */
+  }
+}

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { Card, Flex, Tag, Typography, Rate, Empty, Spin, Button } from 'antd';
+import {
+  CheckCircleOutlined,
+  ThunderboltOutlined,
+  CloseCircleOutlined,
+  EnvironmentOutlined,
+} from '@ant-design/icons';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  GET_USER_ASCENTS_FEED,
+  type AscentFeedItem,
+  type GetUserAscentsFeedQueryVariables,
+  type GetUserAscentsFeedQueryResponse,
+} from '@/app/lib/graphql/operations';
+import styles from './ascents-feed.module.css';
+
+dayjs.extend(relativeTime);
+
+const { Text, Title } = Typography;
+
+interface AscentsFeedProps {
+  userId: string;
+  pageSize?: number;
+}
+
+// Layout name mapping
+const layoutNames: Record<string, string> = {
+  'kilter-1': 'Kilter Original',
+  'kilter-8': 'Kilter Homewall',
+  'tension-9': 'Tension Classic',
+  'tension-10': 'Tension 2 Mirror',
+  'tension-11': 'Tension 2 Spray',
+};
+
+const getLayoutDisplayName = (boardType: string, layoutId: number | null): string => {
+  if (layoutId === null) return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+  const key = `${boardType}-${layoutId}`;
+  return layoutNames[key] || `${boardType.charAt(0).toUpperCase() + boardType.slice(1)}`;
+};
+
+// Status icon and color mapping
+const getStatusIcon = (status: 'flash' | 'send' | 'attempt') => {
+  switch (status) {
+    case 'flash':
+      return <ThunderboltOutlined />;
+    case 'send':
+      return <CheckCircleOutlined />;
+    case 'attempt':
+      return <CloseCircleOutlined />;
+  }
+};
+
+const getStatusColor = (status: 'flash' | 'send' | 'attempt') => {
+  switch (status) {
+    case 'flash':
+      return 'gold';
+    case 'send':
+      return 'green';
+    case 'attempt':
+      return 'default';
+  }
+};
+
+const getStatusText = (status: 'flash' | 'send' | 'attempt') => {
+  switch (status) {
+    case 'flash':
+      return 'Flashed';
+    case 'send':
+      return 'Sent';
+    case 'attempt':
+      return 'Attempted';
+  }
+};
+
+const FeedItem: React.FC<{ item: AscentFeedItem }> = ({ item }) => {
+  const timeAgo = dayjs(item.climbedAt).fromNow();
+  const boardDisplay = getLayoutDisplayName(item.boardType, item.layoutId);
+  const statusText = getStatusText(item.status);
+  const isSuccess = item.status === 'flash' || item.status === 'send';
+
+  return (
+    <Card className={styles.feedItem} size="small">
+      <Flex vertical gap={8}>
+        {/* Header with status and time */}
+        <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
+          <Flex align="center" gap={8}>
+            <Tag
+              icon={getStatusIcon(item.status)}
+              color={getStatusColor(item.status)}
+              className={styles.statusTag}
+            >
+              {statusText}
+            </Tag>
+            <Text strong className={styles.climbName}>
+              {item.climbName}
+            </Text>
+          </Flex>
+          <Text type="secondary" className={styles.timeAgo}>
+            {timeAgo}
+          </Text>
+        </Flex>
+
+        {/* Climb details */}
+        <Flex gap={8} wrap="wrap" align="center">
+          {item.difficultyName && (
+            <Tag color="blue">{item.difficultyName}</Tag>
+          )}
+          <Tag icon={<EnvironmentOutlined />}>{item.angle}°</Tag>
+          <Text type="secondary" className={styles.boardType}>
+            {boardDisplay}
+          </Text>
+          {item.isMirror && <Tag color="purple">Mirrored</Tag>}
+          {item.isBenchmark && <Tag color="cyan">Benchmark</Tag>}
+        </Flex>
+
+        {/* Attempts count for sends */}
+        {item.status === 'send' && item.attemptCount > 1 && (
+          <Text type="secondary" className={styles.attempts}>
+            {item.attemptCount} attempts
+          </Text>
+        )}
+
+        {/* Rating for successful sends */}
+        {isSuccess && item.quality && (
+          <Rate disabled value={item.quality} count={5} className={styles.rating} />
+        )}
+
+        {/* Setter info */}
+        {item.setterUsername && (
+          <Text type="secondary" className={styles.setter}>
+            Set by {item.setterUsername}
+          </Text>
+        )}
+
+        {/* Comment */}
+        {item.comment && (
+          <Text className={styles.comment}>{item.comment}</Text>
+        )}
+      </Flex>
+    </Card>
+  );
+};
+
+export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 }) => {
+  const [items, setItems] = useState<AscentFeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [totalCount, setTotalCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+
+  const fetchFeed = useCallback(
+    async (offset: number, append: boolean = false) => {
+      try {
+        if (append) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+        }
+
+        const client = createGraphQLHttpClient(null);
+        const variables: GetUserAscentsFeedQueryVariables = {
+          userId,
+          input: { limit: pageSize, offset },
+        };
+
+        const response = await client.request<GetUserAscentsFeedQueryResponse>(
+          GET_USER_ASCENTS_FEED,
+          variables
+        );
+
+        const { items: newItems, hasMore: more, totalCount: total } = response.userAscentsFeed;
+
+        if (append) {
+          setItems((prev) => [...prev, ...newItems]);
+        } else {
+          setItems(newItems);
+        }
+        setHasMore(more);
+        setTotalCount(total);
+        setError(null);
+      } catch (err) {
+        console.error('Error fetching ascents feed:', err);
+        setError('Failed to load activity feed');
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [userId, pageSize]
+  );
+
+  // Initial load
+  useEffect(() => {
+    fetchFeed(0);
+  }, [fetchFeed]);
+
+  // Load more when button clicked
+  const handleLoadMore = () => {
+    if (!loadingMore && hasMore) {
+      fetchFeed(items.length, true);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.loading}>
+        <Spin />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Empty
+        description={error}
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+      />
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Empty
+        description="No ascents logged yet"
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.feed}>
+      <Flex vertical gap={12}>
+        {items.map((item) => (
+          <FeedItem key={item.uuid} item={item} />
+        ))}
+      </Flex>
+
+      {hasMore && (
+        <div className={styles.loadMoreContainer} ref={loadMoreRef}>
+          <Button
+            onClick={handleLoadMore}
+            loading={loadingMore}
+            type="default"
+            block
+          >
+            Load more ({items.length} of {totalCount})
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AscentsFeed;

--- a/packages/web/app/components/activity-feed/index.ts
+++ b/packages/web/app/components/activity-feed/index.ts
@@ -1,0 +1,1 @@
+export { AscentsFeed, default } from './ascents-feed';

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -18,6 +18,7 @@ import { UserOutlined, InstagramOutlined } from '@ant-design/icons';
 import { useSession } from 'next-auth/react';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
+import AscentsFeed from '@/app/components/activity-feed';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
@@ -603,6 +604,15 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
               )}
             </div>
           </div>
+        </Card>
+
+        {/* Recent Ascents Feed */}
+        <Card className={styles.statsCard}>
+          <Title level={5}>Recent Activity</Title>
+          <Text type="secondary" className={styles.chartDescription}>
+            Latest ascents and attempts
+          </Text>
+          <AscentsFeed userId={userId} pageSize={10} />
         </Card>
 
         {/* Aggregated Stats - All Boards */}

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -110,3 +110,72 @@ export interface SaveTickMutationVariables {
 export interface SaveTickMutationResponse {
   saveTick: Tick;
 }
+
+// ============================================
+// Activity Feed Operations
+// ============================================
+
+export const GET_USER_ASCENTS_FEED = gql`
+  query GetUserAscentsFeed($userId: ID!, $input: AscentFeedInput) {
+    userAscentsFeed(userId: $userId, input: $input) {
+      items {
+        uuid
+        climbUuid
+        climbName
+        setterUsername
+        boardType
+        layoutId
+        angle
+        isMirror
+        status
+        attemptCount
+        quality
+        difficulty
+        difficultyName
+        isBenchmark
+        comment
+        climbedAt
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+// Type for individual ascent feed item
+export interface AscentFeedItem {
+  uuid: string;
+  climbUuid: string;
+  climbName: string;
+  setterUsername: string | null;
+  boardType: string;
+  layoutId: number | null;
+  angle: number;
+  isMirror: boolean;
+  status: 'flash' | 'send' | 'attempt';
+  attemptCount: number;
+  quality: number | null;
+  difficulty: number | null;
+  difficultyName: string | null;
+  isBenchmark: boolean;
+  comment: string;
+  climbedAt: string;
+}
+
+// Type for the feed query variables
+export interface GetUserAscentsFeedQueryVariables {
+  userId: string;
+  input?: {
+    limit?: number;
+    offset?: number;
+  };
+}
+
+// Type for the feed query response
+export interface GetUserAscentsFeedQueryResponse {
+  userAscentsFeed: {
+    items: AscentFeedItem[];
+    totalCount: number;
+    hasMore: boolean;
+  };
+}


### PR DESCRIPTION
Add a Facebook-style activity feed showing recent climbing ascents on the profile page. The feed displays climb name, grade, status (flash/ send/attempt), angle, board type, and other relevant details.

Changes:
- Add userAscentsFeed GraphQL query with pagination support
- Create AscentFeedItem type with enriched climb data (name, setter, grade)
- Add AscentsFeed React component with infinite scroll support
- Integrate feed into profile page between profile card and stats

The feed architecture is designed to support future features like following other users and viewing a combined activity stream.