### PR TITLE
Replace scroll-based queue drawer expansion with deliberate drag gesture

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -47,6 +47,13 @@
   overflow: hidden;
 }
 
+.queueDragHeader {
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  flex-shrink: 0;
+}
+
 .queueBodyLayout {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The queue drawer height (60% → 100%) was expanding automatically when the user scrolled the queue list content. Now it only resizes when the user deliberately drags the header/drag handle up or down.

- Removed scroll event listener that auto-expanded the drawer
- Added custom drag header with touch event handlers for resize
- Drag up on header: expand to 100%
- Drag down from 100%: collapse to 60%
- Drag down from 60%: close the drawer
- Disabled MUI SwipeableDrawer swipe gestures on queue drawer to prevent conflicts with the custom drag handler

https://claude.ai/code/session_01KBC5LtVtKaZihb3oMcHQp5