### PR TITLE
Fix tour popup first step being too large on mobile

### DIFF
--- a/packages/web/app/components/onboarding/onboarding-tour.module.css
+++ b/packages/web/app/components/onboarding/onboarding-tour.module.css
@@ -1,3 +1,10 @@
+@media (max-width: 768px) {
+  .tour :global(.ant-tour-inner) {
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+}
+
 .stepIcon {
   display: flex;
   justify-content: center;

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Tour, TourStepProps } from 'antd';
 import {
-  SwapOutlined,
   BulbOutlined,
   TeamOutlined,
   UnorderedListOutlined,
@@ -134,11 +133,6 @@ const OnboardingTour: React.FC = () => {
       target: getTarget('#onboarding-climb-card'),
       placement: 'bottom',
       scrollIntoViewOptions: { behavior: 'smooth', block: 'start' },
-      cover: (
-        <div className={styles.stepIcon}>
-          <SwapOutlined />
-        </div>
-      ),
     },
     {
       title: 'Board Controls',
@@ -247,6 +241,7 @@ const OnboardingTour: React.FC = () => {
       onClose={handleClose}
       onFinish={handleClose}
       steps={tourSteps}
+      rootClassName={styles.tour}
       scrollIntoViewOptions={{ behavior: 'smooth', block: 'center' }}
       zIndex={1100}
     />


### PR DESCRIPTION
Remove the decorative cover icon from the first tour step to reduce
popup height and prevent navigation buttons from being hidden. Also add
a max-height constraint with overflow scrolling on the tour inner
content for mobile viewports as a safety net for all steps.

https://claude.ai/code/session_01GpKDwKq2BnjTtHpNGgRXNF