### PR TITLE
Fix missing BluetoothProvider for off-board QueueControlBar

### DIFF
--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -5,6 +5,7 @@ import { PartyProfileProvider } from '../party-manager/party-profile-context';
 import { PersistentSessionProvider, usePersistentSession, useIsOnBoardRoute } from '../persistent-session';
 import { PersistentQueueProvider } from '../queue-control/persistent-queue-provider';
 import { BoardProvider } from '../board-provider/board-provider-context';
+import { BluetoothProvider } from '../board-bluetooth-control/bluetooth-context';
 import QueueControlBar from '../queue-control/queue-control-bar';
 
 interface PersistentSessionWrapperProps {
@@ -66,7 +67,9 @@ function OffBoardQueueBar() {
     >
       <BoardProvider boardName={boardDetails.board_name}>
         <PersistentQueueProvider boardDetails={boardDetails} angle={angle}>
-          <QueueControlBar boardDetails={boardDetails} angle={angle} />
+          <BluetoothProvider boardDetails={boardDetails}>
+            <QueueControlBar boardDetails={boardDetails} angle={angle} />
+          </BluetoothProvider>
         </PersistentQueueProvider>
       </BoardProvider>
     </div>


### PR DESCRIPTION
When the play view drawer was opened from off-board routes (e.g. /settings),
SendClimbToBoardButton crashed because it called useBluetoothContext() without
a BluetoothProvider in the component tree. The OffBoardQueueBar already wrapped
QueueControlBar with BoardProvider and PersistentQueueProvider but was missing
BluetoothProvider.

https://claude.ai/code/session_013Bdw38G3u4TZiabvu3jUaM