### PR TITLE
Fix climblist visible below play view drawer after closing queue list

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -337,6 +337,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           open={isQueueOpen}
           showCloseButton={false}
           swipeEnabled={true}
+          disablePortal
           onClose={() => {
             setIsQueueOpen(false);
             handleExitEditMode();


### PR DESCRIPTION
Add disablePortal to the nested queue SwipeableDrawer inside
PlayViewDrawer. Without it, the queue drawer renders as a separate
portal-level modal. When it closes, MUI's modal manager incorrectly
restores body scroll/overflow, making the underlying ClimbsList peek
through below the still-open play view drawer. The actions drawer
already had disablePortal set correctly.

https://claude.ai/code/session_011pKs3md8vjMz5tbKcYzf9f