### PR TITLE
Fix vertical scrolling on climb board in playview

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -20,7 +20,7 @@
   justify-content: center;
   overflow: hidden;
   position: relative;
-  touch-action: none;
+  touch-action: pan-y;
 }
 
 .climbInfoSection {


### PR DESCRIPTION
Change touch-action from 'none' to 'pan-y' on .boardSection so the
browser allows native vertical scrolling when the user touches the
board. The swipe hook already distinguishes horizontal from vertical
gestures, so CSS-level blocking of vertical touch is unnecessary.

https://claude.ai/code/session_019nFRukEYGwHVuroKeRBgpG