### PR TITLE
feat: Add tall climbs only toggle to playlist generator

### DIFF
--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Typography, Select, Button, Row, Col, InputNumber } from 'antd';
+import { Typography, Select, Button, Row, Col, InputNumber, Switch, Tooltip } from 'antd';
 import { MinusOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
+import { BoardDetails } from '@/app/lib/types';
 import {
   WorkoutType,
   GeneratorOptions,
@@ -22,11 +23,15 @@ import styles from './generator-options-form.module.css';
 
 const { Text } = Typography;
 
+// Kilter Homewall layout ID
+const KILTER_HOMEWALL_LAYOUT_ID = 8;
+
 interface GeneratorOptionsFormProps {
   workoutType: WorkoutType;
   options: GeneratorOptions;
   onChange: (options: GeneratorOptions) => void;
   onReset: () => void;
+  boardDetails: BoardDetails;
 }
 
 const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
@@ -34,8 +39,15 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
   options,
   onChange,
   onReset,
+  boardDetails,
 }) => {
   const grades = TENSION_KILTER_GRADES;
+
+  // Check if we should show the tall climbs filter
+  // Only show for Kilter Homewall on the largest size (10x12)
+  const isKilterHomewall = boardDetails.board_name === 'kilter' && boardDetails.layout_id === KILTER_HOMEWALL_LAYOUT_ID;
+  const isLargestSize = boardDetails.size_name?.toLowerCase().includes('12');
+  const showTallClimbsFilter = isKilterHomewall && isLargestSize;
 
   // Helper to update options
   const updateOption = <K extends keyof GeneratorOptions>(key: K, value: GeneratorOptions[K]) => {
@@ -151,6 +163,19 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
 
       {/* Climb Bias */}
       {renderSelect('Climb Bias', options.climbBias, CLIMB_BIAS_OPTIONS, (v) => updateOption('climbBias', v))}
+
+      {/* Tall Climbs Only - only for Kilter Homewall large size */}
+      {showTallClimbsFilter && (
+        <div className={styles.formRow}>
+          <Tooltip title="Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)">
+            <Text className={styles.label}>Tall Climbs Only</Text>
+          </Tooltip>
+          <Switch
+            checked={options.onlyTallClimbs}
+            onChange={(checked) => updateOption('onlyTallClimbs', checked)}
+          />
+        </div>
+      )}
     </>
   );
 

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -113,6 +113,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
       sortOrder: 'desc',
       page: 1,
       pageSize: 50, // Get a pool of climbs to choose from
+      onlyTallClimbs: options?.onlyTallClimbs || false,
     };
 
     // Apply climb bias filters if user is authenticated
@@ -307,6 +308,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
               options={options}
               onChange={setOptions}
               onReset={handleReset}
+              boardDetails={boardDetails}
             />
           </div>
         </div>

--- a/packages/web/app/components/playlist-generator/types.ts
+++ b/packages/web/app/components/playlist-generator/types.ts
@@ -15,6 +15,7 @@ export interface BaseGeneratorOptions {
   climbBias: ClimbBias;
   minAscents: number;
   minRating: number;
+  onlyTallClimbs: boolean;
 }
 
 // Volume workout - high volume at consistent grade
@@ -109,6 +110,7 @@ export const DEFAULT_VOLUME_OPTIONS: Omit<VolumeOptions, 'targetGrade'> = {
   climbBias: 'unfamiliar',
   minAscents: 5,
   minRating: 1.5,
+  onlyTallClimbs: false,
 };
 
 export const DEFAULT_PYRAMID_OPTIONS: Omit<PyramidOptions, 'targetGrade'> = {
@@ -119,6 +121,7 @@ export const DEFAULT_PYRAMID_OPTIONS: Omit<PyramidOptions, 'targetGrade'> = {
   climbBias: 'unfamiliar',
   minAscents: 5,
   minRating: 1.5,
+  onlyTallClimbs: false,
 };
 
 export const DEFAULT_LADDER_OPTIONS: Omit<LadderOptions, 'targetGrade'> = {
@@ -129,6 +132,7 @@ export const DEFAULT_LADDER_OPTIONS: Omit<LadderOptions, 'targetGrade'> = {
   climbBias: 'unfamiliar',
   minAscents: 5,
   minRating: 1.5,
+  onlyTallClimbs: false,
 };
 
 export const DEFAULT_GRADE_FOCUS_OPTIONS: Omit<GradeFocusOptions, 'targetGrade'> = {
@@ -138,6 +142,7 @@ export const DEFAULT_GRADE_FOCUS_OPTIONS: Omit<GradeFocusOptions, 'targetGrade'>
   climbBias: 'unfamiliar',
   minAscents: 5,
   minRating: 1.5,
+  onlyTallClimbs: false,
 };
 
 // Warm-up configuration


### PR DESCRIPTION
Add option to filter for tall climbs (using bottom 8 rows) when
generating playlists on Kilter Homewall 10x12 boards, matching
the existing search functionality.