### PR TITLE
Enable MoonBoard climb details/view page

### DIFF
--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -64,17 +64,14 @@ function ClimbCardWithActions({
   const cover = <ClimbCardCover climb={climb} boardDetails={boardDetails} onClick={onCoverClick} onDoubleClick={onCoverDoubleClick} />;
   const cardTitle = <ClimbTitle climb={climb} layout="horizontal" showSetterInfo />;
 
-  // Build exclude list - MoonBoard doesn't have a view details page yet
-  const excludeActions: ('tick' | 'openInApp' | 'mirror' | 'share' | 'addToList' | 'viewDetails')[] = [
+  // Build exclude list
+  const excludeActions: ('tick' | 'openInApp' | 'mirror' | 'share' | 'addToList')[] = [
     'tick',
     'openInApp',
     'mirror',
     'share',
     'addToList',
   ];
-  if (boardDetails.board_name === 'moonboard') {
-    excludeActions.push('viewDetails');
-  }
 
   return (
     <div data-testid="climb-card">

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -10,11 +10,13 @@ import { ClimbActions } from '../climb-actions';
 type ClimbViewActionsProps = {
   climb: Climb;
   boardDetails: BoardDetails;
-  auroraAppUrl: string;
+  auroraAppUrl?: string;
   angle: number;
 };
 
 const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbViewActionsProps) => {
+  const isMoonBoard = boardDetails.board_name === 'moonboard';
+
   const getBackToListUrl = () => {
     const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
 
@@ -26,6 +28,15 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
     // Fallback to numeric format
     return `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
   };
+
+  // MoonBoard doesn't have an Aurora app, so exclude 'openInApp'
+  const mobileDropdownActions: ('tick' | 'share' | 'addToList' | 'openInApp')[] = isMoonBoard
+    ? ['tick', 'share', 'addToList']
+    : ['tick', 'share', 'addToList', 'openInApp'];
+
+  const desktopActions: ('favorite' | 'tick' | 'queue' | 'share' | 'addToList' | 'openInApp')[] = isMoonBoard
+    ? ['favorite', 'tick', 'queue', 'share', 'addToList']
+    : ['favorite', 'tick', 'queue', 'share', 'addToList', 'openInApp'];
 
   return (
     <div className={styles.container}>
@@ -50,7 +61,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             boardDetails={boardDetails}
             angle={angle}
             viewMode="dropdown"
-            include={['tick', 'share', 'addToList', 'openInApp']}
+            include={mobileDropdownActions}
             auroraAppUrl={auroraAppUrl}
           />
         </div>
@@ -66,7 +77,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             boardDetails={boardDetails}
             angle={angle}
             viewMode="button"
-            include={['favorite', 'tick', 'queue', 'share', 'addToList', 'openInApp']}
+            include={desktopActions}
             auroraAppUrl={auroraAppUrl}
           />
         </div>

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -16,10 +16,13 @@ import {
 } from '@/app/lib/__generated__/product-sizes-data';
 
 export const getClimb = async (params: ParsedBoardRouteParametersWithUuid): Promise<Climb> => {
-  // Get hardcoded size edges (eliminates database query)
-  const sizeEdges = getSizeEdges(params.board_name, params.size_id);
-  if (!sizeEdges) {
-    throw new Error(`Invalid size_id ${params.size_id} for board ${params.board_name}`);
+  // MoonBoard uses grid-based rendering with a fixed size, so it has no entries in PRODUCT_SIZES.
+  // Skip the size edges validation for MoonBoard.
+  if (params.board_name !== 'moonboard') {
+    const sizeEdges = getSizeEdges(params.board_name, params.size_id);
+    if (!sizeEdges) {
+      throw new Error(`Invalid size_id ${params.size_id} for board ${params.board_name}`);
+    }
   }
 
   const result = await sql`


### PR DESCRIPTION
- Remove viewDetails exclusion from climb-card for MoonBoard climbs
- Fix getClimb to skip sizeEdges validation for MoonBoard (uses fixed grid)
- Add MoonBoard-specific redirect logic using static config instead of
  Aurora generated product-sizes data
- Exclude openInApp action for MoonBoard (no Aurora app URL)
- Make auroraAppUrl optional in ClimbViewActions

Closes #617

https://claude.ai/code/session_014W5j5Jk4pMWrzuWCTQK6aB