### PR TITLE
Phase 5: Party mode & LED as drawer

### DIFF
--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -683,7 +683,7 @@ Additions:
 
 ---
 
-## Phase 5: Party Mode & LED as Drawer
+## Phase 5: Party Mode & LED as Drawer [DONE]
 
 ### What changes
 Convert party mode into a bottom drawer (instead of top drawer) and integrate LED connection into it.
@@ -1061,14 +1061,14 @@ Board layout.tsx (server component)
 - [x] SendClimbToBoardButton dynamic import only loads on desktop
 
 ### Phase 5
-- [ ] Party drawer opens from bottom (not top)
-- [ ] Party drawer has 3 tabs: Start, Join, Connect to Board
-- [ ] LED connection tab shows Bluefy recommendation on iOS
-- [ ] Bluetooth hook works from party drawer LED tab
-- [ ] Start/join/leave session flows work unchanged
-- [ ] LED auto-sends on climb change (existing behavior preserved)
-- [ ] Wake lock activates when Bluetooth connected
-- [ ] No duplicate Bluetooth connections from multiple hook instances
+- [x] Party drawer opens from bottom (not top)
+- [x] Party drawer has 3 tabs: Start, Join, Connect to Board
+- [x] LED connection tab shows Bluefy recommendation on iOS
+- [x] Bluetooth hook works from party drawer LED tab
+- [x] Start/join/leave session flows work unchanged
+- [x] LED auto-sends on climb change (existing behavior preserved)
+- [x] Wake lock activates when Bluetooth connected
+- [x] No duplicate Bluetooth connections from multiple hook instances
 
 ### Phase 6
 - [ ] Queue list items visually match compact climb list items (height, typography)

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -17,6 +17,7 @@ import { BoardSessionBridge } from '@/app/components/persistent-session';
 import { Metadata } from 'next';
 import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 import BottomTabBar from '@/app/components/bottom-tab-bar/bottom-tab-bar';
