### PR TITLE
fix: Resolve playlist duplicate climbs and add cross-layout support

### DIFF
--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -6,6 +6,7 @@ export const typeDefs = /* GraphQL */ `
 
   type Climb {
     uuid: ID!
+    layoutId: Int
     setter_username: String!
     name: String!
     description: String!

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -10,6 +10,7 @@ export type LitUpHoldsMap = Record<number, LitupHold>;
 
 export type Climb = {
   uuid: string;
+  layoutId?: number | null; // GraphQL nullable Int - layout the climb belongs to
   setter_username: string;
   name: string;
   description: string;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-climbs-list.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useEffect, useRef, useCallback, useState } from 'react';
-import { Row, Col, Empty, Typography } from 'antd';
+import { Row, Col, Empty, Typography, Tooltip } from 'antd';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { track } from '@vercel/analytics';
 import { Climb, BoardDetails } from '@/app/lib/types';
@@ -189,16 +190,37 @@ export default function PlaylistClimbsList({
       </div>
 
       <Row gutter={[16, 16]}>
-        {climbs.map((climb) => (
-          <Col xs={24} lg={12} xl={12} key={climb.uuid}>
+        {climbs.map((climb) => {
+          // Check if this climb is from a different layout
+          const isCrossLayout = climb.layoutId != null && climb.layoutId !== boardDetails.layout_id;
+
+          const climbCard = (
             <ClimbCard
               climb={climb}
               boardDetails={boardDetails}
               selected={selectedClimbUuid === climb.uuid}
               onCoverDoubleClick={() => handleClimbClick(climb)}
             />
-          </Col>
-        ))}
+          );
+
+          return (
+            <Col xs={24} lg={12} xl={12} key={climb.uuid}>
+              {isCrossLayout ? (
+                <Tooltip title="This climb is from a different layout and may not display correctly on your board">
+                  <div className={styles.crossLayoutClimb}>
+                    <div className={styles.crossLayoutBadge}>
+                      <ExclamationCircleOutlined />
+                      Different layout
+                    </div>
+                    {climbCard}
+                  </div>
+                </Tooltip>
+              ) : (
+                climbCard
+              )}
+            </Col>
+          );
+        })}
         {isFetching && climbs.length === 0 && (
           <ClimbsListSkeleton aspectRatio={aspectRatio} />
         )}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
@@ -313,3 +313,31 @@
     font-size: 14px;
   }
 }
+
+/* Cross-layout climb styling - climbs from a different layout */
+.crossLayoutClimb {
+  position: relative;
+  opacity: 0.5;
+  filter: grayscale(30%);
+  transition: opacity 0.2s, filter 0.2s;
+}
+
+.crossLayoutClimb:hover {
+  opacity: 0.7;
+  filter: grayscale(15%);
+}
+
+.crossLayoutBadge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #FFFFFF;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -100,6 +100,7 @@ export const GET_PLAYLIST_CLIMBS = gql`
     playlistClimbs(input: $input) {
       climbs {
         uuid
+        layoutId
         setter_username
         name
         description
@@ -265,6 +266,7 @@ export interface GetPlaylistClimbsQueryVariables {
 export interface PlaylistClimbsResult {
   climbs: Array<{
     uuid: string;
+    layoutId?: number | null;
     setter_username: string;
     name: string;
     description: string;

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -3,6 +3,7 @@ import { SetIdList } from './board-data';
 
 export type Climb = {
   uuid: string;
+  layoutId?: number | null; // Layout the climb belongs to - used to identify cross-layout climbs
   setter_username: string;
   name: string;
   description: string;


### PR DESCRIPTION
- Fix duplicate climbs in playlist query by changing COALESCE join condition
  from climbStats.angle to climbs.angle (prevents cartesian product when
  playlistClimbs.angle is NULL)
- Add layoutId field to Climb type in GraphQL schema and TypeScript types
- Include layoutId in playlist climbs query response
- Render cross-layout climbs with greyed out styling and informative badge
  in playlist view to indicate climbs from different layouts