### PR TITLE
Fix onboarding tour first step buttons rendering outside viewport

### DIFF
--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -130,9 +130,8 @@ const OnboardingTour: React.FC = () => {
     {
       title: 'Select a Climb',
       description: withSkip('Double-tap any climb card to make it the active climb and add it to your queue.'),
-      target: getTarget('#onboarding-climb-card'),
+      target: getTarget('#onboarding-climb-card .ant-card-head'),
       placement: 'bottom',
-      scrollIntoViewOptions: { behavior: 'smooth', block: 'start' },
     },
     {
       title: 'Board Controls',


### PR DESCRIPTION
Target the card header (.ant-card-head) instead of the full climb card wrapper for the "Select a Climb" tour step. The full card includes the tall board image, causing the bottom-placed popup and its action buttons to be pushed below the visible area. Also removes the step-level scrollIntoViewOptions override so the Tour's default block: 'center' is used instead of block: 'start'.

https://claude.ai/code/session_01UQx2C7ev53Wu7DZe8R6SQp