### PR TITLE
Fix queue ordering and auto-scroll to active climb

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { Button, Row, Col, Card, Drawer, Space, Popconfirm } from 'antd';
 import { SyncOutlined, DeleteOutlined, ExpandOutlined, FastForwardOutlined, FastBackwardOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
@@ -12,7 +12,7 @@ import { constructPlayUrlWithSlugs, constructClimbViewUrlWithSlugs, parseBoardRo
 import { BoardRouteParameters, BoardRouteParametersWithUuid } from '@/app/lib/types';
 import PreviousClimbButton from './previous-climb-button';
 import { BoardName, BoardDetails, Angle } from '@/app/lib/types';
-import QueueList from './queue-list';
+import QueueList, { QueueListHandle } from './queue-list';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
@@ -38,6 +38,17 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   const params = useParams<BoardRouteParameters>();
   const searchParams = useSearchParams();
   const router = useRouter();
+  const queueListRef = useRef<QueueListHandle>(null);
+
+  // Scroll to current climb when drawer finishes opening
+  const handleDrawerOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      // Small delay to ensure the drawer content is rendered
+      setTimeout(() => {
+        queueListRef.current?.scrollToCurrentClimb();
+      }, 100);
+    }
+  }, []);
 
   const isViewPage = pathname.includes('/view/');
   const isListPage = pathname.includes('/list');
@@ -354,6 +365,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         height="70%" // Adjust as per design preference
         open={isQueueOpen}
         onClose={toggleQueueDrawer}
+        afterOpenChange={handleDrawerOpenChange}
         styles={{ body: { padding: 0 } }}
         extra={
           queue.length > 0 && (
@@ -371,7 +383,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
           )
         }
       >
