### PR TITLE
Pass size_description to generateSizeSlug function calls

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -106,11 +106,11 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
   };
 
   const createClimbUrl = angle !== undefined && boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-    ? `/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name)}/${generateSetSlug(boardDetails.set_names)}/${angle}/create`
+    ? `/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name, boardDetails.size_description)}/${generateSetSlug(boardDetails.set_names)}/${angle}/create`
     : null;
 
   const playlistsUrl = angle !== undefined && boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-    ? `/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name)}/${generateSetSlug(boardDetails.set_names)}/${angle}/playlists`
+    ? `/${boardDetails.board_name}/${generateLayoutSlug(boardDetails.layout_name)}/${generateSizeSlug(boardDetails.size_name, boardDetails.size_description)}/${generateSetSlug(boardDetails.set_names)}/${angle}/playlists`
     : null;
 
   // Hide playlists and classify holds for moonboard (not yet supported)


### PR DESCRIPTION
## Summary
Updated the `generateSizeSlug` function calls in the board page header to include the `size_description` parameter alongside `size_name`.

## Changes
- Modified two URL generation calls in `BoardSeshHeader` component:
  - `createClimbUrl` construction now passes `boardDetails.size_description` to `generateSizeSlug`
  - `playlistsUrl` construction now passes `boardDetails.size_description` to `generateSizeSlug`

## Details
The `generateSizeSlug` function signature was updated to accept both `size_name` and `size_description` parameters. This change ensures that size slug generation includes additional descriptive information, which may be necessary for more accurate URL routing or slug generation logic.

https://claude.ai/code/session_01KWH8MzNCbnsyTZTH2cAuTg