### PR TITLE
Change search drawer to open at 100% height

### DIFF
--- a/packages/web/app/components/search-drawer/search-dropdown.tsx
+++ b/packages/web/app/components/search-drawer/search-dropdown.tsx
@@ -60,7 +60,7 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
       placement="top"
       open={open}
       onClose={handleClose}
-      height="85vh"
+      height="100%"
       showDragHandle
       closable={false}
       footer={drawerFooter}


### PR DESCRIPTION
The search drawer (which opens from the top) was previously limited to
85vh. Updated to 100% so it covers the full viewport.

https://claude.ai/code/session_01U5yPHy8y2C2xXMvvUBWn8q