### PR TITLE
feat: Add climb thumbnail to profile activity feed

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -232,12 +232,15 @@ export const tickQueries = {
         let setterUsername: string | null = null;
         let layoutId: number | null = null;
 
+        let frames: string | null = null;
+
         if (tick.boardType === 'kilter') {
           const climb = await db
             .select({
               name: dbSchema.kilterClimbs.name,
               setterUsername: dbSchema.kilterClimbs.setterUsername,
               layoutId: dbSchema.kilterClimbs.layoutId,
+              frames: dbSchema.kilterClimbs.frames,
             })
             .from(dbSchema.kilterClimbs)
             .where(eq(dbSchema.kilterClimbs.uuid, tick.climbUuid))
@@ -247,6 +250,7 @@ export const tickQueries = {
             climbName = climb[0].name || 'Unnamed Climb';
             setterUsername = climb[0].setterUsername;
             layoutId = climb[0].layoutId;
+            frames = climb[0].frames;
           }
         } else if (tick.boardType === 'tension') {
           const climb = await db
@@ -254,6 +258,7 @@ export const tickQueries = {
               name: dbSchema.tensionClimbs.name,
               setterUsername: dbSchema.tensionClimbs.setterUsername,
               layoutId: dbSchema.tensionClimbs.layoutId,
+              frames: dbSchema.tensionClimbs.frames,
             })
             .from(dbSchema.tensionClimbs)
             .where(eq(dbSchema.tensionClimbs.uuid, tick.climbUuid))
@@ -263,6 +268,7 @@ export const tickQueries = {
             climbName = climb[0].name || 'Unnamed Climb';
             setterUsername = climb[0].setterUsername;
             layoutId = climb[0].layoutId;
+            frames = climb[0].frames;
           }
         }
 
