### PR TITLE
Add /join route and improve Lily display QR code

### DIFF
--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -50,34 +50,34 @@
 #define STATUS_BAR_HEIGHT 20
 #define STATUS_BAR_Y 0
 
-// Previous climb indicator (top navigation)
+// Previous climb indicator (kept for backward compatibility, not displayed)
 #define PREV_INDICATOR_Y 20
 #define PREV_INDICATOR_HEIGHT 22
 
-// Current climb section (condensed)
-#define CURRENT_CLIMB_Y 42
-#define CURRENT_CLIMB_HEIGHT 78
+// Current climb section (moved up - prev indicator removed, redundant with history)
+#define CURRENT_CLIMB_Y 20
+#define CURRENT_CLIMB_HEIGHT 75
 
 // Climb name area
-#define CLIMB_NAME_Y 47
+#define CLIMB_NAME_Y 25
 #define CLIMB_NAME_HEIGHT 30
 
-// Grade badge area (closer to title)
-#define GRADE_Y 77
-#define GRADE_HEIGHT 40
+// Grade badge area (starts at 55, height 36, ends at 91)
+#define GRADE_Y 55
+#define GRADE_HEIGHT 36
 
-// QR code section (moved up)
-#define QR_SECTION_Y 120
-#define QR_SECTION_HEIGHT 95
-#define QR_CODE_SIZE 80
+// QR code section (enlarged for 120px QR code)
+#define QR_SECTION_Y 95
+#define QR_SECTION_HEIGHT 133
+#define QR_CODE_SIZE 120
 
 // Next climb indicator
-#define NEXT_INDICATOR_Y 215
+#define NEXT_INDICATOR_Y 228
 #define NEXT_INDICATOR_HEIGHT 22
 
 // History section (previous climbs in queue)
-#define HISTORY_Y 237
-#define HISTORY_HEIGHT 72
+#define HISTORY_Y 250
+#define HISTORY_HEIGHT 59
 #define HISTORY_ITEM_HEIGHT 18
 #define HISTORY_MAX_ITEMS 3
 #define HISTORY_LABEL_HEIGHT 12
@@ -206,6 +206,9 @@ class LilyGoDisplay {
                    const char* boardType);
     void showNoClimb();
 
+    // Session ID for QR code
+    void setSessionId(const char* sessionId);
+
     // History management
     void addToHistory(const char* name, const char* grade, const char* gradeColor);
     void clearHistory();
@@ -265,6 +268,9 @@ class LilyGoDisplay {
     int _angle;
     String _climbUuid;
     String _boardType;
+
+    // Session ID for QR code URL
+    String _sessionId;
 
     // History
     std::vector<ClimbHistoryEntry> _history;

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -484,6 +484,11 @@ void onGraphQLStateChange(GraphQLConnectionState state) {
                 break;
             }
 
+#ifdef ENABLE_DISPLAY
+            // Pass session ID to display for QR code generation
+            Display.setSessionId(sessionId.c_str());
+#endif
+
             // Build variables JSON (apiKey is in connectionParams, not here)
             String variables = "{\"sessionId\":\"" + sessionId + "\"}";
 

--- a/packages/web/app/join/[sessionId]/page.tsx
+++ b/packages/web/app/join/[sessionId]/page.tsx
@@ -1,0 +1,37 @@
+import { redirect, notFound } from 'next/navigation';
+import { dbz } from '@/app/lib/db/db';
+import { boardSessions } from '@/app/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+interface JoinPageProps {
+  params: Promise<{
+    sessionId: string;
+  }>;
+}
+
+export default async function JoinPage({ params }: JoinPageProps) {
+  const { sessionId } = await params;
+
+  // Look up the session in the database
+  const session = await dbz
+    .select({
+      id: boardSessions.id,
+      boardPath: boardSessions.boardPath,
+      status: boardSessions.status,
+    })
+    .from(boardSessions)
+    .where(eq(boardSessions.id, sessionId))
+    .limit(1);
+
+  if (session.length === 0) {
+    notFound();
+  }
+
+  const { boardPath } = session[0];
+
+  // Redirect to the board path with session query parameter
+  // boardPath format: {board_name}/{layout_id}/{size_id}/{set_ids}/{angle}
+  // Strip leading slashes to avoid creating protocol-relative URLs (//kilter/... → kilter as host)
+  const cleanPath = boardPath.replace(/^\/+/, '');
+  redirect(`/${cleanPath}?session=${sessionId}`);
+}


### PR DESCRIPTION
## Summary

- Add Next.js `/join/[sessionId]` route that looks up board session and redirects to the correct board URL with session parameter
- Update Lily display to show QR code for `boardsesh.com/join/{sessionId}` instead of direct climb URLs (allows joining session from any device)
- Enlarge QR code from 80px to 120px for better scannability
- Remove "Open in App" label and previous climb indicator (redundant with history)
- Show "Project" in italic when climb has no grade
- Adjust layout: move current climb section up, give more space to QR section

## Test plan

- [ ] Visit `/join/{sessionId}` with valid session ID - should redirect to board page with session param
- [ ] Visit `/join/{invalid-id}` - should show 404
- [ ] Flash firmware to LilyGo display
- [ ] Verify QR code shows boardsesh.com/join URL and is larger
- [ ] Verify scanning QR code opens the session in browser
- [ ] Test climb without grade shows "Project" in italic

🤖 Generated with [Claude Code](https://claude.com/claude-code)