### PR TITLE
fix: Fix Bluetooth icon aspect ratio in queue bar

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -309,7 +309,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
               </Col>
 
               {/* Clickable main body for opening the queue */}
-              <Col xs={10} style={{ textAlign: 'center' }}>
+              <Col xs={9} style={{ textAlign: 'center' }}>
                 <div onClick={toggleQueueDrawer} className={`${styles.queueToggle} ${isListPage ? styles.listPage : ''}`}>
                   <ClimbTitle
                     climb={currentClimb}
@@ -322,7 +322,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
 
               {/* Added by indicator (user avatar or Bluetooth icon) */}
               {currentClimbQueueItem && (
-                <Col xs={1} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Col xs={2} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                   {currentClimbQueueItem.addedByUser ? (
                     <Tooltip title={currentClimbQueueItem.addedByUser.username}>
                       <Avatar size="small" src={currentClimbQueueItem.addedByUser.avatarUrl} icon={<UserOutlined />} />


### PR DESCRIPTION
The avatar column was using xs={1} which is too narrow for the Avatar
component to maintain its circular shape. Changed to xs={2} to match
the queue-list-item pattern, and reduced the title area from xs={10}
to xs={9} to maintain the 24-column total.

https://claude.ai/code/session_01678U8LaW65xWacXcWo5UV8