### PR TITLE
feat: MoonBoard bulk import, search, and filter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:help-screenshots": "TEST_USER_EMAIL=$(op read 'op://Boardsesh/Boardsesh local/username') TEST_USER_PASSWORD=$(op read 'op://Boardsesh/Boardsesh local/password') npx playwright test --project=chromium e2e/help-screenshots.spec.ts --config=packages/web/playwright.config.ts",
     "backend:dev": "npm run dev --workspace=boardsesh-backend",
     "backend:start": "npm run start --workspace=boardsesh-backend",
-    "db:up": "[ -f packages/db/docker/tmp/db-setup-complete.flag ] || (echo '❌ Database not initialized. Run `npm run db:setup` first.' && exit 1) && docker-compose up -d postgres neon-proxy redis && sleep 3 && npm run db:migrate",
+    "db:up": "[ -f packages/db/docker/tmp/db-setup-complete.flag ] || (echo '❌ Database not initialized. Run `npm run db:setup` first.' && exit 1) && docker-compose up -d postgres neon-proxy redis && sleep 3 && npm run db:migrate && npm run db:import-moonboard -- packages/db/docker/tmp/problems_2023_01_30",
     "db:setup": "docker-compose up db_setup",
     "db:migrate": "npm run db:migrate --workspace=@boardsesh/db",
     "db:studio": "npm run db:studio --workspace=@boardsesh/db",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:setup": "docker-compose up db_setup",
     "db:migrate": "npm run db:migrate --workspace=@boardsesh/db",
     "db:studio": "npm run db:studio --workspace=@boardsesh/db",
+    "db:import-moonboard": "npm run db:import-moonboard --workspace=@boardsesh/db",
     "controller:build": "cd embedded/projects/board-controller && pio run",
     "controller:upload": "cd embedded/projects/board-controller && pio run -t upload",
     "controller:monitor": "cd embedded/projects/board-controller && pio device monitor",

