### PR TITLE
feat: Add 'Open in App' button to queue list menu and tick drawer

### DIFF
--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -3,12 +3,13 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { Button, Badge, Drawer, Typography, Space } from 'antd';
 import { ActionTooltip } from '../action-tooltip';
-import { CheckOutlined, LoginOutlined } from '@ant-design/icons';
+import { CheckOutlined, LoginOutlined, AppstoreOutlined } from '@ant-design/icons';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
 import AuthModal from '../../auth/auth-modal';
 import { LogAscentDrawer } from '../../logbook/log-ascent-drawer';
 import { track } from '@vercel/analytics';
+import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 
 const { Text, Paragraph } = Typography;
 
@@ -59,6 +60,12 @@ export function TickAction({
     setDrawerVisible(false);
   }, []);
 
+  const handleOpenInApp = useCallback(() => {
+    const url = constructClimbInfoUrl(boardDetails, climb.uuid, angle);
+    window.open(url, '_blank', 'noopener');
+    closeDrawer();
+  }, [boardDetails, climb.uuid, angle, closeDrawer]);
+
   const renderSignInPrompt = () => (
     <Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
       <Text strong style={{ fontSize: 16 }}>Sign in to record ticks</Text>
@@ -67,6 +74,12 @@ export function TickAction({
       </Paragraph>
       <Button type="primary" icon={<LoginOutlined />} onClick={() => setShowAuthModal(true)} block>
         Sign In
+      </Button>
+      <Paragraph type="secondary">
+        Or log your tick in the official app:
+      </Paragraph>
+      <Button icon={<AppstoreOutlined />} onClick={handleOpenInApp} block>
+        Open in App
       </Button>
     </Space>
   );

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { Button, Badge, Drawer, Typography, Space } from 'antd';
-import { CheckOutlined, LoginOutlined } from '@ant-design/icons';
+import { CheckOutlined, LoginOutlined, AppstoreOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { LogAscentDrawer } from './log-ascent-drawer';
 import AuthModal from '../auth/auth-modal';
+import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 
 const { Text, Paragraph } = Typography;
 
@@ -28,6 +29,13 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
     });
   };
   const closeDrawer = () => setDrawerVisible(false);
+
+  const handleOpenInApp = () => {
+    if (!currentClimb) return;
+    const url = constructClimbInfoUrl(boardDetails, currentClimb.uuid, angle);
+    window.open(url, '_blank', 'noopener');
+    closeDrawer();
+  };
 
   const filteredLogbook = logbook.filter((asc) => asc.climb_uuid === currentClimb?.uuid && Number(asc.angle) === angle);
   const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
@@ -66,6 +74,12 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
             </Paragraph>
             <Button type="primary" icon={<LoginOutlined />} onClick={() => setShowAuthModal(true)} block>
               Sign In
+            </Button>
+            <Paragraph type="secondary">
+              Or log your tick in the official app:
+            </Paragraph>
+            <Button icon={<AppstoreOutlined />} onClick={handleOpenInApp} block>
+              Open in App
             </Button>
           </Space>
         </Drawer>

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Row, Col, Avatar, Tooltip, Dropdown, Button } from 'antd';
-import { CheckOutlined, CloseOutlined, UserOutlined, DeleteOutlined, MoreOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { CheckOutlined, CloseOutlined, UserOutlined, DeleteOutlined, MoreOutlined, InfoCircleOutlined, AppstoreOutlined } from '@ant-design/icons';
 import { BoardDetails, ClimbUuid, Climb } from '@/app/lib/types';
 import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
@@ -14,7 +14,7 @@ import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
-import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, parseBoardRouteParams } from '@/app/lib/url-utils';
+import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, parseBoardRouteParams, constructClimbInfoUrl } from '@/app/lib/url-utils';
 
 type QueueListItemProps = {
   item: ClimbQueueItem;
@@ -147,6 +147,12 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
       onTickClick(item.climb);
     }
   }, [item.climb, onTickClick]);
+
+  const handleOpenInApp = useCallback(() => {
+    if (!item.climb) return;
+    const url = constructClimbInfoUrl(boardDetails, item.climb.uuid, item.climb.angle);
+    window.open(url, '_blank', 'noopener');
+  }, [item.climb, boardDetails]);
 
   const swipeHandlers = useSwipeable({
     onSwiping: (eventData) => {
@@ -358,6 +364,12 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
                       label: 'Tick Climb',
                       icon: <CheckOutlined />,
                       onClick: () => item.climb && onTickClick(item.climb),
+                    },
+                    {
+                      key: 'openInApp',
+                      label: 'Open in App',
+                      icon: <AppstoreOutlined />,
+                      onClick: handleOpenInApp,
                     },
                     {
                       key: 'remove',


### PR DESCRIPTION
- Add 'Open in App' option to the queue list item ellipsis menu
- Add 'Open in App' button for non-authenticated users in the tick
  drawer, allowing them to log their tick in the official Aurora app