### PR TITLE
fix: Add 5s delay after login to test session replication theory

### DIFF
--- a/packages/web/app/api/internal/user-sync-cron/route.ts
+++ b/packages/web/app/api/internal/user-sync-cron/route.ts
@@ -200,6 +200,11 @@ export async function GET(request: Request) {
           tokenUpdateClient.release();
         }
 
+        // Wait for Aurora session replication across their backend servers
+        // Testing if this fixes the 404 errors on Vercel (works locally)
+        console.log('[User Sync Cron] Waiting 5 seconds for Aurora session replication...');
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
         console.log(`[User Sync Cron] Syncing user ${cred.userId} for ${boardType}...`);
 
         // syncUserData manages its own connections internally


### PR DESCRIPTION
## Summary
- Adds a 5 second delay between Aurora login and sync to test if session replication lag is causing 404 errors

## Problem
User sync fails with 404 on Vercel but works locally. Shared sync works on both.

## Theory
Aurora's load balancer may route login and sync requests to different backend PHP servers. The session created during login hasn't replicated to the server handling the sync request yet.

## Test plan
- [ ] Deploy to Vercel
- [ ] Wait for cron to run (or trigger manually)
- [ ] Check if user sync succeeds with the delay
- [ ] If successful, we've confirmed the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)