+import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
 
 // Helper to get board details for any board type
 function getBoardDetailsUniversal(parsedParams: ParsedBoardRouteParameters): BoardDetails {
@@ -151,30 +152,32 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
         <ConnectionSettingsProvider>
           <GraphQLQueueProvider parsedParams={parsedParams} boardDetails={boardDetails}>
             <PartyProvider>
-              <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
+              <BluetoothProvider boardDetails={boardDetails}>
+                <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
-              <Content
-                id="content-for-scrollable"
-                style={{
-                  flex: 1,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  overflowX: 'hidden',
-                  paddingLeft: '10px',
-                  paddingRight: '10px',
-                  paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
-                  paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
-                }}
-              >
-                <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
-                  {children}
-                </Suspense>
-              </Content>
+                <Content
+                  id="content-for-scrollable"
+                  style={{
+                    flex: 1,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    overflowX: 'hidden',
+                    paddingLeft: '10px',
+                    paddingRight: '10px',
+                    paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
+                    paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+                  }}
+                >
+                  <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
+                    {children}
+                  </Suspense>
+                </Content>
 
-              <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
-                <QueueControlBar boardDetails={boardDetails} angle={angle} />
-                <BottomTabBar boardDetails={boardDetails} angle={angle} />
-              </div>
+                <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
+                  <QueueControlBar boardDetails={boardDetails} angle={angle} />
+                  <BottomTabBar boardDetails={boardDetails} angle={angle} />
+                </div>
+              </BluetoothProvider>
             </PartyProvider>
           </GraphQLQueueProvider>
         </ConnectionSettingsProvider>

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+// Mock dependencies before importing the module
+const mockTrack = vi.fn();
+vi.mock('@vercel/analytics', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+vi.mock('antd', () => ({
+  message: { error: vi.fn() },
+}));
+
+const mockSendFramesToBoard = vi.fn().mockResolvedValue(true);
+const mockConnect = vi.fn().mockResolvedValue(true);
+const mockDisconnect = vi.fn();
+
+let mockBluetoothState = {
+  isConnected: false,
+  loading: false,
+  connect: mockConnect,
+  disconnect: mockDisconnect,
+  sendFramesToBoard: mockSendFramesToBoard,
+};
+
+vi.mock('../use-board-bluetooth', () => ({
+  useBoardBluetooth: () => mockBluetoothState,
+}));
+
+let mockCurrentClimbQueueItem: { climb: { uuid: string; frames: string; mirrored: boolean } } | null = null;
+
+vi.mock('../../graphql-queue', () => ({
+  useQueueContext: () => ({
+    currentClimbQueueItem: mockCurrentClimbQueueItem,
+  }),
+}));
+
+import { BluetoothProvider, useBluetoothContext, BluetoothContext } from '../bluetooth-context';
+import type { BoardDetails } from '@/app/lib/types';
+
+function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Full Size',
+    set_names: ['Standard', 'Extended'],
+    ...overrides,
+  } as BoardDetails;
+}
+
+function createWrapper(boardDetails?: BoardDetails) {
+  const details = boardDetails ?? createTestBoardDetails();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(BluetoothProvider, { boardDetails: details }, children);
+  };
+}
+
+describe('BluetoothProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentClimbQueueItem = null;
+    mockBluetoothState = {
+      isConnected: false,
+      loading: false,
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      sendFramesToBoard: mockSendFramesToBoard,
+    };
+  });
+
+  describe('useBluetoothContext', () => {
+    it('throws when used outside BluetoothProvider', () => {
+      // Suppress React error boundary console output
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => {
+        renderHook(() => useBluetoothContext());
+      }).toThrow('useBluetoothContext must be used within a BluetoothProvider');
+      consoleSpy.mockRestore();
+    });
+
+    it('returns context values when used inside BluetoothProvider', () => {
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current).toHaveProperty('isConnected');
+      expect(result.current).toHaveProperty('loading');
+      expect(result.current).toHaveProperty('connect');
+      expect(result.current).toHaveProperty('disconnect');
+      expect(result.current).toHaveProperty('sendFramesToBoard');
+      expect(result.current).toHaveProperty('isBluetoothSupported');
+      expect(result.current).toHaveProperty('isIOS');
+    });
+
+    it('provides correct initial connection state', () => {
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe('auto-send on climb change', () => {
+    it('does not send when not connected', () => {
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12p2r13', mirrored: false },
+      };
+      mockBluetoothState.isConnected = false;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockSendFramesToBoard).not.toHaveBeenCalled();
+    });
+
+    it('does not send when connected but no current climb', () => {
+      mockCurrentClimbQueueItem = null;
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockSendFramesToBoard).not.toHaveBeenCalled();
+    });
+
+    it('sends frames when connected and climb is available', async () => {
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12p2r13', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      // The useEffect triggers async sendClimb
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockSendFramesToBoard).toHaveBeenCalledWith('p1r12p2r13', false);
+        });
+      });
+    });
+
+    it('sends with mirrored=true when climb is mirrored', async () => {
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-2', frames: 'p3r14p4r15', mirrored: true },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockSendFramesToBoard).toHaveBeenCalledWith('p3r14p4r15', true);
+        });
+      });
+    });
+
+    it('tracks success analytics when send succeeds', async () => {
+      mockSendFramesToBoard.mockResolvedValue(true);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockTrack).toHaveBeenCalledWith('Climb Sent to Board Success', {
+            climbUuid: 'climb-1',
+            boardLayout: 'Original',
+          });
+        });
+      });
+    });
+
+    it('tracks failure analytics when send fails', async () => {
+      mockSendFramesToBoard.mockResolvedValue(false);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockTrack).toHaveBeenCalledWith('Climb Sent to Board Failure', {
+            climbUuid: 'climb-1',
+            boardLayout: 'Original',
+          });
+        });
+      });
+    });
+  });
+
+  describe('context value stability', () => {
+    it('exposes connect and disconnect functions from the hook', () => {
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.connect).toBe(mockConnect);
+      expect(result.current.disconnect).toBe(mockDisconnect);
+      expect(result.current.sendFramesToBoard).toBe(mockSendFramesToBoard);
+    });
+  });
+});

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -216,6 +216,66 @@ describe('BluetoothProvider', () => {
         });
       });
     });
