### PR TITLE
fix(hold-classification): Invert rating scale and improve collapsed view

### DIFF
--- a/packages/web/app/components/hold-classification/hold-classification-wizard.module.css
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.module.css
@@ -40,7 +40,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100px;
+  height: 180px;
   background: var(--neutral-50, #F9FAFB);
   border-radius: 12px;
   overflow: hidden;

--- a/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
@@ -21,9 +21,10 @@ import styles from './hold-classification-wizard.module.css';
 const { Text, Title } = Typography;
 
 // Zoom factor for the compact hold view (shows ~2 rows of holds)
-const COMPACT_ZOOM_FACTOR = 4;
-// Minimum viewport size around the hold
-const MIN_VIEWPORT_SIZE = 100;
+// Higher value = more zoomed out = can see more holds around the selected one
+const COMPACT_ZOOM_FACTOR = 10;
+// Minimum viewport size around the hold (ensures we see enough context)
+const MIN_VIEWPORT_SIZE = 200;
 
 interface HoldViewProps {
   hold: HoldRenderData;
@@ -480,7 +481,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           <div className={styles.ratingSection}>
             <Text className={styles.sectionTitle}>Hand Rating (1-5)</Text>
             <div className={styles.ratingLabel}>
-              1 = Easy to grip, 5 = Very difficult
+              5 = Easy to grip, 1 = Very difficult
             </div>
             <Rate
               value={currentClassification.handRating || 0}
@@ -493,7 +494,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           <div className={styles.ratingSection}>
             <Text className={styles.sectionTitle}>Foot Rating (1-5)</Text>
             <div className={styles.ratingLabel}>
-              1 = Easy to stand on, 5 = Very difficult
+              5 = Easy to stand on, 1 = Very difficult
             </div>
             <Rate
               value={currentClassification.footRating || 0}


### PR DESCRIPTION
- Invert rating labels so 5 stars = Easy, 1 star = Hard (matches intuitive
  expectation that more stars = better/easier hold)
- Increase collapsed view height from 100px to 180px to show more context
- Increase zoom factor from 4 to 10 and min viewport from 100 to 200 to
  display ~2 rows of holds around the selected hold in collapsed mode