### PR TITLE
Fix collapsed accordion pills not fully collapsing

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -86,6 +86,9 @@
 .expandableInner {
   overflow: hidden;
   min-height: 0;
+}
+
+.expandableInnerPadding {
   padding: 16px 24px 24px;
 }
 
@@ -178,7 +181,7 @@
     font-size: 20px;
   }
 
-  .expandableInner {
+  .expandableInnerPadding {
     padding: 12px 20px 20px;
   }
 

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -356,7 +356,9 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
               </div>
               <div className={`${styles.expandableContent} ${isActive ? styles.expandableContentOpen : ''}`}>
                 <div className={styles.expandableInner}>
-                  {section.content}
+                  <div className={styles.expandableInnerPadding}>
+                    {section.content}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Move padding from .expandableInner to a new .expandableInnerPadding child wrapper so that when the grid collapses to 0fr, the padding collapses with the content instead of keeping the section partially open.

https://claude.ai/code/session_01SnUG13ETRDTfhuRASB3yv3