### PR TITLE
Fix grade alignment in climb card action drawer

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -189,8 +189,6 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
     return (
       <Box sx={{ display: 'flex', gap: '12px', alignItems: 'center', ...(centered ? { position: 'relative' } : {}) }} className={className}>
-        {/* Colorized V grade on the left */}
-        {largeGradeElement}
         {/* Center: Name and quality/setter stacked */}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0, flex: 1, minWidth: 0, alignItems: centered ? 'center' : 'flex-start' }}>
           {/* Row 1: Name with addon */}
@@ -212,6 +210,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
             {secondLineContent.length > 0 ? secondLineContent.join(' · ') : <Box component="span" sx={{ fontStyle: 'italic' }}>project</Box>}
           </Typography>
         </Box>
+        {/* Colorized V grade on the right */}
+        {largeGradeElement}
         {/* Right addon (e.g., ascent status) */}
         {rightAddon}
       </Box>


### PR DESCRIPTION
Move colorized V-grade from between thumbnail and title to the far right in the horizontal ClimbTitle layout. This affects the drawer header and card headers, aligning with the intended design pattern.

https://claude.ai/code/session_019dXZJ2pVsssFNEHjWRCQ59