### PR TITLE
Migrate all localStorage/sessionStorage usage to IndexedDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,15 @@ We are using next.js app router, it's important we try to use server side compon
 - Use Zod for request/response validation
 - Implement both internal and proxy endpoints as needed
 
+### Client-Side Storage: IndexedDB Only
+
+**Never use `localStorage` or `sessionStorage`**. All client-side persistence must use IndexedDB via the `idb` package.
+
+- **Simple key-value preferences** (e.g., view mode, party mode): Use the shared utility at `packages/web/app/lib/user-preferences-db.ts` which provides `getPreference<T>(key)`, `setPreference(key, value)`, and `removePreference(key)`.
+- **Domain-specific data** (e.g., recent searches, session history, onboarding status): Create a dedicated `*-db.ts` file in `packages/web/app/lib/` following the established pattern (lazy `dbPromise` init, SSR guard, try-catch error handling). See `tab-navigation-db.ts` or `onboarding-db.ts` for examples.
+- All IndexedDB access must be guarded with `typeof window === 'undefined'` checks for SSR compatibility.
+- The only acceptable `localStorage` references are in one-time migration code that reads old data and deletes it (see `party-profile-db.ts`).
+
 ### State Management
 
 - URL parameters as source of truth for board configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,8 @@ We are using next.js app router, it's important we try to use server side compon
 - **Simple key-value preferences** (e.g., view mode, party mode): Use the shared utility at `packages/web/app/lib/user-preferences-db.ts` which provides `getPreference<T>(key)`, `setPreference(key, value)`, and `removePreference(key)`.
 - **Domain-specific data** (e.g., recent searches, session history, onboarding status): Create a dedicated `*-db.ts` file in `packages/web/app/lib/` following the established pattern (lazy `dbPromise` init, SSR guard, try-catch error handling). See `tab-navigation-db.ts` or `onboarding-db.ts` for examples.
 - All IndexedDB access must be guarded with `typeof window === 'undefined'` checks for SSR compatibility.
-- The only acceptable `localStorage` references are in one-time migration code that reads old data and deletes it (see `party-profile-db.ts`).
+- When migrating a value from `localStorage` to IndexedDB, include one-time migration logic that reads the old key, writes to IndexedDB, and deletes the localStorage key. See `user-preferences-db.ts` (`getPreference` fallback), `recent-searches-storage.ts`, and `party-profile-db.ts` for examples.
+- The only acceptable `localStorage` references are in one-time migration code that reads old data and deletes it.
 
 ### State Management
 

--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -285,7 +285,7 @@ Add a "compact" display mode for the climb list that renders climbs as slim rows
 
 4. **Modify: `packages/web/app/components/board-page/climbs-list.tsx`**
    - Add a view mode toggle: "Grid" (current cards) vs "List" (compact)
-   - Store preference in localStorage (key: `climbListViewMode`)
+   - Store preference in IndexedDB via `user-preferences-db.ts` (key: `climbListViewMode`)
    - Toggle button in a sticky header area above the list
    - Icons: `AppstoreOutlined` for grid, `UnorderedListOutlined` for list
    - When in list mode: Render `ClimbListItem` instead of `ClimbCard`
@@ -679,7 +679,7 @@ Additions:
 - **Dynamic import of SendClimbToBoardButton**: After this phase, only loaded on desktop in the header. Play drawer (Phase 3) handles its own LED button.
 - **HoldClassificationWizard**: Currently rendered in `header.tsx` and triggered by meatball menu. After redesign, the wizard should be rendered within or triggered from the user drawer. The drawer can manage its own `showHoldClassification` state.
 - **AuthModal**: Currently rendered in `header.tsx`. After redesign, the user drawer handles sign-in. Move `AuthModal` rendering to the user drawer component.
-- **Session data for Recents**: The `session-history-panel.tsx` already reads stored sessions from localStorage. Reuse this data source for the Recents section in the user drawer.
+- **Session data for Recents**: The `session-history-panel.tsx` already reads stored sessions from IndexedDB. Reuse this data source for the Recents section in the user drawer.
 
 ---
 
