### PR TITLE
fix: Prevent account takeover via registration with OAuth user's email

### DIFF
--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -110,8 +110,8 @@ export default function AuthPageContent() {
         return;
       }
 
-      // Fallback for accounts that don't require verification (e.g., adding password to OAuth account)
-      message.success('Account updated! Logging you in...');
+      // Email verification disabled - auto-login after successful registration
+      message.success('Account created! Logging you in...');
 
       const loginResult = await signIn('credentials', {
         email: values.email,

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -88,8 +88,8 @@ export default function AuthModal({
         return;
       }
 
-      // Fallback for accounts that don't require verification (e.g., adding password to OAuth account)
-      message.success('Account updated! Logging you in...');
+      // Email verification disabled - auto-login after successful registration
+      message.success('Account created! Logging you in...');
 
       const loginResult = await signIn('credentials', {
         email: values.email,


### PR DESCRIPTION
Previously, when an OAuth user existed (e.g., Google login), anyone could
register with that same email and add a password to the OAuth user's account
without verification. This allowed attackers to gain access to OAuth-created
accounts.

The fix removes the ability to add passwords to existing OAuth accounts
through the public registration endpoint. If a user already exists, they
must sign in with their existing authentication method.

Fixes #606