### PR TITLE
feat: Add grade coloring based on thecrag.com color scheme

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Flex, Typography } from 'antd';
 import { CopyrightOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getVGradeColor, getGradeTextColor } from '@/app/lib/grade-colors';
+import { getVGradeColor } from '@/app/lib/grade-colors';
 
 const { Text } = Typography;
 
@@ -131,7 +131,6 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   );
 
   const gradeColor = vGrade ? getVGradeColor(vGrade) : undefined;
-  const gradeTextColor = getGradeTextColor(gradeColor);
 
   const largeGradeElement = vGrade && (
     <Text
@@ -139,10 +138,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         fontSize: 28,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
-        color: gradeTextColor,
-        backgroundColor: gradeColor,
-        padding: '6px 10px',
-        borderRadius: 6,
+        color: gradeColor ?? 'var(--ant-color-text-secondary)',
       }}
     >
       {vGrade}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Flex, Typography } from 'antd';
 import { CopyrightOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
+import { getVGradeColor, getGradeTextColor } from '@/app/lib/grade-colors';
 
 const { Text } = Typography;
 
@@ -129,13 +130,19 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     </Text>
   );
 
+  const gradeColor = vGrade ? getVGradeColor(vGrade) : undefined;
+  const gradeTextColor = getGradeTextColor(gradeColor);
+
   const largeGradeElement = vGrade && (
     <Text
       style={{
-        fontSize: 28,
+        fontSize: 20,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
-        color: 'var(--ant-color-text-secondary)',
+        color: gradeTextColor,
+        backgroundColor: gradeColor,
+        padding: '6px 10px',
+        borderRadius: 6,
       }}
     >
       {vGrade}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -136,7 +136,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   const largeGradeElement = vGrade && (
     <Text
       style={{
-        fontSize: 20,
+        fontSize: 28,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
         color: gradeTextColor,

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -28,6 +28,7 @@ import styles from './profile-page.module.css';
 import type { ChartData } from './profile-stats-charts';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_USER_TICKS, type GetUserTicksQueryVariables, type GetUserTicksQueryResponse } from '@/app/lib/graphql/operations';
+import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
 
 dayjs.extend(isoWeek);
 dayjs.extend(isSameOrAfter);
@@ -95,31 +96,10 @@ const difficultyMapping: Record<number, string> = {
   33: '8c+',
 };
 
-const gradeColors: Record<string, string> = {
-  '4a': 'rgba(153,255,153,0.7)',
-  '4b': 'rgba(179,255,128,0.7)',
-  '4c': 'rgba(204,255,102,0.7)',
-  '5a': 'rgba(230,255,77,0.7)',
-  '5b': 'rgba(255,255,51,0.7)',
-  '5c': 'rgba(255,230,25,0.7)',
-  '6a': 'rgba(255,204,51,0.7)',
-  '6a+': 'rgba(255,179,77,0.7)',
-  '6b': 'rgba(255,153,102,0.7)',
-  '6b+': 'rgba(255,128,128,0.7)',
-  '6c': 'rgba(204,102,204,0.7)',
-  '6c+': 'rgba(153,102,255,0.7)',
-  '7a': 'rgba(102,102,255,0.7)',
-  '7a+': 'rgba(77,128,255,0.7)',
-  '7b': 'rgba(51,153,255,0.7)',
-  '7b+': 'rgba(25,179,255,0.7)',
-  '7c': 'rgba(25,204,230,0.7)',
-  '7c+': 'rgba(51,204,204,0.7)',
-  '8a': 'rgba(255,77,77,0.7)',
-  '8a+': 'rgba(204,51,153,0.7)',
-  '8b': 'rgba(153,51,204,0.9)',
-  '8b+': 'rgba(102,51,153,1)',
-  '8c': 'rgba(77,25,128,1)',
-  '8c+': 'rgba(51,0,102,1)',
+// Helper to get grade color with opacity for charts
+const getGradeChartColor = (grade: string): string => {
+  const hexColor = FONT_GRADE_COLORS[grade.toLowerCase()];
+  return hexColor ? getGradeColorWithOpacity(hexColor, 0.8) : 'rgba(200, 200, 200, 0.7)';
 };
 
 const angleColors = [
@@ -505,7 +485,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
         return {
           label: difficulty,
           data,
-          backgroundColor: gradeColors[difficulty],
+          backgroundColor: getGradeChartColor(difficulty),
         };
       })
       .filter((dataset) => dataset.data.some((value) => value > 0));
@@ -793,7 +773,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
                         >
                           <div
                             className={styles.gradeBlock}
-                            style={{ backgroundColor: gradeColors[grade] || '#ccc' }}
+                            style={{ backgroundColor: getGradeChartColor(grade) }}
                           >
                             <span className={styles.gradeBlockLabel}>{grade}</span>
                             <span className={styles.gradeBlockCount}>{count}</span>

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -1,0 +1,150 @@
+/**
+ * V-grade color scheme based on thecrag.com grade coloring
+ *
+ * Color progression from yellow (easy) to purple (hard):
+ * - V0: Yellow
+ * - V1-V2: Orange
+ * - V3-V4: Dark orange/red-orange
+ * - V5-V6: Red
+ * - V7-V10: Dark red/crimson
+ * - V11+: Purple/magenta
+ */
+
+// V-grade to hex color mapping
+export const V_GRADE_COLORS: Record<string, string> = {
+  'V0': '#FFEB3B',   // Yellow
+  'V1': '#FFC107',   // Amber/Yellow-orange
+  'V2': '#FF9800',   // Orange
+  'V3': '#FF7043',   // Deep orange
+  'V4': '#FF5722',   // Red-orange
+  'V5': '#F44336',   // Red
+  'V6': '#E53935',   // Red (slightly darker)
+  'V7': '#D32F2F',   // Dark red
+  'V8': '#C62828',   // Darker red
+  'V9': '#B71C1C',   // Deep red
+  'V10': '#A11B4A',  // Red-purple transition
+  'V11': '#9C27B0',  // Purple
+  'V12': '#7B1FA2',  // Dark purple
+  'V13': '#6A1B9A',  // Darker purple
+  'V14': '#5C1A87',  // Deep purple
+  'V15': '#4A148C',  // Very deep purple
+  'V16': '#38006B',  // Near black purple
+  'V17': '#2A0054',  // Darkest purple
+};
+
+// Font grade to hex color mapping (uses same color as corresponding V-grade)
+export const FONT_GRADE_COLORS: Record<string, string> = {
+  '4a': '#FFEB3B',   // V0
+  '4b': '#FFEB3B',   // V0
+  '4c': '#FFEB3B',   // V0
+  '5a': '#FFC107',   // V1
+  '5b': '#FFC107',   // V1
+  '5c': '#FF9800',   // V2
+  '6a': '#FF7043',   // V3
+  '6a+': '#FF7043',  // V3
+  '6b': '#FF5722',   // V4
+  '6b+': '#FF5722',  // V4
+  '6c': '#F44336',   // V5
+  '6c+': '#F44336',  // V5
+  '7a': '#E53935',   // V6
+  '7a+': '#D32F2F',  // V7
+  '7b': '#C62828',   // V8
+  '7b+': '#C62828',  // V8
+  '7c': '#B71C1C',   // V9
+  '7c+': '#A11B4A',  // V10
+  '8a': '#9C27B0',   // V11
+  '8a+': '#7B1FA2',  // V12
+  '8b': '#6A1B9A',   // V13
+  '8b+': '#5C1A87',  // V14
+  '8c': '#4A148C',   // V15
+  '8c+': '#38006B',  // V16
+};
+
+/**
+ * Get color for a V-grade string (e.g., "V3", "V10")
+ * @param vGrade - V-grade string like "V3" or "V10"
+ * @returns Hex color string, or undefined if not found
+ */
+export function getVGradeColor(vGrade: string | null | undefined): string | undefined {
+  if (!vGrade) return undefined;
+  const normalized = vGrade.toUpperCase();
+  return V_GRADE_COLORS[normalized];
+}
+
+/**
+ * Get color for a Font grade string (e.g., "6a", "7b+")
+ * @param fontGrade - Font grade string like "6a" or "7b+"
+ * @returns Hex color string, or undefined if not found
+ */
+export function getFontGradeColor(fontGrade: string | null | undefined): string | undefined {
+  if (!fontGrade) return undefined;
+  return FONT_GRADE_COLORS[fontGrade.toLowerCase()];
+}
+
+/**
+ * Get color for a difficulty string that may contain both Font and V-grade (e.g., "6a/V3")
+ * Extracts the V-grade and returns its color
+ * @param difficulty - Difficulty string like "6a/V3" or "V5"
+ * @returns Hex color string, or undefined if no V-grade found
+ */
+export function getGradeColor(difficulty: string | null | undefined): string | undefined {
+  if (!difficulty) return undefined;
+
+  // Try to extract V-grade first
+  const vGradeMatch = difficulty.match(/V\d+/i);
+  if (vGradeMatch) {
+    return getVGradeColor(vGradeMatch[0]);
+  }
+
+  // Fall back to Font grade
+  const fontGradeMatch = difficulty.match(/\d[abc]\+?/i);
+  if (fontGradeMatch) {
+    return getFontGradeColor(fontGradeMatch[0]);
+  }
+
+  return undefined;
+}
+
+/**
+ * Get a semi-transparent version of a grade color for backgrounds
+ * @param color - Hex color string
+ * @param opacity - Opacity value between 0 and 1
+ * @returns RGBA color string
+ */
+export function getGradeColorWithOpacity(color: string | undefined, opacity: number = 0.7): string {
+  if (!color) return 'rgba(200, 200, 200, 0.7)';
+
+  // Convert hex to RGB
+  const hex = color.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+}
+
+/**
+ * Determine if a color is light or dark (for text contrast)
+ * @param hexColor - Hex color string
+ * @returns true if the color is light (should use dark text)
+ */
+export function isLightColor(hexColor: string): boolean {
+  const hex = hexColor.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  // Calculate relative luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5;
+}
+
+/**
+ * Get appropriate text color (black or white) for a grade color background
+ * @param gradeColor - Hex color string of the background
+ * @returns 'black' or 'white'
+ */
+export function getGradeTextColor(gradeColor: string | undefined): string {
+  if (!gradeColor) return 'inherit';
+  return isLightColor(gradeColor) ? '#000000' : '#FFFFFF';
+}


### PR DESCRIPTION
- Create grade-colors.ts utility with V-grade to color mappings
- Apply colored badge to V-grade display in ClimbTitle component
- Update profile page to use consistent grade colors for charts and blocks