### PR TITLE
Remove beforeunload warning when queue has pending items

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -932,28 +932,6 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
     ],
   );
 
-  // Warn user before leaving page if queue has items
-  const hasQueueItems = state.queue.length > 0;
-  useEffect(() => {
-    if (!hasQueueItems) {
-      return;
-    }
-
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      // Modern browsers require both preventDefault and returnValue
-      event.preventDefault();
-      // Legacy support - some browsers need returnValue to be set
-      event.returnValue = '';
-      return '';
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [hasQueueItems]);
-
   // Wrap children with FavoritesProvider and PlaylistsProvider to pass hoisted data
   const wrappedChildren = (
     <FavoritesProvider


### PR DESCRIPTION
## Summary
Removed the `beforeunload` event listener that was warning users before leaving the page when the GraphQL queue contained pending items.

## Changes
- Deleted the `useEffect` hook that attached a `beforeunload` event listener to prevent accidental page navigation
- Removed the `hasQueueItems` state dependency that triggered the warning logic
- Removed related event listener cleanup on component unmount

## Rationale
This change simplifies the user experience by allowing users to navigate away from the page without being prompted, even if there are pending queue items. This may be intentional if:
- Queue items are now handled differently (e.g., persisted or queued server-side)
- The warning was causing UX friction without providing sufficient value
- Queue management has been refactored to handle interruptions gracefully

https://claude.ai/code/session_01RUe45z5P7jBsbGxtRgAH8r