### PR TITLE
feat: Add page unload warning when queue is not empty

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -916,9 +916,8 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
   );
 
   // Warn user before leaving page if queue has items
+  const hasQueueItems = state.queue.length > 0;
   useEffect(() => {
-    const hasQueueItems = state.queue.length > 0;
-
     if (!hasQueueItems) {
       return;
     }
@@ -936,7 +935,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [state.queue.length]);
+  }, [hasQueueItems]);
 
   // Wrap children with FavoritesProvider and PlaylistsProvider to pass hoisted data
   const wrappedChildren = (

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -915,6 +915,29 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
     ],
   );
 
+  // Warn user before leaving page if queue has items
+  useEffect(() => {
+    const hasQueueItems = state.queue.length > 0;
+
+    if (!hasQueueItems) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      // Modern browsers require both preventDefault and returnValue
+      event.preventDefault();
+      // Legacy support - some browsers need returnValue to be set
+      event.returnValue = '';
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [state.queue.length]);
+
   // Wrap children with FavoritesProvider and PlaylistsProvider to pass hoisted data
   const wrappedChildren = (
     <FavoritesProvider


### PR DESCRIPTION
Prevents users from accidentally losing their queue by showing a
browser confirmation dialog when refreshing or navigating away.