### PR TITLE
feat: Show Bluetooth icon for ESP32-added climbs in queue

### DIFF
--- a/packages/web/app/components/queue-control/bluetooth-icon.tsx
+++ b/packages/web/app/components/queue-control/bluetooth-icon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface BluetoothIconProps {
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+/**
+ * A discrete Bluetooth icon for queue items added via ESP32 controller.
+ * Uses a standard Bluetooth symbol in a muted grey color.
+ */
+const BluetoothIcon: React.FC<BluetoothIconProps> = ({ style, className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="currentColor"
+    className={className}
+    style={style}
+  >
+    <path d="M14.88 12L17.24 9.64C17.71 9.17 17.71 8.41 17.24 7.94L12.71 3.41C12.32 3.02 11.69 3.02 11.3 3.41L11 3.71V9.59L7.41 6L6 7.41L10.59 12L6 16.59L7.41 18L11 14.41V20.29L11.3 20.59C11.69 20.98 12.32 20.98 12.71 20.59L17.24 16.06C17.71 15.59 17.71 14.83 17.24 14.36L14.88 12ZM13 5.83L15.17 8L13 10.17V5.83ZM13 18.17V13.83L15.17 16L13 18.17Z" />
+  </svg>
+);
+
+export default BluetoothIcon;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,7 +1,8 @@
 'use client';
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Button, Row, Col, Card, Drawer, Space, Popconfirm } from 'antd';
-import { SyncOutlined, DeleteOutlined, ExpandOutlined, FastForwardOutlined, FastBackwardOutlined } from '@ant-design/icons';
+import { Button, Row, Col, Card, Drawer, Space, Popconfirm, Avatar, Tooltip } from 'antd';
+import { SyncOutlined, DeleteOutlined, ExpandOutlined, FastForwardOutlined, FastBackwardOutlined, UserOutlined } from '@ant-design/icons';
+import BluetoothIcon from './bluetooth-icon';
 import { track } from '@vercel/analytics';
 import { useSwipeable } from 'react-swipeable';
 import { useQueueContext } from '../graphql-queue';
@@ -63,7 +64,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   const isViewPage = pathname.includes('/view/');
   const isListPage = pathname.includes('/list');
   const isPlayPage = pathname.includes('/play/');
-  const { currentClimb, mirrorClimb, queue, setQueue, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode } = useQueueContext();
+  const { currentClimb, currentClimbQueueItem, mirrorClimb, queue, setQueue, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode } = useQueueContext();
 
   const nextClimb = getNextClimbQueueItem();
   const previousClimb = getPreviousClimbQueueItem();
@@ -308,7 +309,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
               </Col>
 
               {/* Clickable main body for opening the queue */}
-              <Col xs={11} style={{ textAlign: 'center' }}>
+              <Col xs={10} style={{ textAlign: 'center' }}>
                 <div onClick={toggleQueueDrawer} className={`${styles.queueToggle} ${isListPage ? styles.listPage : ''}`}>
                   <ClimbTitle
                     climb={currentClimb}
@@ -318,6 +319,25 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
                   />
                 </div>
               </Col>
+
+              {/* Added by indicator (user avatar or Bluetooth icon) */}
+              {currentClimbQueueItem && (
+                <Col xs={1} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  {currentClimbQueueItem.addedByUser ? (
+                    <Tooltip title={currentClimbQueueItem.addedByUser.username}>
+                      <Avatar size="small" src={currentClimbQueueItem.addedByUser.avatarUrl} icon={<UserOutlined />} />
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title="Added via Bluetooth">
+                      <Avatar
+                        size="small"
+                        style={{ backgroundColor: 'transparent' }}
+                        icon={<BluetoothIcon style={{ color: themeTokens.neutral[400] }} />}
+                      />
+                    </Tooltip>
+                  )}
+                </Col>
+              )}
 
               {/* Button cluster */}
               <Col xs={9} style={{ textAlign: 'right' }}>

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Row, Col, Avatar, Tooltip, Dropdown, Button } from 'antd';
 import { CheckOutlined, CloseOutlined, UserOutlined, DeleteOutlined, MoreOutlined, InfoCircleOutlined, AppstoreOutlined } from '@ant-design/icons';
+import BluetoothIcon from './bluetooth-icon';
 import { BoardDetails, ClimbUuid, Climb } from '@/app/lib/types';
 import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
@@ -334,7 +335,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
                 currentClimb={item.climb}
               />
             </Col>
-            <Col xs={item.addedByUser ? 13 : 15} sm={item.addedByUser ? 15 : 17}>
+            <Col xs={13} sm={15}>
               <ClimbTitle
                 climb={item.climb}
                 showAngle
@@ -342,13 +343,21 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
                 nameAddon={<AscentStatus climbUuid={item.climb?.uuid} />}
               />
             </Col>
-            {item.addedByUser && (
-              <Col xs={2} sm={2}>
+            <Col xs={2} sm={2}>
+              {item.addedByUser ? (
                 <Tooltip title={item.addedByUser.username}>
                   <Avatar size="small" src={item.addedByUser.avatarUrl} icon={<UserOutlined />} />
                 </Tooltip>
-              </Col>
-            )}
+              ) : (
+                <Tooltip title="Added via Bluetooth">
+                  <Avatar
+                    size="small"
+                    style={{ backgroundColor: 'transparent' }}
+                    icon={<BluetoothIcon style={{ color: themeTokens.neutral[400] }} />}
+                  />
+                </Tooltip>
+              )}
+            </Col>
             <Col xs={3} sm={2}>
               <Dropdown
                 menu={{


### PR DESCRIPTION
Display a discrete grey Bluetooth logo in the queue list and queue bar
for climbs that were added via ESP32 Bluetooth bridge (without a user).

- Add BluetoothIcon component with standard Bluetooth symbol
- Update queue-list-item to show Bluetooth icon when addedByUser is missing
- Update queue-control-bar to show added-by indicator for current climb

https://claude.ai/code/session_01HEmtR2KJiacMGVP3PpstFb