### PR TITLE
Fix action bar pushed out of view by constraining aboveFold height

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -7,7 +7,7 @@
 }
 
 .aboveFold {
-  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Changed aboveFold from min-height: 100% to height: 100%. With min-height, the container could grow beyond the visible area, pushing the action bar offscreen. With a definite height: 100%, the flex layout correctly distributes space: boardSection gets remaining height after climbInfo and actionBar, and the SVG scales the board to fit.

https://claude.ai/code/session_011w4GqHuJm1jV97TP7FqRqS