+
+    it('does not track analytics when send returns undefined (not attempted)', async () => {
+      mockSendFramesToBoard.mockResolvedValue(undefined);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockSendFramesToBoard).toHaveBeenCalled();
+        });
+      });
+
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('exposes disconnect from the hook', () => {
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      result.current.disconnect();
+
+      expect(mockDisconnect).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('connect', () => {
+    it('exposes connect from the hook', async () => {
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        const success = await result.current.connect('p1r12', false);
+        expect(success).toBe(true);
+      });
+
+      expect(mockConnect).toHaveBeenCalledWith('p1r12', false);
+    });
+
+    it('returns false when connect fails', async () => {
+      mockConnect.mockResolvedValue(false);
+
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        const success = await result.current.connect();
+        expect(success).toBe(false);
+      });
+    });
   });
 
   describe('context value stability', () => {

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import { track } from '@vercel/analytics';
+import { useBoardBluetooth } from './use-board-bluetooth';
+import { useQueueContext } from '../graphql-queue';
+import type { BoardDetails } from '@/app/lib/types';
+
+interface BluetoothContextValue {
+  isConnected: boolean;
+  loading: boolean;
+  connect: (initialFrames?: string, mirrored?: boolean) => Promise<boolean>;
+  disconnect: () => void;
+  sendFramesToBoard: (frames: string, mirrored?: boolean) => Promise<boolean | undefined>;
+  isBluetoothSupported: boolean;
+  isIOS: boolean;
+}
+
+const BluetoothContext = createContext<BluetoothContextValue | null>(null);
+
+export function BluetoothProvider({
+  boardDetails,
+  children,
+}: {
+  boardDetails: BoardDetails;
+  children: React.ReactNode;
+}) {
+  const { currentClimbQueueItem } = useQueueContext();
+  const bluetooth = useBoardBluetooth({ boardDetails });
+
+  const isBluetoothSupported =
+    typeof navigator !== 'undefined' && !!navigator.bluetooth;
+
+  const isIOS = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      /iPhone|iPad|iPod/i.test(
+        navigator.userAgent || (navigator as { vendor?: string }).vendor || '',
+      ),
+    [],
+  );
+
+  // Auto-send climb when currentClimbQueueItem changes (only if connected)
+  useEffect(() => {
+    if (bluetooth.isConnected && currentClimbQueueItem) {
+      const sendClimb = async () => {
+        const success = await bluetooth.sendFramesToBoard(
+          currentClimbQueueItem.climb.frames,
+          !!currentClimbQueueItem.climb.mirrored,
+        );
+        if (success) {
+          track('Climb Sent to Board Success', {
+            climbUuid: currentClimbQueueItem.climb?.uuid,
+            boardLayout: `${boardDetails.layout_name}`,
+          });
+        } else {
+          track('Climb Sent to Board Failure', {
+            climbUuid: currentClimbQueueItem.climb?.uuid,
+            boardLayout: `${boardDetails.layout_name}`,
+          });
+        }
+      };
+      sendClimb();
+    }
+  }, [currentClimbQueueItem, bluetooth.isConnected, bluetooth.sendFramesToBoard, boardDetails.layout_name]);
+
+  const value = useMemo(
+    () => ({
+      isConnected: bluetooth.isConnected,
+      loading: bluetooth.loading,
+      connect: bluetooth.connect,
+      disconnect: bluetooth.disconnect,
+      sendFramesToBoard: bluetooth.sendFramesToBoard,
+      isBluetoothSupported,
+      isIOS,
+    }),
+    [
+      bluetooth.isConnected,
+      bluetooth.loading,
+      bluetooth.connect,
+      bluetooth.disconnect,
+      bluetooth.sendFramesToBoard,
+      isBluetoothSupported,
+      isIOS,
+    ],
+  );
+
+  return (
+    <BluetoothContext.Provider value={value}>
+      {children}
+    </BluetoothContext.Provider>
+  );
+}
+
+export function useBluetoothContext() {
+  const context = useContext(BluetoothContext);
+  if (!context) {
+    throw new Error(
+      'useBluetoothContext must be used within a BluetoothProvider',
+    );
+  }
+  return context;
+}
+
+export { BluetoothContext };

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -47,18 +47,26 @@ export function BluetoothProvider({
   useEffect(() => {
     if (isConnected && currentClimbQueueItem) {
       const sendClimb = async () => {
-        const result = await sendFramesToBoard(
-          currentClimbQueueItem.climb.frames,
-          !!currentClimbQueueItem.climb.mirrored,
-        );
-        // undefined means send was not attempted (missing characteristic/frames/boardDetails)
-        // Only track analytics for explicit success (true) or failure (false)
-        if (result === true) {
-          track('Climb Sent to Board Success', {
-            climbUuid: currentClimbQueueItem.climb?.uuid,
-            boardLayout: `${boardDetails.layout_name}`,
-          });
-        } else if (result === false) {
+        try {
+          const result = await sendFramesToBoard(
+            currentClimbQueueItem.climb.frames,
+            !!currentClimbQueueItem.climb.mirrored,
+          );
+          // undefined means send was not attempted (missing characteristic/frames/boardDetails)
+          // Only track analytics for explicit success (true) or failure (false)
+          if (result === true) {
+            track('Climb Sent to Board Success', {
+              climbUuid: currentClimbQueueItem.climb?.uuid,
+              boardLayout: `${boardDetails.layout_name}`,
+            });
+          } else if (result === false) {
+            track('Climb Sent to Board Failure', {
+              climbUuid: currentClimbQueueItem.climb?.uuid,
+              boardLayout: `${boardDetails.layout_name}`,
+            });
+          }
+        } catch (error) {
+          console.error('Error sending climb to board:', error);
           track('Climb Sent to Board Failure', {
             climbUuid: currentClimbQueueItem.climb?.uuid,
             boardLayout: `${boardDetails.layout_name}`,

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -26,7 +26,8 @@ export function BluetoothProvider({
   children: React.ReactNode;
 }) {
   const { currentClimbQueueItem } = useQueueContext();
-  const bluetooth = useBoardBluetooth({ boardDetails });
+  const { isConnected, loading, connect, disconnect, sendFramesToBoard } =
+    useBoardBluetooth({ boardDetails });
 
   const isBluetoothSupported =
     typeof navigator !== 'undefined' && !!navigator.bluetooth;
@@ -42,9 +43,9 @@ export function BluetoothProvider({
 
   // Auto-send climb when currentClimbQueueItem changes (only if connected)
   useEffect(() => {
-    if (bluetooth.isConnected && currentClimbQueueItem) {
+    if (isConnected && currentClimbQueueItem) {
       const sendClimb = async () => {
-        const success = await bluetooth.sendFramesToBoard(
+        const success = await sendFramesToBoard(
           currentClimbQueueItem.climb.frames,
           !!currentClimbQueueItem.climb.mirrored,
         );
@@ -62,24 +63,24 @@ export function BluetoothProvider({
       };
       sendClimb();
     }
-  }, [currentClimbQueueItem, bluetooth.isConnected, bluetooth.sendFramesToBoard, boardDetails.layout_name]);
+  }, [currentClimbQueueItem, isConnected, sendFramesToBoard, boardDetails.layout_name]);
 
   const value = useMemo(
     () => ({
-      isConnected: bluetooth.isConnected,
-      loading: bluetooth.loading,
-      connect: bluetooth.connect,
-      disconnect: bluetooth.disconnect,
-      sendFramesToBoard: bluetooth.sendFramesToBoard,
+      isConnected,
+      loading,
+      connect,
+      disconnect,
+      sendFramesToBoard,
       isBluetoothSupported,
       isIOS,
     }),
     [
-      bluetooth.isConnected,
-      bluetooth.loading,
-      bluetooth.connect,
-      bluetooth.disconnect,
-      bluetooth.sendFramesToBoard,
+      isConnected,
+      loading,
+      connect,
+      disconnect,
+      sendFramesToBoard,
       isBluetoothSupported,
       isIOS,
     ],

--- a/packages/web/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
+++ b/packages/web/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
@@ -10,7 +10,6 @@ import './send-climb-to-board-button.css';
 const { Text, Paragraph } = Typography;
 
 type SendClimbToBoardButtonProps = {
-  boardDetails?: { layout_name?: string };
   buttonType?: 'default' | 'text';
 };
 

--- a/packages/web/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
+++ b/packages/web/app/components/board-bluetooth-control/send-climb-to-board-button.tsx
@@ -1,198 +1,42 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { BulbOutlined, BulbFilled, AppleOutlined } from '@ant-design/icons';
 import { Button, Modal, Typography } from 'antd';
-import { track } from '@vercel/analytics';
+import { useBluetoothContext } from './bluetooth-context';
+import { useQueueContext } from '../graphql-queue';
+import './send-climb-to-board-button.css';
 
 const { Text, Paragraph } = Typography;
-import { useQueueContext } from '../graphql-queue';
-import { BoardDetails } from '@/app/lib/types';
-import './send-climb-to-board-button.css'; // Import your custom styles
-import {
-  getBluetoothPacket,
-  getCharacteristic,
-  requestDevice,
-  splitMessages,
-  writeCharacteristicSeries,
-} from './bluetooth';
-import { HoldRenderData } from '../board-renderer/types';
-import { useWakeLock } from './use-wake-lock';
-import { getLedPlacements } from '@/app/lib/__generated__/led-placements-data';
 
-type SendClimbToBoardButtonProps = { boardDetails: BoardDetails; buttonType?: 'default' | 'text' };
-
-export const convertToMirroredFramesString = (frames: string, holdsData: HoldRenderData[]): string => {
-  // Create a map for quick lookup of mirroredHoldId
-  const holdIdToMirroredIdMap = new Map<number, number>();
-  holdsData.forEach((hold) => {
-    if (hold.mirroredHoldId) {
-      holdIdToMirroredIdMap.set(hold.id, hold.mirroredHoldId);
-    }
-  });
-
-  return frames
-    .split('p') // Split into hold data entries
-    .filter((hold) => hold) // Remove empty entries
-    .map((holdData) => {
-      const [holdId, stateCode] = holdData.split('r').map((str) => Number(str)); // Split hold data into holdId and stateCode
-      const mirroredHoldId = holdIdToMirroredIdMap.get(holdId);
-
-      if (mirroredHoldId === undefined) {
-        throw new Error(`Mirrored hold ID is not defined for hold ID ${holdId}.`);
-      }
-
-      // Construct the mirrored hold data
-      return `p${mirroredHoldId}r${stateCode}`;
-    })
-    .join(''); // Reassemble into a single string
+type SendClimbToBoardButtonProps = {
+  boardDetails?: { layout_name?: string };
+  buttonType?: 'default' | 'text';
 };
 
-// React component
-const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({ boardDetails, buttonType = 'default' }) => {
+const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({
+  buttonType = 'default',
+}) => {
   const { currentClimbQueueItem } = useQueueContext();
-  const [loading, setLoading] = useState(false);
-  const [isConnected, setIsConnected] = useState(false); // Track Bluetooth connection state
+  const { isConnected, loading, connect, isBluetoothSupported, isIOS } =
+    useBluetoothContext();
   const [showBluetoothWarning, setShowBluetoothWarning] = useState(false);
 
-  // Prevent device from sleeping while connected to the board
-  useWakeLock(isConnected);
-
-  // Detect if the device is iOS
-  const isIOS =
-    typeof navigator !== 'undefined' &&
-    /iPhone|iPad|iPod/i.test(navigator.userAgent || (navigator as { vendor?: string }).vendor || '');
-
-  // Check if Web Bluetooth is supported
-  const isBluetoothSupported = typeof navigator !== 'undefined' && !!navigator.bluetooth;
-
-  // Store Bluetooth device and characteristic across renders
-  const bluetoothDeviceRef = useRef<BluetoothDevice | null>(null);
-  const characteristicRef = useRef<BluetoothRemoteGATTCharacteristic | null>(null);
-
-  // Handler for device disconnection
-  const handleDisconnection = useCallback(() => {
-    setIsConnected(false);
-    characteristicRef.current = null;
-    // Don't clear the device ref so we can potentially reconnect to the same device
-  }, []);
-
-  // Clean up disconnect listener from a device
-  const cleanupDeviceListeners = useCallback(
-    (device: BluetoothDevice | null) => {
-      if (device) {
-        device.removeEventListener('gattserverdisconnected', handleDisconnection);
-      }
-    },
-    [handleDisconnection],
-  );
-
-  // Function to send climb data to the board
-  const sendClimbToBoard = useCallback(async () => {
-    if (!currentClimbQueueItem || !characteristicRef.current) return;
-
-    let { frames } = currentClimbQueueItem.climb;
-
-    const placementPositions = getLedPlacements(boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id);
-    if (currentClimbQueueItem.climb?.mirrored) {
-      frames = convertToMirroredFramesString(frames, boardDetails.holdsData);
-    }
-    const bluetoothPacket = getBluetoothPacket(frames, placementPositions, boardDetails.board_name);
-
-    try {
-      if (characteristicRef.current) {
-        await writeCharacteristicSeries(characteristicRef.current, splitMessages(bluetoothPacket));
-        track('Climb Sent to Board Success', {
-          climbUuid: currentClimbQueueItem.climb?.uuid,
-          boardLayout: `${boardDetails.layout_name}`,
-        });
-      }
-    } catch (error) {
-      console.error('Error sending climb to board:', error);
-      track('Climb Sent to Board Failure', {
-        climbUuid: currentClimbQueueItem.climb?.uuid,
-        boardLayout: `${boardDetails.layout_name}`,
-      });
-    }
-  }, [currentClimbQueueItem, boardDetails]);
-
-  // Handle button click to initiate Bluetooth connection
-  const handleClick = useCallback(async () => {
-    if (!navigator.bluetooth) {
+  const handleClick = async () => {
+    if (!isBluetoothSupported) {
       setShowBluetoothWarning(true);
       return;
     }
 
-    setLoading(true);
-
-    try {
-      // Clean up any existing device listeners before requesting a new device
-      cleanupDeviceListeners(bluetoothDeviceRef.current);
-
-      // Always request a new device to allow connecting to a different board
-      // or reconnecting to the same board
-      const device = await requestDevice();
-      const characteristic = await getCharacteristic(device);
-
-      if (characteristic) {
-        // Set up disconnection listener
-        device.addEventListener('gattserverdisconnected', handleDisconnection);
-
-        bluetoothDeviceRef.current = device;
-        characteristicRef.current = characteristic;
-
-        track('Bluetooth Connection Success', {
-          boardLayout: `${boardDetails.layout_name}`,
-        });
-
-        // Send the current climb immediately after connection is established
-        // Button is disabled when no climb is selected, so currentClimbQueueItem should always exist here
-        if (currentClimbQueueItem) {
-          try {
-            let { frames } = currentClimbQueueItem.climb;
-            const placementPositions = getLedPlacements(boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id);
-            if (currentClimbQueueItem.climb?.mirrored) {
-              frames = convertToMirroredFramesString(frames, boardDetails.holdsData);
-            }
-            const bluetoothPacket = getBluetoothPacket(frames, placementPositions, boardDetails.board_name);
-            await writeCharacteristicSeries(characteristic, splitMessages(bluetoothPacket));
-            track('Climb Sent to Board Success', {
-              climbUuid: currentClimbQueueItem.climb?.uuid,
-              boardLayout: `${boardDetails.layout_name}`,
-            });
-          } catch (sendError) {
-            console.error('Error sending climb after connection:', sendError);
-          }
-        }
-
-        // Set connected state after successful send attempt
-        setIsConnected(true);
-      }
-    } catch (error) {
-      console.error('Error connecting to Bluetooth:', error);
-      setIsConnected(false);
-      characteristicRef.current = null;
-      track('Bluetooth Connection Failed', {
-        boardLayout: `${boardDetails.layout_name}`,
-      });
-    } finally {
-      setLoading(false);
+    if (currentClimbQueueItem) {
+      await connect(
+        currentClimbQueueItem.climb.frames,
+        !!currentClimbQueueItem.climb.mirrored,
+      );
+    } else {
+      await connect();
     }
-  }, [cleanupDeviceListeners, handleDisconnection, boardDetails, currentClimbQueueItem]);
-
-  // Clean up on unmount
-  useEffect(() => {
-    return () => {
-      cleanupDeviceListeners(bluetoothDeviceRef.current);
-    };
-  }, [cleanupDeviceListeners]);
-
-  // Automatically send climb when currentClimbQueueItem changes (only if connected)
-  useEffect(() => {
-    if (isConnected) {
-      sendClimbToBoard();
-    }
-  }, [currentClimbQueueItem, isConnected, sendClimbToBoard]);
+  };
 
   return (
     <>
@@ -200,7 +44,13 @@ const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({ boardDe
         id="button-illuminate"
         type={buttonType}
         danger={!isBluetoothSupported}
-        icon={isConnected ? <BulbFilled className={'connect-button-glow'} /> : <BulbOutlined />}
+        icon={
+          isConnected ? (
+            <BulbFilled className="connect-button-glow" />
+          ) : (
+            <BulbOutlined />
+          )
+        }
         onClick={handleClick}
         loading={loading}
         disabled={isBluetoothSupported && !currentClimbQueueItem}
@@ -209,17 +59,22 @@ const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({ boardDe
         title="Web Bluetooth Not Supported"
         open={showBluetoothWarning}
         onCancel={() => setShowBluetoothWarning(false)}
-        footer={<Button onClick={() => setShowBluetoothWarning(false)}>Close</Button>}
+        footer={
+          <Button onClick={() => setShowBluetoothWarning(false)}>Close</Button>
+        }
       >
         <Paragraph>
           <Text>
-            Your browser does not support Web Bluetooth, which means you won&#39;t be able to illuminate routes on the
-            board.
+            Your browser does not support Web Bluetooth, which means you
+            won&#39;t be able to illuminate routes on the board.
           </Text>
         </Paragraph>
         {isIOS ? (
           <>
-            <Paragraph>To control your board from an iOS device, install the Bluefy browser:</Paragraph>
+            <Paragraph>
+              To control your board from an iOS device, install the Bluefy
+              browser:
+            </Paragraph>
             <Button
               type="primary"
               icon={<AppleOutlined />}
@@ -230,7 +85,10 @@ const SendClimbToBoardButton: React.FC<SendClimbToBoardButtonProps> = ({ boardDe
             </Button>
           </>
         ) : (
-          <Paragraph>For the best experience, please use Chrome or another Chromium-based browser.</Paragraph>
+          <Paragraph>
+            For the best experience, please use Chrome or another
+            Chromium-based browser.
+          </Paragraph>
         )}
       </Modal>
     </>

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -84,6 +84,10 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
       const placementPositions = getLedPlacements(boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id);
 
       if (mirrored) {
+        if (!boardDetails.holdsData || Object.keys(boardDetails.holdsData).length === 0) {
+          console.error('Cannot mirror frames: holdsData is missing or empty');
+          return false;
+        }
         framesToSend = convertToMirroredFramesString(frames, boardDetails.holdsData);
       }
 

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -13,7 +13,6 @@ import {
 } from './bluetooth';
 import { HoldRenderData } from '../board-renderer/types';
 import { useWakeLock } from './use-wake-lock';
-import { getLedPlacements } from '@/app/lib/__generated__/led-placements-data';
 
 export const convertToMirroredFramesString = (frames: string, holdsData: HoldRenderData[]): string => {
   // Create a map for quick lookup of mirroredHoldId
@@ -80,6 +79,8 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
       if (!characteristicRef.current || !frames || !boardDetails) return;
 
       let framesToSend = frames;
+      // Lazy-load LED placements data (~50KB) only when actually sending to board
+      const { getLedPlacements } = await import('@/app/lib/__generated__/led-placements-data');
       const placementPositions = getLedPlacements(boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id);
 
       if (mirrored) {

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -174,7 +174,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
 
                 <span id="onboarding-party-light-buttons" style={{ display: 'inline-flex', gap: 4, alignItems: 'center' }}>
                   <ShareBoardButton />
-                  <SendClimbToBoardButton boardDetails={boardDetails} />
+                  <SendClimbToBoardButton />
                 </span>
               </>
             )}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -277,7 +277,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           <ShareBoardButton buttonType="text" />
 
           {/* LED */}
-          <SendClimbToBoardButton boardDetails={boardDetails} buttonType="text" />
+          <SendClimbToBoardButton buttonType="text" />
 
           {/* Tick */}
           <TickButton currentClimb={currentClimb} angle={angle} boardDetails={boardDetails} buttonType="text" />


### PR DESCRIPTION
- Convert party mode drawer from top to bottom placement
- Add 3-tab structure: Start Session, Join Session, Connect to Board (LED)
- When session active, collapse to Session + Connect to Board tabs
- Create BluetoothProvider context to share single Bluetooth connection
  across all consumers (header, play drawer, party drawer LED tab)
- Extract SendClimbToBoardButton to thin wrapper using BluetoothContext
- Auto-send climb on currentClimbQueueItem change via context
- Lazy-load LED placements data (~50KB) via dynamic import in hook
- Add BluetoothProvider to board layout inside GraphQLQueueProvider
- LED tab shows Bluefy recommendation for iOS, connection status,
  and disconnect option when connected

https://claude.ai/code/session_01GQF4BVRhADLumf5Cznosc7