### PR TITLE
Fix avatar button collapsing to zero width in header

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -112,7 +112,7 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
       <UISearchParamsProvider>
         <Flex justify="space-between" align="center" style={{ width: '100%' }} gap={8}>
           {/* Left section: Avatar + Back button */}
-          <Flex align="center" gap={4}>
+          <Flex align="center" gap={4} style={{ flexShrink: 0 }}>
             {pageMode !== 'create' && (
               <UserDrawer boardDetails={boardDetails} angle={angle} />
             )}

--- a/packages/web/app/components/user-drawer/user-drawer.module.css
+++ b/packages/web/app/components/user-drawer/user-drawer.module.css
@@ -101,6 +101,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .avatarLoggedIn {


### PR DESCRIPTION
The avatar button in the top-left corner was rendering as a vertical line because the flex layout allowed it to be squeezed. Added flex-shrink: 0 to both the avatar button and its parent flex container to prevent the center section (flex: 1) from collapsing them.

https://claude.ai/code/session_01DiiXatAad1siBfJMDmLJ3i