### PR TITLE
Change tick icon color from green to subtle grey

### DIFF
--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -58,13 +58,13 @@ export const AscentStatus = ({ climbUuid, fontSize }: { climbUuid: ClimbUuid; fo
         {/* Regular ascent icon */}
         {hasSuccessfulAscent ? (
           <div className={styles.ascentIconRegular}>
-            <CheckOutlined style={{ color: themeTokens.colors.success, fontSize }} />
+            <CheckOutlined style={{ color: themeTokens.neutral[400], fontSize }} />
           </div>
         ) : null}
         {/* Mirrored ascent icon */}
         {hasSuccessfulMirroredAscent ? (
           <div className={styles.ascentIconMirrored}>
-            <CheckOutlined style={{ color: themeTokens.colors.success, fontSize }} />
+            <CheckOutlined style={{ color: themeTokens.neutral[400], fontSize }} />
           </div>
         ) : null}
         {!hasSuccessfulMirroredAscent && !hasSuccessfulAscent ? (
@@ -76,7 +76,7 @@ export const AscentStatus = ({ climbUuid, fontSize }: { climbUuid: ClimbUuid; fo
 
   // Single icon for non-mirroring boards
   return hasSuccessfulAscent ? (
-    <CheckOutlined style={{ color: themeTokens.colors.success, fontSize }} />
+    <CheckOutlined style={{ color: themeTokens.neutral[400], fontSize }} />
   ) : (
     <CloseOutlined style={{ color: themeTokens.colors.error, fontSize }} />
   );


### PR DESCRIPTION
The ascent check mark icon next to the colorised grade was using
the success (green) color which was too prominent. Switch to
neutral[400] grey for a more subtle appearance.

https://claude.ai/code/session_01Et7UDP4Z9vpiFjY8VZx5V2