### PR TITLE
Change search drawer to open from top with grey 70% opacity backdrop

### DIFF
--- a/packages/web/app/components/search-drawer/search-dropdown.tsx
+++ b/packages/web/app/components/search-drawer/search-dropdown.tsx
@@ -57,7 +57,7 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
 
   return (
     <SwipeableDrawer
-      placement="bottom"
+      placement="top"
       open={open}
       onClose={handleClose}
       height="85vh"
@@ -69,6 +69,7 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
         body: { padding: '0 16px 16px', backgroundColor: 'var(--ant-color-bg-layout, #F3F4F6)' },
         footer: { padding: 0, border: 'none' },
         header: { display: 'none' },
+        mask: { backgroundColor: 'rgba(128, 128, 128, 0.7)' },
       }}
     >
       <AccordionSearchForm boardDetails={boardDetails} />


### PR DESCRIPTION
- Switch SwipeableDrawer placement from "bottom" to "top"
- Add mask style with rgba(128, 128, 128, 0.7) for grey 70% opacity overlay

https://claude.ai/code/session_01L6TQ6Mbjsy3GFiouiooEDt