### PR TITLE
Phase 4: Replace header menus with user avatar + left drawer

### DIFF
--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -227,7 +227,7 @@ A new landing/home screen accessible via the first tab. This is a placeholder fo
 
 ---
 
-## Phase 2: Compact Climb List Mode
+## Phase 2: Compact Climb List Mode [DONE]
 
 ### What changes
 Add a "compact" display mode for the climb list that renders climbs as slim rows (similar to QueueListItem) instead of full cards.
@@ -307,7 +307,7 @@ Add a "compact" display mode for the climb list that renders climbs as slim rows
 
 ---
 
-## Phase 3: Now Playing Bar Redesign + Full-screen Play Drawer
+## Phase 3: Now Playing Bar Redesign + Full-screen Play Drawer [DONE]
 
 ### What changes
 - Redesign QueueControlBar to be simpler with only essential controls
@@ -548,7 +548,7 @@ Key implementation details:
 
 ---
 
-## Phase 4: Header Redesign — Board Selector, User Drawer, Simplified Layout
+## Phase 4: Header Redesign — Board Selector, User Drawer, Simplified Layout [DONE]
 
 ### What changes
 - **Remove** the top-right meatball/ellipsis menu entirely
@@ -1005,60 +1005,60 @@ Board layout.tsx (server component)
 - [x] Search input and advanced search button remain in header on list pages (mobile)
 
 ### Phase 2
-- [ ] Compact list items render correctly with proper layout
-- [ ] Grade colors match existing ClimbTitle colors
-- [ ] AscentStatus icon shows on compact list items
-- [ ] Swipe right favorites a climb (visual feedback, auth check)
-- [ ] Swipe left adds to queue (visual feedback + queue updates)
-- [ ] Swipe direction detection works (vertical scroll not blocked)
-- [ ] Ellipsis menu opens bottom drawer with all actions
-- [ ] All actions in drawer work (favorite, queue, tick, share, playlist, open-in-app, mirror, fork, view)
-- [ ] View mode toggle persists across page loads (localStorage)
-- [ ] View mode defaults to compact on all devices
-- [ ] Infinite scroll works in both modes
-- [ ] Scroll position restoration (hash-based) works in both modes
-- [ ] Selected climb highlighting works in compact mode
+- [x] Compact list items render correctly with proper layout
+- [x] Grade colors match existing ClimbTitle colors
+- [x] AscentStatus icon shows on compact list items
+- [x] Swipe right favorites a climb (visual feedback, auth check)
+- [x] Swipe left adds to queue (visual feedback + queue updates)
+- [x] Swipe direction detection works (vertical scroll not blocked)
+- [x] Ellipsis menu opens bottom drawer with all actions
+- [x] All actions in drawer work (favorite, queue, tick, share, playlist, open-in-app, mirror, fork, view)
+- [x] View mode toggle persists across page loads (localStorage)
+- [x] View mode defaults to compact on all devices
+- [x] Infinite scroll works in both modes
+- [x] Scroll position restoration (hash-based) works in both modes
+- [x] Selected climb highlighting works in compact mode
 
 ### Phase 3
