### PR TITLE
Remove Strava trademark references from README and about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boardsesh
 
-**Strava for Board Climbers**
+**Track, Train, and Climb Together**
 
 A centralized hub for all your LED climbing board training.
 
@@ -10,7 +10,7 @@ Try it out at [boardsesh.com](https://www.boardsesh.com/) | [Join us on Discord]
 
 LED climbing boards like Kilter, Tension, Moonboard, Decoy, and Grasshopper have revolutionized indoor training. We believe the climbing community deserves a centralized platform that brings all these boards together—making it easier to track progress, train with friends, and get the most out of your board.
 
-Think of Boardsesh as Strava for board climbers: a unified experience that works across different board types, helping you focus on what matters most—climbing.
+Boardsesh is a unified experience that works across different board types, helping you focus on what matters most—climbing.
 
 ## What Boardsesh Offers
 

--- a/packages/web/app/about/about-content.tsx
+++ b/packages/web/app/about/about-content.tsx
@@ -35,7 +35,7 @@ export default function AboutContent() {
             <div className={styles.heroSection}>
               <Logo size="lg" linkToHome={false} />
               <Title level={2} className={styles.heroTitle}>
-                Strava for Board Climbers
+                Track, Train, and Climb Together
               </Title>
               <Text type="secondary" className={styles.heroSubtitle}>
                 A centralized hub for all your LED climbing board training
@@ -55,8 +55,8 @@ export default function AboutContent() {
                 track progress, train with friends, and get the most out of your board.
               </Paragraph>
               <Paragraph>
-                Think of Boardsesh as Strava for board climbers: a unified experience that works
-                across different board types, helping you focus on what matters most—climbing.
+                Boardsesh is a unified experience that works across different board types, helping
+                you focus on what matters most—climbing.
               </Paragraph>
             </section>
 

--- a/packages/web/app/about/page.tsx
+++ b/packages/web/app/about/page.tsx
@@ -5,7 +5,7 @@ import AboutContent from './about-content';
 export const metadata: Metadata = {
   title: 'About | Boardsesh',
   description:
-    'Boardsesh is like Strava for board climbers - a centralized hub for all your LED climbing board training',
+    'Boardsesh is a centralized hub for all your LED climbing board training - track, train, and climb together',
 };
 
 export default function AboutPage() {


### PR DESCRIPTION
Replace "Strava for Board Climbers" with "Track, Train, and Climb Together" to avoid potential trademark issues while maintaining the same positive, welcoming messaging.

https://claude.ai/code/session_0184WxKZLt7Si5ZAzWwF9wcf