### PR TITLE
Use grade-based background colors in grade selector, remove border

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -131,6 +131,12 @@
   gap: 8px;
 }
 
+/* Grade select with color background */
+.gradeSelectColored :global(.ant-select-selector) {
+  background-color: var(--grade-bg) !important;
+  border-color: transparent !important;
+}
+
 /* Mobile adjustments */
 @media (max-width: 767px) {
   .steppedContainer {

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { InputNumber, Row, Col, Select, Switch, Alert, Typography, Tooltip, Button } from 'antd';
 import { LoginOutlined, SortAscendingOutlined } from '@ant-design/icons';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
+import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import { useBoardProvider } from '@/app/components/board-provider/board-provider-context';
 import SearchClimbNameInput from './search-climb-name-input';
@@ -61,6 +62,16 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
     }
   };
 
+  const getGradeSelectBackground = (difficultyId: number | undefined): string | undefined => {
+    if (!difficultyId || difficultyId === 0) return undefined;
+    const grade = grades.find(g => g.difficulty_id === difficultyId);
+    if (!grade) return undefined;
+    return getGradeTintColor(grade.difficulty_name, 'light');
+  };
+
+  const minGradeBg = getGradeSelectBackground(uiSearchParams.minGrade);
+  const maxGradeBg = getGradeSelectBackground(uiSearchParams.maxGrade);
+
   const sections: SectionConfig[] = [
     {
       key: 'climb',
@@ -82,7 +93,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <Select
                   value={uiSearchParams.minGrade || 0}
                   onChange={(value) => handleGradeChange('min', value)}
-                  className={styles.fullWidth}
+                  className={`${styles.fullWidth} ${minGradeBg ? styles.gradeSelectColored : ''}`}
+                  style={minGradeBg ? { '--grade-bg': minGradeBg } as React.CSSProperties : undefined}
                   placeholder="Min"
                 >
                   <Select.Option value={0}>Any</Select.Option>
@@ -97,7 +109,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <Select
                   value={uiSearchParams.maxGrade || 0}
                   onChange={(value) => handleGradeChange('max', value)}
-                  className={styles.fullWidth}
+                  className={`${styles.fullWidth} ${maxGradeBg ? styles.gradeSelectColored : ''}`}
+                  style={maxGradeBg ? { '--grade-bg': maxGradeBg } as React.CSSProperties : undefined}
                   placeholder="Max"
                 >
                   <Select.Option value={0}>Any</Select.Option>


### PR DESCRIPTION
Apply the same grade tint colors used in the climb list to the min/max grade Select components in the search form. When a grade is selected, the Select shows a light background tint matching that grade's color (via getGradeTintColor 'light' variant) and the border becomes transparent.

https://claude.ai/code/session_01KxsZakTc6PbHAeaodBuFpx