### PR TITLE
feat: Add T-Display-S3 support with BLE proxy mode

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -936,6 +936,8 @@ subscription ControllerEvents($sessionId: ID!) {
       commands { position r g b }
       climbUuid
       climbName
+      climbGrade
+      boardPath
       angle
     }
     ... on ControllerPing {
@@ -951,6 +953,17 @@ subscription ControllerEvents($sessionId: ID!) {
 |-------|-------------|
 | `LedUpdate` | LED commands for current climb (RGB values and positions) |
 | `ControllerPing` | Keep-alive ping (not currently implemented) |
+
+### LedUpdate Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commands` | Array | LED positions with RGB values |
+| `climbUuid` | String | Unique identifier for the climb |
+| `climbName` | String | Display name of the climb |
+| `climbGrade` | String | The climb difficulty/grade (e.g., "V5", "6a/V3") |
+| `boardPath` | String | Board configuration path for context-aware operations (e.g., "kilter/1/12/1,2,3/40") |
+| `angle` | Int | Board angle in degrees |
 
 ### LED Color Mapping
 

--- a/embedded/libs/ble-proxy/library.json
+++ b/embedded/libs/ble-proxy/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "ble-proxy",
+  "version": "1.0.0",
+  "description": "BLE proxy for forwarding data between official app and Aurora boards",
+  "keywords": ["ble", "bluetooth", "proxy", "aurora", "kilter", "tension"],
+  "frameworks": ["arduino"],
+  "platforms": ["espressif32"],
+  "dependencies": {
+    "led-controller": "*",
+    "log-buffer": "*",
+    "config-manager": "*"
+  }
+}

--- a/embedded/libs/ble-proxy/src/ble_client.cpp
+++ b/embedded/libs/ble-proxy/src/ble_client.cpp
@@ -1,3 +1,13 @@
+/**
+ * BLE Client Connection Implementation
+ *
+ * This module uses a singleton pattern with a global instance pointer for
+ * ESP32/NimBLE callback compatibility. The NimBLE library requires C-style
+ * callback functions for notifications, which cannot directly call member
+ * functions. The static instance pointer allows the static callback wrapper
+ * to forward data to the singleton instance.
+ */
+
 #include "ble_client.h"
 #include <log_buffer.h>
 

--- a/embedded/libs/ble-proxy/src/ble_client.cpp
+++ b/embedded/libs/ble-proxy/src/ble_client.cpp
@@ -9,20 +9,15 @@
  */
 
 #include "ble_client.h"
+
 #include <log_buffer.h>
 
 BLEClientConnection BoardClient;
 BLEClientConnection* BLEClientConnection::instance = nullptr;
 
 BLEClientConnection::BLEClientConnection()
-    : pClient(nullptr)
-    , pRxChar(nullptr)
-    , pTxChar(nullptr)
-    , state(BLEClientState::IDLE)
-    , targetAddress()
-    , reconnectTime(0)
-    , connectCallback(nullptr)
-    , dataCallback(nullptr) {
+    : pClient(nullptr), pRxChar(nullptr), pTxChar(nullptr), state(BLEClientState::IDLE), targetAddress(),
+      reconnectTime(0), connectCallback(nullptr), dataCallback(nullptr) {
     instance = this;
 }
 
@@ -145,7 +140,8 @@ void BLEClientConnection::onDisconnect(NimBLEClient* client) {
 }
 
 bool BLEClientConnection::setupService() {
-    if (!pClient) return false;
+    if (!pClient)
+        return false;
 
     // Get Nordic UART Service
     NimBLERemoteService* pService = pClient->getService(NUS_SERVICE_UUID);
@@ -181,9 +177,8 @@ bool BLEClientConnection::setupService() {
     return true;
 }
 
-void BLEClientConnection::notifyCallback(NimBLERemoteCharacteristic* pChar,
-                                          uint8_t* pData, size_t length,
-                                          bool isNotify) {
+void BLEClientConnection::notifyCallback(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length,
+                                         bool isNotify) {
     if (instance && instance->dataCallback) {
         instance->dataCallback(pData, length);
     }

--- a/embedded/libs/ble-proxy/src/ble_client.cpp
+++ b/embedded/libs/ble-proxy/src/ble_client.cpp
@@ -1,0 +1,180 @@
+#include "ble_client.h"
+#include <log_buffer.h>
+
+BLEClientConnection BoardClient;
+BLEClientConnection* BLEClientConnection::instance = nullptr;
+
+BLEClientConnection::BLEClientConnection()
+    : pClient(nullptr)
+    , pRxChar(nullptr)
+    , pTxChar(nullptr)
+    , state(BLEClientState::IDLE)
+    , targetAddress()
+    , reconnectTime(0)
+    , connectCallback(nullptr)
+    , dataCallback(nullptr) {
+    instance = this;
+}
+
+bool BLEClientConnection::connect(NimBLEAddress address) {
+    if (state == BLEClientState::CONNECTED || state == BLEClientState::CONNECTING) {
+        Logger.logln("BLEClient: Already connected or connecting");
+        return false;
+    }
+
+    targetAddress = address;
+    state = BLEClientState::CONNECTING;
+
+    Logger.logln("BLEClient: Connecting to %s", address.toString().c_str());
+
+    // Create client if needed
+    if (!pClient) {
+        pClient = NimBLEDevice::createClient();
+        pClient->setClientCallbacks(this);
+        pClient->setConnectionParams(12, 12, 0, 51);
+        pClient->setConnectTimeout(CLIENT_CONNECT_TIMEOUT_MS / 1000);
+    }
+
+    // Attempt connection
+    if (!pClient->connect(address)) {
+        Logger.logln("BLEClient: Connection failed");
+        state = BLEClientState::DISCONNECTED;
+        reconnectTime = millis() + CLIENT_RECONNECT_DELAY_MS;
+        return false;
+    }
+
+    return true;
+}
+
+void BLEClientConnection::disconnect() {
+    if (pClient && pClient->isConnected()) {
+        Logger.logln("BLEClient: Disconnecting");
+        pClient->disconnect();
+    }
+    state = BLEClientState::IDLE;
+    reconnectTime = 0;
+}
+
+void BLEClientConnection::loop() {
+    // Handle reconnection
+    if (state == BLEClientState::DISCONNECTED || state == BLEClientState::RECONNECTING) {
+        if (reconnectTime > 0 && millis() > reconnectTime) {
+            Logger.logln("BLEClient: Attempting reconnection");
+            state = BLEClientState::RECONNECTING;
+            connect(targetAddress);
+        }
+    }
+}
+
+bool BLEClientConnection::isConnected() const {
+    return state == BLEClientState::CONNECTED && pClient && pClient->isConnected();
+}
+
+BLEClientState BLEClientConnection::getState() const {
+    return state;
+}
+
+bool BLEClientConnection::send(const uint8_t* data, size_t len) {
+    if (!isConnected() || !pRxChar) {
+        return false;
+    }
+
+    // Write to the RX characteristic (board receives this)
+    bool success = pRxChar->writeValue(data, len, false);  // No response needed
+    if (!success) {
+        Logger.logln("BLEClient: Write failed");
+    }
+    return success;
+}
+
+String BLEClientConnection::getConnectedAddress() const {
+    if (pClient && pClient->isConnected()) {
+        return targetAddress.toString().c_str();
+    }
+    return "";
+}
+
+void BLEClientConnection::setConnectCallback(ClientConnectCallback callback) {
+    connectCallback = callback;
+}
+
+void BLEClientConnection::setDataCallback(ClientDataCallback callback) {
+    dataCallback = callback;
+}
+
+void BLEClientConnection::onConnect(NimBLEClient* client) {
+    Logger.logln("BLEClient: Connected to board");
+
+    // Set up the service and characteristics
+    if (setupService()) {
+        state = BLEClientState::CONNECTED;
+        reconnectTime = 0;
+        if (connectCallback) {
+            connectCallback(true);
+        }
+    } else {
+        Logger.logln("BLEClient: Failed to set up service, disconnecting");
+        client->disconnect();
+    }
+}
+
+void BLEClientConnection::onDisconnect(NimBLEClient* client) {
+    Logger.logln("BLEClient: Disconnected from board");
+
+    pRxChar = nullptr;
+    pTxChar = nullptr;
+
+    if (state != BLEClientState::IDLE) {
+        state = BLEClientState::DISCONNECTED;
+        reconnectTime = millis() + CLIENT_RECONNECT_DELAY_MS;
+    }
+
+    if (connectCallback) {
+        connectCallback(false);
+    }
+}
+
+bool BLEClientConnection::setupService() {
+    if (!pClient) return false;
+
+    // Get Nordic UART Service
+    NimBLERemoteService* pService = pClient->getService(NUS_SERVICE_UUID);
+    if (!pService) {
+        Logger.logln("BLEClient: Nordic UART Service not found");
+        return false;
+    }
+
+    // Get RX characteristic (we write to this)
+    pRxChar = pService->getCharacteristic(NUS_RX_CHARACTERISTIC);
+    if (!pRxChar) {
+        Logger.logln("BLEClient: RX characteristic not found");
+        return false;
+    }
+
+    // Get TX characteristic (we receive from this)
+    pTxChar = pService->getCharacteristic(NUS_TX_CHARACTERISTIC);
+    if (!pTxChar) {
+        Logger.logln("BLEClient: TX characteristic not found");
+        return false;
+    }
+
+    // Subscribe to TX notifications
+    if (pTxChar->canNotify()) {
+        if (!pTxChar->subscribe(true, notifyCallback)) {
+            Logger.logln("BLEClient: Failed to subscribe to TX");
+            return false;
+        }
+        Logger.logln("BLEClient: Subscribed to board TX notifications");
+    }
+
+    Logger.logln("BLEClient: Service setup complete");
+    return true;
+}
+
+void BLEClientConnection::notifyCallback(NimBLERemoteCharacteristic* pChar,
+                                          uint8_t* pData, size_t length,
+                                          bool isNotify) {
+    if (instance && instance->dataCallback) {
+        instance->dataCallback(pData, length);
+    }
+}

--- a/embedded/libs/ble-proxy/src/ble_client.h
+++ b/embedded/libs/ble-proxy/src/ble_client.h
@@ -5,21 +5,15 @@
 #include <NimBLEDevice.h>
 
 // Nordic UART Service UUIDs
-#define NUS_SERVICE_UUID        "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
-#define NUS_RX_CHARACTERISTIC   "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
-#define NUS_TX_CHARACTERISTIC   "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+#define NUS_SERVICE_UUID "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
+#define NUS_RX_CHARACTERISTIC "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+#define NUS_TX_CHARACTERISTIC "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
 
 // Connection timing
 #define CLIENT_CONNECT_TIMEOUT_MS 10000
 #define CLIENT_RECONNECT_DELAY_MS 5000
 
-enum class BLEClientState {
-    IDLE,
-    CONNECTING,
-    CONNECTED,
-    RECONNECTING,
-    DISCONNECTED
-};
+enum class BLEClientState { IDLE, CONNECTING, CONNECTED, RECONNECTING, DISCONNECTED };
 
 typedef void (*ClientConnectCallback)(bool connected);
 typedef void (*ClientDataCallback)(const uint8_t* data, size_t len);
@@ -34,7 +28,7 @@ typedef void (*ClientDataCallback)(const uint8_t* data, size_t len);
  * - Auto-reconnects on connection loss
  */
 class BLEClientConnection : public NimBLEClientCallbacks {
-public:
+  public:
     BLEClientConnection();
 
     /**
@@ -91,7 +85,7 @@ public:
     void onConnect(NimBLEClient* pClient) override;
     void onDisconnect(NimBLEClient* pClient) override;
 
-private:
+  private:
     NimBLEClient* pClient;
     NimBLERemoteCharacteristic* pRxChar;  // We write to this
     NimBLERemoteCharacteristic* pTxChar;  // We receive from this
@@ -104,8 +98,7 @@ private:
     ClientDataCallback dataCallback;
 
     bool setupService();
-    static void notifyCallback(NimBLERemoteCharacteristic* pChar,
-                               uint8_t* pData, size_t length, bool isNotify);
+    static void notifyCallback(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length, bool isNotify);
     static BLEClientConnection* instance;
 };
 

--- a/embedded/libs/ble-proxy/src/ble_client.h
+++ b/embedded/libs/ble-proxy/src/ble_client.h
@@ -1,0 +1,114 @@
+#ifndef BLE_CLIENT_H
+#define BLE_CLIENT_H
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+
+// Nordic UART Service UUIDs
+#define NUS_SERVICE_UUID        "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
+#define NUS_RX_CHARACTERISTIC   "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+#define NUS_TX_CHARACTERISTIC   "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+
+// Connection timing
+#define CLIENT_CONNECT_TIMEOUT_MS 10000
+#define CLIENT_RECONNECT_DELAY_MS 5000
+
+enum class BLEClientState {
+    IDLE,
+    CONNECTING,
+    CONNECTED,
+    RECONNECTING,
+    DISCONNECTED
+};
+
+typedef void (*ClientConnectCallback)(bool connected);
+typedef void (*ClientDataCallback)(const uint8_t* data, size_t len);
+
+/**
+ * BLEClientConnection connects to an Aurora board and handles Nordic UART communication.
+ *
+ * Features:
+ * - Connects to Nordic UART Service on target board
+ * - Writes to RX characteristic (sends data to board)
+ * - Receives from TX characteristic via notify (receives data from board)
+ * - Auto-reconnects on connection loss
+ */
+class BLEClientConnection : public NimBLEClientCallbacks {
+public:
+    BLEClientConnection();
+
+    /**
+     * Connect to a target board by address.
+     * @param address Target board's BLE address
+     * @return true if connection attempt started
+     */
+    bool connect(NimBLEAddress address);
+
+    /**
+     * Disconnect from the current board.
+     */
+    void disconnect();
+
+    /**
+     * Process client state (call from loop).
+     */
+    void loop();
+
+    /**
+     * Check if connected to a board.
+     */
+    bool isConnected() const;
+
+    /**
+     * Get current connection state.
+     */
+    BLEClientState getState() const;
+
+    /**
+     * Send data to the connected board.
+     * @param data Data bytes to send
+     * @param len Length of data
+     * @return true if sent successfully
+     */
+    bool send(const uint8_t* data, size_t len);
+
+    /**
+     * Get the address of the connected board.
+     */
+    String getConnectedAddress() const;
+
+    /**
+     * Set callback for connection state changes.
+     */
+    void setConnectCallback(ClientConnectCallback callback);
+
+    /**
+     * Set callback for received data from board.
+     */
+    void setDataCallback(ClientDataCallback callback);
+
+    // NimBLE client callbacks
+    void onConnect(NimBLEClient* pClient) override;
+    void onDisconnect(NimBLEClient* pClient) override;
+
+private:
+    NimBLEClient* pClient;
+    NimBLERemoteCharacteristic* pRxChar;  // We write to this
+    NimBLERemoteCharacteristic* pTxChar;  // We receive from this
+
+    BLEClientState state;
+    NimBLEAddress targetAddress;
+    unsigned long reconnectTime;
+
+    ClientConnectCallback connectCallback;
+    ClientDataCallback dataCallback;
+
+    bool setupService();
+    static void notifyCallback(NimBLERemoteCharacteristic* pChar,
+                               uint8_t* pData, size_t length, bool isNotify);
+    static BLEClientConnection* instance;
+};
+
+extern BLEClientConnection BoardClient;
+
+#endif

--- a/embedded/libs/ble-proxy/src/ble_proxy.cpp
+++ b/embedded/libs/ble-proxy/src/ble_proxy.cpp
@@ -2,9 +2,6 @@
 #include <log_buffer.h>
 #include <config_manager.h>
 
-// Forward declaration - we'll need access to the BLE server
-extern void sendToAppViaBLE(const uint8_t* data, size_t len);
-
 BLEProxy Proxy;
 
 // Static instance pointer for callbacks
@@ -35,7 +32,8 @@ BLEProxy::BLEProxy()
     , scanStartTime(0)
     , reconnectDelay(5000)
     , stateCallback(nullptr)
-    , dataCallback(nullptr) {
+    , dataCallback(nullptr)
+    , sendToAppCallback(nullptr) {
     proxyInstance = this;
 }
 
@@ -132,6 +130,10 @@ void BLEProxy::setDataCallback(ProxyDataCallback callback) {
     dataCallback = callback;
 }
 
+void BLEProxy::setSendToAppCallback(ProxySendToAppCallback callback) {
+    sendToAppCallback = callback;
+}
+
 bool BLEProxy::forwardToBoard(const uint8_t* data, size_t len) {
     if (!isConnectedToBoard()) {
         return false;
@@ -150,7 +152,9 @@ void BLEProxy::forwardToApp(const uint8_t* data, size_t len) {
     }
 
     // Forward to connected app via BLE server
-    sendToAppViaBLE(data, len);
+    if (sendToAppCallback) {
+        sendToAppCallback(data, len);
+    }
 }
 
 void BLEProxy::setState(BLEProxyState newState) {

--- a/embedded/libs/ble-proxy/src/ble_proxy.cpp
+++ b/embedded/libs/ble-proxy/src/ble_proxy.cpp
@@ -1,10 +1,19 @@
+/**
+ * BLE Proxy Implementation
+ *
+ * This module uses a singleton pattern with a static instance pointer for
+ * ESP32/NimBLE callback compatibility. The scanner and client libraries
+ * require C-style callback functions which cannot directly invoke member
+ * functions. Static wrapper functions forward calls to the singleton instance.
+ */
+
 #include "ble_proxy.h"
 #include <log_buffer.h>
 #include <config_manager.h>
 
 BLEProxy Proxy;
 
-// Static instance pointer for callbacks
+// Static instance pointer for callbacks (required for C-style callback wrappers)
 static BLEProxy* proxyInstance = nullptr;
 
 // Static callback wrappers

--- a/embedded/libs/ble-proxy/src/ble_proxy.cpp
+++ b/embedded/libs/ble-proxy/src/ble_proxy.cpp
@@ -1,0 +1,218 @@
+#include "ble_proxy.h"
+#include <log_buffer.h>
+#include <config_manager.h>
+
+// Forward declaration - we'll need access to the BLE server
+extern void sendToAppViaBLE(const uint8_t* data, size_t len);
+
+BLEProxy Proxy;
+
+// Static instance pointer for callbacks
+static BLEProxy* proxyInstance = nullptr;
+
+// Static callback wrappers
+static void onBoardConnectedStatic(bool connected) {
+    if (proxyInstance) {
+        proxyInstance->handleBoardConnected(connected);
+    }
+}
+
+static void onBoardDataStatic(const uint8_t* data, size_t len) {
+    if (proxyInstance) {
+        proxyInstance->handleBoardData(data, len);
+    }
+}
+
+static void onScanCompleteStatic(const std::vector<DiscoveredBoard>& boards) {
+    if (proxyInstance) {
+        proxyInstance->handleScanComplete(boards);
+    }
+}
+
+BLEProxy::BLEProxy()
+    : state(BLEProxyState::PROXY_DISABLED)
+    , enabled(false)
+    , scanStartTime(0)
+    , reconnectDelay(5000)
+    , stateCallback(nullptr)
+    , dataCallback(nullptr) {
+    proxyInstance = this;
+}
+
+void BLEProxy::begin(const String& mac) {
+    targetMac = mac;
+
+    // Load enabled state from config
+    enabled = Config.getBool("proxy_en", false);
+
+    if (enabled) {
+        Logger.logln("BLEProxy: Proxy mode enabled");
+        setState(BLEProxyState::IDLE);
+
+        // Set up callbacks for the board client
+        BoardClient.setConnectCallback(onBoardConnectedStatic);
+        BoardClient.setDataCallback(onBoardDataStatic);
+    } else {
+        Logger.logln("BLEProxy: Proxy mode disabled");
+        setState(BLEProxyState::PROXY_DISABLED);
+    }
+}
+
+void BLEProxy::setEnabled(bool enable) {
+    if (enabled == enable) return;
+
+    enabled = enable;
+    Config.setBool("proxy_en", enable);
+
+    if (enable) {
+        Logger.logln("BLEProxy: Enabling proxy mode");
+        setState(BLEProxyState::IDLE);
+
+        BoardClient.setConnectCallback(onBoardConnectedStatic);
+        BoardClient.setDataCallback(onBoardDataStatic);
+    } else {
+        Logger.logln("BLEProxy: Disabling proxy mode");
+        BoardClient.disconnect();
+        Scanner.stopScan();
+        setState(BLEProxyState::PROXY_DISABLED);
+    }
+}
+
+bool BLEProxy::isEnabled() const {
+    return enabled;
+}
+
+void BLEProxy::loop() {
+    if (!enabled) return;
+
+    switch (state) {
+        case BLEProxyState::IDLE:
+            // Start scanning for boards
+            startScan();
+            break;
+
+        case BLEProxyState::SCANNING:
+            // Handled by scanner callbacks
+            break;
+
+        case BLEProxyState::CONNECTING:
+            // Handled by client callbacks
+            break;
+
+        case BLEProxyState::CONNECTED:
+            BoardClient.loop();
+            break;
+
+        case BLEProxyState::RECONNECTING:
+            BoardClient.loop();
+            break;
+
+        default:
+            break;
+    }
+}
+
+BLEProxyState BLEProxy::getState() const {
+    return state;
+}
+
+bool BLEProxy::isConnectedToBoard() const {
+    return state == BLEProxyState::CONNECTED && BoardClient.isConnected();
+}
+
+String BLEProxy::getConnectedBoardAddress() const {
+    return BoardClient.getConnectedAddress();
+}
+
+void BLEProxy::setStateCallback(ProxyStateCallback callback) {
+    stateCallback = callback;
+}
+
+void BLEProxy::setDataCallback(ProxyDataCallback callback) {
+    dataCallback = callback;
+}
+
+bool BLEProxy::forwardToBoard(const uint8_t* data, size_t len) {
+    if (!isConnectedToBoard()) {
+        return false;
+    }
+
+    if (dataCallback) {
+        dataCallback(data, len, true);  // fromApp = true
+    }
+
+    return BoardClient.send(data, len);
+}
+
+void BLEProxy::forwardToApp(const uint8_t* data, size_t len) {
+    if (dataCallback) {
+        dataCallback(data, len, false);  // fromApp = false
+    }
+
+    // Forward to connected app via BLE server
+    sendToAppViaBLE(data, len);
+}
+
+void BLEProxy::setState(BLEProxyState newState) {
+    if (state != newState) {
+        Logger.logln("BLEProxy: State %d -> %d", (int)state, (int)newState);
+        state = newState;
+        if (stateCallback) {
+            stateCallback(state);
+        }
+    }
+}
+
+void BLEProxy::startScan() {
+    setState(BLEProxyState::SCANNING);
+    scanStartTime = millis();
+
+    Scanner.startScan(nullptr, onScanCompleteStatic, 30);
+}
+
+void BLEProxy::handleScanComplete(const std::vector<DiscoveredBoard>& boards) {
+    if (boards.empty()) {
+        Logger.logln("BLEProxy: No boards found, will retry");
+        setState(BLEProxyState::IDLE);
+        return;
+    }
+
+    const DiscoveredBoard* target = nullptr;
+
+    // If we have a target MAC, find it
+    if (targetMac.length() > 0) {
+        target = Scanner.findByAddress(targetMac);
+        if (!target) {
+            Logger.logln("BLEProxy: Target MAC %s not found", targetMac.c_str());
+        }
+    }
+
+    // Otherwise, use the strongest signal
+    if (!target) {
+        target = Scanner.getBestBoard();
+    }
+
+    if (target) {
+        Logger.logln("BLEProxy: Connecting to %s (%s)",
+                      target->name.c_str(), target->address.toString().c_str());
+        setState(BLEProxyState::CONNECTING);
+        BoardClient.connect(target->address);
+    } else {
+        setState(BLEProxyState::IDLE);
+    }
+}
+
+void BLEProxy::handleBoardConnected(bool connected) {
+    if (connected) {
+        Logger.logln("BLEProxy: Connected to board");
+        setState(BLEProxyState::CONNECTED);
+    } else {
+        Logger.logln("BLEProxy: Board disconnected");
+        setState(BLEProxyState::RECONNECTING);
+    }
+}
+
+void BLEProxy::handleBoardData(const uint8_t* data, size_t len) {
+    // Forward data from board to app
+    forwardToApp(data, len);
+}

--- a/embedded/libs/ble-proxy/src/ble_proxy.cpp
+++ b/embedded/libs/ble-proxy/src/ble_proxy.cpp
@@ -8,8 +8,9 @@
  */
 
 #include "ble_proxy.h"
-#include <log_buffer.h>
+
 #include <config_manager.h>
+#include <log_buffer.h>
 
 BLEProxy Proxy;
 
@@ -36,13 +37,8 @@ static void onScanCompleteStatic(const std::vector<DiscoveredBoard>& boards) {
 }
 
 BLEProxy::BLEProxy()
-    : state(BLEProxyState::PROXY_DISABLED)
-    , enabled(false)
-    , scanStartTime(0)
-    , reconnectDelay(5000)
-    , stateCallback(nullptr)
-    , dataCallback(nullptr)
-    , sendToAppCallback(nullptr) {
+    : state(BLEProxyState::PROXY_DISABLED), enabled(false), scanStartTime(0), reconnectDelay(5000),
+      stateCallback(nullptr), dataCallback(nullptr), sendToAppCallback(nullptr) {
     proxyInstance = this;
 }
 
@@ -66,7 +62,8 @@ void BLEProxy::begin(const String& mac) {
 }
 
 void BLEProxy::setEnabled(bool enable) {
-    if (enabled == enable) return;
+    if (enabled == enable)
+        return;
 
     enabled = enable;
     Config.setBool("proxy_en", enable);
@@ -90,7 +87,8 @@ bool BLEProxy::isEnabled() const {
 }
 
 void BLEProxy::loop() {
-    if (!enabled) return;
+    if (!enabled)
+        return;
 
     switch (state) {
         case BLEProxyState::IDLE:
@@ -206,8 +204,7 @@ void BLEProxy::handleScanComplete(const std::vector<DiscoveredBoard>& boards) {
     }
 
     if (target) {
-        Logger.logln("BLEProxy: Connecting to %s (%s)",
-                      target->name.c_str(), target->address.toString().c_str());
+        Logger.logln("BLEProxy: Connecting to %s (%s)", target->name.c_str(), target->address.toString().c_str());
         setState(BLEProxyState::CONNECTING);
         BoardClient.connect(target->address);
     } else {

--- a/embedded/libs/ble-proxy/src/ble_proxy.h
+++ b/embedded/libs/ble-proxy/src/ble_proxy.h
@@ -17,6 +17,7 @@ enum class BLEProxyState {
 
 typedef void (*ProxyStateCallback)(BLEProxyState state);
 typedef void (*ProxyDataCallback)(const uint8_t* data, size_t len, bool fromApp);
+typedef void (*ProxySendToAppCallback)(const uint8_t* data, size_t len);
 
 /**
  * BLEProxy orchestrates the proxy connection between official app and Aurora board.
@@ -89,6 +90,13 @@ public:
     void setDataCallback(ProxyDataCallback callback);
 
     /**
+     * Set callback for sending data to connected app via BLE server.
+     * This must be set by the main application to provide the BLE send function.
+     * @param callback Function to send data to app via BLE
+     */
+    void setSendToAppCallback(ProxySendToAppCallback callback);
+
+    /**
      * Forward data from app to board.
      * This is called by the nordic-uart-ble server when it receives data.
      * @param data Data bytes
@@ -117,6 +125,7 @@ private:
 
     ProxyStateCallback stateCallback;
     ProxyDataCallback dataCallback;
+    ProxySendToAppCallback sendToAppCallback;
 
     void setState(BLEProxyState newState);
     void startScan();

--- a/embedded/libs/ble-proxy/src/ble_proxy.h
+++ b/embedded/libs/ble-proxy/src/ble_proxy.h
@@ -1,18 +1,19 @@
 #ifndef BLE_PROXY_H
 #define BLE_PROXY_H
 
-#include <Arduino.h>
-#include "ble_scanner.h"
 #include "ble_client.h"
+#include "ble_scanner.h"
+
+#include <Arduino.h>
 
 // Proxy state machine
 enum class BLEProxyState {
-    PROXY_DISABLED,     // Proxy mode not enabled
-    IDLE,               // Waiting to scan
-    SCANNING,           // Scanning for boards
-    CONNECTING,         // Connecting to board
-    CONNECTED,          // Connected and proxying
-    RECONNECTING        // Connection lost, will retry
+    PROXY_DISABLED,  // Proxy mode not enabled
+    IDLE,            // Waiting to scan
+    SCANNING,        // Scanning for boards
+    CONNECTING,      // Connecting to board
+    CONNECTED,       // Connected and proxying
+    RECONNECTING     // Connection lost, will retry
 };
 
 typedef void (*ProxyStateCallback)(BLEProxyState state);
@@ -39,7 +40,7 @@ typedef void (*ProxySendToAppCallback)(const uint8_t* data, size_t len);
  * 4. Data received from board is forwarded to app
  */
 class BLEProxy {
-public:
+  public:
     BLEProxy();
 
     /**
@@ -116,7 +117,7 @@ public:
     void handleBoardConnected(bool connected);
     void handleBoardData(const uint8_t* data, size_t len);
 
-private:
+  private:
     BLEProxyState state;
     bool enabled;
     String targetMac;

--- a/embedded/libs/ble-proxy/src/ble_proxy.h
+++ b/embedded/libs/ble-proxy/src/ble_proxy.h
@@ -1,0 +1,127 @@
+#ifndef BLE_PROXY_H
+#define BLE_PROXY_H
+
+#include <Arduino.h>
+#include "ble_scanner.h"
+#include "ble_client.h"
+
+// Proxy state machine
+enum class BLEProxyState {
+    PROXY_DISABLED,     // Proxy mode not enabled
+    IDLE,               // Waiting to scan
+    SCANNING,           // Scanning for boards
+    CONNECTING,         // Connecting to board
+    CONNECTED,          // Connected and proxying
+    RECONNECTING        // Connection lost, will retry
+};
+
+typedef void (*ProxyStateCallback)(BLEProxyState state);
+typedef void (*ProxyDataCallback)(const uint8_t* data, size_t len, bool fromApp);
+
+/**
+ * BLEProxy orchestrates the proxy connection between official app and Aurora board.
+ *
+ * Architecture:
+ * - Acts as a BLE server (appears as "Kilter Boardsesh" to official app)
+ * - Acts as a BLE client to the actual Aurora board
+ * - Forwards all data bidirectionally
+ *
+ * State Machine:
+ *   DISABLED → IDLE → SCANNING → CONNECTING → CONNECTED
+ *                                     ↑            ↓
+ *                                     └── RECONNECTING ←┘
+ *
+ * Usage:
+ * 1. Call begin() with a target MAC or empty string for auto-detect
+ * 2. Call loop() regularly to process state
+ * 3. Data received from app is forwarded to board
+ * 4. Data received from board is forwarded to app
+ */
+class BLEProxy {
+public:
+    BLEProxy();
+
+    /**
+     * Initialize the proxy.
+     * @param targetMac Optional MAC address of target board (empty for auto-detect)
+     */
+    void begin(const String& targetMac = "");
+
+    /**
+     * Enable or disable proxy mode.
+     */
+    void setEnabled(bool enabled);
+
+    /**
+     * Check if proxy mode is enabled.
+     */
+    bool isEnabled() const;
+
+    /**
+     * Process proxy state (call from loop).
+     */
+    void loop();
+
+    /**
+     * Get current proxy state.
+     */
+    BLEProxyState getState() const;
+
+    /**
+     * Check if proxy is connected to the actual board.
+     */
+    bool isConnectedToBoard() const;
+
+    /**
+     * Get the MAC address of the connected board.
+     */
+    String getConnectedBoardAddress() const;
+
+    /**
+     * Set callback for state changes.
+     */
+    void setStateCallback(ProxyStateCallback callback);
+
+    /**
+     * Set callback for proxied data (for monitoring/display).
+     * @param callback Called with data and direction (fromApp=true means app→board)
+     */
+    void setDataCallback(ProxyDataCallback callback);
+
+    /**
+     * Forward data from app to board.
+     * This is called by the nordic-uart-ble server when it receives data.
+     * @param data Data bytes
+     * @param len Length of data
+     * @return true if forwarded successfully
+     */
+    bool forwardToBoard(const uint8_t* data, size_t len);
+
+    /**
+     * Forward data from board to app.
+     * This is called internally when board sends data.
+     */
+    void forwardToApp(const uint8_t* data, size_t len);
+
+    // Public handlers for static callbacks
+    void handleScanComplete(const std::vector<DiscoveredBoard>& boards);
+    void handleBoardConnected(bool connected);
+    void handleBoardData(const uint8_t* data, size_t len);
+
+private:
+    BLEProxyState state;
+    bool enabled;
+    String targetMac;
+    unsigned long scanStartTime;
+    unsigned long reconnectDelay;
+
+    ProxyStateCallback stateCallback;
+    ProxyDataCallback dataCallback;
+
+    void setState(BLEProxyState newState);
+    void startScan();
+};
+
+extern BLEProxy Proxy;
+
+#endif

--- a/embedded/libs/ble-proxy/src/ble_scanner.cpp
+++ b/embedded/libs/ble-proxy/src/ble_scanner.cpp
@@ -1,0 +1,131 @@
+#include "ble_scanner.h"
+#include <log_buffer.h>
+
+BLEScanner Scanner;
+BLEScanner* BLEScanner::instance = nullptr;
+
+BLEScanner::BLEScanner()
+    : pScan(nullptr)
+    , resultCallback(nullptr)
+    , completeCallback(nullptr)
+    , scanning(false) {
+    instance = this;
+}
+
+void BLEScanner::startScan(ScanResultCallback onResult,
+                           ScanCompleteCallback onComplete,
+                           int timeoutSec) {
+    if (scanning) {
+        Logger.logln("BLEScanner: Already scanning");
+        return;
+    }
+
+    resultCallback = onResult;
+    completeCallback = onComplete;
+    discoveredBoards.clear();
+
+    // Initialize BLE if not already done
+    if (!NimBLEDevice::getInitialized()) {
+        Logger.logln("BLEScanner: BLE not initialized, skipping scan");
+        return;
+    }
+
+    pScan = NimBLEDevice::getScan();
+    pScan->setAdvertisedDeviceCallbacks(this);
+    pScan->setActiveScan(true);
+    pScan->setInterval(100);
+    pScan->setWindow(99);
+    pScan->setMaxResults(0);  // Don't store in NimBLE, we store ourselves
+
+    Logger.logln("BLEScanner: Starting scan for Aurora boards (%d sec)", timeoutSec);
+    scanning = true;
+
+    // Start scan with callback
+    pScan->start(timeoutSec, scanCompleteCB, false);
+}
+
+void BLEScanner::stopScan() {
+    if (scanning && pScan) {
+        Logger.logln("BLEScanner: Stopping scan");
+        pScan->stop();
+        scanning = false;
+    }
+}
+
+bool BLEScanner::isScanning() const {
+    return scanning;
+}
+
+const std::vector<DiscoveredBoard>& BLEScanner::getDiscoveredBoards() const {
+    return discoveredBoards;
+}
+
+const DiscoveredBoard* BLEScanner::getBestBoard() const {
+    if (discoveredBoards.empty()) {
+        return nullptr;
+    }
+
+    const DiscoveredBoard* best = &discoveredBoards[0];
+    for (const auto& board : discoveredBoards) {
+        if (board.rssi > best->rssi) {
+            best = &board;
+        }
+    }
+    return best;
+}
+
+const DiscoveredBoard* BLEScanner::findByAddress(const String& mac) const {
+    for (const auto& board : discoveredBoards) {
+        if (mac.equalsIgnoreCase(board.address.toString().c_str())) {
+            return &board;
+        }
+    }
+    return nullptr;
+}
+
+void BLEScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+    // Check if this device advertises Aurora's service UUID
+    if (!advertisedDevice->isAdvertisingService(NimBLEUUID(AURORA_ADVERTISED_SERVICE_UUID))) {
+        return;
+    }
+
+    // Check if we already found this board
+    for (const auto& board : discoveredBoards) {
+        if (board.address == advertisedDevice->getAddress()) {
+            return;  // Already in list
+        }
+    }
+
+    String name = advertisedDevice->getName().c_str();
+    if (name.length() == 0) {
+        name = "Unknown Board";
+    }
+
+    DiscoveredBoard board(
+        advertisedDevice->getAddress(),
+        name,
+        advertisedDevice->getRSSI()
+    );
+
+    discoveredBoards.push_back(board);
+    Logger.logln("BLEScanner: Found Aurora board: %s (%s, %d dBm)",
+                  name.c_str(),
+                  advertisedDevice->getAddress().toString().c_str(),
+                  advertisedDevice->getRSSI());
+
+    if (resultCallback) {
+        resultCallback(board);
+    }
+}
+
+void BLEScanner::scanCompleteCB(NimBLEScanResults results) {
+    if (instance) {
+        instance->scanning = false;
+        Logger.logln("BLEScanner: Scan complete, found %d Aurora boards",
+                      instance->discoveredBoards.size());
+
+        if (instance->completeCallback) {
+            instance->completeCallback(instance->discoveredBoards);
+        }
+    }
+}

--- a/embedded/libs/ble-proxy/src/ble_scanner.cpp
+++ b/embedded/libs/ble-proxy/src/ble_scanner.cpp
@@ -9,22 +9,17 @@
  */
 
 #include "ble_scanner.h"
+
 #include <log_buffer.h>
 
 BLEScanner Scanner;
 BLEScanner* BLEScanner::instance = nullptr;
 
-BLEScanner::BLEScanner()
-    : pScan(nullptr)
-    , resultCallback(nullptr)
-    , completeCallback(nullptr)
-    , scanning(false) {
+BLEScanner::BLEScanner() : pScan(nullptr), resultCallback(nullptr), completeCallback(nullptr), scanning(false) {
     instance = this;
 }
 
-void BLEScanner::startScan(ScanResultCallback onResult,
-                           ScanCompleteCallback onComplete,
-                           int timeoutSec) {
+void BLEScanner::startScan(ScanResultCallback onResult, ScanCompleteCallback onComplete, int timeoutSec) {
     if (scanning) {
         Logger.logln("BLEScanner: Already scanning");
         return;
@@ -111,17 +106,11 @@ void BLEScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
         name = "Unknown Board";
     }
 
-    DiscoveredBoard board(
-        advertisedDevice->getAddress(),
-        name,
-        advertisedDevice->getRSSI()
-    );
+    DiscoveredBoard board(advertisedDevice->getAddress(), name, advertisedDevice->getRSSI());
 
     discoveredBoards.push_back(board);
-    Logger.logln("BLEScanner: Found Aurora board: %s (%s, %d dBm)",
-                  name.c_str(),
-                  advertisedDevice->getAddress().toString().c_str(),
-                  advertisedDevice->getRSSI());
+    Logger.logln("BLEScanner: Found Aurora board: %s (%s, %d dBm)", name.c_str(),
+                 advertisedDevice->getAddress().toString().c_str(), advertisedDevice->getRSSI());
 
     if (resultCallback) {
         resultCallback(board);
@@ -131,8 +120,7 @@ void BLEScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
 void BLEScanner::scanCompleteCB(NimBLEScanResults results) {
     if (instance) {
         instance->scanning = false;
-        Logger.logln("BLEScanner: Scan complete, found %d Aurora boards",
-                      instance->discoveredBoards.size());
+        Logger.logln("BLEScanner: Scan complete, found %d Aurora boards", instance->discoveredBoards.size());
 
         if (instance->completeCallback) {
             instance->completeCallback(instance->discoveredBoards);

--- a/embedded/libs/ble-proxy/src/ble_scanner.cpp
+++ b/embedded/libs/ble-proxy/src/ble_scanner.cpp
@@ -1,3 +1,13 @@
+/**
+ * BLE Scanner Implementation
+ *
+ * This module uses a singleton pattern with a global instance pointer for
+ * ESP32/NimBLE callback compatibility. The NimBLE scan API requires C-style
+ * callback functions for scan completion events, which cannot directly call
+ * member functions. The static instance pointer allows the static callback
+ * to forward results to the singleton instance.
+ */
+
 #include "ble_scanner.h"
 #include <log_buffer.h>
 

--- a/embedded/libs/ble-proxy/src/ble_scanner.h
+++ b/embedded/libs/ble-proxy/src/ble_scanner.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <NimBLEDevice.h>
+
 #include <vector>
 
 // Aurora boards advertise this service UUID for discovery
@@ -21,8 +22,7 @@ struct DiscoveredBoard {
     bool valid;
 
     DiscoveredBoard() : rssi(0), valid(false) {}
-    DiscoveredBoard(NimBLEAddress addr, const String& n, int r)
-        : address(addr), name(n), rssi(r), valid(true) {}
+    DiscoveredBoard(NimBLEAddress addr, const String& n, int r) : address(addr), name(n), rssi(r), valid(true) {}
 };
 
 typedef void (*ScanResultCallback)(const DiscoveredBoard& board);
@@ -38,7 +38,7 @@ typedef void (*ScanCompleteCallback)(const std::vector<DiscoveredBoard>& boards)
  * - Callback when scan completes
  */
 class BLEScanner : public NimBLEAdvertisedDeviceCallbacks {
-public:
+  public:
     BLEScanner();
 
     /**
@@ -47,8 +47,7 @@ public:
      * @param onComplete Callback when scan finishes
      * @param timeoutSec Scan duration in seconds (default 30)
      */
-    void startScan(ScanResultCallback onResult = nullptr,
-                   ScanCompleteCallback onComplete = nullptr,
+    void startScan(ScanResultCallback onResult = nullptr, ScanCompleteCallback onComplete = nullptr,
                    int timeoutSec = SCAN_TIMEOUT_SEC);
 
     /**
@@ -82,7 +81,7 @@ public:
     // NimBLE callback
     void onResult(NimBLEAdvertisedDevice* advertisedDevice) override;
 
-private:
+  private:
     NimBLEScan* pScan;
     std::vector<DiscoveredBoard> discoveredBoards;
     ScanResultCallback resultCallback;

--- a/embedded/libs/ble-proxy/src/ble_scanner.h
+++ b/embedded/libs/ble-proxy/src/ble_scanner.h
@@ -1,0 +1,98 @@
+#ifndef BLE_SCANNER_H
+#define BLE_SCANNER_H
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <vector>
+
+// Aurora boards advertise this service UUID for discovery
+#define AURORA_ADVERTISED_SERVICE_UUID "4488b571-7806-4df6-bcff-a2897e4953ff"
+
+// Scan timeout in seconds
+#define SCAN_TIMEOUT_SEC 30
+
+/**
+ * Information about a discovered Aurora board
+ */
+struct DiscoveredBoard {
+    NimBLEAddress address;
+    String name;
+    int rssi;
+    bool valid;
+
+    DiscoveredBoard() : rssi(0), valid(false) {}
+    DiscoveredBoard(NimBLEAddress addr, const String& n, int r)
+        : address(addr), name(n), rssi(r), valid(true) {}
+};
+
+typedef void (*ScanResultCallback)(const DiscoveredBoard& board);
+typedef void (*ScanCompleteCallback)(const std::vector<DiscoveredBoard>& boards);
+
+/**
+ * BLEScanner searches for nearby Aurora climbing boards.
+ *
+ * Features:
+ * - Filters by Aurora's advertised service UUID
+ * - Returns RSSI for signal strength indication
+ * - 30 second scan timeout
+ * - Callback when scan completes
+ */
+class BLEScanner : public NimBLEAdvertisedDeviceCallbacks {
+public:
+    BLEScanner();
+
+    /**
+     * Start scanning for Aurora boards.
+     * @param onResult Callback for each board found (optional)
+     * @param onComplete Callback when scan finishes
+     * @param timeoutSec Scan duration in seconds (default 30)
+     */
+    void startScan(ScanResultCallback onResult = nullptr,
+                   ScanCompleteCallback onComplete = nullptr,
+                   int timeoutSec = SCAN_TIMEOUT_SEC);
+
+    /**
+     * Stop an ongoing scan.
+     */
+    void stopScan();
+
+    /**
+     * Check if currently scanning.
+     */
+    bool isScanning() const;
+
+    /**
+     * Get the list of discovered boards from last scan.
+     */
+    const std::vector<DiscoveredBoard>& getDiscoveredBoards() const;
+
+    /**
+     * Get the best (highest RSSI) discovered board.
+     * @return Pointer to best board, or nullptr if none found
+     */
+    const DiscoveredBoard* getBestBoard() const;
+
+    /**
+     * Find a board by MAC address.
+     * @param mac MAC address string
+     * @return Pointer to board, or nullptr if not found
+     */
+    const DiscoveredBoard* findByAddress(const String& mac) const;
+
+    // NimBLE callback
+    void onResult(NimBLEAdvertisedDevice* advertisedDevice) override;
+
+private:
+    NimBLEScan* pScan;
+    std::vector<DiscoveredBoard> discoveredBoards;
+    ScanResultCallback resultCallback;
+    ScanCompleteCallback completeCallback;
+    bool scanning;
+
+    static void scanCompleteCB(NimBLEScanResults results);
+    static BLEScanner* instance;
+};
+
+extern BLEScanner Scanner;
+
+#endif

--- a/embedded/libs/climb-history/library.json
+++ b/embedded/libs/climb-history/library.json
@@ -1,0 +1,11 @@
+{
+  "name": "climb-history",
+  "version": "1.0.0",
+  "description": "Circular buffer for tracking recent climbs with NVS persistence",
+  "keywords": ["climbing", "history", "nvs", "storage"],
+  "frameworks": ["arduino"],
+  "platforms": ["espressif32"],
+  "dependencies": {
+    "config-manager": "*"
+  }
+}

--- a/embedded/libs/climb-history/src/climb_history.cpp
+++ b/embedded/libs/climb-history/src/climb_history.cpp
@@ -1,6 +1,8 @@
 #include "climb_history.h"
-#include <config_manager.h>
+
 #include <ArduinoJson.h>
+
+#include <config_manager.h>
 
 ClimbHistory ClimbHistoryMgr;
 
@@ -18,11 +20,11 @@ void ClimbHistory::begin() {
 }
 
 void ClimbHistory::addClimb(const char* name, const char* grade, const char* uuid) {
-    if (!name || !uuid) return;
+    if (!name || !uuid)
+        return;
 
     // Check if this is the same as the current climb (update)
-    if (hasCurrentClimb_ && history[0].valid &&
-        strcmp(history[0].uuid, uuid) == 0) {
+    if (hasCurrentClimb_ && history[0].valid && strcmp(history[0].uuid, uuid) == 0) {
         // Same climb - just update name/grade in case they changed
         strncpy(history[0].name, name, MAX_CLIMB_NAME_LEN - 1);
         history[0].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
@@ -140,7 +142,8 @@ void ClimbHistory::load() {
     int index = 0;
 
     for (JsonObject obj : arr) {
-        if (index >= MAX_CLIMB_HISTORY) break;
+        if (index >= MAX_CLIMB_HISTORY)
+            break;
 
         const char* name = obj["n"];
         const char* grade = obj["g"];

--- a/embedded/libs/climb-history/src/climb_history.cpp
+++ b/embedded/libs/climb-history/src/climb_history.cpp
@@ -1,0 +1,178 @@
+#include "climb_history.h"
+#include <config_manager.h>
+#include <ArduinoJson.h>
+
+ClimbHistory ClimbHistoryMgr;
+
+const char* ClimbHistory::NVS_KEY_HISTORY = "climb_hist";
+
+ClimbHistory::ClimbHistory() : hasCurrentClimb_(false) {
+    // Initialize all entries as invalid
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        history[i] = ClimbEntry();
+    }
+}
+
+void ClimbHistory::begin() {
+    load();
+}
+
+void ClimbHistory::addClimb(const char* name, const char* grade, const char* uuid) {
+    if (!name || !uuid) return;
+
+    // Check if this is the same as the current climb (update)
+    if (hasCurrentClimb_ && history[0].valid &&
+        strcmp(history[0].uuid, uuid) == 0) {
+        // Same climb - just update name/grade in case they changed
+        strncpy(history[0].name, name, MAX_CLIMB_NAME_LEN - 1);
+        history[0].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+        if (grade) {
+            strncpy(history[0].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+            history[0].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+        }
+        save();
+        return;
+    }
+
+    // Shift existing entries down
+    shiftDown();
+
+    // Add new climb at position 0
+    strncpy(history[0].name, name, MAX_CLIMB_NAME_LEN - 1);
+    history[0].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+
+    if (grade) {
+        strncpy(history[0].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+        history[0].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+    } else {
+        history[0].grade[0] = '\0';
+    }
+
+    strncpy(history[0].uuid, uuid, MAX_CLIMB_UUID_LEN - 1);
+    history[0].uuid[MAX_CLIMB_UUID_LEN - 1] = '\0';
+
+    history[0].valid = true;
+    hasCurrentClimb_ = true;
+
+    save();
+}
+
+void ClimbHistory::clearCurrent() {
+    hasCurrentClimb_ = false;
+    // Note: We don't remove the entry from history, just mark no current climb
+    // This way the display can still show "last climb was X"
+}
+
+const ClimbEntry* ClimbHistory::getCurrentClimb() const {
+    if (!hasCurrentClimb_ || !history[0].valid) {
+        return nullptr;
+    }
+    return &history[0];
+}
+
+const ClimbEntry* ClimbHistory::getClimb(int index) const {
+    if (index < 0 || index >= MAX_CLIMB_HISTORY) {
+        return nullptr;
+    }
+    if (!history[index].valid) {
+        return nullptr;
+    }
+    return &history[index];
+}
+
+int ClimbHistory::getCount() const {
+    int count = 0;
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        if (history[i].valid) {
+            count++;
+        }
+    }
+    return count;
+}
+
+bool ClimbHistory::hasCurrentClimb() const {
+    return hasCurrentClimb_ && history[0].valid;
+}
+
+void ClimbHistory::shiftDown() {
+    // Move each entry to the next position, oldest is discarded
+    for (int i = MAX_CLIMB_HISTORY - 1; i > 0; i--) {
+        history[i] = history[i - 1];
+    }
+    // Position 0 is now ready for new entry
+    history[0] = ClimbEntry();
+}
+
+void ClimbHistory::save() {
+    // Serialize history to JSON
+    JsonDocument doc;
+    JsonArray arr = doc.to<JsonArray>();
+
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        if (history[i].valid) {
+            JsonObject obj = arr.add<JsonObject>();
+            obj["n"] = history[i].name;
+            obj["g"] = history[i].grade;
+            obj["u"] = history[i].uuid;
+        }
+    }
+
+    String json;
+    serializeJson(doc, json);
+
+    // Store in NVS
+    Config.setString(NVS_KEY_HISTORY, json.c_str());
+}
+
+void ClimbHistory::load() {
+    String json = Config.getString(NVS_KEY_HISTORY);
+    if (json.length() == 0) {
+        return;
+    }
+
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, json);
+    if (error) {
+        return;
+    }
+
+    JsonArray arr = doc.as<JsonArray>();
+    int index = 0;
+
+    for (JsonObject obj : arr) {
+        if (index >= MAX_CLIMB_HISTORY) break;
+
+        const char* name = obj["n"];
+        const char* grade = obj["g"];
+        const char* uuid = obj["u"];
+
+        if (name && uuid) {
+            strncpy(history[index].name, name, MAX_CLIMB_NAME_LEN - 1);
+            history[index].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+
+            if (grade) {
+                strncpy(history[index].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+                history[index].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+            }
+
+            strncpy(history[index].uuid, uuid, MAX_CLIMB_UUID_LEN - 1);
+            history[index].uuid[MAX_CLIMB_UUID_LEN - 1] = '\0';
+
+            history[index].valid = true;
+            index++;
+        }
+    }
+
+    // If we loaded at least one entry, consider having a current climb
+    if (index > 0) {
+        hasCurrentClimb_ = true;
+    }
+}
+
+void ClimbHistory::clear() {
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        history[i] = ClimbEntry();
+    }
+    hasCurrentClimb_ = false;
+    Config.remove(NVS_KEY_HISTORY);
+}

--- a/embedded/libs/climb-history/src/climb_history.cpp
+++ b/embedded/libs/climb-history/src/climb_history.cpp
@@ -163,10 +163,9 @@ void ClimbHistory::load() {
         }
     }
 
-    // If we loaded at least one entry, consider having a current climb
-    if (index > 0) {
-        hasCurrentClimb_ = true;
-    }
+    // Note: We don't set hasCurrentClimb_ = true here because loaded history
+    // represents past climbs, not an active current climb. The current climb
+    // is only set when a new climb is explicitly added via addClimb().
 }
 
 void ClimbHistory::clear() {

--- a/embedded/libs/climb-history/src/climb_history.h
+++ b/embedded/libs/climb-history/src/climb_history.h
@@ -1,0 +1,121 @@
+#ifndef CLIMB_HISTORY_H
+#define CLIMB_HISTORY_H
+
+#include <Arduino.h>
+
+// Maximum number of climbs to track in history
+#define MAX_CLIMB_HISTORY 5
+
+// Maximum lengths for climb data
+#define MAX_CLIMB_NAME_LEN 64
+#define MAX_CLIMB_GRADE_LEN 16
+#define MAX_CLIMB_UUID_LEN 40
+
+/**
+ * Data structure for a single climb entry
+ */
+struct ClimbEntry {
+    char name[MAX_CLIMB_NAME_LEN];
+    char grade[MAX_CLIMB_GRADE_LEN];
+    char uuid[MAX_CLIMB_UUID_LEN];
+    bool valid;  // Whether this entry contains data
+
+    ClimbEntry() : valid(false) {
+        name[0] = '\0';
+        grade[0] = '\0';
+        uuid[0] = '\0';
+    }
+};
+
+/**
+ * ClimbHistory manages a circular buffer of recent climbs with NVS persistence.
+ *
+ * Features:
+ * - Stores the last MAX_CLIMB_HISTORY climbs
+ * - Persists to NVS for power cycle recovery
+ * - Provides access to current and previous climbs
+ * - Automatically shifts entries when adding new climbs
+ */
+class ClimbHistory {
+public:
+    ClimbHistory();
+
+    /**
+     * Initialize the climb history.
+     * Loads any persisted data from NVS.
+     */
+    void begin();
+
+    /**
+     * Add a new climb to the history.
+     * This becomes the current climb, and previous climbs shift down.
+     * If the climb UUID matches the current climb, it's treated as an update.
+     *
+     * @param name Climb name
+     * @param grade Climb grade (e.g., "V5", "6c/V5")
+     * @param uuid Climb UUID
+     */
+    void addClimb(const char* name, const char* grade, const char* uuid);
+
+    /**
+     * Clear the current climb (e.g., when LEDs are cleared).
+     * Does not remove from history, just marks no current climb.
+     */
+    void clearCurrent();
+
+    /**
+     * Get the current climb (index 0).
+     * @return Pointer to current climb entry, or nullptr if none
+     */
+    const ClimbEntry* getCurrentClimb() const;
+
+    /**
+     * Get a climb from history by index.
+     * @param index 0 = current, 1 = previous, etc.
+     * @return Pointer to climb entry, or nullptr if invalid index or empty slot
+     */
+    const ClimbEntry* getClimb(int index) const;
+
+    /**
+     * Get the number of valid entries in history.
+     * @return Count of valid entries (0 to MAX_CLIMB_HISTORY)
+     */
+    int getCount() const;
+
+    /**
+     * Check if there's a current climb.
+     * @return true if there's a valid current climb
+     */
+    bool hasCurrentClimb() const;
+
+    /**
+     * Save history to NVS.
+     * Called automatically by addClimb().
+     */
+    void save();
+
+    /**
+     * Load history from NVS.
+     * Called automatically by begin().
+     */
+    void load();
+
+    /**
+     * Clear all history entries and NVS storage.
+     */
+    void clear();
+
+private:
+    ClimbEntry history[MAX_CLIMB_HISTORY];
+    bool hasCurrentClimb_;
+
+    // NVS key for storing history
+    static const char* NVS_KEY_HISTORY;
+
+    // Shift all entries down by 1, discarding the oldest
+    void shiftDown();
+};
+
+extern ClimbHistory ClimbHistoryMgr;
+
+#endif

--- a/embedded/libs/climb-history/src/climb_history.h
+++ b/embedded/libs/climb-history/src/climb_history.h
@@ -37,7 +37,7 @@ struct ClimbEntry {
  * - Automatically shifts entries when adding new climbs
  */
 class ClimbHistory {
-public:
+  public:
     ClimbHistory();
 
     /**
@@ -105,7 +105,7 @@ public:
      */
     void clear();
 
-private:
+  private:
     ClimbEntry history[MAX_CLIMB_HISTORY];
     bool hasCurrentClimb_;
 

--- a/embedded/libs/esp-web-server/src/esp_web_server.cpp
+++ b/embedded/libs/esp-web-server/src/esp_web_server.cpp
@@ -141,6 +141,30 @@ void ESPWebServer::handleRoot() {
             <input type="range" id="brightness" min="0" max="255" value="128">
             <span class="slider-value" id="brightnessValue">128</span>
         </div>
+        <label>Display Brightness</label>
+        <div class="slider-container">
+            <input type="range" id="displayBrightness" min="0" max="255" value="128">
+            <span class="slider-value" id="displayBrightnessValue">128</span>
+        </div>
+    </div>
+
+    <div class="card">
+        <h2>BLE Proxy Mode</h2>
+        <p style="color: #888; font-size: 0.9em; margin-bottom: 15px;">
+            Enable proxy mode to forward data from official Kilter/Tension app to a nearby board.
+            This lets you use the official app while also showing climb info on this device.
+        </p>
+        <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+            <input type="checkbox" id="proxyEnabled" style="width: auto; margin: 0;">
+            <span>Enable BLE Proxy</span>
+        </label>
+        <div id="proxyMacSection" style="display: none; margin-top: 15px;">
+            <label>Target Board MAC (optional)</label>
+            <input type="text" id="proxyMac" placeholder="Auto-detect nearest board">
+            <p style="color: #888; font-size: 0.8em; margin-top: -10px;">
+                Leave empty to connect to the nearest Aurora board
+            </p>
+        </div>
     </div>
 
     <div class="card">
@@ -183,11 +207,16 @@ void ESPWebServer::handleRoot() {
                 document.getElementById('deviceName').value = cfg.device_name || '';
                 document.getElementById('brightness').value = cfg.brightness || 128;
                 document.getElementById('brightnessValue').textContent = cfg.brightness || 128;
+                document.getElementById('displayBrightness').value = cfg.display_brightness || 128;
+                document.getElementById('displayBrightnessValue').textContent = cfg.display_brightness || 128;
                 document.getElementById('sessionId').value = cfg.session_id || '';
                 document.getElementById('apiKey').value = cfg.api_key || '';
                 document.getElementById('backendHost').value = cfg.backend_host || '';
                 document.getElementById('backendPort').value = cfg.backend_port || 443;
                 document.getElementById('backendPath').value = cfg.backend_path || '/graphql';
+                document.getElementById('proxyEnabled').checked = cfg.proxy_enabled || false;
+                document.getElementById('proxyMac').value = cfg.proxy_mac || '';
+                document.getElementById('proxyMacSection').style.display = cfg.proxy_enabled ? 'block' : 'none';
             } catch (e) { console.error('Failed to load config:', e); }
         }
 
@@ -253,11 +282,14 @@ void ESPWebServer::handleRoot() {
             const config = {
                 device_name: document.getElementById('deviceName').value,
                 brightness: parseInt(document.getElementById('brightness').value),
+                display_brightness: parseInt(document.getElementById('displayBrightness').value),
                 session_id: document.getElementById('sessionId').value,
                 api_key: document.getElementById('apiKey').value,
                 backend_host: document.getElementById('backendHost').value,
                 backend_port: parseInt(document.getElementById('backendPort').value),
-                backend_path: document.getElementById('backendPath').value
+                backend_path: document.getElementById('backendPath').value,
+                proxy_enabled: document.getElementById('proxyEnabled').checked,
+                proxy_mac: document.getElementById('proxyMac').value
             };
             try {
                 await fetch('/api/config', {
@@ -288,6 +320,14 @@ void ESPWebServer::handleRoot() {
             document.getElementById('brightnessValue').textContent = this.value;
         };
 
+        document.getElementById('displayBrightness').oninput = function() {
+            document.getElementById('displayBrightnessValue').textContent = this.value;
+        };
+
+        document.getElementById('proxyEnabled').onchange = function() {
+            document.getElementById('proxyMacSection').style.display = this.checked ? 'block' : 'none';
+        };
+
         loadConfig();
         loadWifiStatus();
         setInterval(loadWifiStatus, 10000);
@@ -312,8 +352,11 @@ void ESPWebServer::handleGetConfig() {
     doc["backend_path"] = Config.getString("backend_path", "/graphql");
     doc["device_name"] = Config.getString("device_name", "Boardsesh Controller");
     doc["brightness"] = Config.getInt("brightness", 128);
+    doc["display_brightness"] = Config.getInt("disp_br", 128);
     doc["session_id"] = Config.getString("session_id");
     doc["api_key"] = Config.getString("api_key");
+    doc["proxy_enabled"] = Config.getBool("proxy_en", false);
+    doc["proxy_mac"] = Config.getString("proxy_mac");
 
     sendJson(200, doc);
 }
@@ -354,6 +397,15 @@ void ESPWebServer::handleSetConfig() {
     }
     if (doc["api_key"].is<const char*>()) {
         Config.setString("api_key", doc["api_key"]);
+    }
+    if (doc["display_brightness"].is<int>()) {
+        Config.setInt("disp_br", doc["display_brightness"]);
+    }
+    if (doc["proxy_enabled"].is<bool>()) {
+        Config.setBool("proxy_en", doc["proxy_enabled"]);
+    }
+    if (doc["proxy_mac"].is<const char*>()) {
+        Config.setString("proxy_mac", doc["proxy_mac"]);
     }
 
     sendJson(200, "{\"success\":true}");

--- a/embedded/libs/esp-web-server/src/esp_web_server.cpp
+++ b/embedded/libs/esp-web-server/src/esp_web_server.cpp
@@ -402,7 +402,7 @@ void ESPWebServer::handleSetConfig() {
         Config.setInt("disp_br", doc["display_brightness"]);
     }
     if (doc["proxy_enabled"].is<bool>()) {
-        Config.setBool("proxy_en", doc["proxy_enabled"]);
+        Config.setBool("proxy_en", doc["proxy_enabled"].as<bool>());
     }
     if (doc["proxy_mac"].is<const char*>()) {
         Config.setString("proxy_mac", doc["proxy_mac"]);

--- a/embedded/libs/graphql-ws-client/src/graphql_ws_client.h
+++ b/embedded/libs/graphql-ws-client/src/graphql_ws_client.h
@@ -72,6 +72,7 @@ class GraphQLWSClient {
     uint16_t serverPort;
     String serverPath;
     String apiKey;
+    bool useSSL;
     String sessionId;
     String subscriptionId;
 

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -1,11 +1,5 @@
 #include "led_controller.h"
 
-// For ESP32-S3 T-Display, use a different RMT channel to avoid display conflicts
-#if defined(CONFIG_IDF_TARGET_ESP32S3) && defined(ENABLE_DISPLAY)
-// Use RMT channel 1 (channel 0 might conflict with display DMA)
-#define FASTLED_RMT_MAX_CHANNELS 2
-#endif
-
 LedController LEDs;
 
 LedController::LedController() : numLeds(0), brightness(128), initialized(false) {

--- a/embedded/libs/lilygo-display/library.json
+++ b/embedded/libs/lilygo-display/library.json
@@ -1,0 +1,23 @@
+{
+    "name": "lilygo-display",
+    "version": "1.0.0",
+    "description": "Display driver and UI renderer for LilyGo T-Display S3 (170x320 ST7789)",
+    "keywords": ["esp32", "lcd", "display", "climbing", "boardsesh", "lilygo", "t-display"],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/marcodejongh/boardsesh.git"
+    },
+    "authors": [
+        {
+            "name": "Boardsesh",
+            "email": "hello@boardsesh.com"
+        }
+    ],
+    "license": "MIT",
+    "frameworks": "arduino",
+    "platforms": "espressif32",
+    "dependencies": {
+        "lovyan03/LovyanGFX": "^1.1.12",
+        "ricmoo/qrcode": "^0.0.1"
+    }
+}

--- a/embedded/libs/lilygo-display/src/grade_colors.h
+++ b/embedded/libs/lilygo-display/src/grade_colors.h
@@ -1,0 +1,180 @@
+/**
+ * V-grade color scheme for climbing grades
+ * Ported from packages/web/app/lib/grade-colors.ts
+ *
+ * Color progression from yellow (easy) to purple (hard):
+ * - V0: Yellow
+ * - V1-V2: Orange
+ * - V3-V4: Dark orange/red-orange
+ * - V5-V6: Red
+ * - V7-V10: Dark red/crimson
+ * - V11+: Purple/magenta
+ */
+
+#ifndef GRADE_COLORS_H
+#define GRADE_COLORS_H
+
+#include <Arduino.h>
+
+// Convert RGB888 to RGB565
+#define RGB565(r, g, b) ((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3))
+
+// V-grade colors (RGB565)
+#define COLOR_V0   RGB565(0xFF, 0xEB, 0x3B)  // Yellow #FFEB3B
+#define COLOR_V1   RGB565(0xFF, 0xC1, 0x07)  // Amber #FFC107
+#define COLOR_V2   RGB565(0xFF, 0x98, 0x00)  // Orange #FF9800
+#define COLOR_V3   RGB565(0xFF, 0x70, 0x43)  // Deep orange #FF7043
+#define COLOR_V4   RGB565(0xFF, 0x57, 0x22)  // Red-orange #FF5722
+#define COLOR_V5   RGB565(0xF4, 0x43, 0x36)  // Red #F44336
+#define COLOR_V6   RGB565(0xE5, 0x39, 0x35)  // Red (darker) #E53935
+#define COLOR_V7   RGB565(0xD3, 0x2F, 0x2F)  // Dark red #D32F2F
+#define COLOR_V8   RGB565(0xC6, 0x28, 0x28)  // Darker red #C62828
+#define COLOR_V9   RGB565(0xB7, 0x1C, 0x1C)  // Deep red #B71C1C
+#define COLOR_V10  RGB565(0xA1, 0x1B, 0x4A)  // Red-purple #A11B4A
+#define COLOR_V11  RGB565(0x9C, 0x27, 0xB0)  // Purple #9C27B0
+#define COLOR_V12  RGB565(0x7B, 0x1F, 0xA2)  // Dark purple #7B1FA2
+#define COLOR_V13  RGB565(0x6A, 0x1B, 0x9A)  // Darker purple #6A1B9A
+#define COLOR_V14  RGB565(0x5C, 0x1A, 0x87)  // Deep purple #5C1A87
+#define COLOR_V15  RGB565(0x4A, 0x14, 0x8C)  // Very deep purple #4A148C
+#define COLOR_V16  RGB565(0x38, 0x00, 0x6B)  // Near black purple #38006B
+#define COLOR_V17  RGB565(0x2A, 0x00, 0x54)  // Darkest purple #2A0054
+
+// Default color for unknown grades
+#define COLOR_GRADE_DEFAULT RGB565(0xC8, 0xC8, 0xC8)  // Light gray
+
+/**
+ * Get RGB565 color for a V-grade number (0-17)
+ * @param vGrade V-grade number
+ * @return RGB565 color value
+ */
+inline uint16_t getVGradeColorByNumber(int vGrade) {
+    switch (vGrade) {
+        case 0:  return COLOR_V0;
+        case 1:  return COLOR_V1;
+        case 2:  return COLOR_V2;
+        case 3:  return COLOR_V3;
+        case 4:  return COLOR_V4;
+        case 5:  return COLOR_V5;
+        case 6:  return COLOR_V6;
+        case 7:  return COLOR_V7;
+        case 8:  return COLOR_V8;
+        case 9:  return COLOR_V9;
+        case 10: return COLOR_V10;
+        case 11: return COLOR_V11;
+        case 12: return COLOR_V12;
+        case 13: return COLOR_V13;
+        case 14: return COLOR_V14;
+        case 15: return COLOR_V15;
+        case 16: return COLOR_V16;
+        case 17: return COLOR_V17;
+        default: return vGrade > 17 ? COLOR_V17 : COLOR_GRADE_DEFAULT;
+    }
+}
+
+/**
+ * Get RGB565 color for a Font grade (e.g., "6a", "7b+")
+ * Maps Font grades to their equivalent V-grade colors
+ * @param fontGrade Font grade string
+ * @return RGB565 color value
+ */
+inline uint16_t getFontGradeColor(const char* fontGrade) {
+    if (!fontGrade || strlen(fontGrade) < 2) return COLOR_GRADE_DEFAULT;
+
+    char grade = fontGrade[0];
+    char sub = fontGrade[1];
+    bool plus = (strlen(fontGrade) >= 3 && fontGrade[2] == '+');
+
+    // Map Font grades to V-grade colors
+    if (grade == '4') return COLOR_V0;           // 4a, 4b, 4c -> V0
+    if (grade == '5') {
+        if (sub == 'a' || sub == 'b') return COLOR_V1;  // 5a, 5b -> V1
+        if (sub == 'c') return COLOR_V2;                 // 5c -> V2
+    }
+    if (grade == '6') {
+        if (sub == 'a') return COLOR_V3;                 // 6a, 6a+ -> V3
+        if (sub == 'b') return COLOR_V4;                 // 6b, 6b+ -> V4
+        if (sub == 'c') return COLOR_V5;                 // 6c, 6c+ -> V5
+    }
+    if (grade == '7') {
+        if (sub == 'a' && !plus) return COLOR_V6;        // 7a -> V6
+        if (sub == 'a' && plus) return COLOR_V7;         // 7a+ -> V7
+        if (sub == 'b') return COLOR_V8;                 // 7b, 7b+ -> V8
+        if (sub == 'c' && !plus) return COLOR_V9;        // 7c -> V9
+        if (sub == 'c' && plus) return COLOR_V10;        // 7c+ -> V10
+    }
+    if (grade == '8') {
+        if (sub == 'a' && !plus) return COLOR_V11;       // 8a -> V11
+        if (sub == 'a' && plus) return COLOR_V12;        // 8a+ -> V12
+        if (sub == 'b' && !plus) return COLOR_V13;       // 8b -> V13
+        if (sub == 'b' && plus) return COLOR_V14;        // 8b+ -> V14
+        if (sub == 'c' && !plus) return COLOR_V15;       // 8c -> V15
+        if (sub == 'c' && plus) return COLOR_V16;        // 8c+ -> V16
+    }
+
+    return COLOR_GRADE_DEFAULT;
+}
+
+/**
+ * Get RGB565 color for a grade string (e.g., "V3", "6a/V3", "V10")
+ * Tries to extract V-grade first, falls back to Font grade
+ * @param grade Grade string
+ * @return RGB565 color value
+ */
+inline uint16_t getGradeColor(const char* grade) {
+    if (!grade || strlen(grade) == 0) return COLOR_GRADE_DEFAULT;
+
+    // Look for V-grade pattern (V followed by number)
+    const char* vPos = strchr(grade, 'V');
+    if (!vPos) vPos = strchr(grade, 'v');
+
+    if (vPos) {
+        // Parse the number after V
+        int vGrade = atoi(vPos + 1);
+        if (vGrade >= 0 && vGrade <= 17) {
+            return getVGradeColorByNumber(vGrade);
+        }
+        // Handle V17+
+        if (vGrade > 17) return COLOR_V17;
+    }
+
+    // Try Font grade (look for pattern like "6a" or "7b+")
+    for (const char* p = grade; *p; p++) {
+        if (*p >= '4' && *p <= '8' && p[1] && (p[1] == 'a' || p[1] == 'b' || p[1] == 'c' ||
+            p[1] == 'A' || p[1] == 'B' || p[1] == 'C')) {
+            char fontGrade[4] = {0};
+            fontGrade[0] = *p;
+            fontGrade[1] = (p[1] >= 'A' && p[1] <= 'C') ? (p[1] + 32) : p[1];  // lowercase
+            if (p[2] == '+') fontGrade[2] = '+';
+            return getFontGradeColor(fontGrade);
+        }
+    }
+
+    return COLOR_GRADE_DEFAULT;
+}
+
+/**
+ * Determine if a color is light (for text contrast)
+ * @param color RGB565 color
+ * @return true if color is light and should use dark text
+ */
+inline bool isLightColor(uint16_t color) {
+    // Extract RGB components from RGB565
+    uint8_t r = (color >> 11) << 3;
+    uint8_t g = ((color >> 5) & 0x3F) << 2;
+    uint8_t b = (color & 0x1F) << 3;
+
+    // Calculate relative luminance
+    float luminance = (0.299f * r + 0.587f * g + 0.114f * b) / 255.0f;
+    return luminance > 0.5f;
+}
+
+/**
+ * Get text color (black or white) for good contrast against background
+ * @param bgColor Background RGB565 color
+ * @return RGB565 color for text (black or white)
+ */
+inline uint16_t getGradeTextColor(uint16_t bgColor) {
+    return isLightColor(bgColor) ? 0x0000 : 0xFFFF;  // Black or White
+}
+
+#endif // GRADE_COLORS_H

--- a/embedded/libs/lilygo-display/src/grade_colors.h
+++ b/embedded/libs/lilygo-display/src/grade_colors.h
@@ -20,24 +20,24 @@
 #define RGB565(r, g, b) ((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3))
 
 // V-grade colors (RGB565)
-#define COLOR_V0   RGB565(0xFF, 0xEB, 0x3B)  // Yellow #FFEB3B
-#define COLOR_V1   RGB565(0xFF, 0xC1, 0x07)  // Amber #FFC107
-#define COLOR_V2   RGB565(0xFF, 0x98, 0x00)  // Orange #FF9800
-#define COLOR_V3   RGB565(0xFF, 0x70, 0x43)  // Deep orange #FF7043
-#define COLOR_V4   RGB565(0xFF, 0x57, 0x22)  // Red-orange #FF5722
-#define COLOR_V5   RGB565(0xF4, 0x43, 0x36)  // Red #F44336
-#define COLOR_V6   RGB565(0xE5, 0x39, 0x35)  // Red (darker) #E53935
-#define COLOR_V7   RGB565(0xD3, 0x2F, 0x2F)  // Dark red #D32F2F
-#define COLOR_V8   RGB565(0xC6, 0x28, 0x28)  // Darker red #C62828
-#define COLOR_V9   RGB565(0xB7, 0x1C, 0x1C)  // Deep red #B71C1C
-#define COLOR_V10  RGB565(0xA1, 0x1B, 0x4A)  // Red-purple #A11B4A
-#define COLOR_V11  RGB565(0x9C, 0x27, 0xB0)  // Purple #9C27B0
-#define COLOR_V12  RGB565(0x7B, 0x1F, 0xA2)  // Dark purple #7B1FA2
-#define COLOR_V13  RGB565(0x6A, 0x1B, 0x9A)  // Darker purple #6A1B9A
-#define COLOR_V14  RGB565(0x5C, 0x1A, 0x87)  // Deep purple #5C1A87
-#define COLOR_V15  RGB565(0x4A, 0x14, 0x8C)  // Very deep purple #4A148C
-#define COLOR_V16  RGB565(0x38, 0x00, 0x6B)  // Near black purple #38006B
-#define COLOR_V17  RGB565(0x2A, 0x00, 0x54)  // Darkest purple #2A0054
+#define COLOR_V0 RGB565(0xFF, 0xEB, 0x3B)   // Yellow #FFEB3B
+#define COLOR_V1 RGB565(0xFF, 0xC1, 0x07)   // Amber #FFC107
+#define COLOR_V2 RGB565(0xFF, 0x98, 0x00)   // Orange #FF9800
+#define COLOR_V3 RGB565(0xFF, 0x70, 0x43)   // Deep orange #FF7043
+#define COLOR_V4 RGB565(0xFF, 0x57, 0x22)   // Red-orange #FF5722
+#define COLOR_V5 RGB565(0xF4, 0x43, 0x36)   // Red #F44336
+#define COLOR_V6 RGB565(0xE5, 0x39, 0x35)   // Red (darker) #E53935
+#define COLOR_V7 RGB565(0xD3, 0x2F, 0x2F)   // Dark red #D32F2F
+#define COLOR_V8 RGB565(0xC6, 0x28, 0x28)   // Darker red #C62828
+#define COLOR_V9 RGB565(0xB7, 0x1C, 0x1C)   // Deep red #B71C1C
+#define COLOR_V10 RGB565(0xA1, 0x1B, 0x4A)  // Red-purple #A11B4A
+#define COLOR_V11 RGB565(0x9C, 0x27, 0xB0)  // Purple #9C27B0
+#define COLOR_V12 RGB565(0x7B, 0x1F, 0xA2)  // Dark purple #7B1FA2
+#define COLOR_V13 RGB565(0x6A, 0x1B, 0x9A)  // Darker purple #6A1B9A
+#define COLOR_V14 RGB565(0x5C, 0x1A, 0x87)  // Deep purple #5C1A87
+#define COLOR_V15 RGB565(0x4A, 0x14, 0x8C)  // Very deep purple #4A148C
+#define COLOR_V16 RGB565(0x38, 0x00, 0x6B)  // Near black purple #38006B
+#define COLOR_V17 RGB565(0x2A, 0x00, 0x54)  // Darkest purple #2A0054
 
 // Default color for unknown grades
 #define COLOR_GRADE_DEFAULT RGB565(0xC8, 0xC8, 0xC8)  // Light gray
@@ -49,25 +49,44 @@
  */
 inline uint16_t getVGradeColorByNumber(int vGrade) {
     switch (vGrade) {
-        case 0:  return COLOR_V0;
-        case 1:  return COLOR_V1;
-        case 2:  return COLOR_V2;
-        case 3:  return COLOR_V3;
-        case 4:  return COLOR_V4;
-        case 5:  return COLOR_V5;
-        case 6:  return COLOR_V6;
-        case 7:  return COLOR_V7;
-        case 8:  return COLOR_V8;
-        case 9:  return COLOR_V9;
-        case 10: return COLOR_V10;
-        case 11: return COLOR_V11;
-        case 12: return COLOR_V12;
-        case 13: return COLOR_V13;
-        case 14: return COLOR_V14;
-        case 15: return COLOR_V15;
-        case 16: return COLOR_V16;
-        case 17: return COLOR_V17;
-        default: return vGrade > 17 ? COLOR_V17 : COLOR_GRADE_DEFAULT;
+        case 0:
+            return COLOR_V0;
+        case 1:
+            return COLOR_V1;
+        case 2:
+            return COLOR_V2;
+        case 3:
+            return COLOR_V3;
+        case 4:
+            return COLOR_V4;
+        case 5:
+            return COLOR_V5;
+        case 6:
+            return COLOR_V6;
+        case 7:
+            return COLOR_V7;
+        case 8:
+            return COLOR_V8;
+        case 9:
+            return COLOR_V9;
+        case 10:
+            return COLOR_V10;
+        case 11:
+            return COLOR_V11;
+        case 12:
+            return COLOR_V12;
+        case 13:
+            return COLOR_V13;
+        case 14:
+            return COLOR_V14;
+        case 15:
+            return COLOR_V15;
+        case 16:
+            return COLOR_V16;
+        case 17:
+            return COLOR_V17;
+        default:
+            return vGrade > 17 ? COLOR_V17 : COLOR_GRADE_DEFAULT;
     }
 }
 
@@ -78,37 +97,55 @@ inline uint16_t getVGradeColorByNumber(int vGrade) {
  * @return RGB565 color value
  */
 inline uint16_t getFontGradeColor(const char* fontGrade) {
-    if (!fontGrade || strlen(fontGrade) < 2) return COLOR_GRADE_DEFAULT;
+    if (!fontGrade || strlen(fontGrade) < 2)
+        return COLOR_GRADE_DEFAULT;
 
     char grade = fontGrade[0];
     char sub = fontGrade[1];
     bool plus = (strlen(fontGrade) >= 3 && fontGrade[2] == '+');
 
     // Map Font grades to V-grade colors
-    if (grade == '4') return COLOR_V0;           // 4a, 4b, 4c -> V0
+    if (grade == '4')
+        return COLOR_V0;  // 4a, 4b, 4c -> V0
     if (grade == '5') {
-        if (sub == 'a' || sub == 'b') return COLOR_V1;  // 5a, 5b -> V1
-        if (sub == 'c') return COLOR_V2;                 // 5c -> V2
+        if (sub == 'a' || sub == 'b')
+            return COLOR_V1;  // 5a, 5b -> V1
+        if (sub == 'c')
+            return COLOR_V2;  // 5c -> V2
     }
     if (grade == '6') {
-        if (sub == 'a') return COLOR_V3;                 // 6a, 6a+ -> V3
-        if (sub == 'b') return COLOR_V4;                 // 6b, 6b+ -> V4
-        if (sub == 'c') return COLOR_V5;                 // 6c, 6c+ -> V5
+        if (sub == 'a')
+            return COLOR_V3;  // 6a, 6a+ -> V3
+        if (sub == 'b')
+            return COLOR_V4;  // 6b, 6b+ -> V4
+        if (sub == 'c')
+            return COLOR_V5;  // 6c, 6c+ -> V5
     }
     if (grade == '7') {
-        if (sub == 'a' && !plus) return COLOR_V6;        // 7a -> V6
-        if (sub == 'a' && plus) return COLOR_V7;         // 7a+ -> V7
-        if (sub == 'b') return COLOR_V8;                 // 7b, 7b+ -> V8
-        if (sub == 'c' && !plus) return COLOR_V9;        // 7c -> V9
-        if (sub == 'c' && plus) return COLOR_V10;        // 7c+ -> V10
+        if (sub == 'a' && !plus)
+            return COLOR_V6;  // 7a -> V6
+        if (sub == 'a' && plus)
+            return COLOR_V7;  // 7a+ -> V7
+        if (sub == 'b')
+            return COLOR_V8;  // 7b, 7b+ -> V8
+        if (sub == 'c' && !plus)
+            return COLOR_V9;  // 7c -> V9
+        if (sub == 'c' && plus)
+            return COLOR_V10;  // 7c+ -> V10
     }
     if (grade == '8') {
-        if (sub == 'a' && !plus) return COLOR_V11;       // 8a -> V11
-        if (sub == 'a' && plus) return COLOR_V12;        // 8a+ -> V12
-        if (sub == 'b' && !plus) return COLOR_V13;       // 8b -> V13
-        if (sub == 'b' && plus) return COLOR_V14;        // 8b+ -> V14
-        if (sub == 'c' && !plus) return COLOR_V15;       // 8c -> V15
-        if (sub == 'c' && plus) return COLOR_V16;        // 8c+ -> V16
+        if (sub == 'a' && !plus)
+            return COLOR_V11;  // 8a -> V11
+        if (sub == 'a' && plus)
+            return COLOR_V12;  // 8a+ -> V12
+        if (sub == 'b' && !plus)
+            return COLOR_V13;  // 8b -> V13
+        if (sub == 'b' && plus)
+            return COLOR_V14;  // 8b+ -> V14
+        if (sub == 'c' && !plus)
+            return COLOR_V15;  // 8c -> V15
+        if (sub == 'c' && plus)
+            return COLOR_V16;  // 8c+ -> V16
     }
 
     return COLOR_GRADE_DEFAULT;
@@ -121,11 +158,13 @@ inline uint16_t getFontGradeColor(const char* fontGrade) {
  * @return RGB565 color value
  */
 inline uint16_t getGradeColor(const char* grade) {
-    if (!grade || strlen(grade) == 0) return COLOR_GRADE_DEFAULT;
+    if (!grade || strlen(grade) == 0)
+        return COLOR_GRADE_DEFAULT;
 
     // Look for V-grade pattern (V followed by number)
     const char* vPos = strchr(grade, 'V');
-    if (!vPos) vPos = strchr(grade, 'v');
+    if (!vPos)
+        vPos = strchr(grade, 'v');
 
     if (vPos) {
         // Parse the number after V
@@ -134,17 +173,19 @@ inline uint16_t getGradeColor(const char* grade) {
             return getVGradeColorByNumber(vGrade);
         }
         // Handle V17+
-        if (vGrade > 17) return COLOR_V17;
+        if (vGrade > 17)
+            return COLOR_V17;
     }
 
     // Try Font grade (look for pattern like "6a" or "7b+")
     for (const char* p = grade; *p; p++) {
-        if (*p >= '4' && *p <= '8' && p[1] && (p[1] == 'a' || p[1] == 'b' || p[1] == 'c' ||
-            p[1] == 'A' || p[1] == 'B' || p[1] == 'C')) {
+        if (*p >= '4' && *p <= '8' && p[1] &&
+            (p[1] == 'a' || p[1] == 'b' || p[1] == 'c' || p[1] == 'A' || p[1] == 'B' || p[1] == 'C')) {
             char fontGrade[4] = {0};
             fontGrade[0] = *p;
             fontGrade[1] = (p[1] >= 'A' && p[1] <= 'C') ? (p[1] + 32) : p[1];  // lowercase
-            if (p[2] == '+') fontGrade[2] = '+';
+            if (p[2] == '+')
+                fontGrade[2] = '+';
             return getFontGradeColor(fontGrade);
         }
     }
@@ -177,4 +218,4 @@ inline uint16_t getGradeTextColor(uint16_t bgColor) {
     return isLightColor(bgColor) ? 0x0000 : 0xFFFF;  // Black or White
 }
 
-#endif // GRADE_COLORS_H
+#endif  // GRADE_COLORS_H

--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -1,5 +1,7 @@
 #include "lilygo_display.h"
+
 #include "grade_colors.h"
+
 #include <qrcode.h>
 
 // Global display instance
@@ -76,18 +78,10 @@ LGFX_TDisplayS3::LGFX_TDisplayS3() {
 // ============================================
 
 LilyGoDisplay::LilyGoDisplay()
-    : _wifiConnected(false)
-    , _backendConnected(false)
-    , _bleEnabled(false)
-    , _bleConnected(false)
-    , _hasClimb(false)
-    , _angle(0)
-    , _boardType("kilter")
-    , _hasQRCode(false) {
-}
+    : _wifiConnected(false), _backendConnected(false), _bleEnabled(false), _bleConnected(false), _hasClimb(false),
+      _angle(0), _boardType("kilter"), _hasQRCode(false) {}
 
-LilyGoDisplay::~LilyGoDisplay() {
-}
+LilyGoDisplay::~LilyGoDisplay() {}
 
 bool LilyGoDisplay::begin() {
     // Enable display power
@@ -97,7 +91,7 @@ bool LilyGoDisplay::begin() {
 
     // Initialize display
     _display.init();
-    _display.setRotation(0);  // Portrait mode
+    _display.setRotation(0);      // Portrait mode
     _display.setBrightness(255);  // Max brightness
 
     // Test pattern to verify display works
@@ -203,8 +197,8 @@ void LilyGoDisplay::showConfigPortal(const char* apName, const char* ip) {
     _display.setTextDatum(lgfx::top_left);
 }
 
-void LilyGoDisplay::showClimb(const char* name, const char* grade, const char* gradeColor,
-                               int angle, const char* uuid, const char* boardType) {
+void LilyGoDisplay::showClimb(const char* name, const char* grade, const char* gradeColor, int angle, const char* uuid,
+                              const char* boardType) {
     // Store climb data
     _climbName = name ? name : "";
     _grade = grade ? grade : "";
@@ -243,7 +237,8 @@ void LilyGoDisplay::showNoClimb() {
 }
 
 void LilyGoDisplay::addToHistory(const char* name, const char* grade, const char* gradeColor) {
-    if (!name || strlen(name) == 0) return;
+    if (!name || strlen(name) == 0)
+        return;
 
     ClimbHistoryEntry entry;
     entry.name = name;
@@ -396,7 +391,8 @@ void LilyGoDisplay::drawQRCode() {
     // Calculate scale factor for QR code
     int qrSize = qrCode.size;
     int pixelSize = QR_CODE_SIZE / qrSize;
-    if (pixelSize < 1) pixelSize = 1;
+    if (pixelSize < 1)
+        pixelSize = 1;
 
     int actualQrSize = pixelSize * qrSize;
     int qrX = (SCREEN_WIDTH - actualQrSize) / 2;
@@ -409,8 +405,7 @@ void LilyGoDisplay::drawQRCode() {
     for (uint8_t y = 0; y < qrSize; y++) {
         for (uint8_t x = 0; x < qrSize; x++) {
             if (qrcode_getModule(&qrCode, x, y)) {
-                _display.fillRect(qrX + x * pixelSize, qrY + y * pixelSize,
-                                 pixelSize, pixelSize, COLOR_QR_FG);
+                _display.fillRect(qrX + x * pixelSize, qrY + y * pixelSize, pixelSize, pixelSize, COLOR_QR_FG);
             }
         }
     }

--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -1,4 +1,5 @@
 #include "lilygo_display.h"
+#include "grade_colors.h"
 #include <qrcode.h>
 
 // Global display instance
@@ -340,20 +341,14 @@ void LilyGoDisplay::drawCurrentClimb() {
         int badgeX = (SCREEN_WIDTH - badgeWidth) / 2;
         int badgeY = GRADE_Y;
 
-        // Get grade color
-        uint16_t gradeColor565 = COLOR_ACCENT;
-        if (_gradeColor.length() > 0) {
-            gradeColor565 = hexToRgb565(_gradeColor.c_str());
-        }
+        // Get grade color - calculate from grade string using same logic as frontend
+        uint16_t gradeColor565 = getGradeColor(_grade.c_str());
 
         // Draw rounded rectangle badge
         _display.fillRoundRect(badgeX, badgeY, badgeWidth, badgeHeight, 8, gradeColor565);
 
         // Draw grade text (determine text color based on background brightness)
-        uint8_t r = ((gradeColor565 >> 11) & 0x1F) << 3;
-        uint8_t g = ((gradeColor565 >> 5) & 0x3F) << 2;
-        uint8_t b = (gradeColor565 & 0x1F) << 3;
-        uint16_t textColor = (r + g + b > 384) ? 0x0000 : 0xFFFF;
+        uint16_t textColor = getGradeTextColor(gradeColor565);
 
         _display.setFont(&fonts::FreeSansBold12pt7b);
         _display.setTextColor(textColor);
@@ -446,10 +441,10 @@ void LilyGoDisplay::drawHistory() {
     for (int i = 0; i < itemsToShow; i++) {
         const ClimbHistoryEntry& entry = _history[_history.size() - 1 - i];
 
-        // Draw bullet with grade color
+        // Draw bullet with grade color (calculated from grade string)
         uint16_t bulletColor = COLOR_TEXT_DIM;
-        if (entry.gradeColor.length() > 0) {
-            bulletColor = hexToRgb565(entry.gradeColor.c_str());
+        if (entry.grade.length() > 0) {
+            bulletColor = getGradeColor(entry.grade.c_str());
         }
         _display.fillCircle(8, y + 6, 3, bulletColor);
 

--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -1,0 +1,497 @@
+#include "lilygo_display.h"
+#include <qrcode.h>
+
+// Global display instance
+LilyGoDisplay Display;
+
+// ============================================
+// LGFX_TDisplayS3 Implementation
+// ============================================
+
+LGFX_TDisplayS3::LGFX_TDisplayS3() {
+    // Bus configuration for parallel 8-bit
+    {
+        auto cfg = _bus_instance.config();
+        cfg.port = 0;
+        cfg.freq_write = 20000000;
+        cfg.pin_wr = LCD_WR_PIN;
+        cfg.pin_rd = LCD_RD_PIN;
+        cfg.pin_rs = LCD_RS_PIN;
+
+        cfg.pin_d0 = LCD_D0_PIN;
+        cfg.pin_d1 = LCD_D1_PIN;
+        cfg.pin_d2 = LCD_D2_PIN;
+        cfg.pin_d3 = LCD_D3_PIN;
+        cfg.pin_d4 = LCD_D4_PIN;
+        cfg.pin_d5 = LCD_D5_PIN;
+        cfg.pin_d6 = LCD_D6_PIN;
+        cfg.pin_d7 = LCD_D7_PIN;
+
+        _bus_instance.config(cfg);
+        _panel_instance.setBus(&_bus_instance);
+    }
+
+    // Panel configuration
+    {
+        auto cfg = _panel_instance.config();
+        cfg.pin_cs = LCD_CS_PIN;
+        cfg.pin_rst = LCD_RST_PIN;
+        cfg.pin_busy = -1;
+
+        cfg.memory_width = LILYGO_SCREEN_WIDTH;
+        cfg.memory_height = LILYGO_SCREEN_HEIGHT;
+        cfg.panel_width = LILYGO_SCREEN_WIDTH;
+        cfg.panel_height = LILYGO_SCREEN_HEIGHT;
+        cfg.offset_x = 35;
+        cfg.offset_y = 0;
+        cfg.offset_rotation = 0;
+        cfg.dummy_read_pixel = 8;
+        cfg.dummy_read_bits = 1;
+        cfg.readable = true;
+        cfg.invert = true;
+        cfg.rgb_order = false;
+        cfg.dlen_16bit = false;
+        cfg.bus_shared = true;
+
+        _panel_instance.config(cfg);
+    }
+
+    // Backlight configuration
+    {
+        auto cfg = _light_instance.config();
+        cfg.pin_bl = LCD_BL_PIN;
+        cfg.invert = false;
+        cfg.freq = 12000;
+        cfg.pwm_channel = 0;
+        _light_instance.config(cfg);
+        _panel_instance.setLight(&_light_instance);
+    }
+
+    setPanel(&_panel_instance);
+}
+
+// ============================================
+// LilyGoDisplay Implementation
+// ============================================
+
+LilyGoDisplay::LilyGoDisplay()
+    : _wifiConnected(false)
+    , _backendConnected(false)
+    , _bleEnabled(false)
+    , _bleConnected(false)
+    , _hasClimb(false)
+    , _angle(0)
+    , _boardType("kilter")
+    , _hasQRCode(false) {
+}
+
+LilyGoDisplay::~LilyGoDisplay() {
+}
+
+bool LilyGoDisplay::begin() {
+    // Enable display power
+    pinMode(LCD_POWER_PIN, OUTPUT);
+    digitalWrite(LCD_POWER_PIN, HIGH);
+    delay(100);
+
+    // Initialize display
+    _display.init();
+    _display.setRotation(0);  // Portrait mode
+    _display.setBrightness(255);  // Max brightness
+
+    // Test pattern to verify display works
+    _display.fillScreen(0xF800);  // RED
+    delay(500);
+    _display.fillScreen(0x07E0);  // GREEN
+    delay(500);
+    _display.fillScreen(0x001F);  // BLUE
+    delay(500);
+
+    _display.fillScreen(COLOR_BACKGROUND);
+    _display.setTextColor(COLOR_TEXT);
+
+    // Initialize buttons
+    pinMode(BUTTON_1_PIN, INPUT_PULLUP);
+    pinMode(BUTTON_2_PIN, INPUT_PULLUP);
+
+    return true;
+}
+
+void LilyGoDisplay::setWiFiStatus(bool connected) {
+    _wifiConnected = connected;
+    drawStatusBar();
+}
+
+void LilyGoDisplay::setBackendStatus(bool connected) {
+    _backendConnected = connected;
+    drawStatusBar();
+}
+
+void LilyGoDisplay::setBleStatus(bool enabled, bool connected) {
+    _bleEnabled = enabled;
+    _bleConnected = connected;
+    drawStatusBar();
+}
+
+void LilyGoDisplay::showConnecting() {
+    _display.fillScreen(COLOR_BACKGROUND);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_TEXT);
+    _display.setTextDatum(lgfx::middle_center);
+    _display.drawString("Connecting...", SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 - 20);
+
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT_DIM);
+    _display.drawString("Boardsesh Queue", SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 20);
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
+void LilyGoDisplay::showError(const char* message, const char* ipAddress) {
+    _display.fillScreen(COLOR_BACKGROUND);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_STATUS_ERROR);
+    _display.setTextDatum(lgfx::middle_center);
+    _display.drawString("Error", SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 - 30);
+
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT);
+    _display.drawString(message, SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 10);
+
+    // Show IP if provided
+    if (ipAddress && strlen(ipAddress) > 0) {
+        _display.setTextColor(COLOR_TEXT_DIM);
+        _display.setFont(&fonts::Font0);
+        _display.drawString(ipAddress, SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 50);
+    }
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
+void LilyGoDisplay::showConfigPortal(const char* apName, const char* ip) {
+    _display.fillScreen(COLOR_BACKGROUND);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_ACCENT);
+    _display.setTextDatum(lgfx::top_center);
+    _display.drawString("WiFi Setup", SCREEN_WIDTH / 2, 20);
+
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT);
+    _display.drawString("Connect to WiFi:", SCREEN_WIDTH / 2, 60);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_STATUS_OK);
+    _display.drawString(apName, SCREEN_WIDTH / 2, 90);
+
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT);
+    _display.drawString("Then open browser:", SCREEN_WIDTH / 2, 140);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_ACCENT);
+    _display.drawString(ip, SCREEN_WIDTH / 2, 170);
+
+    _display.setFont(&fonts::Font0);
+    _display.setTextColor(COLOR_TEXT_DIM);
+    _display.drawString("Enter your WiFi", SCREEN_WIDTH / 2, 220);
+    _display.drawString("credentials to continue", SCREEN_WIDTH / 2, 235);
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
+void LilyGoDisplay::showClimb(const char* name, const char* grade, const char* gradeColor,
+                               int angle, const char* uuid, const char* boardType) {
+    // Store climb data
+    _climbName = name ? name : "";
+    _grade = grade ? grade : "";
+    _gradeColor = gradeColor ? gradeColor : "";
+    _angle = angle;
+    _climbUuid = uuid ? uuid : "";
+    _boardType = boardType ? boardType : "kilter";
+    _hasClimb = true;
+
+    // Generate QR code for the climb
+    if (_climbUuid.length() > 0) {
+        String url;
+        if (_boardType == "tension") {
+            url = "https://tensionboardapp2.com/climbs/";
+        } else {
+            url = "https://kilterboardapp.com/climbs/";
+        }
+        url += _climbUuid;
+        generateQRCode(url.c_str());
+    }
+
+    // Update display
+    refresh();
+}
+
+void LilyGoDisplay::showNoClimb() {
+    _hasClimb = false;
+    _climbName = "";
+    _grade = "";
+    _gradeColor = "";
+    _angle = 0;
+    _climbUuid = "";
+    _hasQRCode = false;
+
+    refresh();
+}
+
+void LilyGoDisplay::addToHistory(const char* name, const char* grade, const char* gradeColor) {
+    if (!name || strlen(name) == 0) return;
+
+    ClimbHistoryEntry entry;
+    entry.name = name;
+    entry.grade = grade ? grade : "";
+    entry.gradeColor = gradeColor ? gradeColor : "";
+
+    _history.push_back(entry);
+
+    // Keep only last N items
+    while (_history.size() > MAX_HISTORY_ITEMS) {
+        _history.erase(_history.begin());
+    }
+}
+
+void LilyGoDisplay::clearHistory() {
+    _history.clear();
+}
+
+void LilyGoDisplay::refresh() {
+    drawStatusBar();
+    drawCurrentClimb();
+    drawQRCode();
+    drawHistory();
+}
+
+void LilyGoDisplay::drawStatusBar() {
+    // Clear status bar area
+    _display.fillRect(0, STATUS_BAR_Y, SCREEN_WIDTH, STATUS_BAR_HEIGHT, COLOR_BACKGROUND);
+
+    // WiFi indicator
+    _display.setTextSize(1);
+    _display.setFont(&fonts::Font0);
+    _display.setCursor(4, STATUS_BAR_Y + 6);
+    _display.setTextColor(_wifiConnected ? COLOR_STATUS_OK : COLOR_STATUS_ERROR);
+    _display.print("WiFi");
+
+    // Draw status dot
+    _display.fillCircle(35, STATUS_BAR_Y + 10, 4, _wifiConnected ? COLOR_STATUS_OK : COLOR_STATUS_OFF);
+
+    // Backend indicator
+    _display.setCursor(55, STATUS_BAR_Y + 6);
+    _display.setTextColor(_backendConnected ? COLOR_STATUS_OK : COLOR_STATUS_ERROR);
+    _display.print("WS");
+    _display.fillCircle(75, STATUS_BAR_Y + 10, 4, _backendConnected ? COLOR_STATUS_OK : COLOR_STATUS_OFF);
+
+    // BLE indicator (if enabled)
+    if (_bleEnabled) {
+        _display.setCursor(95, STATUS_BAR_Y + 6);
+        _display.setTextColor(_bleConnected ? COLOR_STATUS_OK : COLOR_TEXT_DIM);
+        _display.print("BLE");
+        _display.fillCircle(120, STATUS_BAR_Y + 10, 4, _bleConnected ? COLOR_STATUS_OK : COLOR_STATUS_OFF);
+    }
+
+    // Angle display (right side)
+    if (_hasClimb && _angle > 0) {
+        _display.setTextColor(COLOR_TEXT);
+        _display.setCursor(SCREEN_WIDTH - 35, STATUS_BAR_Y + 6);
+        _display.printf("%d", _angle);
+        _display.drawCircle(SCREEN_WIDTH - 8, STATUS_BAR_Y + 7, 2, COLOR_TEXT);  // Degree symbol
+    }
+}
+
+void LilyGoDisplay::drawCurrentClimb() {
+    int yStart = CURRENT_CLIMB_Y;
+
+    // Clear current climb area
+    _display.fillRect(0, yStart, SCREEN_WIDTH, CURRENT_CLIMB_HEIGHT, COLOR_BACKGROUND);
+
+    if (!_hasClimb) {
+        // Show "waiting for climb" message
+        _display.setFont(&fonts::Font2);
+        _display.setTextColor(COLOR_TEXT_DIM);
+        _display.setTextDatum(lgfx::middle_center);
+        _display.drawString("Waiting for climb...", SCREEN_WIDTH / 2, yStart + CURRENT_CLIMB_HEIGHT / 2);
+        _display.setTextDatum(lgfx::top_left);
+        return;
+    }
+
+    // Draw climb name (may need to truncate)
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_TEXT);
+    _display.setTextDatum(lgfx::top_center);
+
+    String displayName = _climbName;
+    if (displayName.length() > 18) {
+        displayName = displayName.substring(0, 15) + "...";
+    }
+    _display.drawString(displayName.c_str(), SCREEN_WIDTH / 2, CLIMB_NAME_Y);
+
+    // Draw grade badge
+    if (_grade.length() > 0) {
+        // Calculate badge dimensions
+        int badgeWidth = 80;
+        int badgeHeight = 36;
+        int badgeX = (SCREEN_WIDTH - badgeWidth) / 2;
+        int badgeY = GRADE_Y;
+
+        // Get grade color
+        uint16_t gradeColor565 = COLOR_ACCENT;
+        if (_gradeColor.length() > 0) {
+            gradeColor565 = hexToRgb565(_gradeColor.c_str());
+        }
+
+        // Draw rounded rectangle badge
+        _display.fillRoundRect(badgeX, badgeY, badgeWidth, badgeHeight, 8, gradeColor565);
+
+        // Draw grade text (determine text color based on background brightness)
+        uint8_t r = ((gradeColor565 >> 11) & 0x1F) << 3;
+        uint8_t g = ((gradeColor565 >> 5) & 0x3F) << 2;
+        uint8_t b = (gradeColor565 & 0x1F) << 3;
+        uint16_t textColor = (r + g + b > 384) ? 0x0000 : 0xFFFF;
+
+        _display.setFont(&fonts::FreeSansBold12pt7b);
+        _display.setTextColor(textColor);
+        _display.setTextDatum(lgfx::middle_center);
+
+        // Extract just the V-grade for display if combined format
+        String displayGrade = _grade;
+        int slashPos = displayGrade.indexOf('/');
+        if (slashPos > 0) {
+            displayGrade = displayGrade.substring(slashPos + 1);
+        }
+
+        _display.drawString(displayGrade.c_str(), badgeX + badgeWidth / 2, badgeY + badgeHeight / 2);
+    }
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
+void LilyGoDisplay::generateQRCode(const char* url) {
+    // Store URL and generate QR code
+    _qrUrl = url;
+    _hasQRCode = true;
+}
+
+void LilyGoDisplay::drawQRCode() {
+    int yStart = QR_SECTION_Y;
+
+    // Clear QR code area
+    _display.fillRect(0, yStart, SCREEN_WIDTH, QR_SECTION_HEIGHT, COLOR_BACKGROUND);
+
+    if (!_hasClimb || !_hasQRCode || _climbUuid.length() == 0) {
+        return;
+    }
+
+    // Draw "Open in App" label
+    _display.setFont(&fonts::Font0);
+    _display.setTextColor(COLOR_TEXT_DIM);
+    _display.setTextDatum(lgfx::top_center);
+    _display.drawString("Open in App", SCREEN_WIDTH / 2, yStart + 2);
+
+    // Generate QR code from stored URL
+    QRCode qrCode;
+    qrcode_initText(&qrCode, _qrCodeData, QR_VERSION, ECC_LOW, _qrUrl.c_str());
+
+    // Calculate scale factor for QR code
+    int qrSize = qrCode.size;
+    int pixelSize = QR_CODE_SIZE / qrSize;
+    if (pixelSize < 1) pixelSize = 1;
+
+    int actualQrSize = pixelSize * qrSize;
+    int qrX = (SCREEN_WIDTH - actualQrSize) / 2;
+    int qrY = yStart + 15;
+
+    // Draw white background for QR code
+    _display.fillRect(qrX - 4, qrY - 4, actualQrSize + 8, actualQrSize + 8, COLOR_QR_BG);
+
+    // Draw QR code modules
+    for (uint8_t y = 0; y < qrSize; y++) {
+        for (uint8_t x = 0; x < qrSize; x++) {
+            if (qrcode_getModule(&qrCode, x, y)) {
+                _display.fillRect(qrX + x * pixelSize, qrY + y * pixelSize,
+                                 pixelSize, pixelSize, COLOR_QR_FG);
+            }
+        }
+    }
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
+void LilyGoDisplay::drawHistory() {
+    int yStart = HISTORY_Y;
+
+    // Clear history area
+    _display.fillRect(0, yStart, SCREEN_WIDTH, HISTORY_HEIGHT, COLOR_BACKGROUND);
+
+    if (_history.empty()) {
+        return;
+    }
+
+    // Draw "Previous:" label
+    _display.setFont(&fonts::Font0);
+    _display.setTextColor(COLOR_TEXT_DIM);
+    _display.setCursor(4, yStart);
+    _display.print("Previous:");
+
+    // Draw history items
+    int y = yStart + 12;
+    int itemsToShow = min((int)_history.size(), HISTORY_MAX_ITEMS);
+
+    for (int i = 0; i < itemsToShow; i++) {
+        const ClimbHistoryEntry& entry = _history[_history.size() - 1 - i];
+
+        // Draw bullet with grade color
+        uint16_t bulletColor = COLOR_TEXT_DIM;
+        if (entry.gradeColor.length() > 0) {
+            bulletColor = hexToRgb565(entry.gradeColor.c_str());
+        }
+        _display.fillCircle(8, y + 6, 3, bulletColor);
+
+        // Draw climb name (truncated)
+        String name = entry.name;
+        if (name.length() > 12) {
+            name = name.substring(0, 10) + "..";
+        }
+
+        _display.setTextColor(COLOR_TEXT);
+        _display.setCursor(16, y + 2);
+        _display.print(name.c_str());
+
+        // Draw grade
+        _display.setTextColor(bulletColor);
+        _display.setCursor(SCREEN_WIDTH - 35, y + 2);
+
+        String grade = entry.grade;
+        int slashPos = grade.indexOf('/');
+        if (slashPos > 0) {
+            grade = grade.substring(slashPos + 1);
+        }
+        _display.print(grade.c_str());
+
+        y += HISTORY_ITEM_HEIGHT;
+    }
+}
+
+uint16_t LilyGoDisplay::hexToRgb565(const char* hex) {
+    if (!hex || hex[0] != '#' || strlen(hex) < 7) {
+        return COLOR_TEXT;  // Default to white if invalid
+    }
+
+    // Parse #RRGGBB
+    char r_str[3] = {hex[1], hex[2], 0};
+    char g_str[3] = {hex[3], hex[4], 0};
+    char b_str[3] = {hex[5], hex[6], 0};
+
+    uint8_t r = strtol(r_str, NULL, 16);
+    uint8_t g = strtol(g_str, NULL, 16);
+    uint8_t b = strtol(b_str, NULL, 16);
+
+    // Convert to RGB565
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+}

--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -479,7 +479,8 @@ void LilyGoDisplay::drawHistory() {
 }
 
 uint16_t LilyGoDisplay::hexToRgb565(const char* hex) {
-    if (!hex || hex[0] != '#' || strlen(hex) < 7) {
+    // Check for null or empty string first, then validate format
+    if (!hex || strlen(hex) < 7 || hex[0] != '#') {
         return COLOR_TEXT;  // Default to white if invalid
     }
 

--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -223,7 +223,7 @@ void LilyGoDisplay::showClimb(const char* name, const char* grade, const char* g
             url = "https://kilterboardapp.com/climbs/";
         }
         url += _climbUuid;
-        generateQRCode(url.c_str());
+        setQRCodeUrl(url.c_str());
     }
 
     // Update display
@@ -367,8 +367,8 @@ void LilyGoDisplay::drawCurrentClimb() {
     _display.setTextDatum(lgfx::top_left);
 }
 
-void LilyGoDisplay::generateQRCode(const char* url) {
-    // Store URL and generate QR code
+void LilyGoDisplay::setQRCodeUrl(const char* url) {
+    // Store URL for QR code generation (actual generation happens in drawQRCode)
     _qrUrl = url;
     _hasQRCode = true;
 }

--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -176,6 +176,8 @@ private:
     static const int MAX_HISTORY_ITEMS = 5;
 
     // QR code data
+    // QR Version 6: size = 6*4+17 = 41 modules per side
+    // Buffer = ((41*41)+7)/8 = 211 bytes
     static const int QR_VERSION = 6;
     static const int QR_BUFFER_SIZE = 211;
     uint8_t _qrCodeData[QR_BUFFER_SIZE];

--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -187,7 +187,7 @@ private:
     void drawCurrentClimb();
     void drawQRCode();
     void drawHistory();
-    void generateQRCode(const char* url);
+    void setQRCodeUrl(const char* url);
 
     // Utility
     uint16_t hexToRgb565(const char* hex);

--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -1,0 +1,198 @@
+#ifndef LILYGO_DISPLAY_H
+#define LILYGO_DISPLAY_H
+
+#include <Arduino.h>
+#include <LovyanGFX.hpp>
+#include <vector>
+
+// ============================================
+// LilyGo T-Display S3 Pin Configuration
+// ============================================
+
+// Parallel 8-bit data pins
+#define LCD_D0_PIN      39
+#define LCD_D1_PIN      40
+#define LCD_D2_PIN      41
+#define LCD_D3_PIN      42
+#define LCD_D4_PIN      45
+#define LCD_D5_PIN      46
+#define LCD_D6_PIN      47
+#define LCD_D7_PIN      48
+
+// Control pins
+#define LCD_WR_PIN      8   // Write strobe
+#define LCD_RD_PIN      9   // Read strobe
+#define LCD_RS_PIN      7   // Register select (DC)
+#define LCD_CS_PIN      6   // Chip select
+#define LCD_RST_PIN     5   // Reset
+
+// Backlight and power
+#define LCD_BL_PIN      38
+#define LCD_POWER_PIN   15
+
+// Built-in buttons
+#define BUTTON_1_PIN    0   // GPIO0 - Boot button
+#define BUTTON_2_PIN    14  // GPIO14 - User button
+
+// ============================================
+// Display Settings
+// ============================================
+
+#define LILYGO_SCREEN_WIDTH    170
+#define LILYGO_SCREEN_HEIGHT   320
+
+// ============================================
+// UI Layout (170x320 Portrait)
+// ============================================
+
+// Status bar at top
+#define STATUS_BAR_HEIGHT   20
+#define STATUS_BAR_Y        0
+
+// Current climb section
+#define CURRENT_CLIMB_Y     20
+#define CURRENT_CLIMB_HEIGHT 120
+
+// Climb name area
+#define CLIMB_NAME_Y        25
+#define CLIMB_NAME_HEIGHT   40
+
+// Grade badge area
+#define GRADE_Y             70
+#define GRADE_HEIGHT        60
+
+// QR code section
+#define QR_SECTION_Y        140
+#define QR_SECTION_HEIGHT   115
+#define QR_CODE_SIZE        100
+
+// History section
+#define HISTORY_Y           255
+#define HISTORY_HEIGHT      65
+#define HISTORY_ITEM_HEIGHT 18
+#define HISTORY_MAX_ITEMS   3
+
+// ============================================
+// Colors (RGB565)
+// ============================================
+
+#define COLOR_BACKGROUND    0x0000  // Black
+#define COLOR_TEXT          0xFFFF  // White
+#define COLOR_TEXT_DIM      0x7BEF  // Gray
+#define COLOR_ACCENT        0x07FF  // Cyan
+
+#define COLOR_STATUS_OK     0x07E0  // Green
+#define COLOR_STATUS_WARN   0xFD20  // Orange
+#define COLOR_STATUS_ERROR  0xF800  // Red
+#define COLOR_STATUS_OFF    0x4208  // Dark gray
+
+#define COLOR_QR_FG         0x0000  // Black
+#define COLOR_QR_BG         0xFFFF  // White
+
+// ============================================
+// LilyGo T-Display S3 Display Class
+// ============================================
+
+class LGFX_TDisplayS3 : public lgfx::LGFX_Device {
+    lgfx::Panel_ST7789 _panel_instance;
+    lgfx::Bus_Parallel8 _bus_instance;
+    lgfx::Light_PWM _light_instance;
+
+public:
+    LGFX_TDisplayS3();
+};
+
+// ============================================
+// Climb History Entry
+// ============================================
+
+struct ClimbHistoryEntry {
+    String name;
+    String grade;
+    String gradeColor;  // Hex color from backend
+};
+
+// ============================================
+// LilyGo Display Manager
+// ============================================
+
+class LilyGoDisplay {
+public:
+    LilyGoDisplay();
+    ~LilyGoDisplay();
+
+    // Initialization
+    bool begin();
+
+    // Status indicators
+    void setWiFiStatus(bool connected);
+    void setBackendStatus(bool connected);
+    void setBleStatus(bool enabled, bool connected);
+
+    // Full screen modes
+    void showConnecting();
+    void showError(const char* message, const char* ipAddress = nullptr);
+    void showConfigPortal(const char* apName, const char* ip);
+
+    // Climb display
+    void showClimb(const char* name, const char* grade, const char* gradeColor,
+                   int angle, const char* uuid, const char* boardType);
+    void showNoClimb();
+
+    // History management
+    void addToHistory(const char* name, const char* grade, const char* gradeColor);
+    void clearHistory();
+
+    // Refresh all sections
+    void refresh();
+
+    // Get display for custom drawing
+    LGFX_TDisplayS3& getDisplay() { return _display; }
+
+    // Screen dimensions
+    static const int SCREEN_WIDTH = LILYGO_SCREEN_WIDTH;
+    static const int SCREEN_HEIGHT = LILYGO_SCREEN_HEIGHT;
+
+private:
+    LGFX_TDisplayS3 _display;
+
+    // Status state
+    bool _wifiConnected;
+    bool _backendConnected;
+    bool _bleEnabled;
+    bool _bleConnected;
+
+    // Current climb state
+    bool _hasClimb;
+    String _climbName;
+    String _grade;
+    String _gradeColor;
+    int _angle;
+    String _climbUuid;
+    String _boardType;
+
+    // History
+    std::vector<ClimbHistoryEntry> _history;
+    static const int MAX_HISTORY_ITEMS = 5;
+
+    // QR code data
+    static const int QR_VERSION = 6;
+    static const int QR_BUFFER_SIZE = 211;
+    uint8_t _qrCodeData[QR_BUFFER_SIZE];
+    String _qrUrl;
+    bool _hasQRCode;
+
+    // Internal drawing methods
+    void drawStatusBar();
+    void drawCurrentClimb();
+    void drawQRCode();
+    void drawHistory();
+    void generateQRCode(const char* url);
+
+    // Utility
+    uint16_t hexToRgb565(const char* hex);
+};
+
+extern LilyGoDisplay Display;
+
+#endif // LILYGO_DISPLAY_H

--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -2,6 +2,7 @@
 #define LILYGO_DISPLAY_H
 
 #include <Arduino.h>
+
 #include <LovyanGFX.hpp>
 #include <vector>
 
@@ -10,84 +11,84 @@
 // ============================================
 
 // Parallel 8-bit data pins
-#define LCD_D0_PIN      39
-#define LCD_D1_PIN      40
-#define LCD_D2_PIN      41
-#define LCD_D3_PIN      42
-#define LCD_D4_PIN      45
-#define LCD_D5_PIN      46
-#define LCD_D6_PIN      47
-#define LCD_D7_PIN      48
+#define LCD_D0_PIN 39
+#define LCD_D1_PIN 40
+#define LCD_D2_PIN 41
+#define LCD_D3_PIN 42
+#define LCD_D4_PIN 45
+#define LCD_D5_PIN 46
+#define LCD_D6_PIN 47
+#define LCD_D7_PIN 48
 
 // Control pins
-#define LCD_WR_PIN      8   // Write strobe
-#define LCD_RD_PIN      9   // Read strobe
-#define LCD_RS_PIN      7   // Register select (DC)
-#define LCD_CS_PIN      6   // Chip select
-#define LCD_RST_PIN     5   // Reset
+#define LCD_WR_PIN 8   // Write strobe
+#define LCD_RD_PIN 9   // Read strobe
+#define LCD_RS_PIN 7   // Register select (DC)
+#define LCD_CS_PIN 6   // Chip select
+#define LCD_RST_PIN 5  // Reset
 
 // Backlight and power
-#define LCD_BL_PIN      38
-#define LCD_POWER_PIN   15
+#define LCD_BL_PIN 38
+#define LCD_POWER_PIN 15
 
 // Built-in buttons
-#define BUTTON_1_PIN    0   // GPIO0 - Boot button
-#define BUTTON_2_PIN    14  // GPIO14 - User button
+#define BUTTON_1_PIN 0   // GPIO0 - Boot button
+#define BUTTON_2_PIN 14  // GPIO14 - User button
 
 // ============================================
 // Display Settings
 // ============================================
 
-#define LILYGO_SCREEN_WIDTH    170
-#define LILYGO_SCREEN_HEIGHT   320
+#define LILYGO_SCREEN_WIDTH 170
+#define LILYGO_SCREEN_HEIGHT 320
 
 // ============================================
 // UI Layout (170x320 Portrait)
 // ============================================
 
 // Status bar at top
-#define STATUS_BAR_HEIGHT   20
-#define STATUS_BAR_Y        0
+#define STATUS_BAR_HEIGHT 20
+#define STATUS_BAR_Y 0
 
 // Current climb section
-#define CURRENT_CLIMB_Y     20
+#define CURRENT_CLIMB_Y 20
 #define CURRENT_CLIMB_HEIGHT 120
 
 // Climb name area
-#define CLIMB_NAME_Y        25
-#define CLIMB_NAME_HEIGHT   40
+#define CLIMB_NAME_Y 25
+#define CLIMB_NAME_HEIGHT 40
 
 // Grade badge area
-#define GRADE_Y             70
-#define GRADE_HEIGHT        60
+#define GRADE_Y 70
+#define GRADE_HEIGHT 60
 
 // QR code section
-#define QR_SECTION_Y        140
-#define QR_SECTION_HEIGHT   115
-#define QR_CODE_SIZE        100
+#define QR_SECTION_Y 140
+#define QR_SECTION_HEIGHT 115
+#define QR_CODE_SIZE 100
 
 // History section
-#define HISTORY_Y           255
-#define HISTORY_HEIGHT      65
+#define HISTORY_Y 255
+#define HISTORY_HEIGHT 65
 #define HISTORY_ITEM_HEIGHT 18
-#define HISTORY_MAX_ITEMS   3
+#define HISTORY_MAX_ITEMS 3
 
 // ============================================
 // Colors (RGB565)
 // ============================================
 
-#define COLOR_BACKGROUND    0x0000  // Black
-#define COLOR_TEXT          0xFFFF  // White
-#define COLOR_TEXT_DIM      0x7BEF  // Gray
-#define COLOR_ACCENT        0x07FF  // Cyan
+#define COLOR_BACKGROUND 0x0000  // Black
+#define COLOR_TEXT 0xFFFF        // White
+#define COLOR_TEXT_DIM 0x7BEF    // Gray
+#define COLOR_ACCENT 0x07FF      // Cyan
 
-#define COLOR_STATUS_OK     0x07E0  // Green
-#define COLOR_STATUS_WARN   0xFD20  // Orange
-#define COLOR_STATUS_ERROR  0xF800  // Red
-#define COLOR_STATUS_OFF    0x4208  // Dark gray
+#define COLOR_STATUS_OK 0x07E0     // Green
+#define COLOR_STATUS_WARN 0xFD20   // Orange
+#define COLOR_STATUS_ERROR 0xF800  // Red
+#define COLOR_STATUS_OFF 0x4208    // Dark gray
 
-#define COLOR_QR_FG         0x0000  // Black
-#define COLOR_QR_BG         0xFFFF  // White
+#define COLOR_QR_FG 0x0000  // Black
+#define COLOR_QR_BG 0xFFFF  // White
 
 // ============================================
 // LilyGo T-Display S3 Display Class
@@ -98,7 +99,7 @@ class LGFX_TDisplayS3 : public lgfx::LGFX_Device {
     lgfx::Bus_Parallel8 _bus_instance;
     lgfx::Light_PWM _light_instance;
 
-public:
+  public:
     LGFX_TDisplayS3();
 };
 
@@ -117,7 +118,7 @@ struct ClimbHistoryEntry {
 // ============================================
 
 class LilyGoDisplay {
-public:
+  public:
     LilyGoDisplay();
     ~LilyGoDisplay();
 
@@ -135,8 +136,8 @@ public:
     void showConfigPortal(const char* apName, const char* ip);
 
     // Climb display
-    void showClimb(const char* name, const char* grade, const char* gradeColor,
-                   int angle, const char* uuid, const char* boardType);
+    void showClimb(const char* name, const char* grade, const char* gradeColor, int angle, const char* uuid,
+                   const char* boardType);
     void showNoClimb();
 
     // History management
@@ -153,7 +154,7 @@ public:
     static const int SCREEN_WIDTH = LILYGO_SCREEN_WIDTH;
     static const int SCREEN_HEIGHT = LILYGO_SCREEN_HEIGHT;
 
-private:
+  private:
     LGFX_TDisplayS3 _display;
 
     // Status state
@@ -197,4 +198,4 @@ private:
 
 extern LilyGoDisplay Display;
 
-#endif // LILYGO_DISPLAY_H
+#endif  // LILYGO_DISPLAY_H

--- a/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.h
+++ b/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.h
@@ -19,6 +19,7 @@
 typedef void (*BLEConnectCallback)(bool connected);
 typedef void (*BLEDataCallback)(const uint8_t* data, size_t len);
 typedef void (*BLELedDataCallback)(const LedCommand* commands, int count, int angle);
+typedef void (*BLERawForwardCallback)(const uint8_t* data, size_t len);
 
 class NordicUartBLE : public NimBLEServerCallbacks, public NimBLECharacteristicCallbacks {
   public:
@@ -37,6 +38,10 @@ class NordicUartBLE : public NimBLEServerCallbacks, public NimBLECharacteristicC
     void setConnectCallback(BLEConnectCallback callback);
     void setDataCallback(BLEDataCallback callback);
     void setLedDataCallback(BLELedDataCallback callback);
+
+    // Raw data forwarding callback (called before Aurora protocol processing)
+    // Used by BLE proxy to forward data to the actual board
+    void setRawForwardCallback(BLERawForwardCallback callback);
 
     // NimBLE callbacks
     void onConnect(NimBLEServer* server, ble_gap_conn_desc* desc) override;
@@ -74,6 +79,7 @@ class NordicUartBLE : public NimBLEServerCallbacks, public NimBLECharacteristicC
     BLEConnectCallback connectCallback;
     BLEDataCallback dataCallback;
     BLELedDataCallback ledDataCallback;
+    BLERawForwardCallback rawForwardCallback;
 
     void startAdvertising();
 };

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -2,6 +2,12 @@
 ;
 ; Boardsesh Board Controller Firmware
 ; Supports ESP32 and ESP32-S3 development boards
+;
+; Build variants:
+;   esp32s3dev       - Standard board controller (LEDs only)
+;   esp32s3dev-proxy - Board controller with BLE proxy
+;   tdisplay-s3      - T-Display-S3 with display + BLE proxy
+;   esp32dev         - Standard ESP32 (legacy)
 
 [platformio]
 default_envs = esp32s3dev
@@ -33,7 +39,10 @@ build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH=512
 
+; ============================================
 ; ESP32-S3 Development Board (recommended)
+; Standard LED controller without proxy/display
+; ============================================
 [env:esp32s3dev]
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
@@ -44,7 +53,67 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT=1
     -D ARDUINO_USB_MODE=1
 
-; Standard ESP32 Development Board
+; ============================================
+; ESP32-S3 with BLE Proxy Mode
+; LED controller + BLE proxy (no display)
+; ============================================
+[env:esp32s3dev-proxy]
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+
+lib_deps =
+    ${env.lib_deps}
+    ble-proxy=symlink://../../libs/ble-proxy
+    climb-history=symlink://../../libs/climb-history
+
+build_flags =
+    ${env.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+    -D ENABLE_BLE_PROXY=1
+
+; ============================================
+; LilyGo T-Display-S3 (170x320 LCD)
+; Display + BLE proxy + LED controller
+; ============================================
+[env:tdisplay-s3]
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+
+lib_deps =
+    ${env.lib_deps}
+    ble-proxy=symlink://../../libs/ble-proxy
+    climb-history=symlink://../../libs/climb-history
+    lilygo-display=symlink://../../libs/lilygo-display
+    ; Display libraries
+    lovyan03/LovyanGFX@^1.1.12
+    ricmoo/QRCode@^0.0.1
+
+build_flags =
+    ${env.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+    -D ENABLE_BLE_PROXY=1
+    -D ENABLE_DISPLAY=1
+    ; PSRAM support
+    -D BOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    ; LilyGo T-Display S3 specific
+    -D TFT_WIDTH=170
+    -D TFT_HEIGHT=320
+    ; Move LED pin to avoid conflict with LCD_RST (GPIO 5)
+    -D TDISPLAY_LED_PIN=43
+
+; ============================================
+; Standard ESP32 Development Board (legacy)
+; ============================================
 [env:esp32dev]
 board = esp32dev
 board_build.mcu = esp32

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -110,6 +110,8 @@ build_flags =
     -D TFT_HEIGHT=320
     ; Move LED pin to avoid conflict with LCD_RST (GPIO 5)
     -D TDISPLAY_LED_PIN=43
+    ; Use fewer RMT channels to avoid conflict with display
+    -D FASTLED_RMT_MAX_CHANNELS=2
 
 ; ============================================
 ; Standard ESP32 Development Board (legacy)

--- a/embedded/projects/board-controller/src/config/board_config.h
+++ b/embedded/projects/board-controller/src/config/board_config.h
@@ -6,7 +6,13 @@
 #define FIRMWARE_VERSION "1.0.0"
 
 // LED configuration
-#define LED_PIN 5         // GPIO pin for LED data
+// Note: GPIO 5 conflicts with LCD_RST on T-Display-S3
+// Use TDISPLAY_LED_PIN build flag to override for display builds
+#ifdef TDISPLAY_LED_PIN
+#define LED_PIN TDISPLAY_LED_PIN
+#else
+#define LED_PIN 5         // GPIO pin for LED data (default for non-display builds)
+#endif
 #define NUM_LEDS 200      // Total number of LEDs
 #define LED_TYPE WS2812B  // LED strip type
 #define COLOR_ORDER GRB   // Color order

--- a/embedded/projects/board-controller/src/config/board_config.h
+++ b/embedded/projects/board-controller/src/config/board_config.h
@@ -11,7 +11,7 @@
 #ifdef TDISPLAY_LED_PIN
 #define LED_PIN TDISPLAY_LED_PIN
 #else
-#define LED_PIN 5         // GPIO pin for LED data (default for non-display builds)
+#define LED_PIN 5  // GPIO pin for LED data (default for non-display builds)
 #endif
 #define NUM_LEDS 200      // Total number of LEDs
 #define LED_TYPE WS2812B  // LED strip type

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -14,6 +14,7 @@
 // Conditional libraries for display and proxy modes
 #ifdef ENABLE_BLE_PROXY
 #include <ble_proxy.h>
+
 #include <climb_history.h>
 #endif
 
@@ -96,7 +97,6 @@ void setup() {
     // Startup animation (brief to confirm LEDs working)
     startupAnimation();
 
-
     // Initialize WiFi
     Logger.logln("Initializing WiFi...");
     WiFiMgr.begin();
@@ -167,7 +167,6 @@ void loop() {
 
     // Process web server
     WebConfig.loop();
-
 }
 
 void onWiFiStateChange(WiFiConnectionState state) {
@@ -303,7 +302,8 @@ void onGraphQLStateChange(GraphQLConnectionState state) {
             GraphQL.subscribe("controller-events",
                               "subscription ControllerEvents($sessionId: ID!) { "
                               "controllerEvents(sessionId: $sessionId) { "
-                              "... on LedUpdate { __typename commands { position r g b } climbUuid climbName climbGrade boardPath angle } "
+                              "... on LedUpdate { __typename commands { position r g b } climbUuid climbName "
+                              "climbGrade boardPath angle } "
                               "... on ControllerPing { __typename timestamp } "
                               "} }",
                               variables.c_str());
@@ -368,14 +368,9 @@ void handleLedUpdateExtended(JsonObject& data) {
     if (climbName && climbUuid) {
         // lilygo-display uses showClimb with gradeColor (hex), but we don't have it
         // Pass empty string for gradeColor - display will use default
-        Display.showClimb(
-            climbName,
-            climbGrade ? climbGrade : "",
-            "",  // gradeColor - not available from backend yet
-            angle,
-            climbUuid,
-            boardType.c_str()
-        );
+        Display.showClimb(climbName, climbGrade ? climbGrade : "",
+                          "",  // gradeColor - not available from backend yet
+                          angle, climbUuid, boardType.c_str());
     } else {
         // No climb - clear display
         Display.showNoClimb();

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -124,6 +124,7 @@ void setup() {
     String targetMac = Config.getString("proxy_mac");
     Proxy.begin(targetMac);
     Proxy.setStateCallback(onProxyStateChange);
+    Proxy.setSendToAppCallback(sendToAppViaBLE);
 #endif
 
 #ifdef ENABLE_DISPLAY

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -36,7 +36,9 @@ void onBLEData(const uint8_t* data, size_t len);
 void onBLELedData(const LedCommand* commands, int count, int angle);
 void onGraphQLStateChange(GraphQLConnectionState state);
 void onGraphQLMessage(JsonDocument& doc);
+#ifdef ENABLE_DISPLAY
 void handleLedUpdateExtended(JsonObject& data);
+#endif
 void startupAnimation();
 
 #ifdef ENABLE_BLE_PROXY
@@ -319,6 +321,7 @@ void onGraphQLStateChange(GraphQLConnectionState state) {
 }
 
 void onGraphQLMessage(JsonDocument& doc) {
+#ifdef ENABLE_DISPLAY
     // Handle extended LedUpdate data (for display)
     JsonObject payloadObj = doc["payload"];
     if (payloadObj["data"].is<JsonObject>()) {
@@ -332,14 +335,17 @@ void onGraphQLMessage(JsonDocument& doc) {
             }
         }
     }
+#else
+    (void)doc;  // Suppress unused parameter warning
+#endif
 }
 
+#ifdef ENABLE_DISPLAY
 /**
  * Handle extended LedUpdate data for display
  * This is called in addition to GraphQL.handleLedUpdate (which handles LED control)
  */
 void handleLedUpdateExtended(JsonObject& data) {
-#ifdef ENABLE_DISPLAY
     // Get boardPath for QR code generation and board type detection
     const char* boardPath = data["boardPath"];
 
@@ -374,11 +380,8 @@ void handleLedUpdateExtended(JsonObject& data) {
         // No climb - clear display
         Display.showNoClimb();
     }
-#else
-    // Without display enabled, nothing to do with extended data
-    (void)data;  // Suppress unused parameter warning
-#endif
 }
+#endif
 
 void startupAnimation() {
     // Simple chase animation to verify LED wiring

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -28,7 +28,6 @@
 // State
 bool wifiConnected = false;
 bool backendConnected = false;
-String currentBoardPath = "";  // Stored from LedUpdate events
 
 // Forward declarations
 void onWiFiStateChange(WiFiConnectionState state);
@@ -340,11 +339,8 @@ void onGraphQLMessage(JsonDocument& doc) {
  */
 void handleLedUpdateExtended(JsonObject& data) {
 #ifdef ENABLE_DISPLAY
-    // Store boardPath for QR code generation
+    // Get boardPath for QR code generation and board type detection
     const char* boardPath = data["boardPath"];
-    if (boardPath) {
-        currentBoardPath = boardPath;
-    }
 
     // Update display with climb info
     const char* climbName = data["climbName"];
@@ -378,11 +374,8 @@ void handleLedUpdateExtended(JsonObject& data) {
         Display.showNoClimb();
     }
 #else
-    // Store boardPath even without display (might be useful for logging)
-    const char* boardPath = data["boardPath"];
-    if (boardPath) {
-        currentBoardPath = boardPath;
-    }
+    // Without display enabled, nothing to do with extended data
+    (void)data;  // Suppress unused parameter warning
 #endif
 }
 

--- a/embedded/projects/climb-queue-display/README.md
+++ b/embedded/projects/climb-queue-display/README.md
@@ -1,0 +1,154 @@
+# Boardsesh Climb Queue Display
+
+ESP32 firmware for displaying climb queue information on a LilyGo T-Display S3.
+
+## Hardware
+
+- **Device**: LilyGo T-Display S3
+- **Display**: 1.9" TFT LCD, 170x320 pixels, ST7789 driver
+- **Interface**: Parallel 8-bit bus
+- **MCU**: ESP32-S3 with WiFi/BLE
+- **Buttons**: GPIO 0 (Boot) and GPIO 14 (User)
+
+## Features
+
+1. **Current Climb Display** - Shows climb name and grade with colored badge
+2. **Previous Climbs History** - Shows last 3-5 climbs with grade colors
+3. **QR Code** - Scan to open current climb in official Kilter/Tension app
+4. **BLE Proxy Mode** - Forward LED commands to official boards (optional)
+
+## Display Layout (170x320 Portrait)
+
+```
+┌─────────────────────┐ Y=0
+│  WiFi ● WS ● BLE ●  │ Status bar (20px)
+├─────────────────────┤ Y=20
+│                     │
+│   Current Climb     │ Climb name
+│   ┌───────────┐     │
+│   │    V3     │     │ Grade badge (colored)
+│   └───────────┘     │
+├─────────────────────┤ Y=140
+│    Open in App      │
+│    ┌─────────┐      │
+│    │ QR CODE │      │ 100x100 pixels
+│    │         │      │
+│    └─────────┘      │
+├─────────────────────┤ Y=255
+│ Previous:           │
+│ ● Climb A    V2     │ History (3 items)
+│ ● Climb B    V4     │
+│ ● Climb C    V1     │
+└─────────────────────┘ Y=320
+```
+
+## Building
+
+### Prerequisites
+
+1. Install [PlatformIO](https://platformio.org/)
+2. Clone this repository
+
+### Build
+
+```bash
+cd embedded/projects/climb-queue-display
+pio run
+```
+
+### Upload
+
+```bash
+pio run -t upload
+```
+
+### Monitor Serial Output
+
+```bash
+pio device monitor
+```
+
+## Configuration
+
+The device hosts a web configuration portal on port 80 when connected to WiFi.
+
+### Required Settings
+
+| Setting | Description |
+|---------|-------------|
+| `api_key` | Controller API key from Boardsesh web app |
+| `session_id` | Party session ID to subscribe to |
+
+### Optional Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `board_type` | `kilter` | Board type: `kilter` or `tension` |
+| `ble_proxy_enabled` | `false` | Enable BLE proxy mode |
+| `ble_board_address` | (auto) | Saved board BLE address |
+| `backend_host` | `boardsesh.com` | Backend server hostname |
+| `backend_port` | `443` | Backend server port |
+| `backend_path` | `/graphql` | GraphQL endpoint path |
+
+## BLE Proxy Mode
+
+When enabled, the device can forward LED commands to an official Kilter or Tension board:
+
+1. Enable `ble_proxy_enabled` in config
+2. The device will scan for nearby Aurora boards
+3. Once connected, LED commands from Boardsesh are forwarded to the board
+4. The board address is saved for automatic reconnection
+
+## Grade Colors
+
+Grade colors are sent from the Boardsesh backend as hex strings (e.g., `#FF7043`). The firmware converts these to RGB565 for display. This keeps colors in sync with the web UI automatically.
+
+Color progression:
+- **V0-V2**: Yellow to Orange
+- **V3-V4**: Orange-red
+- **V5-V6**: Red
+- **V7-V10**: Dark red to purple
+- **V11+**: Purple shades
+
+## App URL QR Codes
+
+The QR code links to the climb in the official app:
+- **Kilter**: `https://kilterboardapp.com/climbs/{uuid}`
+- **Tension**: `https://tensionboardapp2.com/climbs/{uuid}`
+
+## Dependencies
+
+- [LovyanGFX](https://github.com/lovyan03/LovyanGFX) - Display driver
+- [qrcode](https://github.com/ricmoo/QRCode) - QR code generation
+- [NimBLE-Arduino](https://github.com/h2zero/NimBLE-Arduino) - BLE stack
+- [ArduinoJson](https://github.com/bblanchon/ArduinoJson) - JSON parsing
+- [WebSockets](https://github.com/Links2004/arduinoWebSockets) - WebSocket client
+
+Plus shared Boardsesh libraries:
+- config-manager
+- log-buffer
+- wifi-utils
+- graphql-ws-client
+- esp-web-server
+- aurora-ble-client
+
+## Troubleshooting
+
+### Display shows "Configure WiFi"
+Connect to the device's AP and configure WiFi credentials.
+
+### Display shows "Configure API key"
+1. Go to Boardsesh web app
+2. Register a controller device
+3. Copy the API key to device config
+
+### Display shows "Configure session"
+Set the `session_id` to a valid party session ID.
+
+### QR code not showing
+The QR code only appears when there's a current climb with a valid UUID.
+
+### BLE not connecting
+- Ensure `ble_proxy_enabled` is true
+- Check that the board is powered and not connected to another device
+- Try clearing `ble_board_address` to force a new scan

--- a/embedded/projects/climb-queue-display/partitions.csv
+++ b/embedded/projects/climb-queue-display/partitions.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x400000,
+app1,     app,  ota_1,   0x410000,0x400000,
+spiffs,   data, spiffs,  0x810000,0x7F0000,

--- a/embedded/projects/climb-queue-display/platformio.ini
+++ b/embedded/projects/climb-queue-display/platformio.ini
@@ -1,0 +1,64 @@
+; PlatformIO Project Configuration File
+;
+; Boardsesh Climb Queue Display Firmware
+; For LilyGo T-Display S3 (170x320 ST7789)
+; https://www.lilygo.cc/products/t-display-s3
+
+[platformio]
+default_envs = lilygo_t_display_s3
+
+[env]
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+
+; Shared local libraries (symlink)
+lib_deps =
+    config-manager=symlink://../../libs/config-manager
+    log-buffer=symlink://../../libs/log-buffer
+    wifi-utils=symlink://../../libs/wifi-utils
+    graphql-ws-client=symlink://../../libs/graphql-ws-client
+    esp-web-server=symlink://../../libs/esp-web-server
+    lilygo-display=symlink://../../libs/lilygo-display
+    ; BLE client library for proxy mode - disabled for now due to NimBLE compilation issues
+    ; TODO: Re-enable once NimBLE API compatibility is fixed
+    ; aurora-ble-client=symlink://../../libs/aurora-ble-client
+    ; External libraries from PlatformIO registry
+    bblanchon/ArduinoJson@^7.0.0
+    links2004/WebSockets@^2.4.0
+    ; LovyanGFX for hardware display driver
+    lovyan03/LovyanGFX@^1.1.12
+    ; NimBLE for BLE proxy mode - disabled for now
+    ; h2zero/NimBLE-Arduino@^1.4.0
+    ; QR code generation
+    ricmoo/qrcode@^0.0.1
+
+build_flags =
+    -D CORE_DEBUG_LEVEL=3
+    ; Enable PSRAM
+    -D BOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+
+; LilyGo T-Display S3 (170x320 ST7789)
+; Using esp32-s3-devkitc-1 board definition for better PSRAM/SSL compatibility
+[env:lilygo_t_display_s3]
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+
+build_flags =
+    ${env.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+    ; LilyGo T-Display S3 specific
+    -D TFT_WIDTH=170
+    -D TFT_HEIGHT=320
+
+; Partition table for firmware + NVS
+board_build.partitions = partitions.csv

--- a/embedded/projects/climb-queue-display/src/config/display_config.h
+++ b/embedded/projects/climb-queue-display/src/config/display_config.h
@@ -1,0 +1,41 @@
+#ifndef DISPLAY_CONFIG_H
+#define DISPLAY_CONFIG_H
+
+// ============================================
+// Device Identification
+// ============================================
+
+#define DEVICE_NAME "Boardsesh Queue Display"
+#define FIRMWARE_VERSION "1.1.0"
+
+// ============================================
+// Backend Configuration Defaults
+// ============================================
+
+#define DEFAULT_BACKEND_HOST    "boardsesh.com"
+#define DEFAULT_BACKEND_PORT    443
+#define DEFAULT_BACKEND_PATH    "/graphql"
+
+// ============================================
+// BLE Configuration
+// ============================================
+
+#define BLE_SCAN_TIMEOUT_SEC    30
+#define BLE_RECONNECT_INTERVAL_MS 30000
+
+// ============================================
+// App URL Prefixes for QR Codes
+// ============================================
+
+#define KILTER_APP_URL_PREFIX   "https://kilterboardapp.com/climbs/"
+#define TENSION_APP_URL_PREFIX  "https://tensionboardapp2.com/climbs/"
+
+// ============================================
+// Debug Options
+// ============================================
+
+#define DEBUG_SERIAL    true
+#define DEBUG_DISPLAY   false
+#define DEBUG_GRAPHQL   false
+
+#endif // DISPLAY_CONFIG_H

--- a/embedded/projects/climb-queue-display/src/config/display_config.h
+++ b/embedded/projects/climb-queue-display/src/config/display_config.h
@@ -12,30 +12,30 @@
 // Backend Configuration Defaults
 // ============================================
 
-#define DEFAULT_BACKEND_HOST    "boardsesh.com"
-#define DEFAULT_BACKEND_PORT    443
-#define DEFAULT_BACKEND_PATH    "/graphql"
+#define DEFAULT_BACKEND_HOST "boardsesh.com"
+#define DEFAULT_BACKEND_PORT 443
+#define DEFAULT_BACKEND_PATH "/graphql"
 
 // ============================================
 // BLE Configuration
 // ============================================
 
-#define BLE_SCAN_TIMEOUT_SEC    30
+#define BLE_SCAN_TIMEOUT_SEC 30
 #define BLE_RECONNECT_INTERVAL_MS 30000
 
 // ============================================
 // App URL Prefixes for QR Codes
 // ============================================
 
-#define KILTER_APP_URL_PREFIX   "https://kilterboardapp.com/climbs/"
-#define TENSION_APP_URL_PREFIX  "https://tensionboardapp2.com/climbs/"
+#define KILTER_APP_URL_PREFIX "https://kilterboardapp.com/climbs/"
+#define TENSION_APP_URL_PREFIX "https://tensionboardapp2.com/climbs/"
 
 // ============================================
 // Debug Options
 // ============================================
 
-#define DEBUG_SERIAL    true
-#define DEBUG_DISPLAY   false
-#define DEBUG_GRAPHQL   false
+#define DEBUG_SERIAL true
+#define DEBUG_DISPLAY false
+#define DEBUG_GRAPHQL false
 
-#endif // DISPLAY_CONFIG_H
+#endif  // DISPLAY_CONFIG_H

--- a/embedded/projects/climb-queue-display/src/main.cpp
+++ b/embedded/projects/climb-queue-display/src/main.cpp
@@ -1,12 +1,13 @@
 #include <Arduino.h>
 
 // Shared libraries
-#include <log_buffer.h>
-#include <config_manager.h>
-#include <wifi_utils.h>
-#include <graphql_ws_client.h>
 #include <esp_web_server.h>
+#include <wifi_utils.h>
+
+#include <config_manager.h>
+#include <graphql_ws_client.h>
 #include <lilygo_display.h>
+#include <log_buffer.h>
 
 // BLE client for proxy mode - disabled for now due to NimBLE API issues
 // TODO: Re-enable once aurora-ble-client is updated for NimBLE 1.4.x
@@ -78,7 +79,8 @@ void setup() {
     Logger.logln("Initializing display...");
     if (!Display.begin()) {
         Logger.logln("ERROR: Display initialization failed!");
-        while (1) delay(1000);
+        while (1)
+            delay(1000);
     }
 
     Display.showConnecting();
@@ -156,8 +158,7 @@ void loop() {
 
         // Retry scanning if not connected
         unsigned long now = millis();
-        if (!bleConnected && !BLEClient.isScanning() &&
-            now - lastBleScanTime > BLE_SCAN_INTERVAL) {
+        if (!bleConnected && !BLEClient.isScanning() && now - lastBleScanTime > BLE_SCAN_INTERVAL) {
             Logger.logln("Retrying BLE scan...");
             BLEClient.startScan(15);
             if (BLEClient.isScanning()) {
@@ -283,12 +284,13 @@ void onGraphQLStateChange(GraphQLConnectionState state) {
 
             String variables = "{\"sessionId\":\"" + sessionId + "\"}";
             GraphQL.subscribe("controller-events",
-                "subscription ControllerEvents($sessionId: ID!) { "
-                "controllerEvents(sessionId: $sessionId) { "
-                "... on LedUpdate { __typename commands { position r g b } climbUuid climbName climbGrade boardPath angle } "
-                "... on ControllerPing { __typename timestamp } "
-                "} }",
-                variables.c_str());
+                              "subscription ControllerEvents($sessionId: ID!) { "
+                              "controllerEvents(sessionId: $sessionId) { "
+                              "... on LedUpdate { __typename commands { position r g b } climbUuid climbName "
+                              "climbGrade boardPath angle } "
+                              "... on ControllerPing { __typename timestamp } "
+                              "} }",
+                              variables.c_str());
 
             hasCurrentClimb = false;
             Display.showNoClimb();
@@ -339,10 +341,8 @@ void handleLedUpdate(JsonObject& data) {
     int angle = data["angle"] | 0;
     int count = commands.isNull() ? 0 : commands.size();
 
-    Logger.logln("LED Update: %s [%s] @ %d degrees (%d holds)",
-                 climbName ? climbName : "(none)",
-                 climbGrade ? climbGrade : "?",
-                 angle, count);
+    Logger.logln("LED Update: %s [%s] @ %d degrees (%d holds)", climbName ? climbName : "(none)",
+                 climbGrade ? climbGrade : "?", angle, count);
 
     // Handle clear command
     if (commands.isNull() || count == 0) {
@@ -374,8 +374,7 @@ void handleLedUpdate(JsonObject& data) {
     }
 
     // Add previous climb to history if different
-    if (hasCurrentClimb && currentClimbUuid.length() > 0 &&
-        climbUuid && String(climbUuid) != currentClimbUuid) {
+    if (hasCurrentClimb && currentClimbUuid.length() > 0 && climbUuid && String(climbUuid) != currentClimbUuid) {
         Display.addToHistory(currentClimbName.c_str(), currentGrade.c_str(), currentGradeColor.c_str());
     }
 
@@ -385,7 +384,8 @@ void handleLedUpdate(JsonObject& data) {
     currentLedCommands.reserve(count);
     int i = 0;
     for (JsonObject cmd : commands) {
-        if (i >= MAX_LED_COMMANDS) break;
+        if (i >= MAX_LED_COMMANDS)
+            break;
         LedCommand ledCmd;
         ledCmd.position = cmd["position"];
         ledCmd.r = cmd["r"];

--- a/embedded/projects/climb-queue-display/src/main.cpp
+++ b/embedded/projects/climb-queue-display/src/main.cpp
@@ -1,0 +1,427 @@
+#include <Arduino.h>
+
+// Shared libraries
+#include <log_buffer.h>
+#include <config_manager.h>
+#include <wifi_utils.h>
+#include <graphql_ws_client.h>
+#include <esp_web_server.h>
+#include <lilygo_display.h>
+
+// BLE client for proxy mode - disabled for now due to NimBLE API issues
+// TODO: Re-enable once aurora-ble-client is updated for NimBLE 1.4.x
+// #include <aurora_ble_client.h>
+#define BLE_PROXY_DISABLED 1
+
+// Project configuration
+#include "config/display_config.h"
+
+// ============================================
+// State
+// ============================================
+
+bool wifiConnected = false;
+bool backendConnected = false;
+String boardType = "kilter";
+
+#if !BLE_PROXY_DISABLED
+bool bleConnected = false;
+bool bleProxyEnabled = false;
+unsigned long lastBleScanTime = 0;
+const unsigned long BLE_SCAN_INTERVAL = 30000;
+std::vector<LedCommand> currentLedCommands;
+#endif
+
+unsigned long lastDisplayUpdate = 0;
+const unsigned long DISPLAY_UPDATE_INTERVAL = 100;
+const int MAX_LED_COMMANDS = 500;
+
+// Current climb data
+String currentClimbUuid = "";
+String currentClimbName = "";
+String currentGrade = "";
+String currentGradeColor = "";
+bool hasCurrentClimb = false;
+
+// ============================================
+// Forward Declarations
+// ============================================
+
+void onWiFiStateChange(WiFiConnectionState state);
+void onGraphQLStateChange(GraphQLConnectionState state);
+void onLedUpdate(const LedCommand* commands, int count, const char* climbUuid,
+                 const char* climbName, const char* grade, const char* gradeColor, int angle);
+
+#if !BLE_PROXY_DISABLED
+void onBleConnect(bool connected, const char* deviceName);
+void onBleScan(const char* deviceName, const char* address);
+void forwardToBoard();
+#endif
+
+// ============================================
+// Setup
+// ============================================
+
+void setup() {
+    Serial.begin(115200);
+    delay(1000);
+
+    Logger.logln("=================================");
+    Logger.logln("%s v%s", DEVICE_NAME, FIRMWARE_VERSION);
+    Logger.logln("LilyGo T-Display S3 (170x320)");
+    Logger.logln("=================================");
+
+    // Initialize config manager first (needed for display settings)
+    Config.begin();
+
+    // Initialize display
+    Logger.logln("Initializing display...");
+    if (!Display.begin()) {
+        Logger.logln("ERROR: Display initialization failed!");
+        while (1) delay(1000);
+    }
+
+    Display.showConnecting();
+
+    // Load board type
+    boardType = Config.getString("board_type", "kilter");
+
+    // Initialize WiFi
+    Logger.logln("Initializing WiFi...");
+    WiFiMgr.begin();
+    WiFiMgr.setStateCallback(onWiFiStateChange);
+
+    // Try to connect to saved WiFi or start AP mode for setup
+    if (!WiFiMgr.connectSaved()) {
+        Logger.logln("No saved WiFi credentials - starting AP mode");
+        String apName = "Boardsesh-Queue-" + String((uint32_t)(ESP.getEfuseMac() & 0xFFFF), HEX);
+        if (WiFiMgr.startAP(apName.c_str())) {
+            Display.showConfigPortal(apName.c_str(), WiFiMgr.getAPIP().c_str());
+        } else {
+            Display.showError("AP Mode Failed");
+        }
+    }
+
+    // Initialize web config server
+    Logger.logln("Starting web server...");
+    WebConfig.begin();
+
+    // Initialize BLE client for proxy mode
+#if !BLE_PROXY_DISABLED
+    bleProxyEnabled = Config.getBool("ble_proxy_enabled", false);
+    if (bleProxyEnabled) {
+        Logger.logln("Initializing BLE client for proxy mode...");
+        BLEClient.begin();
+        BLEClient.setConnectCallback(onBleConnect);
+        BLEClient.setScanCallback(onBleScan);
+
+        String savedBoardAddress = Config.getString("ble_board_address");
+        if (savedBoardAddress.length() > 0) {
+            Logger.logln("Connecting to saved board: %s", savedBoardAddress.c_str());
+            BLEClient.connect(savedBoardAddress.c_str());
+        } else {
+            BLEClient.setAutoConnect(true);
+            BLEClient.startScan(BLE_SCAN_TIMEOUT_SEC);
+        }
+    }
+    Display.setBleStatus(bleProxyEnabled, false);
+#else
+    Logger.logln("BLE proxy mode disabled in this build");
+    Display.setBleStatus(false, false);
+#endif
+
+    Logger.logln("Setup complete!");
+}
+
+// ============================================
+// Main Loop
+// ============================================
+
+void loop() {
+    // Process WiFi
+    WiFiMgr.loop();
+
+    // Process WebSocket if WiFi connected
+    if (wifiConnected) {
+        GraphQL.loop();
+    }
+
+    // Process web server (works in both AP and STA mode)
+    WebConfig.loop();
+
+    // Process BLE client if proxy mode enabled
+#if !BLE_PROXY_DISABLED
+    if (bleProxyEnabled) {
+        BLEClient.loop();
+
+        // Retry scanning if not connected
+        unsigned long now = millis();
+        if (!bleConnected && !BLEClient.isScanning() &&
+            now - lastBleScanTime > BLE_SCAN_INTERVAL) {
+            Logger.logln("Retrying BLE scan...");
+            BLEClient.startScan(15);
+            if (BLEClient.isScanning()) {
+                lastBleScanTime = now;
+            }
+        }
+    }
+#endif
+
+    // Handle button presses
+    static bool lastButton1 = HIGH;
+    static unsigned long button1PressTime = 0;
+    bool button1 = digitalRead(BUTTON_1_PIN);
+
+    // Button 1 - long press (3 sec) to reset config
+    if (button1 == LOW && lastButton1 == HIGH) {
+        button1PressTime = millis();
+        Logger.logln("Button 1 pressed - hold 3s to reset config");
+    }
+    if (button1 == LOW && button1PressTime > 0 && millis() - button1PressTime > 3000) {
+        Logger.logln("Resetting configuration...");
+        Display.showError("Resetting...");
+
+        Config.setString("wifi_ssid", "");
+        Config.setString("wifi_pass", "");
+        Config.setString("api_key", "");
+        Config.setString("session_id", "");
+
+        delay(1000);
+        ESP.restart();
+    }
+    if (button1 == HIGH) {
+        button1PressTime = 0;
+    }
+    lastButton1 = button1;
+}
+
+// ============================================
+// WiFi Callbacks
+// ============================================
+
+void onWiFiStateChange(WiFiConnectionState state) {
+    switch (state) {
+        case WiFiConnectionState::CONNECTED: {
+            Logger.logln("WiFi connected: %s", WiFiMgr.getIP().c_str());
+            wifiConnected = true;
+            Display.setWiFiStatus(true);
+
+            // Stop AP mode if it was active
+            if (WiFiMgr.isAPMode()) {
+                WiFiMgr.stopAP();
+            }
+
+            // Get backend config
+            String host = Config.getString("backend_host", DEFAULT_BACKEND_HOST);
+            int port = Config.getInt("backend_port", DEFAULT_BACKEND_PORT);
+            String path = Config.getString("backend_path", DEFAULT_BACKEND_PATH);
+            String apiKey = Config.getString("api_key");
+
+            if (apiKey.length() == 0) {
+                Logger.logln("No API key configured");
+                Display.showError("Configure API key", WiFiMgr.getIP().c_str());
+                break;
+            }
+
+            String sessionId = Config.getString("session_id");
+            if (sessionId.length() == 0) {
+                Logger.logln("No session ID configured");
+                Display.showError("Configure session", WiFiMgr.getIP().c_str());
+                break;
+            }
+
+            Logger.logln("Connecting to backend: %s:%d%s", host.c_str(), port, path.c_str());
+            Display.showConnecting();
+
+            GraphQL.setStateCallback(onGraphQLStateChange);
+            GraphQL.setLedUpdateCallback(onLedUpdate);
+            GraphQL.begin(host.c_str(), port, path.c_str(), apiKey.c_str());
+            break;
+        }
+
+        case WiFiConnectionState::DISCONNECTED:
+            Logger.logln("WiFi disconnected");
+            wifiConnected = false;
+            backendConnected = false;
+            Display.setWiFiStatus(false);
+            Display.setBackendStatus(false);
+            Display.showConnecting();
+            break;
+
+        case WiFiConnectionState::CONNECTING:
+            Logger.logln("WiFi connecting...");
+            break;
+
+        case WiFiConnectionState::CONNECTION_FAILED:
+            Logger.logln("WiFi connection failed");
+            Display.showError("WiFi failed");
+            break;
+
+        case WiFiConnectionState::AP_MODE:
+            Logger.logln("WiFi AP mode active: %s", WiFiMgr.getAPIP().c_str());
+            break;
+    }
+}
+
+// ============================================
+// GraphQL Callbacks
+// ============================================
+
+void onGraphQLStateChange(GraphQLConnectionState state) {
+    switch (state) {
+        case GraphQLConnectionState::CONNECTION_ACK: {
+            Logger.logln("Backend connected!");
+            backendConnected = true;
+            Display.setBackendStatus(true);
+
+            String sessionId = Config.getString("session_id");
+            if (sessionId.length() == 0) {
+                Logger.logln("No session ID configured");
+                Display.showError("Configure session");
+                break;
+            }
+
+            String variables = "{\"sessionId\":\"" + sessionId + "\"}";
+            GraphQL.subscribe("controller-events",
+                "subscription ControllerEvents($sessionId: ID!) { "
+                "controllerEvents(sessionId: $sessionId) { "
+                "... on LedUpdate { __typename commands { position r g b } climbUuid climbName grade gradeColor angle } "
+                "... on ControllerPing { __typename timestamp } "
+                "} }",
+                variables.c_str());
+
+            hasCurrentClimb = false;
+            Display.showNoClimb();
+            break;
+        }
+
+        case GraphQLConnectionState::SUBSCRIBED:
+            Logger.logln("Subscribed to session updates");
+            break;
+
+        case GraphQLConnectionState::DISCONNECTED:
+            Logger.logln("Backend disconnected");
+            backendConnected = false;
+            Display.setBackendStatus(false);
+            Display.showConnecting();
+            break;
+
+        default:
+            break;
+    }
+}
+
+// ============================================
+// LED Update Callback
+// ============================================
+
+void onLedUpdate(const LedCommand* commands, int count, const char* climbUuid,
+                 const char* climbName, const char* grade, const char* gradeColor, int angle) {
+    Logger.logln("LED Update: %s [%s] @ %d degrees (%d holds)",
+                 climbName ? climbName : "(none)",
+                 grade ? grade : "?",
+                 angle, count);
+
+    // Handle clear command
+    if (commands == nullptr || count == 0) {
+        if (hasCurrentClimb && currentClimbName.length() > 0) {
+            Display.addToHistory(currentClimbName.c_str(), currentGrade.c_str(), currentGradeColor.c_str());
+        }
+
+        hasCurrentClimb = false;
+        currentClimbUuid = "";
+        currentClimbName = "";
+        currentGrade = "";
+        currentGradeColor = "";
+
+        Display.showNoClimb();
+
+#if !BLE_PROXY_DISABLED
+        currentLedCommands.clear();
+        if (bleProxyEnabled && bleConnected) {
+            BLEClient.clearLeds();
+        }
+#endif
+        return;
+    }
+
+    // Validate count
+    if (count > MAX_LED_COMMANDS) {
+        Logger.logln("WARNING: Received %d LED commands, limiting to %d", count, MAX_LED_COMMANDS);
+        count = MAX_LED_COMMANDS;
+    }
+
+    // Add previous climb to history if different
+    if (hasCurrentClimb && currentClimbUuid.length() > 0 &&
+        climbUuid && String(climbUuid) != currentClimbUuid) {
+        Display.addToHistory(currentClimbName.c_str(), currentGrade.c_str(), currentGradeColor.c_str());
+    }
+
+#if !BLE_PROXY_DISABLED
+    // Store LED commands for BLE forwarding
+    currentLedCommands.clear();
+    currentLedCommands.reserve(count);
+    for (int i = 0; i < count; i++) {
+        currentLedCommands.push_back(commands[i]);
+    }
+#endif
+
+    // Update state
+    currentClimbUuid = climbUuid ? climbUuid : "";
+    currentClimbName = climbName ? climbName : "";
+    currentGrade = grade ? grade : "";
+    currentGradeColor = gradeColor ? gradeColor : "";
+    hasCurrentClimb = true;
+
+    // Update display
+    Display.showClimb(climbName, grade, gradeColor, angle, climbUuid, boardType.c_str());
+
+#if !BLE_PROXY_DISABLED
+    // Forward to BLE board
+    forwardToBoard();
+#endif
+}
+
+// ============================================
+// BLE Callbacks
+// ============================================
+
+#if !BLE_PROXY_DISABLED
+void onBleConnect(bool connected, const char* deviceName) {
+    bleConnected = connected;
+    Display.setBleStatus(bleProxyEnabled, connected);
+
+    if (connected) {
+        Logger.logln("BLE: Connected to board: %s", deviceName ? deviceName : "(unknown)");
+
+        String address = BLEClient.getConnectedDeviceAddress();
+        if (address.length() > 0) {
+            Config.setString("ble_board_address", address.c_str());
+        }
+
+        if (hasCurrentClimb && currentLedCommands.size() > 0) {
+            Logger.logln("BLE: Sending current climb to newly connected board");
+            forwardToBoard();
+        }
+    } else {
+        Logger.logln("BLE: Disconnected from board");
+    }
+}
+
+void onBleScan(const char* deviceName, const char* address) {
+    Logger.logln("BLE: Found board: %s (%s)", deviceName, address);
+}
+
+void forwardToBoard() {
+    if (!bleProxyEnabled || !bleConnected || currentLedCommands.empty()) {
+        return;
+    }
+
+    Logger.logln("BLE: Forwarding %d LED commands to board", currentLedCommands.size());
+    if (BLEClient.sendLedCommands(currentLedCommands.data(), currentLedCommands.size())) {
+        Logger.logln("BLE: LED commands sent successfully");
+    } else {
+        Logger.logln("BLE: Failed to send LED commands");
+    }
+}
+#endif

--- a/embedded/test/lib/climb-history/library.json
+++ b/embedded/test/lib/climb-history/library.json
@@ -1,0 +1,1 @@
+../../../../libs/climb-history/library.json

--- a/embedded/test/lib/climb-history/src/climb_history.cpp
+++ b/embedded/test/lib/climb-history/src/climb_history.cpp
@@ -1,1 +1,180 @@
-../../../../libs/climb-history/src/climb_history.cpp
+#include "climb_history.h"
+
+#include <ArduinoJson.h>
+
+#include <config_manager.h>
+
+ClimbHistory ClimbHistoryMgr;
+
+const char* ClimbHistory::NVS_KEY_HISTORY = "climb_hist";
+
+ClimbHistory::ClimbHistory() : hasCurrentClimb_(false) {
+    // Initialize all entries as invalid
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        history[i] = ClimbEntry();
+    }
+}
+
+void ClimbHistory::begin() {
+    load();
+}
+
+void ClimbHistory::addClimb(const char* name, const char* grade, const char* uuid) {
+    if (!name || !uuid)
+        return;
+
+    // Check if this is the same as the current climb (update)
+    if (hasCurrentClimb_ && history[0].valid && strcmp(history[0].uuid, uuid) == 0) {
+        // Same climb - just update name/grade in case they changed
+        strncpy(history[0].name, name, MAX_CLIMB_NAME_LEN - 1);
+        history[0].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+        if (grade) {
+            strncpy(history[0].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+            history[0].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+        }
+        save();
+        return;
+    }
+
+    // Shift existing entries down
+    shiftDown();
+
+    // Add new climb at position 0
+    strncpy(history[0].name, name, MAX_CLIMB_NAME_LEN - 1);
+    history[0].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+
+    if (grade) {
+        strncpy(history[0].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+        history[0].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+    } else {
+        history[0].grade[0] = '\0';
+    }
+
+    strncpy(history[0].uuid, uuid, MAX_CLIMB_UUID_LEN - 1);
+    history[0].uuid[MAX_CLIMB_UUID_LEN - 1] = '\0';
+
+    history[0].valid = true;
+    hasCurrentClimb_ = true;
+
+    save();
+}
+
+void ClimbHistory::clearCurrent() {
+    hasCurrentClimb_ = false;
+    // Note: We don't remove the entry from history, just mark no current climb
+    // This way the display can still show "last climb was X"
+}
+
+const ClimbEntry* ClimbHistory::getCurrentClimb() const {
+    if (!hasCurrentClimb_ || !history[0].valid) {
+        return nullptr;
+    }
+    return &history[0];
+}
+
+const ClimbEntry* ClimbHistory::getClimb(int index) const {
+    if (index < 0 || index >= MAX_CLIMB_HISTORY) {
+        return nullptr;
+    }
+    if (!history[index].valid) {
+        return nullptr;
+    }
+    return &history[index];
+}
+
+int ClimbHistory::getCount() const {
+    int count = 0;
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        if (history[i].valid) {
+            count++;
+        }
+    }
+    return count;
+}
+
+bool ClimbHistory::hasCurrentClimb() const {
+    return hasCurrentClimb_ && history[0].valid;
+}
+
+void ClimbHistory::shiftDown() {
+    // Move each entry to the next position, oldest is discarded
+    for (int i = MAX_CLIMB_HISTORY - 1; i > 0; i--) {
+        history[i] = history[i - 1];
+    }
+    // Position 0 is now ready for new entry
+    history[0] = ClimbEntry();
+}
+
+void ClimbHistory::save() {
+    // Serialize history to JSON
+    JsonDocument doc;
+    JsonArray arr = doc.to<JsonArray>();
+
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        if (history[i].valid) {
+            JsonObject obj = arr.add<JsonObject>();
+            obj["n"] = history[i].name;
+            obj["g"] = history[i].grade;
+            obj["u"] = history[i].uuid;
+        }
+    }
+
+    String json;
+    serializeJson(doc, json);
+
+    // Store in NVS
+    Config.setString(NVS_KEY_HISTORY, json.c_str());
+}
+
+void ClimbHistory::load() {
+    String json = Config.getString(NVS_KEY_HISTORY);
+    if (json.length() == 0) {
+        return;
+    }
+
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, json);
+    if (error) {
+        return;
+    }
+
+    JsonArray arr = doc.as<JsonArray>();
+    int index = 0;
+
+    for (JsonObject obj : arr) {
+        if (index >= MAX_CLIMB_HISTORY)
+            break;
+
+        const char* name = obj["n"];
+        const char* grade = obj["g"];
+        const char* uuid = obj["u"];
+
+        if (name && uuid) {
+            strncpy(history[index].name, name, MAX_CLIMB_NAME_LEN - 1);
+            history[index].name[MAX_CLIMB_NAME_LEN - 1] = '\0';
+
+            if (grade) {
+                strncpy(history[index].grade, grade, MAX_CLIMB_GRADE_LEN - 1);
+                history[index].grade[MAX_CLIMB_GRADE_LEN - 1] = '\0';
+            }
+
+            strncpy(history[index].uuid, uuid, MAX_CLIMB_UUID_LEN - 1);
+            history[index].uuid[MAX_CLIMB_UUID_LEN - 1] = '\0';
+
+            history[index].valid = true;
+            index++;
+        }
+    }
+
+    // Note: We don't set hasCurrentClimb_ = true here because loaded history
+    // represents past climbs, not an active current climb. The current climb
+    // is only set when a new climb is explicitly added via addClimb().
+}
+
+void ClimbHistory::clear() {
+    for (int i = 0; i < MAX_CLIMB_HISTORY; i++) {
+        history[i] = ClimbEntry();
+    }
+    hasCurrentClimb_ = false;
+    Config.remove(NVS_KEY_HISTORY);
+}

--- a/embedded/test/lib/climb-history/src/climb_history.cpp
+++ b/embedded/test/lib/climb-history/src/climb_history.cpp
@@ -1,0 +1,1 @@
+../../../../libs/climb-history/src/climb_history.cpp

--- a/embedded/test/lib/climb-history/src/climb_history.h
+++ b/embedded/test/lib/climb-history/src/climb_history.h
@@ -1,1 +1,121 @@
-../../../../libs/climb-history/src/climb_history.h
+#ifndef CLIMB_HISTORY_H
+#define CLIMB_HISTORY_H
+
+#include <Arduino.h>
+
+// Maximum number of climbs to track in history
+#define MAX_CLIMB_HISTORY 5
+
+// Maximum lengths for climb data
+#define MAX_CLIMB_NAME_LEN 64
+#define MAX_CLIMB_GRADE_LEN 16
+#define MAX_CLIMB_UUID_LEN 40
+
+/**
+ * Data structure for a single climb entry
+ */
+struct ClimbEntry {
+    char name[MAX_CLIMB_NAME_LEN];
+    char grade[MAX_CLIMB_GRADE_LEN];
+    char uuid[MAX_CLIMB_UUID_LEN];
+    bool valid;  // Whether this entry contains data
+
+    ClimbEntry() : valid(false) {
+        name[0] = '\0';
+        grade[0] = '\0';
+        uuid[0] = '\0';
+    }
+};
+
+/**
+ * ClimbHistory manages a circular buffer of recent climbs with NVS persistence.
+ *
+ * Features:
+ * - Stores the last MAX_CLIMB_HISTORY climbs
+ * - Persists to NVS for power cycle recovery
+ * - Provides access to current and previous climbs
+ * - Automatically shifts entries when adding new climbs
+ */
+class ClimbHistory {
+  public:
+    ClimbHistory();
+
+    /**
+     * Initialize the climb history.
+     * Loads any persisted data from NVS.
+     */
+    void begin();
+
+    /**
+     * Add a new climb to the history.
+     * This becomes the current climb, and previous climbs shift down.
+     * If the climb UUID matches the current climb, it's treated as an update.
+     *
+     * @param name Climb name
+     * @param grade Climb grade (e.g., "V5", "6c/V5")
+     * @param uuid Climb UUID
+     */
+    void addClimb(const char* name, const char* grade, const char* uuid);
+
+    /**
+     * Clear the current climb (e.g., when LEDs are cleared).
+     * Does not remove from history, just marks no current climb.
+     */
+    void clearCurrent();
+
+    /**
+     * Get the current climb (index 0).
+     * @return Pointer to current climb entry, or nullptr if none
+     */
+    const ClimbEntry* getCurrentClimb() const;
+
+    /**
+     * Get a climb from history by index.
+     * @param index 0 = current, 1 = previous, etc.
+     * @return Pointer to climb entry, or nullptr if invalid index or empty slot
+     */
+    const ClimbEntry* getClimb(int index) const;
+
+    /**
+     * Get the number of valid entries in history.
+     * @return Count of valid entries (0 to MAX_CLIMB_HISTORY)
+     */
+    int getCount() const;
+
+    /**
+     * Check if there's a current climb.
+     * @return true if there's a valid current climb
+     */
+    bool hasCurrentClimb() const;
+
+    /**
+     * Save history to NVS.
+     * Called automatically by addClimb().
+     */
+    void save();
+
+    /**
+     * Load history from NVS.
+     * Called automatically by begin().
+     */
+    void load();
+
+    /**
+     * Clear all history entries and NVS storage.
+     */
+    void clear();
+
+  private:
+    ClimbEntry history[MAX_CLIMB_HISTORY];
+    bool hasCurrentClimb_;
+
+    // NVS key for storing history
+    static const char* NVS_KEY_HISTORY;
+
+    // Shift all entries down by 1, discarding the oldest
+    void shiftDown();
+};
+
+extern ClimbHistory ClimbHistoryMgr;
+
+#endif

--- a/embedded/test/lib/climb-history/src/climb_history.h
+++ b/embedded/test/lib/climb-history/src/climb_history.h
@@ -1,0 +1,1 @@
+../../../../libs/climb-history/src/climb_history.h

--- a/embedded/test/lib/grade-colors/library.json
+++ b/embedded/test/lib/grade-colors/library.json
@@ -1,0 +1,12 @@
+{
+    "name": "grade-colors",
+    "version": "1.0.0",
+    "description": "V-grade color scheme for climbing grades (test build)",
+    "platforms": ["native", "espressif32"],
+    "dependencies": {
+        "mocks": "*"
+    },
+    "build": {
+        "flags": ["-std=c++17", "-DUNIT_TEST"]
+    }
+}

--- a/embedded/test/lib/grade-colors/src/grade_colors.h
+++ b/embedded/test/lib/grade-colors/src/grade_colors.h
@@ -1,0 +1,1 @@
+../../../../libs/lilygo-display/src/grade_colors.h

--- a/embedded/test/lib/grade-colors/src/grade_colors.h
+++ b/embedded/test/lib/grade-colors/src/grade_colors.h
@@ -1,1 +1,221 @@
-../../../../libs/lilygo-display/src/grade_colors.h
+/**
+ * V-grade color scheme for climbing grades
+ * Ported from packages/web/app/lib/grade-colors.ts
+ *
+ * Color progression from yellow (easy) to purple (hard):
+ * - V0: Yellow
+ * - V1-V2: Orange
+ * - V3-V4: Dark orange/red-orange
+ * - V5-V6: Red
+ * - V7-V10: Dark red/crimson
+ * - V11+: Purple/magenta
+ */
+
+#ifndef GRADE_COLORS_H
+#define GRADE_COLORS_H
+
+#include <Arduino.h>
+
+// Convert RGB888 to RGB565
+#define RGB565(r, g, b) ((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3))
+
+// V-grade colors (RGB565)
+#define COLOR_V0 RGB565(0xFF, 0xEB, 0x3B)   // Yellow #FFEB3B
+#define COLOR_V1 RGB565(0xFF, 0xC1, 0x07)   // Amber #FFC107
+#define COLOR_V2 RGB565(0xFF, 0x98, 0x00)   // Orange #FF9800
+#define COLOR_V3 RGB565(0xFF, 0x70, 0x43)   // Deep orange #FF7043
+#define COLOR_V4 RGB565(0xFF, 0x57, 0x22)   // Red-orange #FF5722
+#define COLOR_V5 RGB565(0xF4, 0x43, 0x36)   // Red #F44336
+#define COLOR_V6 RGB565(0xE5, 0x39, 0x35)   // Red (darker) #E53935
+#define COLOR_V7 RGB565(0xD3, 0x2F, 0x2F)   // Dark red #D32F2F
+#define COLOR_V8 RGB565(0xC6, 0x28, 0x28)   // Darker red #C62828
+#define COLOR_V9 RGB565(0xB7, 0x1C, 0x1C)   // Deep red #B71C1C
+#define COLOR_V10 RGB565(0xA1, 0x1B, 0x4A)  // Red-purple #A11B4A
+#define COLOR_V11 RGB565(0x9C, 0x27, 0xB0)  // Purple #9C27B0
+#define COLOR_V12 RGB565(0x7B, 0x1F, 0xA2)  // Dark purple #7B1FA2
+#define COLOR_V13 RGB565(0x6A, 0x1B, 0x9A)  // Darker purple #6A1B9A
+#define COLOR_V14 RGB565(0x5C, 0x1A, 0x87)  // Deep purple #5C1A87
+#define COLOR_V15 RGB565(0x4A, 0x14, 0x8C)  // Very deep purple #4A148C
+#define COLOR_V16 RGB565(0x38, 0x00, 0x6B)  // Near black purple #38006B
+#define COLOR_V17 RGB565(0x2A, 0x00, 0x54)  // Darkest purple #2A0054
+
+// Default color for unknown grades
+#define COLOR_GRADE_DEFAULT RGB565(0xC8, 0xC8, 0xC8)  // Light gray
+
+/**
+ * Get RGB565 color for a V-grade number (0-17)
+ * @param vGrade V-grade number
+ * @return RGB565 color value
+ */
+inline uint16_t getVGradeColorByNumber(int vGrade) {
+    switch (vGrade) {
+        case 0:
+            return COLOR_V0;
+        case 1:
+            return COLOR_V1;
+        case 2:
+            return COLOR_V2;
+        case 3:
+            return COLOR_V3;
+        case 4:
+            return COLOR_V4;
+        case 5:
+            return COLOR_V5;
+        case 6:
+            return COLOR_V6;
+        case 7:
+            return COLOR_V7;
+        case 8:
+            return COLOR_V8;
+        case 9:
+            return COLOR_V9;
+        case 10:
+            return COLOR_V10;
+        case 11:
+            return COLOR_V11;
+        case 12:
+            return COLOR_V12;
+        case 13:
+            return COLOR_V13;
+        case 14:
+            return COLOR_V14;
+        case 15:
+            return COLOR_V15;
+        case 16:
+            return COLOR_V16;
+        case 17:
+            return COLOR_V17;
+        default:
+            return vGrade > 17 ? COLOR_V17 : COLOR_GRADE_DEFAULT;
+    }
+}
+
+/**
+ * Get RGB565 color for a Font grade (e.g., "6a", "7b+")
+ * Maps Font grades to their equivalent V-grade colors
+ * @param fontGrade Font grade string
+ * @return RGB565 color value
+ */
+inline uint16_t getFontGradeColor(const char* fontGrade) {
+    if (!fontGrade || strlen(fontGrade) < 2)
+        return COLOR_GRADE_DEFAULT;
+
+    char grade = fontGrade[0];
+    char sub = fontGrade[1];
+    bool plus = (strlen(fontGrade) >= 3 && fontGrade[2] == '+');
+
+    // Map Font grades to V-grade colors
+    if (grade == '4')
+        return COLOR_V0;  // 4a, 4b, 4c -> V0
+    if (grade == '5') {
+        if (sub == 'a' || sub == 'b')
+            return COLOR_V1;  // 5a, 5b -> V1
+        if (sub == 'c')
+            return COLOR_V2;  // 5c -> V2
+    }
+    if (grade == '6') {
+        if (sub == 'a')
+            return COLOR_V3;  // 6a, 6a+ -> V3
+        if (sub == 'b')
+            return COLOR_V4;  // 6b, 6b+ -> V4
+        if (sub == 'c')
+            return COLOR_V5;  // 6c, 6c+ -> V5
+    }
+    if (grade == '7') {
+        if (sub == 'a' && !plus)
+            return COLOR_V6;  // 7a -> V6
+        if (sub == 'a' && plus)
+            return COLOR_V7;  // 7a+ -> V7
+        if (sub == 'b')
+            return COLOR_V8;  // 7b, 7b+ -> V8
+        if (sub == 'c' && !plus)
+            return COLOR_V9;  // 7c -> V9
+        if (sub == 'c' && plus)
+            return COLOR_V10;  // 7c+ -> V10
+    }
+    if (grade == '8') {
+        if (sub == 'a' && !plus)
+            return COLOR_V11;  // 8a -> V11
+        if (sub == 'a' && plus)
+            return COLOR_V12;  // 8a+ -> V12
+        if (sub == 'b' && !plus)
+            return COLOR_V13;  // 8b -> V13
+        if (sub == 'b' && plus)
+            return COLOR_V14;  // 8b+ -> V14
+        if (sub == 'c' && !plus)
+            return COLOR_V15;  // 8c -> V15
+        if (sub == 'c' && plus)
+            return COLOR_V16;  // 8c+ -> V16
+    }
+
+    return COLOR_GRADE_DEFAULT;
+}
+
+/**
+ * Get RGB565 color for a grade string (e.g., "V3", "6a/V3", "V10")
+ * Tries to extract V-grade first, falls back to Font grade
+ * @param grade Grade string
+ * @return RGB565 color value
+ */
+inline uint16_t getGradeColor(const char* grade) {
+    if (!grade || strlen(grade) == 0)
+        return COLOR_GRADE_DEFAULT;
+
+    // Look for V-grade pattern (V followed by number)
+    const char* vPos = strchr(grade, 'V');
+    if (!vPos)
+        vPos = strchr(grade, 'v');
+
+    if (vPos) {
+        // Parse the number after V
+        int vGrade = atoi(vPos + 1);
+        if (vGrade >= 0 && vGrade <= 17) {
+            return getVGradeColorByNumber(vGrade);
+        }
+        // Handle V17+
+        if (vGrade > 17)
+            return COLOR_V17;
+    }
+
+    // Try Font grade (look for pattern like "6a" or "7b+")
+    for (const char* p = grade; *p; p++) {
+        if (*p >= '4' && *p <= '8' && p[1] &&
+            (p[1] == 'a' || p[1] == 'b' || p[1] == 'c' || p[1] == 'A' || p[1] == 'B' || p[1] == 'C')) {
+            char fontGrade[4] = {0};
+            fontGrade[0] = *p;
+            fontGrade[1] = (p[1] >= 'A' && p[1] <= 'C') ? (p[1] + 32) : p[1];  // lowercase
+            if (p[2] == '+')
+                fontGrade[2] = '+';
+            return getFontGradeColor(fontGrade);
+        }
+    }
+
+    return COLOR_GRADE_DEFAULT;
+}
+
+/**
+ * Determine if a color is light (for text contrast)
+ * @param color RGB565 color
+ * @return true if color is light and should use dark text
+ */
+inline bool isLightColor(uint16_t color) {
+    // Extract RGB components from RGB565
+    uint8_t r = (color >> 11) << 3;
+    uint8_t g = ((color >> 5) & 0x3F) << 2;
+    uint8_t b = (color & 0x1F) << 3;
+
+    // Calculate relative luminance
+    float luminance = (0.299f * r + 0.587f * g + 0.114f * b) / 255.0f;
+    return luminance > 0.5f;
+}
+
+/**
+ * Get text color (black or white) for good contrast against background
+ * @param bgColor Background RGB565 color
+ * @return RGB565 color for text (black or white)
+ */
+inline uint16_t getGradeTextColor(uint16_t bgColor) {
+    return isLightColor(bgColor) ? 0x0000 : 0xFFFF;  // Black or White
+}
+
+#endif  // GRADE_COLORS_H

--- a/embedded/test/lib/mocks/src/Arduino.h
+++ b/embedded/test/lib/mocks/src/Arduino.h
@@ -183,14 +183,17 @@ class String {
     }
 
     bool startsWith(const String& prefix) const {
-        if (prefix.length() > data_.length()) return false;
+        if (prefix.length() > data_.length())
+            return false;
         return data_.compare(0, prefix.length(), prefix.c_str()) == 0;
     }
 
     bool startsWith(const char* prefix) const {
-        if (!prefix) return false;
+        if (!prefix)
+            return false;
         size_t prefixLen = strlen(prefix);
-        if (prefixLen > data_.length()) return false;
+        if (prefixLen > data_.length())
+            return false;
         return data_.compare(0, prefixLen, prefix) == 0;
     }
 

--- a/embedded/test/lib/mocks/src/Arduino.h
+++ b/embedded/test/lib/mocks/src/Arduino.h
@@ -182,6 +182,18 @@ class String {
         return String(data_.substr(beginIndex, endIndex - beginIndex).c_str());
     }
 
+    bool startsWith(const String& prefix) const {
+        if (prefix.length() > data_.length()) return false;
+        return data_.compare(0, prefix.length(), prefix.c_str()) == 0;
+    }
+
+    bool startsWith(const char* prefix) const {
+        if (!prefix) return false;
+        size_t prefixLen = strlen(prefix);
+        if (prefixLen > data_.length()) return false;
+        return data_.compare(0, prefixLen, prefix) == 0;
+    }
+
     void toCharArray(char* buf, size_t bufsize) const {
         if (buf && bufsize > 0) {
             size_t len = (bufsize - 1 < data_.length()) ? bufsize - 1 : data_.length();

--- a/embedded/test/lib/mocks/src/ArduinoJson.h
+++ b/embedded/test/lib/mocks/src/ArduinoJson.h
@@ -368,8 +368,7 @@ class JsonDocument {
         return T();
     }
 
-    template<typename T>
-    T as() {
+    template <typename T> T as() {
         if constexpr (std::is_same_v<T, JsonObject>) {
             return JsonObject(&root_);
         } else if constexpr (std::is_same_v<T, JsonArray>) {

--- a/embedded/test/lib/mocks/src/ArduinoJson.h
+++ b/embedded/test/lib/mocks/src/ArduinoJson.h
@@ -368,6 +368,16 @@ class JsonDocument {
         return T();
     }
 
+    template<typename T>
+    T as() {
+        if constexpr (std::is_same_v<T, JsonObject>) {
+            return JsonObject(&root_);
+        } else if constexpr (std::is_same_v<T, JsonArray>) {
+            return JsonArray(&root_);
+        }
+        return T();
+    }
+
     void clear() { root_ = JsonVariant(); }
 
     JsonVariant& getRoot() { return root_; }

--- a/embedded/test/platformio.ini
+++ b/embedded/test/platformio.ini
@@ -28,6 +28,7 @@ lib_deps =
     graphql-ws-client
     nordic-uart-ble
     esp-web-server
+    climb-history
 lib_extra_dirs =
     lib
 test_framework = unity

--- a/embedded/test/platformio.ini
+++ b/embedded/test/platformio.ini
@@ -29,6 +29,7 @@ lib_deps =
     nordic-uart-ble
     esp-web-server
     climb-history
+    grade-colors
 lib_extra_dirs =
     lib
 test_framework = unity

--- a/embedded/test/test_climb_history/test_climb_history.cpp
+++ b/embedded/test/test_climb_history/test_climb_history.cpp
@@ -1,0 +1,287 @@
+/**
+ * Unit Tests for Climb History Library
+ *
+ * Tests the circular buffer climb history with NVS persistence.
+ */
+
+#include <unity.h>
+#include <climb_history.h>
+#include <Preferences.h>
+#include <cstring>
+
+// Test instance (use the global ClimbHistoryMgr)
+void setUp(void) {
+    Preferences::resetAll();  // Clear all mock storage between tests
+    ClimbHistoryMgr.clear();   // Clear history state
+}
+
+void tearDown(void) {
+    // Nothing to clean up
+}
+
+// =============================================================================
+// Basic Add/Get Tests
+// =============================================================================
+
+void test_addClimb_and_getCurrentClimb(void) {
+    ClimbHistoryMgr.addClimb("Test Climb", "V5", "uuid-123");
+
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_NOT_NULL(climb);
+    TEST_ASSERT_EQUAL_STRING("Test Climb", climb->name);
+    TEST_ASSERT_EQUAL_STRING("V5", climb->grade);
+    TEST_ASSERT_EQUAL_STRING("uuid-123", climb->uuid);
+    TEST_ASSERT_TRUE(climb->valid);
+}
+
+void test_hasCurrentClimb_false_when_empty(void) {
+    TEST_ASSERT_FALSE(ClimbHistoryMgr.hasCurrentClimb());
+}
+
+void test_hasCurrentClimb_true_after_add(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V3", "uuid-1");
+    TEST_ASSERT_TRUE(ClimbHistoryMgr.hasCurrentClimb());
+}
+
+void test_getCurrentClimb_null_when_empty(void) {
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_NULL(climb);
+}
+
+void test_getCount_returns_zero_when_empty(void) {
+    TEST_ASSERT_EQUAL(0, ClimbHistoryMgr.getCount());
+}
+
+void test_getCount_increments_with_adds(void) {
+    ClimbHistoryMgr.addClimb("Climb 1", "V1", "uuid-1");
+    TEST_ASSERT_EQUAL(1, ClimbHistoryMgr.getCount());
+
+    ClimbHistoryMgr.addClimb("Climb 2", "V2", "uuid-2");
+    TEST_ASSERT_EQUAL(2, ClimbHistoryMgr.getCount());
+
+    ClimbHistoryMgr.addClimb("Climb 3", "V3", "uuid-3");
+    TEST_ASSERT_EQUAL(3, ClimbHistoryMgr.getCount());
+}
+
+// =============================================================================
+// History Shifting Tests
+// =============================================================================
+
+void test_history_shifts_down_when_new_climb_added(void) {
+    ClimbHistoryMgr.addClimb("First", "V1", "uuid-1");
+    ClimbHistoryMgr.addClimb("Second", "V2", "uuid-2");
+
+    // Current should be Second
+    const ClimbEntry* current = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_EQUAL_STRING("Second", current->name);
+
+    // Previous should be First
+    const ClimbEntry* previous = ClimbHistoryMgr.getClimb(1);
+    TEST_ASSERT_NOT_NULL(previous);
+    TEST_ASSERT_EQUAL_STRING("First", previous->name);
+}
+
+void test_history_maintains_order(void) {
+    ClimbHistoryMgr.addClimb("Climb 1", "V1", "uuid-1");
+    ClimbHistoryMgr.addClimb("Climb 2", "V2", "uuid-2");
+    ClimbHistoryMgr.addClimb("Climb 3", "V3", "uuid-3");
+    ClimbHistoryMgr.addClimb("Climb 4", "V4", "uuid-4");
+
+    TEST_ASSERT_EQUAL_STRING("Climb 4", ClimbHistoryMgr.getClimb(0)->name);
+    TEST_ASSERT_EQUAL_STRING("Climb 3", ClimbHistoryMgr.getClimb(1)->name);
+    TEST_ASSERT_EQUAL_STRING("Climb 2", ClimbHistoryMgr.getClimb(2)->name);
+    TEST_ASSERT_EQUAL_STRING("Climb 1", ClimbHistoryMgr.getClimb(3)->name);
+}
+
+void test_history_limits_to_max(void) {
+    // Add more than MAX_CLIMB_HISTORY (5) climbs
+    for (int i = 0; i < 7; i++) {
+        char name[32];
+        char uuid[32];
+        snprintf(name, sizeof(name), "Climb %d", i);
+        snprintf(uuid, sizeof(uuid), "uuid-%d", i);
+        ClimbHistoryMgr.addClimb(name, "V1", uuid);
+    }
+
+    // Should only have MAX_CLIMB_HISTORY entries
+    TEST_ASSERT_EQUAL(MAX_CLIMB_HISTORY, ClimbHistoryMgr.getCount());
+
+    // Most recent should be Climb 6
+    TEST_ASSERT_EQUAL_STRING("Climb 6", ClimbHistoryMgr.getClimb(0)->name);
+
+    // Oldest in history should be Climb 2 (0 and 1 were pushed out)
+    TEST_ASSERT_EQUAL_STRING("Climb 2", ClimbHistoryMgr.getClimb(MAX_CLIMB_HISTORY - 1)->name);
+}
+
+// =============================================================================
+// Update Existing Climb Tests
+// =============================================================================
+
+void test_same_uuid_updates_instead_of_shifts(void) {
+    ClimbHistoryMgr.addClimb("Original Name", "V3", "uuid-same");
+    ClimbHistoryMgr.addClimb("Updated Name", "V4", "uuid-same");
+
+    // Should still only have 1 entry
+    TEST_ASSERT_EQUAL(1, ClimbHistoryMgr.getCount());
+
+    // Name and grade should be updated
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_EQUAL_STRING("Updated Name", climb->name);
+    TEST_ASSERT_EQUAL_STRING("V4", climb->grade);
+    TEST_ASSERT_EQUAL_STRING("uuid-same", climb->uuid);
+}
+
+void test_update_only_applies_to_current(void) {
+    ClimbHistoryMgr.addClimb("First", "V1", "uuid-1");
+    ClimbHistoryMgr.addClimb("Second", "V2", "uuid-2");
+
+    // Now add with uuid-1 (which is now in position 1, not current)
+    ClimbHistoryMgr.addClimb("New Climb", "V3", "uuid-1");
+
+    // This should add a NEW entry (not update position 1)
+    TEST_ASSERT_EQUAL(3, ClimbHistoryMgr.getCount());
+    TEST_ASSERT_EQUAL_STRING("New Climb", ClimbHistoryMgr.getClimb(0)->name);
+}
+
+// =============================================================================
+// Clear Current Tests
+// =============================================================================
+
+void test_clearCurrent_marks_no_current(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    TEST_ASSERT_TRUE(ClimbHistoryMgr.hasCurrentClimb());
+
+    ClimbHistoryMgr.clearCurrent();
+    TEST_ASSERT_FALSE(ClimbHistoryMgr.hasCurrentClimb());
+}
+
+void test_clearCurrent_keeps_history(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    ClimbHistoryMgr.clearCurrent();
+
+    // Count should still be 1 (entry exists, just not "current")
+    TEST_ASSERT_EQUAL(1, ClimbHistoryMgr.getCount());
+
+    // getClimb should still work
+    const ClimbEntry* climb = ClimbHistoryMgr.getClimb(0);
+    TEST_ASSERT_NOT_NULL(climb);
+    TEST_ASSERT_EQUAL_STRING("Climb", climb->name);
+}
+
+void test_getCurrentClimb_null_after_clearCurrent(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    ClimbHistoryMgr.clearCurrent();
+
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_NULL(climb);
+}
+
+// =============================================================================
+// Get Climb By Index Tests
+// =============================================================================
+
+void test_getClimb_returns_null_for_negative_index(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    TEST_ASSERT_NULL(ClimbHistoryMgr.getClimb(-1));
+}
+
+void test_getClimb_returns_null_for_out_of_bounds_index(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    TEST_ASSERT_NULL(ClimbHistoryMgr.getClimb(MAX_CLIMB_HISTORY));
+}
+
+void test_getClimb_returns_null_for_empty_slot(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", "uuid-1");
+    // Only 1 entry, so index 1 should be null
+    TEST_ASSERT_NULL(ClimbHistoryMgr.getClimb(1));
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+void test_addClimb_with_null_name_is_ignored(void) {
+    ClimbHistoryMgr.addClimb(nullptr, "V1", "uuid-1");
+    TEST_ASSERT_EQUAL(0, ClimbHistoryMgr.getCount());
+}
+
+void test_addClimb_with_null_uuid_is_ignored(void) {
+    ClimbHistoryMgr.addClimb("Climb", "V1", nullptr);
+    TEST_ASSERT_EQUAL(0, ClimbHistoryMgr.getCount());
+}
+
+void test_addClimb_with_null_grade_is_ok(void) {
+    ClimbHistoryMgr.addClimb("Climb", nullptr, "uuid-1");
+    TEST_ASSERT_EQUAL(1, ClimbHistoryMgr.getCount());
+
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_EQUAL_STRING("", climb->grade);
+}
+
+void test_addClimb_truncates_long_name(void) {
+    // Create a very long name
+    char longName[100];
+    memset(longName, 'A', sizeof(longName) - 1);
+    longName[sizeof(longName) - 1] = '\0';
+
+    ClimbHistoryMgr.addClimb(longName, "V1", "uuid-1");
+
+    const ClimbEntry* climb = ClimbHistoryMgr.getCurrentClimb();
+    TEST_ASSERT_TRUE(strlen(climb->name) < MAX_CLIMB_NAME_LEN);
+}
+
+void test_clear_removes_all_history(void) {
+    ClimbHistoryMgr.addClimb("Climb 1", "V1", "uuid-1");
+    ClimbHistoryMgr.addClimb("Climb 2", "V2", "uuid-2");
+    TEST_ASSERT_EQUAL(2, ClimbHistoryMgr.getCount());
+
+    ClimbHistoryMgr.clear();
+
+    TEST_ASSERT_EQUAL(0, ClimbHistoryMgr.getCount());
+    TEST_ASSERT_FALSE(ClimbHistoryMgr.hasCurrentClimb());
+    TEST_ASSERT_NULL(ClimbHistoryMgr.getCurrentClimb());
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    // Basic add/get tests
+    RUN_TEST(test_addClimb_and_getCurrentClimb);
+    RUN_TEST(test_hasCurrentClimb_false_when_empty);
+    RUN_TEST(test_hasCurrentClimb_true_after_add);
+    RUN_TEST(test_getCurrentClimb_null_when_empty);
+    RUN_TEST(test_getCount_returns_zero_when_empty);
+    RUN_TEST(test_getCount_increments_with_adds);
+
+    // History shifting tests
+    RUN_TEST(test_history_shifts_down_when_new_climb_added);
+    RUN_TEST(test_history_maintains_order);
+    RUN_TEST(test_history_limits_to_max);
+
+    // Update existing climb tests
+    RUN_TEST(test_same_uuid_updates_instead_of_shifts);
+    RUN_TEST(test_update_only_applies_to_current);
+
+    // Clear current tests
+    RUN_TEST(test_clearCurrent_marks_no_current);
+    RUN_TEST(test_clearCurrent_keeps_history);
+    RUN_TEST(test_getCurrentClimb_null_after_clearCurrent);
+
+    // Get climb by index tests
+    RUN_TEST(test_getClimb_returns_null_for_negative_index);
+    RUN_TEST(test_getClimb_returns_null_for_out_of_bounds_index);
+    RUN_TEST(test_getClimb_returns_null_for_empty_slot);
+
+    // Edge cases
+    RUN_TEST(test_addClimb_with_null_name_is_ignored);
+    RUN_TEST(test_addClimb_with_null_uuid_is_ignored);
+    RUN_TEST(test_addClimb_with_null_grade_is_ok);
+    RUN_TEST(test_addClimb_truncates_long_name);
+    RUN_TEST(test_clear_removes_all_history);
+
+    return UNITY_END();
+}

--- a/embedded/test/test_climb_history/test_climb_history.cpp
+++ b/embedded/test/test_climb_history/test_climb_history.cpp
@@ -4,15 +4,16 @@
  * Tests the circular buffer climb history with NVS persistence.
  */
 
-#include <unity.h>
-#include <climb_history.h>
 #include <Preferences.h>
+
+#include <climb_history.h>
 #include <cstring>
+#include <unity.h>
 
 // Test instance (use the global ClimbHistoryMgr)
 void setUp(void) {
     Preferences::resetAll();  // Clear all mock storage between tests
-    ClimbHistoryMgr.clear();   // Clear history state
+    ClimbHistoryMgr.clear();  // Clear history state
 }
 
 void tearDown(void) {
@@ -246,7 +247,7 @@ void test_clear_removes_all_history(void) {
 // Main
 // =============================================================================
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     UNITY_BEGIN();
 
     // Basic add/get tests

--- a/embedded/test/test_grade_colors/test_grade_colors.cpp
+++ b/embedded/test/test_grade_colors/test_grade_colors.cpp
@@ -5,8 +5,8 @@
  * These are pure functions that require no hardware mocks.
  */
 
-#include <unity.h>
 #include <grade_colors.h>
+#include <unity.h>
 
 void setUp(void) {
     // Nothing to set up - pure functions
@@ -58,12 +58,9 @@ void test_vgrade_negative_returns_default_gray(void) {
 
 void test_vgrade_all_values_0_to_17(void) {
     // Verify each V-grade returns a unique color
-    uint16_t expectedColors[] = {
-        COLOR_V0, COLOR_V1, COLOR_V2, COLOR_V3, COLOR_V4,
-        COLOR_V5, COLOR_V6, COLOR_V7, COLOR_V8, COLOR_V9,
-        COLOR_V10, COLOR_V11, COLOR_V12, COLOR_V13, COLOR_V14,
-        COLOR_V15, COLOR_V16, COLOR_V17
-    };
+    uint16_t expectedColors[] = {COLOR_V0,  COLOR_V1,  COLOR_V2,  COLOR_V3,  COLOR_V4,  COLOR_V5,
+                                 COLOR_V6,  COLOR_V7,  COLOR_V8,  COLOR_V9,  COLOR_V10, COLOR_V11,
+                                 COLOR_V12, COLOR_V13, COLOR_V14, COLOR_V15, COLOR_V16, COLOR_V17};
 
     for (int i = 0; i <= 17; i++) {
         uint16_t color = getVGradeColorByNumber(i);
@@ -289,7 +286,7 @@ void test_text_color_on_default_gray_is_black(void) {
 // Main
 // =============================================================================
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     UNITY_BEGIN();
 
     // getVGradeColorByNumber tests

--- a/embedded/test/test_grade_colors/test_grade_colors.cpp
+++ b/embedded/test/test_grade_colors/test_grade_colors.cpp
@@ -1,0 +1,349 @@
+/**
+ * Unit Tests for Grade Colors Library
+ *
+ * Tests the V-grade color scheme functions for climbing grades.
+ * These are pure functions that require no hardware mocks.
+ */
+
+#include <unity.h>
+#include <grade_colors.h>
+
+void setUp(void) {
+    // Nothing to set up - pure functions
+}
+
+void tearDown(void) {
+    // Nothing to clean up
+}
+
+// =============================================================================
+// getVGradeColorByNumber Tests
+// =============================================================================
+
+void test_vgrade_0_returns_yellow(void) {
+    uint16_t color = getVGradeColorByNumber(0);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V0, color);
+}
+
+void test_vgrade_5_returns_red(void) {
+    uint16_t color = getVGradeColorByNumber(5);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V5, color);
+}
+
+void test_vgrade_10_returns_red_purple(void) {
+    uint16_t color = getVGradeColorByNumber(10);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V10, color);
+}
+
+void test_vgrade_17_returns_darkest_purple(void) {
+    uint16_t color = getVGradeColorByNumber(17);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V17, color);
+}
+
+void test_vgrade_greater_than_17_returns_v17_color(void) {
+    uint16_t color = getVGradeColorByNumber(20);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V17, color);
+
+    color = getVGradeColorByNumber(100);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V17, color);
+}
+
+void test_vgrade_negative_returns_default_gray(void) {
+    uint16_t color = getVGradeColorByNumber(-1);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+
+    color = getVGradeColorByNumber(-5);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_vgrade_all_values_0_to_17(void) {
+    // Verify each V-grade returns a unique color
+    uint16_t expectedColors[] = {
+        COLOR_V0, COLOR_V1, COLOR_V2, COLOR_V3, COLOR_V4,
+        COLOR_V5, COLOR_V6, COLOR_V7, COLOR_V8, COLOR_V9,
+        COLOR_V10, COLOR_V11, COLOR_V12, COLOR_V13, COLOR_V14,
+        COLOR_V15, COLOR_V16, COLOR_V17
+    };
+
+    for (int i = 0; i <= 17; i++) {
+        uint16_t color = getVGradeColorByNumber(i);
+        TEST_ASSERT_EQUAL_UINT16(expectedColors[i], color);
+    }
+}
+
+// =============================================================================
+// getFontGradeColor Tests
+// =============================================================================
+
+void test_font_grade_4a_returns_v0_color(void) {
+    uint16_t color = getFontGradeColor("4a");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V0, color);
+}
+
+void test_font_grade_5a_returns_v1_color(void) {
+    uint16_t color = getFontGradeColor("5a");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V1, color);
+}
+
+void test_font_grade_5c_returns_v2_color(void) {
+    uint16_t color = getFontGradeColor("5c");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V2, color);
+}
+
+void test_font_grade_6a_returns_v3_color(void) {
+    uint16_t color = getFontGradeColor("6a");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V3, color);
+}
+
+void test_font_grade_6b_returns_v4_color(void) {
+    uint16_t color = getFontGradeColor("6b");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V4, color);
+}
+
+void test_font_grade_7a_plus_returns_v7_color(void) {
+    uint16_t color = getFontGradeColor("7a+");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V7, color);
+}
+
+void test_font_grade_7c_plus_returns_v10_color(void) {
+    uint16_t color = getFontGradeColor("7c+");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V10, color);
+}
+
+void test_font_grade_8a_returns_v11_color(void) {
+    uint16_t color = getFontGradeColor("8a");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V11, color);
+}
+
+void test_font_grade_8c_plus_returns_v16_color(void) {
+    uint16_t color = getFontGradeColor("8c+");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V16, color);
+}
+
+void test_font_grade_null_returns_default(void) {
+    uint16_t color = getFontGradeColor(nullptr);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_font_grade_empty_returns_default(void) {
+    uint16_t color = getFontGradeColor("");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_font_grade_single_char_returns_default(void) {
+    uint16_t color = getFontGradeColor("6");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_font_grade_invalid_returns_default(void) {
+    uint16_t color = getFontGradeColor("xyz");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+
+    color = getFontGradeColor("9a");  // 9 is out of range
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+// =============================================================================
+// getGradeColor Tests
+// =============================================================================
+
+void test_grade_color_v3_returns_v3_color(void) {
+    uint16_t color = getGradeColor("V3");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V3, color);
+}
+
+void test_grade_color_lowercase_v3_returns_v3_color(void) {
+    uint16_t color = getGradeColor("v3");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V3, color);
+}
+
+void test_grade_color_v10_returns_v10_color(void) {
+    uint16_t color = getGradeColor("V10");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V10, color);
+}
+
+void test_grade_color_v17_returns_v17_color(void) {
+    uint16_t color = getGradeColor("V17");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V17, color);
+}
+
+void test_grade_color_combined_format_extracts_vgrade(void) {
+    // Combined format like "6a/V3" should use V3
+    uint16_t color = getGradeColor("6a/V3");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V3, color);
+}
+
+void test_grade_color_combined_format_v10(void) {
+    uint16_t color = getGradeColor("7c+/V10");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V10, color);
+}
+
+void test_grade_color_font_only_falls_back_to_font_grade(void) {
+    // Font-only grade should use font grade mapping
+    uint16_t color = getGradeColor("6b+");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V4, color);  // 6b maps to V4
+}
+
+void test_grade_color_uppercase_font_grade(void) {
+    // Should handle uppercase font grades
+    uint16_t color = getGradeColor("6A");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_V3, color);
+}
+
+void test_grade_color_null_returns_default(void) {
+    uint16_t color = getGradeColor(nullptr);
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_grade_color_empty_returns_default(void) {
+    uint16_t color = getGradeColor("");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+void test_grade_color_invalid_returns_default(void) {
+    uint16_t color = getGradeColor("unknown");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+
+    color = getGradeColor("123");
+    TEST_ASSERT_EQUAL_UINT16(COLOR_GRADE_DEFAULT, color);
+}
+
+// =============================================================================
+// isLightColor Tests
+// =============================================================================
+
+void test_is_light_color_v0_yellow_is_light(void) {
+    // V0 is yellow, which is a light color
+    bool isLight = isLightColor(COLOR_V0);
+    TEST_ASSERT_TRUE(isLight);
+}
+
+void test_is_light_color_v1_amber_is_light(void) {
+    // V1 is amber, which should be light
+    bool isLight = isLightColor(COLOR_V1);
+    TEST_ASSERT_TRUE(isLight);
+}
+
+void test_is_light_color_v17_dark_purple_is_dark(void) {
+    // V17 is darkest purple, which is dark
+    bool isLight = isLightColor(COLOR_V17);
+    TEST_ASSERT_FALSE(isLight);
+}
+
+void test_is_light_color_v10_is_dark(void) {
+    // V10 is red-purple, which is dark
+    bool isLight = isLightColor(COLOR_V10);
+    TEST_ASSERT_FALSE(isLight);
+}
+
+void test_is_light_color_white_is_light(void) {
+    // Pure white
+    bool isLight = isLightColor(0xFFFF);
+    TEST_ASSERT_TRUE(isLight);
+}
+
+void test_is_light_color_black_is_dark(void) {
+    // Pure black
+    bool isLight = isLightColor(0x0000);
+    TEST_ASSERT_FALSE(isLight);
+}
+
+void test_is_light_color_default_gray_is_light(void) {
+    // Default gray should be light
+    bool isLight = isLightColor(COLOR_GRADE_DEFAULT);
+    TEST_ASSERT_TRUE(isLight);
+}
+
+// =============================================================================
+// getGradeTextColor Tests
+// =============================================================================
+
+void test_text_color_on_light_bg_is_black(void) {
+    // Light background (V0 yellow) should get black text
+    uint16_t textColor = getGradeTextColor(COLOR_V0);
+    TEST_ASSERT_EQUAL_UINT16(0x0000, textColor);  // Black
+}
+
+void test_text_color_on_dark_bg_is_white(void) {
+    // Dark background (V17 purple) should get white text
+    uint16_t textColor = getGradeTextColor(COLOR_V17);
+    TEST_ASSERT_EQUAL_UINT16(0xFFFF, textColor);  // White
+}
+
+void test_text_color_on_white_is_black(void) {
+    uint16_t textColor = getGradeTextColor(0xFFFF);
+    TEST_ASSERT_EQUAL_UINT16(0x0000, textColor);  // Black
+}
+
+void test_text_color_on_black_is_white(void) {
+    uint16_t textColor = getGradeTextColor(0x0000);
+    TEST_ASSERT_EQUAL_UINT16(0xFFFF, textColor);  // White
+}
+
+void test_text_color_on_default_gray_is_black(void) {
+    uint16_t textColor = getGradeTextColor(COLOR_GRADE_DEFAULT);
+    TEST_ASSERT_EQUAL_UINT16(0x0000, textColor);  // Black (gray is light)
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    // getVGradeColorByNumber tests
+    RUN_TEST(test_vgrade_0_returns_yellow);
+    RUN_TEST(test_vgrade_5_returns_red);
+    RUN_TEST(test_vgrade_10_returns_red_purple);
+    RUN_TEST(test_vgrade_17_returns_darkest_purple);
+    RUN_TEST(test_vgrade_greater_than_17_returns_v17_color);
+    RUN_TEST(test_vgrade_negative_returns_default_gray);
+    RUN_TEST(test_vgrade_all_values_0_to_17);
+
+    // getFontGradeColor tests
+    RUN_TEST(test_font_grade_4a_returns_v0_color);
+    RUN_TEST(test_font_grade_5a_returns_v1_color);
+    RUN_TEST(test_font_grade_5c_returns_v2_color);
+    RUN_TEST(test_font_grade_6a_returns_v3_color);
+    RUN_TEST(test_font_grade_6b_returns_v4_color);
+    RUN_TEST(test_font_grade_7a_plus_returns_v7_color);
+    RUN_TEST(test_font_grade_7c_plus_returns_v10_color);
+    RUN_TEST(test_font_grade_8a_returns_v11_color);
+    RUN_TEST(test_font_grade_8c_plus_returns_v16_color);
+    RUN_TEST(test_font_grade_null_returns_default);
+    RUN_TEST(test_font_grade_empty_returns_default);
+    RUN_TEST(test_font_grade_single_char_returns_default);
+    RUN_TEST(test_font_grade_invalid_returns_default);
+
+    // getGradeColor tests
+    RUN_TEST(test_grade_color_v3_returns_v3_color);
+    RUN_TEST(test_grade_color_lowercase_v3_returns_v3_color);
+    RUN_TEST(test_grade_color_v10_returns_v10_color);
+    RUN_TEST(test_grade_color_v17_returns_v17_color);
+    RUN_TEST(test_grade_color_combined_format_extracts_vgrade);
+    RUN_TEST(test_grade_color_combined_format_v10);
+    RUN_TEST(test_grade_color_font_only_falls_back_to_font_grade);
+    RUN_TEST(test_grade_color_uppercase_font_grade);
+    RUN_TEST(test_grade_color_null_returns_default);
+    RUN_TEST(test_grade_color_empty_returns_default);
+    RUN_TEST(test_grade_color_invalid_returns_default);
+
+    // isLightColor tests
+    RUN_TEST(test_is_light_color_v0_yellow_is_light);
+    RUN_TEST(test_is_light_color_v1_amber_is_light);
+    RUN_TEST(test_is_light_color_v17_dark_purple_is_dark);
+    RUN_TEST(test_is_light_color_v10_is_dark);
+    RUN_TEST(test_is_light_color_white_is_light);
+    RUN_TEST(test_is_light_color_black_is_dark);
+    RUN_TEST(test_is_light_color_default_gray_is_light);
+
+    // getGradeTextColor tests
+    RUN_TEST(test_text_color_on_light_bg_is_black);
+    RUN_TEST(test_text_color_on_dark_bg_is_white);
+    RUN_TEST(test_text_color_on_white_is_black);
+    RUN_TEST(test_text_color_on_black_is_white);
+    RUN_TEST(test_text_color_on_default_gray_is_black);
+
+    return UNITY_END();
+}

--- a/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
@@ -86,8 +86,12 @@ export const controllerSubscriptions = {
         .set({ lastSeenAt: new Date() })
         .where(eq(esp32Controllers.id, controller.id));
 
+      // Get session details to get boardPath
+      const sessionData = await roomManager.getSessionById(sessionId);
+      const boardPath = sessionData?.boardPath || '';
+
       console.log(
-        `[Controller] Controller ${controller.id} subscribed to session ${sessionId}`
+        `[Controller] Controller ${controller.id} subscribed to session ${sessionId} (boardPath: ${boardPath})`
       );
 
       // Create subscription to queue events
@@ -128,6 +132,8 @@ export const controllerSubscriptions = {
                 commands,
                 climbUuid: climb.uuid,
                 climbName: climb.name,
+                climbGrade: climb.difficulty,
+                boardPath,
                 angle: climb.angle,
               };
               push(ledUpdate);
@@ -137,6 +143,7 @@ export const controllerSubscriptions = {
               const ledUpdate: ControllerEvent = {
                 __typename: 'LedUpdate',
                 commands: [],
+                boardPath,
               };
               push(ledUpdate);
             }
@@ -160,6 +167,8 @@ export const controllerSubscriptions = {
             commands,
             climbUuid: climb.uuid,
             climbName: climb.name,
+            climbGrade: climb.difficulty,
+            boardPath,
             angle: climb.angle,
           },
         };

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -1433,6 +1433,8 @@ export const typeDefs = /* GraphQL */ `
     commands: [LedCommand!]!
     climbUuid: String
     climbName: String
+    climbGrade: String
+    boardPath: String
     angle: Int
   }
 


### PR DESCRIPTION
## Summary

- Add support for LilyGo T-Display-S3 with built-in display showing climb info and QR codes
- New BLE proxy mode to forward data between official Kilter/Tension app and actual board
- Display shows current climb name/grade with QR code to join session
- Three build variants: standard, proxy-only, and T-Display-S3 with display + proxy

## Changes

### New Libraries
- **lilygo-display**: Display driver using LovyanGFX for T-Display-S3's parallel 8-bit interface
- **ble-proxy**: BLE client/server for proxying data to nearby Aurora boards
- **climb-history**: Circular buffer for tracking recent climbs (persisted to NVS)

### Backend Changes
- Add `climbGrade` and `boardPath` fields to `LedUpdate` GraphQL type for display info

### Firmware Changes
- Fix GPIO 5 pin conflict between LED data and LCD reset on T-Display-S3
- Add display brightness and BLE proxy configuration to web server UI
- Support `ws://` and `wss://` protocol prefixes in GraphQL WebSocket client
- Add raw data forwarding callback to nordic-uart-ble for proxy mode

### Build Variants
| Environment | Features |
|-------------|----------|
| `esp32s3dev` | Standard board controller (LEDs only) |
| `esp32s3dev-proxy` | Board controller + BLE proxy |
| `tdisplay-s3` | T-Display-S3 with display + BLE proxy |

## Test plan

- [x] Build and flash `tdisplay-s3` variant
- [x] Verify display shows test pattern (red/green/blue) then "Connecting..."
- [x] Verify display remains visible after LED initialization
- [ ] Test BLE proxy mode with official app
- [ ] Test climb info display when receiving LedUpdate from backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)