### PR TITLE
Add mobile onboarding tour for climb list page

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -13,6 +13,7 @@ import SearchResultsFooter from '@/app/components/search-drawer/search-results-f
 import QueueList from '@/app/components/queue-control/queue-list';
 import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { useQueueContext } from '@/app/components/graphql-queue';
+import OnboardingTour from '@/app/components/onboarding/onboarding-tour';
 import styles from './layout-client.module.css';
 
 const { Content, Sider } = Layout;
@@ -117,6 +118,7 @@ const ListLayoutClient: React.FC<PropsWithChildren<ListLayoutClientProps>> = ({ 
           <TabsWrapper boardDetails={boardDetails} />
         </UISearchParamsProvider>
       </Sider>
+      <OnboardingTour />
     </Layout>
   );
 };

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -133,12 +133,13 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
   return (
     <div style={{ paddingTop: '5px' }}>
       <Row gutter={[16, 16]}>
-        {climbs.map((climb) => (
+        {climbs.map((climb, index) => (
           <Col xs={24} lg={12} xl={12} id={climb.uuid} key={climb.uuid}>
             <div
               ref={(el) => {
                 climbsRefs.current[climb.uuid] = el;
               }}
+              {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}
             >
               <ClimbCard
                 climb={climb}

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -288,8 +288,10 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                   </div>
                 )}
 
-                <ShareBoardButton />
-                <SendClimbToBoardButton boardDetails={boardDetails} />
+                <span id="onboarding-party-light-buttons" style={{ display: 'inline-flex', gap: 4 }}>
+                  <ShareBoardButton />
+                  <SendClimbToBoardButton boardDetails={boardDetails} />
+                </span>
 
                 {/* Desktop: User menu or login button */}
                 <div className={styles.desktopOnly}>

--- a/packages/web/app/components/onboarding/onboarding-tour.module.css
+++ b/packages/web/app/components/onboarding/onboarding-tour.module.css
@@ -1,0 +1,9 @@
+.stepIcon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0 8px;
+  font-size: 28px;
+  color: #06B6D4;
+}

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Tour, TourStepProps } from 'antd';
+import {
+  SwapOutlined,
+  BulbOutlined,
+  TeamOutlined,
+  UnorderedListOutlined,
+  ColumnWidthOutlined,
+  CloseCircleOutlined,
+  SearchOutlined,
+  HeatMapOutlined,
+} from '@ant-design/icons';
+import { useSession } from 'next-auth/react';
+import { shouldShowOnboarding, saveOnboardingStatus } from '@/app/lib/onboarding-db';
+import styles from './onboarding-tour.module.css';
+
+// Delay in ms before the tour starts after the page loads
+const TOUR_START_DELAY = 800;
+// Delay in ms for drawer open/close animation
+const DRAWER_ANIMATION_DELAY = 450;
+
+// Helper to create a target function with the correct type for AntD Tour
+const getTarget = (selector: string): (() => HTMLElement) | null => {
+  return (() => document.querySelector<HTMLElement>(selector)!) as (() => HTMLElement) | null;
+};
+
+const OnboardingTour: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const { data: session } = useSession();
+  const drawerOpenedByTour = useRef(false);
+  const isMobileRef = useRef(false);
+
+  useEffect(() => {
+    // Only show on mobile
+    const checkMobile = () => {
+      isMobileRef.current = window.matchMedia('(max-width: 768px)').matches;
+    };
+    checkMobile();
+
+    if (!isMobileRef.current) return;
+
+    const checkOnboarding = async () => {
+      const userId = session?.user?.id;
+      const shouldShow = await shouldShowOnboarding(userId);
+      if (shouldShow) {
+        // Wait for the page to settle before showing the tour
+        setTimeout(() => {
+          // Double-check that the climb card exists (page has loaded)
+          const climbCard = document.getElementById('onboarding-climb-card');
+          if (climbCard) {
+            setOpen(true);
+          }
+        }, TOUR_START_DELAY);
+      }
+    };
+
+    checkOnboarding();
+  }, [session?.user?.id]);
+
+  const handleClose = useCallback(async () => {
+    // Close the drawer if it was opened by the tour
+    if (drawerOpenedByTour.current) {
+      const toggle = document.getElementById('onboarding-queue-toggle');
+      if (toggle) toggle.click();
+      drawerOpenedByTour.current = false;
+    }
+
+    setOpen(false);
+    setCurrent(0);
+
+    // Save completion status
+    const userId = session?.user?.id;
+    await saveOnboardingStatus(userId);
+  }, [session?.user?.id]);
+
+  const handleStepChange = useCallback((step: number) => {
+    const QUEUE_DRAWER_OPEN_STEP = 4;
+    const QUEUE_DRAWER_CLOSE_STEP = 6;
+
+    // Opening the queue drawer before step 5 (index 4)
+    if (step === QUEUE_DRAWER_OPEN_STEP && !drawerOpenedByTour.current) {
+      const toggle = document.getElementById('onboarding-queue-toggle');
+      if (toggle) {
+        toggle.click();
+        drawerOpenedByTour.current = true;
+      }
+      // Delay step transition to let drawer animate in
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Close the queue drawer when moving past step 6 (index 5)
+    if (step === QUEUE_DRAWER_CLOSE_STEP && drawerOpenedByTour.current) {
+      const toggle = document.getElementById('onboarding-queue-toggle');
+      if (toggle) {
+        toggle.click();
+        drawerOpenedByTour.current = false;
+      }
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Going backwards from step 5 to step 4 - close drawer
+    if (step === QUEUE_DRAWER_OPEN_STEP - 1 && drawerOpenedByTour.current) {
+      const toggle = document.getElementById('onboarding-queue-toggle');
+      if (toggle) {
+        toggle.click();
+        drawerOpenedByTour.current = false;
+      }
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    setCurrent(step);
+  }, []);
+
+  const tourSteps: TourStepProps[] = [
+    {
+      title: 'Select a Climb',
+      description: 'Double-tap any climb card to make it the active climb and add it to your queue.',
+      target: getTarget('#onboarding-climb-card'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <SwapOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Board Controls',
+      description:
+        'Use the light button to illuminate holds on your board via Bluetooth, or start a party session to climb with friends.',
+      target: getTarget('#onboarding-party-light-buttons'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <BulbOutlined />
+          <TeamOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Navigate Your Queue',
+      description: 'Swipe left or right on this bar to go to the next or previous climb in your queue.',
+      target: getTarget('#onboarding-queue-bar'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <ColumnWidthOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'View Your Queue',
+      description: 'Tap here to open the queue drawer and see all your climbs, history, and suggestions.',
+      target: getTarget('#onboarding-queue-toggle'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <UnorderedListOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Queue Item Actions',
+      description:
+        'Swipe queue items left to remove them from the queue, or swipe right to log an ascent.',
+      target: getTarget('[data-testid="queue-item"]'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <ColumnWidthOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Close the Queue',
+      description: 'Tap outside the drawer to close it and return to the climb list.',
+      target: null,
+      cover: (
+        <div className={styles.stepIcon}>
+          <CloseCircleOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Search by Hold',
+      description:
+        'Open the search panel and use the "Search by Hold" tab to find climbs that use specific holds on the board.',
+      target: getTarget('#onboarding-search-button'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <SearchOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Heatmap',
+      description:
+        'The heatmap shows how frequently each hold is used across matching climbs. It uses your current search filters (grades, ascents, etc.), so adjust those first to see relevant hold usage.',
+      target: getTarget('#onboarding-search-button'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <HeatMapOutlined />
+        </div>
+      ),
+    },
+  ];
+
+  if (!open) return null;
+
+  return (
+    <Tour
+      open={open}
+      current={current}
+      onChange={handleStepChange}
+      onClose={handleClose}
+      onFinish={handleClose}
+      steps={tourSteps}
+      scrollIntoViewOptions={{ behavior: 'smooth', block: 'center' }}
+      zIndex={1100}
+    />
+  );
+};
+
+export default OnboardingTour;

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -11,6 +11,7 @@ import {
   CloseCircleOutlined,
   SearchOutlined,
   HeatMapOutlined,
+  DragOutlined,
 } from '@ant-design/icons';
 import { useSession } from 'next-auth/react';
 import { shouldShowOnboarding, saveOnboardingStatus } from '@/app/lib/onboarding-db';
@@ -77,8 +78,9 @@ const OnboardingTour: React.FC = () => {
   }, [session?.user?.id]);
 
   const handleStepChange = useCallback((step: number) => {
+    // Steps 4-6 are inside the queue drawer (swipe actions, drag & drop, close drawer)
     const QUEUE_DRAWER_OPEN_STEP = 4;
-    const QUEUE_DRAWER_CLOSE_STEP = 6;
+    const QUEUE_DRAWER_CLOSE_STEP = 7;
 
     // Opening the queue drawer before step 5 (index 4)
     if (step === QUEUE_DRAWER_OPEN_STEP && !drawerOpenedByTour.current) {
@@ -92,7 +94,7 @@ const OnboardingTour: React.FC = () => {
       return;
     }
 
-    // Close the queue drawer when moving past step 6 (index 5)
+    // Close the queue drawer when moving to the step after drawer section
     if (step === QUEUE_DRAWER_CLOSE_STEP && drawerOpenedByTour.current) {
       const toggle = document.getElementById('onboarding-queue-toggle');
       if (toggle) {
@@ -103,7 +105,7 @@ const OnboardingTour: React.FC = () => {
       return;
     }
 
-    // Going backwards from step 5 to step 4 - close drawer
+    // Going backwards out of the drawer section - close drawer
     if (step === QUEUE_DRAWER_OPEN_STEP - 1 && drawerOpenedByTour.current) {
       const toggle = document.getElementById('onboarding-queue-toggle');
       if (toggle) {
@@ -168,6 +170,17 @@ const OnboardingTour: React.FC = () => {
       cover: (
         <div className={styles.stepIcon}>
           <ColumnWidthOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Reorder Your Queue',
+      description:
+        'Press and hold a queue item, then drag it up or down to reorder your queue.',
+      target: getTarget('[data-testid="queue-item"]'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <DragOutlined />
         </div>
       ),
     },

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -220,7 +220,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   const rightActionOpacity = Math.min(1, Math.abs(swipeOffset) / SWIPE_THRESHOLD);
 
   return (
-    <div className="queue-bar-shadow" data-testid="queue-control-bar" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
+    <div id="onboarding-queue-bar" className="queue-bar-shadow" data-testid="queue-control-bar" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
       {/* Main Control Bar */}
       <Card
         variant="borderless"
@@ -311,6 +311,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
 
                   {/* Clickable climb info for opening the queue */}
                   <div
+                    id="onboarding-queue-toggle"
                     onClick={toggleQueueDrawer}
                     className={`${styles.queueToggle} ${isListPage ? styles.listPage : ''}`}
                     style={{ minWidth: 0, flex: 1 }}

--- a/packages/web/app/components/search-drawer/search-button.tsx
+++ b/packages/web/app/components/search-drawer/search-button.tsx
@@ -53,7 +53,7 @@ const SearchButton = ({ boardDetails }: { boardDetails: BoardDetails }) => {
         color="cyan"
         style={{ zIndex: 100 }}
       >
-        <Button type="default" icon={<SearchOutlined />} onClick={() => setIsOpen(true)} />
+        <Button id="onboarding-search-button" type="default" icon={<SearchOutlined />} onClick={() => setIsOpen(true)} />
       </Badge>
 
       <Drawer

--- a/packages/web/app/lib/onboarding-db.ts
+++ b/packages/web/app/lib/onboarding-db.ts
@@ -1,0 +1,83 @@
+import { openDB, IDBPDatabase } from 'idb';
+
+const DB_NAME = 'boardsesh-onboarding';
+const DB_VERSION = 1;
+const STORE_NAME = 'onboarding';
+
+// Increment this when new steps are added to the onboarding tour.
+// This will cause the tour to show again for all users.
+export const ONBOARDING_VERSION = 1;
+
+export interface OnboardingStatus {
+  completedVersion: number;
+  completedAt: string;
+}
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+
+const initDB = async (): Promise<IDBPDatabase> => {
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      },
+    });
+  }
+  return dbPromise;
+};
+
+/**
+ * Get the storage key for onboarding status.
+ * Uses the user ID when logged in for per-user tracking,
+ * or a generic key for anonymous users.
+ */
+const getStorageKey = (userId?: string | number | null): string => {
+  return userId ? `onboarding-${userId}` : 'onboarding-anonymous';
+};
+
+/**
+ * Get the onboarding status from IndexedDB
+ */
+export const getOnboardingStatus = async (userId?: string | number | null): Promise<OnboardingStatus | null> => {
+  try {
+    const db = await initDB();
+    const key = getStorageKey(userId);
+    return await db.get(STORE_NAME, key);
+  } catch (error) {
+    console.error('Failed to get onboarding status:', error);
+    return null;
+  }
+};
+
+/**
+ * Save the onboarding status to IndexedDB
+ */
+export const saveOnboardingStatus = async (userId?: string | number | null): Promise<void> => {
+  try {
+    const db = await initDB();
+    const key = getStorageKey(userId);
+    const status: OnboardingStatus = {
+      completedVersion: ONBOARDING_VERSION,
+      completedAt: new Date().toISOString(),
+    };
+    await db.put(STORE_NAME, status, key);
+  } catch (error) {
+    console.error('Failed to save onboarding status:', error);
+  }
+};
+
+/**
+ * Check if onboarding should be shown.
+ * Returns true if onboarding hasn't been completed or a newer version is available.
+ */
+export const shouldShowOnboarding = async (userId?: string | number | null): Promise<boolean> => {
+  try {
+    const status = await getOnboardingStatus(userId);
+    if (!status) return true;
+    return status.completedVersion < ONBOARDING_VERSION;
+  } catch {
+    return true;
+  }
+};


### PR DESCRIPTION
Implements an 8-step guided tour using Ant Design's Tour component that
introduces new users to the UI on mobile devices. The tour covers:
selecting climbs, board controls (light/party), queue bar swipe navigation,
queue drawer interaction, queue item swipe actions, closing the drawer,
search by hold, and heatmap functionality.

Onboarding completion is persisted in IndexedDB, keyed by user ID when
logged in or a generic key for anonymous users. A version number ensures
the tour re-shows when new steps are added.

https://claude.ai/code/session_01CKTs7S8H4dJ1AH51ifqXh2