--- a/packages/backend/src/db/queries/climbs/create-climb-filters.ts
+++ b/packages/backend/src/db/queries/climbs/create-climb-filters.ts
@@ -72,7 +72,8 @@ export const createClimbFilters = (
 
   // Size-specific conditions using pre-fetched static edge values
   // This eliminates the need for a JOIN on product_sizes in the main query
-  const sizeConditions: SQL[] = [
+  // MoonBoard climbs have NULL edge values (single fixed size), so skip edge filtering
+  const sizeConditions: SQL[] = params.board_name === 'moonboard' ? [] : [
     sql`${tables.climbs.edgeLeft} > ${sizeEdges.edgeLeft}`,
     sql`${tables.climbs.edgeRight} < ${sizeEdges.edgeRight}`,
     sql`${tables.climbs.edgeBottom} > ${sizeEdges.edgeBottom}`,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -48,7 +48,8 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts"
   },
   "dependencies": {
     "@boardsesh/shared-schema": "*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -48,6 +48,7 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",
+    "test": "tsx --test scripts/**/*.test.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts"
   },

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -18,6 +18,27 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// =============================================================================
+// Data Source
+// =============================================================================
+// MoonBoard problem data comes from a community-provided dump:
+//   GitHub issue: https://github.com/spookykat/MoonBoard/issues/6#issuecomment-1783515787
+//   Direct download: https://github.com/spookykat/MoonBoard/files/13193317/problems_2023_01_30.zip
+//   Date: 2023-01-30
+//
+// The ZIP contains these JSON files:
+//   - problems MoonBoard 2016 .json
+//   - problems MoonBoard Masters 2017 25.json
+//   - problems MoonBoard Masters 2017 40.json
+//   - problems MoonBoard Masters 2019 25.json
+//   - problems MoonBoard Masters 2019 40.json
+//   - problems Mini MoonBoard 2020 40.json
+//
+// During `npm run db:setup`, the ZIP is downloaded and extracted automatically
+// to packages/db/docker/tmp/problems_2023_01_30/. The import runs as part of
+// `npm run db:up` after migrations.
+// =============================================================================
+
 // Load environment files (same as migrate.ts)
 config({ path: path.resolve(__dirname, '../../../.env.local') });
 config({ path: path.resolve(__dirname, '../../web/.env.local') });
@@ -137,7 +158,9 @@ const BATCH_SIZE = 500;
 // =============================================================================
 
 async function importMoonBoardProblems() {
-  const dumpPath = process.argv[2] || path.join(process.env.HOME || '~', 'Downloads', 'problems_2023_01_30');
+  const dumpPath = process.argv[2]
+    ? path.resolve(process.cwd(), process.argv[2])
+    : path.join(process.env.HOME || '~', 'Downloads', 'problems_2023_01_30');
 
   // Verify dump directory exists
   if (!fs.existsSync(dumpPath)) {

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -1,0 +1,416 @@
+import { drizzle } from 'drizzle-orm/neon-serverless';
+import { Pool, neonConfig } from '@neondatabase/serverless';
+import ws from 'ws';
+import { config } from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import { sql } from 'drizzle-orm';
+import { boardClimbs, boardClimbStats, boardClimbHolds } from '../src/schema/boards/unified.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load environment files (same as migrate.ts)
+config({ path: path.resolve(__dirname, '../../../.env.local') });
+config({ path: path.resolve(__dirname, '../../web/.env.local') });
+config({ path: path.resolve(__dirname, '../../web/.env.development.local') });
+
+// Enable WebSocket for Neon
+neonConfig.webSocketConstructor = ws;
+
+// Configure Neon for local development (uses neon-proxy on port 4444)
+function configureNeonForLocal(connectionString: string): void {
+  const connectionStringUrl = new URL(connectionString);
+  const isLocalDb = connectionStringUrl.hostname === 'db.localtest.me';
+
+  if (isLocalDb) {
+    neonConfig.fetchEndpoint = (host) => {
+      const [protocol, port] = host === 'db.localtest.me' ? ['http', 4444] : ['https', 443];
+      return `${protocol}://${host}:${port}/sql`;
+    };
+    neonConfig.useSecureWebSocket = false;
+    neonConfig.wsProxy = (host) => (host === 'db.localtest.me' ? `${host}:4444/v2` : `${host}/v2`);
+  }
+}
+
+// =============================================================================
+// Types for the MoonBoard JSON dump
+// =============================================================================
+
+interface MoonBoardMove {
+  problemId: number;
+  description: string; // e.g., "J3", "E4"
+  isStart: boolean;
+  isEnd: boolean;
+}
+
+interface MoonBoardProblem {
+  name: string;
+  grade: string; // e.g., "7C", "6B+"
+  userGrade: string | null;
+  setbyId: string;
+  setby: string;
+  method: string;
+  userRating: number;
+  repeats: number;
+  holdsetup: {
+    description: string;
+    holdsets: unknown;
+    apiId: number;
+  };
+  isBenchmark: boolean;
+  isMaster: boolean;
+  upgraded: boolean;
+  downgraded: boolean;
+  moves: MoonBoardMove[];
+  holdsets: unknown[];
+  hasBetaVideo: boolean;
+  moonBoardConfigurationId: number;
+  apiId: number;
+  dateInserted: string;
+  dateUpdated: string;
+  dateDeleted: string | null;
+}
+
+interface DumpFile {
+  total: number;
+  data: MoonBoardProblem[];
+}
+
+// =============================================================================
+// Mapping constants
+// =============================================================================
+
+// Fixed namespace UUID for deterministic v5 UUID generation
+const MOONBOARD_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'; // DNS namespace
+
+// holdsetup.apiId → layout ID in our database
+const HOLDSETUP_TO_LAYOUT: Record<number, number> = {
+  1: 2,  // MoonBoard 2016
+  15: 4, // MoonBoard Masters 2017
+  17: 5, // MoonBoard Masters 2019
+  19: 6, // Mini MoonBoard 2020
+};
+
+// Grade string → difficulty ID (matching MOONBOARD_GRADES in moonboard-config.ts)
+// Note: "5+" from MoonBoard maps to 5a (difficulty 13 / V1)
+const GRADE_TO_DIFFICULTY: Record<string, number> = {
+  '5+': 13,
+  '6A': 16, '6a': 16,
+  '6A+': 17, '6a+': 17,
+  '6B': 18, '6b': 18,
+  '6B+': 19, '6b+': 19,
+  '6C': 20, '6c': 20,
+  '6C+': 21, '6c+': 21,
+  '7A': 22, '7a': 22,
+  '7A+': 23, '7a+': 23,
+  '7B': 24, '7b': 24,
+  '7B+': 25, '7b+': 25,
+  '7C': 26, '7c': 26,
+  '7C+': 27, '7c+': 27,
+  '8A': 28, '8a': 28,
+  '8A+': 29, '8a+': 29,
+  '8B': 30, '8b': 30,
+  '8B+': 31, '8b+': 31,
+};
+
+// Hold state codes for frames encoding
+const HOLD_STATE_CODES = {
+  start: 42,
+  hand: 43,
+  finish: 44,
+};
+
+// MoonBoard grid: 11 columns (A-K)
+const COLUMNS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K'];
+const NUM_COLUMNS = 11;
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/**
+ * Generate deterministic UUID v5 from a string using a fixed namespace.
+ */
+function uuidv5(name: string, namespace: string): string {
+  // Parse namespace UUID into bytes
+  const nsBytes = Buffer.from(namespace.replace(/-/g, ''), 'hex');
+
+  // Hash namespace + name with SHA-1
+  const hash = crypto.createHash('sha1');
+  hash.update(nsBytes);
+  hash.update(name);
+  const bytes = hash.digest();
+
+  // Set version (5) and variant (RFC 4122)
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  // Format as UUID string
+  const hex = bytes.subarray(0, 16).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Convert a grid coordinate (e.g., "J3") to a numeric hold ID.
+ * ID = (row - 1) * 11 + colIndex + 1
+ */
+function coordinateToHoldId(coord: string): number {
+  const col = coord.charAt(0).toUpperCase();
+  const row = parseInt(coord.slice(1), 10);
+  const colIndex = COLUMNS.indexOf(col);
+  if (colIndex === -1) throw new Error(`Invalid column in coordinate: ${coord}`);
+  return (row - 1) * NUM_COLUMNS + colIndex + 1;
+}
+
+/**
+ * Convert moves to frames string.
+ * Format: p{holdId}r{roleCode}
+ */
+function movesToFrames(moves: MoonBoardMove[]): string {
+  return moves.map((move) => {
+    const holdId = coordinateToHoldId(move.description);
+    let role: number;
+    if (move.isStart) {
+      role = HOLD_STATE_CODES.start;
+    } else if (move.isEnd) {
+      role = HOLD_STATE_CODES.finish;
+    } else {
+      role = HOLD_STATE_CODES.hand;
+    }
+    return `p${holdId}r${role}`;
+  }).join('');
+}
+
+/**
+ * Get the hold state name for a move.
+ */
+function moveToHoldState(move: MoonBoardMove): string {
+  if (move.isStart) return 'STARTING';
+  if (move.isEnd) return 'FINISH';
+  return 'HAND';
+}
+
+// =============================================================================
+// Files to import
+// =============================================================================
+
+interface FileConfig {
+  filename: string;
+  angle: number;
+}
+
+const FILES_TO_IMPORT: FileConfig[] = [
+  { filename: 'problems MoonBoard 2016 .json', angle: 40 },
+  { filename: 'problems MoonBoard Masters 2017 25.json', angle: 25 },
+  { filename: 'problems MoonBoard Masters 2017 40.json', angle: 40 },
+  { filename: 'problems MoonBoard Masters 2019 25.json', angle: 25 },
+  { filename: 'problems MoonBoard Masters 2019 40.json', angle: 40 },
+  { filename: 'problems Mini MoonBoard 2020 40.json', angle: 40 },
+];
+
+const BATCH_SIZE = 500;
+
+// =============================================================================
+// Main import function
+// =============================================================================
+
+async function importMoonBoardProblems() {
+  const dumpPath = process.argv[2] || path.join(process.env.HOME || '~', 'Downloads', 'problems_2023_01_30');
+
+  // Verify dump directory exists
+  if (!fs.existsSync(dumpPath)) {
+    console.error(`❌ Dump directory not found: ${dumpPath}`);
+    console.error('   Usage: npm run db:import-moonboard [/path/to/dump]');
+    process.exit(1);
+  }
+
+  // Check for DATABASE_URL first, then POSTGRES_URL
+  const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL;
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL or POSTGRES_URL is not set');
+    process.exit(1);
+  }
+
+  // Safety: Block local dev URLs in production builds
+  const isLocalUrl = databaseUrl.includes('localhost') ||
+                     databaseUrl.includes('localtest.me') ||
+                     databaseUrl.includes('127.0.0.1');
+
+  if (process.env.VERCEL && isLocalUrl) {
+    console.error('❌ Refusing to run import with local DATABASE_URL in Vercel build');
+    process.exit(1);
+  }
+
+  const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
+  console.log(`🔄 Importing MoonBoard problems to: ${dbHost}`);
+  console.log(`📂 Reading dump from: ${dumpPath}`);
+
+  try {
+    configureNeonForLocal(databaseUrl);
+    const pool = new Pool({ connectionString: databaseUrl });
+    const db = drizzle(pool);
+
+    let totalClimbs = 0;
+    let totalStats = 0;
+    let totalHolds = 0;
+    let totalSkipped = 0;
+
+    for (const fileConfig of FILES_TO_IMPORT) {
+      const filePath = path.join(dumpPath, fileConfig.filename);
+      if (!fs.existsSync(filePath)) {
+        console.warn(`⚠️  File not found, skipping: ${fileConfig.filename}`);
+        continue;
+      }
+
+      console.log(`\n📖 Processing: ${fileConfig.filename}`);
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const dump: DumpFile = JSON.parse(raw);
+      console.log(`   Total problems in file: ${dump.data.length}`);
+
+      // Filter out deleted problems
+      const problems = dump.data.filter((p) => p.dateDeleted === null);
+      const deleted = dump.data.length - problems.length;
+      if (deleted > 0) {
+        console.log(`   Skipping ${deleted} deleted problems`);
+        totalSkipped += deleted;
+      }
+
+      // Prepare records
+      const climbRecords: (typeof boardClimbs.$inferInsert)[] = [];
+      const statsRecords: (typeof boardClimbStats.$inferInsert)[] = [];
+      const holdsRecords: (typeof boardClimbHolds.$inferInsert)[] = [];
+      let skippedGrade = 0;
+      let skippedLayout = 0;
+
+      for (const problem of problems) {
+        const layoutId = HOLDSETUP_TO_LAYOUT[problem.holdsetup.apiId];
+        if (!layoutId) {
+          skippedLayout++;
+          continue;
+        }
+
+        const difficultyId = GRADE_TO_DIFFICULTY[problem.grade];
+        if (difficultyId === undefined) {
+          skippedGrade++;
+          continue;
+        }
+
+        const uuid = uuidv5(`moonboard:${problem.apiId}`, MOONBOARD_UUID_NAMESPACE);
+        const frames = movesToFrames(problem.moves);
+
+        climbRecords.push({
+          uuid,
+          boardType: 'moonboard',
+          layoutId,
+          setterId: null,
+          setterUsername: problem.setby,
+          name: problem.name,
+          description: '',
+          hsm: null,
+          edgeLeft: null,
+          edgeRight: null,
+          edgeBottom: null,
+          edgeTop: null,
+          angle: fileConfig.angle,
+          framesCount: 1,
+          framesPace: 0,
+          frames,
+          isDraft: false,
+          isListed: true,
+          createdAt: problem.dateInserted,
+          synced: true,
+          syncError: null,
+          userId: null,
+        });
+
+        statsRecords.push({
+          boardType: 'moonboard',
+          climbUuid: uuid,
+          angle: fileConfig.angle,
+          displayDifficulty: difficultyId,
+          benchmarkDifficulty: problem.isBenchmark ? difficultyId : null,
+          ascensionistCount: problem.repeats,
+          difficultyAverage: difficultyId,
+          qualityAverage: problem.userRating,
+          faUsername: null,
+          faAt: null,
+        });
+
+        for (const move of problem.moves) {
+          const holdId = coordinateToHoldId(move.description);
+          holdsRecords.push({
+            boardType: 'moonboard',
+            climbUuid: uuid,
+            holdId,
+            frameNumber: 0,
+            holdState: moveToHoldState(move),
+          });
+        }
+      }
+
+      if (skippedGrade > 0) console.log(`   Skipped ${skippedGrade} problems with unknown grade`);
+      if (skippedLayout > 0) console.log(`   Skipped ${skippedLayout} problems with unknown holdsetup`);
+
+      // Batch insert climbs
+      console.log(`   Inserting ${climbRecords.length} climbs...`);
+      for (let i = 0; i < climbRecords.length; i += BATCH_SIZE) {
+        const batch = climbRecords.slice(i, i + BATCH_SIZE);
+        await db.insert(boardClimbs).values(batch).onConflictDoNothing();
+        if ((i + BATCH_SIZE) % 5000 === 0 || i + BATCH_SIZE >= climbRecords.length) {
+          process.stdout.write(`\r   Climbs: ${Math.min(i + BATCH_SIZE, climbRecords.length)}/${climbRecords.length}`);
+        }
+      }
+      console.log('');
+      totalClimbs += climbRecords.length;
+
+      // Batch insert stats (upsert to refresh on re-run)
+      console.log(`   Inserting ${statsRecords.length} stats...`);
+      for (let i = 0; i < statsRecords.length; i += BATCH_SIZE) {
+        const batch = statsRecords.slice(i, i + BATCH_SIZE);
+        await db.insert(boardClimbStats).values(batch).onConflictDoUpdate({
+          target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
+          set: {
+            displayDifficulty: sql`excluded.display_difficulty`,
+            benchmarkDifficulty: sql`excluded.benchmark_difficulty`,
+            ascensionistCount: sql`excluded.ascensionist_count`,
+            difficultyAverage: sql`excluded.difficulty_average`,
+            qualityAverage: sql`excluded.quality_average`,
+          },
+        });
+        if ((i + BATCH_SIZE) % 5000 === 0 || i + BATCH_SIZE >= statsRecords.length) {
+          process.stdout.write(`\r   Stats: ${Math.min(i + BATCH_SIZE, statsRecords.length)}/${statsRecords.length}`);
+        }
+      }
+      console.log('');
+      totalStats += statsRecords.length;
+
+      // Batch insert holds
+      console.log(`   Inserting ${holdsRecords.length} holds...`);
+      for (let i = 0; i < holdsRecords.length; i += BATCH_SIZE) {
+        const batch = holdsRecords.slice(i, i + BATCH_SIZE);
+        await db.insert(boardClimbHolds).values(batch).onConflictDoNothing();
+        if ((i + BATCH_SIZE) % 5000 === 0 || i + BATCH_SIZE >= holdsRecords.length) {
+          process.stdout.write(`\r   Holds: ${Math.min(i + BATCH_SIZE, holdsRecords.length)}/${holdsRecords.length}`);
+        }
+      }
+      console.log('');
+      totalHolds += holdsRecords.length;
+    }
+
+    console.log('\n✅ Import completed!');
+    console.log(`   Total climbs: ${totalClimbs}`);
+    console.log(`   Total stats: ${totalStats}`);
+    console.log(`   Total holds: ${totalHolds}`);
+    console.log(`   Total skipped (deleted): ${totalSkipped}`);
+
+    await pool.end();
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Import failed:', error);
+    process.exit(1);
+  }
+}
+
+importMoonBoardProblems();

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -4,10 +4,17 @@ import ws from 'ws';
 import { config } from 'dotenv';
 import path from 'path';
 import fs from 'fs';
-import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 import { sql } from 'drizzle-orm';
 import { boardClimbs, boardClimbStats, boardClimbHolds } from '../src/schema/boards/unified.js';
+import {
+  uuidv5,
+  coordinateToHoldId,
+  movesToFrames,
+  moveToHoldState,
+  MOONBOARD_UUID_NAMESPACE,
+  type MoonBoardMove,
+} from './moonboard-helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -37,13 +44,6 @@ function configureNeonForLocal(connectionString: string): void {
 // =============================================================================
 // Types for the MoonBoard JSON dump
 // =============================================================================
-
-interface MoonBoardMove {
-  problemId: number;
-  description: string; // e.g., "J3", "E4"
-  isStart: boolean;
-  isEnd: boolean;
-}
 
 interface MoonBoardProblem {
   name: string;
@@ -82,9 +82,6 @@ interface DumpFile {
 // Mapping constants
 // =============================================================================
 
-// Fixed namespace UUID for deterministic v5 UUID generation
-const MOONBOARD_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'; // DNS namespace
-
 // holdsetup.apiId → layout ID in our database
 const HOLDSETUP_TO_LAYOUT: Record<number, number> = {
   1: 2,  // MoonBoard 2016
@@ -114,83 +111,6 @@ const GRADE_TO_DIFFICULTY: Record<string, number> = {
   '8B': 30, '8b': 30,
   '8B+': 31, '8b+': 31,
 };
-
-// Hold state codes for frames encoding
-const HOLD_STATE_CODES = {
-  start: 42,
-  hand: 43,
-  finish: 44,
-};
-
-// MoonBoard grid: 11 columns (A-K)
-const COLUMNS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K'];
-const NUM_COLUMNS = 11;
-
-// =============================================================================
-// Helper functions
-// =============================================================================
-
-/**
- * Generate deterministic UUID v5 from a string using a fixed namespace.
- */
-function uuidv5(name: string, namespace: string): string {
-  // Parse namespace UUID into bytes
-  const nsBytes = Buffer.from(namespace.replace(/-/g, ''), 'hex');
-
-  // Hash namespace + name with SHA-1
-  const hash = crypto.createHash('sha1');
-  hash.update(nsBytes);
-  hash.update(name);
-  const bytes = hash.digest();
-
-  // Set version (5) and variant (RFC 4122)
-  bytes[6] = (bytes[6] & 0x0f) | 0x50;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-
-  // Format as UUID string
-  const hex = bytes.subarray(0, 16).toString('hex');
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
-}
-
-/**
- * Convert a grid coordinate (e.g., "J3") to a numeric hold ID.
- * ID = (row - 1) * 11 + colIndex + 1
- */
-function coordinateToHoldId(coord: string): number {
-  const col = coord.charAt(0).toUpperCase();
-  const row = parseInt(coord.slice(1), 10);
-  const colIndex = COLUMNS.indexOf(col);
-  if (colIndex === -1) throw new Error(`Invalid column in coordinate: ${coord}`);
-  return (row - 1) * NUM_COLUMNS + colIndex + 1;
-}
-
-/**
- * Convert moves to frames string.
- * Format: p{holdId}r{roleCode}
- */
-function movesToFrames(moves: MoonBoardMove[]): string {
-  return moves.map((move) => {
-    const holdId = coordinateToHoldId(move.description);
-    let role: number;
-    if (move.isStart) {
-      role = HOLD_STATE_CODES.start;
-    } else if (move.isEnd) {
-      role = HOLD_STATE_CODES.finish;
-    } else {
-      role = HOLD_STATE_CODES.hand;
-    }
-    return `p${holdId}r${role}`;
-  }).join('');
-}
-
-/**
- * Get the hold state name for a move.
- */
-function moveToHoldState(move: MoonBoardMove): string {
-  if (move.isStart) return 'STARTING';
-  if (move.isEnd) return 'FINISH';
-  return 'HAND';
-}
 
 // =============================================================================
 // Files to import

--- a/packages/db/scripts/moonboard-helpers.test.ts
+++ b/packages/db/scripts/moonboard-helpers.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  coordinateToHoldId,
+  movesToFrames,
+  moveToHoldState,
+  uuidv5,
+  MOONBOARD_UUID_NAMESPACE,
+  HOLD_STATE_CODES,
+  type MoonBoardMove,
+} from './moonboard-helpers.js';
+
+describe('coordinateToHoldId', () => {
+  it('converts A1 to hold ID 1 (first hold, bottom-left)', () => {
+    assert.equal(coordinateToHoldId('A1'), 1);
+  });
+
+  it('converts K1 to hold ID 11 (last column, row 1)', () => {
+    assert.equal(coordinateToHoldId('K1'), 11);
+  });
+
+  it('converts A2 to hold ID 12 (first column, row 2)', () => {
+    assert.equal(coordinateToHoldId('A2'), 12);
+  });
+
+  it('converts K18 to hold ID 198 (last hold on standard 11x18 board)', () => {
+    // (18 - 1) * 11 + 10 + 1 = 187 + 11 = 198
+    assert.equal(coordinateToHoldId('K18'), 198);
+  });
+
+  it('handles lowercase column letters', () => {
+    assert.equal(coordinateToHoldId('a1'), 1);
+    assert.equal(coordinateToHoldId('k18'), 198);
+  });
+
+  it('converts common MoonBoard coordinates correctly', () => {
+    // E5 = (5 - 1) * 11 + 4 + 1 = 44 + 5 = 49
+    assert.equal(coordinateToHoldId('E5'), 49);
+    // J3 = (3 - 1) * 11 + 9 + 1 = 22 + 10 = 32
+    assert.equal(coordinateToHoldId('J3'), 32);
+    // F10 = (10 - 1) * 11 + 5 + 1 = 99 + 6 = 105
+    assert.equal(coordinateToHoldId('F10'), 105);
+  });
+
+  it('throws for invalid column letter', () => {
+    assert.throws(() => coordinateToHoldId('Z1'), /Invalid column/);
+    assert.throws(() => coordinateToHoldId('L1'), /Invalid column/);
+  });
+});
+
+describe('movesToFrames', () => {
+  it('converts a single start move', () => {
+    const moves: MoonBoardMove[] = [
+      { problemId: 1, description: 'A1', isStart: true, isEnd: false },
+    ];
+    assert.equal(movesToFrames(moves), `p1r${HOLD_STATE_CODES.start}`);
+  });
+
+  it('converts a single finish move', () => {
+    const moves: MoonBoardMove[] = [
+      { problemId: 1, description: 'K18', isStart: false, isEnd: true },
+    ];
+    assert.equal(movesToFrames(moves), `p198r${HOLD_STATE_CODES.finish}`);
+  });
+
+  it('converts a single hand move', () => {
+    const moves: MoonBoardMove[] = [
+      { problemId: 1, description: 'E5', isStart: false, isEnd: false },
+    ];
+    assert.equal(movesToFrames(moves), `p49r${HOLD_STATE_CODES.hand}`);
+  });
+
+  it('converts a full problem with start, hand, and finish moves', () => {
+    const moves: MoonBoardMove[] = [
+      { problemId: 1, description: 'A1', isStart: true, isEnd: false },
+      { problemId: 1, description: 'E5', isStart: false, isEnd: false },
+      { problemId: 1, description: 'K18', isStart: false, isEnd: true },
+    ];
+    const result = movesToFrames(moves);
+    assert.equal(result, 'p1r42p49r43p198r44');
+  });
+
+  it('returns empty string for empty moves array', () => {
+    assert.equal(movesToFrames([]), '');
+  });
+});
+
+describe('moveToHoldState', () => {
+  it('returns STARTING for start moves', () => {
+    assert.equal(moveToHoldState({ problemId: 1, description: 'A1', isStart: true, isEnd: false }), 'STARTING');
+  });
+
+  it('returns FINISH for end moves', () => {
+    assert.equal(moveToHoldState({ problemId: 1, description: 'K18', isStart: false, isEnd: true }), 'FINISH');
+  });
+
+  it('returns HAND for regular moves', () => {
+    assert.equal(moveToHoldState({ problemId: 1, description: 'E5', isStart: false, isEnd: false }), 'HAND');
+  });
+});
+
+describe('uuidv5', () => {
+  it('produces a valid UUID format', () => {
+    const uuid = uuidv5('test', MOONBOARD_UUID_NAMESPACE);
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    assert.match(uuid, uuidRegex);
+  });
+
+  it('sets version 5 in the UUID', () => {
+    const uuid = uuidv5('test', MOONBOARD_UUID_NAMESPACE);
+    // Version is the 13th character (index 14 after dashes)
+    assert.equal(uuid.charAt(14), '5');
+  });
+
+  it('sets the correct variant bits', () => {
+    const uuid = uuidv5('test', MOONBOARD_UUID_NAMESPACE);
+    // Variant is the 17th hex char (index 19 after dashes), must be 8, 9, a, or b
+    const variantChar = uuid.charAt(19);
+    assert.ok(['8', '9', 'a', 'b'].includes(variantChar), `Expected variant char to be 8/9/a/b, got: ${variantChar}`);
+  });
+
+  it('produces deterministic output (same input = same UUID)', () => {
+    const uuid1 = uuidv5('moonboard:12345', MOONBOARD_UUID_NAMESPACE);
+    const uuid2 = uuidv5('moonboard:12345', MOONBOARD_UUID_NAMESPACE);
+    assert.equal(uuid1, uuid2);
+  });
+
+  it('produces different UUIDs for different inputs', () => {
+    const uuid1 = uuidv5('moonboard:12345', MOONBOARD_UUID_NAMESPACE);
+    const uuid2 = uuidv5('moonboard:67890', MOONBOARD_UUID_NAMESPACE);
+    assert.notEqual(uuid1, uuid2);
+  });
+
+  it('matches RFC 4122 reference value for DNS namespace', () => {
+    // Well-known test vector: uuid5("python.org", DNS namespace) = "886313e1-3b8a-5372-9b90-0c9aee199e5d"
+    const uuid = uuidv5('python.org', MOONBOARD_UUID_NAMESPACE);
+    assert.equal(uuid, '886313e1-3b8a-5372-9b90-0c9aee199e5d');
+  });
+});

--- a/packages/db/scripts/moonboard-helpers.ts
+++ b/packages/db/scripts/moonboard-helpers.ts
@@ -1,0 +1,96 @@
+import crypto from 'crypto';
+
+// =============================================================================
+// Mapping constants
+// =============================================================================
+
+// Fixed namespace UUID for deterministic v5 UUID generation
+export const MOONBOARD_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'; // DNS namespace
+
+// Hold state codes for frames encoding
+export const HOLD_STATE_CODES = {
+  start: 42,
+  hand: 43,
+  finish: 44,
+};
+
+// MoonBoard grid: 11 columns (A-K)
+export const COLUMNS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K'];
+export const NUM_COLUMNS = 11;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface MoonBoardMove {
+  problemId: number;
+  description: string; // e.g., "J3", "E4"
+  isStart: boolean;
+  isEnd: boolean;
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/**
+ * Generate deterministic UUID v5 from a string using a fixed namespace.
+ */
+export function uuidv5(name: string, namespace: string): string {
+  // Parse namespace UUID into bytes
+  const nsBytes = Buffer.from(namespace.replace(/-/g, ''), 'hex');
+
+  // Hash namespace + name with SHA-1
+  const hash = crypto.createHash('sha1');
+  hash.update(nsBytes);
+  hash.update(name);
+  const bytes = hash.digest();
+
+  // Set version (5) and variant (RFC 4122)
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  // Format as UUID string
+  const hex = bytes.subarray(0, 16).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Convert a grid coordinate (e.g., "J3") to a numeric hold ID.
+ * ID = (row - 1) * 11 + colIndex + 1
+ */
+export function coordinateToHoldId(coord: string): number {
+  const col = coord.charAt(0).toUpperCase();
+  const row = parseInt(coord.slice(1), 10);
+  const colIndex = COLUMNS.indexOf(col);
+  if (colIndex === -1) throw new Error(`Invalid column in coordinate: ${coord}`);
+  return (row - 1) * NUM_COLUMNS + colIndex + 1;
+}
+
+/**
+ * Convert moves to frames string.
+ * Format: p{holdId}r{roleCode}
+ */
+export function movesToFrames(moves: MoonBoardMove[]): string {
+  return moves.map((move) => {
+    const holdId = coordinateToHoldId(move.description);
+    let role: number;
+    if (move.isStart) {
+      role = HOLD_STATE_CODES.start;
+    } else if (move.isEnd) {
+      role = HOLD_STATE_CODES.finish;
+    } else {
+      role = HOLD_STATE_CODES.hand;
+    }
+    return `p${holdId}r${role}`;
+  }).join('');
+}
+
+/**
+ * Get the hold state name for a move.
+ */
+export function moveToHoldState(move: MoonBoardMove): string {
+  if (move.isStart) return 'STARTING';
+  if (move.isEnd) return 'FINISH';
+  return 'HAND';
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { notFound, permanentRedirect } from 'next/navigation';
-import { BoardRouteParametersWithUuid, SearchRequestPagination, BoardDetails, Climb } from '@/app/lib/types';
+import { BoardRouteParametersWithUuid, SearchRequestPagination, BoardDetails } from '@/app/lib/types';
 import {
   parseBoardRouteParams,
   parsedRouteSearchParamsToSearchParams,
@@ -12,118 +12,7 @@ import ClimbsList from '@/app/components/board-page/climbs-list';
 import { cachedSearchClimbs } from '@/app/lib/graphql/server-cached-client';
 import { SEARCH_CLIMBS, type ClimbSearchResponse } from '@/app/lib/graphql/operations/climb-search';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { MOONBOARD_HOLD_STATE_CODES, MOONBOARD_HOLD_STATES } from '@/app/lib/moonboard-config';
 import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
-import { dbz } from '@/app/lib/db/db';
-import { UNIFIED_TABLES } from '@/app/lib/db/queries/util/table-select';
-import { boardClimbStats } from '@boardsesh/db/schema';
-import { eq, and, desc } from 'drizzle-orm';
-import { getGradeByDifficultyId } from '@/app/lib/board-data';
-import type { LitUpHoldsMap } from '@/app/components/board-renderer/types';
-
-
-// Parse Moonboard frames string to lit up holds map
-function parseMoonboardFrames(frames: string): LitUpHoldsMap {
-  const map: LitUpHoldsMap = {};
-  // Format: p{holdId}r{roleCode} e.g., "p1r42p45r43p198r44"
-  // Role codes: 42=start, 43=hand, 44=finish (see MOONBOARD_HOLD_STATE_CODES)
-  const regex = /p(\d+)r(\d+)/g;
-  let match;
-  while ((match = regex.exec(frames)) !== null) {
-    const holdId = parseInt(match[1], 10);
-    const roleCode = parseInt(match[2], 10);
-
-    // Determine which hold state to use based on role code
-    let holdStateKey: 'start' | 'hand' | 'finish';
-    if (roleCode === MOONBOARD_HOLD_STATE_CODES.start) {
-      holdStateKey = 'start';
-    } else if (roleCode === MOONBOARD_HOLD_STATE_CODES.finish) {
-      holdStateKey = 'finish';
-    } else if (roleCode === MOONBOARD_HOLD_STATE_CODES.hand) {
-      holdStateKey = 'hand';
-    } else {
-      // Unexpected role code - log a warning and default to 'hand'
-      console.warn(
-        `[MoonBoard] Unexpected role code ${roleCode} for hold ${holdId} in frames "${frames.slice(0, 50)}${frames.length > 50 ? '...' : ''}". Defaulting to HAND state.`
-      );
-      holdStateKey = 'hand';
-    }
-    const holdState = MOONBOARD_HOLD_STATES[holdStateKey];
-
-    map[holdId] = {
-      state: holdState.name,
-      color: holdState.color,
-      displayColor: holdState.displayColor,
-    };
-  }
-  return map;
-}
-
-// Query Moonboard climbs directly from the database
-async function getMoonboardClimbs(layoutId: number, angle: number, limit: number): Promise<Climb[]> {
-  const { climbs } = UNIFIED_TABLES;
-
-  const results = await dbz
-    .select({
-      uuid: climbs.uuid,
-      name: climbs.name,
-      description: climbs.description,
-      frames: climbs.frames,
-      angle: climbs.angle,
-      setterUsername: climbs.setterUsername,
-      createdAt: climbs.createdAt,
-      // Join with climb stats for grade info
-      displayDifficulty: boardClimbStats.displayDifficulty,
-      benchmarkDifficulty: boardClimbStats.benchmarkDifficulty,
-      qualityAverage: boardClimbStats.qualityAverage,
-      ascensionistCount: boardClimbStats.ascensionistCount,
-    })
-    .from(climbs)
-    .leftJoin(
-      boardClimbStats,
-      and(
-        eq(boardClimbStats.boardType, 'moonboard'),
-        eq(boardClimbStats.climbUuid, climbs.uuid),
-        eq(boardClimbStats.angle, angle)
-      )
-    )
-    .where(
-      and(
-        eq(climbs.boardType, 'moonboard'),
-        eq(climbs.layoutId, layoutId),
-        eq(climbs.angle, angle)
-      )
-    )
-    .orderBy(desc(climbs.createdAt))
-    .limit(limit);
-
-  return results.map((row) => {
-    // Look up grade info from the shared BOULDER_GRADES constant.
-    // displayDifficulty is stored as double precision in the database but represents
-    // an integer difficulty_id. getGradeByDifficultyId rounds it to handle any
-    // floating point imprecision from database/ORM serialization.
-    const gradeInfo = row.displayDifficulty ? getGradeByDifficultyId(row.displayDifficulty) : undefined;
-
-    return {
-      uuid: row.uuid,
-      setter_username: row.setterUsername || 'Unknown',
-      name: row.name || 'Unnamed Climb',
-      description: row.description || '',
-      frames: row.frames || '',
-      angle: row.angle || angle,
-      ascensionist_count: row.ascensionistCount || 0,
-      // Format difficulty as "6a/V3" style for ClimbTitle to extract V-grade
-      difficulty: gradeInfo ? gradeInfo.difficulty_name : '',
-      // Set quality_average to "3" when we have a grade so ClimbTitle shows it
-      // (hasGrade check requires quality_average && quality_average !== '0')
-      quality_average: gradeInfo ? (row.qualityAverage ? String(row.qualityAverage) : '3') : '0',
-      stars: 0,
-      difficulty_error: '0',
-      litUpHoldsMap: parseMoonboardFrames(row.frames || ''),
-      benchmark_difficulty: row.benchmarkDifficulty ? String(row.benchmarkDifficulty) : null,
-    };
-  });
-}
 
 export default async function DynamicResultsPage(props: {
   params: Promise<BoardRouteParametersWithUuid>;
@@ -243,27 +132,11 @@ export default async function DynamicResultsPage(props: {
   }
 
   try {
-    // Moonboard queries the database directly (no GraphQL support yet)
-    if (parsedParams.board_name === 'moonboard') {
-      const moonboardClimbs = await getMoonboardClimbs(
-        parsedParams.layout_id,
-        parsedParams.angle,
-        searchParamsObject.pageSize || 50
-      );
-      searchResponse = {
-        searchClimbs: {
-          climbs: moonboardClimbs,
-          totalCount: moonboardClimbs.length,
-          hasMore: false,
-        },
-      };
-    } else {
-      searchResponse = await cachedSearchClimbs<ClimbSearchResponse>(
-        SEARCH_CLIMBS,
-        { input: searchInput },
-        isDefaultSearch,
-      );
-    }
+    searchResponse = await cachedSearchClimbs<ClimbSearchResponse>(
+      SEARCH_CLIMBS,
+      { input: searchInput },
+      isDefaultSearch,
+    );
   } catch (error) {
     // Log the error for server-side visibility. We intentionally degrade to empty results
     // rather than returning a 404, since the client-side React Query in QueueContext will

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -54,9 +54,6 @@ export const useQueueDataFetching = ({
     ] as const;
   }, [searchParams, parsedParams]);
 
-  // Moonboard doesn't support GraphQL search yet
-  const isMoonboard = parsedParams.board_name === 'moonboard';
-
   const {
     data,
     fetchNextPage,
@@ -67,10 +64,6 @@ export const useQueueDataFetching = ({
   } = useInfiniteQuery({
     queryKey,
     queryFn: async ({ pageParam }): Promise<SearchClimbsResult> => {
-      // Return empty results for Moonboard (GraphQL doesn't support it yet)
-      if (isMoonboard) {
-        return { climbs: [], totalCount: 0, hasMore: false };
-      }
       // Build GraphQL input from search params
       const input = {
         boardName: parsedParams.board_name,

--- a/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
+++ b/packages/web/app/components/setup-wizard/consolidated-board-config.tsx
@@ -277,7 +277,14 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
     if (defaultSizeId !== null) {
       setSelectedSize(defaultSizeId);
     } else {
-      setSelectedSize(undefined);
+      // Fall back to first available size from board configs (needed for moonboard
+      // which has sizes in boardConfigs but not in the generated product-sizes-data)
+      const availableSizes = boardConfigs.sizes[`${selectedBoard}-${selectedLayout}`] || [];
+      if (availableSizes.length > 0) {
+        setSelectedSize(availableSizes[0].id);
+      } else {
+        setSelectedSize(undefined);
+      }
     }
 
     setSelectedSets([]);
@@ -537,22 +544,24 @@ const ConsolidatedBoardConfig = ({ boardConfigs }: ConsolidatedBoardConfigProps)
                 </Form.Item>
               </Col>
 
-              <Col xs={24} sm={12}>
-                <Form.Item label="Size" noStyle>
-                  <Select
-                    value={selectedSize}
-                    onChange={handleSizeChange}
-                    placeholder="Select size"
-                    disabled={!selectedLayout}
-                  >
-                    {sizes.map(({ id, name, description }) => (
-                      <Option key={id} value={id}>
-                        {`${name} ${description}`}
-                      </Option>
-                    ))}
-                  </Select>
-                </Form.Item>
-              </Col>
+              {selectedBoard !== 'moonboard' && (
+                <Col xs={24} sm={12}>
+                  <Form.Item label="Size" noStyle>
+                    <Select
+                      value={selectedSize}
+                      onChange={handleSizeChange}
+                      placeholder="Select size"
+                      disabled={!selectedLayout}
+                    >
+                      {sizes.map(({ id, name, description }) => (
+                        <Option key={id} value={id}>
+                          {`${name} ${description}`}
+                        </Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                </Col>
+              )}
 
               <Col xs={24} sm={12}>
                 <Form.Item label="Hold Sets" noStyle>

--- a/packages/web/app/lib/board-data.ts
+++ b/packages/web/app/lib/board-data.ts
@@ -161,9 +161,9 @@ export type BoulderGrade = typeof BOULDER_GRADES[number];
 // Alias for backwards compatibility
 export const TENSION_KILTER_GRADES = BOULDER_GRADES;
 
-// MoonBoard only supports grades V3+ (6A and above)
+// MoonBoard supports grades from 5+ (V1) and above
 // Uses Font grade notation (uppercase) for display
-export const MOONBOARD_MIN_DIFFICULTY_ID = 16; // 6a/V3
+export const MOONBOARD_MIN_DIFFICULTY_ID = 13; // 5a/V1 (MoonBoard "5+" grade)
 
 // Helper to get grades for a specific board
 export function getGradesForBoard(boardName: BoardName) {

--- a/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
+++ b/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
@@ -61,7 +61,8 @@ export const createClimbFilters = (
 
   // Size-specific conditions using pre-fetched static edge values
   // This eliminates the need for a JOIN on product_sizes in the main query
-  const sizeConditions: SQL[] = [
+  // MoonBoard climbs have NULL edge values (single fixed size), so skip edge filtering
+  const sizeConditions: SQL[] = params.board_name === 'moonboard' ? [] : [
     sql`${tables.climbs.edgeLeft} > ${sizeEdges.edgeLeft}`,
     sql`${tables.climbs.edgeRight} < ${sizeEdges.edgeRight}`,
     sql`${tables.climbs.edgeBottom} > ${sizeEdges.edgeBottom}`,

--- a/packages/web/app/lib/db/queries/util/table-select.ts
+++ b/packages/web/app/lib/db/queries/util/table-select.ts
@@ -81,7 +81,7 @@ export function getUnifiedTable<K extends keyof UnifiedTableSet>(
  * @returns True if the board name is valid
  */
 export function isValidBoardName(boardName: string): boardName is BoardName {
-  return boardName === 'kilter' || boardName === 'tension';
+  return boardName === 'kilter' || boardName === 'tension' || boardName === 'moonboard';
 }
 
 /**

--- a/packages/web/app/lib/moonboard-config.ts
+++ b/packages/web/app/lib/moonboard-config.ts
@@ -6,8 +6,11 @@ export const MOONBOARD_ENABLED = true;
 
 // MoonBoard grades - uses uppercase Font notation for display
 // These grades match the board_difficulty_grades table and BOULDER_GRADES in board-data.ts
-// MoonBoard only supports V3+ (starting from 6a)
+// MoonBoard supports grades from 5+ (V1) and above
 export const MOONBOARD_GRADES = [
+  { value: '5+', label: '5+ (V1)', difficultyId: 13 },
+  { value: '5B', label: '5B (V1)', difficultyId: 14 },
+  { value: '5C', label: '5C (V2)', difficultyId: 15 },
   { value: '6A', label: '6A (V3)', difficultyId: 16 },
   { value: '6A+', label: '6A+ (V3)', difficultyId: 17 },
   { value: '6B', label: '6B (V4)', difficultyId: 18 },

--- a/packages/web/app/lib/moonboard-config.ts
+++ b/packages/web/app/lib/moonboard-config.ts
@@ -33,6 +33,7 @@ export const MOONBOARD_LAYOUTS = {
   'moonboard-2024': { id: 3, name: 'MoonBoard 2024', folder: 'moonboard2024' },
   'moonboard-masters-2017': { id: 4, name: 'MoonBoard Masters 2017', folder: 'moonboardmasters2017' },
   'moonboard-masters-2019': { id: 5, name: 'MoonBoard Masters 2019', folder: 'moonboardmasters2019' },
+  'mini-moonboard-2020': { id: 6, name: 'Mini MoonBoard 2020', folder: 'minimoonboard2020' },
 } as const;
 
 export type MoonBoardLayoutKey = keyof typeof MOONBOARD_LAYOUTS;
@@ -71,6 +72,12 @@ export const MOONBOARD_SETS: Record<MoonBoardLayoutKey, { id: number; name: stri
     { id: 21, name: 'Wooden Holds', imageFile: 'woodenholds.png' },
     { id: 22, name: 'Wooden Holds B', imageFile: 'woodenholdsb.png' },
     { id: 23, name: 'Wooden Holds C', imageFile: 'woodenholdsc.png' },
+  ],
+  'mini-moonboard-2020': [
+    { id: 24, name: 'Original School Holds', imageFile: 'originalschoolholds.png' },
+    { id: 25, name: 'Wooden Holds', imageFile: 'woodenholds.png' },
+    { id: 26, name: 'Wooden Holds B', imageFile: 'woodenholdsb.png' },
+    { id: 27, name: 'Wooden Holds C', imageFile: 'woodenholdsc.png' },
   ],
 };
 


### PR DESCRIPTION
## Summary

- **Bulk import script** for MoonBoard problems into the unified database schema (`packages/db/scripts/import-moonboard-problems.ts`), plus Mini MoonBoard 2020 layout config
- **Fix MoonBoard search, filters, and infinite scroll** — removes temporary scaffolding that short-circuited GraphQL search for MoonBoard, skips edge-based size filtering (MoonBoard has NULL edges / single fixed size), fixes `isValidBoardName` to include moonboard, hides the size selector in the setup wizard, and adds a fallback for auto-selecting the size from board configs
- **Fix 5+ grade support** — lower `MOONBOARD_MIN_DIFFICULTY_ID` to include 5+/V1 climbs in grade filters, add missing grades to `MOONBOARD_GRADES`
- **Tests** for import script helpers — 21 tests covering coordinate conversion, frame encoding, hold state mapping, and UUID v5 generation

## Changes

### Commit 1: `feat: add MoonBoard bulk import script and Mini MoonBoard 2020 layout`
- Add `import-moonboard-problems.ts` bulk import script with `npm run db:import-moonboard`
- Add Mini MoonBoard 2020 layout to `moonboard-config.ts`

### Commit 2: `fix: enable MoonBoard search, filters, and infinite scroll`
- Remove moonboard early-return in client-side `useInfiniteQuery` (`use-queue-data-fetching.tsx`)
- Remove SSR moonboard bypass (`getMoonboardClimbs` direct DB query) from list page — use standard GraphQL path
- Skip size-edge SQL conditions for moonboard in both backend and web `create-climb-filters.ts`
- Fix `isValidBoardName()` in web to include `'moonboard'`
- Hide size selector for moonboard in setup wizard (single fixed size)
- Add fallback size auto-selection from `boardConfigs` when generated data is unavailable

### Commit 3: `fix: add 5+ grade support, extract and test import helpers`
- Lower `MOONBOARD_MIN_DIFFICULTY_ID` from 16 to 13 so 5+ (V1) climbs appear in grade filters
- Add 5+, 5B, 5C grades to `MOONBOARD_GRADES`
- Extract pure helper functions into `moonboard-helpers.ts` for testability
- Add 21 tests (`moonboard-helpers.test.ts`) with `node:test` — run via `npm test` in `packages/db`

## Test plan

- [ ] Run `npm test --workspace=@boardsesh/db` — all 21 tests pass
- [ ] Select MoonBoard in setup wizard — size selector should be hidden, sets should auto-populate
- [ ] Navigate to MoonBoard list page — SSR should render climbs with grades
- [ ] Scroll down — infinite scroll should load more climbs
- [ ] Apply filters (grade, name, setter) — results should update correctly
- [ ] Grade filter should include 5+ (V1) as the lowest option for MoonBoard
- [ ] Verify kilter/tension search still works normally (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)