### PR TITLE
Increase grade color vibrancy in softenColor

### DIFF
--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -178,12 +178,12 @@ function hexToHSL(hex: string): { h: number; s: number; l: number } {
 
 /**
  * Create a softened version of a hex color for use as text color.
- * Preserves the hue but uses moderate saturation and lightness so the color
- * is distinguishable without being visually overwhelming on bold/large text.
+ * Preserves the hue with high saturation to stay close to the original color
+ * while using controlled lightness for readability on bold/large text.
  */
 function softenColor(hex: string): string {
   const { h } = hexToHSL(hex);
-  return `hsl(${Math.round(h)}, 40%, 45%)`;
+  return `hsl(${Math.round(h)}, 72%, 44%)`;
 }
 
 /**


### PR DESCRIPTION
Raised saturation from 40% to 72% and adjusted lightness from 45% to 44%
so grade colors are less muted and closer to their original hex values
while remaining readable as text.

https://claude.ai/code/session_017G7BdxnDkuvG3pLMRFh1vD