-- [ ] QueueControlBar is ~45px tall (20% shorter than before) with 36px thumbnail
-- [ ] Bar appears on **all pages** when there is an active local queue
-- [ ] Bar appears on **all pages** when there is an active party session
-- [ ] Bar does NOT appear when there is no queue and no active session
-- [ ] On non-board pages, tapping the bar navigates back to the board route
-- [ ] On board pages, tapping the bar opens full-screen drawer (mobile only)
-- [ ] On board pages, tapping the bar navigates to /play/ route (desktop)
-- [ ] Global bar hides when navigating to a board route (board layout renders its own)
-- [ ] No duplicate bars visible on board routes
-- [ ] `FloatingSessionThumbnail` is fully removed — no floating card appears anywhere
-- [ ] Play drawer shows board renderer correctly (lazy-mounted)
-- [ ] Card-swipe navigation works in play drawer (content translates, next card slides in)
-- [ ] Card-swipe navigation works in QueueControlBar (current climb slides out, next slides in)
-- [ ] Mirror/favorite/tick actions work in play drawer
-- [ ] Drag-to-close works smoothly (custom react-swipeable handle)
-- [ ] Back button closes play drawer (hash-based `#playing`)
-- [ ] Queue button opens queue drawer (play drawer closes first)
-- [ ] Party button opens party drawer
-- [ ] Desktop QueueControlBar still has mirror, play link, prev/next buttons
-- [ ] /play/ URLs still work for direct links on all devices
-- [ ] Wake lock activates when play drawer is open
-- [ ] Page content has proper bottom padding when global bar is visible
+- [x] QueueControlBar is ~45px tall (20% shorter than before) with 36px thumbnail
+- [x] Bar appears on **all pages** when there is an active local queue
+- [x] Bar appears on **all pages** when there is an active party session
+- [x] Bar does NOT appear when there is no queue and no active session
+- [x] On non-board pages, tapping the bar navigates back to the board route
+- [x] On board pages, tapping the bar opens full-screen drawer (mobile only)
+- [x] On board pages, tapping the bar navigates to /play/ route (desktop)
+- [x] Global bar hides when navigating to a board route (board layout renders its own)
+- [x] No duplicate bars visible on board routes
+- [x] `FloatingSessionThumbnail` is fully removed — no floating card appears anywhere
+- [x] Play drawer shows board renderer correctly (lazy-mounted)
+- [x] Card-swipe navigation works in play drawer (content translates, next card slides in)
+- [x] Card-swipe navigation works in QueueControlBar (current climb slides out, next slides in)
+- [x] Mirror/favorite/tick actions work in play drawer
+- [x] Drag-to-close works smoothly (custom react-swipeable handle)
+- [x] Back button closes play drawer (hash-based `#playing`)
+- [x] Queue button opens queue drawer (play drawer closes first)
+- [x] Party button opens party drawer
+- [x] Desktop QueueControlBar still has mirror, play link, prev/next buttons
+- [x] /play/ URLs still work for direct links on all devices
+- [x] Wake lock activates when play drawer is open
+- [x] Page content has proper bottom padding when global bar is visible
 
 ### Phase 4
-- [ ] Meatball menu is completely removed (mobile and desktop)
-- [ ] Desktop user dropdown is completely removed
-- [ ] User avatar button appears top-left on all pages
-- [ ] Tapping avatar opens left-side user drawer
-- [ ] User drawer shows correct content when logged in (avatar, username, email, all menu items)
-- [ ] User drawer shows sign-in prompt when logged out
-- [ ] "Change Board" navigates to setup wizard or shows board list
-- [ ] "Recents" shows recently visited board configurations
-- [ ] "Classify Holds" opens HoldClassificationWizard from the drawer
-- [ ] Logout works from the drawer
-- [ ] Desktop header still has Create, Party, LED buttons inline
-- [ ] Mobile header is simplified (Avatar, Logo, Angle)
-- [ ] All removed items are accessible via user drawer or other new locations
-- [ ] Onboarding tour steps still target valid elements
-- [ ] SendClimbToBoardButton dynamic import only loads on desktop
+- [x] Meatball menu is completely removed (mobile and desktop)
+- [x] Desktop user dropdown is completely removed
+- [x] User avatar button appears top-left on all pages
+- [x] Tapping avatar opens left-side user drawer
+- [x] User drawer shows correct content when logged in (avatar, username, email, all menu items)
+- [x] User drawer shows sign-in prompt when logged out
+- [x] "Change Board" navigates to setup wizard or shows board list
+- [x] "Recents" shows recently visited board configurations
+- [x] "Classify Holds" opens HoldClassificationWizard from the drawer
+- [x] Logout works from the drawer
+- [x] Desktop header still has Create, Party, LED buttons inline
+- [x] Mobile header is simplified (Avatar, Logo, Angle)
+- [x] All removed items are accessible via user drawer or other new locations
+- [x] Onboarding tour steps still target valid elements
+- [x] SendClimbToBoardButton dynamic import only loads on desktop
 
 ### Phase 5
 - [ ] Party drawer opens from bottom (not top)

--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -6,10 +6,6 @@
   display: flex;
 }
 
