### PR TITLE
feat: Count distinct climbs per grade on profile page

### DIFF
--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -322,6 +322,31 @@ export const typeDefs = /* GraphQL */ `
   }
 
   # ============================================
+  # Profile Statistics Types
+  # ============================================
+
+  # Count of distinct climbs for a specific grade
+  type GradeCount {
+    grade: String!
+    count: Int!
+  }
+
+  # Statistics for a specific board layout
+  type LayoutStats {
+    layoutKey: String!
+    boardType: String!
+    layoutId: Int
+    distinctClimbCount: Int!
+    gradeCounts: [GradeCount!]!
+  }
+
+  # Aggregated profile statistics across all boards
+  type ProfileStats {
+    totalDistinctClimbs: Int!
+    layoutStats: [LayoutStats!]!
+  }
+
+  # ============================================
   # Playlist Types
   # ============================================
 
@@ -516,6 +541,8 @@ export const typeDefs = /* GraphQL */ `
     userTicks(userId: ID!, boardType: String!): [Tick!]!
     # Get public ascent activity feed for a specific user (all boards, with climb details)
     userAscentsFeed(userId: ID!, input: AscentFeedInput): AscentFeedResult!
+    # Get profile statistics with distinct climb counts per grade (public)
+    userProfileStats(userId: ID!): ProfileStats!
 
     # ============================================
     # Playlist Queries (require auth)

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -257,6 +257,28 @@ export type GetTicksInput = {
   climbUuids?: string[];
 };
 
+// ============================================
+// Profile Statistics Types
+// ============================================
+
+export type GradeCount = {
+  grade: string;
+  count: number;
+};
+
+export type LayoutStats = {
+  layoutKey: string;
+  boardType: string;
+  layoutId: number | null;
+  distinctClimbCount: number;
+  gradeCounts: GradeCount[];
+};
+
+export type ProfileStats = {
+  totalDistinctClimbs: number;
+  layoutStats: LayoutStats[];
+};
+
 /**
  * Event types for GraphQL subscriptions
  *

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -181,3 +181,53 @@ export interface GetUserAscentsFeedQueryResponse {
     hasMore: boolean;
   };
 }
+
+// ============================================
+// Profile Statistics Operations
+// ============================================
+
+export const GET_USER_PROFILE_STATS = gql`
+  query GetUserProfileStats($userId: ID!) {
+    userProfileStats(userId: $userId) {
+      totalDistinctClimbs
+      layoutStats {
+        layoutKey
+        boardType
+        layoutId
+        distinctClimbCount
+        gradeCounts {
+          grade
+          count
+        }
+      }
+    }
+  }
+`;
+
+// Type for grade count
+export interface GradeCount {
+  grade: string;
+  count: number;
+}
+
+// Type for layout stats
+export interface LayoutStats {
+  layoutKey: string;
+  boardType: string;
+  layoutId: number | null;
+  distinctClimbCount: number;
+  gradeCounts: GradeCount[];
+}
+
+// Type for the profile stats query variables
+export interface GetUserProfileStatsQueryVariables {
+  userId: string;
+}
+
+// Type for the profile stats query response
+export interface GetUserProfileStatsQueryResponse {
+  userProfileStats: {
+    totalDistinctClimbs: number;
+    layoutStats: LayoutStats[];
+  };
+}


### PR DESCRIPTION
- Add new GraphQL query `userProfileStats` that returns distinct climb
  counts per grade per board layout using server-side deduplication
- Add backend resolver that groups ticks by climbUuid to count unique
  climbs rather than total ascents
- Update profile page to use server-side stats for the Statistics
  Summary Card showing distinct climbs by grade
- Charts still use frontend data with timeframe filtering

This ensures that if a user climbed the same problem 5 times, it only
counts as 1 climb for that grade, not 5 ascents.