### PR TITLE
Add error handling and notFound() calls to board route pages

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PropsWithChildren } from 'react';
+import { notFound } from 'next/navigation';
 
 import { BoardRouteParameters, ParsedBoardRouteParameters } from '@/app/lib/types';
 import { parseBoardRouteParams } from '@/app/lib/url-utils';
@@ -12,23 +13,28 @@ interface LayoutProps {
 }
 
 export default async function PlayLayout(props: PropsWithChildren<LayoutProps>) {
-  const params = await props.params;
-  const { children } = props;
+  try {
+    const params = await props.params;
+    const { children } = props;
 
-  // Check if any parameters are in numeric format (old URLs)
-  const hasNumericParams = [params.layout_id, params.size_id, params.set_ids].some((param) =>
-    param.includes(',') ? param.split(',').every((id) => /^\d+$/.test(id.trim())) : /^\d+$/.test(param),
-  );
+    // Check if any parameters are in numeric format (old URLs)
+    const hasNumericParams = [params.layout_id, params.size_id, params.set_ids].some((param) =>
+      param.includes(',') ? param.split(',').every((id) => /^\d+$/.test(id.trim())) : /^\d+$/.test(param),
+    );
 
-  let parsedParams: ParsedBoardRouteParameters;
+    let parsedParams: ParsedBoardRouteParameters;
 
-  if (hasNumericParams) {
-    parsedParams = parseBoardRouteParams(params);
-  } else {
-    parsedParams = await parseBoardRouteParamsWithSlugs(params);
+    if (hasNumericParams) {
+      parsedParams = parseBoardRouteParams(params);
+    } else {
+      parsedParams = await parseBoardRouteParamsWithSlugs(params);
+    }
+
+    const boardDetails = await getBoardDetails(parsedParams);
+
+    return <PlayLayoutClient boardDetails={boardDetails}>{children}</PlayLayoutClient>;
+  } catch (error) {
+    console.error('Error in play layout:', error);
+    notFound();
   }
-
-  const boardDetails = await getBoardDetails(parsedParams);
-
-  return <PlayLayoutClient boardDetails={boardDetails}>{children}</PlayLayoutClient>;
 }


### PR DESCRIPTION
## Summary
Added comprehensive error handling to all board-related route pages and layouts by wrapping server-side logic in try-catch blocks and calling `notFound()` when errors occur. This ensures graceful error handling instead of unhandled promise rejections.

## Key Changes
- **Create climb page** (`create/page.tsx`): Wrapped route parameter parsing and board initialization in try-catch, calls `notFound()` on error
- **Import page** (`import/page.tsx`): Added error handling around MoonBoard import logic with `notFound()` fallback
- **Board layout** (`layout.tsx`): Wrapped board details fetching and parameter parsing with error handling
- **List layout** (`list/layout.tsx`): Added try-catch around board details initialization
- **List page** (`list/page.tsx`): Wrapped climb search and board details fetching with error handling
- **Play page** (`play/[climb_uuid]/page.tsx`): Added error handling for climb fetching and board initialization
- **Play layout** (`play/layout.tsx`): Wrapped board details fetching with error handling

## Implementation Details
- All changes follow the same pattern: wrap the entire async function body in a try-catch block
- Errors are logged to console with descriptive messages indicating which page encountered the error
- `notFound()` from `next/navigation` is called in catch blocks to return a 404 response
- This prevents unhandled promise rejections and provides better user experience with proper HTTP status codes
- No changes to the core business logic, only error handling wrapper added