### PR TITLE
fix: Hide cross-layout climbs in playlist view with info notice

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view.module.css
@@ -314,30 +314,7 @@
   }
 }
 
-/* Cross-layout climb styling - climbs from a different layout */
-.crossLayoutClimb {
-  position: relative;
-  opacity: 0.5;
-  filter: grayscale(30%);
-  transition: opacity 0.2s, filter 0.2s;
-}
-
-.crossLayoutClimb:hover {
-  opacity: 0.7;
-  filter: grayscale(15%);
-}
-
-.crossLayoutBadge {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 10;
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #FFFFFF;
-  font-size: 11px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
+/* Hidden climbs notice */
+.hiddenClimbsNotice {
+  margin-bottom: 16px;
 }


### PR DESCRIPTION
Instead of showing cross-layout climbs with reduced opacity and a warning
badge, we now filter them out entirely and show an info alert at the top
indicating how many climbs from other layouts are being hidden. This
provides a cleaner UI while still informing users about hidden content.