### PR TITLE
Add IndexedDB persistence for local climbing queues

### DIFF
--- a/packages/web/app/lib/queue-storage-db.ts
+++ b/packages/web/app/lib/queue-storage-db.ts
@@ -1,0 +1,183 @@
+import { openDB, IDBPDatabase } from 'idb';
+import { ClimbQueueItem } from '../components/queue-control/types';
+import { BoardDetails } from './types';
+
+const DB_NAME = 'boardsesh-queue';
+const DB_VERSION = 1;
+const STORE_NAME = 'queues';
+
+/**
+ * Stored queue state for a specific board configuration
+ */
+export interface StoredQueueState {
+  boardPath: string;
+  queue: ClimbQueueItem[];
+  currentClimbQueueItem: ClimbQueueItem | null;
+  boardDetails: BoardDetails;
+  updatedAt: number;
+}
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+
+const initDB = async (): Promise<IDBPDatabase> => {
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          // Create store with boardPath as key
+          db.createObjectStore(STORE_NAME);
+        }
+      },
+    });
+  }
+  return dbPromise;
+};
+
+/**
+ * Get the queue key for a board path
+ * Uses the full board path as key for simplicity
+ */
+function getQueueKey(boardPath: string): string {
+  return `queue:${boardPath}`;
+}
+
+/**
+ * Get stored queue state for a specific board path
+ */
+export const getStoredQueue = async (boardPath: string): Promise<StoredQueueState | null> => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const db = await initDB();
+    const key = getQueueKey(boardPath);
+    const stored = await db.get(STORE_NAME, key);
+
+    if (stored) {
+      // Filter out any corrupted items
+      const filteredQueue = (stored.queue || []).filter(
+        (item: ClimbQueueItem | null | undefined): item is ClimbQueueItem =>
+          item != null && item.climb != null
+      );
+
+      return {
+        ...stored,
+        queue: filteredQueue,
+      };
+    }
+
+    return null;
+  } catch (error) {
+    console.error('[QueueStorage] Failed to get stored queue:', error);
+    return null;
+  }
+};
+
+/**
+ * Save queue state for a specific board path
+ */
+export const saveQueueState = async (state: StoredQueueState): Promise<void> => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const db = await initDB();
+    const key = getQueueKey(state.boardPath);
+
+    // Ensure we save with timestamp
+    const stateWithTimestamp: StoredQueueState = {
+      ...state,
+      updatedAt: Date.now(),
+    };
+
+    await db.put(STORE_NAME, stateWithTimestamp, key);
+  } catch (error) {
+    console.error('[QueueStorage] Failed to save queue state:', error);
+    throw error;
+  }
+};
+
+/**
+ * Clear stored queue for a specific board path
+ */
+export const clearStoredQueue = async (boardPath: string): Promise<void> => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const db = await initDB();
+    const key = getQueueKey(boardPath);
+    await db.delete(STORE_NAME, key);
+  } catch (error) {
+    console.error('[QueueStorage] Failed to clear stored queue:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get all stored queue states (for debugging or cleanup)
+ */
+export const getAllStoredQueues = async (): Promise<StoredQueueState[]> => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const db = await initDB();
+    const allKeys = await db.getAllKeys(STORE_NAME);
+    const queues: StoredQueueState[] = [];
+
+    for (const key of allKeys) {
+      const stored = await db.get(STORE_NAME, key);
+      if (stored) {
+        queues.push(stored);
+      }
+    }
+
+    return queues;
+  } catch (error) {
+    console.error('[QueueStorage] Failed to get all stored queues:', error);
+    return [];
+  }
+};
+
+/**
+ * Clean up old stored queues (older than specified days)
+ * Default: 30 days
+ */
+export const cleanupOldQueues = async (maxAgeDays: number = 30): Promise<number> => {
+  if (typeof window === 'undefined') {
+    return 0;
+  }
+
+  try {
+    const db = await initDB();
+    const allKeys = await db.getAllKeys(STORE_NAME);
+    const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    let cleanedCount = 0;
+
+    for (const key of allKeys) {
+      const stored = await db.get(STORE_NAME, key);
+      if (stored && stored.updatedAt) {
+        const age = now - stored.updatedAt;
+        if (age > maxAgeMs) {
+          await db.delete(STORE_NAME, key);
+          cleanedCount++;
+        }
+      }
+    }
+
+    if (cleanedCount > 0) {
+      console.log(`[QueueStorage] Cleaned up ${cleanedCount} old queue(s)`);
+    }
+
+    return cleanedCount;
+  } catch (error) {
+    console.error('[QueueStorage] Failed to cleanup old queues:', error);
+    return 0;
+  }
+};


### PR DESCRIPTION
## Summary
This PR adds IndexedDB-based persistence for local climbing queues, allowing users to resume their queue state after browser refreshes or navigation without losing progress. The implementation includes automatic cleanup of stale queue data and debounced saves to optimize database writes.

## Key Changes

- **New Queue Storage Module** (`queue-storage-db.ts`): Created a new IndexedDB abstraction layer that handles:
  - Saving and retrieving queue state for specific board paths
  - Automatic cleanup of queues older than 30 days
  - Corruption filtering to ensure data integrity
  - Server-side rendering safety checks

- **Enhanced PersistentSessionContext**: 
  - Added `isLocalQueueLoaded` state to track whether the queue has been loaded from storage
  - Implemented `loadStoredQueue()` method to retrieve persisted queue data
  - Added debounced saves to IndexedDB (500ms debounce) to reduce write frequency
  - Integrated automatic cleanup of old queues on provider mount
  - Proper cleanup of pending saves on unmount

- **Improved QueueContext Initialization**:
  - Enhanced the queue initialization effect to handle both in-memory and IndexedDB-persisted state
  - Added logic to load from IndexedDB on initial page load after browser refresh
  - Maintains separate paths for in-memory navigation vs. fresh page loads
  - Changed dependency array to trigger on `isLocalQueueLoaded` changes

## Implementation Details

- **Debouncing**: Queue saves are debounced to 500ms to prevent excessive IndexedDB writes while maintaining responsiveness
- **Data Integrity**: Stored queues are filtered to remove corrupted items (null/undefined climbs) on retrieval
- **Cleanup Strategy**: Old queues (>30 days) are automatically cleaned up on app startup to prevent unbounded storage growth
- **Party Mode Compatibility**: Queue persistence is disabled when party mode is active, maintaining existing behavior
- **SSR Safe**: All IndexedDB operations check for `window` availability to support server-side rendering

## Testing Considerations
- Verify queue persists across browser refreshes
- Confirm navigation between board routes maintains queue state
- Test that party mode doesn't interfere with local queue persistence
- Validate cleanup removes only queues older than 30 days

https://claude.ai/code/session_015oMGwcYkR4zWN1iRQEKwN1