-.mobileMenuButton {
-  display: none;
-}
-
 .header {
   touch-action: manipulation;
   padding-top: env(safe-area-inset-top, 0px);
@@ -28,9 +24,5 @@
 
   .desktopOnly {
     display: none;
-  }
-
-  .mobileMenuButton {
-    display: flex;
   }
 }

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -28,6 +28,7 @@
 
   /* Status colors */
   --color-success: #10B981;
+  --color-error: #EF4444;
 
   /* Borders */
   --border-subtle: rgba(0, 0, 0, 0.06);

--- a/packages/web/app/components/setup-wizard/session-history-panel.tsx
+++ b/packages/web/app/components/setup-wizard/session-history-panel.tsx
@@ -5,110 +5,17 @@ import { Collapse, Spin, Typography, Card, Button, Space, Tag } from 'antd';
 import { HistoryOutlined, PlayCircleOutlined, TeamOutlined } from '@ant-design/icons';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
+import {
+  type StoredSession,
+  getRecentSessions,
+  formatRelativeTime,
+  extractBoardName,
+} from '@/app/lib/session-history-db';
+
+// Re-export for backwards compatibility with existing consumers
+export { saveSessionToHistory } from '@/app/lib/session-history-db';
 
 const { Text } = Typography;
-
-// Type for session from storage/API
-type StoredSession = {
-  id: string;
-  name: string | null;
-  boardPath: string;
-  createdAt: string;
-  lastActivity: string;
-  participantCount?: number;
-};
-
-/**
- * Format relative time for display
- */
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / (1000 * 60));
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins} min${diffMins === 1 ? '' : 's'} ago`;
-  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  return date.toLocaleDateString();
-}
-
-/**
- * Extract board name from boardPath
- */
-function extractBoardName(boardPath: string): string {
-  const parts = boardPath.split('/').filter(Boolean);
-  if (parts.length > 0) {
-    return parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
-  }
-  return 'Unknown Board';
-}
-
-// IndexedDB configuration for session history
-const DB_NAME = 'boardsesh-sessions';
-const DB_VERSION = 1;
-const STORE_NAME = 'session-history';
-
-async function initSessionDB() {
-  if (typeof window === 'undefined' || !window.indexedDB) {
-    return null;
-  }
-
-  return new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve(request.result);
-
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
-        store.createIndex('lastActivity', 'lastActivity', { unique: false });
-      }
-    };
-  });
-}
-
-async function getRecentSessions(): Promise<StoredSession[]> {
-  const db = await initSessionDB();
-  if (!db) return [];
-
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly');
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.getAll();
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => {
-      const sessions = request.result as StoredSession[];
-      // Filter to sessions from last 7 days and sort by last activity
-      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-      const recentSessions = sessions
-        .filter((s) => new Date(s.lastActivity || s.createdAt) > sevenDaysAgo)
-        .sort((a, b) => new Date(b.lastActivity || b.createdAt).getTime() - new Date(a.lastActivity || a.createdAt).getTime());
-      resolve(recentSessions);
-    };
-  });
-}
-
-// Export function to save session to history
-export async function saveSessionToHistory(session: StoredSession): Promise<void> {
-  const db = await initSessionDB();
-  if (!db) return;
-
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readwrite');
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.put(session);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve();
-  });
-}
 
 const SessionHistoryPanel = () => {
   const router = useRouter();

--- a/packages/web/app/components/user-drawer/user-drawer.module.css
+++ b/packages/web/app/components/user-drawer/user-drawer.module.css
@@ -99,6 +99,43 @@
   height: 32px;
 }
 
+.avatarLoggedIn {
+  background-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.avatarLoggedOut {
+  background-color: var(--neutral-300);
+  cursor: pointer;
+}
+
+.userName {
+  font-size: 18px;
+}
+
+.userEmail {
+  font-size: 14px;
+}
+
+.sectionLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  padding: 4px 16px;
+  display: block;
+}
+
+.recentItemIcon {
+  color: var(--neutral-400);
+  font-size: 16px;
+}
+
+.recentItemAction {
+  color: var(--color-primary);
+  font-size: 16px;
+}
+
 .dangerItem {
   color: var(--color-error);
 }

--- a/packages/web/app/components/user-drawer/user-drawer.module.css
+++ b/packages/web/app/components/user-drawer/user-drawer.module.css
@@ -93,10 +93,16 @@
   color: var(--neutral-500);
 }
 
+.avatarButton {
+  padding: 0;
+  width: 32px;
+  height: 32px;
+}
+
 .dangerItem {
-  color: #EF4444;
+  color: var(--color-error);
 }
 
 .dangerItem .menuItemIcon {
-  color: #EF4444;
+  color: var(--color-error);
 }

--- a/packages/web/app/components/user-drawer/user-drawer.module.css
+++ b/packages/web/app/components/user-drawer/user-drawer.module.css
@@ -1,0 +1,102 @@
+.profileSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 15px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 150ms ease;
+  border-radius: 8px;
+}
+
+.menuItem:hover {
+  background: var(--neutral-100);
+}
+
+.menuItem:active {
+  background: var(--neutral-200);
+}
+
+.menuItemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  font-size: 18px;
+  color: var(--neutral-600);
+  flex-shrink: 0;
+}
+
+.menuItemLabel {
+  flex: 1;
+  text-align: left;
+}
+
+.divider {
+  height: 1px;
+  background: var(--neutral-200);
+  margin: 8px 0;
+}
+
+.drawerBody {
+  padding: 0 8px;
+}
+
+.recentItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 150ms ease;
+  border-radius: 8px;
+}
+
+.recentItem:hover {
+  background: var(--neutral-100);
+}
+
+.recentItemInfo {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.recentItemName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recentItemMeta {
+  font-size: 12px;
+  color: var(--neutral-500);
+}
+
+.dangerItem {
+  color: #EF4444;
+}
+
+.dangerItem .menuItemIcon {
+  color: #EF4444;
+}

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Avatar, Typography, Button } from 'antd';
+import {
+  UserOutlined,
+  SettingOutlined,
+  LineChartOutlined,
+  LogoutOutlined,
+  LoginOutlined,
+  QuestionCircleOutlined,
+  InfoCircleOutlined,
+  AimOutlined,
+  TagOutlined,
+  SwapOutlined,
+  HistoryOutlined,
+  PlayCircleOutlined,
+  TeamOutlined,
+} from '@ant-design/icons';
+import { useSession, signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import AuthModal from '../auth/auth-modal';
+import { HoldClassificationWizard } from '../hold-classification';
+import { BoardDetails } from '@/app/lib/types';
+import { generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib/url-utils';
+import { themeTokens } from '@/app/theme/theme-config';
+import styles from './user-drawer.module.css';
+
+const { Text } = Typography;
+
+// Session history types and helpers (reused from session-history-panel)
+type StoredSession = {
+  id: string;
+  name: string | null;
+  boardPath: string;
+  createdAt: string;
+  lastActivity: string;
+  participantCount?: number;
+};
+
+const DB_NAME = 'boardsesh-sessions';
+const DB_VERSION = 1;
+const STORE_NAME = 'session-history';
+
+async function initSessionDB() {
+  if (typeof window === 'undefined' || !window.indexedDB) {
+    return null;
+  }
+
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('lastActivity', 'lastActivity', { unique: false });
+      }
+    };
+  });
+}
+
+async function getRecentSessions(): Promise<StoredSession[]> {
+  const db = await initSessionDB();
+  if (!db) return [];
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const sessions = request.result as StoredSession[];
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const recentSessions = sessions
+        .filter((s) => new Date(s.lastActivity || s.createdAt) > sevenDaysAgo)
+        .sort(
+          (a, b) =>
+            new Date(b.lastActivity || b.createdAt).getTime() -
+            new Date(a.lastActivity || a.createdAt).getTime(),
+        );
+      resolve(recentSessions);
+    };
+  });
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins} min${diffMins === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return date.toLocaleDateString();
+}
+
+function extractBoardName(boardPath: string): string {
+  const parts = boardPath.split('/').filter(Boolean);
+  if (parts.length > 0) {
+    return parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
+  }
+  return 'Unknown Board';
+}
+
+interface UserDrawerProps {
+  boardDetails: BoardDetails;
+  angle?: number;
+}
+
+export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [showHoldClassification, setShowHoldClassification] = useState(false);
+  const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
+
+  const isMoonboard = boardDetails.board_name === 'moonboard';
+
+  // Load recent sessions when drawer opens
+  useEffect(() => {
+    if (isOpen) {
+      getRecentSessions()
+        .then(setRecentSessions)
+        .catch(console.error);
+    }
+  }, [isOpen]);
+
+  const handleClose = () => setIsOpen(false);
+
+  const handleSignOut = () => {
+    signOut();
+    handleClose();
+  };
+
+  const handleResumeSession = (storedSession: StoredSession) => {
+    const url = new URL(storedSession.boardPath, window.location.origin);
+    url.searchParams.set('session', storedSession.id);
+    router.push(url.pathname + url.search);
+    handleClose();
+  };
+
+  const playlistsUrl = (() => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+    if (layout_name && size_name && set_names && angle !== undefined) {
+      return `/${board_name}/${generateLayoutSlug(layout_name)}/${generateSizeSlug(size_name, size_description)}/${generateSetSlug(set_names)}/${angle}/playlists`;
+    }
+    return null;
+  })();
+
+  const userAvatar = session?.user?.image;
+  const userName = session?.user?.name;
+  const userEmail = session?.user?.email;
+
+  return (
+    <>
+      <Button
+        type="text"
+        onClick={() => setIsOpen(true)}
+        aria-label="User menu"
+        style={{ padding: 0, width: 32, height: 32 }}
+      >
+        <Avatar
+          size={28}
+          src={userAvatar}
+          icon={!userAvatar ? <UserOutlined /> : undefined}
+          style={{
+            backgroundColor: session?.user ? themeTokens.colors.primary : themeTokens.neutral[300],
+            cursor: 'pointer',
+          }}
+        />
+      </Button>
+
+      <SwipeableDrawer
+        placement="left"
+        open={isOpen}
+        onClose={handleClose}
+        closable
+        width={300}
+        styles={{
+          body: { padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[2]}px` },
+        }}
+        title={null}
+      >
+        <div className={styles.drawerBody}>
+          {/* Profile section */}
+          <div className={styles.profileSection}>
+            <Avatar
+              size={64}
+              src={userAvatar}
+              icon={!userAvatar ? <UserOutlined /> : undefined}
+              style={{
+                backgroundColor: session?.user ? themeTokens.colors.primary : themeTokens.neutral[300],
+              }}
+            />
+            {session?.user ? (
+              <>
+                {userName && (
+                  <Text strong style={{ fontSize: themeTokens.typography.fontSize.lg }}>
+                    {userName}
+                  </Text>
+                )}
+                {userEmail && (
+                  <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
+                    {userEmail}
+                  </Text>
+                )}
+                <Link
+                  href={`/crusher/${session.user.id}`}
+                  onClick={handleClose}
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Button type="link" size="small">View Profile</Button>
+                </Link>
+              </>
+            ) : (
+              <Button
+                type="primary"
+                icon={<LoginOutlined />}
+                onClick={() => {
+                  handleClose();
+                  setShowAuthModal(true);
+                }}
+              >
+                Sign in
+              </Button>
+            )}
+          </div>
+
+          <div className={styles.divider} />
+
+          {/* Navigation section */}
+          <nav>
+            <Link
+              href="/"
+              className={styles.menuItem}
+              onClick={handleClose}
+            >
+              <span className={styles.menuItemIcon}><SwapOutlined /></span>
+              <span className={styles.menuItemLabel}>Change Board</span>
+            </Link>
+
+            <Link
+              href="/settings"
+              className={styles.menuItem}
+              onClick={handleClose}
+            >
+              <span className={styles.menuItemIcon}><SettingOutlined /></span>
+              <span className={styles.menuItemLabel}>Settings</span>
+            </Link>
+
+            {!isMoonboard && (
+              <button
+                className={styles.menuItem}
+                onClick={() => {
+                  handleClose();
+                  setShowHoldClassification(true);
+                }}
+              >
+                <span className={styles.menuItemIcon}><AimOutlined /></span>
+                <span className={styles.menuItemLabel}>Classify Holds</span>
+              </button>
+            )}
+
+            {playlistsUrl && !isMoonboard && (
+              <Link
+                href={playlistsUrl}
+                className={styles.menuItem}
+                onClick={handleClose}
+              >
+                <span className={styles.menuItemIcon}><TagOutlined /></span>
+                <span className={styles.menuItemLabel}>My Playlists</span>
+              </Link>
+            )}
+          </nav>
+
+          {/* Recents section */}
+          {recentSessions.length > 0 && (
+            <>
+              <div className={styles.divider} />
+              <Text
+                type="secondary"
+                style={{
+                  fontSize: themeTokens.typography.fontSize.xs,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                  fontWeight: themeTokens.typography.fontWeight.semibold,
+                  padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[4]}px`,
+                  display: 'block',
+                }}
+              >
+                Recent Sessions
+              </Text>
+              {recentSessions.slice(0, 5).map((storedSession) => (
+                <button
+                  key={storedSession.id}
+                  className={styles.recentItem}
+                  onClick={() => handleResumeSession(storedSession)}
+                >
+                  <HistoryOutlined style={{ color: themeTokens.neutral[400], fontSize: 16 }} />
+                  <div className={styles.recentItemInfo}>
+                    <div className={styles.recentItemName}>
+                      {storedSession.name || `${extractBoardName(storedSession.boardPath)} Session`}
+                    </div>
+                    <div className={styles.recentItemMeta}>
+                      {extractBoardName(storedSession.boardPath)}
+                      {storedSession.participantCount !== undefined && storedSession.participantCount > 0 && (
+                        <> <TeamOutlined /> {storedSession.participantCount}</>
+                      )}
+                      {' '}{formatRelativeTime(storedSession.lastActivity || storedSession.createdAt)}
+                    </div>
+                  </div>
+                  <PlayCircleOutlined style={{ color: themeTokens.colors.primary, fontSize: 16 }} />
+                </button>
+              ))}
+            </>
+          )}
+
+          <div className={styles.divider} />
+
+          {/* Help/About section */}
+          <Link
+            href="/help"
+            className={styles.menuItem}
+            onClick={handleClose}
+          >
+            <span className={styles.menuItemIcon}><QuestionCircleOutlined /></span>
+            <span className={styles.menuItemLabel}>Help</span>
+          </Link>
+
+          <Link
+            href="/about"
+            className={styles.menuItem}
+            onClick={handleClose}
+          >
+            <span className={styles.menuItemIcon}><InfoCircleOutlined /></span>
+            <span className={styles.menuItemLabel}>About</span>
+          </Link>
+
+          {/* Profile link in menu (when logged in) */}
+          {session?.user && (
+            <Link
+              href={`/crusher/${session.user.id}`}
+              className={styles.menuItem}
+              onClick={handleClose}
+            >
+              <span className={styles.menuItemIcon}><LineChartOutlined /></span>
+              <span className={styles.menuItemLabel}>Profile</span>
+            </Link>
+          )}
+
+          {/* Logout */}
+          {session?.user && (
+            <>
+              <div className={styles.divider} />
+              <button
+                className={`${styles.menuItem} ${styles.dangerItem}`}
+                onClick={handleSignOut}
+              >
+                <span className={styles.menuItemIcon}><LogoutOutlined /></span>
+                <span className={styles.menuItemLabel}>Logout</span>
+              </button>
+            </>
+          )}
+        </div>
+      </SwipeableDrawer>
+
+      <AuthModal
+        open={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        title="Sign in to Boardsesh"
+        description="Sign in to access all features including saving favorites, tracking ascents, and more."
+      />
+
+      <HoldClassificationWizard
+        open={showHoldClassification}
+        onClose={() => setShowHoldClassification(false)}
+        boardDetails={boardDetails}
+      />
+    </>
+  );
+}

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -17,6 +17,7 @@ import {
   PlayCircleOutlined,
   TeamOutlined,
 } from '@ant-design/icons';
+
 import { useSession, signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -25,7 +26,6 @@ import AuthModal from '../auth/auth-modal';
 import { HoldClassificationWizard } from '../hold-classification';
 import { BoardDetails } from '@/app/lib/types';
 import { generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib/url-utils';
-import { themeTokens } from '@/app/theme/theme-config';
 import {
   type StoredSession,
   getRecentSessions,
@@ -33,8 +33,6 @@ import {
   extractBoardName,
 } from '@/app/lib/session-history-db';
 import styles from './user-drawer.module.css';
-
-const { Text } = Typography;
 
 interface UserDrawerProps {
   boardDetails: BoardDetails;
@@ -89,6 +87,7 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
   const userAvatar = session?.user?.image;
   const userName = session?.user?.name;
   const userEmail = session?.user?.email;
+  const avatarClass = session?.user ? styles.avatarLoggedIn : styles.avatarLoggedOut;
 
   return (
     <>
@@ -102,10 +101,7 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
           size={28}
           src={userAvatar}
           icon={!userAvatar ? <UserOutlined /> : undefined}
-          style={{
-            backgroundColor: session?.user ? themeTokens.colors.primary : themeTokens.neutral[300],
-            cursor: 'pointer',
-          }}
+          className={avatarClass}
         />
       </Button>
 
@@ -115,9 +111,6 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
         onClose={handleClose}
         closable
         width={300}
-        styles={{
-          body: { padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[2]}px` },
-        }}
         title={null}
       >
         <div className={styles.drawerBody}>
