### PR TITLE
fix: Ensure logbook fetch retries when auth token becomes available

### DIFF
--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/app/lib/url-utils', () => ({
 
 vi.mock('../../../board-provider/board-provider-context', () => ({
   useBoardProvider: vi.fn(() => ({
-    getLogbook: vi.fn()
+    getLogbook: vi.fn().mockResolvedValue(true)
   }))
 }));
 
@@ -129,7 +129,7 @@ const createWrapper = () => {
 
 describe('useQueueDataFetching', () => {
   const mockSetHasDoneFirstFetch = vi.fn();
-  const mockGetLogbook = vi.fn();
+  const mockGetLogbook = vi.fn().mockResolvedValue(true);
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -266,8 +266,13 @@ export const useQueueDataFetching = ({
 
     const climbUuids = JSON.parse(climbUuidsString);
     if (climbUuids.length > 0) {
-      getLogbook(climbUuids);
-      fetchedUuidsRef.current = climbUuidsString;
+      // Only mark as fetched if the fetch actually succeeded
+      // This ensures we retry when wsAuthToken becomes available
+      getLogbook(climbUuids).then((success) => {
+        if (success) {
+          fetchedUuidsRef.current = climbUuidsString;
+        }
+      });
     }
   }, [climbUuidsString, getLogbook]);
 


### PR DESCRIPTION
The queue climb history wasn't displaying because when getLogbook was
called before wsAuthToken was available, the fetch would fail silently
but fetchedUuidsRef was still set. This prevented the retry when the
token became available.

Changes:
- getLogbook now returns a boolean indicating fetch success
- fetchedUuidsRef is only set when the fetch actually succeeds
- Updated tests to reflect the new return type