### PR TITLE
Use VERCEL_ENV for Sentry production detection

### DIFF
--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -5,9 +5,8 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-// Only enable Sentry on boardsesh.com to avoid polluting error tracking
-const isProductionDomain =
-  process.env.VERCEL_URL?.includes("boardsesh.com") ?? false;
+// Only enable Sentry on production deployments to avoid polluting error tracking
+const isProductionDomain = process.env.VERCEL_ENV === "production";
 
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -4,9 +4,8 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-// Only enable Sentry on boardsesh.com to avoid polluting error tracking
-const isProductionDomain =
-  process.env.VERCEL_URL?.includes("boardsesh.com") ?? false;
+// Only enable Sentry on production deployments to avoid polluting error tracking
+const isProductionDomain = process.env.VERCEL_ENV === "production";
 
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",


### PR DESCRIPTION
## Summary
Updated Sentry configuration to use Vercel's `VERCEL_ENV` environment variable instead of checking if the domain includes "boardsesh.com". This provides a more reliable and maintainable way to detect production deployments.

## Changes
- Updated `sentry.edge.config.ts` to use `process.env.VERCEL_ENV === "production"` instead of domain string matching
- Updated `sentry.server.config.ts` with the same change
- Updated comments to reflect that Sentry is now enabled on "production deployments" rather than a specific domain

## Benefits
- **More reliable**: Uses Vercel's official environment variable rather than relying on domain naming conventions
- **Better for multi-domain setups**: Works correctly regardless of custom domains or deployment URLs
- **Cleaner logic**: Removes the optional chaining and nullish coalescing operator in favor of a direct equality check
- **Future-proof**: Automatically works with any production deployment without hardcoding domain names