### PR TITLE
Fix search pills not reflecting active state and header not showing summary

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -18,6 +18,7 @@ import { Metadata } from 'next';
 import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 import BottomTabBar from '@/app/components/bottom-tab-bar/bottom-tab-bar';
 import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
+import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 
 // Helper to get board details for any board type
 function getBoardDetailsUniversal(parsedParams: ParsedBoardRouteParameters): BoardDetails {
@@ -153,30 +154,32 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
           <GraphQLQueueProvider parsedParams={parsedParams} boardDetails={boardDetails}>
             <PartyProvider>
               <BluetoothProvider boardDetails={boardDetails}>
-                <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
+                <UISearchParamsProvider>
+                  <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
-                <Content
-                  id="content-for-scrollable"
-                  style={{
-                    flex: 1,
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    overflowX: 'hidden',
-                    paddingLeft: '10px',
-                    paddingRight: '10px',
-                    paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
-                    paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
-                  }}
-                >
-                  <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
-                    {children}
-                  </Suspense>
-                </Content>
+                  <Content
+                    id="content-for-scrollable"
+                    style={{
+                      flex: 1,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      overflowX: 'hidden',
+                      paddingLeft: '10px',
+                      paddingRight: '10px',
+                      paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
+                      paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+                    }}
+                  >
+                    <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
+                      {children}
+                    </Suspense>
+                  </Content>
 
-                <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
-                  <QueueControlBar boardDetails={boardDetails} angle={angle} />
-                  <BottomTabBar boardDetails={boardDetails} angle={angle} />
-                </div>
+                  <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 10 }}>
+                    <QueueControlBar boardDetails={boardDetails} angle={angle} />
+                    <BottomTabBar boardDetails={boardDetails} angle={angle} />
+                  </div>
+                </UISearchParamsProvider>
               </BluetoothProvider>
             </PartyProvider>
           </GraphQLQueueProvider>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -10,7 +10,6 @@ import { themeTokens } from '@/app/theme/theme-config';
 import AccordionSearchForm from '@/app/components/search-drawer/accordion-search-form';
 import SearchResultsFooter from '@/app/components/search-drawer/search-results-footer';
 import QueueList from '@/app/components/queue-control/queue-list';
-import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { useQueueContext } from '@/app/components/graphql-queue';
 import OnboardingTour from '@/app/components/onboarding/onboarding-tour';
 import styles from './layout-client.module.css';
@@ -98,15 +97,13 @@ const TabsWrapper: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails })
 
 const ListLayoutClient: React.FC<PropsWithChildren<ListLayoutClientProps>> = ({ boardDetails, children }) => {
   return (
-    <UISearchParamsProvider>
-      <Layout className={styles.listLayout}>
-        <Content className={styles.mainContent}>{children}</Content>
-        <Sider width={400} className={styles.sider} theme="light" style={{ padding: '0 8px 20px 8px' }}>
-          <TabsWrapper boardDetails={boardDetails} />
-        </Sider>
-        <OnboardingTour />
-      </Layout>
-    </UISearchParamsProvider>
+    <Layout className={styles.listLayout}>
+      <Content className={styles.mainContent}>{children}</Content>
+      <Sider width={400} className={styles.sider} theme="light" style={{ padding: '0 8px 20px 8px' }}>
+        <TabsWrapper boardDetails={boardDetails} />
+      </Sider>
+      <OnboardingTour />
+    </Layout>
   );
 };
 

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -5,7 +5,6 @@ import { Header } from 'antd/es/layout/layout';
 import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import SearchPill from '../search-drawer/search-pill';
 import SearchDropdown from '../search-drawer/search-dropdown';
-import { UISearchParamsProvider } from '../queue-control/ui-searchparams-provider';
 import { BoardDetails } from '@/app/lib/types';
 import { ExperimentOutlined } from '@ant-design/icons';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -109,66 +108,64 @@ export default function BoardSeshHeader({ boardDetails, angle }: BoardSeshHeader
         zIndex: 10,
       }}
     >
