### PR TITLE
fix(auth): Add UUID generation for users table id column

### DIFF
--- a/packages/db/src/schema/auth/users.ts
+++ b/packages/db/src/schema/auth/users.ts
@@ -9,7 +9,7 @@ import type { AdapterAccount } from "next-auth/adapters";
 
 // NextAuth.js tables
 export const users = pgTable("users", {
-  id: text("id").notNull().primaryKey(),
+  id: text("id").notNull().primaryKey().$defaultFn(() => crypto.randomUUID()),
   name: text("name"),
   email: text("email").notNull(),
   emailVerified: timestamp("emailVerified", { mode: "date" }),


### PR DESCRIPTION
## Summary
- Adds `$defaultFn(() => crypto.randomUUID())` to the users table `id` column
- Fixes OAuth user creation failure (`adapter_error_createUser`) where the DrizzleAdapter couldn't insert new users because no default ID was being generated

## Problem
When using Google OAuth, users couldn't sign in because the NextAuth DrizzleAdapter was generating:
```sql
insert into "users" ("id", ...) values (default, ...)
```

The `id` column had no default value, causing the insert to fail.

## Test plan
- [ ] Deploy to production
- [ ] Test Google OAuth sign-in with a new user
- [ ] Verify user is created successfully in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)