@@ -771,7 +771,7 @@ Ensure the desktop experience remains cohesive while the mobile experience is tr
 2. **Sidebar stays** - Queue/Search/Search by Hold tabs in the sidebar (existing `ListLayoutClient` with 3 tabs, not 2)
 3. **Header keeps** - Party, LED, Create buttons in header (wrapped in `.desktopOnly` class from `header.module.css`). User avatar + left drawer works the same on desktop (no separate user dropdown).
 4. **Play view** - Desktop users still use the full `/play/` page route with the sidebar layout (`play/layout-client.tsx`)
-5. **Climb list** - Default to compact (list) mode on all devices. Grid (card) mode available via toggle. Respect any stored localStorage preference.
+5. **Climb list** - Default to compact (list) mode on all devices. Grid (card) mode available via toggle. Respect any stored IndexedDB preference.
 6. **QueueControlBar** - Shows additional prev/next buttons on desktop (existing `.navButtons` CSS class already handles this), keeps mirror button visible, keeps play link
 
 ### Files to modify
@@ -959,7 +959,7 @@ Board layout.tsx (server component)
 - **One new context likely needed**: `BluetoothContext` to share Bluetooth connection state across `SendClimbToBoardButton` (desktop header), play drawer LED button, and party drawer LED tab. A plain hook would create independent connection instances. Alternatively, keep the hook-only approach but mount it in exactly one place and pass state down via props.
 - **Existing contexts consumed**: `QueueContext` (via `useQueueContext()`), `BoardProvider` (via `useBoardProvider()`), `FavoritesProvider` (via `useFavorite()`), `PersistentSessionContext` (via `usePersistentSession()` — used by `GlobalQueueControlBar` for off-route rendering)
 - **Global bar visibility**: Derived from `PersistentSessionContext` state: `hasActiveQueue = (localQueue.length > 0 || !!localCurrentClimbQueueItem || !!activeSession)`. Combined with `useIsOnBoardRoute()` to determine whether the global instance or board-route instance should render.
-- **View mode preference**: localStorage (`climbListViewMode: 'compact' | 'grid'`). Default to `'compact'` on all devices when no stored preference.
+- **View mode preference**: IndexedDB via `user-preferences-db.ts` (`climbListViewMode: 'compact' | 'grid'`). Default to `'compact'` on all devices when no stored preference.
 - **Play drawer open state**: Local state in QueueControlBar. Use a single `activeDrawer: 'none' | 'play' | 'queue'` state to prevent drawer stacking conflicts.
 - **Bottom tab active state**: Derived from current URL pathname via `usePathname()`
 - **Bluetooth connection state**: Extracted to shared hook or context (see above)
@@ -1013,7 +1013,7 @@ Board layout.tsx (server component)
 - [x] Swipe direction detection works (vertical scroll not blocked)
 - [x] Ellipsis menu opens bottom drawer with all actions
 - [x] All actions in drawer work (favorite, queue, tick, share, playlist, open-in-app, mirror, fork, view)
-- [x] View mode toggle persists across page loads (localStorage)
+- [x] View mode toggle persists across page loads (IndexedDB)
 - [x] View mode defaults to compact on all devices
 - [x] Infinite scroll works in both modes
 - [x] Scroll position restoration (hash-based) works in both modes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9930,6 +9930,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