-        <QueueList boardDetails={boardDetails} onClimbNavigate={() => setIsQueueOpen(false)} />
+        <QueueList ref={queueListRef} boardDetails={boardDetails} onClimbNavigate={() => setIsQueueOpen(false)} />
       </Drawer>
     </div>
   );

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Button, Row, Col, Card, Drawer, Space, Popconfirm } from 'antd';
 import { SyncOutlined, DeleteOutlined, ExpandOutlined, FastForwardOutlined, FastBackwardOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
@@ -39,12 +39,22 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   const searchParams = useSearchParams();
   const router = useRouter();
   const queueListRef = useRef<QueueListHandle>(null);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Scroll to current climb when drawer finishes opening
   const handleDrawerOpenChange = useCallback((open: boolean) => {
     if (open) {
       // Small delay to ensure the drawer content is rendered
-      setTimeout(() => {
+      scrollTimeoutRef.current = setTimeout(() => {
         queueListRef.current?.scrollToCurrentClimb();
       }, 100);
     }

--- a/packages/web/app/components/queue-control/queue-list.module.css
+++ b/packages/web/app/components/queue-control/queue-list.module.css
@@ -1,0 +1,3 @@
+.historyDivider {
+  margin: 8px 0;
+}

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, useImperativeHandle, forwardRef } from 'react';
 import { Divider, Row, Col, Button, Flex, Drawer, Space, Typography, Skeleton } from 'antd';
 import { PlusOutlined, LoginOutlined } from '@ant-design/icons';
 import { useQueueContext } from '../graphql-queue';
@@ -18,12 +18,16 @@ import AuthModal from '../auth/auth-modal';
 
 const { Text, Paragraph } = Typography;
 
+export type QueueListHandle = {
+  scrollToCurrentClimb: () => void;
+};
+
 type QueueListProps = {
   boardDetails: BoardDetails;
   onClimbNavigate?: () => void;
 };
 
-const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) => {
+const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, onClimbNavigate }, ref) => {
   const {
     viewOnlyMode,
     currentClimbQueueItem,
@@ -45,6 +49,18 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
   const [tickDrawerVisible, setTickDrawerVisible] = useState(false);
   const [tickClimb, setTickClimb] = useState<Climb | null>(null);
   const [showAuthModal, setShowAuthModal] = useState(false);
+
+  // Ref for scrolling to current climb
+  const currentClimbRef = useRef<HTMLDivElement>(null);
+
+  // Expose scroll method to parent via ref
+  useImperativeHandle(ref, () => ({
+    scrollToCurrentClimb: () => {
+      if (currentClimbRef.current) {
+        currentClimbRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    },
+  }));
 
   const handleTickClick = useCallback((climb: Climb) => {
     setTickClimb(climb);
@@ -129,31 +145,67 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
     };
   }, [handleObserver, viewOnlyMode]);
 
+  // Find the index of the current climb in the queue
+  const currentIndex = queue.findIndex((item) => item.uuid === currentClimbQueueItem?.uuid);
+
+  // Split queue into upcoming (current + future) and history (past)
+  // Upcoming items are displayed first, then history items below
+  const upcomingItems = currentIndex >= 0 ? queue.slice(currentIndex) : queue;
+  const historyItems = currentIndex > 0 ? queue.slice(0, currentIndex) : [];
+
   return (
     <>
       <Flex vertical>
-        {queue.map((climbQueueItem, index) => {
+        {/* Current and upcoming items (displayed first) */}
+        {upcomingItems.map((climbQueueItem) => {
           const isCurrent = currentClimbQueueItem?.uuid === climbQueueItem.uuid;
-          const isHistory =
-            queue.findIndex((item) => item.uuid === currentClimbQueueItem?.uuid) >
-            queue.findIndex((item) => item.uuid === climbQueueItem.uuid);
+          // Get the original index in the queue for drag-and-drop
+          const originalIndex = queue.findIndex((item) => item.uuid === climbQueueItem.uuid);
 
           return (
-            <QueueListItem
-              key={climbQueueItem.uuid}
-              item={climbQueueItem}
-              index={index}
-              isCurrent={isCurrent}
-              isHistory={isHistory}
-              viewOnlyMode={viewOnlyMode}
-              boardDetails={boardDetails}
-              setCurrentClimbQueueItem={setCurrentClimbQueueItem}
-              removeFromQueue={removeFromQueue}
-              onTickClick={handleTickClick}
-              onClimbNavigate={onClimbNavigate}
-            />
+            <div key={climbQueueItem.uuid} ref={isCurrent ? currentClimbRef : undefined}>
+              <QueueListItem
+                item={climbQueueItem}
+                index={originalIndex}
+                isCurrent={isCurrent}
+                isHistory={false}
+                viewOnlyMode={viewOnlyMode}
+                boardDetails={boardDetails}
+                setCurrentClimbQueueItem={setCurrentClimbQueueItem}
+                removeFromQueue={removeFromQueue}
+                onTickClick={handleTickClick}
+                onClimbNavigate={onClimbNavigate}
+              />
+            </div>
           );
         })}
+
+        {/* History items (displayed below current/upcoming) */}
+        {historyItems.length > 0 && (
+          <>
+            <Divider style={{ margin: `${themeTokens.spacing[2]} 0` }}>History</Divider>
+            {historyItems.map((climbQueueItem) => {
+              // Get the original index in the queue for drag-and-drop
+              const originalIndex = queue.findIndex((item) => item.uuid === climbQueueItem.uuid);
+
+              return (
+                <QueueListItem
+                  key={climbQueueItem.uuid}
+                  item={climbQueueItem}
+                  index={originalIndex}
+                  isCurrent={false}
+                  isHistory={true}
+                  viewOnlyMode={viewOnlyMode}
+                  boardDetails={boardDetails}
+                  setCurrentClimbQueueItem={setCurrentClimbQueueItem}
+                  removeFromQueue={removeFromQueue}
+                  onTickClick={handleTickClick}
+                  onClimbNavigate={onClimbNavigate}
+                />
+              );
+            })}
+          </>
+        )}
       </Flex>
       {!viewOnlyMode && (
         <>
@@ -264,6 +316,8 @@ const QueueList: React.FC<QueueListProps> = ({ boardDetails, onClimbNavigate }) 
       />
     </>
   );
-};
+});
+
+QueueList.displayName = 'QueueList';
 
 export default QueueList;

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -15,6 +15,7 @@ import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { LogAscentDrawer } from '../logbook/log-ascent-drawer';
 import AuthModal from '../auth/auth-modal';
+import styles from './queue-list.module.css';
 
 const { Text, Paragraph } = Typography;
 
@@ -183,7 +184,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
         {/* History items (displayed below current/upcoming) */}
         {historyItems.length > 0 && (
           <>
-            <Divider style={{ margin: `${themeTokens.spacing[2]} 0` }}>History</Divider>
+            <Divider className={styles.historyDivider}>History</Divider>
             {historyItems.map((climbQueueItem) => {
               // Get the original index in the queue for drag-and-drop
               const originalIndex = queue.findIndex((item) => item.uuid === climbQueueItem.uuid);


### PR DESCRIPTION
- Reorder queue display to show current and upcoming items at the top
- Move history items (completed climbs) below a "History" divider
- Auto-scroll to the current climb when the drawer opens