### PR TITLE
Animate search drawer accordion sections on expand/collapse

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -27,12 +27,17 @@
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
-/* Collapsed row */
+/* Header row - always visible */
 .collapsedRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 18px 24px;
+  transition: padding 250ms ease;
+}
+
+.collapsedRowActive {
+  padding: 24px 24px 4px 24px;
 }
 
 .collapsedLabel {
@@ -40,6 +45,14 @@
   color: var(--ant-color-text-tertiary, #9CA3AF);
   font-weight: 400;
   flex-shrink: 0;
+  transition: font-size 250ms ease, color 250ms ease;
+}
+
+.sectionCardActive .collapsedLabel {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ant-color-text, #111827);
+  line-height: 1.2;
 }
 
 .collapsedSummary {
@@ -51,19 +64,29 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: opacity 200ms ease;
 }
 
-/* Expanded content */
-.expandedContent {
-  padding: 24px;
+.collapsedSummaryHidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
-.sectionTitle {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--ant-color-text, #111827);
-  margin: 0 0 20px 0;
-  line-height: 1.2;
+/* Expandable content area */
+.expandableContent {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 250ms ease;
+}
+
+.expandableContentOpen {
+  grid-template-rows: 1fr;
+}
+
+.expandableInner {
+  overflow: hidden;
+  min-height: 0;
+  padding: 16px 24px 24px;
 }
 
 /* Panel content sections (reused from before) */
@@ -147,13 +170,16 @@
     padding: 16px 20px;
   }
 
-  .expandedContent {
-    padding: 20px;
+  .collapsedRowActive {
+    padding: 20px 20px 4px 20px;
   }
 
-  .sectionTitle {
+  .sectionCardActive .collapsedLabel {
     font-size: 20px;
-    margin-bottom: 16px;
+  }
+
+  .expandableInner {
+    padding: 12px 20px 20px;
   }
 
   .switchRow {

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -348,17 +348,17 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
               className={`${styles.sectionCard} ${isActive ? styles.sectionCardActive : ''}`}
               {...(!isActive ? { onClick: () => setActiveKey(section.key) } : {})}
             >
-              {isActive ? (
-                <div className={styles.expandedContent}>
-                  <h2 className={styles.sectionTitle}>{section.title}</h2>
+              <div className={`${styles.collapsedRow} ${isActive ? styles.collapsedRowActive : ''}`}>
+                <span className={styles.collapsedLabel}>{isActive ? section.title : section.label}</span>
+                <span className={`${styles.collapsedSummary} ${isActive ? styles.collapsedSummaryHidden : ''}`}>
+                  {summaryText}
+                </span>
+              </div>
+              <div className={`${styles.expandableContent} ${isActive ? styles.expandableContentOpen : ''}`}>
+                <div className={styles.expandableInner}>
                   {section.content}
                 </div>
-              ) : (
-                <div className={styles.collapsedRow}>
-                  <span className={styles.collapsedLabel}>{section.label}</span>
-                  <span className={styles.collapsedSummary}>{summaryText}</span>
-                </div>
-              )}
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
Restructure the accordion sections to always render both the header row and content area, using CSS grid-template-rows (0fr/1fr) for smooth height animation. The label font-size, header padding, and summary opacity also transition for a polished expand/collapse effect.

https://claude.ai/code/session_01MCSzKkPUqRQdS8EWEzpyf8