### PR TITLE
fix(db): Remove FK constraint from board_beta_links

### DIFF
--- a/packages/db/drizzle/0033_drop_beta_links_fk.sql
+++ b/packages/db/drizzle/0033_drop_beta_links_fk.sql
@@ -1,0 +1,3 @@
+-- Drop the foreign key constraint on board_beta_links
+-- Beta links may arrive before their corresponding climbs during sync from Aurora API
+ALTER TABLE "board_beta_links" DROP CONSTRAINT IF EXISTS "board_beta_links_climb_fk";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1767753600000,
       "tag": "0032_verify_existing_users",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1767840000000,
+      "tag": "0033_drop_beta_links_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -333,11 +333,7 @@ export const boardBetaLinks = pgTable('board_beta_links', {
   createdAt: text('created_at'),
 }, (table) => ({
   pk: primaryKey({ columns: [table.boardType, table.climbUuid, table.link] }),
-  climbFk: foreignKey({
-    columns: [table.climbUuid],
-    foreignColumns: [boardClimbs.uuid],
-    name: 'board_beta_links_climb_fk',
-  }).onUpdate('cascade').onDelete('restrict'),
+  // Note: No FK to board_climbs - beta links may arrive before their corresponding climbs during sync
 }));
 
 // =============================================================================

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -9,6 +9,9 @@ import { boardseshTicks, auroraCredentials, playlists, playlistClimbs, playlistO
 import { randomUUID } from 'crypto';
 import { convertQuality } from './convert-quality';
 
+// Note: getTable is still used for legacy ascents/bids tables which are being phased out
+// (already consolidated into boardsesh_ticks, will be dropped in Phase 6)
+
 /**
  * Get NextAuth user ID from Aurora user ID
  */

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -9,9 +9,6 @@ import { boardseshTicks, auroraCredentials, playlists, playlistClimbs, playlistO
 import { randomUUID } from 'crypto';
 import { convertQuality } from './convert-quality';
 
-// Note: getTable is still used for legacy ascents/bids tables which are being phased out
-// (already consolidated into boardsesh_ticks, will be dropped in Phase 6)
-
 /**
  * Get NextAuth user ID from Aurora user ID
  */


### PR DESCRIPTION
## Summary
- Removes the foreign key constraint `board_beta_links_climb_fk` from `board_beta_links` table
- Beta links may arrive before their corresponding climbs during sync from Aurora API
- Same issue that was fixed for `board_climb_stats` in migration 0031

## Root Cause
The shared sync cron job was failing because beta links can reference climbs that haven't been synced yet:
```
insert or update on table "board_beta_links" violates foreign key constraint "board_beta_links_climb_fk"
Key (climb_uuid)=(1E3771C3EEE947C2B7E86C88FA44E748) is not present in table "board_climbs"
```

## Test plan
- [ ] Deploy and verify shared sync cron job completes successfully
- [ ] Verify beta links can be inserted even when their climbs don't exist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)