### PR TITLE
Update root README with positive messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,24 @@
 # Boardsesh
 
-**An open source alternative for LED climbing board control**
+**Strava for Board Climbers**
+
+A centralized hub for all your LED climbing board training.
 
 Try it out at [boardsesh.com](https://www.boardsesh.com/) | [Join us on Discord](https://discord.gg/YXA8GsXfQK)
 
-## The Problem
+## Our Vision
 
-LED climbing boards like Moonboard, Kilter, Tension, Decoy, and Grasshopper have become incredibly popular in the climbing community. These boards represent a significant investment—a 7x10 Kilter homewall with mainline holds runs around $10,000, plus another $2,000 or so for the LED lighting system.
+LED climbing boards like Kilter, Tension, Moonboard, Decoy, and Grasshopper have revolutionized indoor training. We believe the climbing community deserves a centralized platform that brings all these boards together—making it easier to track progress, train with friends, and get the most out of your board.
 
-Here's the thing: those climbing holds will work forever. No apps, no licensing, no connectivity required. But to use the LED system that makes these boards truly interactive, we're all dependent on Moon Climbing or Aurora Climbing. Each company servicing a large part of the market without cross-compatibility.
+Think of Boardsesh as Strava for board climbers: a unified experience that works across different board types, helping you focus on what matters most—climbing.
 
-> **Single Vendor Risk**
->
-> Thousands of dollars worth of climbing equipment relies on software from two small companies. If that software stops working, your expensive LED system becomes unusable.
-
-You're also at the mercy of the whims of the owners of these companies. Not too long ago Moon Board tried to block creation of new problems on one of their older boards: [see this Reddit discussion](https://www.reddit.com/r/climbing/s/VqKGxWSfDT). This was rolled back, but there are no guarantees this won't happen again. Either of these companies could also change owners. What if a future owner wants to introduce a subscription model?
-
-## Development Has Stalled
-
-Instead of spending their time building great app experiences, both companies have implemented app attest which blocks external access to the climb data. However, the climb data isn't theirs—it's the users'.
-
-## Our Solution: Open Source
-
-Frustrated with the lack of development and anxious about being locked into a single vendor, we built Boardsesh—an open source alternative that anyone can use, modify, and host themselves.
-
-With Boardsesh, you get:
+## What Boardsesh Offers
 
 - **Queue management** — Coordinate climbs when training with others
 - **Real-time collaboration** — Share sessions with friends via Party Mode
-- **Active development** — New features and bug fixes from the community
-- **No lock-in** — Self-host if you want complete control
-- **Transparency** — See exactly how your data is used
+- **Multi-board support** — One app for Kilter, Tension, and more
+- **Active development** — New features and improvements from the community
+- **Self-hosting option** — Run your own instance if you prefer
 
 ## Open Source
 
@@ -38,10 +26,14 @@ Boardsesh is completely open source under the Apache license. You can view the c
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup instructions.
 
-## Open to Collaboration
+## API Documentation
 
-We would welcome collaboration with the official app vendors and would love to integrate through more official means. Unfortunately, so far Aurora has been hostile to any collaboration attempts.
+Building something cool with climbing data? We provide a public API that developers can use to access climb information and build their own integrations. [Explore the API Documentation →](https://www.boardsesh.com/docs)
+
+## Join the Community
+
+We're always looking to collaborate with climbers, developers, and anyone passionate about improving the board climbing experience. Whether you want to contribute code, suggest features, or just say hello—we'd love to hear from you.
 
 ---
 
-*Your expensive climbing board shouldn't stop working because a single app goes down. Together, we can build something better—software that belongs to the climbing community.*
+*Together, we can build the best training companion for board climbers everywhere.*


### PR DESCRIPTION
Align README.md with the about page updates:
- Changed headline to "Strava for Board Climbers"
- Replaced "The Problem" and "Development Has Stalled" sections with "Our Vision"
- Removed critical language about vendor lock-in and development stagnation
- Added "API Documentation" section with link to /docs
- Added "Join the Community" section
- Updated closing message to be welcoming

https://claude.ai/code/session_0184WxKZLt7Si5ZAzWwF9wcf