### PR TITLE
Fix board bottom rows clipped: use flex fill instead of aspect-ratio …

### DIFF
--- a/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
@@ -1,7 +1,6 @@
 .carouselContainer {
   position: relative;
   overflow: hidden;
-  max-height: 100%;
 }
 
 .peekBoardContainer {

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -30,6 +30,8 @@ export interface SwipeBoardCarouselProps {
   className?: string;
   /** CSS class for the inner board wrapper that translates during swipe */
   boardContainerClassName?: string;
+  /** When true, skip aspect-ratio and let the container fill its parent (parent controls sizing via flex). */
+  fillContainer?: boolean;
 }
 
 const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
@@ -43,6 +45,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   canSwipePrevious,
   className,
   boardContainerClassName,
+  fillContainer,
 }) => {
   const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -94,7 +97,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   return (
     <div
       className={`${styles.carouselContainer} ${className ?? ''}`}
-      style={{ aspectRatio: `${boardDetails.boardWidth} / ${boardDetails.boardHeight}` }}
+      style={fillContainer ? undefined : { aspectRatio: `${boardDetails.boardWidth} / ${boardDetails.boardHeight}` }}
       {...swipeHandlers}
     >
       <div

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -13,9 +13,8 @@
 }
 
 .boardSection {
-  flex-shrink: 1;
+  flex: 1;
   min-height: 0;
-  max-height: 80dvh;
   width: 100%;
   overflow: hidden;
   position: relative;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -217,6 +217,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               canSwipePrevious={canSwipePrevious}
               className={styles.boardSection}
               boardContainerClassName={styles.swipeCardContainer}
+              fillContainer
             />
           )}
 


### PR DESCRIPTION
…sizing

The aspect-ratio inline style on the carousel container fought against flex-shrink, preventing the board from shrinking to fit. Now the play view uses flex: 1 on boardSection so the board fills remaining space after climbInfo and actionBar, and the SVG's preserveAspectRatio scales the complete board to fit within that space.

Added fillContainer prop to SwipeBoardCarousel to conditionally skip the aspect-ratio inline style when the parent controls sizing via flex.

https://claude.ai/code/session_011w4GqHuJm1jV97TP7FqRqS