### PR TITLE
Fix play view board sizing: cap height and center smaller boards

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -15,8 +15,9 @@
 .boardSection {
   flex: 1;
   min-height: 0;
+  max-height: 60dvh;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
Add max-height: 60dvh to boardSection to prevent large boards (e.g. 10x12
Kilter Home Wall) from pushing controls below the fold. Change align-items
to center so smaller boards (e.g. 12x12 Kilter OG) are vertically centered
instead of top-aligned with excess whitespace below.

https://claude.ai/code/session_01HuL29QsYGnpEBSuybZBsbB