### PR TITLE
Remove ascent indicator from queue control bar climb title

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -22,7 +22,6 @@ import QueueList, { QueueListHandle } from './queue-list';
 import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
-import { AscentStatus } from './queue-list-item';
 import { themeTokens } from '@/app/theme/theme-config';
 import { TOUR_DRAWER_EVENT } from '../onboarding/onboarding-tour';
 import { ShareBoardButton } from '../board-page/share-button';
@@ -313,7 +312,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       <ClimbTitle
                         climb={currentClimb}
                         showAngle
-                        nameAddon={currentClimb?.name && <AscentStatus climbUuid={currentClimb.uuid} />}
                       />
                     </div>
 
@@ -329,7 +327,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         <ClimbTitle
                           climb={peekClimbData}
                           showAngle
-                          nameAddon={peekClimbData?.name && <AscentStatus climbUuid={peekClimbData.uuid} />}
                         />
                       </div>
                     )}


### PR DESCRIPTION
The AscentStatus component (checkmark/X icon) was shown next to the climb name in the queue control bar. This removes it from both the current climb and the peek (swipe preview) climb titles.

https://claude.ai/code/session_01A5UTFJoUcYLwA2yraDvuJS