### PR TITLE
Filter out browser extension errors in Sentry

### DIFF
--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -21,6 +21,25 @@ Sentry.init({
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+
+  // Filter out errors from browser extensions and third-party scripts
+  beforeSend(event, hint) {
+    const error = hint.originalException;
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
+
+    // Ignore browser extension errors (runtime.sendMessage, etc.)
+    if (
+      errorMessage.includes("runtime.sendMessage") ||
+      errorMessage.includes("Extension context invalidated") ||
+      errorMessage.includes("message channel closed") ||
+      errorMessage.includes("message port closed")
+    ) {
+      return null;
+    }
+
+    return event;
+  },
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Summary
Added a `beforeSend` hook to the Sentry configuration to filter out errors originating from browser extensions and third-party scripts, reducing noise in error tracking.

## Changes
- Implemented `beforeSend` callback in Sentry initialization to intercept and filter error events
- Added detection for common browser extension error messages:
  - `runtime.sendMessage` errors
  - `Extension context invalidated` errors
  - `message channel closed` errors
  - `message port closed` errors
- Errors matching these patterns are now dropped (return `null`) before being sent to Sentry
- All other errors continue to be reported normally

## Implementation Details
The filter extracts the error message from the event hint and performs string matching against known browser extension error patterns. This approach is lightweight and prevents cluttering the error dashboard with extension-related noise while maintaining visibility into actual application errors.

https://claude.ai/code/session_01SwZmsKCHYKX18cT2egMWAx