@@ -303,6 +309,7 @@ export const tickQueries = {
           isBenchmark: tick.isBenchmark,
           comment: tick.comment || '',
           climbedAt: tick.climbedAt,
+          frames,
         };
       })
     );

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -305,6 +305,8 @@ export const typeDefs = /* GraphQL */ `
     isBenchmark: Boolean!
     comment: String!
     climbedAt: String!
+    # Climb display data for thumbnails
+    frames: String
   }
 
   type AscentFeedResult {

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import Link from 'next/link';
+import { BoardDetails, BoardName } from '@/app/lib/types';
+import BoardRenderer from '@/app/components/board-renderer/board-renderer';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+import { getBoardDetails } from '@/app/lib/__generated__/product-sizes-data';
+import { getDefaultBoardConfig, getDefaultClimbViewPath } from '@/app/lib/default-board-configs';
+import styles from './ascents-feed.module.css';
+
+interface AscentThumbnailProps {
+  boardType: string;
+  layoutId: number | null;
+  angle: number;
+  climbUuid: string;
+  climbName: string;
+  frames: string | null;
+  isMirror: boolean;
+}
+
+const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
+  boardType,
+  layoutId,
+  angle,
+  climbUuid,
+  climbName,
+  frames,
+  isMirror,
+}) => {
+  // Memoize board details to avoid recomputing on every render
+  const boardDetails = useMemo<BoardDetails | null>(() => {
+    if (!layoutId) return null;
+
+    const boardName = boardType as BoardName;
+    const config = getDefaultBoardConfig(boardName, layoutId);
+    if (!config) return null;
+
+    try {
+      return getBoardDetails({
+        board_name: boardName,
+        layout_id: layoutId,
+        size_id: config.sizeId,
+        set_ids: config.setIds,
+      });
+    } catch (error) {
+      console.error('Failed to get board details for thumbnail:', error);
+      return null;
+    }
+  }, [boardType, layoutId]);
+
+  // Memoize lit up holds map
+  const litUpHoldsMap = useMemo(() => {
+    if (!frames || !boardType) return undefined;
+    const framesData = convertLitUpHoldsStringToMap(frames, boardType as BoardName);
+    return framesData[0];
+  }, [frames, boardType]);
+
+  // Get climb view path
+  const climbViewPath = useMemo(() => {
+    if (!layoutId) return null;
+    return getDefaultClimbViewPath(boardType as BoardName, layoutId, angle, climbUuid);
+  }, [boardType, layoutId, angle, climbUuid]);
+
+  // If we can't render the thumbnail, don't show anything
+  if (!boardDetails || !litUpHoldsMap || !climbViewPath) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={climbViewPath}
+      className={styles.thumbnailLink}
+      title={`View ${climbName}`}
+    >
+      <div className={styles.thumbnailContainer}>
+        <BoardRenderer
+          boardDetails={boardDetails}
+          litUpHoldsMap={litUpHoldsMap}
+          mirrored={isMirror}
+          thumbnail
+        />
+      </div>
+    </Link>
+  );
+};
+
+export default AscentThumbnail;

--- a/packages/web/app/components/activity-feed/ascents-feed.module.css
+++ b/packages/web/app/components/activity-feed/ascents-feed.module.css
@@ -16,6 +16,40 @@
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 }
 
+.feedItemContent {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Thumbnail styles */
+.thumbnailLink {
+  display: block;
+  flex-shrink: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.thumbnailLink:hover {
+  transform: scale(1.02);
+  opacity: 0.9;
+}
+
+.thumbnailContainer {
+  width: 64px;
+  height: 64px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--neutral-100, #F3F4F6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thumbnailContainer svg {
+  width: 100%;
+  height: 100%;
+  max-height: none;
+}
+
 .statusTag {
   font-weight: 500;
 }
@@ -77,5 +111,10 @@
 
   .feedItem {
     padding: 8px; /* spacing.2 */
+  }
+
+  .thumbnailContainer {
+    width: 56px;
+    height: 56px;
   }
 }

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -17,6 +17,7 @@ import {
   type GetUserAscentsFeedQueryVariables,
   type GetUserAscentsFeedQueryResponse,
 } from '@/app/lib/graphql/operations';
+import AscentThumbnail from './ascent-thumbnail';
 import styles from './ascents-feed.module.css';
 
 dayjs.extend(relativeTime);
@@ -85,62 +86,78 @@ const FeedItem: React.FC<{ item: AscentFeedItem }> = ({ item }) => {
 
   return (
     <Card className={styles.feedItem} size="small">
-      <Flex vertical gap={8}>
-        {/* Header with status and time */}
-        <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
-          <Flex align="center" gap={8}>
-            <Tag
-              icon={getStatusIcon(item.status)}
-              color={getStatusColor(item.status)}
-              className={styles.statusTag}
-            >
-              {statusText}
-            </Tag>
-            <Text strong className={styles.climbName}>
-              {item.climbName}
+      <Flex gap={12}>
+        {/* Thumbnail */}
+        {item.frames && item.layoutId && (
+          <AscentThumbnail
+            boardType={item.boardType}
+            layoutId={item.layoutId}
+            angle={item.angle}
+            climbUuid={item.climbUuid}
+            climbName={item.climbName}
+            frames={item.frames}
+            isMirror={item.isMirror}
+          />
+        )}
+
+        {/* Content */}
+        <Flex vertical gap={8} className={styles.feedItemContent}>
+          {/* Header with status and time */}
+          <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
+            <Flex align="center" gap={8}>
+              <Tag
+                icon={getStatusIcon(item.status)}
+                color={getStatusColor(item.status)}
+                className={styles.statusTag}
+              >
+                {statusText}
+              </Tag>
+              <Text strong className={styles.climbName}>
+                {item.climbName}
+              </Text>
+            </Flex>
+            <Text type="secondary" className={styles.timeAgo}>
+              {timeAgo}
             </Text>
           </Flex>
-          <Text type="secondary" className={styles.timeAgo}>
-            {timeAgo}
-          </Text>
-        </Flex>
 
-        {/* Climb details */}
-        <Flex gap={8} wrap="wrap" align="center">
-          {item.difficultyName && (
-            <Tag color="blue">{item.difficultyName}</Tag>
+          {/* Climb details */}
+          <Flex gap={8} wrap="wrap" align="center">
+            {item.difficultyName && (
+              <Tag color="blue">{item.difficultyName}</Tag>
+            )}
+            <Tag icon={<EnvironmentOutlined />}>{item.angle}°</Tag>
+            <Text type="secondary" className={styles.boardType}>
+              {boardDisplay}
+            </Text>
+            {item.isMirror && <Tag color="purple">Mirrored</Tag>}
+            {item.isBenchmark && <Tag color="cyan">Benchmark</Tag>}
+          </Flex>
+
+          {/* Attempts count for sends */}
+          {item.status === 'send' && item.attemptCount > 1 && (
+            <Text type="secondary" className={styles.attempts}>
+              {item.attemptCount} attempts
+            </Text>
           )}
-          <Tag icon={<EnvironmentOutlined />}>{item.angle}°</Tag>
-          <Text type="secondary" className={styles.boardType}>
-            {boardDisplay}
-          </Text>
-          {item.isMirror && <Tag color="purple">Mirrored</Tag>}
-          {item.isBenchmark && <Tag color="cyan">Benchmark</Tag>}
+
+          {/* Rating for successful sends */}
+          {isSuccess && item.quality && (
+            <Rate disabled value={item.quality} count={5} className={styles.rating} />
+          )}
+
+          {/* Setter info */}
+          {item.setterUsername && (
+            <Text type="secondary" className={styles.setter}>
+              Set by {item.setterUsername}
+            </Text>
+          )}
+
+          {/* Comment */}
+          {item.comment && (
+            <Text className={styles.comment}>{item.comment}</Text>
+          )}
         </Flex>
-
-        {/* Attempts count for sends */}
-        {item.status === 'send' && item.attemptCount > 1 && (
-          <Text type="secondary" className={styles.attempts}>
-            {item.attemptCount} attempts
-          </Text>
-        )}
-
-        {/* Rating for successful sends */}
-        {isSuccess && item.quality && (
-          <Rate disabled value={item.quality} count={5} className={styles.rating} />
-        )}
-
-        {/* Setter info */}
-        {item.setterUsername && (
-          <Text type="secondary" className={styles.setter}>
-            Set by {item.setterUsername}
-          </Text>
-        )}
-
-        {/* Comment */}
-        {item.comment && (
-          <Text className={styles.comment}>{item.comment}</Text>
-        )}
       </Flex>
     </Card>
   );

--- a/packages/web/app/lib/default-board-configs.ts
+++ b/packages/web/app/lib/default-board-configs.ts
@@ -1,0 +1,58 @@
+/**
+ * Default board configurations for each layout.
+ * Used for rendering thumbnails when the exact size/sets configuration is not known.
+ * These represent the most common configurations for each layout.
+ */
+
+import { BoardName } from '@/app/lib/types';
+import { SetIdList } from '@/app/lib/board-data';
+
+export interface DefaultBoardConfig {
+  sizeId: number;
+  setIds: SetIdList;
+}
+
+/**
+ * Default configurations for each layout.
+ * Key format: "{boardName}-{layoutId}"
+ */
+const DEFAULT_CONFIGS: Record<string, DefaultBoardConfig> = {
+  // Kilter Original (layout 1) - 12x14 Commercial with Bolt Ons + Screw Ons
+  'kilter-1': { sizeId: 7, setIds: [1, 20] },
+  // Kilter Homewall (layout 8) - 10x12 Full Ride LED Kit with all sets
+  'kilter-8': { sizeId: 25, setIds: [26, 27, 28, 29] },
+  // Tension Original (layout 9) - Full Wall with all sets
+  'tension-9': { sizeId: 1, setIds: [8, 9, 10, 11] },
+  // Tension Board 2 Mirror (layout 10) - 12x12 with Wood + Plastic
+  'tension-10': { sizeId: 6, setIds: [12, 13] },
+  // Tension Board 2 Spray (layout 11) - 12x12 with Wood + Plastic
+  'tension-11': { sizeId: 6, setIds: [12, 13] },
+};
+
+/**
+ * Get the default board configuration for a given board type and layout.
+ * Returns null if no default configuration is found.
+ */
+export function getDefaultBoardConfig(
+  boardName: BoardName,
+  layoutId: number,
+): DefaultBoardConfig | null {
+  const key = `${boardName}-${layoutId}`;
+  return DEFAULT_CONFIGS[key] || null;
+}
+
+/**
+ * Get the board path for a climb based on the default configuration.
+ * Used for constructing URLs to climb view pages.
+ */
+export function getDefaultClimbViewPath(
+  boardName: BoardName,
+  layoutId: number,
+  angle: number,
+  climbUuid: string,
+): string | null {
+  const config = getDefaultBoardConfig(boardName, layoutId);
+  if (!config) return null;
+
+  return `/${boardName}/${layoutId}/${config.sizeId}/${config.setIds.join(',')}/${angle}/view/${climbUuid}`;
+}

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -135,6 +135,7 @@ export const GET_USER_ASCENTS_FEED = gql`
         isBenchmark
         comment
         climbedAt
+        frames
       }
       totalCount
       hasMore
@@ -160,6 +161,7 @@ export interface AscentFeedItem {
   isBenchmark: boolean;
   comment: string;
   climbedAt: string;
+  frames: string | null;
 }
 
 // Type for the feed query variables


### PR DESCRIPTION
- Add frames field to AscentFeedItem GraphQL type and backend resolver
- Create AscentThumbnail component to render climb preview in activity feed
- Add default board config utility for generating board details from layout
- Update FeedItem component to display thumbnail alongside climb details
- Clicking thumbnail navigates to climb view page