### PR TITLE
Fix iOS bottom bar transparency not extending below browser pill

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
@@ -1,4 +1,5 @@
 .tabBar {
+  position: relative;
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -8,6 +9,23 @@
   backdrop-filter: blur(10px);
   padding-top: 4px;
   padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Extend the glass effect well below the tab bar to cover the area
+   behind the iOS Safari bottom toolbar and home indicator pill.
+   Without this, iOS shows a solid background in the gap between
+   the fixed bottom bar and the screen edge. */
+.tabBar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: 200px;
+  background: rgba(255, 255, 255, 0.4);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  pointer-events: none;
 }
 
 .tabItem {


### PR DESCRIPTION
Add a ::after pseudo-element to the bottom tab bar that extends the glass effect (backdrop-filter blur + semi-transparent background) 200px below the bar. On iOS Safari, the area between the fixed bottom bar and the screen edge shows a solid grey background. This pseudo-element covers that gap so the frosted glass effect continues seamlessly through the home indicator and browser toolbar area.

https://claude.ai/code/session_013rVug2xdKaRqxQXMCtZxRq