### PR TITLE
Remove invalid showRecentSearches prop from AccordionSearchForm

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -83,7 +83,7 @@ const TabsWrapper: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails })
         children: (
           <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
             <div style={{ flex: 1, overflow: 'auto' }}>
-              <AccordionSearchForm boardDetails={boardDetails} showRecentSearches={false} />
+              <AccordionSearchForm boardDetails={boardDetails} />
             </div>
             <SearchResultsFooter />
           </div>


### PR DESCRIPTION
The showRecentSearches prop was being passed to AccordionSearchForm but
was never defined in AccordionSearchFormProps or used by the component,
causing a TypeScript compilation error.

https://claude.ai/code/session_01C4sSGDxMTyyyE1QyjbHpF8