### PR TITLE
Fix session persistence and join redirect to preserve board angle and view

### DIFF
--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -47,12 +47,16 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
     if (sessionIdFromUrl && boardDetailsRef.current) {
       // Activate session when URL has session param and either:
       // - Session ID changed
-      // - Board configuration path changed (e.g., navigating to different angle)
-      // Note: We use baseBoardPath to ignore changes to /play/[uuid] segments
-      if (activeSession?.sessionId !== sessionIdFromUrl || activeSession?.boardPath !== baseBoardPath) {
+      // - Board configuration path changed (e.g., navigating to different board/layout/size/sets)
+      // Note: We compare baseBoardPaths to ignore changes to angle, /play/[uuid], /list segments
+      // This ensures session continuity when navigating between climbs or changing angles
+      const activeSessionBasePath = activeSession?.boardPath ? getBaseBoardPath(activeSession.boardPath) : '';
+      if (activeSession?.sessionId !== sessionIdFromUrl || activeSessionBasePath !== baseBoardPath) {
+        // Store the full pathname (including angle and view segment like /list)
+        // This allows the /join redirect to send users to the exact page with angle
         activateSession({
           sessionId: sessionIdFromUrl,
-          boardPath: baseBoardPath,
+          boardPath: pathname,
           boardDetails: boardDetailsRef.current,
           parsedParams: parsedParamsRef.current,
         });
@@ -63,6 +67,7 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({
   }, [
     sessionIdFromUrl,
     baseBoardPath,
+    pathname,
     // boardDetails and parsedParams removed - accessed via refs to prevent unnecessary reconnections
     // Their object references change on every render but the actual values don't affect session activation
     activeSession?.sessionId,

--- a/packages/web/app/join/[sessionId]/page.tsx
+++ b/packages/web/app/join/[sessionId]/page.tsx
@@ -11,6 +11,34 @@ interface JoinPageProps {
   }>;
 }
 
+// Default angle to use when boardPath doesn't include one (for backward compatibility)
+const DEFAULT_ANGLE = 40;
+
+/**
+ * Ensures the board path ends with a view segment (/list, /play/uuid, /view/slug, /create)
+ * If not, appends /list to provide a good landing page for joined users.
+ *
+ * Handles three cases:
+ * 1. Path already has view segment: /board/.../40/list → use as-is
+ * 2. Path has angle but no view: /board/.../40 → append /list
+ * 3. Old format without angle: /board/.../sets → append default angle and /list
+ */
+function ensureViewSegment(path: string): string {
+  // Check if path already ends with a view segment
+  if (/\/(list|create)$/.test(path) || /\/(play|view)\/[^/]+$/.test(path)) {
+    return path;
+  }
+
+  // Check if path ends with an angle (a number)
+  if (/\/\d+$/.test(path)) {
+    // Has angle, just append /list
+    return `${path}/list`;
+  }
+
+  // Old format without angle - append default angle and /list
+  return `${path}/${DEFAULT_ANGLE}/list`;
+}
+
 export default async function JoinPage({ params }: JoinPageProps) {
   const { sessionId } = await params;
 
@@ -42,8 +70,12 @@ export default async function JoinPage({ params }: JoinPageProps) {
   const { boardPath } = session[0];
 
   // Redirect to the board path with session query parameter
-  // boardPath format: {board_name}/{layout_id}/{size_id}/{set_ids}/{angle}
+  // boardPath format: {board_name}/{layout_id}/{size_id}/{set_ids}[/{angle}][/list|/play/uuid]
   // Strip leading slashes to avoid creating protocol-relative URLs (//kilter/... → kilter as host)
   const cleanPath = boardPath.replace(/^\/+/, '');
-  redirect(`/${cleanPath}?session=${validatedSessionId}`);
+
+  // Ensure the path ends with a view segment (/list) for a good user experience
+  const redirectPath = ensureViewSegment(cleanPath);
+
+  redirect(`/${redirectPath}?session=${validatedSessionId}`);
 }


### PR DESCRIPTION
## Summary
This PR fixes session persistence and the join redirect flow to properly preserve the full board path including angle and view segments (like `/list`). Previously, session activation was losing angle information, and joined users were redirected to incomplete paths.

## Key Changes

- **BoardSessionBridge**: Updated session activation logic to compare base board paths (ignoring angle/view segments) when determining if a new session should be activated, while storing the full pathname (including angle and view) in the session. This ensures:
  - Session continuity when navigating between climbs or changing angles
  - The `/join` redirect can send users to the exact page they were on

- **JoinPage**: Added `ensureViewSegment()` helper function to guarantee redirect paths end with a view segment (`/list`, `/play/uuid`, `/view/slug`, or `/create`). This handles three cases:
  1. Path already has view segment → use as-is
  2. Path has angle but no view → append `/list`
  3. Old format without angle → append default angle (40°) and `/list`

- Updated dependency array in `BoardSessionBridge` to include `pathname` since it's now used in the activation logic

## Implementation Details

The fix maintains backward compatibility with old session formats that may not include angle information, while ensuring new sessions preserve the complete navigation state for better UX when users join via the `/join` endpoint.

https://claude.ai/code/session_01U86KCiu7R7spWuV3kFhW7H