### PR TITLE
Add await to fetchCredentials calls in aurora credentials

### DIFF
--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -238,7 +238,7 @@ export default function AuroraCredentialsSection() {
       message.success(`${selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} account linked successfully`);
       setIsModalOpen(false);
       form.resetFields();
-      fetchCredentials();
+      await fetchCredentials();
     } catch (error) {
       message.error(error instanceof Error ? error.message : 'Failed to link account');
     } finally {
@@ -261,7 +261,7 @@ export default function AuroraCredentialsSection() {
       }
 
       message.success('Account unlinked successfully');
-      fetchCredentials();
+      await fetchCredentials();
     } catch (error) {
       message.error(error instanceof Error ? error.message : 'Failed to unlink account');
     } finally {


### PR DESCRIPTION
## Summary
Added `await` keyword to `fetchCredentials()` function calls in the aurora credentials section to ensure the async operation completes before proceeding.

## Changes
- Added `await` to `fetchCredentials()` call after successfully linking an account
- Added `await` to `fetchCredentials()` call after successfully unlinking an account

## Details
These changes ensure that the credentials are properly refreshed after account linking/unlinking operations complete. By awaiting the async `fetchCredentials()` function, we guarantee that the UI will display updated credential information before the user can perform subsequent actions. This prevents potential race conditions and improves the reliability of the credential management flow.