### PR TITLE
refactor: Remove duplicate tokenizer code and use design tokens

### DIFF
--- a/packages/web/app/docs/docs-client.tsx
+++ b/packages/web/app/docs/docs-client.tsx
@@ -19,7 +19,7 @@ import {
   ThunderboltOutlined,
   BookOutlined,
 } from '@ant-design/icons';
-import { themeTokens } from '@/app/theme/theme-config';
+import styles from './docs.module.css';
 
 const { Title, Text, Paragraph, Link } = Typography;
 
@@ -27,35 +27,18 @@ const { Title, Text, Paragraph, Link } = Typography;
 const SwaggerUI = lazy(() => import('./swagger-ui'));
 const GraphQLSchemaViewer = lazy(() => import('./graphql-schema'));
 
-// Code block styling tokens
-const codeBlockStyles = {
-  light: {
-    background: themeTokens.neutral[100],
-    padding: themeTokens.spacing[3],
-    borderRadius: themeTokens.borderRadius.sm,
-    overflow: 'auto' as const,
-  },
-  dark: {
-    background: themeTokens.neutral[900],
-    color: '#d4d4d4',
-    padding: themeTokens.spacing[4],
-    borderRadius: themeTokens.borderRadius.md,
-    overflow: 'auto' as const,
-  },
-};
-
 function LoadingSpinner() {
   return (
-    <div style={{ textAlign: 'center', padding: themeTokens.spacing[10] }}>
+    <div className={styles.loadingContainer}>
       <Spin size="large" />
-      <div style={{ marginTop: themeTokens.spacing[4] }}>Loading documentation...</div>
+      <div className={styles.loadingText}>Loading documentation...</div>
     </div>
   );
 }
 
 function OverviewTab() {
   return (
-    <div style={{ maxWidth: 800 }}>
+    <div className={styles.contentSection}>
       <Title level={2}>Boardsesh API Overview</Title>
 
       <Paragraph>
@@ -63,7 +46,7 @@ function OverviewTab() {
         training boards (Kilter, Tension):
       </Paragraph>
 
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space direction="vertical" size="large" className={styles.fullWidth}>
         <Card>
           <Title level={4}>
             <ApiOutlined /> REST API
@@ -112,7 +95,7 @@ function OverviewTab() {
             <strong>WebSocket API:</strong> Obtain a JWT token from{' '}
             <code>GET /api/internal/ws-auth</code> and include it in the connection parameters:
           </Paragraph>
-          <pre style={codeBlockStyles.light}>
+          <pre className={styles.codeBlockLight}>
 {`import { createClient } from 'graphql-ws';
 
 const client = createClient({
@@ -136,7 +119,7 @@ const client = createClient({
 
 function WebSocketGuideTab() {
   return (
-    <div style={{ maxWidth: 800 }}>
+    <div className={styles.contentSection}>
       <Title level={2}>WebSocket Connection Guide</Title>
 
       <Paragraph>
@@ -151,7 +134,7 @@ function WebSocketGuideTab() {
 
       <Title level={4}>Connection Setup</Title>
 
-      <pre style={codeBlockStyles.dark}>
+      <pre className={styles.codeBlockDark}>
 {`import { createClient } from 'graphql-ws';
 
 // 1. Get auth token (requires session cookie)
@@ -208,7 +191,7 @@ const unsubscribe = client.subscribe(
         Sessions are the core collaboration unit. Users join sessions to share a climb queue.
       </Paragraph>
 
-      <pre style={codeBlockStyles.dark}>
+      <pre className={styles.codeBlockDark}>
 {`// Join or create a session
 const result = await client.query({
   query: \`
@@ -240,7 +223,7 @@ const result = await client.query({
         When reconnecting, use delta sync to catch up without full state transfer:
       </Paragraph>
 
-      <pre style={codeBlockStyles.dark}>
+      <pre className={styles.codeBlockDark}>
 {`// Store the last known sequence number
 let lastSequence = 0;
 
@@ -271,7 +254,7 @@ lastSequence = eventsReplay.currentSequence;`}
         type="warning"
         message="Connection Handling"
         description="The WebSocket connection may be interrupted by network changes. Implement reconnection logic with the graphql-ws retry options and use delta sync to maintain state consistency."
-        style={{ marginTop: themeTokens.spacing[6] }}
+        className={styles.alertWithMargin}
       />
     </div>
   );
@@ -279,8 +262,8 @@ lastSequence = eventsReplay.currentSequence;`}
 
 export default function DocsClientPage() {
   return (
-    <div style={{ padding: themeTokens.spacing[6], maxWidth: 1400, margin: '0 auto' }}>
-      <div style={{ marginBottom: themeTokens.spacing[6] }}>
+    <div className={styles.docsContainer}>
+      <div className={styles.docsHeader}>
         <Title level={1}>
           <BookOutlined /> API Documentation
         </Title>

--- a/packages/web/app/docs/docs.module.css
+++ b/packages/web/app/docs/docs.module.css
@@ -1,0 +1,108 @@
+/* Docs page styles */
+
+.docsContainer {
+  padding: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.docsHeader {
+  margin-bottom: 24px;
+}
+
+.contentSection {
+  max-width: 800px;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.searchContainer {
+  margin-bottom: 16px;
+}
+
+.searchInput {
+  max-width: 400px;
+}
+
+.operationsDescription {
+  margin-bottom: 16px;
+}
+
+/* Loading spinner styles */
+.loadingContainer {
+  text-align: center;
+  padding: 40px;
+}
+
+.loadingText {
+  margin-top: 16px;
+}
+
+/* Code block styles */
+.codeBlockLight {
+  background: #f3f4f6;
+  padding: 12px;
+  border-radius: 4px;
+  overflow: auto;
+}
+
+.codeBlockDark {
+  background: #111827;
+  color: #d4d4d4;
+  padding: 16px;
+  border-radius: 8px;
+  overflow: auto;
+}
+
+/* Schema block styles */
+.schemaBlock {
+  background: #111827;
+  color: #d4d4d4;
+  padding: 16px;
+  border-radius: 8px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.5;
+  font-family: Monaco, Menlo, "Ubuntu Mono", monospace;
+}
+
+/* Alert spacing */
+.alertWithMargin {
+  margin-top: 24px;
+}
+
+/* Swagger loading container */
+.swaggerLoading {
+  padding: 20px;
+  text-align: center;
+}
+
+.swaggerLoadingText {
+  margin-top: 16px;
+}
+
+.swaggerAlert {
+  margin: 20px;
+}
+
+.swaggerInstructions {
+  margin-bottom: 8px;
+}
+
+.swaggerInstructionsFinal {
+  margin-bottom: 0;
+}
+
+.swaggerCommandBlock {
+  background: #f3f4f6;
+  padding: 12px;
+  border-radius: 4px;
+  margin-top: 8px;
+}
+
+.swaggerNote {
+  margin-top: 8px;
+  margin-bottom: 0;
+}

--- a/packages/web/app/docs/swagger-ui.tsx
+++ b/packages/web/app/docs/swagger-ui.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import { Alert, Spin, Typography } from 'antd';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
-import { themeTokens } from '@/app/theme/theme-config';
+import styles from './docs.module.css';
 
 const { Text, Paragraph } = Typography;
 
@@ -48,9 +48,9 @@ export default function SwaggerUIComponent() {
 
   if (loadState === 'loading') {
     return (
-      <div style={{ padding: themeTokens.spacing[5], textAlign: 'center' }}>
+      <div className={styles.swaggerLoading}>
         <Spin size="large" />
-        <div style={{ marginTop: themeTokens.spacing[4] }}>
+        <div className={styles.swaggerLoadingText}>
           <Text type="secondary">Loading API documentation...</Text>
         </div>
       </div>
@@ -64,28 +64,21 @@ export default function SwaggerUIComponent() {
         message="OpenAPI Specification Not Generated"
         description={
           <div>
-            <Paragraph style={{ marginBottom: themeTokens.spacing[2] }}>
+            <Paragraph className={styles.swaggerInstructions}>
               The OpenAPI specification file has not been generated yet. This is expected during local development.
             </Paragraph>
-            <Paragraph style={{ marginBottom: 0 }}>
+            <Paragraph className={styles.swaggerInstructionsFinal}>
               Run the following command to generate it:
             </Paragraph>
-            <pre
-              style={{
-                background: themeTokens.neutral[100],
-                padding: themeTokens.spacing[3],
-                borderRadius: themeTokens.borderRadius.sm,
-                marginTop: themeTokens.spacing[2],
-              }}
-            >
+            <pre className={styles.swaggerCommandBlock}>
               npm run generate:openapi
             </pre>
-            <Paragraph type="secondary" style={{ marginTop: themeTokens.spacing[2], marginBottom: 0 }}>
+            <Paragraph type="secondary" className={styles.swaggerNote}>
               In production, this runs automatically during the build process.
             </Paragraph>
           </div>
         }
-        style={{ margin: themeTokens.spacing[5] }}
+        className={styles.swaggerAlert}
       />
     );
   }
@@ -96,7 +89,7 @@ export default function SwaggerUIComponent() {
         type="error"
         message="Failed to Load API Documentation"
         description={`Error: ${errorMessage}`}
-        style={{ margin: themeTokens.spacing[5] }}
+        className={styles.swaggerAlert}
       />
     );
   }

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -43,6 +43,16 @@ export const themeTokens = {
     surfaceOverlay: 'rgba(255, 255, 255, 0.95)', // Semi-transparent overlay
   },
 
+  // Syntax highlighting colors (VS Code dark theme inspired)
+  syntax: {
+    keyword: '#569cd6',
+    type: '#4ec9b0',
+    string: '#ce9178',
+    comment: '#6a9955',
+    parameter: '#9cdcfe',
+    default: '#d4d4d4',
+  },
+
   // Shadows
   shadows: {
     xs: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
@@ -126,3 +136,4 @@ export const themeTokens = {
 export type ThemeTokens = typeof themeTokens;
 export type ColorTokens = typeof themeTokens.colors;
 export type NeutralTokens = typeof themeTokens.neutral;
+export type SyntaxTokens = typeof themeTokens.syntax;


### PR DESCRIPTION
- Import tokenizeLine from graphql-tokenizer.ts instead of duplicating it
  in graphql-schema.tsx
- Add syntax highlighting colors to theme-config.ts design tokens
- Replace hardcoded color values with themeTokens.syntax references
- Convert inline style properties to CSS modules (docs.module.css)
- Addresses code quality issues: duplicate code, hardcoded colors, and
  style property usage per CLAUDE.md guidelines

https://claude.ai/code/session_0142mvYq4YmiK8cdAo6Z1ENd