### PR TITLE
feat: Add playlist view page with edit drawer

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/page.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { notFound } from 'next/navigation';
+import { getServerSession } from 'next-auth/next';
+import { BoardRouteParameters } from '@/app/lib/types';
+import { getBoardDetails } from '@/app/lib/__generated__/product-sizes-data';
+import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
+import { Metadata } from 'next';
+import { authOptions } from '@/app/lib/auth/auth-options';
+import PlaylistViewContent from './playlist-view-content';
+import styles from './playlist-view.module.css';
+
+type PlaylistRouteParameters = BoardRouteParameters & {
+  playlist_uuid: string;
+};
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Playlist | Boardsesh',
+    description: 'View playlist details and climbs',
+  };
+}
+
+export default async function PlaylistViewPage(props: { params: Promise<PlaylistRouteParameters> }) {
+  const params = await props.params;
+
+  try {
+    const parsedParams = await parseBoardRouteParamsWithSlugs(params);
+    const boardDetails = await getBoardDetails(parsedParams);
+
+    // Get auth session for ownership check
+    const session = await getServerSession(authOptions);
+
+    return (
+      <div className={styles.pageContainer}>
+        <PlaylistViewContent
+          playlistUuid={params.playlist_uuid}
+          boardDetails={boardDetails}
+          angle={parsedParams.angle}
+          currentUserId={session?.user?.id}
+        />
+      </div>
+    );
+  } catch (error) {
+    console.error('Error loading playlist view:', error);
+    notFound();
+  }
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-edit-drawer.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-edit-drawer.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { Drawer, Form, Input, Switch, ColorPicker, message, Space, Typography, Button } from 'antd';
+import { GlobalOutlined, LockOutlined } from '@ant-design/icons';
+import type { Color } from 'antd/es/color-picker';
+import { executeGraphQL } from '@/app/lib/graphql/client';
+import {
+  UPDATE_PLAYLIST,
+  UpdatePlaylistMutationResponse,
+  UpdatePlaylistMutationVariables,
+  Playlist,
+} from '@/app/lib/graphql/operations/playlists';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const { Text } = Typography;
+
+// Validate hex color format
+const isValidHexColor = (color: string): boolean => {
+  return /^#([0-9A-Fa-f]{3}){1,2}$/.test(color);
+};
+
+type PlaylistEditDrawerProps = {
+  open: boolean;
+  playlist: Playlist;
+  onClose: () => void;
+  onSuccess: (updatedPlaylist: Playlist) => void;
+};
+
+export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess }: PlaylistEditDrawerProps) {
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
+  const [isPublic, setIsPublic] = useState(playlist.isPublic);
+  const { token } = useWsAuthToken();
+
+  // Reset form when drawer opens with new playlist
+  useEffect(() => {
+    if (open && playlist) {
+      form.setFieldsValue({
+        name: playlist.name,
+        description: playlist.description || '',
+        color: playlist.color || undefined,
+        isPublic: playlist.isPublic,
+      });
+      setIsPublic(playlist.isPublic);
+    }
+  }, [open, playlist, form]);
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      const values = await form.validateFields();
+      setLoading(true);
+
+      // Extract and validate hex color
+      let colorHex: string | undefined;
+      if (values.color) {
+        let rawColor: string | undefined;
+        if (typeof values.color === 'string') {
+          rawColor = values.color;
+        } else if (typeof values.color === 'object' && 'toHexString' in values.color) {
+          rawColor = (values.color as Color).toHexString();
+        }
+        if (rawColor && isValidHexColor(rawColor)) {
+          colorHex = rawColor;
+        }
+      }
+
+      const response = await executeGraphQL<UpdatePlaylistMutationResponse, UpdatePlaylistMutationVariables>(
+        UPDATE_PLAYLIST,
+        {
+          input: {
+            playlistId: playlist.uuid,
+            name: values.name,
+            description: values.description || undefined,
+            color: colorHex,
+            isPublic: values.isPublic,
+          },
+        },
+        token,
+      );
+
+      message.success('Playlist updated successfully');
+      onSuccess(response.updatePlaylist);
+      onClose();
+    } catch (error) {
+      if (error instanceof Error && 'errorFields' in error) {
+        // Form validation error
+        return;
+      }
+      console.error('Error updating playlist:', error);
+      message.error('Failed to update playlist');
+    } finally {
+      setLoading(false);
+    }
+  }, [form, playlist.uuid, token, onSuccess, onClose]);
+
+  const handleCancel = useCallback(() => {
+    form.resetFields();
+    onClose();
+  }, [form, onClose]);
+
+  const handleVisibilityChange = useCallback((checked: boolean) => {
+    setIsPublic(checked);
+    form.setFieldValue('isPublic', checked);
+  }, [form]);
+
+  return (
+    <Drawer
+      title="Edit Playlist"
+      open={open}
+      onClose={handleCancel}
+      placement="bottom"
+      height="auto"
+      styles={{
+        body: {
+          paddingBottom: themeTokens.spacing[6],
+        },
+      }}
+      extra={
+        <Space>
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button type="primary" onClick={handleSubmit} loading={loading}>
+            Save
+          </Button>
+        </Space>
+      }
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        style={{ maxWidth: 600, margin: '0 auto' }}
+      >
+        <Form.Item
+          name="name"
+          label="Playlist Name"
+          rules={[
+            { required: true, message: 'Please enter a playlist name' },
+            { max: 100, message: 'Name must be 100 characters or less' },
+          ]}
+        >
+          <Input placeholder="e.g., Hard Crimps" maxLength={100} showCount />
+        </Form.Item>
+
+        <Form.Item
+          name="description"
+          label="Description"
+          rules={[{ max: 500, message: 'Description must be 500 characters or less' }]}
+        >
+          <Input.TextArea
+            placeholder="Optional description for your playlist..."
+            rows={3}
+            maxLength={500}
+            showCount
+          />
+        </Form.Item>
+
+        <Form.Item name="color" label="Color">
+          <ColorPicker format="hex" showText allowClear />
+        </Form.Item>
+
+        <Form.Item
+          name="isPublic"
+          label="Visibility"
+          valuePropName="checked"
+        >
+          <Space direction="vertical" size={4}>
+            <Switch
+              checked={isPublic}
+              onChange={handleVisibilityChange}
+              checkedChildren={<GlobalOutlined />}
+              unCheckedChildren={<LockOutlined />}
+            />
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {isPublic
+                ? 'Public playlists can be viewed by anyone with the link'
+                : 'Private playlists are only visible to you'}
+            </Text>
+          </Space>
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-actions.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-actions.module.css
@@ -1,0 +1,50 @@
+/* Playlist View Actions Styles */
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.actionButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* Mobile layout */
+.mobileActions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+}
+
+.mobileLeft {
+  flex-shrink: 0;
+}
+
+.mobileRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.desktopActions {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .desktopActions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .mobileActions {
+    display: none;
+  }
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-actions.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-actions.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { Button } from 'antd';
+import { EditOutlined } from '@ant-design/icons';
+import { BoardDetails } from '@/app/lib/types';
+import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import BackButton from '@/app/components/back-button';
+import styles from './playlist-view-actions.module.css';
+
+type PlaylistViewActionsProps = {
+  boardDetails: BoardDetails;
+  angle: number;
+  isOwner: boolean;
+  onEditClick: () => void;
+};
+
+const PlaylistViewActions = ({ boardDetails, angle, isOwner, onEditClick }: PlaylistViewActionsProps) => {
+  const getBackToListUrl = () => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+
+    // Use slug-based URL construction if slug names are available
+    if (layout_name && size_name && set_names) {
+      return constructClimbListWithSlugs(board_name, layout_name, size_name, size_description, set_names, angle);
+    }
+
+    // Fallback to numeric format
+    return `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
+  };
+
+  return (
+    <div className={styles.container}>
+      {/* Mobile view */}
+      <div className={styles.mobileActions}>
+        <div className={styles.mobileLeft}>
+          <BackButton fallbackUrl={getBackToListUrl()} />
+        </div>
+
+        {isOwner && (
+          <div className={styles.mobileRight}>
+            <Button icon={<EditOutlined />} onClick={onEditClick}>
+              Edit
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Desktop view */}
+      <div className={styles.desktopActions}>
+        <BackButton fallbackUrl={getBackToListUrl()} className={styles.backButton} />
+
+        {isOwner && (
+          <div className={styles.actionButtons}>
+            <Button icon={<EditOutlined />} onClick={onEditClick}>
+              Edit Playlist
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlaylistViewActions;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Spin, Typography, Button } from 'antd';
+import {
+  TagOutlined,
+  CalendarOutlined,
+  NumberOutlined,
+  GlobalOutlined,
+  LockOutlined,
+  FrownOutlined,
+} from '@ant-design/icons';
+import { BoardDetails } from '@/app/lib/types';
+import { executeGraphQL } from '@/app/lib/graphql/client';
+import {
+  GET_PLAYLIST,
+  GetPlaylistQueryResponse,
+  GetPlaylistQueryVariables,
+  Playlist,
+} from '@/app/lib/graphql/operations/playlists';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { themeTokens } from '@/app/theme/theme-config';
+import PlaylistViewActions from './playlist-view-actions';
+import PlaylistEditDrawer from './playlist-edit-drawer';
+import styles from './playlist-view.module.css';
+
+const { Title, Text } = Typography;
+
+// Validate hex color format
+const isValidHexColor = (color: string): boolean => {
+  return /^#([0-9A-Fa-f]{3}){1,2}$/.test(color);
+};
+
+type PlaylistViewContentProps = {
+  playlistUuid: string;
+  boardDetails: BoardDetails;
+  angle: number;
+  currentUserId?: string;
+};
+
+export default function PlaylistViewContent({
+  playlistUuid,
+  boardDetails,
+  angle,
+  currentUserId,
+}: PlaylistViewContentProps) {
+  const [playlist, setPlaylist] = useState<Playlist | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editDrawerOpen, setEditDrawerOpen] = useState(false);
+  const { token, isLoading: tokenLoading } = useWsAuthToken();
+
+  const fetchPlaylist = useCallback(async () => {
+    if (tokenLoading) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await executeGraphQL<GetPlaylistQueryResponse, GetPlaylistQueryVariables>(
+        GET_PLAYLIST,
+        { playlistId: playlistUuid },
+        token,
+      );
+
+      if (!response.playlist) {
+        setError('Playlist not found');
+        return;
+      }
+
+      setPlaylist(response.playlist);
+    } catch (err) {
+      console.error('Error fetching playlist:', err);
+      setError('Failed to load playlist');
+    } finally {
+      setLoading(false);
+    }
+  }, [playlistUuid, token, tokenLoading]);
+
+  useEffect(() => {
+    fetchPlaylist();
+  }, [fetchPlaylist]);
+
+  const handleEditSuccess = useCallback((updatedPlaylist: Playlist) => {
+    setPlaylist(updatedPlaylist);
+  }, []);
+
+  // Check if current user is the owner
+  const isOwner = playlist?.userRole === 'owner';
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  // Get color for indicator
+  const getPlaylistColor = () => {
+    if (playlist?.color && isValidHexColor(playlist.color)) {
+      return playlist.color;
+    }
+    return themeTokens.colors.primary;
+  };
+
+  if (loading || tokenLoading) {
+    return (
+      <div className={styles.loadingContainer}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (error || !playlist) {
+    return (
+      <div className={styles.errorContainer}>
+        <FrownOutlined className={styles.errorIcon} />
+        <div className={styles.errorTitle}>
+          {error === 'Playlist not found' ? 'Playlist Not Found' : 'Unable to Load Playlist'}
+        </div>
+        <div className={styles.errorMessage}>
+          {error === 'Playlist not found'
+            ? 'This playlist may have been deleted or you may not have permission to view it.'
+            : 'There was an error loading this playlist. Please try again.'}
+        </div>
+        <Button onClick={fetchPlaylist}>Try Again</Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Actions Section */}
+      <div className={styles.actionsSection}>
+        <PlaylistViewActions
+          boardDetails={boardDetails}
+          angle={angle}
+          isOwner={isOwner}
+          onEditClick={() => setEditDrawerOpen(true)}
+        />
+      </div>
+
+      {/* Main Content */}
+      <div className={styles.contentWrapper}>
+        <div className={styles.detailsSection}>
+          {/* Header with color indicator and name */}
+          <div className={styles.playlistHeader}>
+            <div
+              className={styles.colorIndicator}
+              style={{ backgroundColor: getPlaylistColor() }}
+            >
+              <TagOutlined className={styles.colorIndicatorIcon} />
+            </div>
+            <div className={styles.headerContent}>
+              <Title level={2} className={styles.playlistName}>
+                {playlist.name}
+              </Title>
+              <div className={styles.playlistMeta}>
+                <span className={styles.metaItem}>
+                  <NumberOutlined />
+                  {playlist.climbCount} {playlist.climbCount === 1 ? 'climb' : 'climbs'}
+                </span>
+                <span className={styles.metaItem}>
+                  <CalendarOutlined />
+                  Created {formatDate(playlist.createdAt)}
+                </span>
+                <span
+                  className={`${styles.visibilityBadge} ${
+                    playlist.isPublic ? styles.publicBadge : styles.privateBadge
+                  }`}
+                >
+                  {playlist.isPublic ? (
+                    <>
+                      <GlobalOutlined /> Public
+                    </>
+                  ) : (
+                    <>
+                      <LockOutlined /> Private
+                    </>
+                  )}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Description */}
+          {playlist.description ? (
+            <div className={styles.descriptionSection}>
+              <div className={styles.descriptionLabel}>Description</div>
+              <Text className={styles.descriptionText}>{playlist.description}</Text>
+            </div>
+          ) : isOwner ? (
+            <div className={styles.descriptionSection}>
+              <div className={styles.descriptionLabel}>Description</div>
+              <Text className={styles.noDescription}>
+                No description yet. Click Edit to add one.
+              </Text>
+            </div>
+          ) : null}
+
+          {/* Stats */}
+          <div className={styles.statsSection}>
+            <div className={styles.statItem}>
+              <span className={styles.statValue}>{playlist.climbCount}</span>
+              <span className={styles.statLabel}>
+                {playlist.climbCount === 1 ? 'Climb' : 'Climbs'}
+              </span>
+            </div>
+            {playlist.updatedAt !== playlist.createdAt && (
+              <div className={styles.statItem}>
+                <span className={styles.statValue}>
+                  {formatDate(playlist.updatedAt)}
+                </span>
+                <span className={styles.statLabel}>Last Updated</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Edit Drawer */}
+      {playlist && (
+        <PlaylistEditDrawer
+          open={editDrawerOpen}
+          playlist={playlist}
+          onClose={() => setEditDrawerOpen(false)}
+          onSuccess={handleEditSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
@@ -1,0 +1,275 @@
+/* Playlist View Page Styles */
+
+.pageContainer {
+  padding: 16px;
+  min-height: 100vh;
+  background-color: #F9FAFB;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+/* Actions section - white card container */
+.actionsSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+/* Main content wrapper */
+.contentWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Playlist details section */
+.detailsSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+/* Header with color indicator */
+.playlistHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.colorIndicator {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.colorIndicatorIcon {
+  font-size: 24px;
+  color: #FFFFFF;
+}
+
+.headerContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.playlistName {
+  margin: 0 0 4px 0 !important;
+  font-size: 24px !important;
+  font-weight: 600 !important;
+  word-break: break-word;
+}
+
+.playlistMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: #6B7280;
+  font-size: 14px;
+}
+
+.metaItem {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Description section */
+.descriptionSection {
+  padding-top: 16px;
+  border-top: 1px solid #E5E7EB;
+}
+
+.descriptionLabel {
+  font-size: 12px;
+  color: #9CA3AF;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.descriptionText {
+  color: #374151;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.noDescription {
+  color: #9CA3AF;
+  font-style: italic;
+}
+
+/* Stats section */
+.statsSection {
+  display: flex;
+  gap: 24px;
+  padding-top: 16px;
+  border-top: 1px solid #E5E7EB;
+  margin-top: 16px;
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+}
+
+.statValue {
+  font-size: 24px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.statLabel {
+  font-size: 12px;
+  color: #6B7280;
+}
+
+/* Loading and error states */
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  text-align: center;
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.errorIcon {
+  font-size: 48px;
+  color: #9CA3AF;
+  margin-bottom: 16px;
+}
+
+.errorTitle {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 8px;
+}
+
+.errorMessage {
+  color: #6B7280;
+  margin-bottom: 20px;
+}
+
+/* Visibility badge */
+.visibilityBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.publicBadge {
+  background-color: #ECFDF5;
+  color: #059669;
+}
+
+.privateBadge {
+  background-color: #F3F4F6;
+  color: #6B7280;
+}
+
+/* Mobile adjustments */
+@media (max-width: 767px) {
+  .pageContainer {
+    padding: 12px;
+  }
+
+  .actionsSection {
+    padding: 12px;
+    border-radius: 8px;
+    margin-bottom: 12px;
+  }
+
+  .detailsSection {
+    padding: 16px;
+    border-radius: 8px;
+  }
+
+  .contentWrapper {
+    gap: 12px;
+  }
+
+  .playlistHeader {
+    gap: 12px;
+  }
+
+  .colorIndicator {
+    width: 40px;
+    height: 40px;
+  }
+
+  .colorIndicatorIcon {
+    font-size: 20px;
+  }
+
+  .playlistName {
+    font-size: 20px !important;
+  }
+
+  .playlistMeta {
+    gap: 8px;
+    font-size: 13px;
+  }
+
+  .statsSection {
+    gap: 16px;
+  }
+
+  .statValue {
+    font-size: 20px;
+  }
+}
+
+/* Desktop layout */
+@media (min-width: 992px) {
+  .pageContainer {
+    padding: 24px;
+  }
+
+  .actionsSection {
+    padding: 20px;
+  }
+
+  .detailsSection {
+    padding: 24px;
+  }
+
+  .contentWrapper {
+    gap: 24px;
+  }
+
+  .colorIndicator {
+    width: 56px;
+    height: 56px;
+  }
+
+  .colorIndicatorIcon {
+    font-size: 28px;
+  }
+
+  .playlistName {
+    font-size: 28px !important;
+  }
+}


### PR DESCRIPTION
- Add playlist view page route at /[board]/[...]/playlist/[playlist_uuid]
- Display playlist details including name, description, color, visibility
- Show climb count and creation/update dates
- Add edit functionality via bottom drawer (mobile-friendly)
- Allow editing name, description, color, and visibility for playlist owners
- Use existing GraphQL operations for fetching and updating playlists
- Follow existing UI patterns with back button and responsive layout