### PR TITLE
Remove left border from active climb and queue list items

### DIFF
--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -81,7 +81,6 @@ const ClimbListItemSkeleton = () => (
       gap: themeTokens.spacing[3],
       backgroundColor: themeTokens.semantic.surface,
       borderBottom: `1px solid ${themeTokens.neutral[200]}`,
-      borderLeft: '3px solid transparent',
     }}
   >
     {/* Thumbnail placeholder */}

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -183,7 +183,6 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
             gap: themeTokens.spacing[3],
             backgroundColor: selected ? (getGradeTintColor(climb.difficulty, 'light') ?? themeTokens.semantic.selected) : themeTokens.semantic.surface,
             borderBottom: `1px solid ${themeTokens.neutral[200]}`,
-            borderLeft: selected ? `3px solid ${gradeColor ?? themeTokens.colors.primary}` : '3px solid transparent',
             transform: `translateX(${swipeOffset}px)`,
             transition: swipeOffset === 0 ? `transform ${themeTokens.transitions.fast}` : 'none',
             cursor: 'pointer',

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -16,7 +16,7 @@ import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeTintColor, getGradeColor } from '@/app/lib/grade-colors';
+import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, parseBoardRouteParams, constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import styles from './queue-list-item.module.css';
@@ -320,7 +320,6 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
                 ? themeTokens.neutral[100]
                 : themeTokens.semantic.surface,
             opacity: isSwipeComplete ? 0 : isHistory ? 0.6 : 1,
-            borderLeft: isCurrent ? `3px solid ${getGradeColor(item.climb?.difficulty) ?? themeTokens.colors.primary}` : undefined,
             transform: `translateX(${swipeOffset}px)`,
             transition: swipeOffset === 0 || isSwipeComplete ? `transform ${themeTokens.transitions.fast}, opacity ${themeTokens.transitions.fast}` : 'none',
             cursor: isEditMode ? 'pointer' : undefined,


### PR DESCRIPTION
Keep the background color on active/selected items but remove the
3px left border indicator from climb list items, queue list items,
and the skeleton placeholder.

https://claude.ai/code/session_01WNqGW8E5xDJy3J6Hh13P6b