### PR TITLE
feat: Add climb cards to playlist view with infinite scroll

### DIFF
--- a/.github/workflows/backend-typecheck.yml
+++ b/.github/workflows/backend-typecheck.yml
@@ -33,8 +33,14 @@ jobs:
       - name: Build shared-schema
         run: npm run build --workspace=@boardsesh/shared-schema
 
+      - name: Build crypto package
+        run: npm run build --workspace=@boardsesh/crypto
+
       - name: Build db package
         run: npm run build --workspace=@boardsesh/db
+
+      - name: Build aurora-sync package
+        run: npm run build --workspace=@boardsesh/aurora-sync
 
       - name: TypeScript check backend
         run: npm run build --workspace=boardsesh-backend

--- a/package-lock.json
+++ b/package-lock.json
@@ -3974,7 +3974,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.57.0"
@@ -6050,7 +6050,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6712,7 +6712,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7693,7 +7693,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8643,7 +8643,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -9039,7 +9039,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.57.0"
@@ -9058,7 +9058,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9275,7 +9275,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9295,7 +9294,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -9449,7 +9447,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -9559,7 +9557,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
@@ -10129,7 +10126,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -10152,12 +10149,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10169,12 +10166,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10186,12 +10183,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10203,12 +10200,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10220,12 +10217,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10237,12 +10234,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10254,12 +10251,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10271,12 +10268,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10288,12 +10285,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10305,12 +10302,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10322,12 +10319,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10339,12 +10336,12 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10356,12 +10353,12 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10373,12 +10370,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10390,12 +10387,12 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10407,12 +10404,12 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10424,12 +10421,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10441,12 +10438,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10458,12 +10455,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10475,12 +10472,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10492,12 +10489,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10509,12 +10506,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10526,12 +10523,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10543,12 +10540,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10560,12 +10557,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10577,12 +10574,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10591,7 +10588,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/backend/src/graphql/resolvers/playlists/queries.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries.ts
@@ -1,12 +1,74 @@
-import { eq, and, inArray, desc, sql, or, isNull } from 'drizzle-orm';
-import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { eq, and, inArray, desc, sql, or, isNull, asc } from 'drizzle-orm';
+import type { ConnectionContext, Climb } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client.js';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers.js';
 import {
   GetUserPlaylistsInputSchema,
   GetPlaylistsForClimbInputSchema,
+  GetPlaylistClimbsInputSchema,
 } from '../../../validation/schemas.js';
