### PR TITLE
feat: Add board statistics summary with percentage breakdown by layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,7 +4563,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.57.0"
@@ -7327,7 +7327,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8077,7 +8077,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10233,7 +10233,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -10713,7 +10713,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.57.0"
@@ -10732,7 +10732,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -10964,7 +10964,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10984,7 +10983,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -11284,7 +11282,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {

--- a/packages/web/app/components/beta-videos/beta-videos.tsx
+++ b/packages/web/app/components/beta-videos/beta-videos.tsx
@@ -43,11 +43,11 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
     setSelectedVideo(null);
   };
 
-  const renderVideoCard = (betaLink: BetaLink, index: number) => {
+  const renderVideoCard = (betaLink: BetaLink) => {
     const embedUrl = getInstagramEmbedUrl(betaLink.link);
 
     return (
-      <Col xs={24} key={index}>
+      <Col xs={24} key={betaLink.link}>
         <Card
           hoverable
           size="small"
@@ -75,7 +75,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                   pointerEvents: 'none',
                 }}
                 scrolling="no"
-                title={`Beta video ${index + 1} thumbnail`}
+                title={`Beta video by ${betaLink.foreign_username || 'unknown'}`}
               />
             </div>
           ) : (
@@ -182,7 +182,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
             children: (
               <>
                 <Row gutter={[12, 12]}>
-                  {visibleVideos.map((betaLink, index) => renderVideoCard(betaLink, index))}
+                  {visibleVideos.map((betaLink) => renderVideoCard(betaLink))}
                 </Row>
                 {hasMoreVideos && (
                   <Button

--- a/packages/web/app/components/beta-videos/beta-videos.tsx
+++ b/packages/web/app/components/beta-videos/beta-videos.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Card, Row, Col, Typography, Empty, Modal } from 'antd';
-import { InstagramOutlined, UserOutlined } from '@ant-design/icons';
+import { Card, Row, Col, Typography, Empty, Modal, Collapse, Button, Space } from 'antd';
+import { InstagramOutlined, UserOutlined, VideoCameraOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
 import { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import { themeTokens } from '@/app/theme/theme-config';
 
-const { Title, Text } = Typography;
+const { Text } = Typography;
 
 interface BetaVideosProps {
   betaLinks: BetaLink[];
@@ -16,6 +16,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedVideo, setSelectedVideo] = useState<BetaLink | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
+  const [showAllVideos, setShowAllVideos] = useState(false);
 
   const getInstagramEmbedUrl = (link: string) => {
     // Extract Instagram post ID from the URL
@@ -42,102 +43,170 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
     setSelectedVideo(null);
   };
 
-  return (
-    <div>
-      <Title level={4} style={{ marginBottom: themeTokens.spacing[4], marginTop: 0 }}>
+  const renderVideoCard = (betaLink: BetaLink, index: number) => {
+    const embedUrl = getInstagramEmbedUrl(betaLink.link);
+
+    return (
+      <Col xs={24} key={index}>
+        <Card
+          hoverable
+          size="small"
+          styles={{ body: { padding: 0 } }}
+          onClick={() => handleVideoClick(betaLink)}
+        >
+          {embedUrl ? (
+            <div
+              style={{
+                position: 'relative',
+                paddingBottom: '100%',
+                overflow: 'hidden',
+                borderRadius: `${themeTokens.borderRadius.md}px ${themeTokens.borderRadius.md}px 0 0`,
+              }}
+            >
+              <iframe
+                src={embedUrl}
+                style={{
+                  position: 'absolute',
+                  top: '-20%',
+                  left: 0,
+                  width: '100%',
+                  height: '140%',
+                  border: 'none',
+                  pointerEvents: 'none',
+                }}
+                scrolling="no"
+                title={`Beta video ${index + 1} thumbnail`}
+              />
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: themeTokens.spacing[8],
+                textAlign: 'center',
+                background: themeTokens.neutral[100],
+              }}
+            >
+              <InstagramOutlined style={{ fontSize: 32, color: themeTokens.neutral[400] }} />
+              <p style={{ margin: `${themeTokens.spacing[2]}px 0 0`, color: themeTokens.neutral[500] }}>
+                Unable to load video
+              </p>
+            </div>
+          )}
+          <div
+            style={{
+              padding: themeTokens.spacing[3],
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              borderTop: `1px solid ${themeTokens.neutral[100]}`,
+            }}
+          >
+            {betaLink.foreign_username && (
+              <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
+                <UserOutlined style={{ marginRight: 4 }} />@{betaLink.foreign_username}
+                {betaLink.angle && <span style={{ marginLeft: 8 }}>{betaLink.angle}°</span>}
+              </Text>
+            )}
+            <a
+              href={betaLink.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                color: themeTokens.colors.primary,
+                fontSize: themeTokens.typography.fontSize.sm,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <InstagramOutlined /> View
+            </a>
+          </div>
+        </Card>
+      </Col>
+    );
+  };
+
+  // Determine which videos to display
+  const visibleVideos = showAllVideos ? betaLinks : betaLinks.slice(0, 1);
+  const hasMoreVideos = betaLinks.length > 1;
+
+  const summaryLabel = (
+    <Space size="middle">
+      <Text strong>
+        <VideoCameraOutlined style={{ marginRight: 8 }} />
         Beta Videos
-      </Title>
+      </Text>
+      <Text type="secondary">
+        {betaLinks.length} video{betaLinks.length !== 1 ? 's' : ''} available
+      </Text>
+    </Space>
+  );
 
-      {betaLinks.length === 0 ? (
-        <Empty description="No beta videos available" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-      ) : (
-        <Row gutter={[12, 12]}>
-          {betaLinks.map((betaLink, index) => {
-            const embedUrl = getInstagramEmbedUrl(betaLink.link);
+  // Empty state
+  if (betaLinks.length === 0) {
+    return (
+      <Collapse
+        ghost
+        defaultActiveKey={[]}
+        items={[
+          {
+            key: 'beta',
+            label: (
+              <Space size="middle">
+                <Text strong>
+                  <VideoCameraOutlined style={{ marginRight: 8 }} />
+                  Beta Videos
+                </Text>
+                <Text type="secondary">No videos available</Text>
+              </Space>
+            ),
+            children: <Empty description="No beta videos available" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+          },
+        ]}
+        style={{ margin: '-12px -8px' }}
+      />
+    );
+  }
 
-            return (
-              <Col xs={24} key={index}>
-                <Card
-                  hoverable
-                  size="small"
-                  styles={{ body: { padding: 0 } }}
-                  onClick={() => handleVideoClick(betaLink)}
-                >
-                  {embedUrl ? (
-                    <div
-                      style={{
-                        position: 'relative',
-                        paddingBottom: '100%',
-                        overflow: 'hidden',
-                        borderRadius: `${themeTokens.borderRadius.md}px ${themeTokens.borderRadius.md}px 0 0`,
-                      }}
-                    >
-                      <iframe
-                        src={embedUrl}
-                        style={{
-                          position: 'absolute',
-                          top: '-20%',
-                          left: 0,
-                          width: '100%',
-                          height: '140%',
-                          border: 'none',
-                          pointerEvents: 'none',
-                        }}
-                        scrolling="no"
-                        title={`Beta video ${index + 1} thumbnail`}
-                      />
-                    </div>
-                  ) : (
-                    <div
-                      style={{
-                        padding: themeTokens.spacing[8],
-                        textAlign: 'center',
-                        background: themeTokens.neutral[100],
-                      }}
-                    >
-                      <InstagramOutlined style={{ fontSize: 32, color: themeTokens.neutral[400] }} />
-                      <p style={{ margin: `${themeTokens.spacing[2]}px 0 0`, color: themeTokens.neutral[500] }}>
-                        Unable to load video
-                      </p>
-                    </div>
-                  )}
-                  <div
-                    style={{
-                      padding: themeTokens.spacing[3],
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      borderTop: `1px solid ${themeTokens.neutral[100]}`,
+  return (
+    <>
+      <Collapse
+        ghost
+        defaultActiveKey={['beta']}
+        items={[
+          {
+            key: 'beta',
+            label: summaryLabel,
+            children: (
+              <>
+                <Row gutter={[12, 12]}>
+                  {visibleVideos.map((betaLink, index) => renderVideoCard(betaLink, index))}
+                </Row>
+                {hasMoreVideos && (
+                  <Button
+                    type="text"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowAllVideos(!showAllVideos);
                     }}
+                    style={{
+                      width: '100%',
+                      marginTop: themeTokens.spacing[3],
+                      color: themeTokens.colors.primary,
+                    }}
+                    icon={showAllVideos ? <UpOutlined /> : <DownOutlined />}
                   >
-                    {betaLink.foreign_username && (
-                      <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
-                        <UserOutlined style={{ marginRight: 4 }} />@{betaLink.foreign_username}
-                        {betaLink.angle && <span style={{ marginLeft: 8 }}>{betaLink.angle}°</span>}
-                      </Text>
-                    )}
-                    <a
-                      href={betaLink.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      style={{
-                        color: themeTokens.colors.primary,
-                        fontSize: themeTokens.typography.fontSize.sm,
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 4,
-                      }}
-                    >
-                      <InstagramOutlined /> View
-                    </a>
-                  </div>
-                </Card>
-              </Col>
-            );
-          })}
-        </Row>
-      )}
+                    {showAllVideos ? 'Show less' : `Show ${betaLinks.length - 1} more video${betaLinks.length - 1 !== 1 ? 's' : ''}`}
+                  </Button>
+                )}
+              </>
+            ),
+          },
+        ]}
+        style={{ margin: '-12px -8px' }}
+      />
 
       {modalVisible && (
         <Modal
@@ -191,7 +260,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
           )}
         </Modal>
       )}
-    </div>
+    </>
   );
 };
 

--- a/packages/web/app/components/beta-videos/beta-videos.tsx
+++ b/packages/web/app/components/beta-videos/beta-videos.tsx
@@ -174,7 +174,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
     <>
       <Collapse
         ghost
-        defaultActiveKey={['beta']}
+        defaultActiveKey={[]}
         items={[
           {
             key: 'beta',

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -1,23 +1,98 @@
 'use client';
 
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useMemo } from 'react';
+import { Typography, Collapse, Space, Tag } from 'antd';
+import { BookOutlined, CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
 import { LogbookView } from './logbook-view';
 import { Climb } from '@/app/lib/types';
+import { useBoardProvider } from '../board-provider/board-provider-context';
+import dayjs from 'dayjs';
 
-const { Title } = Typography;
+const { Text } = Typography;
 
 interface LogbookSectionProps {
   climb: Climb;
 }
 
 export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
-  return (
-    <>
-      <Title level={5} style={{ marginTop: 0, marginBottom: 12 }}>
+  const { logbook } = useBoardProvider();
+
+  // Calculate summary statistics
+  const summary = useMemo(() => {
+    const climbAscents = logbook.filter((ascent) => ascent.climb_uuid === climb.uuid);
+
+    if (climbAscents.length === 0) {
+      return null;
+    }
+
+    // Calculate total attempts
+    const totalAttempts = climbAscents.reduce((sum, ascent) => sum + (ascent.tries || 1), 0);
+
+    // Calculate sessions (group by date - same day = same session)
+    const sessionDates = new Set(
+      climbAscents.map((ascent) => dayjs(ascent.climbed_at).format('YYYY-MM-DD'))
+    );
+    const sessionCount = sessionDates.size;
+
+    // Count successful ascents vs attempts
+    const successfulAscents = climbAscents.filter((a) => a.is_ascent).length;
+    const failedAttempts = climbAscents.filter((a) => !a.is_ascent).length;
+
+    return {
+      totalAttempts,
+      sessionCount,
+      entryCount: climbAscents.length,
+      successfulAscents,
+      failedAttempts,
+    };
+  }, [logbook, climb.uuid]);
+
+  // If no logbook entries, show empty state without collapse
+  if (!summary) {
+    return (
+      <>
+        <Text type="secondary" style={{ display: 'block', textAlign: 'center', padding: '16px 0' }}>
+          <BookOutlined style={{ marginRight: 8 }} />
+          No ascents logged for this climb
+        </Text>
+      </>
+    );
+  }
+
+  const summaryLabel = (
+    <Space size="middle" wrap>
+      <Text strong>
+        <BookOutlined style={{ marginRight: 8 }} />
         Your Logbook
-      </Title>
-      <LogbookView currentClimb={climb} />
-    </>
+      </Text>
+      <Text type="secondary">
+        {summary.totalAttempts} attempt{summary.totalAttempts !== 1 ? 's' : ''} in {summary.sessionCount} session{summary.sessionCount !== 1 ? 's' : ''}
+      </Text>
+      {summary.successfulAscents > 0 && (
+        <Tag icon={<CheckCircleOutlined />} color="success">
+          {summary.successfulAscents} send{summary.successfulAscents !== 1 ? 's' : ''}
+        </Tag>
+      )}
+      {summary.failedAttempts > 0 && (
+        <Tag icon={<CloseCircleOutlined />} color="default">
+          {summary.failedAttempts} logged attempt{summary.failedAttempts !== 1 ? 's' : ''}
+        </Tag>
+      )}
+    </Space>
+  );
+
+  return (
+    <Collapse
+      ghost
+      defaultActiveKey={[]}
+      items={[
+        {
+          key: 'logbook',
+          label: summaryLabel,
+          children: <LogbookView currentClimb={climb} />,
+        },
+      ]}
+      style={{ margin: '-12px -8px' }}
+    />
   );
 };

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -49,12 +49,10 @@ export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
   // If no logbook entries, show empty state without collapse
   if (!summary) {
     return (
-      <>
-        <Text type="secondary" style={{ display: 'block', textAlign: 'center', padding: '16px 0' }}>
-          <BookOutlined style={{ marginRight: 8 }} />
-          No ascents logged for this climb
-        </Text>
-      </>
+      <Text type="secondary" style={{ display: 'block', textAlign: 'center', padding: '16px 0' }}>
+        <BookOutlined style={{ marginRight: 8 }} />
+        No ascents logged for this climb
+      </Text>
     );
   }
 

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -41,7 +41,6 @@ export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
     return {
       totalAttempts,
       sessionCount,
-      entryCount: climbAscents.length,
       successfulAscents,
       failedAttempts,
     };

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -13,8 +13,9 @@ import {
   Space,
   DatePicker,
   message,
+  Tooltip,
 } from 'antd';
-import { UserOutlined, InstagramOutlined } from '@ant-design/icons';
+import { UserOutlined, InstagramOutlined, FireOutlined, TrophyOutlined } from '@ant-design/icons';
 import { useSession } from 'next-auth/react';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
@@ -516,6 +517,80 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
     return { chartDataBar, chartDataPie, chartDataWeeklyBar };
   }, [filteredLogbook]);
 
+  // Calculate overall statistics summary (for the header)
+  const statisticsSummary = useMemo(() => {
+    const layoutStats: Record<string, { count: number; flashes: number; sends: number; attempts: number; grades: Record<string, number> }> = {};
+    let totalAscents = 0;
+    let totalFlashes = 0;
+    let totalSends = 0;
+
+    BOARD_TYPES.forEach((boardType) => {
+      const ticks = allBoardsTicks[boardType] || [];
+
+      ticks.forEach((entry) => {
+        const layoutKey = getLayoutKey(boardType, entry.layoutId);
+
+        if (!layoutStats[layoutKey]) {
+          layoutStats[layoutKey] = { count: 0, flashes: 0, sends: 0, attempts: 0, grades: {} };
+        }
+
+        // Only count successful ascents (not attempts)
+        if (entry.status !== 'attempt') {
+          layoutStats[layoutKey].count += 1;
+          totalAscents += 1;
+
+          // Track flash vs send
+          if (entry.status === 'flash' || entry.tries === 1) {
+            layoutStats[layoutKey].flashes += 1;
+            totalFlashes += 1;
+          } else {
+            layoutStats[layoutKey].sends += 1;
+            totalSends += 1;
+          }
+
+          // Track grades for each layout
+          if (entry.difficulty !== null) {
+            const grade = difficultyMapping[entry.difficulty];
+            if (grade) {
+              layoutStats[layoutKey].grades[grade] = (layoutStats[layoutKey].grades[grade] || 0) + 1;
+            }
+          }
+        } else {
+          layoutStats[layoutKey].attempts += 1;
+        }
+      });
+    });
+
+    // Calculate percentages and sort by count
+    const layoutPercentages = Object.entries(layoutStats)
+      .map(([layoutKey, stats]) => {
+        const [boardType, layoutIdStr] = layoutKey.split('-');
+        const layoutId = layoutIdStr === 'unknown' ? null : parseInt(layoutIdStr, 10);
+        return {
+          layoutKey,
+          boardType,
+          layoutId,
+          displayName: getLayoutDisplayName(boardType, layoutId),
+          color: getLayoutColor(boardType, layoutId),
+          count: stats.count,
+          flashes: stats.flashes,
+          sends: stats.sends,
+          attempts: stats.attempts,
+          grades: stats.grades,
+          percentage: totalAscents > 0 ? Math.round((stats.count / totalAscents) * 100) : 0,
+        };
+      })
+      .filter((layout) => layout.count > 0)
+      .sort((a, b) => b.count - a.count);
+
+    return {
+      totalAscents,
+      totalFlashes,
+      totalSends,
+      layoutPercentages,
+    };
+  }, [allBoardsTicks]);
+
   if (loading) {
     return (
       <Layout className={styles.layout}>
@@ -605,6 +680,116 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
             </div>
           </div>
         </Card>
+
+        {/* Statistics Summary Card */}
+        {!loadingAggregated && statisticsSummary.totalAscents > 0 && (
+          <Card className={styles.statsCard}>
+            {/* Total Ascents Header */}
+            <div className={styles.statsSummaryHeader}>
+              <div className={styles.totalAscentsContainer}>
+                <Text className={styles.totalAscentsLabel}>Total Ascents</Text>
+                <Title level={2} className={styles.totalAscentsValue}>
+                  {statisticsSummary.totalAscents}
+                </Title>
+              </div>
+              <div className={styles.quickStats}>
+                <div className={styles.quickStat}>
+                  <FireOutlined className={styles.quickStatIcon} />
+                  <div className={styles.quickStatContent}>
+                    <Text className={styles.quickStatValue}>{statisticsSummary.totalFlashes}</Text>
+                    <Text type="secondary" className={styles.quickStatLabel}>Flashes</Text>
+                  </div>
+                </div>
+                <div className={styles.quickStat}>
+                  <TrophyOutlined className={styles.quickStatIcon} />
+                  <div className={styles.quickStatContent}>
+                    <Text className={styles.quickStatValue}>{statisticsSummary.totalSends}</Text>
+                    <Text type="secondary" className={styles.quickStatLabel}>Sends</Text>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Board/Layout Percentage Bar */}
+            <div className={styles.percentageBarContainer}>
+              <div className={styles.percentageBar}>
+                {statisticsSummary.layoutPercentages.map((layout) => (
+                  <Tooltip
+                    key={layout.layoutKey}
+                    title={`${layout.displayName}: ${layout.count} ascents (${layout.percentage}%)`}
+                  >
+                    <div
+                      className={styles.percentageSegment}
+                      style={{
+                        width: `${layout.percentage}%`,
+                        backgroundColor: layout.color,
+                      }}
+                    >
+                      {layout.percentage >= 15 && (
+                        <span className={styles.percentageLabel}>
+                          {layout.displayName.split(' ').slice(-1)[0]} {layout.percentage}%
+                        </span>
+                      )}
+                    </div>
+                  </Tooltip>
+                ))}
+              </div>
+              <div className={styles.percentageLegend}>
+                {statisticsSummary.layoutPercentages.map((layout) => (
+                  <div key={layout.layoutKey} className={styles.legendItem}>
+                    <div
+                      className={styles.legendColor}
+                      style={{ backgroundColor: layout.color }}
+                    />
+                    <Text className={styles.legendText}>
+                      {layout.displayName} ({layout.percentage}%)
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Grade Blocks by Layout */}
+            <div className={styles.gradeBlocksContainer}>
+              <Text strong className={styles.gradeBlocksTitle}>Grades by Board</Text>
+              {statisticsSummary.layoutPercentages.map((layout) => (
+                <div key={layout.layoutKey} className={styles.layoutGradeRow}>
+                  <div className={styles.layoutGradeHeader}>
+                    <div
+                      className={styles.layoutIndicator}
+                      style={{ backgroundColor: layout.color }}
+                    />
+                    <Text className={styles.layoutName}>{layout.displayName}</Text>
+                    <Text type="secondary" className={styles.layoutCount}>
+                      {layout.count} ascents
+                    </Text>
+                  </div>
+                  <div className={styles.gradeBlocks}>
+                    {Object.entries(layout.grades)
+                      .sort((a, b) => {
+                        const gradeOrder = Object.values(difficultyMapping);
+                        return gradeOrder.indexOf(a[0]) - gradeOrder.indexOf(b[0]);
+                      })
+                      .map(([grade, count]) => (
+                        <Tooltip
+                          key={grade}
+                          title={`${grade}: ${count} ascent${count !== 1 ? 's' : ''}`}
+                        >
+                          <div
+                            className={styles.gradeBlock}
+                            style={{ backgroundColor: gradeColors[grade] || '#ccc' }}
+                          >
+                            <span className={styles.gradeBlockLabel}>{grade}</span>
+                            <span className={styles.gradeBlockCount}>{count}</span>
+                          </div>
+                        </Tooltip>
+                      ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
 
         {/* Aggregated Stats - All Boards */}
         <Card className={styles.statsCard}>

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -149,13 +149,13 @@
 
 .totalAscentsLabel {
   font-size: 14px;
-  color: #6B7280; /* neutral.500 */
+  color: var(--neutral-500);
   margin-bottom: 4px;
 }
 
 .totalAscentsValue {
   margin: 0 !important;
-  color: #111827; /* neutral.900 */
+  color: var(--neutral-900);
 }
 
 .quickStats {
@@ -171,7 +171,7 @@
 
 .quickStatIcon {
   font-size: 24px;
-  color: #06B6D4; /* primary */
+  color: var(--color-primary);
 }
 
 .quickStatContent {
@@ -199,7 +199,7 @@
   height: 32px;
   border-radius: 8px; /* borderRadius.md */
   overflow: hidden;
-  background: #F3F4F6; /* neutral.100 */
+  background: var(--neutral-100);
 }
 
 .percentageSegment {
@@ -240,12 +240,12 @@
 
 .legendText {
   font-size: 12px;
-  color: #374151; /* neutral.700 */
+  color: var(--neutral-700);
 }
 
 /* Grade Blocks */
 .gradeBlocksContainer {
-  border-top: 1px solid #E5E7EB; /* neutral.200 */
+  border-top: 1px solid var(--neutral-200);
   padding-top: 16px; /* spacing.4 */
 }
 

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -133,6 +133,198 @@
   height: 300px;
 }
 
+/* Statistics Summary Styles */
+.statsSummaryHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px; /* spacing.5 */
+  gap: 16px; /* spacing.4 */
+}
+
+.totalAscentsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.totalAscentsLabel {
+  font-size: 14px;
+  color: #6B7280; /* neutral.500 */
+  margin-bottom: 4px;
+}
+
+.totalAscentsValue {
+  margin: 0 !important;
+  color: #111827; /* neutral.900 */
+}
+
+.quickStats {
+  display: flex;
+  gap: 24px; /* spacing.6 */
+}
+
+.quickStat {
+  display: flex;
+  align-items: center;
+  gap: 8px; /* spacing.2 */
+}
+
+.quickStatIcon {
+  font-size: 24px;
+  color: #06B6D4; /* primary */
+}
+
+.quickStatContent {
+  display: flex;
+  flex-direction: column;
+}
+
+.quickStatValue {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.quickStatLabel {
+  font-size: 12px;
+}
+
+/* Percentage Bar */
+.percentageBarContainer {
+  margin-bottom: 24px; /* spacing.6 */
+}
+
+.percentageBar {
+  display: flex;
+  height: 32px;
+  border-radius: 8px; /* borderRadius.md */
+  overflow: hidden;
+  background: #F3F4F6; /* neutral.100 */
+}
+
+.percentageSegment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2px;
+  transition: width 300ms ease;
+}
+
+.percentageLabel {
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.percentageLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px; /* spacing.3 */
+  margin-top: 12px; /* spacing.3 */
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legendColor {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.legendText {
+  font-size: 12px;
+  color: #374151; /* neutral.700 */
+}
+
+/* Grade Blocks */
+.gradeBlocksContainer {
+  border-top: 1px solid #E5E7EB; /* neutral.200 */
+  padding-top: 16px; /* spacing.4 */
+}
+
+.gradeBlocksTitle {
+  display: block;
+  margin-bottom: 16px; /* spacing.4 */
+  font-size: 14px;
+}
+
+.layoutGradeRow {
+  margin-bottom: 16px; /* spacing.4 */
+}
+
+.layoutGradeRow:last-child {
+  margin-bottom: 0;
+}
+
+.layoutGradeHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px; /* spacing.2 */
+  margin-bottom: 8px; /* spacing.2 */
+}
+
+.layoutIndicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.layoutName {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.layoutCount {
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.gradeBlocks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.gradeBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 6px;
+  min-width: 44px;
+  cursor: default;
+  transition: transform 150ms ease;
+}
+
+.gradeBlock:hover {
+  transform: scale(1.05);
+}
+
+.gradeBlockLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  line-height: 1;
+}
+
+.gradeBlockCount {
+  font-size: 14px;
+  font-weight: 700;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  line-height: 1.2;
+}
+
 @media (max-width: 768px) {
   .content {
     padding: 16px; /* spacing.4 */
@@ -169,5 +361,67 @@
   .barChartWrapper,
   .pieChartWrapper {
     height: 250px;
+  }
+
+  /* Statistics Summary Mobile Styles */
+  .statsSummaryHeader {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .totalAscentsContainer {
+    align-items: center;
+    margin-bottom: 16px;
+  }
+
+  .quickStats {
+    justify-content: center;
+    gap: 32px;
+  }
+
+  .percentageBar {
+    height: 24px;
+  }
+
+  .percentageLabel {
+    font-size: 10px;
+  }
+
+  .percentageLegend {
+    justify-content: center;
+  }
+
+  .gradeBlocksContainer {
+    text-align: center;
+  }
+
+  .layoutGradeHeader {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .layoutCount {
+    margin-left: 0;
+    width: 100%;
+    text-align: center;
+    margin-top: 4px;
+  }
+
+  .gradeBlocks {
+    justify-content: center;
+  }
+
+  .gradeBlock {
+    padding: 4px 8px;
+    min-width: 38px;
+  }
+
+  .gradeBlockLabel {
+    font-size: 10px;
+  }
+
+  .gradeBlockCount {
+    font-size: 12px;
   }
 }


### PR DESCRIPTION
Add a statistics summary card to the profile page showing:
- Total ascents count with flash and send breakdown
- Horizontal percentage bar showing ascent distribution by board/layout
- Colored grade blocks for each board layout

Closes #571