-      <UISearchParamsProvider>
-        <Flex justify="space-between" align="center" style={{ width: '100%' }} gap={8}>
-          {/* Left section: Avatar + Back button */}
-          <Flex align="center" gap={4} style={{ flexShrink: 0 }}>
-            {pageMode !== 'create' && (
-              <UserDrawer boardDetails={boardDetails} angle={angle} />
-            )}
+      <Flex justify="space-between" align="center" style={{ width: '100%' }} gap={8}>
+        {/* Left section: Avatar + Back button */}
+        <Flex align="center" gap={4} style={{ flexShrink: 0 }}>
+          {pageMode !== 'create' && (
+            <UserDrawer boardDetails={boardDetails} angle={angle} />
+          )}
 
-            {/* Play page: Show back button next to logo (mobile only) */}
-            {pageMode === 'play' && (
-              <div className={styles.mobileOnly}>
-                <Button
-                  icon={<LeftOutlined />}
-                  type="text"
-                  aria-label="Back to climb list"
-                  onClick={() => router.push(getBackToListUrl())}
-                />
-              </div>
-            )}
-          </Flex>
-
-          {/* Center Section - Content varies by page mode */}
-          <Flex justify="center" gap={2} style={{ flex: 1 }} align="center">
-            {/* List page: Show search pill (mobile only) */}
-            {pageMode === 'list' && (
-              <div className={styles.mobileOnly} style={{ flex: 1 }}>
-                <SearchPill onClick={() => setSearchDropdownOpen(true)} />
-              </div>
-            )}
-          </Flex>
-
-          {/* Right Section */}
-          <Flex gap={4} align="center">
-            {/* Create mode: Show cancel and publish buttons */}
-            {pageMode === 'create' ? (
-              <CreateModeButtons />
-            ) : (
-              <>
-                {angle !== undefined && <AngleSelector boardName={boardDetails.board_name} boardDetails={boardDetails} currentAngle={angle} currentClimb={currentClimb} />}
-
-                {/* Desktop: show Create Climb button */}
-                {createClimbUrl && (
-                  <div className={styles.desktopOnly}>
-                    <Link href={createClimbUrl}>
-                      <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
-                    </Link>
-                  </div>
-                )}
-              </>
-            )}
-          </Flex>
+          {/* Play page: Show back button next to logo (mobile only) */}
+          {pageMode === 'play' && (
+            <div className={styles.mobileOnly}>
+              <Button
+                icon={<LeftOutlined />}
+                type="text"
+                aria-label="Back to climb list"
+                onClick={() => router.push(getBackToListUrl())}
+              />
+            </div>
+          )}
         </Flex>
 
-        {/* Search dropdown drawer (mobile) */}
-        <SearchDropdown
-          boardDetails={boardDetails}
-          open={searchDropdownOpen}
-          onClose={() => setSearchDropdownOpen(false)}
-        />
-      </UISearchParamsProvider>
+        {/* Center Section - Content varies by page mode */}
+        <Flex justify="center" gap={2} style={{ flex: 1 }} align="center">
+          {/* List page: Show search pill (mobile only) */}
+          {pageMode === 'list' && (
+            <div className={styles.mobileOnly} style={{ flex: 1 }}>
+              <SearchPill onClick={() => setSearchDropdownOpen(true)} />
+            </div>
+          )}
+        </Flex>
+
+        {/* Right Section */}
+        <Flex gap={4} align="center">
+          {/* Create mode: Show cancel and publish buttons */}
+          {pageMode === 'create' ? (
+            <CreateModeButtons />
+          ) : (
+            <>
+              {angle !== undefined && <AngleSelector boardName={boardDetails.board_name} boardDetails={boardDetails} currentAngle={angle} currentClimb={currentClimb} />}
+
+              {/* Desktop: show Create Climb button */}
+              {createClimbUrl && (
+                <div className={styles.desktopOnly}>
+                  <Link href={createClimbUrl}>
+                    <Button icon={<PlusOutlined />} type="text" title="Create new climb" />
+                  </Link>
+                </div>
+              )}
+            </>
+          )}
+        </Flex>
+      </Flex>
+
+      {/* Search dropdown drawer (mobile) */}
+      <SearchDropdown
+        boardDetails={boardDetails}
+        open={searchDropdownOpen}
+        onClose={() => setSearchDropdownOpen(false)}
+      />
     </Header>
   );
 }