@@ -127,29 +120,20 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
               size={64}
               src={userAvatar}
               icon={!userAvatar ? <UserOutlined /> : undefined}
-              style={{
-                backgroundColor: session?.user ? themeTokens.colors.primary : themeTokens.neutral[300],
-              }}
+              className={avatarClass}
             />
             {session?.user ? (
               <>
                 {userName && (
-                  <Text strong style={{ fontSize: themeTokens.typography.fontSize.lg }}>
+                  <Typography.Text strong className={styles.userName}>
                     {userName}
-                  </Text>
+                  </Typography.Text>
                 )}
                 {userEmail && (
-                  <Text type="secondary" style={{ fontSize: themeTokens.typography.fontSize.sm }}>
+                  <Typography.Text type="secondary" className={styles.userEmail}>
                     {userEmail}
-                  </Text>
+                  </Typography.Text>
                 )}
-                <Link
-                  href={`/crusher/${session.user.id}`}
-                  onClick={handleClose}
-                  style={{ textDecoration: 'none' }}
-                >
-                  <Button type="link" size="small">View Profile</Button>
-                </Link>
               </>
             ) : (
               <Button
@@ -178,6 +162,17 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
               <span className={styles.menuItemLabel}>Change Board</span>
             </Link>
 
+            {session?.user && (
+              <Link
+                href={`/crusher/${session.user.id}`}
+                className={styles.menuItem}
+                onClick={handleClose}
+              >
+                <span className={styles.menuItemIcon}><LineChartOutlined /></span>
+                <span className={styles.menuItemLabel}>Profile</span>
+              </Link>
+            )}
+
             <Link
               href="/settings"
               className={styles.menuItem}
@@ -189,6 +184,7 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
 
             {!isMoonboard && (
               <button
+                type="button"
                 className={styles.menuItem}
                 onClick={() => {
                   handleClose();
@@ -216,26 +212,17 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
           {recentSessions.length > 0 && (
             <>
               <div className={styles.divider} />
-              <Text
-                type="secondary"
-                style={{
-                  fontSize: themeTokens.typography.fontSize.xs,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px',
-                  fontWeight: themeTokens.typography.fontWeight.semibold,
-                  padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[4]}px`,
-                  display: 'block',
-                }}
-              >
+              <Typography.Text type="secondary" className={styles.sectionLabel}>
                 Recent Sessions
-              </Text>
+              </Typography.Text>
               {recentSessions.slice(0, 5).map((storedSession) => (
                 <button
+                  type="button"
                   key={storedSession.id}
                   className={styles.recentItem}
                   onClick={() => handleResumeSession(storedSession)}
                 >
-                  <HistoryOutlined style={{ color: themeTokens.neutral[400], fontSize: 16 }} />
+                  <HistoryOutlined className={styles.recentItemIcon} />
                   <div className={styles.recentItemInfo}>
                     <div className={styles.recentItemName}>
                       {storedSession.name || `${extractBoardName(storedSession.boardPath)} Session`}
@@ -248,7 +235,7 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
                       {' '}{formatRelativeTime(storedSession.lastActivity || storedSession.createdAt)}
                     </div>
                   </div>
-                  <PlayCircleOutlined style={{ color: themeTokens.colors.primary, fontSize: 16 }} />
+                  <PlayCircleOutlined className={styles.recentItemAction} />
                 </button>
               ))}
             </>
@@ -275,23 +262,12 @@ export default function UserDrawer({ boardDetails, angle }: UserDrawerProps) {
             <span className={styles.menuItemLabel}>About</span>
           </Link>
 
-          {/* Profile link in menu (when logged in) */}
-          {session?.user && (
-            <Link
-              href={`/crusher/${session.user.id}`}
-              className={styles.menuItem}
-              onClick={handleClose}
-            >
-              <span className={styles.menuItemIcon}><LineChartOutlined /></span>
-              <span className={styles.menuItemLabel}>Profile</span>
-            </Link>
-          )}
-
           {/* Logout */}
           {session?.user && (
             <>
               <div className={styles.divider} />
               <button
+                type="button"
                 className={`${styles.menuItem} ${styles.dangerItem}`}
                 onClick={handleSignOut}
               >

--- a/packages/web/app/lib/session-history-db.ts
+++ b/packages/web/app/lib/session-history-db.ts
@@ -1,0 +1,95 @@
+// Shared session history utilities for IndexedDB storage of board sessions.
+// Used by both session-history-panel and user-drawer.
+
+export type StoredSession = {
+  id: string;
+  name: string | null;
+  boardPath: string;
+  createdAt: string;
+  lastActivity: string;
+  participantCount?: number;
+};
+
+const DB_NAME = 'boardsesh-sessions';
+const DB_VERSION = 1;
+const STORE_NAME = 'session-history';
+
+async function initSessionDB(): Promise<IDBDatabase | null> {
+  if (typeof window === 'undefined' || !window.indexedDB) {
+    return null;
+  }
+
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('lastActivity', 'lastActivity', { unique: false });
+      }
+    };
+  });
+}
+
+export async function getRecentSessions(): Promise<StoredSession[]> {
+  const db = await initSessionDB();
+  if (!db) return [];
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const sessions = request.result as StoredSession[];
+      // Filter to sessions from last 7 days and sort by last activity
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const recentSessions = sessions
+        .filter((s) => new Date(s.lastActivity || s.createdAt) > sevenDaysAgo)
+        .sort((a, b) => new Date(b.lastActivity || b.createdAt).getTime() - new Date(a.lastActivity || a.createdAt).getTime());
+      resolve(recentSessions);
+    };
+  });
+}
+
+export async function saveSessionToHistory(session: StoredSession): Promise<void> {
+  const db = await initSessionDB();
+  if (!db) return;
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(session);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+}
+
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins} min${diffMins === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return date.toLocaleDateString();
+}
+
+export function extractBoardName(boardPath: string): string {
+  const parts = boardPath.split('/').filter(Boolean);
+  if (parts.length > 0) {
+    return parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
+  }
+  return 'Unknown Board';
+}


### PR DESCRIPTION
- Add UserDrawer component with left-side SwipeableDrawer containing:
  - User profile section (avatar, name, email, view profile link)
  - Sign in button for unauthenticated users
  - Navigation: Change Board, Settings, Classify Holds, My Playlists
  - Recent Sessions from IndexedDB (with resume functionality)
  - Help, About, Profile links
  - Logout action
- Replace meatball menu (mobile) and user dropdown (desktop) with
  single avatar button that opens the drawer on all breakpoints
- Remove dead code: mobileMenuItems, userMenuItems arrays, signOut
  handler, showAuthModal/showHoldClassification state from header
- Move AuthModal and HoldClassificationWizard rendering to UserDrawer
- Remove unused .mobileMenuButton CSS class
- Mark phases 2, 3, 4 as done in design plan with completed checklists

https://claude.ai/code/session_01CDv4qpEpPe6XnVFNqbBNWh