### PR TITLE
Allow viewing other users' public playlists

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlist/[playlist_uuid]/playlist-view-content.tsx
@@ -125,9 +125,9 @@ export default function PlaylistViewContent({
     fetchPlaylist();
   }, [fetchPlaylist]);
 
-  // Update lastAccessedAt when playlist loads (fire-and-forget)
+  // Update lastAccessedAt when playlist loads (fire-and-forget, only for owners)
   useEffect(() => {
-    if (playlist && token && !lastAccessedUpdatedRef.current) {
+    if (playlist && token && playlist.userRole === 'owner' && !lastAccessedUpdatedRef.current) {
       lastAccessedUpdatedRef.current = true;
       executeGraphQL<UpdatePlaylistLastAccessedMutationResponse, UpdatePlaylistLastAccessedMutationVariables>(
         UPDATE_PLAYLIST_LAST_ACCESSED,


### PR DESCRIPTION
## Summary
- **Backend**: `playlist` and `playlistClimbs` resolvers no longer require authentication/ownership to access public playlists. Private playlists still require ownership.
- **Frontend**: `updatePlaylistLastAccessed` mutation is now guarded to only fire for playlist owners, preventing errors when non-owners view a public playlist.

## Test plan
- [ ] View your own playlist (should still work, `userRole` = 'owner', all edit/delete/generate actions visible)
- [ ] View another user's **public** playlist by UUID (should now work, `userRole` = null, owner-only actions hidden)
- [ ] Verify a **private** playlist from another user still returns not found
- [ ] Verify "Queue All" works on someone else's public playlist (fetches `playlistClimbs`)
- [ ] Verify `lastAccessedAt` is NOT updated when viewing someone else's playlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)