### PR TITLE
feat: Add popular climb ordering option

### DIFF
--- a/packages/web/app/components/search-drawer/basic-search-form.tsx
+++ b/packages/web/app/components/search-drawer/basic-search-form.tsx
@@ -258,6 +258,7 @@ const BasicSearchForm: React.FC<BasicSearchFormProps> = ({ boardDetails }) => {
                 className={styles.fullWidth}
               >
                 <Select.Option value="ascents">Ascents</Select.Option>
+                <Select.Option value="popular">Popular</Select.Option>
                 <Select.Option value="difficulty">Difficulty</Select.Option>
                 <Select.Option value="name">Name</Select.Option>
                 <Select.Option value="quality">Quality</Select.Option>

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -83,7 +83,7 @@ export type SearchRequest = {
   minAscents: number;
   minGrade: number;
   minRating: number;
-  sortBy: 'ascents' | 'difficulty' | 'name' | 'quality';
+  sortBy: 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular';
   sortOrder: 'asc' | 'desc';
   name: string;
   onlyClassics: boolean;

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -161,7 +161,7 @@ export const urlParamsToSearchParams = (urlParams: URLSearchParams): SearchReque
     minAscents: Number(urlParams.get('minAscents') ?? DEFAULT_SEARCH_PARAMS.minAscents),
     minGrade: Number(urlParams.get('minGrade') ?? DEFAULT_SEARCH_PARAMS.minGrade),
     minRating: Number(urlParams.get('minRating') ?? DEFAULT_SEARCH_PARAMS.minRating),
-    sortBy: (urlParams.get('sortBy') ?? DEFAULT_SEARCH_PARAMS.sortBy) as 'ascents' | 'difficulty' | 'name' | 'quality',
+    sortBy: (urlParams.get('sortBy') ?? DEFAULT_SEARCH_PARAMS.sortBy) as 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular',
     sortOrder: (urlParams.get('sortOrder') ?? DEFAULT_SEARCH_PARAMS.sortOrder) as 'asc' | 'desc',
     name: urlParams.get('name') ?? DEFAULT_SEARCH_PARAMS.name,
     onlyClassics: urlParams.get('onlyClassics') === 'true',


### PR DESCRIPTION
Add a new "Popular" sort option that sums ascents across all angles for
each climb, allowing users to find climbs that are popular across the
entire angle range rather than just the currently selected angle.