### PR TITLE
Use MUI theme-compatible border color in angle selector

### DIFF
--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -157,7 +157,7 @@ export default function AngleSelector({ boardName, boardDetails, currentAngle, c
         styles={{ wrapper: { width: '90%' }, body: { padding: 12 } }}
       >
         {currentClimb && (
-          <Box sx={{ mb: 2, pb: 2, borderBottom: `1px solid ${themeTokens.neutral[200]}` }}>
+          <Box sx={{ mb: 2, pb: 2, borderBottom: 1, borderColor: 'divider' }}>
             <DrawerClimbHeader climb={currentClimb} boardDetails={boardDetails} />
           </Box>
         )}


### PR DESCRIPTION
Replace hardcoded themeTokens.neutral[200] border color with MUI's
borderColor: 'divider' for better dark mode compatibility.

https://claude.ai/code/session_01RYMcDyvuFU6uQEZwCF35Ys