### PR TITLE
Fix skeleton list item alignment to match actual ClimbListItem layout

### DIFF
--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -83,8 +83,10 @@ const ClimbListItemSkeleton = () => (
       borderBottom: `1px solid ${themeTokens.neutral[200]}`,
     }}
   >
-    {/* Thumbnail placeholder */}
-    <Skeleton.Avatar active shape="square" size={48} style={{ flexShrink: 0 }} />
+    {/* Thumbnail placeholder - matches ClimbListItem width of themeTokens.spacing[16] (64px) */}
+    <div style={{ width: themeTokens.spacing[16], flexShrink: 0 }}>
+      <Skeleton.Avatar active shape="square" size={48} />
+    </div>
 
     {/* Center: Name and setter lines */}
     <Flex vertical gap={4} style={{ flex: 1, minWidth: 0 }}>
@@ -92,11 +94,13 @@ const ClimbListItemSkeleton = () => (
       <Skeleton.Input active size="small" style={{ width: '35%', minWidth: 60, height: 12 }} />
     </Flex>
 
-    {/* Right: Grade placeholder */}
-    <Skeleton.Input active size="small" style={{ width: 32, minWidth: 32, height: 24, flexShrink: 0 }} />
+    {/* Right: Ascent + Grade placeholder - matches ClimbListItem flex container */}
+    <div style={{ display: 'flex', alignItems: 'center', gap: themeTokens.spacing[1], flexShrink: 0 }}>
+      <Skeleton.Avatar active shape="square" size={24} />
+    </div>
 
     {/* Ellipsis dot placeholder */}
-    <Skeleton.Avatar active shape="circle" size={16} style={{ flexShrink: 0 }} />
+    <Skeleton.Button active size="small" style={{ width: 24, minWidth: 24, height: 24 }} />
   </div>
 );
 


### PR DESCRIPTION
The skeleton placeholders for grade and ellipsis were misaligned because:
- Thumbnail used a raw 48px Skeleton.Avatar instead of a 64px container matching ClimbListItem's themeTokens.spacing[16] width
- Grade used Skeleton.Input which ignores inline width styles due to Ant Design's internal min-width CSS, causing it to render too wide
- Ellipsis used a small circle avatar instead of a properly sized button

https://claude.ai/code/session_01MhWs5M8MDAArce9EAoArUH