### PR TITLE
Move colorized grade to left of climb title, add ascent status on right

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -8,6 +8,7 @@ import { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useQueueContext } from '@/app/components/graphql-queue';
 import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import ClimbTitle from '@/app/components/climb-card/climb-title';
+import { AscentStatus } from '@/app/components/queue-control/queue-list-item';
 import { constructClimbListWithSlugs, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION } from '@/app/hooks/use-card-swipe-navigation';
@@ -149,7 +150,13 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
             padding: `${themeTokens.spacing[1]}px ${themeTokens.spacing[3]}px`,
           }}
         >
-          <ClimbTitle climb={displayClimb} layout="horizontal" showSetterInfo titleFontSize={themeTokens.typography.fontSize['2xl']} />
+          <ClimbTitle
+            climb={displayClimb}
+            layout="horizontal"
+            showSetterInfo
+            titleFontSize={themeTokens.typography.fontSize['2xl']}
+            rightAddon={displayClimb && <AscentStatus climbUuid={displayClimb.uuid} fontSize={themeTokens.typography.fontSize['2xl']} />}
+          />
         </div>
         <div {...swipeHandlers} className={styles.swipeContainer}>
           <div

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -26,6 +26,8 @@ type ClimbTitleProps = {
   showSetterInfo?: boolean;
   /** Custom element to render after the name (e.g., AscentStatus) */
   nameAddon?: React.ReactNode;
+  /** Custom element to render on the far right (e.g., AscentStatus in play view) */
+  rightAddon?: React.ReactNode;
   /** Use ellipsis for text overflow */
   ellipsis?: boolean;
   /** Additional className for the container */
@@ -47,6 +49,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   showAngle = false,
   showSetterInfo = false,
   nameAddon,
+  rightAddon,
   ellipsis = true,
   className,
   layout = 'stacked',
@@ -140,7 +143,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   const largeGradeElement = vGrade && (
     <Text
       style={{
-        fontSize: 28,
+        fontSize: nameFontSize,
         fontWeight: themeTokens.typography.fontWeight.bold,
         lineHeight: 1,
         color: gradeColor ?? 'var(--ant-color-text-secondary)',
@@ -177,7 +180,9 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
     return (
       <Flex gap={12} align="center" className={className} style={centered ? { position: 'relative' } : undefined}>
-        {/* Left side: Name and quality/setter stacked */}
+        {/* Colorized V grade on the left */}
+        {largeGradeElement}
+        {/* Center: Name and quality/setter stacked */}
         <Flex vertical gap={0} style={{ flex: 1, minWidth: 0 }} align={centered ? 'center' : 'flex-start'}>
           {/* Row 1: Name with addon */}
           <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[2] }}>
@@ -196,14 +201,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
             {secondLineContent.length > 0 ? secondLineContent.join(' · ') : <span style={{ fontStyle: 'italic' }}>project</span>}
           </Text>
         </Flex>
-        {/* Large V grade: absolutely positioned when centered to avoid pushing text off-center */}
-        {centered ? (
-          <div style={{ position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)' }}>
-            {largeGradeElement}
-          </div>
-        ) : (
-          largeGradeElement
-        )}
+        {/* Right addon (e.g., ascent status) */}
+        {rightAddon}
       </Flex>
     );
   }

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -21,6 +21,7 @@ import { useQueueContext } from '../graphql-queue';
 import { useFavorite, ClimbActions } from '../climb-actions';
 import { ShareBoardButton } from '../board-page/share-button';
 import { TickButton } from '../logbook/tick-button';
+import { AscentStatus } from '../queue-control/queue-list-item';
 import QueueList, { QueueListHandle } from '../queue-control/queue-list';
 import ClimbTitle from '../climb-card/climb-title';
 import BoardRenderer from '../board-renderer/board-renderer';
@@ -237,6 +238,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             showAngle
             centered
             titleFontSize={themeTokens.typography.fontSize.xl}
+            rightAddon={currentClimb && <AscentStatus climbUuid={currentClimb.uuid} fontSize={themeTokens.typography.fontSize.xl} />}
           />
         </div>
 


### PR DESCRIPTION
In the horizontal ClimbTitle layout, the V-grade now appears on the left
side of the title (matching the title font size) instead of on the right.
Both play views pass AscentStatus as a rightAddon where the grade used to be.

https://claude.ai/code/session_012ufhdrDTSWNuyMb9H4rXi2