### PR TITLE
Use 80dvh max-height for board section

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -13,9 +13,9 @@
 }
 
 .boardSection {
-  flex-shrink: 0;
+  flex-shrink: 1;
   min-height: 0;
-  max-height: 60dvh;
+  max-height: 80dvh;
   width: 100%;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
Give the board 80dvh of the viewport, leaving 20dvh for the climb info and action bar below it. This prevents the board from being clipped while keeping controls visible.

https://claude.ai/code/session_01HuL29QsYGnpEBSuybZBsbB