### PR TITLE
fix: Correct light button vertical alignment in header

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -231,6 +231,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
         background: '#fff',
         height: '8dvh',
         minHeight: 48,
+        lineHeight: 'normal',
         display: 'flex',
         padding: '0 12px',
       }}
@@ -288,7 +289,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
                   </div>
                 )}
 
-                <span id="onboarding-party-light-buttons" style={{ display: 'inline-flex', gap: 4 }}>
+                <span id="onboarding-party-light-buttons" style={{ display: 'inline-flex', gap: 4, alignItems: 'center' }}>
                   <ShareBoardButton />
                   <SendClimbToBoardButton boardDetails={boardDetails} />
                 </span>


### PR DESCRIPTION
The onboarding tour wrapper span caused the light and share buttons
to render too high because AntD Header's default line-height: 64px
was not overridden, and the inline-flex span lacked alignItems: center.

https://claude.ai/code/session_014J9fi3cnsE251kPjaSp34z