### PR TITLE
feat(sync): Railway user sync with rate limiting

### DIFF
--- a/packages/aurora-sync/.env.1password
+++ b/packages/aurora-sync/.env.1password
@@ -1,2 +1,2 @@
 DATABASE_URL="op://Boardsesh/Postgres PROD/connection_string"
-CREDENTIALS_ENCRYPTION_KEY="op://Boardsesh/Encryption key/password"
+AURORA_CREDENTIALS_SECRET="op://Boardsesh/Encryption key/password"

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -66,6 +66,52 @@ export class SyncRunner {
   }
 
   /**
+   * Sync the next user that needs syncing (oldest lastSyncAt first)
+   * Only syncs 1 user per call to avoid IP blocking from Aurora API
+   */
+  async syncNextUser(): Promise<SyncSummary> {
+    const results: SyncSummary = {
+      total: 1,
+      successful: 0,
+      failed: 0,
+      errors: [],
+    };
+
+    // Get the next credential to sync (oldest lastSyncAt first)
+    const cred = await this.getNextCredentialToSync();
+
+    if (!cred) {
+      this.log(`[SyncRunner] No users with Aurora credentials to sync`);
+      results.total = 0;
+      return results;
+    }
+
+    this.log(`[SyncRunner] Syncing next user: ${cred.userId} for ${cred.boardType}`);
+
+    try {
+      await this.syncSingleCredential(cred);
+      results.successful++;
+      this.log(`[SyncRunner] ✓ Successfully synced user ${cred.userId} for ${cred.boardType}`);
+    } catch (error) {
+      results.failed++;
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      results.errors.push({
+        userId: cred.userId,
+        boardType: cred.boardType,
+        error: errorMsg,
+      });
+      this.handleError(error instanceof Error ? error : new Error(errorMsg), {
+        userId: cred.userId,
+        board: cred.boardType,
+      });
+      this.log(`[SyncRunner] ✗ Failed to sync user ${cred.userId} for ${cred.boardType}: ${errorMsg}`);
+    }
+
+    return results;
+  }
+
+  /**
+   * @deprecated Use syncNextUser() instead to avoid IP blocking
    * Sync all users with active credentials
    */
   async syncAllUsers(): Promise<SyncSummary> {
@@ -143,6 +189,27 @@ export class SyncRunner {
       );
 
     return credentials as CredentialRecord[];
+  }
+
+  private async getNextCredentialToSync(): Promise<CredentialRecord | null> {
+    // Use HTTP for simple lookup query (no transaction needed)
+    // Get the credential with the oldest lastSyncAt (or null = never synced)
+    const db = createHttpDb();
+    const credentials = await db
+      .select()
+      .from(auroraCredentials)
+      .where(
+        and(
+          or(eq(auroraCredentials.syncStatus, 'active'), eq(auroraCredentials.syncStatus, 'error')),
+          isNotNull(auroraCredentials.encryptedUsername),
+          isNotNull(auroraCredentials.encryptedPassword),
+          isNotNull(auroraCredentials.auroraUserId),
+        ),
+      )
+      .orderBy(auroraCredentials.lastSyncAt) // NULL values come first, then oldest
+      .limit(1);
+
+    return credentials.length > 0 ? (credentials[0] as CredentialRecord) : null;
   }
 
   private async syncSingleCredential(cred: CredentialRecord): Promise<void> {

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -1,7 +1,7 @@
 import { neon, neonConfig, Pool } from '@neondatabase/serverless';
 import { drizzle as drizzleHttp } from 'drizzle-orm/neon-http';
 import { drizzle } from 'drizzle-orm/neon-serverless';
-import { eq, and, or, isNotNull } from 'drizzle-orm';
+import { eq, and, or, isNotNull, asc, nullsFirst } from 'drizzle-orm';
 import ws from 'ws';
 
 import { auroraCredentials } from '@boardsesh/db/schema/auth';
@@ -206,7 +206,7 @@ export class SyncRunner {
           isNotNull(auroraCredentials.auroraUserId),
         ),
       )
-      .orderBy(auroraCredentials.lastSyncAt) // NULL values come first, then oldest
+      .orderBy(nullsFirst(asc(auroraCredentials.lastSyncAt))) // Never-synced users first, then oldest
       .limit(1);
 
     return credentials.length > 0 ? (credentials[0] as CredentialRecord) : null;

--- a/packages/backend/src/handlers/sync.ts
+++ b/packages/backend/src/handlers/sync.ts
@@ -6,7 +6,8 @@ const CRON_SECRET = process.env.CRON_SECRET;
 
 /**
  * Handle sync cron endpoint
- * Triggered by external cron service to sync all users
+ * Triggered by external cron service to sync the next user
+ * Only syncs 1 user per call to avoid IP blocking from Aurora API
  */
 export async function handleSyncCron(req: IncomingMessage, res: ServerResponse): Promise<void> {
   // Apply CORS headers
@@ -27,7 +28,7 @@ export async function handleSyncCron(req: IncomingMessage, res: ServerResponse):
     return;
   }
 
-  console.log('[Sync] Starting sync cron job...');
+  console.log('[Sync] Starting sync cron job (1 user)...');
 
   const runner = new SyncRunner({
     onLog: (msg: string) => console.log(`[Sync] ${msg}`),
@@ -37,7 +38,7 @@ export async function handleSyncCron(req: IncomingMessage, res: ServerResponse):
   });
 
   try {
-    const result = await runner.syncAllUsers();
+    const result = await runner.syncNextUser();
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(
@@ -53,7 +54,7 @@ export async function handleSyncCron(req: IncomingMessage, res: ServerResponse):
       }),
     );
 
-    console.log(`[Sync] Completed: ${result.successful}/${result.total} users synced successfully`);
+    console.log(`[Sync] Completed: ${result.successful}/${result.total} user synced`);
   } catch (error) {
     console.error('[Sync] Cron job failed:', error);
     res.writeHead(500, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- Add `syncNextUser()` method that syncs only 1 user per cron run (oldest `lastSyncAt` first)
- Update cron handler to use `syncNextUser()` instead of `syncAllUsers()` to avoid IP blocking
- Improve error handling with cleaner, truncated error messages
- Fix `.env.1password` to use correct `AURORA_CREDENTIALS_SECRET` variable name

## Why
Aurora API may block IPs that make too many requests. By syncing only 1 user per cron trigger, we spread the load across multiple runs. With 5 users and a 5-minute cron interval, each user gets synced roughly every 25 minutes.

## Test plan
- [ ] Deploy to Railway
- [ ] Set `AURORA_CREDENTIALS_SECRET` environment variable
- [ ] Trigger sync endpoint: `curl -X POST https://ws.boardsesh.com/sync-cron -H "Authorization: Bearer $CRON_SECRET"`
- [ ] Verify only 1 user is synced per request
- [ ] Verify logs are less verbose

🤖 Generated with [Claude Code](https://claude.com/claude-code)