### PR TITLE
Fix onboarding tour: step sizing, queue drawer visibility, and add skip button

### DIFF
--- a/packages/web/app/components/onboarding/onboarding-tour.module.css
+++ b/packages/web/app/components/onboarding/onboarding-tour.module.css
@@ -7,3 +7,15 @@
   font-size: 28px;
   color: #06B6D4;
 }
+
+.skipLink {
+  margin-top: 12px;
+  text-align: right;
+}
+
+.skipLink a {
+  font-size: 13px;
+  color: #999;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -19,6 +19,7 @@ import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { AscentStatus } from './queue-list-item';
 import { themeTokens } from '@/app/theme/theme-config';
+import { TOUR_DRAWER_EVENT } from '../onboarding/onboarding-tour';
 import styles from './queue-control-bar.module.css';
 
 // Swipe threshold in pixels to trigger navigation
@@ -49,6 +50,16 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
         clearTimeout(scrollTimeoutRef.current);
       }
     };
+  }, []);
+
+  // Listen for tour events to open/close the queue drawer
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { open } = (e as CustomEvent<{ open: boolean }>).detail;
+      setIsQueueOpen(open);
+    };
+    window.addEventListener(TOUR_DRAWER_EVENT, handler);
+    return () => window.removeEventListener(TOUR_DRAWER_EVENT, handler);
   }, []);
 
   // Scroll to current climb when drawer finishes opening


### PR DESCRIPTION
- Fix first step rendering too large by adding placement: bottom and
  scrollIntoViewOptions with block: start so the climb card scrolls to
  the top with room for the popover below
- Fix board controls step rendered too high by adding placement: bottom
- Fix queue drawer not opening during tour steps 4-6 by replacing
  unreliable .click() DOM calls with custom event dispatch
  (TOUR_DRAWER_EVENT) that QueueControlBar listens for directly
- Set mask: false on queue drawer steps (4-6) so the drawer content
  is visible above the tour overlay instead of hidden behind it
- Add "Skip tour" link to every step for easy dismissal

https://claude.ai/code/session_019B7Zp7Tvsv7MJdpu9noH2N