### PR TITLE
Disable Sentry error tracking on non-production domains

### DIFF
--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -4,8 +4,17 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// Only enable Sentry on boardsesh.com to avoid polluting error tracking
+const isProductionDomain =
+  typeof window !== "undefined" &&
+  window.location.hostname.includes("boardsesh.com");
+
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",
+
+  // Only send errors when running on boardsesh.com
+  enabled: isProductionDomain,
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -5,8 +5,15 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// Only enable Sentry on boardsesh.com to avoid polluting error tracking
+const isProductionDomain =
+  process.env.VERCEL_URL?.includes("boardsesh.com") ?? false;
+
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",
+
+  // Only send errors when running on boardsesh.com
+  enabled: isProductionDomain,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -4,8 +4,15 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// Only enable Sentry on boardsesh.com to avoid polluting error tracking
+const isProductionDomain =
+  process.env.VERCEL_URL?.includes("boardsesh.com") ?? false;
+
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",
+
+  // Only send errors when running on boardsesh.com
+  enabled: isProductionDomain,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,


### PR DESCRIPTION
## Summary
This PR restricts Sentry error tracking to only the production domain (boardsesh.com) to prevent development, staging, and preview deployments from polluting the error tracking dashboard.

## Changes
- **instrumentation-client.ts**: Added client-side domain check using `window.location.hostname` to enable Sentry only on boardsesh.com
- **sentry.server.config.ts**: Added server-side domain check using `VERCEL_URL` environment variable to enable Sentry only on boardsesh.com
- **sentry.edge.config.ts**: Added edge runtime domain check using `VERCEL_URL` environment variable to enable Sentry only on boardsesh.com

## Implementation Details
- Each configuration file now includes a `isProductionDomain` check that validates the deployment domain
- Client-side uses `window.location.hostname.includes("boardsesh.com")` with a safety check for SSR
- Server and edge configurations use `process.env.VERCEL_URL?.includes("boardsesh.com")` with a fallback to `false`
- The `enabled` option is set in each Sentry.init() call to control whether errors are sent to Sentry