### PR TITLE
Fix iOS bottom bar: use solid background instead of translucent glass

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.module.css
@@ -11,10 +11,10 @@
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-/* Extend the glass effect well below the tab bar to cover the area
-   behind the iOS Safari bottom toolbar and home indicator pill.
-   Without this, iOS shows a solid background in the gap between
-   the fixed bottom bar and the screen edge. */
+/* Extend background below the tab bar to cover the area behind the
+   iOS Safari bottom toolbar / home indicator pill.  This region is
+   below the viewport edge so there is no page content to blur through;
+   use a solid surface color instead of a translucent glass effect. */
 .tabBar::after {
   content: '';
   position: absolute;
@@ -22,9 +22,7 @@
   right: 0;
   top: 100%;
   height: 200px;
-  background: rgba(255, 255, 255, 0.4);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background: var(--semantic-surface);
   pointer-events: none;
 }
 


### PR DESCRIPTION
The ::after pseudo-element below the tab bar extends past the viewport edge where there is no page content to blur through. backdrop-filter over the dark area iOS renders below the viewport produced a solid grey appearance. Switch to a solid var(--semantic-surface) background since transparency serves no purpose in this region.

https://claude.ai/code/session_013rVug2xdKaRqxQXMCtZxRq