### PR TITLE
Add swipe peek animation to play view for smooth climb transitions

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -1,17 +1,16 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback } from 'react';
 import { Button, Empty } from 'antd';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { track } from '@vercel/analytics';
 import { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useQueueContext } from '@/app/components/graphql-queue';
-import BoardRenderer from '@/app/components/board-renderer/board-renderer';
+import SwipeBoardCarousel from '@/app/components/board-renderer/swipe-board-carousel';
 import ClimbTitle from '@/app/components/climb-card/climb-title';
 import { AscentStatus } from '@/app/components/queue-control/queue-list-item';
 import { constructClimbListWithSlugs, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
-import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION } from '@/app/hooks/use-card-swipe-navigation';
 import styles from './play-view.module.css';
 
 type PlayViewClientProps = {
@@ -111,49 +110,6 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
 
   const nextItem = getNextClimbQueueItem();
   const prevItem = getPreviousClimbQueueItem();
-  const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
-
-  const { swipeHandlers, swipeOffset, isAnimating, animationDirection, enterDirection, clearEnterAnimation } = useCardSwipeNavigation({
-    onSwipeNext: handleNext,
-    onSwipePrevious: handlePrevious,
-    canSwipeNext: !!nextItem,
-    canSwipePrevious: !!prevItem,
-    threshold: 80,
-    delayNavigation: true,
-  });
-
-  // Clear enterDirection after transition completes
-  useEffect(() => {
-    if (enterDirection) {
-      enterFallbackRef.current = setTimeout(() => {
-        clearEnterAnimation();
-      }, 170);
-    }
-    return () => {
-      if (enterFallbackRef.current) {
-        clearTimeout(enterFallbackRef.current);
-        enterFallbackRef.current = null;
-      }
-    };
-  }, [enterDirection, clearEnterAnimation]);
-
-  const getSwipeTransition = () => {
-    if (enterDirection) return 'none';
-    if (isAnimating) return `transform ${EXIT_DURATION}ms ease-out`;
-    if (swipeOffset === 0) return `transform ${SNAP_BACK_DURATION}ms ease`;
-    return 'none';
-  };
-
-  // Peek: determine which climb to preview during swipe
-  const showPeek = swipeOffset !== 0 || isAnimating;
-  const peekIsNext = animationDirection === 'left' || (animationDirection === null && swipeOffset < 0);
-  const peekItem = peekIsNext ? nextItem : prevItem;
-
-  const getPeekTransform = () => {
-    return peekIsNext
-      ? `translateX(max(0px, calc(100% + ${swipeOffset}px)))`
-      : `translateX(min(0px, calc(-100% + ${swipeOffset}px)))`;
-  };
 
   if (!displayClimb) {
     return (
@@ -187,38 +143,18 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
             rightAddon={displayClimb && <AscentStatus climbUuid={displayClimb.uuid} fontSize={themeTokens.typography.fontSize['2xl']} />}
           />
         </div>
-        <div {...swipeHandlers} className={styles.swipeContainer}>
-          <div
-            className={styles.boardContainer}
-            style={{
-              transform: `translateX(${swipeOffset}px)`,
-              transition: getSwipeTransition(),
-            }}
-          >
-            <BoardRenderer
-              boardDetails={boardDetails}
-              litUpHoldsMap={displayClimb.litUpHoldsMap}
-              mirrored={isMirrored}
-              fillHeight
-            />
-          </div>
-          {showPeek && peekItem?.climb && (
-            <div
-              className={styles.peekBoardContainer}
-              style={{
-                transform: getPeekTransform(),
-                transition: getSwipeTransition(),
-              }}
-            >
-              <BoardRenderer
-                boardDetails={boardDetails}
-                litUpHoldsMap={peekItem.climb.litUpHoldsMap}
-                mirrored={!!peekItem.climb.mirrored}
-                fillHeight
-              />
-            </div>
-          )}
-        </div>
+        <SwipeBoardCarousel
+          boardDetails={boardDetails}
+          currentClimb={{ litUpHoldsMap: displayClimb.litUpHoldsMap, mirrored: isMirrored }}
+          nextClimb={nextItem?.climb}
+          previousClimb={prevItem?.climb}
+          onSwipeNext={handleNext}
+          onSwipePrevious={handlePrevious}
+          canSwipeNext={!!nextItem}
+          canSwipePrevious={!!prevItem}
+          className={styles.swipeContainer}
+          boardContainerClassName={styles.boardContainer}
+        />
       </div>
     </div>
   );

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -31,6 +31,18 @@
   touch-action: manipulation;
   overflow: hidden;
   min-height: 0;
+  position: relative;
+}
+
+.peekBoardContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 .boardContainer {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view.module.css
@@ -34,17 +34,6 @@
   position: relative;
 }
 
-.peekBoardContainer {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-}
-
 .boardContainer {
   flex: 1;
   display: flex;

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
@@ -1,0 +1,13 @@
+.carouselContainer {
+  position: relative;
+  overflow: hidden;
+}
+
+.peekBoardContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import BoardRenderer from './board-renderer';
+import {
+  useCardSwipeNavigation,
+  EXIT_DURATION,
+  SNAP_BACK_DURATION,
+  ENTER_ANIMATION_DURATION,
+} from '@/app/hooks/use-card-swipe-navigation';
+import type { BoardDetails } from '@/app/lib/types';
+import type { LitUpHoldsMap } from './types';
+import styles from './swipe-board-carousel.module.css';
+
+interface ClimbBoardData {
+  litUpHoldsMap: LitUpHoldsMap;
+  mirrored?: boolean;
+}
+
+export interface SwipeBoardCarouselProps {
+  boardDetails: BoardDetails;
+  currentClimb: ClimbBoardData;
+  nextClimb?: ClimbBoardData | null;
+  previousClimb?: ClimbBoardData | null;
+  onSwipeNext: () => void;
+  onSwipePrevious: () => void;
+  canSwipeNext: boolean;
+  canSwipePrevious: boolean;
+  /** CSS class for the outer swipe container (must provide overflow:hidden, position:relative) */
+  className?: string;
+  /** CSS class for the inner board wrapper that translates during swipe */
+  boardContainerClassName?: string;
+}
+
+const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
+  boardDetails,
+  currentClimb,
+  nextClimb,
+  previousClimb,
+  onSwipeNext,
+  onSwipePrevious,
+  canSwipeNext,
+  canSwipePrevious,
+  className,
+  boardContainerClassName,
+}) => {
+  const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
+
+  const { swipeHandlers, swipeOffset, isAnimating, animationDirection, enterDirection, clearEnterAnimation } =
+    useCardSwipeNavigation({
+      onSwipeNext,
+      onSwipePrevious,
+      canSwipeNext,
+      canSwipePrevious,
+      threshold: 80,
+      delayNavigation: true,
+    });
+
+  // Clear enterDirection after enter transition completes
+  useEffect(() => {
+    if (enterDirection) {
+      enterFallbackRef.current = setTimeout(() => {
+        clearEnterAnimation();
+      }, ENTER_ANIMATION_DURATION);
+    }
+    return () => {
+      if (enterFallbackRef.current) {
+        clearTimeout(enterFallbackRef.current);
+        enterFallbackRef.current = null;
+      }
+    };
+  }, [enterDirection, clearEnterAnimation]);
+
+  const getSwipeTransition = () => {
+    if (enterDirection) return 'none';
+    if (isAnimating) return `transform ${EXIT_DURATION}ms ease-out`;
+    if (swipeOffset === 0) return `transform ${SNAP_BACK_DURATION}ms ease`;
+    return 'none';
+  };
+
+  // Peek: determine which climb to preview during swipe
+  const showPeek = swipeOffset !== 0 || isAnimating;
+  const peekIsNext = animationDirection === 'left' || (animationDirection === null && swipeOffset < 0);
+  const peekClimb = peekIsNext ? nextClimb : previousClimb;
+
+  const getPeekTransform = () => {
+    return peekIsNext
+      ? `translateX(max(0px, calc(100% + ${swipeOffset}px)))`
+      : `translateX(min(0px, calc(-100% + ${swipeOffset}px)))`;
+  };
+
+  const transition = getSwipeTransition();
+
+  return (
+    <div className={`${styles.carouselContainer} ${className ?? ''}`} {...swipeHandlers}>
+      <div
+        className={boardContainerClassName}
+        style={{
+          transform: `translateX(${swipeOffset}px)`,
+          transition,
+        }}
+      >
+        <BoardRenderer
+          boardDetails={boardDetails}
+          litUpHoldsMap={currentClimb.litUpHoldsMap}
+          mirrored={!!currentClimb.mirrored}
+          fillHeight
+        />
+      </div>
+      {showPeek && peekClimb && (
+        <div
+          className={styles.peekBoardContainer}
+          style={{
+            transform: getPeekTransform(),
+            transition,
+          }}
+        >
+          <BoardRenderer
+            boardDetails={boardDetails}
+            litUpHoldsMap={peekClimb.litUpHoldsMap}
+            mirrored={!!peekClimb.mirrored}
+            fillHeight
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SwipeBoardCarousel;

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -45,16 +45,6 @@
   overflow: hidden;
 }
 
-.peekBoardContainer {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
-
-
 .queueBodyLayout {
   display: flex;
   flex-direction: column;

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -45,6 +45,15 @@
   overflow: hidden;
 }
 
+.peekBoardContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 
 .queueBodyLayout {
   display: flex;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -23,8 +23,7 @@ import { ShareBoardButton } from '../board-page/share-button';
 import { TickButton } from '../logbook/tick-button';
 import QueueList, { QueueListHandle } from '../queue-control/queue-list';
 import ClimbTitle from '../climb-card/climb-title';
-import BoardRenderer from '../board-renderer/board-renderer';
-import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION } from '@/app/hooks/use-card-swipe-navigation';
+import SwipeBoardCarousel from '../board-renderer/swipe-board-carousel';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { themeTokens } from '@/app/theme/theme-config';
 import DrawerContext from '@rc-component/drawer/es/context';
@@ -155,50 +154,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const canSwipeNext = !viewOnlyMode && !!nextItem;
   const canSwipePrevious = !viewOnlyMode && !!prevItem;
 
-  const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
-
-  const { swipeHandlers, swipeOffset, isAnimating, animationDirection, enterDirection, clearEnterAnimation } = useCardSwipeNavigation({
-    onSwipeNext: handleSwipeNext,
-    onSwipePrevious: handleSwipePrevious,
-    canSwipeNext,
-    canSwipePrevious,
-    threshold: 80,
-    delayNavigation: true,
-  });
-
-  // Clear enterDirection after transition completes
-  useEffect(() => {
-    if (enterDirection) {
-      enterFallbackRef.current = setTimeout(() => {
-        clearEnterAnimation();
-      }, 170);
-    }
-    return () => {
-      if (enterFallbackRef.current) {
-        clearTimeout(enterFallbackRef.current);
-        enterFallbackRef.current = null;
-      }
-    };
-  }, [enterDirection, clearEnterAnimation]);
-
-  const getSwipeTransition = () => {
-    if (enterDirection) return 'none';
-    if (isAnimating) return `transform ${EXIT_DURATION}ms ease-out`;
-    if (swipeOffset === 0) return `transform ${SNAP_BACK_DURATION}ms ease`;
-    return 'none';
-  };
-
-  // Peek: determine which climb to preview during swipe
-  const showPeek = swipeOffset !== 0 || isAnimating;
-  const peekIsNext = animationDirection === 'left' || (animationDirection === null && swipeOffset < 0);
-  const peekItem = peekIsNext ? nextItem : prevItem;
-
-  const getPeekTransform = () => {
-    return peekIsNext
-      ? `translateX(max(0px, calc(100% + ${swipeOffset}px)))`
-      : `translateX(min(0px, calc(-100% + ${swipeOffset}px)))`;
-  };
-
   const isMirrored = !!currentClimb?.mirrored;
 
   return (
@@ -238,40 +193,20 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         </div>
 
         {/* Board renderer with card-swipe */}
-        <div className={styles.boardSection} {...swipeHandlers}>
-          <div
-            className={styles.swipeCardContainer}
-            style={{
-              transform: `translateX(${swipeOffset}px)`,
-              transition: getSwipeTransition(),
-            }}
-          >
-            {isOpen && currentClimb && (
-              <BoardRenderer
-                boardDetails={boardDetails}
-                litUpHoldsMap={currentClimb.litUpHoldsMap}
-                mirrored={isMirrored}
-                fillHeight
-              />
-            )}
-          </div>
-          {showPeek && peekItem?.climb && (
-            <div
-              className={styles.peekBoardContainer}
-              style={{
-                transform: getPeekTransform(),
-                transition: getSwipeTransition(),
-              }}
-            >
-              <BoardRenderer
-                boardDetails={boardDetails}
-                litUpHoldsMap={peekItem.climb.litUpHoldsMap}
-                mirrored={!!peekItem.climb.mirrored}
-                fillHeight
-              />
-            </div>
-          )}
-        </div>
+        {isOpen && currentClimb && (
+          <SwipeBoardCarousel
+            boardDetails={boardDetails}
+            currentClimb={currentClimb}
+            nextClimb={nextItem?.climb}
+            previousClimb={prevItem?.climb}
+            onSwipeNext={handleSwipeNext}
+            onSwipePrevious={handleSwipePrevious}
+            canSwipeNext={canSwipeNext}
+            canSwipePrevious={canSwipePrevious}
+            className={styles.boardSection}
+            boardContainerClassName={styles.swipeCardContainer}
+          />
+        )}
 
         {/* Climb info below board */}
         <div className={styles.climbInfoSection}>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -19,7 +19,7 @@ import { AscentStatus } from './queue-list-item';
 import { themeTokens } from '@/app/theme/theme-config';
 import { TOUR_DRAWER_EVENT } from '../onboarding/onboarding-tour';
 import { ShareBoardButton } from '../board-page/share-button';
-import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION } from '@/app/hooks/use-card-swipe-navigation';
+import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMATION_DURATION } from '@/app/hooks/use-card-swipe-navigation';
 import PlayViewDrawer from '../play-view/play-view-drawer';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import styles from './queue-control-bar.module.css';
@@ -251,7 +251,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     if (enterDirection) {
       enterFallbackRef.current = setTimeout(() => {
         clearEnterAnimation();
-      }, 170);
+      }, ENTER_ANIMATION_DURATION);
     }
     return () => {
       if (enterFallbackRef.current) {

--- a/packages/web/app/hooks/use-card-swipe-navigation.ts
+++ b/packages/web/app/hooks/use-card-swipe-navigation.ts
@@ -6,6 +6,7 @@ import { useSwipeable } from 'react-swipeable';
 const EXIT_DURATION = 300; // ms for slide-off animation
 const SNAP_BACK_DURATION = 200; // ms for snap-back animation
 const CLIP_EXIT_DURATION = 100; // ms before starting enter — text leaves narrow clip area faster than full EXIT_DURATION
+const ENTER_ANIMATION_DURATION = 170; // ms for enter crossfade/transition after navigation
 
 export interface UseCardSwipeNavigationOptions {
   onSwipeNext: () => void;
@@ -173,4 +174,4 @@ export function useCardSwipeNavigation({
   };
 }
 
-export { EXIT_DURATION, SNAP_BACK_DURATION };
+export { EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMATION_DURATION };


### PR DESCRIPTION
Switch both PlayViewDrawer (mobile) and PlayViewClient (desktop) to use
delayNavigation mode with a peek board that slides in from the edge
during swipe gestures, matching the queue control bar behavior.

https://claude.ai/code/session_015fVwW9knbEys6k5Qd4bWzu