### PR TITLE
Refactor: Use getBoardDetailsForBoard utility function

### DIFF
--- a/packages/web/app/api/og/climb/route.tsx
+++ b/packages/web/app/api/og/climb/route.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
 import { getClimb } from '@/app/lib/data/queries';
-import { getBoardDetails } from '@/app/lib/__generated__/product-sizes-data';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { convertLitUpHoldsStringToMap, getImageUrl } from '@/app/components/board-renderer/util';
 import { HoldRenderData } from '@/app/components/board-renderer/types';
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
       climb_uuid,
     });
 
-    const [boardDetails, currentClimb] = await Promise.all([getBoardDetails(parsedParams), getClimb(parsedParams)]);
+    const [boardDetails, currentClimb] = await Promise.all([getBoardDetailsForBoard(parsedParams), getClimb(parsedParams)]);
 
     // Process climb holds
     const framesData = convertLitUpHoldsStringToMap(currentClimb.frames, parsedParams.board_name);


### PR DESCRIPTION
## Summary
Updated the OG image generation route for climbs to use the new `getBoardDetailsForBoard` utility function instead of the generated `getBoardDetails` function.

## Changes
- Replaced import of `getBoardDetails` from `@/app/lib/__generated__/product-sizes-data` with `getBoardDetailsForBoard` from `@/app/lib/board-utils`
- Updated the function call in the Promise.all to use the new utility function

## Details
This change consolidates board detail retrieval logic by using a dedicated utility function from `board-utils` instead of relying on generated code. This improves maintainability and provides a single source of truth for board detail lookups across the application.

https://claude.ai/code/session_013ieuLLo3AJjfGukxouDrPZ