### PR TITLE
Fix janky scroll-based queue drawer expansion

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -113,47 +113,23 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     setSelectedItems(new Set());
   }, []);
 
-  // Handle scroll-based drawer expansion with smooth animation
+  // Handle scroll-based drawer expansion - two-state snap
   useEffect(() => {
     const scrollEl = queueScrollRef.current;
     if (!scrollEl || !isQueueOpen) return;
 
-    const calculateHeight = (scrollTop: number, scrollHeight: number, clientHeight: number) => {
-      if (scrollTop <= 0) {
-        return '60%';
-      }
-      
-      // Calculate maximum scrollable distance
-      const maxScroll = scrollHeight - clientHeight;
-      if (maxScroll <= 0) {
-        return '60%';
-      }
-      
-      // Calculate progress from 0 to 1 based on scroll position relative to max scroll
-      // Use a smooth curve - starts expanding quickly, then slows down
-      const scrollProgress = Math.min(scrollTop / maxScroll, 1);
-      // Apply easing function for smoother expansion (ease-out curve)
-      const easedProgress = 1 - Math.pow(1 - scrollProgress, 2);
-      
-      // Interpolate between 60% and 100%
-      const heightPercent = 60 + (easedProgress * 40);
-      return `${heightPercent}%`;
-    };
+    const EXPAND_THRESHOLD = 10; // px of scroll to trigger expansion
 
     const handleScroll = () => {
-      const scrollTop = scrollEl.scrollTop;
-      const scrollHeight = scrollEl.scrollHeight;
-      const clientHeight = scrollEl.clientHeight;
-      setQueueDrawerHeight(calculateHeight(scrollTop, scrollHeight, clientHeight));
+      const isScrolled = scrollEl.scrollTop > EXPAND_THRESHOLD;
+      setQueueDrawerHeight(isScrolled ? '100%' : '60%');
     };
 
-    // Check initial scroll position when drawer opens
+    // Check initial scroll position
     handleScroll();
 
     scrollEl.addEventListener('scroll', handleScroll, { passive: true });
-    return () => {
-      scrollEl.removeEventListener('scroll', handleScroll);
-    };
+    return () => scrollEl.removeEventListener('scroll', handleScroll);
   }, [isQueueOpen]);
 
   // Reset drawer height when queue drawer closes
@@ -226,7 +202,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     >
       <div className={styles.drawerContent}>
         {/* Board renderer with card-swipe */}
-        {isOpen && currentClimb && (
+        {currentClimb && (
           <SwipeBoardCarousel
             boardDetails={boardDetails}
             currentClimb={currentClimb}


### PR DESCRIPTION
## Summary
- Replace progressive per-frame height interpolation (60% → 72% → 85% → 100%) with a two-state snap (60% compact / 100% expanded) triggered by a 10px scroll threshold
- Eliminates per-scroll-frame React re-renders — at most 2 state changes per interaction, with CSS `transition` handling the smooth animation
- Remove redundant `isOpen` guard on `SwipeBoardCarousel` since the parent drawer already controls visibility

## Test plan
- [ ] Open queue drawer → starts at 60% height
- [ ] Scroll down in queue list → drawer snaps smoothly to 100%
- [ ] Scroll back to top → drawer snaps smoothly back to 60%
- [ ] Swipe down on drag handle → drawer dismisses
- [ ] Close and reopen → starts at 60% again

🤖 Generated with [Claude Code](https://claude.com/claude-code)