### PR TITLE
Redesign search drawer with Airbnb-style stepped cards

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -1,45 +1,72 @@
-/* Accordion Search Form */
-.accordion :global(.ant-collapse-header) {
-  font-weight: 600;
-  font-size: 14px;
-  padding: 12px 12px !important;
-}
-
-.accordion :global(.ant-collapse-content-box) {
-  padding: 8px 12px 16px !important;
-}
-
-.accordion :global(.ant-collapse-item) {
-  border-bottom: 1px solid #E5E7EB !important;
-}
-
-.accordion :global(.ant-collapse-item:last-child) {
-  border-bottom: none !important;
-}
-
-/* Summary tags shown when panel is collapsed */
-.summaryTags {
+/* Stepped card container */
+.steppedContainer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  align-items: center;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0;
 }
 
-.summaryTag {
-  border-radius: 9999px;
-  background-color: #ECFEFF;
-  color: #0891B2;
-  border: none;
-  font-size: 12px;
-  padding: 0 8px;
-  line-height: 22px;
-  max-width: 120px;
+/* Section card base */
+.sectionCard {
+  background: var(--ant-color-bg-container, #FFFFFF);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  transition: box-shadow 200ms ease;
+}
+
+.sectionCard:not(.sectionCardActive) {
+  cursor: pointer;
+}
+
+.sectionCard:not(.sectionCardActive):hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.sectionCardActive {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+/* Collapsed row */
+.collapsedRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 24px;
+}
+
+.collapsedLabel {
+  font-size: 14px;
+  color: var(--ant-color-text-tertiary, #9CA3AF);
+  font-weight: 400;
+  flex-shrink: 0;
+}
+
+.collapsedSummary {
+  font-size: 14px;
+  color: var(--ant-color-text, #111827);
+  font-weight: 500;
+  text-align: right;
+  max-width: 65%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Panel content sections */
+/* Expanded content */
+.expandedContent {
+  padding: 24px;
+}
+
+.sectionTitle {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ant-color-text, #111827);
+  margin: 0 0 20px 0;
+  line-height: 1.2;
+}
+
+/* Panel content sections (reused from before) */
 .panelContent {
   display: flex;
   flex-direction: column;
@@ -67,8 +94,8 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  background-color: #F9FAFB;
-  border-radius: 8px;
+  background-color: var(--ant-color-bg-layout, #F9FAFB);
+  border-radius: 12px;
   padding: 4px 0;
 }
 
@@ -76,25 +103,20 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 12px;
+  padding: 12px 16px;
   transition: background-color 150ms ease;
 }
 
 .switchRow:hover {
-  background-color: #F3F4F6;
+  background-color: var(--ant-color-fill-quaternary, #F3F4F6);
 }
 
 /* Sort toggle */
 .sortToggle {
   font-size: 13px;
-  color: #6B7280;
+  color: var(--ant-color-text-secondary, #6B7280);
   padding: 0;
   height: auto;
-}
-
-.sortControls {
-  overflow: hidden;
-  transition: max-height 200ms ease;
 }
 
 /* Progress alert */
@@ -117,11 +139,28 @@
 
 /* Mobile adjustments */
 @media (max-width: 767px) {
+  .steppedContainer {
+    gap: 10px;
+  }
+
+  .collapsedRow {
+    padding: 16px 20px;
+  }
+
+  .expandedContent {
+    padding: 20px;
+  }
+
+  .sectionTitle {
+    font-size: 20px;
+    margin-bottom: 16px;
+  }
+
   .switchRow {
-    padding: 8px 10px;
+    padding: 10px 14px;
   }
 
   .panelContent {
-    gap: 12px;
+    gap: 14px;
   }
 }

--- a/packages/web/app/components/search-drawer/search-dropdown.module.css
+++ b/packages/web/app/components/search-drawer/search-dropdown.module.css
@@ -1,0 +1,44 @@
+/* Search Dropdown Drawer */
+.drawerRoot :global(.ant-drawer-body) {
+  background-color: var(--ant-color-bg-layout, #F3F4F6);
+}
+
+/* Footer bar */
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: var(--ant-color-bg-container, #FFFFFF);
+  border-top: 1px solid var(--ant-color-border-secondary, #F0F0F0);
+}
+
+/* Clear all - underlined text link */
+.clearAllButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ant-color-text, #111827);
+  text-decoration: underline;
+  cursor: pointer;
+  line-height: 1.5;
+}
+
+.clearAllButton:hover {
+  color: var(--ant-color-text-secondary, #6B7280);
+}
+
+.clearAllButton:active {
+  opacity: 0.7;
+}
+
+/* Search button */
+.searchButton {
+  border-radius: 12px !important;
+  height: 48px !important;
+  padding: 0 24px !important;
+  font-size: 16px !important;
+  font-weight: 600 !important;
+}

--- a/packages/web/app/components/search-drawer/search-dropdown.tsx
+++ b/packages/web/app/components/search-drawer/search-dropdown.tsx
@@ -1,19 +1,16 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Typography, Spin, Space, Badge } from 'antd';
-import { FilterOutlined } from '@ant-design/icons';
+import { Button, Spin } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import AccordionSearchForm from './accordion-search-form';
-import ClearButton from './clear-button';
 import { BoardDetails } from '@/app/lib/types';
 import { useQueueContext } from '@/app/components/graphql-queue';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import { hasActiveFilters, getSearchPillSummary } from './search-summary-utils';
 import { addRecentSearch } from './recent-searches-storage';
-import searchFormStyles from './search-form.module.css';
-
-const { Text } = Typography;
+import styles from './search-dropdown.module.css';
 
 interface SearchDropdownProps {
   boardDetails: BoardDetails;
@@ -23,11 +20,10 @@ interface SearchDropdownProps {
 
 const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onClose }) => {
   const { totalSearchResultCount, isFetchingClimbs } = useQueueContext();
-  const { uiSearchParams } = useUISearchParams();
+  const { uiSearchParams, clearClimbSearchParams } = useUISearchParams();
   const filtersActive = hasActiveFilters(uiSearchParams);
 
   const handleClose = useCallback(() => {
-    // Save current filters as a recent search when closing if filters differ from defaults
     if (filtersActive) {
       const label = getSearchPillSummary(uiSearchParams);
       addRecentSearch(label, uiSearchParams);
@@ -35,54 +31,44 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
     onClose();
   }, [filtersActive, uiSearchParams, onClose]);
 
-  const drawerTitle = (
-    <Space size={8}>
-      <span>Search Climbs</span>
-      {filtersActive && !isFetchingClimbs && (
-        <Badge
-          count={totalSearchResultCount ?? 0}
-          overflowCount={9999}
-          showZero={false}
-          color="cyan"
-          size="small"
-        />
-      )}
-    </Space>
-  );
+  const resultCount = totalSearchResultCount ?? 0;
+  const showResultCount = filtersActive && !isFetchingClimbs && resultCount > 0;
 
-  const drawerFooter = filtersActive ? (
-    <div className={searchFormStyles.searchFooter}>
-      <div className={searchFormStyles.resultCount}>
-        {isFetchingClimbs ? (
-          <Spin size="small" />
-        ) : (
-          <Space size={8}>
-            <FilterOutlined style={{ color: '#06B6D4' }} />
-            <Text type="secondary">
-              <span className={searchFormStyles.resultBadge}>
-                {(totalSearchResultCount ?? 0).toLocaleString()}
-              </span>{' '}
-              results
-            </Text>
-          </Space>
-        )}
-      </div>
-      <ClearButton />
+  const drawerFooter = (
+    <div className={styles.footer}>
+      <button
+        type="button"
+        className={styles.clearAllButton}
+        onClick={clearClimbSearchParams}
+      >
+        Clear all
+      </button>
+      <Button
+        type="primary"
+        icon={isFetchingClimbs ? <Spin size="small" /> : <SearchOutlined />}
+        onClick={handleClose}
+        className={styles.searchButton}
+        size="large"
+      >
+        Search{showResultCount ? ` \u00B7 ${resultCount.toLocaleString()}` : ''}
+      </Button>
     </div>
-  ) : null;
+  );
 
   return (
     <SwipeableDrawer
-      title={drawerTitle}
       placement="bottom"
       open={open}
       onClose={handleClose}
       height="85vh"
       showDragHandle
+      closable={false}
       footer={drawerFooter}
+      rootClassName={styles.drawerRoot}
       styles={{
-        body: { padding: '0 4px 16px' },
+        body: { padding: '0 16px 16px', backgroundColor: 'var(--ant-color-bg-layout, #F3F4F6)' },
         footer: { padding: 0, border: 'none' },
+        header: { display: 'none' },
       }}
     >
       <AccordionSearchForm boardDetails={boardDetails} />


### PR DESCRIPTION
Replace AntD Collapse accordion with custom card-based sections that
expand/collapse one at a time. Collapsed sections show label and summary,
expanded sections show bold title and form content. Add modern footer
with underlined "Clear all" and primary "Search" button with result count.

https://claude.ai/code/session_01BPAVQvmoWEHiRDCP1mxUsF