### PR TITLE
fix(railway): Add watchPaths to trigger backend deploys on shared package changes

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,16 @@
 [build]
 builder = "dockerfile"
 dockerfilePath = "Dockerfile.backend"
+watchPaths = [
+  "packages/backend/**",
+  "packages/shared-schema/**",
+  "packages/crypto/**",
+  "packages/db/**",
+  "packages/aurora-sync/**",
+  "package.json",
+  "package-lock.json",
+  "Dockerfile.backend"
+]
 
 [deploy]
 healthcheckPath = "/health"


### PR DESCRIPTION
## Summary
- Add `watchPaths` configuration to `railway.toml` so the backend service redeploys when shared packages change
- Includes all packages the backend depends on: `shared-schema`, `crypto`, `db`, `aurora-sync`
- Also watches root `package.json`, `package-lock.json`, and `Dockerfile.backend`

## Test plan
- [ ] Merge this PR
- [ ] Make a small change to `packages/shared-schema/` and push
- [ ] Verify Railway triggers a backend deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)