### PR TITLE
feat: Implement Phase 1 & 2 of Spotify-inspired redesign

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -16,6 +16,7 @@ import { PartyProvider } from '@/app/components/party-manager/party-context';
 import { BoardSessionBridge } from '@/app/components/persistent-session';
 import { Metadata } from 'next';
 import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
+import BottomTabBar from '@/app/components/bottom-tab-bar/bottom-tab-bar';
 
 // Helper to get board details for any board type
 function getBoardDetailsUniversal(parsedParams: ParsedBoardRouteParameters): BoardDetails {
@@ -139,7 +140,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
     parsedParams = await parseBoardRouteParamsWithSlugs(params);
   }
 
-  const { board_name, angle } = parsedParams;
+  const { angle } = parsedParams;
 
   // Fetch the board details server-side
   const boardDetails = getBoardDetailsUniversal(parsedParams);
@@ -171,7 +172,8 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               </Content>
 
               <Affix offsetBottom={0}>
-                <QueueControlBar board={board_name} boardDetails={boardDetails} angle={angle} />
+                <QueueControlBar boardDetails={boardDetails} angle={angle} />
+                <BottomTabBar boardDetails={boardDetails} angle={angle} />
               </Affix>
             </PartyProvider>
           </GraphQLQueueProvider>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -1,12 +1,31 @@
 'use client';
-import React, { useEffect, useRef, useCallback } from 'react';
-import { Row, Col } from 'antd';
+import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { Row, Col, Button, Flex } from 'antd';
+import { AppstoreOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { track } from '@vercel/analytics';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueContext } from '../graphql-queue';
 import ClimbCard from '../climb-card/climb-card';
+import ClimbListItem from '../climb-card/climb-list-item';
 import { ClimbCardSkeleton } from './board-page-skeleton';
 import { useSearchParams } from 'next/navigation';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type ViewMode = 'grid' | 'list';
