### PR TITLE
Fix climb title centering in play view horizontal layout

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -176,7 +176,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     }
 
     return (
-      <Flex gap={12} align="center" className={className}>
+      <Flex gap={12} align="center" className={className} style={centered ? { position: 'relative' } : undefined}>
         {/* Left side: Name and quality/setter stacked */}
         <Flex vertical gap={0} style={{ flex: 1, minWidth: 0 }} align={centered ? 'center' : 'flex-start'}>
           {/* Row 1: Name with addon */}
@@ -196,8 +196,14 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
             {secondLineContent.length > 0 ? secondLineContent.join(' · ') : <span style={{ fontStyle: 'italic' }}>project</span>}
           </Text>
         </Flex>
-        {/* Right side: Large V grade spanning both rows */}
-        {largeGradeElement}
+        {/* Large V grade: absolutely positioned when centered to avoid pushing text off-center */}
+        {centered ? (
+          <div style={{ position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)' }}>
+            {largeGradeElement}
+          </div>
+        ) : (
+          largeGradeElement
+        )}
       </Flex>
     );
   }


### PR DESCRIPTION
When centered prop is true, absolutely position the large V-grade element
so it doesn't push the title and info text off-center. The grade still
appears on the right side but no longer affects the flow layout.

https://claude.ai/code/session_01XtirYJLTSiW6mzsv5qbAFz