### PR TITLE
feat: Add /join route and WiFi setup screen improvements

### DIFF
--- a/embedded/libs/lilygo-display/src/lilygo_display.cpp
+++ b/embedded/libs/lilygo-display/src/lilygo_display.cpp
@@ -198,6 +198,69 @@ void LilyGoDisplay::showConfigPortal(const char* apName, const char* ip) {
     _display.setTextDatum(lgfx::top_left);
 }
 
+void LilyGoDisplay::showSetupScreen(const char* apName) {
+    _display.fillScreen(COLOR_BACKGROUND);
+
+    // Header
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_ACCENT);
+    _display.setTextDatum(lgfx::top_center);
+    _display.drawString("WiFi Setup", SCREEN_WIDTH / 2, 8);
+
+    // Step 1: Connect to WiFi AP
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT);
+    _display.drawString("1. Connect to WiFi:", SCREEN_WIDTH / 2, 38);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_STATUS_OK);
+    _display.drawString(apName, SCREEN_WIDTH / 2, 58);
+
+    // QR Code section - generate QR for http://192.168.4.1
+    const char* configUrl = "http://192.168.4.1";
+    QRCode qrCode;
+    qrcode_initText(&qrCode, _qrCodeData, QR_VERSION, ECC_LOW, configUrl);
+
+    // Calculate QR code size and position
+    int qrSize = qrCode.size;
+    int pixelSize = 100 / qrSize;  // Target ~100px QR code
+    if (pixelSize < 1) pixelSize = 1;
+
+    int actualQrSize = pixelSize * qrSize;
+    int qrX = (SCREEN_WIDTH - actualQrSize) / 2;
+    int qrY = 90;
+
+    // Draw white background for QR code
+    _display.fillRect(qrX - 4, qrY - 4, actualQrSize + 8, actualQrSize + 8, COLOR_QR_BG);
+
+    // Draw QR code modules
+    for (uint8_t y = 0; y < qrSize; y++) {
+        for (uint8_t x = 0; x < qrSize; x++) {
+            if (qrcode_getModule(&qrCode, x, y)) {
+                _display.fillRect(qrX + x * pixelSize, qrY + y * pixelSize, pixelSize, pixelSize, COLOR_QR_FG);
+            }
+        }
+    }
+
+    // Step 2: Instructions below QR code
+    int instructionY = qrY + actualQrSize + 16;
+
+    _display.setFont(&fonts::Font2);
+    _display.setTextColor(COLOR_TEXT);
+    _display.drawString("2. Scan QR code or", SCREEN_WIDTH / 2, instructionY);
+    _display.drawString("open in browser:", SCREEN_WIDTH / 2, instructionY + 18);
+
+    _display.setFont(&fonts::FreeSansBold9pt7b);
+    _display.setTextColor(COLOR_ACCENT);
+    _display.drawString("192.168.4.1", SCREEN_WIDTH / 2, instructionY + 40);
+
+    _display.setFont(&fonts::Font0);
+    _display.setTextColor(COLOR_TEXT_DIM);
+    _display.drawString("to configure settings", SCREEN_WIDTH / 2, instructionY + 65);
+
+    _display.setTextDatum(lgfx::top_left);
+}
+
 void LilyGoDisplay::setSessionId(const char* sessionId) {
     _sessionId = sessionId ? sessionId : "";
 }

--- a/embedded/libs/lilygo-display/src/lilygo_display.h
+++ b/embedded/libs/lilygo-display/src/lilygo_display.h
@@ -200,6 +200,7 @@ class LilyGoDisplay {
     void showConnecting();
     void showError(const char* message, const char* ipAddress = nullptr);
     void showConfigPortal(const char* apName, const char* ip);
+    void showSetupScreen(const char* apName);
 
     // Climb display
     void showClimb(const char* name, const char* grade, const char* gradeColor, int angle, const char* uuid,

--- a/embedded/libs/wifi-utils/src/wifi_utils.h
+++ b/embedded/libs/wifi-utils/src/wifi_utils.h
@@ -8,8 +8,10 @@
 
 #define WIFI_CONNECT_TIMEOUT_MS 30000
 #define WIFI_RECONNECT_INTERVAL_MS 5000
+#define DEFAULT_AP_NAME "Boardsesh-Setup"
+#define DEFAULT_AP_IP "192.168.4.1"
 
-enum class WiFiConnectionState { DISCONNECTED, CONNECTING, CONNECTED, CONNECTION_FAILED };
+enum class WiFiConnectionState { DISCONNECTED, CONNECTING, CONNECTED, CONNECTION_FAILED, AP_MODE };
 
 typedef void (*WiFiStateCallback)(WiFiConnectionState state);
 
@@ -23,6 +25,13 @@ class WiFiUtils {
     bool connect(const char* ssid, const char* password, bool save = true);
     bool connectSaved();
     void disconnect();
+
+    // Access Point mode
+    bool startAP(const char* apName = DEFAULT_AP_NAME);
+    void stopAP();
+    bool isAPMode();
+    String getAPIP();
+    bool hasSavedCredentials();
 
     bool isConnected();
     WiFiConnectionState getState();


### PR DESCRIPTION
## Summary

- Add `/join` route for easier session joining
- Improve LilyGo display QR code for session joining
- Add WiFi setup screen with QR code when no WiFi credentials are configured

### WiFi Setup Screen
When the device boots without saved WiFi credentials:
- Starts Access Point with SSID "Boardsesh-Setup"
- Shows setup screen with QR code linking to http://192.168.4.1
- Defers BLE initialization until WiFi is configured (saves resources)
- Web interface shows AP mode status and allows network configuration

### Files Changed
- `wifi_utils`: Add AP_MODE state, startAP/stopAP methods
- `lilygo_display`: Add showSetupScreen() with QR code
- `main.cpp`: Defer BLE init, show setup screen in AP mode
- `esp_web_server`: Handle AP mode in WiFi status endpoint

## Test plan

- [ ] Flash firmware to device with no saved WiFi credentials
- [ ] Verify device creates "Boardsesh-Setup" access point
- [ ] Connect phone/laptop to AP
- [ ] Scan QR code - should open http://192.168.4.1
- [ ] Configure WiFi credentials in web interface
- [ ] Verify device connects to configured network and exits AP mode
- [ ] Verify BLE only initializes after WiFi connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)