+import { getBoardTables, isValidBoardName } from '../../../db/queries/util/table-select.js';
+import { getSizeEdges } from '../../../db/queries/util/product-sizes-data.js';
+import type { LitUpHoldsMap, HoldState } from '@boardsesh/shared-schema';
+
+// Hold state mapping for converting frames string to lit up holds map
+type HoldColor = string;
+type HoldCode = number;
+type BoardName = 'kilter' | 'tension';
+
+const HOLD_STATE_MAP: Record<
+  BoardName,
+  Record<HoldCode, { name: HoldState; color: HoldColor; displayColor?: HoldColor }>
+> = {
+  kilter: {
+    42: { name: 'STARTING', color: '#00FF00' },
+    43: { name: 'HAND', color: '#00FFFF' },
+    44: { name: 'FINISH', color: '#FF00FF' },
+    45: { name: 'FOOT', color: '#FFA500' },
+    12: { name: 'STARTING', color: '#00FF00' },
+    13: { name: 'HAND', color: '#00FFFF' },
+    14: { name: 'FINISH', color: '#FF00FF' },
+    15: { name: 'FOOT', color: '#FFA500' },
+  },
+  tension: {
+    1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
+    2: { name: 'HAND', displayColor: '#4444FF', color: '#0000FF' },
+    3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
+    4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
+    5: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
+    6: { name: 'HAND', displayColor: '#4444FF', color: '#0000FF' },
+    7: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
+    8: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
+  },
+};
+
+function convertLitUpHoldsStringToMap(litUpHolds: string, board: BoardName): Record<number, LitUpHoldsMap> {
+  return litUpHolds
+    .split(',')
+    .filter((frame) => frame)
+    .reduce(
+      (frameMap, frameString, frameIndex) => {
+        const frameHoldsMap = Object.fromEntries(
+          frameString
+            .split('p')
+            .filter((hold) => hold)
+            .map((holdData) => holdData.split('r').map((str) => Number(str)))
+            .map(([holdId, stateCode]) => {
+              const stateInfo = HOLD_STATE_MAP[board]?.[stateCode];
+              if (!stateInfo) {
+                return [holdId || 0, { state: `${holdId}=${stateCode}` as HoldState, color: '#FFF', displayColor: '#FFF' }];
+              }
+              const { name, color, displayColor } = stateInfo;
+              return [holdId, { state: name, color, displayColor: displayColor || color }];
+            }),
+        );
+        frameMap[frameIndex] = frameHoldsMap as LitUpHoldsMap;
+        return frameMap;
+      },
+      {} as Record<number, LitUpHoldsMap>,
+    );
+}
 
 export const playlistQueries = {
   /**
@@ -199,5 +261,143 @@ export const playlistQueries = {
       );
 
     return results.map(r => r.playlistUuid);
+  },
+
+  /**
+   * Get climbs in a playlist with full climb data
+   */
+  playlistClimbs: async (
+    _: unknown,
+    { input }: { input: {
+      playlistId: string;
+      boardName: string;
+      layoutId: number;
+      sizeId: number;
+      setIds: string;
+      page?: number;
+      pageSize?: number;
+    } },
+    ctx: ConnectionContext
+  ): Promise<{ climbs: Climb[]; totalCount: number; hasMore: boolean }> => {
+    requireAuthenticated(ctx);
+    validateInput(GetPlaylistClimbsInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+    const boardName = input.boardName as BoardName;
+
+    // Validate board name
+    if (!isValidBoardName(boardName)) {
+      throw new Error(`Invalid board name: ${boardName}. Must be 'kilter' or 'tension'`);
+    }
+
+    // Get size edges for filtering
+    const sizeEdges = getSizeEdges(boardName, input.sizeId);
+    if (!sizeEdges) {
+      throw new Error(`Invalid size ID: ${input.sizeId} for board: ${boardName}`);
+    }
+
+    const page = input.page ?? 0;
+    const pageSize = input.pageSize ?? 20;
+
+    // First, verify the user has access to this playlist
+    const playlistResult = await db
+      .select({
+        id: dbSchema.playlists.id,
+      })
+      .from(dbSchema.playlists)
+      .innerJoin(
+        dbSchema.playlistOwnership,
+        eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id)
+      )
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, input.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (playlistResult.length === 0) {
+      throw new Error('Playlist not found or access denied');
+    }
+
+    const playlistId = playlistResult[0].id;
+    const tables = getBoardTables(boardName);
+
+    // Get total count of climbs in the playlist
+    const countResult = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(dbSchema.playlistClimbs)
+      .where(eq(dbSchema.playlistClimbs.playlistId, playlistId));
+
+    const totalCount = countResult[0]?.count || 0;
+
+    // Get playlist climbs with full climb data
+    const results = await db
+      .select({
+        // Playlist climb data
+        climbUuid: dbSchema.playlistClimbs.climbUuid,
+        angle: dbSchema.playlistClimbs.angle,
+        position: dbSchema.playlistClimbs.position,
+        // Climb data
+        uuid: tables.climbs.uuid,
+        setter_username: tables.climbs.setterUsername,
+        name: tables.climbs.name,
+        description: tables.climbs.description,
+        frames: tables.climbs.frames,
+        // Stats data - use the angle from playlist if available
+        ascensionist_count: tables.climbStats.ascensionistCount,
+        difficulty: tables.difficultyGrades.boulderName,
+        quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
+        difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
+        benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
+      })
+      .from(dbSchema.playlistClimbs)
+      .innerJoin(
+        tables.climbs,
+        eq(tables.climbs.uuid, dbSchema.playlistClimbs.climbUuid)
+      )
+      .leftJoin(
+        tables.climbStats,
+        and(
+          eq(tables.climbStats.climbUuid, dbSchema.playlistClimbs.climbUuid),
+          eq(tables.climbStats.angle, sql`COALESCE(${dbSchema.playlistClimbs.angle}, ${tables.climbStats.angle})`)
+        )
+      )
+      .leftJoin(
+        tables.difficultyGrades,
+        eq(tables.difficultyGrades.difficulty, sql`ROUND(${tables.climbStats.displayDifficulty}::numeric)`)
+      )
+      .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+      .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
+      .limit(pageSize + 1)
+      .offset(page * pageSize);
+
+    // Check if there are more results available
+    const hasMore = results.length > pageSize;
+    const trimmedResults = hasMore ? results.slice(0, pageSize) : results;
+
+    // Transform results to Climb type
+    const climbs: Climb[] = trimmedResults.map((result) => ({
+      uuid: result.uuid || result.climbUuid,
+      setter_username: result.setter_username || '',
+      name: result.name || '',
+      description: result.description || '',
+      frames: result.frames || '',
+      angle: result.angle ?? 0,
+      ascensionist_count: Number(result.ascensionist_count || 0),
+      difficulty: result.difficulty || '',
+      quality_average: result.quality_average?.toString() || '0',
+      stars: Math.round((Number(result.quality_average) || 0) * 5),
+      difficulty_error: result.difficulty_error?.toString() || '0',
+      benchmark_difficulty: result.benchmark_difficulty?.toString() || null,
+      litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', boardName)[0],
+    }));
+
+    return {
+      climbs,
+      totalCount,
+      hasMore,
+    };
   },
 };

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -359,3 +359,13 @@ export const GetPlaylistsForClimbInputSchema = z.object({
   layoutId: z.number().int().positive(),
   climbUuid: ExternalUUIDSchema,
 });
