### PR TITLE
fix(hold-classification): Fix holds drawer display and header visibility

### DIFF
--- a/packages/web/app/components/hold-classification/hold-classification-wizard.module.css
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.module.css
@@ -1,22 +1,3 @@
-.drawerHeader {
-  display: flex;
-  align-items: center;
-  width: 100%;
-}
-
-.backButton {
-  margin-right: 8px;
-}
-
-.drawerTitle {
-  flex: 1;
-  font-weight: 600;
-}
-
-.headerSpacer {
-  width: 32px;
-}
-
 .container {
   display: flex;
   flex-direction: column;
@@ -41,6 +22,8 @@
   flex-direction: column;
   align-items: center;
   height: 180px;
+  min-height: 180px;
+  flex-shrink: 0;
   background: var(--neutral-50, #F9FAFB);
   border-radius: 12px;
   overflow: hidden;

--- a/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
@@ -343,7 +343,10 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         open={open}
         onClose={onClose}
         placement="bottom"
-        styles={{ wrapper: { height: '100vh' } }}
+        styles={{
+          wrapper: { height: '100dvh' },
+          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+        }}
       >
         <div className={styles.loadingContainer}>
           <Spin size="large" />
@@ -361,7 +364,10 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         open={open}
         onClose={onClose}
         placement="bottom"
-        styles={{ wrapper: { height: '100vh' } }}
+        styles={{
+          wrapper: { height: '100dvh' },
+          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+        }}
       >
         <div className={styles.emptyState}>
           <Text>No holds found for this board configuration.</Text>
@@ -379,7 +385,10 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         open={open}
         onClose={onClose}
         placement="bottom"
-        styles={{ wrapper: { height: '100vh' } }}
+        styles={{
+          wrapper: { height: '100dvh' },
+          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+        }}
       >
         <div className={styles.completeContainer}>
           <CheckCircleFilled className={styles.completeIcon} />
@@ -402,18 +411,15 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
 
   return (
     <Drawer
-      title={
-        <div className={styles.drawerHeader}>
-          <span className={styles.drawerTitle}>Classify Hold</span>
-        </div>
-      }
+      title="Classify Hold"
       open={open}
       onClose={onClose}
       placement="bottom"
       styles={{
-        wrapper: { height: '100vh' },
+        wrapper: { height: '100dvh' },
         header: {
           borderBottom: `1px solid ${themeTokens.neutral[200]}`,
+          paddingTop: 'max(16px, env(safe-area-inset-top))',
         },
         body: {
           padding: 16,


### PR DESCRIPTION
- Add min-height and flex-shrink:0 to holdViewSection to prevent it from
  collapsing in collapsed mode, ensuring 2 rows of holds remain visible
- Add safe area padding to drawer header to prevent iOS notch from hiding
  the close button and title
- Use 100dvh instead of 100vh for better mobile viewport handling
- Remove unused CSS classes (drawerHeader, backButton, etc.)