### PR TITLE
fix: Debounce navigation mutations to prevent WebSocket disconnection

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1034,6 +1034,13 @@ The `navigateQueue` mutation allows ESP32 controllers to browse the queue via ha
 4. Backend updates current climb and broadcasts `CurrentClimbChanged`
 5. ESP32 receives `LedUpdate` with new climb data
 
+**Debounce Behavior:**
+- Navigation mutations are debounced with a 100ms delay to prevent WebSocket disconnection from rapid button presses
+- UI updates immediately (optimistic), but only ONE mutation is sent after 100ms of button inactivity
+- Example: Pressing "next" 10 times quickly results in 10 immediate display updates but only 1 mutation (to the final position)
+- During rapid navigation, incoming `LedUpdate` events skip queue index sync to preserve optimistic state
+- Only one mutation can be in-flight at a time; new mutations wait for the previous to complete
+
 ### Manual Authorization
 
 If auto-authorization doesn't apply (e.g., controller owner is not in session), use:

--- a/embedded/libs/graphql-ws-client/src/graphql_ws_client.h
+++ b/embedded/libs/graphql-ws-client/src/graphql_ws_client.h
@@ -87,6 +87,9 @@ class GraphQLWSClient {
     // Get current display hash (for deduplication)
     uint32_t getCurrentDisplayHash() { return currentDisplayHash; }
 
+    // Check if a mutation is currently in flight
+    bool isMutationInFlight() { return mutationInFlight; }
+
     // Set the controller ID for comparison with incoming clientId
     void setControllerId(const String& id) { controllerId = id; }
 
@@ -116,6 +119,8 @@ class GraphQLWSClient {
     unsigned long reconnectTime;
     uint32_t lastSentLedHash;     // Hash of last sent LED positions (to avoid duplicates)
     uint32_t currentDisplayHash;  // Hash of currently displayed LEDs (from backend LedUpdate)
+    bool mutationInFlight;        // True if a mutation is pending completion
+    unsigned long mutationSentTime;  // When the current mutation was sent (for timeout)
 
     void onWebSocketEvent(WStype_t type, uint8_t* payload, size_t length);
     void sendConnectionInit();


### PR DESCRIPTION
## Summary
- Fixes WebSocket disconnection caused by rapid button presses sending too many GraphQL mutations
- Adds 100ms debounce for navigation mutations - UI updates immediately (optimistic), but only one mutation is sent after button presses stop
- Prevents overlapping mutations by tracking in-flight state

## Changes
- **main.cpp**: Add debounce logic with stored UUID, skip queue index sync during pending navigation
- **graphql_ws_client**: Track mutation in-flight state, skip sending if previous mutation still pending, clear flag on error responses
- **websocket-implementation.md**: Document debounce behavior in Queue Navigation section

## Test plan
- [x] Press navigation button rapidly (10+ times) - should not disconnect
- [x] Display should update optimistically with each press
- [x] Only ONE mutation should be sent after 100ms of no button presses
- [x] Display should not go blank during rapid navigation
- [x] Firmware builds successfully
- [x] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)