--- a/packages/web/app/components/search-drawer/recent-search-pills.module.css
+++ b/packages/web/app/components/search-drawer/recent-search-pills.module.css
@@ -49,6 +49,21 @@
   background: #E5E7EB;
 }
 
+.pillActive {
+  border-color: #06B6D4;
+  background: #ECFEFF;
+  color: #0E7490;
+}
+
+.pillActive:hover {
+  background: #CFFAFE;
+  border-color: #06B6D4;
+}
+
+.pillActive .pillIcon {
+  color: #06B6D4;
+}
+
 .pillIcon {
   font-size: 10px;
   /* themeTokens.neutral[400] */

--- a/packages/web/app/components/search-drawer/recent-search-pills.tsx
+++ b/packages/web/app/components/search-drawer/recent-search-pills.tsx
@@ -2,14 +2,16 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { HistoryOutlined } from '@ant-design/icons';
-import { getRecentSearches, RecentSearch, RECENT_SEARCHES_CHANGED_EVENT } from './recent-searches-storage';
+import { getRecentSearches, getFilterKey, RecentSearch, RECENT_SEARCHES_CHANGED_EVENT } from './recent-searches-storage';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import { SearchRequestPagination } from '@/app/lib/types';
 import styles from './recent-search-pills.module.css';
 
 const RecentSearchPills: React.FC = () => {
   const [searches, setSearches] = useState<RecentSearch[]>([]);
-  const { updateFilters } = useUISearchParams();
+  const { uiSearchParams, updateFilters } = useUISearchParams();
+
+  const currentFilterKey = getFilterKey(uiSearchParams);
 
   const refreshSearches = useCallback(() => {
     setSearches(getRecentSearches());
@@ -35,18 +37,21 @@ const RecentSearchPills: React.FC = () => {
   return (
     <div className={styles.container}>
       <div className={styles.pillList}>
-        {searches.map((search) => (
-          <button
-            key={search.id}
-            type="button"
-            className={styles.pill}
-            onClick={() => handleApply(search.filters)}
-            title={search.label}
-          >
-            <HistoryOutlined className={styles.pillIcon} />
-            <span className={styles.pillLabel}>{search.label}</span>
-          </button>
-        ))}
+        {searches.map((search) => {
+          const isActive = getFilterKey(search.filters) === currentFilterKey;
+          return (
+            <button
+              key={search.id}
+              type="button"
+              className={`${styles.pill} ${isActive ? styles.pillActive : ''}`}
+              onClick={() => handleApply(search.filters)}
+              title={search.label}
+            >
+              <HistoryOutlined className={styles.pillIcon} />
+              <span className={styles.pillLabel}>{search.label}</span>
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/web/app/components/search-drawer/recent-searches-storage.ts
+++ b/packages/web/app/components/search-drawer/recent-searches-storage.ts
@@ -11,7 +11,7 @@ export const RECENT_SEARCHES_CHANGED_EVENT = 'boardsesh:recent-searches-changed'
 const STORAGE_KEY = 'boardsesh_recent_searches';
 const MAX_ITEMS = 10;
 
-function getFilterKey(filters: Partial<SearchRequestPagination>): string {
+export function getFilterKey(filters: Partial<SearchRequestPagination>): string {
   // Exclude page/pageSize from comparison since they're not meaningful for deduplication
   const { page: _page, pageSize: _pageSize, ...rest } = filters as SearchRequestPagination;
   return JSON.stringify(rest, Object.keys(rest).sort());


### PR DESCRIPTION
The root cause was two separate UISearchParamsProvider instances: one in the
header and one in list layout-client. They maintained independent state, so
clicking a recent search pill updated the layout provider but the header's
SearchPill read from its own provider.

Fix: Move UISearchParamsProvider to the angle layout (common parent) so both
header and content share the same search state. Also add visual active state
(cyan highlight) to recent search pills by comparing current filters.

https://claude.ai/code/session_01RpkcogPzPhL7ZmeoU2hDER