### PR TITLE
Fix board clipping by using aspect-ratio sizing instead of flex fill

### DIFF
--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -92,7 +92,11 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   const transition = getSwipeTransition();
 
   return (
-    <div className={`${styles.carouselContainer} ${className ?? ''}`} {...swipeHandlers}>
+    <div
+      className={`${styles.carouselContainer} ${className ?? ''}`}
+      style={{ aspectRatio: `${boardDetails.boardWidth} / ${boardDetails.boardHeight}` }}
+      {...swipeHandlers}
+    >
       <div
         className={boardContainerClassName}
         style={{

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -13,12 +13,10 @@
 }
 
 .boardSection {
-  flex: 1;
+  flex-shrink: 0;
   min-height: 0;
   max-height: 60dvh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  width: 100%;
   overflow: hidden;
   position: relative;
   touch-action: none;


### PR DESCRIPTION
The previous approach (flex: 1 + max-height + align-items: center) caused the board to be clipped at the top because centering within an overflowing container hides both top and bottom equally.

Instead, use CSS aspect-ratio on the carousel container to match the board's actual proportions. The container now sizes naturally to the board's width/ height ratio, capped at max-height: 60dvh. This eliminates wasted space for all board sizes - no clipping for large boards like 10x12 Kilter Home Wall, and minimal whitespace for smaller boards like 12x12 Kilter OG.

https://claude.ai/code/session_01HuL29QsYGnpEBSuybZBsbB