### PR TITLE
Soften grade colors in list/play/queue views

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -14,7 +14,7 @@ import { useQueueContext } from '../graphql-queue';
 import { useFavorite } from '../climb-actions';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeColor, getGradeTintColor } from '@/app/lib/grade-colors';
+import { getSoftGradeColor, getGradeTintColor } from '@/app/lib/grade-colors';
 
 const { Text } = Typography;
 
@@ -106,7 +106,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
   // Extract V grade for colorized display
   const vGradeMatch = climb.difficulty?.match(/V\d+/i);
   const vGrade = vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
-  const gradeColor = getGradeColor(climb.difficulty);
+  const gradeColor = getSoftGradeColor(climb.difficulty);
   const hasQuality = climb.quality_average && climb.quality_average !== '0';
 
   // Swipe action visibility

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Flex, Typography } from 'antd';
 import { CopyrightOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getVGradeColor } from '@/app/lib/grade-colors';
+import { getSoftVGradeColor } from '@/app/lib/grade-colors';
 
 const { Text } = Typography;
 
@@ -135,7 +135,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     </Text>
   );
 
-  const gradeColor = vGrade ? getVGradeColor(vGrade) : undefined;
+  const gradeColor = vGrade ? getSoftVGradeColor(vGrade) : undefined;
 
   const largeGradeElement = vGrade && (
     <Text

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -17,7 +17,7 @@ import { BoardDetails } from '@/app/lib/types';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import { holdIdToCoordinate, MOONBOARD_GRADES, MOONBOARD_ANGLES } from '@/app/lib/moonboard-config';
-import { getFontGradeColor } from '@/app/lib/grade-colors';
+import { getSoftFontGradeColor } from '@/app/lib/grade-colors';
 import { themeTokens } from '@/app/theme/theme-config';
 import { parseScreenshot } from '@boardsesh/moonboard-ocr/browser';
 import { convertOcrHoldsToMap } from '@/app/lib/moonboard-climbs-db';
@@ -449,7 +449,7 @@ export default function CreateClimbForm({
               fontSize: 28,
               fontWeight: themeTokens.typography.fontWeight.bold,
               lineHeight: 1,
-              color: getFontGradeColor(userGrade) ?? 'var(--ant-color-text-secondary)',
+              color: getSoftFontGradeColor(userGrade) ?? 'var(--ant-color-text-secondary)',
               flexShrink: 0,
             }}
           >

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -149,6 +149,73 @@ export function getGradeTextColor(gradeColor: string | undefined): string {
   return isLightColor(gradeColor) ? '#000000' : '#FFFFFF';
 }
 
+/**
+ * Convert a hex color to HSL components.
+ * @returns Object with h (0-360), s (0-1), l (0-1)
+ */
+function hexToHSL(hex: string): { h: number; s: number; l: number } {
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.substring(0, 2), 16) / 255;
+  const g = parseInt(clean.substring(2, 4), 16) / 255;
+  const b = parseInt(clean.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return { h: 0, s: 0, l };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return { h: h * 360, s, l };
+}
+
+/**
+ * Create a softened version of a hex color for use as text color.
+ * Preserves the hue but uses moderate saturation and lightness so the color
+ * is distinguishable without being visually overwhelming on bold/large text.
+ */
+function softenColor(hex: string): string {
+  const { h } = hexToHSL(hex);
+  return `hsl(${Math.round(h)}, 40%, 45%)`;
+}
+
+/**
+ * Get a softened color for a V-grade string (e.g., "V3", "V10").
+ * Returns a muted version of the grade color suitable for large/bold text in list views.
+ */
+export function getSoftVGradeColor(vGrade: string | null | undefined): string | undefined {
+  const color = getVGradeColor(vGrade);
+  if (!color) return undefined;
+  return softenColor(color);
+}
+
+/**
+ * Get a softened color for a Font grade string (e.g., "6a", "7b+").
+ * Returns a muted version of the grade color suitable for large/bold text in list views.
+ */
+export function getSoftFontGradeColor(fontGrade: string | null | undefined): string | undefined {
+  const color = getFontGradeColor(fontGrade);
+  if (!color) return undefined;
+  return softenColor(color);
+}
+
+/**
+ * Get a softened color for a difficulty string (e.g., "6a/V3", "V5").
+ * Returns a muted version of the grade color suitable for large/bold text in list views.
+ */
+export function getSoftGradeColor(difficulty: string | null | undefined): string | undefined {
+  const color = getGradeColor(difficulty);
+  if (!color) return undefined;
+  return softenColor(color);
+}
+
 function hexToHue(hex: string): number {
   const clean = hex.replace('#', '');
   const r = parseInt(clean.substring(0, 2), 16) / 255;


### PR DESCRIPTION
Use muted HSL colors (40% saturation, 45% lightness) for grade text
in list items, queue items, control bar, and create-climb form while
preserving the original vivid colors on the profile page charts.

https://claude.ai/code/session_01JHwwicqrwLVPrz2K3qPyw4