@@ -16596,6 +16606,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/coverage-v8": "^4.0.16",
         "bufferutil": "^4.1.0",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^27.3.0",
         "oxlint": "^1.35.0",
         "prettier": "^3.7.4",

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -148,7 +148,7 @@ Once deployed, users connect via:
 https://boardsesh.com?backendUrl=wss://boardsesh-ws.yourdomain.com
 ```
 
-The `backendUrl` parameter is saved to localStorage for future sessions.
+The `backendUrl` is configured via the `NEXT_PUBLIC_WS_URL` environment variable.
 
 ## API
 

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -61,7 +61,7 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
 
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);
-    setPreference(VIEW_MODE_PREFERENCE_KEY, mode);
+    setPreference(VIEW_MODE_PREFERENCE_KEY, mode).catch(() => {});
     track('View Mode Changed', { mode });
   }, []);
 

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -11,10 +11,11 @@ import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton'
 import { useSearchParams } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
 import RecentSearchPills from '../search-drawer/recent-search-pills';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 
 type ViewMode = 'grid' | 'list';
 
-const VIEW_MODE_STORAGE_KEY = 'climbListViewMode';
+const VIEW_MODE_PREFERENCE_KEY = 'climbListViewMode';
 
 type ClimbsListProps = ParsedBoardRouteParameters & {
   boardDetails: BoardDetails;
@@ -51,23 +52,16 @@ const ClimbsList = ({ boardDetails, initialClimbs }: ClimbsListProps) => {
 
   // Read stored view mode preference after mount to avoid hydration mismatch
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+    getPreference<ViewMode>(VIEW_MODE_PREFERENCE_KEY).then((stored) => {
       if (stored === 'grid' || stored === 'list') {
         setViewMode(stored);
       }
-    } catch {
-      // localStorage not available
-    }
+    });
   }, []);
 
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);
-    try {
-      localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
-    } catch {
-      // localStorage not available
-    }
+    setPreference(VIEW_MODE_PREFERENCE_KEY, mode);
     track('View Mode Changed', { mode });
   }, []);
 

--- a/packages/web/app/components/connection-manager/connection-settings-context.tsx
+++ b/packages/web/app/components/connection-manager/connection-settings-context.tsx
@@ -32,16 +32,19 @@ export const ConnectionSettingsProvider: React.FC<{ children: React.ReactNode }>
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    getPreference<PartyMode>(PARTY_MODE_PREFERENCE_KEY).then((storedMode) => {
-      if (storedMode === 'direct' || storedMode === 'backend') {
-        setStoredPartyMode(storedMode);
-      }
+    getPreference<PartyMode>(PARTY_MODE_PREFERENCE_KEY)
+      .then((storedMode) => {
+        if (storedMode === 'direct' || storedMode === 'backend') {
+          setStoredPartyMode(storedMode);
+        }
 
-      // Clean up old preference keys if they exist
-      removePreference('boardsesh:backendUrl').catch(() => {});
-
-      setIsLoaded(true);
-    });
+        // Clean up old preference keys if they exist
+        removePreference('boardsesh:backendUrl').catch(() => {});
+      })
+      .catch(() => {})
+      .finally(() => {
+        setIsLoaded(true);
+      });
   }, []);
 
   // Effective party mode - env var forces backend mode

--- a/packages/web/app/components/connection-manager/connection-settings-context.tsx
+++ b/packages/web/app/components/connection-manager/connection-settings-context.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { getPreference, setPreference, removePreference } from '@/app/lib/user-preferences-db';
 
-const PARTY_MODE_STORAGE_KEY = 'boardsesh:partyMode';
+const PARTY_MODE_PREFERENCE_KEY = 'boardsesh:partyMode';
 
 // Backend URL from environment variable (for production deployment)
 const BACKEND_URL = process.env.NEXT_PUBLIC_WS_URL || null;
@@ -27,20 +28,20 @@ export const ConnectionSettingsProvider: React.FC<{ children: React.ReactNode }>
   const [storedPartyMode, setStoredPartyMode] = useState<PartyMode>('direct');
   const [isLoaded, setIsLoaded] = useState(false);
 
-  // Load party mode from localStorage on mount
+  // Load party mode from IndexedDB on mount
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const storedMode = localStorage.getItem(PARTY_MODE_STORAGE_KEY) as PartyMode | null;
+    if (typeof window === 'undefined') return;
 
+    getPreference<PartyMode>(PARTY_MODE_PREFERENCE_KEY).then((storedMode) => {
       if (storedMode === 'direct' || storedMode === 'backend') {
         setStoredPartyMode(storedMode);
       }
 
       // Clean up old localStorage keys if they exist
-      localStorage.removeItem('boardsesh:backendUrl');
+      removePreference('boardsesh:backendUrl');
 
       setIsLoaded(true);
-    }
+    });
   }, []);
 
   // Effective party mode - env var forces backend mode
@@ -53,7 +54,7 @@ export const ConnectionSettingsProvider: React.FC<{ children: React.ReactNode }>
 
   const setPartyMode = useCallback((mode: PartyMode) => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(PARTY_MODE_STORAGE_KEY, mode);
+      setPreference(PARTY_MODE_PREFERENCE_KEY, mode);
       setStoredPartyMode(mode);
     }
   }, []);

--- a/packages/web/app/components/connection-manager/connection-settings-context.tsx
+++ b/packages/web/app/components/connection-manager/connection-settings-context.tsx
@@ -37,8 +37,8 @@ export const ConnectionSettingsProvider: React.FC<{ children: React.ReactNode }>
         setStoredPartyMode(storedMode);
       }
 
-      // Clean up old localStorage keys if they exist
-      removePreference('boardsesh:backendUrl');
+      // Clean up old preference keys if they exist
+      removePreference('boardsesh:backendUrl').catch(() => {});
 
       setIsLoaded(true);
     });
@@ -54,7 +54,7 @@ export const ConnectionSettingsProvider: React.FC<{ children: React.ReactNode }>
 
   const setPartyMode = useCallback((mode: PartyMode) => {
     if (typeof window !== 'undefined') {
-      setPreference(PARTY_MODE_PREFERENCE_KEY, mode);
+      setPreference(PARTY_MODE_PREFERENCE_KEY, mode).catch(() => {});
       setStoredPartyMode(mode);
     }
   }, []);

--- a/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
@@ -1,0 +1,149 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getRecentSearches,
+  addRecentSearch,
+  getFilterKey,
+  type RecentSearch,
+} from '../recent-searches-storage';
+
+const DB_NAME = 'boardsesh-recent-searches';
+const STORE_NAME = 'searches';
+
+beforeEach(async () => {
+  localStorage.clear();
+  const db = await openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+  await db.clear(STORE_NAME);
+  db.close();
+});
+
+describe('recent-searches-storage', () => {
+  describe('getRecentSearches', () => {
+    it('should return empty array when no searches exist', async () => {
+      const result = await getRecentSearches();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('addRecentSearch', () => {
+    it('should add a search and retrieve it', async () => {
+      await addRecentSearch('Test search', { minGrade: 10 });
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Test search');
+      expect(results[0].filters).toEqual({ minGrade: 10 });
+    });
+
+    it('should add new searches to the front', async () => {
+      await addRecentSearch('First', { minGrade: 5 });
+      await addRecentSearch('Second', { minGrade: 10 });
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(2);
+      expect(results[0].label).toBe('Second');
+      expect(results[1].label).toBe('First');
+    });
+
+    it('should deduplicate searches with the same filters', async () => {
+      await addRecentSearch('Search A', { minGrade: 10 });
+      await addRecentSearch('Search B', { minGrade: 10 });
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Search B');
+    });
+
+    it('should cap at 10 items', async () => {
+      for (let i = 0; i < 12; i++) {
+        await addRecentSearch(`Search ${i}`, { minGrade: i });
+      }
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(10);
+      expect(results[0].label).toBe('Search 11');
+    });
+  });
+
+  describe('getFilterKey', () => {
+    it('should exclude page and pageSize from the key', () => {
+      const key1 = getFilterKey({ minGrade: 10, page: 1, pageSize: 20 });
+      const key2 = getFilterKey({ minGrade: 10, page: 5, pageSize: 50 });
+      expect(key1).toBe(key2);
+    });
+
+    it('should produce different keys for different filters', () => {
+      const key1 = getFilterKey({ minGrade: 10 });
+      const key2 = getFilterKey({ minGrade: 20 });
+      expect(key1).not.toBe(key2);
+    });
+  });
+
+  describe('localStorage migration', () => {
+    it('should migrate recent searches from localStorage on first read', async () => {
+      const legacyData: RecentSearch[] = [
+        {
+          id: 'legacy-1',
+          label: 'Old search',
+          filters: { minGrade: 5 },
+          timestamp: Date.now() - 1000,
+        },
+      ];
+      localStorage.setItem('boardsesh_recent_searches', JSON.stringify(legacyData));
+
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Old search');
+      expect(results[0].id).toBe('legacy-1');
+
+      // localStorage key should be cleaned up
+      expect(localStorage.getItem('boardsesh_recent_searches')).toBeNull();
+    });
+
+    it('should not re-migrate if IndexedDB already has data', async () => {
+      // Add something to IndexedDB first
+      await addRecentSearch('New search', { minGrade: 10 });
+
+      // Set legacy data in localStorage
+      const legacyData: RecentSearch[] = [
+        {
+          id: 'legacy-1',
+          label: 'Old search',
+          filters: { minGrade: 5 },
+          timestamp: Date.now() - 1000,
+        },
+      ];
+      localStorage.setItem('boardsesh_recent_searches', JSON.stringify(legacyData));
+
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('New search');
+
+      // localStorage should remain since migration was skipped
+      expect(localStorage.getItem('boardsesh_recent_searches')).not.toBeNull();
+    });
+
+    it('should persist migrated data for subsequent reads', async () => {
+      const legacyData: RecentSearch[] = [
+        {
+          id: 'legacy-1',
+          label: 'Old search',
+          filters: { minGrade: 5 },
+          timestamp: Date.now(),
+        },
+      ];
+      localStorage.setItem('boardsesh_recent_searches', JSON.stringify(legacyData));
+
+      // First read triggers migration
+      await getRecentSearches();
+
+      // Second read should return from IndexedDB
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Old search');
+    });
+  });
+});

--- a/packages/web/app/components/search-drawer/recent-search-pills.tsx
+++ b/packages/web/app/components/search-drawer/recent-search-pills.tsx
@@ -14,7 +14,7 @@ const RecentSearchPills: React.FC = () => {
   const currentFilterKey = getFilterKey(uiSearchParams);
 
   const refreshSearches = useCallback(() => {
-    setSearches(getRecentSearches());
+    getRecentSearches().then(setSearches);
   }, []);
 
   useEffect(() => {

--- a/packages/web/app/components/search-drawer/recent-searches-storage.ts
+++ b/packages/web/app/components/search-drawer/recent-searches-storage.ts
@@ -58,7 +58,8 @@ export async function getRecentSearches(): Promise<RecentSearch[]> {
     }
 
     return [];
-  } catch {
+  } catch (error) {
+    console.error('Failed to get recent searches:', error);
     return [];
   }
 }
@@ -85,7 +86,7 @@ export async function addRecentSearch(label: string, filters: Partial<SearchRequ
     if (!db) return;
     await db.put(STORE_NAME, updated, STORE_KEY);
     window.dispatchEvent(new CustomEvent(RECENT_SEARCHES_CHANGED_EVENT));
-  } catch {
-    // Silently fail if IndexedDB is unavailable
+  } catch (error) {
+    console.error('Failed to add recent search:', error);
   }
 }

--- a/packages/web/app/components/search-drawer/search-dropdown.tsx
+++ b/packages/web/app/components/search-drawer/search-dropdown.tsx
@@ -26,7 +26,7 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({ boardDetails, open, onC
   const handleClose = useCallback(() => {
     if (filtersActive) {
       const label = getSearchPillSummary(uiSearchParams);
-      addRecentSearch(label, uiSearchParams);
+      addRecentSearch(label, uiSearchParams).catch(() => {});
     }
     onClose();
   }, [filtersActive, uiSearchParams, onClose]);

--- a/packages/web/app/lib/__tests__/user-preferences-db.test.ts
+++ b/packages/web/app/lib/__tests__/user-preferences-db.test.ts
@@ -1,0 +1,133 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getPreference, setPreference, removePreference } from '../user-preferences-db';
+
+const DB_NAME = 'boardsesh-user-preferences';
+const STORE_NAME = 'preferences';
+
+beforeEach(async () => {
+  localStorage.clear();
+  // Clear the store contents using a separate short-lived connection
+  const db = await openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+  await db.clear(STORE_NAME);
+  db.close();
+});
+
+describe('user-preferences-db', () => {
+  describe('setPreference / getPreference', () => {
+    it('should store and retrieve a string preference', async () => {
+      await setPreference('testKey', 'testValue');
+      const result = await getPreference<string>('testKey');
+      expect(result).toBe('testValue');
+    });
+
+    it('should store and retrieve an object preference', async () => {
+      const obj = { foo: 'bar', num: 42 };
+      await setPreference('objKey', obj);
+      const result = await getPreference<typeof obj>('objKey');
+      expect(result).toEqual(obj);
+    });
+
+    it('should return null for a non-existent key', async () => {
+      const result = await getPreference<string>('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should overwrite an existing preference', async () => {
+      await setPreference('key', 'first');
+      await setPreference('key', 'second');
+      const result = await getPreference<string>('key');
+      expect(result).toBe('second');
+    });
+  });
+
+  describe('removePreference', () => {
+    it('should remove an existing preference', async () => {
+      await setPreference('toRemove', 'value');
+      await removePreference('toRemove');
+      const result = await getPreference<string>('toRemove');
+      expect(result).toBeNull();
+    });
+
+    it('should not throw when removing a non-existent key', async () => {
+      await expect(removePreference('nonexistent')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('localStorage migration', () => {
+    it('should migrate climbListViewMode from localStorage on first read', async () => {
+      localStorage.setItem('climbListViewMode', 'grid');
+
+      const result = await getPreference<string>('climbListViewMode');
+      expect(result).toBe('grid');
+
+      // localStorage key should be cleaned up
+      expect(localStorage.getItem('climbListViewMode')).toBeNull();
+    });
+
+    it('should migrate boardsesh:partyMode from localStorage on first read', async () => {
+      localStorage.setItem('boardsesh:partyMode', 'backend');
+
+      const result = await getPreference<string>('boardsesh:partyMode');
+      expect(result).toBe('backend');
+
+      expect(localStorage.getItem('boardsesh:partyMode')).toBeNull();
+    });
+
+    it('should not re-migrate if IndexedDB already has the value', async () => {
+      // Pre-populate IndexedDB
+      await setPreference('climbListViewMode', 'list');
+
+      // Set a different value in localStorage (simulating stale data)
+      localStorage.setItem('climbListViewMode', 'grid');
+
+      const result = await getPreference<string>('climbListViewMode');
+      expect(result).toBe('list');
+
+      // localStorage should remain untouched since migration was skipped
+      expect(localStorage.getItem('climbListViewMode')).toBe('grid');
+    });
+
+    it('should return null when neither IndexedDB nor localStorage has the value', async () => {
+      const result = await getPreference<string>('climbListViewMode');
+      expect(result).toBeNull();
+    });
+
+    it('should not attempt migration for keys without a legacy mapping', async () => {
+      localStorage.setItem('someOtherKey', 'value');
+
+      const result = await getPreference<string>('someOtherKey');
+      expect(result).toBeNull();
+
+      // localStorage should be untouched
+      expect(localStorage.getItem('someOtherKey')).toBe('value');
+    });
+
+    it('should parse JSON values during migration', async () => {
+      localStorage.setItem('climbListViewMode', JSON.stringify({ mode: 'grid' }));
+
+      const result = await getPreference<{ mode: string }>('climbListViewMode');
+      expect(result).toEqual({ mode: 'grid' });
+
+      expect(localStorage.getItem('climbListViewMode')).toBeNull();
+    });
+
+    it('should persist migrated value so subsequent reads come from IndexedDB', async () => {
+      localStorage.setItem('climbListViewMode', 'grid');
+
+      // First read triggers migration
+      await getPreference<string>('climbListViewMode');
+
+      // Second read should return from IndexedDB (localStorage is already cleared)
+      const result = await getPreference<string>('climbListViewMode');
+      expect(result).toBe('grid');
+    });
+  });
+});

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -43,9 +43,15 @@ export const getPreference = async <T>(key: string): Promise<T | null> => {
     if (legacyKey) {
       const legacyValue = localStorage.getItem(legacyKey);
       if (legacyValue !== null) {
-        await db.put(STORE_NAME, legacyValue, key);
+        let parsed: unknown = legacyValue;
+        try {
+          parsed = JSON.parse(legacyValue);
+        } catch {
+          // Value is a plain string, use as-is
+        }
+        await db.put(STORE_NAME, parsed, key);
         localStorage.removeItem(legacyKey);
-        return legacyValue as T;
+        return parsed as T;
       }
     }
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -87,6 +87,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.16",
     "bufferutil": "^4.1.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^27.3.0",
     "oxlint": "^1.35.0",
     "prettier": "^3.7.4",


### PR DESCRIPTION
Replace localStorage with IndexedDB for all client-side persistence:
- Create shared user-preferences-db.ts utility for simple key-value preferences
- Migrate recent searches storage to its own IndexedDB database
- Migrate climb list view mode preference to use user-preferences-db
- Migrate party mode connection setting to use user-preferences-db
- Add IndexedDB-only storage guidelines to CLAUDE.md
- Fix outdated localStorage reference in backend README

https://claude.ai/code/session_01GvnUnrUcF6uodjf37ZwCgm