### PR TITLE
Fix bottom rows clipped by constraining carousel to parent height

### DIFF
--- a/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
@@ -1,6 +1,7 @@
 .carouselContainer {
   position: relative;
   overflow: hidden;
+  max-height: 100%;
 }
 
 .peekBoardContainer {


### PR DESCRIPTION
The carousel container's aspect-ratio made it taller than the parent's
80dvh max-height, causing overflow clipping. Adding max-height: 100%
ensures the carousel respects the parent constraint and the SVG's
preserveAspectRatio scales the full board to fit.

https://claude.ai/code/session_011w4GqHuJm1jV97TP7FqRqS