### PR TITLE
Refine Sentry initialization to only track production errors

### DIFF
--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -5,9 +5,10 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Only enable Sentry on boardsesh.com to avoid polluting error tracking
+// Check hostname to ensure we don't send errors from localhost or preview deployments
 const isProductionDomain =
   typeof window !== "undefined" &&
-  window.location.hostname.includes("boardsesh.com");
+  window.location.hostname === "boardsesh.com";
 
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -6,7 +6,10 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Only enable Sentry on production deployments to avoid polluting error tracking
-const isProductionDomain = process.env.VERCEL_ENV === "production";
+// Check both NODE_ENV and VERCEL_ENV to ensure we don't send errors from local dev or preview deployments
+const isProductionDomain =
+  process.env.NODE_ENV === "production" &&
+  process.env.VERCEL_ENV === "production";
 
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -5,7 +5,10 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Only enable Sentry on production deployments to avoid polluting error tracking
-const isProductionDomain = process.env.VERCEL_ENV === "production";
+// Check both NODE_ENV and VERCEL_ENV to ensure we don't send errors from local dev or preview deployments
+const isProductionDomain =
+  process.env.NODE_ENV === "production" &&
+  process.env.VERCEL_ENV === "production";
 
 Sentry.init({
   dsn: "https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400",


### PR DESCRIPTION
## Summary
This PR improves Sentry error tracking configuration to ensure errors are only reported from production environments, preventing noise from local development and preview deployments.

## Changes
- **instrumentation-client.ts**: Changed hostname check from `includes("boardsesh.com")` to exact match `=== "boardsesh.com"` to prevent false positives from subdomains
- **sentry.edge.config.ts**: Added `NODE_ENV === "production"` check alongside `VERCEL_ENV === "production"` to ensure both conditions are met before initializing Sentry
- **sentry.server.config.ts**: Added `NODE_ENV === "production"` check alongside `VERCEL_ENV === "production"` to ensure both conditions are met before initializing Sentry

## Implementation Details
The changes enforce stricter production environment detection across all three Sentry configuration entry points:
- Client-side now uses exact hostname matching instead of substring matching
- Server-side and edge configurations now require both `NODE_ENV` and `VERCEL_ENV` to be set to "production", providing defense-in-depth against accidental error reporting from non-production environments

This prevents error pollution in Sentry from localhost development, preview deployments, and other non-production environments.

https://claude.ai/code/session_013jBTzFjbJQFyfsDM5pT4t1