### PR TITLE
fix: Session joining shows infinite spinner

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -116,8 +116,11 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children }: G
 
   // Check if persistent session is active for this board
   // Uses baseBoardPath to ensure navigation between climbs doesn't break the session check
+  // Compare base paths since activeSession.boardPath may include angle/view segments
   const isPersistentSessionActive = persistentSession.activeSession?.sessionId === sessionId &&
-    persistentSession.activeSession?.boardPath === baseBoardPath;
+    (persistentSession.activeSession?.boardPath
+      ? getBaseBoardPath(persistentSession.activeSession.boardPath)
+      : '') === baseBoardPath;
 
   // Build current user info for queue items
   const currentUserInfo: QueueItemUser | undefined = useMemo(() => {


### PR DESCRIPTION
## Summary

- Fixes session joining from BoardSesh UI showing infinite spinner even when WebSocket is connected
- Root cause: commit 257cc734 changed `board-session-bridge.tsx` to store full pathname in `activeSession.boardPath`, but `QueueContext.tsx` still compared against `baseBoardPath`
- Fix applies `getBaseBoardPath()` to normalize the stored path before comparison

## Test plan

- [ ] Start a session from the BoardSesh UI
- [ ] Verify session indicator shows "connected" (no infinite spinner)
- [ ] Verify queue updates work and user list shows participants
- [ ] Navigate between climbs while in session - connection should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)