### PR TITLE
fix: Skip database migrations on preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "npm ci --legacy-peer-deps --omit=optional",
-  "buildCommand": "npm run build:shared && npm run build:db && npm run build --workspace=@boardsesh/moonboard-ocr && if [ \"$VERCEL_ENV\" != \"preview\" ]; then npm run db:migrate; fi && cd packages/web && npm run build",
+  "buildCommand": "npm run build:shared && npm run build --workspace=@boardsesh/crypto && npm run build:db && npm run build --workspace=@boardsesh/moonboard-ocr && if [ \"$VERCEL_ENV\" != \"preview\" ]; then npm run db:migrate; fi && cd packages/web && npm run build",
   "outputDirectory": "packages/web/.next",
   "framework": "nextjs",
   "crons": [


### PR DESCRIPTION
Skip running db:migrate on preview deployments to test if the Neon
preview branch has the schema but is missing the drizzle migrations table.