### PR TITLE
fix(sync): Use correct conflict target for board_climbs upsert

### DIFF
--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -133,7 +133,7 @@ async function upsertTableData(
           .insert(climbsSchema)
           .values(values)
           .onConflictDoUpdate({
-            target: [climbsSchema.boardType, climbsSchema.uuid],
+            target: climbsSchema.uuid,
             set: {
               layoutId: sql`excluded.layout_id`,
               setterId: sql`excluded.setter_id`,
@@ -589,8 +589,8 @@ export async function syncUserData(
           error instanceof Error
             ? error.message.includes('violates foreign key constraint')
               ? `FK constraint violation: ${error.message.split('violates foreign key constraint')[1]?.split('"')[1] || 'unknown'}`
-              : error.message.slice(0, 200)
-            : String(error).slice(0, 200);
+              : error.message.slice(0, 500)
+            : String(error).slice(0, 500);
         log(`Database error: ${errorMessage}`);
         throw new Error(`Database error: ${errorMessage}`);
       } finally {


### PR DESCRIPTION
## Summary
- Fix the `onConflictDoUpdate` target for draft_climbs sync
- Increase error message truncation limit from 200 to 500 chars for better debugging

## Problem
The draft_climbs upsert was using `(board_type, uuid)` as the conflict target, but `board_climbs` table has `uuid` as the sole primary key. This caused the insert to fail.

## Fix
Changed conflict target from `[climbsSchema.boardType, climbsSchema.uuid]` to just `climbsSchema.uuid`.

## Test plan
- [x] Tested locally against production database
- [ ] Deploy and verify sync works for all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)