### PR TITLE
Fix double-tap on climb list item adding climb to queue twice

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -12,6 +12,7 @@ import { AscentStatus } from '../queue-control/queue-list-item';
 import { ClimbActions } from '../climb-actions';
 import { useQueueContext } from '../graphql-queue';
 import { useFavorite } from '../climb-actions';
+import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeColor, getGradeTintColor } from '@/app/lib/grade-colors';
 
@@ -35,6 +36,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const { addToQueue } = useQueueContext();
   const { isFavorited, toggleFavorite } = useFavorite({ climbUuid: climb.uuid });
+  const { ref: doubleTapRef, onDoubleClick: handleDoubleClick } = useDoubleTap(onSelect);
 
   const handleSwipeLeft = useCallback(() => {
     // Swipe left = add to queue
@@ -169,7 +171,11 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
         {/* Swipeable content */}
         <div
           {...swipeHandlers}
-          onClick={onSelect}
+          ref={(node: HTMLDivElement | null) => {
+            doubleTapRef(node);
+            swipeHandlers.ref(node);
+          }}
+          onDoubleClick={handleDoubleClick}
           style={{
             display: 'flex',
             alignItems: 'center',


### PR DESCRIPTION
ClimbListItem was binding onSelect (which calls setCurrentClimb) to onClick,
so each tap in a double-tap fired setCurrentClimb independently. Each call
creates a new ClimbQueueItem with a unique UUID, bypassing the reducer's
dedup check and adding the climb to the queue twice.

Switch to using the useDoubleTap hook (already used by ClimbCardCover and
QueueListItem) so the callback fires exactly once on a double-tap, and
iOS Safari's double-tap-to-zoom is properly prevented.

https://claude.ai/code/session_01S5Z1GocqHqzb7uYj9q12hJ