+
+export const GetPlaylistClimbsInputSchema = z.object({
+  playlistId: z.string().min(1),
+  boardName: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+  sizeId: z.number().int().positive(),
+  setIds: z.string().min(1),
+  page: z.number().int().min(0).optional(),
+  pageSize: z.number().int().min(1).max(100).optional(),
+});

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -389,6 +389,22 @@ export const typeDefs = /* GraphQL */ `
     climbUuid: String!
   }
 
+  input GetPlaylistClimbsInput {
+    playlistId: ID!
+    boardName: String!
+    layoutId: Int!
+    sizeId: Int!
+    setIds: String!
+    page: Int
+    pageSize: Int
+  }
+
+  type PlaylistClimbsResult {
+    climbs: [Climb!]!
+    totalCount: Int!
+    hasMore: Boolean!
+  }
+
   type Query {
     session(sessionId: ID!): Session
     # Get buffered events since a sequence number for delta sync (Phase 2)
@@ -462,6 +478,8 @@ export const typeDefs = /* GraphQL */ `
     playlist(playlistId: ID!): Playlist
     # Get playlists that contain a specific climb
     playlistsForClimb(input: GetPlaylistsForClimbInput!): [ID!]!
+    # Get climbs in a playlist with full climb data
+    playlistClimbs(input: GetPlaylistClimbsInput!): PlaylistClimbsResult!
   }
 
   type Mutation {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-climbs-list.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { Row, Col, Empty, Typography } from 'antd';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { track } from '@vercel/analytics';
+import { Climb, BoardDetails } from '@/app/lib/types';
+import { executeGraphQL } from '@/app/lib/graphql/client';
+import {
+  GET_PLAYLIST_CLIMBS,
+  GetPlaylistClimbsQueryResponse,
+  GetPlaylistClimbsQueryVariables,
+} from '@/app/lib/graphql/operations/playlists';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import ClimbCard from '@/app/components/climb-card/climb-card';
+import { ClimbCardSkeleton } from '@/app/components/board-page/board-page-skeleton';
+import styles from './playlist-view.module.css';
+
+const { Text } = Typography;
+
+type PlaylistClimbsListProps = {
+  playlistUuid: string;
+  boardDetails: BoardDetails;
+  angle: number;
+};
+
+const ClimbsListSkeleton = ({ aspectRatio }: { aspectRatio: number }) => {
+  return (
+    <>
+      {Array.from({ length: 6 }, (_, i) => (
+        <Col xs={24} lg={12} xl={12} key={i}>
+          <ClimbCardSkeleton aspectRatio={aspectRatio} />
+        </Col>
+      ))}
+    </>
+  );
+};
+
+export default function PlaylistClimbsList({
+  playlistUuid,
+  boardDetails,
+  angle,
+}: PlaylistClimbsListProps) {
+  const { token, isLoading: tokenLoading } = useWsAuthToken();
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  const [selectedClimbUuid, setSelectedClimbUuid] = useState<string | null>(null);
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useInfiniteQuery({
+    queryKey: ['playlistClimbs', playlistUuid, boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id, angle],
+    queryFn: async ({ pageParam = 0 }) => {
+      const response = await executeGraphQL<
+        GetPlaylistClimbsQueryResponse,
+        GetPlaylistClimbsQueryVariables
+      >(
+        GET_PLAYLIST_CLIMBS,
+        {
+          input: {
+            playlistId: playlistUuid,
+            boardName: boardDetails.board_name,
+            layoutId: boardDetails.layout_id,
+            sizeId: boardDetails.size_id,
+            setIds: boardDetails.set_ids.join(','),
+            page: pageParam,
+            pageSize: 20,
+          },
+        },
+        token,
+      );
+      return response.playlistClimbs;
+    },
+    enabled: !tokenLoading && !!token,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined;
+      return allPages.length;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Flatten all pages of climbs
+  const climbs: Climb[] = data?.pages.flatMap((page) => page.climbs as Climb[]) ?? [];
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  // Intersection Observer callback for infinite scroll
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [target] = entries;
+      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        track('Playlist Infinite Scroll Load More', {
+          playlistUuid,
+          currentCount: climbs.length,
+          hasMore: hasNextPage,
+        });
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage, climbs.length, playlistUuid],
+  );
+
+  // Set up Intersection Observer
+  useEffect(() => {
+    const element = loadMoreRef.current;
+    if (!element) return;
+
+    const scrollContainer = document.getElementById('content-for-scrollable');
+
+    const observer = new IntersectionObserver(handleObserver, {
+      root: scrollContainer,
+      rootMargin: '100px',
+      threshold: 0,
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleObserver]);
+
+  // Handle climb selection
+  const handleClimbClick = useCallback((climb: Climb) => {
+    setSelectedClimbUuid(climb.uuid);
+    track('Playlist Climb Card Clicked', {
+      climbUuid: climb.uuid,
+      playlistUuid,
+    });
+  }, [playlistUuid]);
+
+  const aspectRatio = boardDetails.boardWidth / boardDetails.boardHeight;
+
+  // Loading state
+  if ((isLoading || tokenLoading) && climbs.length === 0) {
+    return (
+      <div className={styles.climbsSection}>
+        <div className={styles.climbsSectionHeader}>
+          <Text strong className={styles.climbsSectionTitle}>Climbs</Text>
+        </div>
+        <Row gutter={[16, 16]}>
+          <ClimbsListSkeleton aspectRatio={aspectRatio} />
+        </Row>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className={styles.climbsSection}>
+        <div className={styles.climbsSectionHeader}>
+          <Text strong className={styles.climbsSectionTitle}>Climbs</Text>
+        </div>
+        <Empty
+          description="Failed to load climbs"
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+        />
+      </div>
+    );
+  }
+
+  // Empty state
+  if (climbs.length === 0 && !isFetching) {
+    return (
+      <div className={styles.climbsSection}>
+        <div className={styles.climbsSectionHeader}>
+          <Text strong className={styles.climbsSectionTitle}>Climbs</Text>
+        </div>
+        <Empty
+          description="No climbs in this playlist yet"
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.climbsSection}>
+      <div className={styles.climbsSectionHeader}>
+        <Text strong className={styles.climbsSectionTitle}>
+          Climbs ({totalCount})
+        </Text>
+      </div>
+
+      <Row gutter={[16, 16]}>
+        {climbs.map((climb) => (
+          <Col xs={24} lg={12} xl={12} key={climb.uuid}>
+            <ClimbCard
+              climb={climb}
+              boardDetails={boardDetails}
+              selected={selectedClimbUuid === climb.uuid}
+              onCoverDoubleClick={() => handleClimbClick(climb)}
+            />
+          </Col>
+        ))}
+        {isFetching && climbs.length === 0 && (
+          <ClimbsListSkeleton aspectRatio={aspectRatio} />
+        )}
+      </Row>
+
+      {/* Sentinel element for Intersection Observer */}
+      <div ref={loadMoreRef} style={{ minHeight: '20px', marginTop: '16px' }}>
+        {isFetchingNextPage && (
+          <Row gutter={[16, 16]}>
+            <ClimbsListSkeleton aspectRatio={aspectRatio} />
+          </Row>
+        )}
+        {!hasNextPage && climbs.length > 0 && (
+          <div style={{ textAlign: 'center', padding: '20px', color: '#888' }}>
+            {climbs.length === totalCount ? `All ${totalCount} climbs loaded` : 'No more climbs'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
@@ -22,6 +22,7 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { themeTokens } from '@/app/theme/theme-config';
 import PlaylistViewActions from './playlist-view-actions';
 import PlaylistEditDrawer from './playlist-edit-drawer';
+import PlaylistClimbsList from './playlist-climbs-list';
 import styles from './playlist-view.module.css';
 
 const { Title, Text } = Typography;
@@ -219,6 +220,13 @@ export default function PlaylistViewContent({
             )}
           </div>
         </div>
+
+        {/* Climbs List */}
+        <PlaylistClimbsList
+          playlistUuid={playlistUuid}
+          boardDetails={boardDetails}
+          angle={angle}
+        />
       </div>
 
       {/* Edit Drawer */}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
@@ -242,6 +242,25 @@
   }
 }
 
+/* Climbs section */
+.climbsSection {
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+}
+
+.climbsSectionHeader {
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.climbsSectionTitle {
+  font-size: 16px;
+  color: #111827;
+}
+
 /* Desktop layout */
 @media (min-width: 992px) {
   .pageContainer {
@@ -271,5 +290,26 @@
 
   .playlistName {
     font-size: 28px !important;
+  }
+
+  .climbsSection {
+    padding: 24px;
+  }
+}
+
+/* Mobile adjustments for climbs section */
+@media (max-width: 767px) {
+  .climbsSection {
+    padding: 16px;
+    border-radius: 8px;
+  }
+
+  .climbsSectionHeader {
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+  }
+
+  .climbsSectionTitle {
+    font-size: 14px;
   }
 }

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -94,6 +94,31 @@ export const REMOVE_CLIMB_FROM_PLAYLIST = gql`
   }
 `;
 
+// Get climbs in a playlist with full climb data
+export const GET_PLAYLIST_CLIMBS = gql`
+  query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {
+    playlistClimbs(input: $input) {
+      climbs {
+        uuid
+        setter_username
+        name
+        description
+        frames
+        angle
+        ascensionist_count
+        difficulty
+        quality_average
+        stars
+        difficulty_error
+        litUpHoldsMap
+        benchmark_difficulty
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
 // TypeScript types for operations
 
 export interface Playlist {
@@ -221,4 +246,42 @@ export interface RemoveClimbFromPlaylistMutationVariables {
 
 export interface RemoveClimbFromPlaylistMutationResponse {
   removeClimbFromPlaylist: boolean;
+}
+
+export interface GetPlaylistClimbsInput {
+  playlistId: string;
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface GetPlaylistClimbsQueryVariables {
+  input: GetPlaylistClimbsInput;
+}
+
+export interface PlaylistClimbsResult {
+  climbs: Array<{
+    uuid: string;
+    setter_username: string;
+    name: string;
+    description: string;
+    frames: string;
+    angle: number;
+    ascensionist_count: number;
+    difficulty: string;
+    quality_average: string;
+    stars: number;
+    difficulty_error: string;
+    litUpHoldsMap: Record<string, unknown>;
+    benchmark_difficulty: string | null;
+  }>;
+  totalCount: number;
+  hasMore: boolean;
+}
+
+export interface GetPlaylistClimbsQueryResponse {
+  playlistClimbs: PlaylistClimbsResult;
 }


### PR DESCRIPTION
Add a climbs list to the playlist view page that displays all climbs
in the playlist using the same ClimbCard components and infinite scroll
pattern as the main climb list. This provides a consistent user experience
across the app.

Changes:
- Add playlistClimbs GraphQL query to fetch climbs with full data
- Create PlaylistClimbsList component with infinite scroll
- Integrate the climb list into the playlist view page