### PR TITLE
fix(db): Remove FK constraint from board_climb_stats

### DIFF
--- a/packages/db/drizzle/0031_drop_climb_stats_fk.sql
+++ b/packages/db/drizzle/0031_drop_climb_stats_fk.sql
@@ -1,0 +1,3 @@
+-- Drop the foreign key constraint on board_climb_stats
+-- Stats may arrive before their corresponding climbs during sync from Aurora API
+ALTER TABLE "board_climb_stats" DROP CONSTRAINT IF EXISTS "board_climb_stats_climb_fk";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1767580800000,
       "tag": "0030_drop_legacy_ascents_bids",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1767667200000,
+      "tag": "0031_drop_climb_stats_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -277,11 +277,7 @@ export const boardClimbStats = pgTable('board_climb_stats', {
   faAt: timestamp('fa_at', { mode: 'string' }),
 }, (table) => ({
   pk: primaryKey({ columns: [table.boardType, table.climbUuid, table.angle] }),
-  climbFk: foreignKey({
-    columns: [table.climbUuid],
-    foreignColumns: [boardClimbs.uuid],
-    name: 'board_climb_stats_climb_fk',
-  }).onUpdate('cascade').onDelete('cascade'),
+  // Note: No FK to board_climbs - stats may arrive before their corresponding climbs during sync
 }));
 
 export const boardClimbHolds = pgTable('board_climb_holds', {

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -9,6 +9,9 @@ import { boardseshTicks, auroraCredentials, playlists, playlistClimbs, playlistO
 import { randomUUID } from 'crypto';
 import { convertQuality } from './convert-quality';
 
+// Note: getTable is still used for legacy ascents/bids tables which are being phased out
+// (already consolidated into boardsesh_ticks, will be dropped in Phase 6)
+
 /**
  * Get NextAuth user ID from Aurora user ID
  */

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -9,9 +9,6 @@ import { boardseshTicks, auroraCredentials, playlists, playlistClimbs, playlistO
 import { randomUUID } from 'crypto';
 import { convertQuality } from './convert-quality';
 
-// Note: getTable is still used for legacy ascents/bids tables which are being phased out
-// (already consolidated into boardsesh_ticks, will be dropped in Phase 6)
-
 /**
  * Get NextAuth user ID from Aurora user ID
  */


### PR DESCRIPTION
## Summary
- Remove foreign key constraint on `board_climb_stats` that references `board_climbs`
- Stats can now be synced even when corresponding climbs haven't been synced yet
- Fixes sync failures caused by Aurora API returning stats before their parent climbs

## Test plan
- [ ] Run `npm run db:migrate` to apply the migration
- [ ] Trigger a shared sync and verify climb_stats inserts succeed
- [ ] Verify existing queries still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)