### PR TITLE
Fix useUISearchParams missing provider on list route

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -98,15 +98,15 @@ const TabsWrapper: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails })
 
 const ListLayoutClient: React.FC<PropsWithChildren<ListLayoutClientProps>> = ({ boardDetails, children }) => {
   return (
-    <Layout className={styles.listLayout}>
-      <Content className={styles.mainContent}>{children}</Content>
-      <Sider width={400} className={styles.sider} theme="light" style={{ padding: '0 8px 20px 8px' }}>
-        <UISearchParamsProvider>
+    <UISearchParamsProvider>
+      <Layout className={styles.listLayout}>
+        <Content className={styles.mainContent}>{children}</Content>
+        <Sider width={400} className={styles.sider} theme="light" style={{ padding: '0 8px 20px 8px' }}>
           <TabsWrapper boardDetails={boardDetails} />
-        </UISearchParamsProvider>
-      </Sider>
-      <OnboardingTour />
-    </Layout>
+        </Sider>
+        <OnboardingTour />
+      </Layout>
+    </UISearchParamsProvider>
   );
 };
 


### PR DESCRIPTION
UISearchParamsProvider only wrapped the Sider (sidebar), but
RecentSearchPills was moved into ClimbsList which renders inside
Content. Lift the provider to wrap both Content and Sider so all
descendants have access to the search params context.

Fixes: useUISearchParams must be used within a SearchParamsProvider

https://claude.ai/code/session_017X8jDcSEuyuhzU2XcTXuoN