### PR TITLE
fix: Make quality and difficulty optional in SaveTickOptions

### DIFF
--- a/packages/web/app/components/board-provider/board-provider-context.tsx
+++ b/packages/web/app/components/board-provider/board-provider-context.tsx
@@ -36,8 +36,8 @@ export interface SaveTickOptions {
   isMirror: boolean;
   status: TickStatus;
   attemptCount: number;
-  quality: number; // 1-5
-  difficulty: number;
+  quality?: number; // 1-5, optional for attempts
+  difficulty?: number; // optional for attempts
   isBenchmark: boolean;
   comment: string;
   climbedAt: string;


### PR DESCRIPTION
When logging attempts (not ascents), quality and difficulty fields
should be undefined. The SaveTickOptions interface now correctly
marks these as optional to match the SaveTickInput type in the
shared schema.