### PR TITLE
Fix swipe-to-close on search drawer

### DIFF
--- a/packages/web/app/components/search-drawer/search-dropdown.tsx
+++ b/packages/web/app/components/search-drawer/search-dropdown.tsx
@@ -63,6 +63,7 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
       height="100%"
       showDragHandle
       closable={false}
+      swipeEnabled
       footer={drawerFooter}
       rootClassName={styles.drawerRoot}
       styles={{


### PR DESCRIPTION
The search drawer had closable={false} to hide the X button, but
SwipeableDrawer defaults swipeEnabled to (closable !== false), which
inadvertently disabled swipe gestures. Explicitly set swipeEnabled
to re-enable swipe-to-dismiss.

https://claude.ai/code/session_01XfsYVU6LZhSuqaec1XaTMA