+
+const VIEW_MODE_STORAGE_KEY = 'climbListViewMode';
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === 'undefined') return 'grid';
+  try {
+    const stored = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+    if (stored === 'grid' || stored === 'list') return stored;
+  } catch {
+    // localStorage not available
+  }
+  // Default: list on mobile, grid on desktop
+  return window.matchMedia('(min-width: 768px)').matches ? 'grid' : 'list';
+}
 
 type ClimbsListProps = ParsedBoardRouteParameters & {
   boardDetails: BoardDetails;
@@ -34,6 +53,17 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
 
   const searchParams = useSearchParams();
   const page = searchParams.get('page');
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+
+  const handleViewModeChange = useCallback((mode: ViewMode) => {
+    setViewMode(mode);
+    try {
+      localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    } catch {
+      // localStorage not available
+    }
+    track('View Mode Changed', { mode });
+  }, []);
 
   // Queue Context provider uses React Query infinite to fetch results, which can only happen clientside.
   // That data equals null at the start, so when its null we use the initialClimbs array which we
@@ -131,40 +161,92 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
   }, [handleObserver]);
 
   return (
-    <div style={{ paddingTop: '5px' }}>
-      <Row gutter={[16, 16]}>
-        {climbs.map((climb, index) => (
-          <Col xs={24} lg={12} xl={12} id={climb.uuid} key={climb.uuid}>
+    <div style={{ paddingTop: themeTokens.spacing[1] }}>
+      {/* View mode toggle */}
+      <Flex
+        justify="flex-end"
+        style={{
+          padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[1]}px ${themeTokens.spacing[2]}px`,
+        }}
+      >
+        <Button.Group size="small">
+          <Button
+            icon={<UnorderedListOutlined />}
+            type={viewMode === 'list' ? 'primary' : 'default'}
+            onClick={() => handleViewModeChange('list')}
+            aria-label="List view"
+          />
+          <Button
+            icon={<AppstoreOutlined />}
+            type={viewMode === 'grid' ? 'primary' : 'default'}
+            onClick={() => handleViewModeChange('grid')}
+            aria-label="Grid view"
+          />
+        </Button.Group>
+      </Flex>
+
+      {viewMode === 'grid' ? (
+        /* Grid (card) mode */
+        <Row gutter={[themeTokens.spacing[4], themeTokens.spacing[4]]}>
+          {climbs.map((climb, index) => (
+            <Col xs={24} lg={12} xl={12} id={climb.uuid} key={climb.uuid}>
+              <div
+                ref={(el) => {
+                  climbsRefs.current[climb.uuid] = el;
+                }}
+                {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}
+              >
+                <ClimbCard
+                  climb={climb}
+                  boardDetails={boardDetails}
+                  selected={currentClimb?.uuid === climb.uuid}
+                  onCoverDoubleClick={() => handleClimbDoubleClick(climb)}
+                />
+              </div>
+            </Col>
+          ))}
+          {isFetchingClimbs && (!climbs || climbs.length === 0) ? (
+            <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />
+          ) : null}
+        </Row>
+      ) : (
+        /* List (compact) mode */
+        <div>
+          {climbs.map((climb, index) => (
             <div
+              key={climb.uuid}
+              id={climb.uuid}
               ref={(el) => {
                 climbsRefs.current[climb.uuid] = el;
               }}
               {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}
             >
-              <ClimbCard
+              <ClimbListItem
                 climb={climb}
                 boardDetails={boardDetails}
                 selected={currentClimb?.uuid === climb.uuid}
-                onCoverDoubleClick={() => handleClimbDoubleClick(climb)}
+                onSelect={() => handleClimbDoubleClick(climb)}
               />
             </div>
-          </Col>
-        ))}
-        {isFetchingClimbs && (!climbs || climbs.length === 0) ? (
-          <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />
-        ) : null}
-      </Row>
+          ))}
+          {isFetchingClimbs && (!climbs || climbs.length === 0) ? (
+            <Row gutter={[themeTokens.spacing[4], themeTokens.spacing[4]]}>
+              <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />
+            </Row>
+          ) : null}
+        </div>
+      )}
 
       {/* Sentinel element for Intersection Observer - needs min-height to be observable */}
-      <div ref={loadMoreRef} style={{ minHeight: '20px', marginTop: '16px' }}>
+      <div ref={loadMoreRef} style={{ minHeight: themeTokens.spacing[5], marginTop: themeTokens.spacing[4] }}>
         {isFetchingClimbs && climbs.length > 0 && (
-          <Row gutter={[16, 16]}>
+          <Row gutter={[themeTokens.spacing[4], themeTokens.spacing[4]]}>
             <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />
           </Row>
         )}
         {!hasMoreResults && climbs.length > 0 && (
-          <div style={{ textAlign: 'center', padding: '20px', color: '#888' }}>
-            No more climbs 🤐
+          <div style={{ textAlign: 'center', padding: themeTokens.spacing[5], color: themeTokens.neutral[400] }}>
+            No more climbs
           </div>
         )}
       </div>

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
@@ -1,0 +1,38 @@
+.tabBar {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 100%;
+  border-top: 1px solid #e5e7eb;
+  background-color: #fff;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.tabItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 6px 0 4px;
+  cursor: pointer;
+  transition: color 150ms ease;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  user-select: none;
+  background: none;
+  border: none;
+}
+
+.tabLabel {
+  font-size: 10px;
+  margin-top: 2px;
+  line-height: 1;
+}
+
+/* Hide on desktop - search/queue available in sidebar, create in header */
+@media (min-width: 768px) {
+  .tabBar {
+    display: none;
+  }
+}

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Drawer, Button, Flex } from 'antd';
+import { UnorderedListOutlined, SearchOutlined, PlusOutlined, TagOutlined, EditOutlined } from '@ant-design/icons';
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import { track } from '@vercel/analytics';
+import { BoardDetails } from '@/app/lib/types';
+import { generateLayoutSlug, generateSizeSlug, generateSetSlug, constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import SearchForm from '../search-drawer/search-form';
+import SearchResultsFooter from '../search-drawer/search-results-footer';
+import { UISearchParamsProvider } from '../queue-control/ui-searchparams-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+import styles from './bottom-tab-bar.module.css';
+
+type Tab = 'climbs' | 'search' | 'create';
+
+interface BottomTabBarProps {
+  boardDetails: BoardDetails;
+  angle: number;
+}
+
+function BottomTabBarInner({ boardDetails, angle }: BottomTabBarProps) {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const pathname = usePathname();
+
+  const isListPage = pathname.includes('/list');
+
+  const getActiveTab = (): Tab => {
+    if (isSearchOpen) return 'search';
+    if (isCreateOpen) return 'create';
+    if (isListPage) return 'climbs';
+    return 'climbs';
+  };
+
+  const activeTab = getActiveTab();
+
+  const listUrl = (() => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+    if (layout_name && size_name && set_names) {
+      return constructClimbListWithSlugs(board_name, layout_name, size_name, size_description, set_names, angle);
+    }
+    return null;
+  })();
+
+  const createClimbUrl = (() => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+    if (layout_name && size_name && set_names) {
+      return `/${board_name}/${generateLayoutSlug(layout_name)}/${generateSizeSlug(size_name, size_description)}/${generateSetSlug(set_names)}/${angle}/create`;
+    }
+    return null;
+  })();
+
+  const playlistsUrl = (() => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+    if (layout_name && size_name && set_names) {
+      return `/${board_name}/${generateLayoutSlug(layout_name)}/${generateSizeSlug(size_name, size_description)}/${generateSetSlug(set_names)}/${angle}/playlists`;
+    }
+    return null;
+  })();
+
+  const handleSearchTab = () => {
+    setIsCreateOpen(false);
+    setIsSearchOpen(true);
+    track('Bottom Tab Bar', { tab: 'search' });
+  };
+
+  const handleCreateTab = () => {
+    setIsSearchOpen(false);
+    setIsCreateOpen(true);
+    track('Bottom Tab Bar', { tab: 'create' });
+  };
+
+  const handleClimbsTab = () => {
+    setIsSearchOpen(false);
+    setIsCreateOpen(false);
+    track('Bottom Tab Bar', { tab: 'climbs' });
+  };
+
+  const getTabColor = (tab: Tab) =>
+    activeTab === tab ? themeTokens.colors.primary : themeTokens.neutral[400];
+
+  return (
+    <>
+      <div className={styles.tabBar}>
+        {/* Climbs tab */}
+        {listUrl ? (
+          <Link href={listUrl} className={styles.tabItem} onClick={handleClimbsTab} style={{ color: getTabColor('climbs'), textDecoration: 'none' }}>
+            <UnorderedListOutlined style={{ fontSize: 20 }} />
+            <span className={styles.tabLabel}>Climbs</span>
+          </Link>
+        ) : (
+          <button className={styles.tabItem} onClick={handleClimbsTab} style={{ color: getTabColor('climbs') }}>
+            <UnorderedListOutlined style={{ fontSize: 20 }} />
+            <span className={styles.tabLabel}>Climbs</span>
+          </button>
+        )}
+
+        {/* Search tab */}
+        <button
+          className={styles.tabItem}
+          onClick={handleSearchTab}
+          style={{ color: getTabColor('search') }}
+          aria-label="Search climbs"
+          role="tab"
+          aria-selected={activeTab === 'search'}
+        >
+          <SearchOutlined style={{ fontSize: 20 }} />
+          <span className={styles.tabLabel}>Search</span>
+        </button>
+
+        {/* Create tab */}
+        <button
+          className={styles.tabItem}
+          onClick={handleCreateTab}
+          style={{ color: getTabColor('create') }}
+          aria-label="Create new"
+          role="tab"
+          aria-selected={activeTab === 'create'}
+        >
+          <PlusOutlined style={{ fontSize: 20 }} />
+          <span className={styles.tabLabel}>New</span>
+        </button>
+      </div>
+
+      {/* Search Drawer */}
+      <Drawer
+        title="Search Climbs"
+        placement="right"
+        open={isSearchOpen}
+        onClose={() => setIsSearchOpen(false)}
+        footer={<SearchResultsFooter />}
+        styles={{
+          body: { padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[4]}px ${themeTokens.spacing[4]}px` },
+          footer: { padding: 0, border: 'none' },
+          wrapper: { width: '90%' },
+        }}
+      >
+        <SearchForm boardDetails={boardDetails} />
+      </Drawer>
+
+      {/* Create Drawer */}
+      <Drawer
+        title="Create"
+        placement="bottom"
+        open={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        styles={{
+          wrapper: { height: 'auto' },
+          body: { padding: `${themeTokens.spacing[2]}px 0` },
+        }}
+      >
+        <Flex vertical>
+          {createClimbUrl && (
+            <Link
+              href={createClimbUrl}
+              onClick={() => setIsCreateOpen(false)}
+              style={{ textDecoration: 'none' }}
+            >
+              <Button
+                type="text"
+                icon={<EditOutlined />}
+                block
+                style={{
+                  height: 48,
+                  justifyContent: 'flex-start',
+                  paddingLeft: themeTokens.spacing[4],
+                  fontSize: themeTokens.typography.fontSize.base,
+                  color: 'inherit',
+                }}
+              >
+                Create Climb
+              </Button>
+            </Link>
+          )}
+          {playlistsUrl && (
+            <Link
+              href={playlistsUrl}
+              onClick={() => setIsCreateOpen(false)}
+              style={{ textDecoration: 'none' }}
+            >
+              <Button
+                type="text"
+                icon={<TagOutlined />}
+                block
+                style={{
+                  height: 48,
+                  justifyContent: 'flex-start',
+                  paddingLeft: themeTokens.spacing[4],
+                  fontSize: themeTokens.typography.fontSize.base,
+                  color: 'inherit',
+                }}
+              >
+                My Playlists
+              </Button>
+            </Link>
+          )}
+        </Flex>
+      </Drawer>
+    </>
+  );
+}
+
+const BottomTabBar: React.FC<BottomTabBarProps> = (props) => {
+  return (
+    <UISearchParamsProvider>
+      <BottomTabBarInner {...props} />
+    </UISearchParamsProvider>
+  );
+};
+
+export default BottomTabBar;

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Drawer, Button, Typography } from 'antd';
+import { MoreOutlined, HeartOutlined, HeartFilled, PlusOutlined } from '@ant-design/icons';
+import { useSwipeable } from 'react-swipeable';
+import { Climb, BoardDetails } from '@/app/lib/types';
+import ClimbThumbnail from './climb-thumbnail';
+import { AscentStatus } from '../queue-control/queue-list-item';
+import { ClimbActions } from '../climb-actions';
+import { useQueueContext } from '../graphql-queue';
+import { useFavorite } from '../climb-actions';
+import { themeTokens } from '@/app/theme/theme-config';
+import { getGradeColor } from '@/app/lib/grade-colors';
+
+const { Text } = Typography;
+
+// Swipe threshold in pixels to trigger the swipe action
+const SWIPE_THRESHOLD = 100;
+// Maximum swipe distance
+const MAX_SWIPE = 120;
+
+type ClimbListItemProps = {
+  climb: Climb;
+  boardDetails: BoardDetails;
+  selected?: boolean;
+  onSelect?: () => void;
+};
+
+const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDetails, selected, onSelect }) => {
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [isHorizontalSwipe, setIsHorizontalSwipe] = useState<boolean | null>(null);
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+  const { addToQueue } = useQueueContext();
+  const { isFavorited, toggleFavorite } = useFavorite({ climbUuid: climb.uuid });
+
+  const handleSwipeLeft = useCallback(() => {
+    // Swipe left = add to queue
+    addToQueue(climb);
+    setSwipeOffset(0);
+  }, [climb, addToQueue]);
+
+  const handleSwipeRight = useCallback(() => {
+    // Swipe right = toggle favorite
+    toggleFavorite();
+    setSwipeOffset(0);
+  }, [toggleFavorite]);
+
+  const swipeHandlers = useSwipeable({
+    onSwiping: (eventData) => {
+      const { deltaX, deltaY, event } = eventData;
+
+      // On first movement, determine if this is a horizontal or vertical swipe
+      if (isHorizontalSwipe === null) {
+        const absX = Math.abs(deltaX);
+        const absY = Math.abs(deltaY);
+        if (absX > 10 || absY > 10) {
+          setIsHorizontalSwipe(absX > absY);
+        }
+        return;
+      }
+
+      // If it's a vertical swipe, don't interfere
+      if (!isHorizontalSwipe) return;
+
+      // Horizontal swipe - prevent scroll and update offset
+      if ('nativeEvent' in event) {
+        event.nativeEvent.preventDefault();
+      } else {
+        event.preventDefault();
+      }
+      const clampedOffset = Math.max(-MAX_SWIPE, Math.min(MAX_SWIPE, deltaX));
+      setSwipeOffset(clampedOffset);
+    },
+    onSwipedLeft: (eventData) => {
+      if (isHorizontalSwipe && Math.abs(eventData.deltaX) >= SWIPE_THRESHOLD) {
+        handleSwipeLeft();
+      } else {
+        setSwipeOffset(0);
+      }
+      setIsHorizontalSwipe(null);
+    },
+    onSwipedRight: (eventData) => {
+      if (isHorizontalSwipe && Math.abs(eventData.deltaX) >= SWIPE_THRESHOLD) {
+        handleSwipeRight();
+      } else {
+        setSwipeOffset(0);
+      }
+      setIsHorizontalSwipe(null);
+    },
+    onTouchEndOrOnMouseUp: () => {
+      if (Math.abs(swipeOffset) < SWIPE_THRESHOLD) {
+        setSwipeOffset(0);
+      }
+      setIsHorizontalSwipe(null);
+    },
+    trackMouse: false,
+    trackTouch: true,
+    preventScrollOnSwipe: false,
+  });
+
+  // Extract V grade for colorized display
+  const vGradeMatch = climb.difficulty?.match(/V\d+/i);
+  const vGrade = vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
+  const gradeColor = getGradeColor(climb.difficulty);
+  const hasQuality = climb.quality_average && climb.quality_average !== '0';
+
+  // Swipe action visibility
+  const showLeftAction = swipeOffset > 0; // Swiping right reveals favorite on left
+  const showRightAction = swipeOffset < 0; // Swiping left reveals queue on right
+  const leftActionOpacity = Math.min(1, swipeOffset / SWIPE_THRESHOLD);
+  const rightActionOpacity = Math.min(1, Math.abs(swipeOffset) / SWIPE_THRESHOLD);
+
+  // Build exclude list for moonboard
+  const excludeActions: ('tick' | 'openInApp' | 'mirror' | 'share' | 'addToList' | 'viewDetails')[] = [];
+  if (boardDetails.board_name === 'moonboard') {
+    excludeActions.push('viewDetails');
+  }
+
+  return (
+    <>
+      <div style={{ position: 'relative', overflow: 'hidden' }}>
+        {/* Left action background (favorite - revealed on swipe right) */}
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: MAX_SWIPE,
+            backgroundColor: themeTokens.colors.error,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+            paddingLeft: themeTokens.spacing[4],
+            opacity: leftActionOpacity,
+            visibility: showLeftAction ? 'visible' : 'hidden',
+          }}
+        >
+          {isFavorited ? (
+            <HeartFilled style={{ color: 'white', fontSize: 20 }} />
+          ) : (
+            <HeartOutlined style={{ color: 'white', fontSize: 20 }} />
+          )}
+        </div>
+
+        {/* Right action background (add to queue - revealed on swipe left) */}
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: MAX_SWIPE,
+            backgroundColor: themeTokens.colors.primary,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            paddingRight: themeTokens.spacing[4],
+            opacity: rightActionOpacity,
+            visibility: showRightAction ? 'visible' : 'hidden',
+          }}
+        >
+          <PlusOutlined style={{ color: 'white', fontSize: 20 }} />
+        </div>
+
+        {/* Swipeable content */}
+        <div
+          {...swipeHandlers}
+          onClick={onSelect}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
+            gap: themeTokens.spacing[3],
+            backgroundColor: selected ? themeTokens.semantic.selected : themeTokens.semantic.surface,
+            borderBottom: `1px solid ${themeTokens.neutral[200]}`,
+            borderLeft: selected ? `3px solid ${themeTokens.colors.primary}` : '3px solid transparent',
+            transform: `translateX(${swipeOffset}px)`,
+            transition: swipeOffset === 0 ? `transform ${themeTokens.transitions.fast}` : 'none',
+            cursor: 'pointer',
+            userSelect: 'none',
+          }}
+        >
+          {/* Thumbnail */}
+          <div style={{ width: 48, flexShrink: 0 }}>
+            <ClimbThumbnail
+              boardDetails={boardDetails}
+              currentClimb={climb}
+              enableNavigation
+            />
+          </div>
+
+          {/* Center: Name, quality, setter */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[1] }}>
+              <Text
+                style={{
+                  fontSize: themeTokens.typography.fontSize.sm,
+                  fontWeight: themeTokens.typography.fontWeight.semibold,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {climb.name}
+              </Text>
+              <AscentStatus climbUuid={climb.uuid} />
+            </div>
+            <Text
+              type="secondary"
+              style={{
+                fontSize: themeTokens.typography.fontSize.xs,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: 'block',
+              }}
+            >
+              {hasQuality ? `${climb.quality_average}\u2605` : ''}{' '}
+              {climb.setter_username && `${climb.setter_username}`}
+            </Text>
+          </div>
+
+          {/* Right: V-grade colorized */}
+          {vGrade && (
+            <Text
+              style={{
+                fontSize: themeTokens.typography.fontSize['2xl'],
+                fontWeight: themeTokens.typography.fontWeight.bold,
+                lineHeight: 1,
+                color: gradeColor ?? themeTokens.neutral[500],
+                flexShrink: 0,
+              }}
+            >
+              {vGrade}
+            </Text>
+          )}
+          {!vGrade && climb.difficulty && (
+            <Text
+              type="secondary"
+              style={{
+                fontSize: themeTokens.typography.fontSize.sm,
+                fontWeight: themeTokens.typography.fontWeight.semibold,
+                flexShrink: 0,
+              }}
+            >
+              {climb.difficulty}
+            </Text>
+          )}
+
+          {/* Ellipsis menu button */}
+          <Button
+            type="text"
+            size="small"
+            icon={<MoreOutlined />}
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsActionsOpen(true);
+            }}
+            style={{ flexShrink: 0, color: themeTokens.neutral[400] }}
+          />
+        </div>
+      </div>
+
+      {/* Actions Drawer */}
+      <Drawer
+        title={
+          <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[3] }}>
+            <div style={{ width: 48, flexShrink: 0 }}>
+              <ClimbThumbnail boardDetails={boardDetails} currentClimb={climb} />
+            </div>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <Text
+                strong
+                style={{
+                  display: 'block',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {climb.name}
+              </Text>
+              <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.xs }}>
+                {climb.difficulty} {hasQuality ? `${climb.quality_average}\u2605` : ''}
+              </Text>
+            </div>
+          </div>
+        }
+        placement="bottom"
+        open={isActionsOpen}
+        onClose={() => setIsActionsOpen(false)}
+        styles={{
+          wrapper: { height: 'auto' },
+          body: { padding: `${themeTokens.spacing[2]}px 0` },
+        }}
+      >
+        <ClimbActions
+          climb={climb}
+          boardDetails={boardDetails}
+          angle={climb.angle}
+          viewMode="button"
+          exclude={excludeActions}
+          onActionComplete={() => setIsActionsOpen(false)}
+        />
+      </Drawer>
+    </>
+  );
+}, (prev, next) => {
+  return prev.climb.uuid === next.climb.uuid
+    && prev.selected === next.selected
+    && prev.boardDetails === next.boardDetails;
+});
+
+ClimbListItem.displayName = 'ClimbListItem';
+
+export default ClimbListItem;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -10,9 +10,8 @@ import NextClimbButton from './next-climb-button';
 import { usePathname, useParams, useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { constructPlayUrlWithSlugs, constructClimbViewUrlWithSlugs, parseBoardRouteParams } from '@/app/lib/url-utils';
-import { BoardRouteParameters, BoardRouteParametersWithUuid } from '@/app/lib/types';
+import { BoardRouteParameters, BoardDetails, Angle } from '@/app/lib/types';
 import PreviousClimbButton from './previous-climb-button';
-import { BoardName, BoardDetails, Angle } from '@/app/lib/types';
 import QueueList, { QueueListHandle } from './queue-list';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
@@ -27,13 +26,12 @@ const SWIPE_THRESHOLD = 100;
 // Maximum swipe distance (matches queue-list-item)
 const MAX_SWIPE = 120;
 
-export interface QueueControlBar {
+export interface QueueControlBarProps {
   boardDetails: BoardDetails;
-  board: BoardName;
   angle: Angle;
 }
 
-const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: QueueControlBar) => {
+const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }) => {
   const [isQueueOpen, setIsQueueOpen] = useState(false);
   const [swipeOffset, setSwipeOffset] = useState(0);
   const pathname = usePathname();
@@ -231,7 +229,7 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
   const rightActionOpacity = Math.min(1, Math.abs(swipeOffset) / SWIPE_THRESHOLD);
 
   return (
-    <div id="onboarding-queue-bar" className="queue-bar-shadow" data-testid="queue-control-bar" style={{ flexShrink: 0, width: '100%', backgroundColor: '#fff' }}>
+    <div id="onboarding-queue-bar" className="queue-bar-shadow" data-testid="queue-control-bar" style={{ flexShrink: 0, width: '100%', backgroundColor: themeTokens.semantic.surface }}>
       {/* Main Control Bar */}
       <Card
         variant="borderless"
@@ -300,10 +298,10 @@ const QueueControlBar: React.FC<QueueControlBar> = ({ boardDetails, angle }: Que
             {...swipeHandlers}
             className={styles.swipeContainer}
             style={{
-              padding: '4px 12px 0px 12px',
+              padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[3]}px 0 ${themeTokens.spacing[3]}px`,
               transform: `translateX(${swipeOffset}px)`,
               transition: swipeOffset === 0 ? `transform ${themeTokens.transitions.fast}` : 'none',
-              backgroundColor: '#fff',
+              backgroundColor: themeTokens.semantic.surface,
             }}
           >
             <Row justify="space-between" align="middle" style={{ width: '100%' }}>

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -309,7 +309,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
           style={{
             display: 'flex',
             alignItems: 'center',
-            padding: '12px 8px',
+            padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[2]}px`,
             backgroundColor: isCurrent
               ? themeTokens.semantic.selected
               : isHistory
@@ -318,9 +318,6 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
             opacity: isSwipeComplete ? 0 : isHistory ? 0.6 : 1,
             cursor: 'grab',
             position: 'relative',
-            WebkitUserSelect: 'none',
-            MozUserSelect: 'none',
-            msUserSelect: 'none',
             userSelect: 'none',
             borderLeft: isCurrent ? `3px solid ${themeTokens.colors.primary}` : undefined,
             transform: `translateX(${swipeOffset}px)`,

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -247,7 +247,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
                 style={{
                   display: 'flex',
                   alignItems: 'center',
-                  padding: '12px 8px',
+                  padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[2]}px`,
                   borderBottom: `1px solid ${themeTokens.neutral[200]}`,
                 }}
               >
@@ -326,8 +326,8 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
           open={tickDrawerVisible}
           styles={{ wrapper: { height: '50%' } }}
         >
-          <Space orientation="vertical" size="large" style={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
-            <Text strong style={{ fontSize: 16 }}>Sign in to record ticks</Text>
+          <Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center', padding: `${themeTokens.spacing[6]}px 0` }}>
+            <Text strong style={{ fontSize: themeTokens.typography.fontSize.base }}>Sign in to record ticks</Text>
             <Paragraph type="secondary">
               Create a Boardsesh account to log your climbs and track your progress.
             </Paragraph>


### PR DESCRIPTION
Phase 1 - Bottom Tab Bar:
- Add persistent bottom tab bar with Climbs, Search, and New tabs
- Hidden on desktop via CSS media query (>=768px)
- Search tab opens existing search drawer
- Create tab opens bottom drawer with Create Climb and Playlists
- iOS safe area padding support

Phase 2 - Compact Climb List:
- Add ClimbListItem component with compact Spotify-like row layout
- Colorized V-grade display, thumbnail, name, quality, setter info
- Swipe right to favorite, swipe left to add to queue
- Ellipsis menu with full action drawer
- View mode toggle (list/grid) with localStorage persistence
- Defaults to list mode on mobile, grid on desktop

Code quality fixes:
- Fix Space orientation->direction bug in queue-list.tsx
- Replace hardcoded colors (#fff, #888) with theme tokens throughout
- Replace hardcoded spacing with theme token values
- Fix QueueControlBar interface naming (QueueControlBarProps)
- Remove unused board prop from QueueControlBar
- Remove unused imports and vendor prefixes
- Clean up dead code across queue components

https://claude.ai/code/session_01SrNcg1JnQosgiCfsKLvchM