### PR TITLE
Fix GraphQL schema sync: generate operations from schema, fix nested …

### DIFF
--- a/embedded/scripts/prebuild.py
+++ b/embedded/scripts/prebuild.py
@@ -10,7 +10,6 @@ Usage in platformio.ini:
 """
 
 import os
-import sys
 import subprocess
 import hashlib
 from pathlib import Path


### PR DESCRIPTION
…brace parser

- Replace hardcoded GraphQL operation strings with schema-driven generation using generateFieldSelection() that auto-generates field selections from parsed types, keeping operations in sync as the schema evolves
- Add ESP32_FIELD_EXCLUSIONS config with documented reasons for each field intentionally omitted from LedUpdate (memory constraints on ~320KB RAM)
- Fix nested brace parser: replace [^}]+ regex with brace-counting algorithm that correctly handles directives with object arguments like @directive(config: { key: "value" })
- Simplify string literals during parsing to prevent mismatched braces in strings from confusing the brace counter
- Remove unused sys import from prebuild.py

https://claude.ai/code/session_01W3bsxwa8MoQ27ps5TW6Z2i