### PR TITLE
fix: Convert null to undefined for SwaggerUI spec prop

### DIFF
--- a/packages/web/app/docs/swagger-ui.tsx
+++ b/packages/web/app/docs/swagger-ui.tsx
@@ -101,5 +101,5 @@ export default function SwaggerUIComponent() {
     );
   }
 
-  return <SwaggerUI spec={spec} />;
+  return <SwaggerUI spec={spec ?? undefined} />;
 }


### PR DESCRIPTION
The spec state has type `object | null` but SwaggerUI expects
`string | object | undefined`. Use nullish coalescing to convert
null to undefined to satisfy the type requirement.

https://claude.ai/code/session_0129Hsz3VrS2HYNQ14fy83tq