### PR TITLE
fix(db): Drop FK constraint on board_climbs.layout_id

### DIFF
--- a/packages/db/drizzle/0039_drop_board_climbs_layout_fk.sql
+++ b/packages/db/drizzle/0039_drop_board_climbs_layout_fk.sql
@@ -1,0 +1,3 @@
+-- Drop the foreign key constraint on board_climbs.layout_id
+-- This allows draft climbs to be synced even when their layout doesn't exist yet
+ALTER TABLE "board_climbs" DROP CONSTRAINT IF EXISTS "board_climbs_layout_fk";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1768272000000,
       "tag": "0038_drop_legacy_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1768358400000,
+      "tag": "0039_drop_board_climbs_layout_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -257,11 +257,7 @@ export const boardClimbs = pgTable('board_climbs', {
     table.edgeBottom,
     table.edgeTop,
   ),
-  layoutFk: foreignKey({
-    columns: [table.boardType, table.layoutId],
-    foreignColumns: [boardLayouts.boardType, boardLayouts.id],
-    name: 'board_climbs_layout_fk',
-  }).onUpdate('cascade').onDelete('cascade'),
+  // Note: No FK to board_layouts - climbs may reference layouts that don't exist during sync
 }));
 
 export const boardClimbStats = pgTable('board_climb_stats', {


### PR DESCRIPTION
Draft climbs from Aurora sync may reference layouts that don't exist in our database. Remove the FK constraint to allow these inserts.