### PR TITLE
Fix TypeScript type error in Space component

### DIFF
--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Button, Space, Skeleton } from 'antd';
+import { Button, Flex, Skeleton } from 'antd';
 import { signIn } from 'next-auth/react';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -98,7 +98,7 @@ export default function SocialLoginButtons({
   };
 
   return (
-    <Space direction="vertical" size="middle" block>
+    <Flex vertical gap="middle">
       {providers.google && (
         <Button
           block
@@ -135,6 +135,6 @@ export default function SocialLoginButtons({
           Continue with Facebook
         </Button>
       )}
-    </Space>
+    </Flex>
   );
 }


### PR DESCRIPTION
The Space component from Ant Design doesn't have a 'block' prop. Replace with Flex which provides the same vertical layout with gap="middle" and naturally takes full width.