### PR TITLE
Add comments and votes system (Milestone 2)

### DIFF
--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -26,6 +26,8 @@ import { controllerSubscriptions, controllerEventResolver } from './controller/s
 import { socialFollowQueries, socialFollowMutations } from './social/follows';
 import { socialSearchQueries } from './social/search';
 import { socialFeedQueries } from './social/feed';
+import { socialCommentQueries, socialCommentMutations } from './social/comments';
+import { socialVoteQueries, socialVoteMutations } from './social/votes';
 
 export const resolvers = {
   // Scalar types
@@ -45,6 +47,8 @@ export const resolvers = {
     ...socialFollowQueries,
     ...socialSearchQueries,
     ...socialFeedQueries,
+    ...socialCommentQueries,
+    ...socialVoteQueries,
   },
 
   Mutation: {
@@ -56,6 +60,8 @@ export const resolvers = {
     ...playlistMutations,
     ...controllerMutations,
     ...socialFollowMutations,
+    ...socialCommentMutations,
+    ...socialVoteMutations,
   },
 
   Subscription: {

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -209,8 +209,8 @@ export const socialCommentQueries = {
       OFFSET ${offset}
     `);
 
-    // Cast the result to CommentRow array
-    const rows = (rawResult as unknown as CommentRow[]);
+    // Convert RowList to a plain array, then cast to CommentRow[]
+    const rows = Array.from(rawResult as Iterable<unknown>) as CommentRow[];
     const comments = rows.map(mapCommentRow);
 
     return {

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -206,7 +206,7 @@ export const socialCommentQueries = {
           : sql`0`
         } as "userVote"
       FROM "comments" c
-      INNER JOIN "user" u ON c."user_id" = u."id"
+      INNER JOIN "users" u ON c."user_id" = u."id"
       LEFT JOIN "user_profiles" up ON c."user_id" = up."user_id"
       LEFT JOIN "comments" parent_c ON c."parent_comment_id" = parent_c."id"
       LEFT JOIN LATERAL (

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -209,9 +209,9 @@ export const socialCommentQueries = {
       OFFSET ${offset}
     `);
 
-    // Convert RowList to a plain array, then cast to CommentRow[]
-    const rows = Array.from(rawResult as Iterable<unknown>) as CommentRow[];
-    const comments = rows.map(mapCommentRow);
+    // db.execute() returns QueryResult (neon-serverless) with .rows property
+    const rawRows = (rawResult as unknown as { rows: CommentRow[] }).rows;
+    const comments = rawRows.map(mapCommentRow);
 
     return {
       comments,

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -1,0 +1,489 @@
+import { eq, and, isNull, count, sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import {
+  AddCommentInputSchema,
+  UpdateCommentInputSchema,
+  CommentsInputSchema,
+} from '../../../validation/schemas';
+import { validateEntityExists } from './entity-validation';
+import crypto from 'crypto';
+
+interface CommentRow {
+  id: number;
+  uuid: string;
+  userId: string;
+  entityType: string;
+  entityId: string;
+  parentCommentId: number | null;
+  body: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  userName: string | null;
+  userImage: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  parentUuid: string | null;
+  replyCount: number;
+  upvotes: number;
+  downvotes: number;
+  userVote: number | null;
+}
+
+function mapCommentRow(row: CommentRow) {
+  const isDeleted = row.deletedAt !== null;
+  return {
+    uuid: row.uuid,
+    userId: row.userId,
+    userDisplayName: row.displayName || row.userName || undefined,
+    userAvatarUrl: row.avatarUrl || row.userImage || undefined,
+    entityType: row.entityType,
+    entityId: row.entityId,
+    parentCommentUuid: row.parentUuid || null,
+    body: isDeleted ? null : row.body,
+    isDeleted,
+    replyCount: Number(row.replyCount || 0),
+    upvotes: Number(row.upvotes || 0),
+    downvotes: Number(row.downvotes || 0),
+    voteScore: Number(row.upvotes || 0) - Number(row.downvotes || 0),
+    userVote: Number(row.userVote || 0),
+    createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : String(row.updatedAt),
+  };
+}
+
+/**
+ * Helper to get aggregate vote counts for a comment using the query builder
+ */
+async function getCommentVoteCounts(commentUuid: string) {
+  const upvoteResult = await db
+    .select({ count: count() })
+    .from(dbSchema.votes)
+    .where(
+      and(
+        eq(dbSchema.votes.entityType, 'comment'),
+        eq(dbSchema.votes.entityId, commentUuid),
+        eq(dbSchema.votes.value, 1),
+      ),
+    );
+  const downvoteResult = await db
+    .select({ count: count() })
+    .from(dbSchema.votes)
+    .where(
+      and(
+        eq(dbSchema.votes.entityType, 'comment'),
+        eq(dbSchema.votes.entityId, commentUuid),
+        eq(dbSchema.votes.value, -1),
+      ),
+    );
+
+  return {
+    upvotes: Number(upvoteResult[0]?.count || 0),
+    downvotes: Number(downvoteResult[0]?.count || 0),
+  };
+}
+
+export const socialCommentQueries = {
+  comments: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ) => {
+    const validated = validateInput(CommentsInputSchema, input, 'input');
+    const { entityType, entityId, parentCommentUuid, sortBy, limit = 20, offset = 0 } = validated;
+
+    const authenticatedUserId = ctx.isAuthenticated ? ctx.userId : null;
+
+    // If parentCommentUuid is provided, resolve to internal ID for filtering replies
+    let parentCommentFilter: ReturnType<typeof sql>;
+    if (parentCommentUuid) {
+      const [parentComment] = await db
+        .select({ id: dbSchema.comments.id })
+        .from(dbSchema.comments)
+        .where(eq(dbSchema.comments.uuid, parentCommentUuid))
+        .limit(1);
+
+      if (!parentComment) {
+        return { comments: [], totalCount: 0, hasMore: false };
+      }
+
+      parentCommentFilter = sql`c."parent_comment_id" = ${parentComment.id}`;
+    } else {
+      parentCommentFilter = sql`c."parent_comment_id" IS NULL`;
+    }
+
+    // Build ORDER BY based on sortBy
+    let orderByClause: ReturnType<typeof sql>;
+    switch (sortBy) {
+      case 'top':
+        orderByClause = sql`(COALESCE(v_up.cnt, 0) - COALESCE(v_down.cnt, 0)) DESC, c."created_at" DESC`;
+        break;
+      case 'controversial':
+        orderByClause = sql`
+          CASE WHEN COALESCE(v_up.cnt, 0) + COALESCE(v_down.cnt, 0) = 0 THEN 0
+          ELSE POWER(COALESCE(v_up.cnt, 0) + COALESCE(v_down.cnt, 0),
+            LEAST(COALESCE(v_up.cnt, 0)::float, COALESCE(v_down.cnt, 0)::float) /
+            GREATEST(COALESCE(v_up.cnt, 0)::float, COALESCE(v_down.cnt, 0)::float, 1)
+          ) END DESC, c."created_at" DESC`;
+        break;
+      case 'hot':
+        orderByClause = sql`
+          SIGN(COALESCE(v_up.cnt, 0) - COALESCE(v_down.cnt, 0)) *
+          LOG(GREATEST(ABS(COALESCE(v_up.cnt, 0) - COALESCE(v_down.cnt, 0)), 1)) +
+          EXTRACT(EPOCH FROM c."created_at") / 45000 DESC`;
+        break;
+      default: // 'new'
+        orderByClause = sql`c."created_at" DESC`;
+    }
+
+    // Total count query using query builder
+    const countResult = await db
+      .select({ count: count() })
+      .from(dbSchema.comments)
+      .where(
+        and(
+          eq(dbSchema.comments.entityType, entityType),
+          eq(dbSchema.comments.entityId, entityId),
+          parentCommentUuid
+            ? sql`"parent_comment_id" IS NOT NULL`
+            : isNull(dbSchema.comments.parentCommentId),
+        ),
+      );
+    // Refine count for parentCommentUuid case (need to check specific parent)
+    let totalCount: number;
+    if (parentCommentUuid) {
+      const [parentComment] = await db
+        .select({ id: dbSchema.comments.id })
+        .from(dbSchema.comments)
+        .where(eq(dbSchema.comments.uuid, parentCommentUuid))
+        .limit(1);
+
+      if (!parentComment) {
+        totalCount = 0;
+      } else {
+        const pcResult = await db
+          .select({ count: count() })
+          .from(dbSchema.comments)
+          .where(
+            and(
+              eq(dbSchema.comments.entityType, entityType),
+              eq(dbSchema.comments.entityId, entityId),
+              eq(dbSchema.comments.parentCommentId, parentComment.id),
+            ),
+          );
+        totalCount = Number(pcResult[0]?.count || 0);
+      }
+    } else {
+      totalCount = Number(countResult[0]?.count || 0);
+    }
+
+    // Main query with JOINs — use raw SQL but cast result properly
+    const rawResult = await db.execute(sql`
+      SELECT
+        c."id",
+        c."uuid",
+        c."user_id" as "userId",
+        c."entity_type" as "entityType",
+        c."entity_id" as "entityId",
+        c."parent_comment_id" as "parentCommentId",
+        c."body",
+        c."created_at" as "createdAt",
+        c."updated_at" as "updatedAt",
+        c."deleted_at" as "deletedAt",
+        u."name" as "userName",
+        u."image" as "userImage",
+        up."display_name" as "displayName",
+        up."avatar_url" as "avatarUrl",
+        parent_c."uuid" as "parentUuid",
+        COALESCE(reply_cnt.cnt, 0) as "replyCount",
+        COALESCE(v_up.cnt, 0) as "upvotes",
+        COALESCE(v_down.cnt, 0) as "downvotes",
+        ${authenticatedUserId
+          ? sql`COALESCE(my_vote."value", 0)`
+          : sql`0`
+        } as "userVote"
+      FROM "comments" c
+      INNER JOIN "user" u ON c."user_id" = u."id"
+      LEFT JOIN "user_profiles" up ON c."user_id" = up."user_id"
+      LEFT JOIN "comments" parent_c ON c."parent_comment_id" = parent_c."id"
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) as cnt FROM "comments" r
+        WHERE r."parent_comment_id" = c."id" AND r."deleted_at" IS NULL
+      ) reply_cnt ON true
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) as cnt FROM "votes" v
+        WHERE v."entity_type" = 'comment' AND v."entity_id" = c."uuid" AND v."value" = 1
+      ) v_up ON true
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) as cnt FROM "votes" v
+        WHERE v."entity_type" = 'comment' AND v."entity_id" = c."uuid" AND v."value" = -1
+      ) v_down ON true
+      ${authenticatedUserId
+        ? sql`LEFT JOIN "votes" my_vote ON my_vote."entity_type" = 'comment' AND my_vote."entity_id" = c."uuid" AND my_vote."user_id" = ${authenticatedUserId}`
+        : sql``
+      }
+      WHERE c."entity_type" = ${entityType}
+        AND c."entity_id" = ${entityId}
+        AND ${parentCommentFilter}
+      ORDER BY ${orderByClause}
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `);
+
+    // Cast the result to CommentRow array
+    const rows = (rawResult as unknown as CommentRow[]);
+    const comments = rows.map(mapCommentRow);
+
+    return {
+      comments,
+      totalCount,
+      hasMore: offset + comments.length < totalCount,
+    };
+  },
+};
+
+export const socialCommentMutations = {
+  addComment: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ) => {
+    requireAuthenticated(ctx);
+    applyRateLimit(ctx, 10);
+
+    const validated = validateInput(AddCommentInputSchema, input, 'input');
+    const { entityType, entityId, parentCommentUuid, body } = validated;
+    const userId = ctx.userId!;
+
+    await validateEntityExists(entityType, entityId);
+
+    let parentCommentId: number | null = null;
+    if (parentCommentUuid) {
+      const [parent] = await db
+        .select({
+          id: dbSchema.comments.id,
+          entityType: dbSchema.comments.entityType,
+          entityId: dbSchema.comments.entityId,
+          deletedAt: dbSchema.comments.deletedAt,
+        })
+        .from(dbSchema.comments)
+        .where(eq(dbSchema.comments.uuid, parentCommentUuid))
+        .limit(1);
+
+      if (!parent) {
+        throw new Error('Parent comment not found');
+      }
+      if (parent.deletedAt) {
+        throw new Error('Cannot reply to a deleted comment');
+      }
+      if (parent.entityType !== entityType || parent.entityId !== entityId) {
+        throw new Error('Parent comment belongs to a different entity');
+      }
+      parentCommentId = parent.id;
+    }
+
+    const uuid = crypto.randomUUID();
+
+    const [inserted] = await db
+      .insert(dbSchema.comments)
+      .values({
+        uuid,
+        userId,
+        entityType,
+        entityId,
+        parentCommentId,
+        body,
+      })
+      .returning();
+
+    // Fetch user info
+    const [user] = await db
+      .select({
+        name: dbSchema.users.name,
+        image: dbSchema.users.image,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
+      .from(dbSchema.users)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+      .where(eq(dbSchema.users.id, userId))
+      .limit(1);
+
+    return {
+      uuid: inserted.uuid,
+      userId: inserted.userId,
+      userDisplayName: user?.displayName || user?.name || undefined,
+      userAvatarUrl: user?.avatarUrl || user?.image || undefined,
+      entityType: inserted.entityType,
+      entityId: inserted.entityId,
+      parentCommentUuid: parentCommentUuid || null,
+      body: inserted.body,
+      isDeleted: false,
+      replyCount: 0,
+      upvotes: 0,
+      downvotes: 0,
+      voteScore: 0,
+      userVote: 0,
+      createdAt: inserted.createdAt.toISOString(),
+      updatedAt: inserted.updatedAt.toISOString(),
+    };
+  },
+
+  updateComment: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ) => {
+    requireAuthenticated(ctx);
+    applyRateLimit(ctx, 10);
+
+    const validated = validateInput(UpdateCommentInputSchema, input, 'input');
+    const { commentUuid, body } = validated;
+    const userId = ctx.userId!;
+
+    const [comment] = await db
+      .select()
+      .from(dbSchema.comments)
+      .where(eq(dbSchema.comments.uuid, commentUuid))
+      .limit(1);
+
+    if (!comment) {
+      throw new Error('Comment not found');
+    }
+    if (comment.userId !== userId) {
+      throw new Error('You can only edit your own comments');
+    }
+    if (comment.deletedAt) {
+      throw new Error('Cannot edit a deleted comment');
+    }
+
+    const now = new Date();
+    const [updated] = await db
+      .update(dbSchema.comments)
+      .set({ body, updatedAt: now })
+      .where(eq(dbSchema.comments.uuid, commentUuid))
+      .returning();
+
+    // Fetch enriched data for the response
+    const [user] = await db
+      .select({
+        name: dbSchema.users.name,
+        image: dbSchema.users.image,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
+      .from(dbSchema.users)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+      .where(eq(dbSchema.users.id, userId))
+      .limit(1);
+
+    // Fetch vote data using query builder
+    const { upvotes, downvotes } = await getCommentVoteCounts(commentUuid);
+
+    // Reply count
+    const replyResult = await db
+      .select({ count: count() })
+      .from(dbSchema.comments)
+      .where(
+        and(
+          eq(dbSchema.comments.parentCommentId, comment.id),
+          isNull(dbSchema.comments.deletedAt),
+        ),
+      );
+    const replyCount = Number(replyResult[0]?.count || 0);
+
+    // User's own vote
+    const [myVote] = await db
+      .select({ value: dbSchema.votes.value })
+      .from(dbSchema.votes)
+      .where(
+        and(
+          eq(dbSchema.votes.entityType, 'comment'),
+          eq(dbSchema.votes.entityId, commentUuid),
+          eq(dbSchema.votes.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    // Get parent UUID if applicable
+    let parentCommentUuid: string | null = null;
+    if (updated.parentCommentId) {
+      const [parentComment] = await db
+        .select({ uuid: dbSchema.comments.uuid })
+        .from(dbSchema.comments)
+        .where(eq(dbSchema.comments.id, updated.parentCommentId))
+        .limit(1);
+      parentCommentUuid = parentComment?.uuid || null;
+    }
+
+    return {
+      uuid: updated.uuid,
+      userId: updated.userId,
+      userDisplayName: user?.displayName || user?.name || undefined,
+      userAvatarUrl: user?.avatarUrl || user?.image || undefined,
+      entityType: updated.entityType,
+      entityId: updated.entityId,
+      parentCommentUuid,
+      body: updated.body,
+      isDeleted: false,
+      replyCount,
+      upvotes,
+      downvotes,
+      voteScore: upvotes - downvotes,
+      userVote: myVote?.value || 0,
+      createdAt: updated.createdAt.toISOString(),
+      updatedAt: updated.updatedAt.toISOString(),
+    };
+  },
+
+  deleteComment: async (
+    _: unknown,
+    { commentUuid }: { commentUuid: string },
+    ctx: ConnectionContext,
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    const userId = ctx.userId!;
+
+    const [comment] = await db
+      .select()
+      .from(dbSchema.comments)
+      .where(eq(dbSchema.comments.uuid, commentUuid))
+      .limit(1);
+
+    if (!comment) {
+      throw new Error('Comment not found');
+    }
+    if (comment.userId !== userId) {
+      throw new Error('You can only delete your own comments');
+    }
+    if (comment.deletedAt) {
+      return true; // Already deleted
+    }
+
+    // Check if comment has replies
+    const replyResult = await db
+      .select({ count: count() })
+      .from(dbSchema.comments)
+      .where(eq(dbSchema.comments.parentCommentId, comment.id));
+
+    const hasReplies = Number(replyResult[0]?.count || 0) > 0;
+
+    if (hasReplies) {
+      // Soft delete — preserve thread structure
+      await db
+        .update(dbSchema.comments)
+        .set({ deletedAt: new Date() })
+        .where(eq(dbSchema.comments.uuid, commentUuid));
+    } else {
+      // Hard delete
+      await db
+        .delete(dbSchema.comments)
+        .where(eq(dbSchema.comments.uuid, commentUuid));
+    }
+
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/social/entity-validation.ts
+++ b/packages/backend/src/graphql/resolvers/social/entity-validation.ts
@@ -1,0 +1,109 @@
+import { eq, and, isNull } from 'drizzle-orm';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
+
+const VALID_BOARD_TYPES = ['kilter', 'tension', 'moonboard'];
+
+/**
+ * Validates that a target entity exists before allowing a comment or vote.
+ * Performs minimal SELECT ... LIMIT 1 existence checks.
+ */
+export async function validateEntityExists(
+  entityType: SocialEntityType,
+  entityId: string,
+): Promise<void> {
+  switch (entityType) {
+    case 'climb': {
+      const [climb] = await db
+        .select({ uuid: dbSchema.boardClimbs.uuid })
+        .from(dbSchema.boardClimbs)
+        .where(eq(dbSchema.boardClimbs.uuid, entityId))
+        .limit(1);
+      if (!climb) {
+        throw new Error('Climb not found');
+      }
+      break;
+    }
+
+    case 'tick': {
+      const [tick] = await db
+        .select({ uuid: dbSchema.boardseshTicks.uuid })
+        .from(dbSchema.boardseshTicks)
+        .where(eq(dbSchema.boardseshTicks.uuid, entityId))
+        .limit(1);
+      if (!tick) {
+        throw new Error('Tick not found');
+      }
+      break;
+    }
+
+    case 'playlist_climb': {
+      // Format: "playlistUuid:climbUuid"
+      const parts = entityId.split(':');
+      if (parts.length !== 2) {
+        throw new Error('Invalid playlist_climb entity ID format. Expected "playlistUuid:climbUuid"');
+      }
+      const [playlistUuid, climbUuid] = parts;
+
+      const [playlist] = await db
+        .select({ id: dbSchema.playlists.id })
+        .from(dbSchema.playlists)
+        .where(eq(dbSchema.playlists.uuid, playlistUuid))
+        .limit(1);
+
+      if (!playlist) {
+        throw new Error('Playlist not found');
+      }
+
+      const [playlistClimb] = await db
+        .select({ id: dbSchema.playlistClimbs.id })
+        .from(dbSchema.playlistClimbs)
+        .where(
+          and(
+            eq(dbSchema.playlistClimbs.playlistId, playlist.id),
+            eq(dbSchema.playlistClimbs.climbUuid, climbUuid),
+          ),
+        )
+        .limit(1);
+
+      if (!playlistClimb) {
+        throw new Error('Climb not found in playlist');
+      }
+      break;
+    }
+
+    case 'comment': {
+      const [comment] = await db
+        .select({ id: dbSchema.comments.id })
+        .from(dbSchema.comments)
+        .where(
+          and(
+            eq(dbSchema.comments.uuid, entityId),
+            isNull(dbSchema.comments.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (!comment) {
+        throw new Error('Comment not found');
+      }
+      break;
+    }
+
+    case 'board': {
+      if (!VALID_BOARD_TYPES.includes(entityId)) {
+        throw new Error(`Invalid board type: ${entityId}`);
+      }
+      break;
+    }
+
+    case 'proposal': {
+      // Proposals don't exist yet — skip validation
+      break;
+    }
+
+    default: {
+      throw new Error(`Unknown entity type: ${entityType}`);
+    }
+  }
+}

--- a/packages/backend/src/graphql/resolvers/social/entity-validation.ts
+++ b/packages/backend/src/graphql/resolvers/social/entity-validation.ts
@@ -39,7 +39,7 @@ export async function validateEntityExists(
     }
 
     case 'playlist_climb': {
-      // Format: "playlistUuid:climbUuid"
+      // Format: "playlistUuid:climbUuid" or "playlistUuid:_all" for general playlist discussion
       const parts = entityId.split(':');
       if (parts.length !== 2) {
         throw new Error('Invalid playlist_climb entity ID format. Expected "playlistUuid:climbUuid"');
@@ -56,19 +56,22 @@ export async function validateEntityExists(
         throw new Error('Playlist not found');
       }
 
-      const [playlistClimb] = await db
-        .select({ id: dbSchema.playlistClimbs.id })
-        .from(dbSchema.playlistClimbs)
-        .where(
-          and(
-            eq(dbSchema.playlistClimbs.playlistId, playlist.id),
-            eq(dbSchema.playlistClimbs.climbUuid, climbUuid),
-          ),
-        )
-        .limit(1);
+      // "_all" is used for general playlist discussion — only validate playlist exists
+      if (climbUuid !== '_all') {
+        const [playlistClimb] = await db
+          .select({ id: dbSchema.playlistClimbs.id })
+          .from(dbSchema.playlistClimbs)
+          .where(
+            and(
+              eq(dbSchema.playlistClimbs.playlistId, playlist.id),
+              eq(dbSchema.playlistClimbs.climbUuid, climbUuid),
+            ),
+          )
+          .limit(1);
 
-      if (!playlistClimb) {
-        throw new Error('Climb not found in playlist');
+        if (!playlistClimb) {
+          throw new Error('Climb not found in playlist');
+        }
       }
       break;
     }
@@ -98,8 +101,7 @@ export async function validateEntityExists(
     }
 
     case 'proposal': {
-      // Proposals don't exist yet — skip validation
-      break;
+      throw new Error('Proposals are not yet supported');
     }
 
     default: {

--- a/packages/backend/src/graphql/resolvers/social/votes.ts
+++ b/packages/backend/src/graphql/resolvers/social/votes.ts
@@ -1,0 +1,226 @@
+import { eq, and, count, inArray } from 'drizzle-orm';
+import type { ConnectionContext, SocialEntityType } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import {
+  VoteInputSchema,
+  BulkVoteSummaryInputSchema,
+  SocialEntityTypeSchema,
+} from '../../../validation/schemas';
+import { validateEntityExists } from './entity-validation';
+
+async function getVoteSummary(
+  entityType: SocialEntityType,
+  entityId: string,
+  authenticatedUserId: string | null | undefined,
+) {
+  const upvoteResult = await db
+    .select({ count: count() })
+    .from(dbSchema.votes)
+    .where(
+      and(
+        eq(dbSchema.votes.entityType, entityType),
+        eq(dbSchema.votes.entityId, entityId),
+        eq(dbSchema.votes.value, 1),
+      ),
+    );
+  const downvoteResult = await db
+    .select({ count: count() })
+    .from(dbSchema.votes)
+    .where(
+      and(
+        eq(dbSchema.votes.entityType, entityType),
+        eq(dbSchema.votes.entityId, entityId),
+        eq(dbSchema.votes.value, -1),
+      ),
+    );
+
+  const upvotes = Number(upvoteResult[0]?.count || 0);
+  const downvotes = Number(downvoteResult[0]?.count || 0);
+
+  let userVote = 0;
+  if (authenticatedUserId) {
+    const [myVote] = await db
+      .select({ value: dbSchema.votes.value })
+      .from(dbSchema.votes)
+      .where(
+        and(
+          eq(dbSchema.votes.entityType, entityType),
+          eq(dbSchema.votes.entityId, entityId),
+          eq(dbSchema.votes.userId, authenticatedUserId),
+        ),
+      )
+      .limit(1);
+    userVote = myVote?.value || 0;
+  }
+
+  return {
+    entityType,
+    entityId,
+    upvotes,
+    downvotes,
+    voteScore: upvotes - downvotes,
+    userVote,
+  };
+}
+
+export const socialVoteQueries = {
+  voteSummary: async (
+    _: unknown,
+    { entityType, entityId }: { entityType: string; entityId: string },
+    ctx: ConnectionContext,
+  ) => {
+    const validatedType = validateInput(SocialEntityTypeSchema, entityType, 'entityType') as SocialEntityType;
+    const authenticatedUserId = ctx.isAuthenticated ? ctx.userId : null;
+
+    return getVoteSummary(validatedType, entityId, authenticatedUserId);
+  },
+
+  bulkVoteSummaries: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ) => {
+    const validated = validateInput(BulkVoteSummaryInputSchema, input, 'input');
+    const { entityType, entityIds } = validated;
+    const authenticatedUserId = ctx.isAuthenticated ? ctx.userId : null;
+
+    if (entityIds.length === 0) return [];
+
+    // Batch query upvote counts grouped by entity_id
+    const upvoteResults = await db
+      .select({
+        entityId: dbSchema.votes.entityId,
+        count: count(),
+      })
+      .from(dbSchema.votes)
+      .where(
+        and(
+          eq(dbSchema.votes.entityType, entityType),
+          inArray(dbSchema.votes.entityId, entityIds),
+          eq(dbSchema.votes.value, 1),
+        ),
+      )
+      .groupBy(dbSchema.votes.entityId);
+
+    const downvoteResults = await db
+      .select({
+        entityId: dbSchema.votes.entityId,
+        count: count(),
+      })
+      .from(dbSchema.votes)
+      .where(
+        and(
+          eq(dbSchema.votes.entityType, entityType),
+          inArray(dbSchema.votes.entityId, entityIds),
+          eq(dbSchema.votes.value, -1),
+        ),
+      )
+      .groupBy(dbSchema.votes.entityId);
+
+    const votesMap = new Map<string, { upvotes: number; downvotes: number }>();
+    for (const row of upvoteResults) {
+      votesMap.set(row.entityId, {
+        upvotes: Number(row.count || 0),
+        downvotes: 0,
+      });
+    }
+    for (const row of downvoteResults) {
+      const existing = votesMap.get(row.entityId) || { upvotes: 0, downvotes: 0 };
+      existing.downvotes = Number(row.count || 0);
+      votesMap.set(row.entityId, existing);
+    }
+
+    // Batch fetch user votes if authenticated
+    const userVotesMap = new Map<string, number>();
+    if (authenticatedUserId) {
+      const userVotes = await db
+        .select({
+          entityId: dbSchema.votes.entityId,
+          value: dbSchema.votes.value,
+        })
+        .from(dbSchema.votes)
+        .where(
+          and(
+            eq(dbSchema.votes.entityType, entityType),
+            inArray(dbSchema.votes.entityId, entityIds),
+            eq(dbSchema.votes.userId, authenticatedUserId),
+          ),
+        );
+
+      for (const v of userVotes) {
+        userVotesMap.set(v.entityId, v.value);
+      }
+    }
+
+    return entityIds.map((entityId) => {
+      const votes = votesMap.get(entityId) || { upvotes: 0, downvotes: 0 };
+      return {
+        entityType,
+        entityId,
+        upvotes: votes.upvotes,
+        downvotes: votes.downvotes,
+        voteScore: votes.upvotes - votes.downvotes,
+        userVote: userVotesMap.get(entityId) || 0,
+      };
+    });
+  },
+};
+
+export const socialVoteMutations = {
+  vote: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ) => {
+    requireAuthenticated(ctx);
+    applyRateLimit(ctx, 30);
+
+    const validated = validateInput(VoteInputSchema, input, 'input');
+    const { entityType, entityId, value } = validated;
+    const userId = ctx.userId!;
+
+    await validateEntityExists(entityType as SocialEntityType, entityId);
+
+    // Check for existing vote
+    const [existing] = await db
+      .select({ id: dbSchema.votes.id, value: dbSchema.votes.value })
+      .from(dbSchema.votes)
+      .where(
+        and(
+          eq(dbSchema.votes.userId, userId),
+          eq(dbSchema.votes.entityType, entityType as SocialEntityType),
+          eq(dbSchema.votes.entityId, entityId),
+        ),
+      )
+      .limit(1);
+
+    if (existing) {
+      if (existing.value === value) {
+        // Same value — toggle off (remove vote)
+        await db
+          .delete(dbSchema.votes)
+          .where(eq(dbSchema.votes.id, existing.id));
+      } else {
+        // Different value — update
+        await db
+          .update(dbSchema.votes)
+          .set({ value })
+          .where(eq(dbSchema.votes.id, existing.id));
+      }
+    } else {
+      // No existing vote — insert
+      await db
+        .insert(dbSchema.votes)
+        .values({
+          userId,
+          entityType: entityType as SocialEntityType,
+          entityId,
+          value,
+        });
+    }
+
+    return getVoteSummary(entityType as SocialEntityType, entityId, userId);
+  },
+};

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -451,3 +451,79 @@ export const FollowingAscentsFeedInputSchema = z.object({
   limit: z.number().int().min(1).max(50).optional().default(20),
   offset: z.number().int().min(0).optional().default(0),
 });
+
+// ============================================
+// Comments & Votes Schemas
+// ============================================
+
+/**
+ * Social entity type validation schema
+ */
+export const SocialEntityTypeSchema = z.enum([
+  'playlist_climb',
+  'climb',
+  'tick',
+  'comment',
+  'proposal',
+  'board',
+]);
+
+/**
+ * Sort mode validation schema
+ */
+export const SortModeSchema = z.enum(['new', 'top', 'controversial', 'hot']);
+
+/**
+ * Time period validation schema
+ */
+export const TimePeriodSchema = z.enum(['hour', 'day', 'week', 'month', 'year', 'all']);
+
+/**
+ * Add comment input validation schema
+ */
+export const AddCommentInputSchema = z.object({
+  entityType: SocialEntityTypeSchema,
+  entityId: z.string().min(1, 'Entity ID cannot be empty').max(200, 'Entity ID too long'),
+  parentCommentUuid: UUIDSchema.optional(),
+  body: z.string().min(1, 'Comment body cannot be empty').max(2000, 'Comment body too long'),
+});
+
+/**
+ * Update comment input validation schema
+ */
+export const UpdateCommentInputSchema = z.object({
+  commentUuid: UUIDSchema,
+  body: z.string().min(1, 'Comment body cannot be empty').max(2000, 'Comment body too long'),
+});
+
+/**
+ * Vote input validation schema
+ */
+export const VoteInputSchema = z.object({
+  entityType: SocialEntityTypeSchema,
+  entityId: z.string().min(1, 'Entity ID cannot be empty').max(200, 'Entity ID too long'),
+  value: z.number().int().refine((v) => v === 1 || v === -1, {
+    message: 'Vote value must be +1 or -1',
+  }),
+});
+
+/**
+ * Comments query input validation schema
+ */
+export const CommentsInputSchema = z.object({
+  entityType: SocialEntityTypeSchema,
+  entityId: z.string().min(1).max(200),
+  parentCommentUuid: UUIDSchema.optional(),
+  sortBy: SortModeSchema.optional().default('new'),
+  timePeriod: TimePeriodSchema.optional().default('all'),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+});
+
+/**
+ * Bulk vote summary input validation schema
+ */
+export const BulkVoteSummaryInputSchema = z.object({
+  entityType: SocialEntityTypeSchema,
+  entityIds: z.array(z.string().min(1).max(200)).min(1).max(100),
+});

--- a/packages/db/drizzle/0045_add_comments_votes.sql
+++ b/packages/db/drizzle/0045_add_comments_votes.sql
@@ -1,0 +1,44 @@
+-- Create social entity type enum
+DO $$ BEGIN
+  CREATE TYPE "social_entity_type" AS ENUM('playlist_climb', 'climb', 'tick', 'comment', 'proposal', 'board');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Create comments table
+CREATE TABLE IF NOT EXISTS "comments" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "uuid" text NOT NULL UNIQUE,
+  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "entity_type" "social_entity_type" NOT NULL,
+  "entity_id" text NOT NULL,
+  "parent_comment_id" bigint,
+  "body" text NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  "deleted_at" timestamp
+);
+
+-- Create votes table
+CREATE TABLE IF NOT EXISTS "votes" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "entity_type" "social_entity_type" NOT NULL,
+  "entity_id" text NOT NULL,
+  "value" integer NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "vote_value_check" CHECK ("value" IN (1, -1))
+);
+
+-- Comments indexes
+CREATE INDEX IF NOT EXISTS "comments_entity_created_at_idx" ON "comments" ("entity_type", "entity_id", "created_at");
+CREATE INDEX IF NOT EXISTS "comments_user_created_at_idx" ON "comments" ("user_id", "created_at");
+CREATE INDEX IF NOT EXISTS "comments_parent_comment_idx" ON "comments" ("parent_comment_id");
+
+-- Votes indexes
+CREATE UNIQUE INDEX IF NOT EXISTS "votes_unique_user_entity" ON "votes" ("user_id", "entity_type", "entity_id");
+CREATE INDEX IF NOT EXISTS "votes_entity_idx" ON "votes" ("entity_type", "entity_id");
+CREATE INDEX IF NOT EXISTS "votes_user_idx" ON "votes" ("user_id");
+
+-- Self-referencing foreign key for comment threading
+ALTER TABLE "comments" ADD CONSTRAINT "comments_parent_fk" FOREIGN KEY ("parent_comment_id") REFERENCES "comments" ("id") ON DELETE SET NULL;

--- a/packages/db/drizzle/0045_add_comments_votes.sql
+++ b/packages/db/drizzle/0045_add_comments_votes.sql
@@ -9,7 +9,7 @@ END $$;
 CREATE TABLE IF NOT EXISTS "comments" (
   "id" bigserial PRIMARY KEY NOT NULL,
   "uuid" text NOT NULL UNIQUE,
-  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL REFERENCES "users" ("id") ON DELETE CASCADE,
   "entity_type" "social_entity_type" NOT NULL,
   "entity_id" text NOT NULL,
   "parent_comment_id" bigint,
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS "comments" (
 -- Create votes table
 CREATE TABLE IF NOT EXISTS "votes" (
   "id" bigserial PRIMARY KEY NOT NULL,
-  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL REFERENCES "users" ("id") ON DELETE CASCADE,
   "entity_type" "social_entity_type" NOT NULL,
   "entity_id" text NOT NULL,
   "value" integer NOT NULL,

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1768790400000,
       "tag": "0044_add_user_follows",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1768876800000,
+      "tag": "0045_add_comments_votes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/index.ts
+++ b/packages/db/src/schema/app/index.ts
@@ -5,3 +5,4 @@ export * from './playlists';
 export * from './hold-classifications';
 export * from './controllers';
 export * from './follows';
+export * from './social';

--- a/packages/db/src/schema/app/social.ts
+++ b/packages/db/src/schema/app/social.ts
@@ -1,0 +1,91 @@
+import {
+  pgTable,
+  bigserial,
+  bigint,
+  text,
+  integer,
+  timestamp,
+  index,
+  uniqueIndex,
+  check,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { users } from '../auth/users';
+
+export const socialEntityTypeEnum = pgEnum('social_entity_type', [
+  'playlist_climb',
+  'climb',
+  'tick',
+  'comment',
+  'proposal',
+  'board',
+]);
+
+export const comments = pgTable(
+  'comments',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    uuid: text('uuid').notNull().unique(),
+    userId: text('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    entityType: socialEntityTypeEnum('entity_type').notNull(),
+    entityId: text('entity_id').notNull(),
+    parentCommentId: bigint('parent_comment_id', { mode: 'number' }),
+    body: text('body').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    deletedAt: timestamp('deleted_at'),
+  },
+  (table) => ({
+    entityCreatedAtIdx: index('comments_entity_created_at_idx').on(
+      table.entityType,
+      table.entityId,
+      table.createdAt
+    ),
+    userCreatedAtIdx: index('comments_user_created_at_idx').on(
+      table.userId,
+      table.createdAt
+    ),
+    parentCommentIdx: index('comments_parent_comment_idx').on(
+      table.parentCommentId
+    ),
+  })
+);
+
+export const votes = pgTable(
+  'votes',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    userId: text('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    entityType: socialEntityTypeEnum('entity_type').notNull(),
+    entityId: text('entity_id').notNull(),
+    value: integer('value').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    uniqueVote: uniqueIndex('votes_unique_user_entity').on(
+      table.userId,
+      table.entityType,
+      table.entityId
+    ),
+    entityIdx: index('votes_entity_idx').on(table.entityType, table.entityId),
+    userIdx: index('votes_user_idx').on(table.userId),
+    valueCheck: check('vote_value_check', sql`${table.value} IN (1, -1)`),
+  })
+);
+
+export type Comment = typeof comments.$inferSelect;
+export type NewComment = typeof comments.$inferInsert;
+export type Vote = typeof votes.$inferSelect;
+export type NewVote = typeof votes.$inferInsert;
+export type SocialEntityType =
+  | 'playlist_climb'
+  | 'climb'
+  | 'tick'
+  | 'comment'
+  | 'proposal'
+  | 'board';

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -342,6 +342,89 @@ export type FollowingAscentsFeedResult = {
   hasMore: boolean;
 };
 
+// ============================================
+// Comments & Votes Types
+// ============================================
+
+export type SocialEntityType =
+  | 'playlist_climb'
+  | 'climb'
+  | 'tick'
+  | 'comment'
+  | 'proposal'
+  | 'board';
+
+export type SortMode = 'new' | 'top' | 'controversial' | 'hot';
+
+export type TimePeriod = 'hour' | 'day' | 'week' | 'month' | 'year' | 'all';
+
+export type Comment = {
+  uuid: string;
+  userId: string;
+  userDisplayName?: string;
+  userAvatarUrl?: string;
+  entityType: SocialEntityType;
+  entityId: string;
+  parentCommentUuid?: string | null;
+  body: string | null;
+  isDeleted: boolean;
+  replyCount: number;
+  upvotes: number;
+  downvotes: number;
+  voteScore: number;
+  userVote: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CommentConnection = {
+  comments: Comment[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+export type VoteSummary = {
+  entityType: SocialEntityType;
+  entityId: string;
+  upvotes: number;
+  downvotes: number;
+  voteScore: number;
+  userVote: number;
+};
+
+export type AddCommentInput = {
+  entityType: SocialEntityType;
+  entityId: string;
+  parentCommentUuid?: string;
+  body: string;
+};
+
+export type UpdateCommentInput = {
+  commentUuid: string;
+  body: string;
+};
+
+export type VoteInput = {
+  entityType: SocialEntityType;
+  entityId: string;
+  value: number;
+};
+
+export type CommentsInput = {
+  entityType: SocialEntityType;
+  entityId: string;
+  parentCommentUuid?: string;
+  sortBy?: SortMode;
+  timePeriod?: TimePeriod;
+  limit?: number;
+  offset?: number;
+};
+
+export type BulkVoteSummaryInput = {
+  entityType: SocialEntityType;
+  entityIds: string[];
+};
+
 /**
  * Event types for GraphQL subscriptions
  *

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import ClimbViewActions from '@/app/components/climb-view/climb-view-actions';
+import ClimbSocialSection from '@/app/components/social/climb-social-section';
 import { Metadata } from 'next';
 import { dbz } from '@/app/lib/db/db';
 import { eq, and } from 'drizzle-orm';
@@ -208,6 +209,9 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
             </div>
             <div className={styles.logbookSection}>
               <LogbookSection climb={climbWithProcessedData} />
+            </div>
+            <div className={styles.logbookSection}>
+              <ClimbSocialSection climbUuid={parsedParams.climb_uuid} />
             </div>
           </div>
         </div>

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -16,6 +16,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { FollowingAscentFeedItem } from '@boardsesh/shared-schema';
 import AscentThumbnail from './ascent-thumbnail';
+import VoteButton from '@/app/components/social/vote-button';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
 
@@ -161,6 +162,11 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
                 {item.comment}
               </MuiTypography>
             )}
+
+            {/* Vote */}
+            <Box sx={{ mt: 0.5 }}>
+              <VoteButton entityType="tick" entityId={item.uuid} />
+            </Box>
           </Box>
         </Box>
       </CardContent>

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -165,7 +165,7 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
 
             {/* Vote */}
             <Box sx={{ mt: 0.5 }}>
-              <VoteButton entityType="tick" entityId={item.uuid} />
+              <VoteButton entityType="tick" entityId={item.uuid} likeOnly />
             </Box>
           </Box>
         </Box>

--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -311,6 +311,27 @@
   color: var(--neutral-400);
 }
 
+/* Discussion section */
+.discussionSection {
+  background-color: var(--semantic-surface);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+@media (max-width: 767px) {
+  .discussionSection {
+    padding: 16px;
+    border-radius: 8px;
+  }
+}
+
+@media (min-width: 992px) {
+  .discussionSection {
+    padding: 24px;
+  }
+}
+
 /* Hidden climbs notice */
 .hiddenClimbsNotice {
   margin-bottom: 16px;

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -17,7 +17,6 @@ import {
   AddClimbToPlaylistMutationResponse,
 } from '@/app/lib/graphql/operations/playlists';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { useBoardProvider } from '@/app/components/board-provider/board-provider-context';
 import { WorkoutType, GeneratorOptions, PlannedClimbSlot, WORKOUT_TYPES } from './types';
 import WorkoutTypeSelector from './workout-type-selector';
 import GeneratorOptionsForm, { getDefaultOptions } from './generator-options-form';
@@ -46,8 +45,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   angle,
   onSuccess,
 }) => {
-  const { token } = useWsAuthToken();
-  const { isAuthenticated } = useBoardProvider();
+  const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
 
   // Default target grade (middle of range)

--- a/packages/web/app/components/social/climb-social-section.tsx
+++ b/packages/web/app/components/social/climb-social-section.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import VoteButton from './vote-button';
+import CommentSection from './comment-section';
+
+interface ClimbSocialSectionProps {
+  climbUuid: string;
+}
+
+export default function ClimbSocialSection({ climbUuid }: ClimbSocialSectionProps) {
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <VoteButton entityType="climb" entityId={climbUuid} />
+      </Box>
+      <CommentSection entityType="climb" entityId={climbUuid} title="Discussion" />
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/comment-form.tsx
+++ b/packages/web/app/components/social/comment-form.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import MuiButton from '@mui/material/Button';
+import MuiTypography from '@mui/material/Typography';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const MAX_BODY_LENGTH = 2000;
+const COUNTER_THRESHOLD = 1800;
+
+interface CommentFormProps {
+  onSubmit: (body: string) => Promise<void>;
+  onCancel?: () => void;
+  initialBody?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  submitLabel?: string;
+}
+
+export default function CommentForm({
+  onSubmit,
+  onCancel,
+  initialBody = '',
+  placeholder = 'Add a comment...',
+  autoFocus = false,
+  submitLabel = 'Post',
+}: CommentFormProps) {
+  const [body, setBody] = useState(initialBody);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = body.trim();
+    if (!trimmed || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+      if (!initialBody) {
+        setBody('');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [body, isSubmitting, onSubmit, initialBody]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const isOverLimit = body.length > MAX_BODY_LENGTH;
+  const showCounter = body.length > COUNTER_THRESHOLD;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <TextField
+        multiline
+        minRows={2}
+        maxRows={6}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        disabled={isSubmitting}
+        size="small"
+        fullWidth
+      />
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Box>
+          {showCounter && (
+            <MuiTypography
+              variant="caption"
+              sx={{ color: isOverLimit ? themeTokens.colors.error : themeTokens.neutral[400] }}
+            >
+              {body.length}/{MAX_BODY_LENGTH}
+            </MuiTypography>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {onCancel && (
+            <MuiButton size="small" onClick={onCancel} disabled={isSubmitting}>
+              Cancel
+            </MuiButton>
+          )}
+          <MuiButton
+            size="small"
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!body.trim() || isOverLimit || isSubmitting}
+          >
+            {submitLabel}
+          </MuiButton>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/comment-item.tsx
+++ b/packages/web/app/components/social/comment-item.tsx
@@ -43,6 +43,7 @@ interface CommentItemProps {
   entityType: SocialEntityType;
   entityId: string;
   depth?: number;
+  currentUserId?: string | null;
 }
 
 export default function CommentItem({
@@ -52,6 +53,7 @@ export default function CommentItem({
   entityType,
   entityId,
   depth = 0,
+  currentUserId,
 }: CommentItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [showReplyForm, setShowReplyForm] = useState(false);
@@ -61,6 +63,7 @@ export default function CommentItem({
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
 
+  const isAuthor = isAuthenticated && !!currentUserId && comment.userId === currentUserId;
   const timeAgo = dayjs(comment.createdAt).fromNow();
   const wasEdited = comment.createdAt !== comment.updatedAt;
 
@@ -183,6 +186,7 @@ export default function CommentItem({
             entityType={entityType}
             entityId={entityId}
             depth={1}
+            currentUserId={currentUserId}
           />
         ))}
       </Box>
@@ -263,7 +267,7 @@ export default function CommentItem({
                   Reply
                 </MuiButton>
               )}
-              {isAuthenticated && (
+              {isAuthor && (
                 <>
                   <IconButton
                     size="small"
@@ -318,6 +322,7 @@ export default function CommentItem({
               entityType={entityType}
               entityId={entityId}
               depth={1}
+              currentUserId={currentUserId}
             />
           ))}
         </Box>

--- a/packages/web/app/components/social/comment-item.tsx
+++ b/packages/web/app/components/social/comment-item.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
+import MuiAvatar from '@mui/material/Avatar';
+import MuiButton from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import PersonOutlined from '@mui/icons-material/PersonOutlined';
+import EditOutlined from '@mui/icons-material/EditOutlined';
+import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
+import ReplyOutlined from '@mui/icons-material/ReplyOutlined';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import type { Comment as CommentType, SocialEntityType } from '@boardsesh/shared-schema';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  UPDATE_COMMENT,
+  DELETE_COMMENT,
+  GET_COMMENTS,
+  ADD_COMMENT,
+  type UpdateCommentMutationVariables,
+  type UpdateCommentMutationResponse,
+  type DeleteCommentMutationVariables,
+  type DeleteCommentMutationResponse,
+  type AddCommentMutationVariables,
+  type AddCommentMutationResponse,
+  type GetCommentsQueryVariables,
+  type GetCommentsQueryResponse,
+} from '@/app/lib/graphql/operations';
+import { themeTokens } from '@/app/theme/theme-config';
+import VoteButton from './vote-button';
+import CommentForm from './comment-form';
+
+dayjs.extend(relativeTime);
+
+interface CommentItemProps {
+  comment: CommentType;
+  onCommentUpdated: (comment: CommentType) => void;
+  onCommentDeleted: (uuid: string) => void;
+  entityType: SocialEntityType;
+  entityId: string;
+  depth?: number;
+}
+
+export default function CommentItem({
+  comment,
+  onCommentUpdated,
+  onCommentDeleted,
+  entityType,
+  entityId,
+  depth = 0,
+}: CommentItemProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [replies, setReplies] = useState<CommentType[]>([]);
+  const [repliesLoaded, setRepliesLoaded] = useState(false);
+  const [repliesLoading, setRepliesLoading] = useState(false);
+  const { token, isAuthenticated } = useWsAuthToken();
+  const { showMessage } = useSnackbar();
+
+  const timeAgo = dayjs(comment.createdAt).fromNow();
+  const wasEdited = comment.createdAt !== comment.updatedAt;
+
+  const handleEdit = useCallback(
+    async (body: string) => {
+      if (!token) return;
+      try {
+        const client = createGraphQLHttpClient(token);
+        const response = await client.request<UpdateCommentMutationResponse, UpdateCommentMutationVariables>(
+          UPDATE_COMMENT,
+          { input: { commentUuid: comment.uuid, body } },
+        );
+        onCommentUpdated(response.updateComment);
+        setIsEditing(false);
+      } catch {
+        showMessage('Failed to update comment', 'error');
+      }
+    },
+    [token, comment.uuid, onCommentUpdated, showMessage],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!token) return;
+    try {
+      const client = createGraphQLHttpClient(token);
+      await client.request<DeleteCommentMutationResponse, DeleteCommentMutationVariables>(
+        DELETE_COMMENT,
+        { commentUuid: comment.uuid },
+      );
+      onCommentDeleted(comment.uuid);
+    } catch {
+      showMessage('Failed to delete comment', 'error');
+    }
+  }, [token, comment.uuid, onCommentDeleted, showMessage]);
+
+  const handleReply = useCallback(
+    async (body: string) => {
+      if (!token) return;
+      try {
+        const client = createGraphQLHttpClient(token);
+        const response = await client.request<AddCommentMutationResponse, AddCommentMutationVariables>(
+          ADD_COMMENT,
+          {
+            input: {
+              entityType,
+              entityId,
+              parentCommentUuid: comment.uuid,
+              body,
+            },
+          },
+        );
+        setReplies((prev) => [response.addComment, ...prev]);
+        setShowReplyForm(false);
+        setRepliesLoaded(true);
+      } catch {
+        showMessage('Failed to post reply', 'error');
+      }
+    },
+    [token, entityType, entityId, comment.uuid, showMessage],
+  );
+
+  const loadReplies = useCallback(async () => {
+    if (repliesLoaded || repliesLoading) return;
+    setRepliesLoading(true);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<GetCommentsQueryResponse, GetCommentsQueryVariables>(
+        GET_COMMENTS,
+        {
+          input: {
+            entityType,
+            entityId,
+            parentCommentUuid: comment.uuid,
+            sortBy: 'new',
+            limit: 50,
+            offset: 0,
+          },
+        },
+      );
+      setReplies(response.comments.comments);
+      setRepliesLoaded(true);
+    } catch {
+      showMessage('Failed to load replies', 'error');
+    } finally {
+      setRepliesLoading(false);
+    }
+  }, [token, entityType, entityId, comment.uuid, repliesLoaded, repliesLoading, showMessage]);
+
+  const handleReplyUpdated = useCallback((updated: CommentType) => {
+    setReplies((prev) => prev.map((r) => (r.uuid === updated.uuid ? updated : r)));
+  }, []);
+
+  const handleReplyDeleted = useCallback((uuid: string) => {
+    setReplies((prev) => prev.filter((r) => r.uuid !== uuid));
+  }, []);
+
+  if (comment.isDeleted) {
+    return (
+      <Box sx={{ pl: depth > 0 ? 6 : 0, py: 0.5 }}>
+        <MuiTypography variant="body2" color="text.disabled" sx={{ fontStyle: 'italic' }}>
+          [deleted]
+        </MuiTypography>
+        {/* Still show replies if they exist */}
+        {comment.replyCount > 0 && !repliesLoaded && depth === 0 && (
+          <MuiButton
+            size="small"
+            onClick={loadReplies}
+            disabled={repliesLoading}
+            sx={{ textTransform: 'none', ml: -0.5 }}
+          >
+            Show {comment.replyCount} {comment.replyCount === 1 ? 'reply' : 'replies'}
+          </MuiButton>
+        )}
+        {replies.map((reply) => (
+          <CommentItem
+            key={reply.uuid}
+            comment={reply}
+            onCommentUpdated={handleReplyUpdated}
+            onCommentDeleted={handleReplyDeleted}
+            entityType={entityType}
+            entityId={entityId}
+            depth={1}
+          />
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ pl: depth > 0 ? 6 : 0, py: 1 }}>
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        {/* Avatar */}
+        <MuiAvatar
+          src={comment.userAvatarUrl ?? undefined}
+          sx={{ width: 28, height: 28, mt: 0.25 }}
+          component="a"
+          href={`/crusher/${comment.userId}`}
+        >
+          {!comment.userAvatarUrl && <PersonOutlined sx={{ fontSize: 16 }} />}
+        </MuiAvatar>
+
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          {/* Header */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <MuiTypography
+              variant="body2"
+              fontWeight={600}
+              component="a"
+              href={`/crusher/${comment.userId}`}
+              sx={{ textDecoration: 'none', color: 'text.primary' }}
+            >
+              {comment.userDisplayName || 'User'}
+            </MuiTypography>
+            <MuiTypography variant="caption" color="text.secondary">
+              {timeAgo}
+            </MuiTypography>
+            {wasEdited && (
+              <MuiTypography variant="caption" color="text.secondary">
+                (edited)
+              </MuiTypography>
+            )}
+          </Box>
+
+          {/* Body or Edit Form */}
+          {isEditing ? (
+            <CommentForm
+              initialBody={comment.body || ''}
+              onSubmit={handleEdit}
+              onCancel={() => setIsEditing(false)}
+              submitLabel="Save"
+              autoFocus
+            />
+          ) : (
+            <MuiTypography variant="body2" sx={{ mt: 0.25, whiteSpace: 'pre-wrap' }}>
+              {comment.body}
+            </MuiTypography>
+          )}
+
+          {/* Actions */}
+          {!isEditing && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+              <VoteButton
+                entityType="comment"
+                entityId={comment.uuid}
+                initialUpvotes={comment.upvotes}
+                initialDownvotes={comment.downvotes}
+                initialUserVote={comment.userVote}
+              />
+              {isAuthenticated && depth === 0 && (
+                <MuiButton
+                  size="small"
+                  startIcon={<ReplyOutlined sx={{ fontSize: 16 }} />}
+                  onClick={() => setShowReplyForm(!showReplyForm)}
+                  sx={{
+                    textTransform: 'none',
+                    color: themeTokens.neutral[500],
+                    fontSize: themeTokens.typography.fontSize.xs,
+                  }}
+                >
+                  Reply
+                </MuiButton>
+              )}
+              {isAuthenticated && (
+                <>
+                  <IconButton
+                    size="small"
+                    onClick={() => setIsEditing(true)}
+                    sx={{ color: themeTokens.neutral[400] }}
+                    aria-label="Edit comment"
+                  >
+                    <EditOutlined sx={{ fontSize: 16 }} />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={handleDelete}
+                    sx={{ color: themeTokens.neutral[400] }}
+                    aria-label="Delete comment"
+                  >
+                    <DeleteOutlined sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </>
+              )}
+            </Box>
+          )}
+
+          {/* Reply Form */}
+          {showReplyForm && (
+            <Box sx={{ mt: 1 }}>
+              <CommentForm
+                onSubmit={handleReply}
+                onCancel={() => setShowReplyForm(false)}
+                placeholder="Write a reply..."
+                autoFocus
+              />
+            </Box>
+          )}
+
+          {/* Replies */}
+          {comment.replyCount > 0 && !repliesLoaded && depth === 0 && (
+            <MuiButton
+              size="small"
+              onClick={loadReplies}
+              disabled={repliesLoading}
+              sx={{ textTransform: 'none', mt: 0.5, ml: -0.5 }}
+            >
+              Show {comment.replyCount} {comment.replyCount === 1 ? 'reply' : 'replies'}
+            </MuiButton>
+          )}
+          {replies.map((reply) => (
+            <CommentItem
+              key={reply.uuid}
+              comment={reply}
+              onCommentUpdated={handleReplyUpdated}
+              onCommentDeleted={handleReplyDeleted}
+              entityType={entityType}
+              entityId={entityId}
+              depth={1}
+            />
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/comment-list.tsx
+++ b/packages/web/app/components/social/comment-list.tsx
@@ -23,11 +23,12 @@ interface CommentListProps {
   entityType: SocialEntityType;
   entityId: string;
   refreshKey?: number;
+  currentUserId?: string | null;
 }
 
 const PAGE_SIZE = 20;
 
-export default function CommentList({ entityType, entityId, refreshKey = 0 }: CommentListProps) {
+export default function CommentList({ entityType, entityId, refreshKey = 0, currentUserId }: CommentListProps) {
   const [comments, setComments] = useState<CommentType[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -153,6 +154,7 @@ export default function CommentList({ entityType, entityId, refreshKey = 0 }: Co
               onCommentDeleted={handleCommentDeleted}
               entityType={entityType}
               entityId={entityId}
+              currentUserId={currentUserId}
             />
           ))}
           {hasMore && (

--- a/packages/web/app/components/social/comment-list.tsx
+++ b/packages/web/app/components/social/comment-list.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useState, useCallback, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import MuiButton from '@mui/material/Button';
+import MuiTypography from '@mui/material/Typography';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import CircularProgress from '@mui/material/CircularProgress';
+import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import type { Comment as CommentType, SocialEntityType, SortMode } from '@boardsesh/shared-schema';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import {
+  GET_COMMENTS,
+  type GetCommentsQueryVariables,
+  type GetCommentsQueryResponse,
+} from '@/app/lib/graphql/operations';
+import { themeTokens } from '@/app/theme/theme-config';
+import CommentItem from './comment-item';
+
+interface CommentListProps {
+  entityType: SocialEntityType;
+  entityId: string;
+  refreshKey?: number;
+}
+
+const PAGE_SIZE = 20;
+
+export default function CommentList({ entityType, entityId, refreshKey = 0 }: CommentListProps) {
+  const [comments, setComments] = useState<CommentType[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [sortBy, setSortBy] = useState<SortMode>('new');
+  const { token } = useWsAuthToken();
+
+  const fetchComments = useCallback(
+    async (offset: number, append: boolean) => {
+      try {
+        const client = createGraphQLHttpClient(token);
+        const response = await client.request<GetCommentsQueryResponse, GetCommentsQueryVariables>(
+          GET_COMMENTS,
+          {
+            input: {
+              entityType,
+              entityId,
+              sortBy,
+              limit: PAGE_SIZE,
+              offset,
+            },
+          },
+        );
+
+        const result = response.comments;
+        if (append) {
+          setComments((prev) => [...prev, ...result.comments]);
+        } else {
+          setComments(result.comments);
+        }
+        setTotalCount(result.totalCount);
+        setHasMore(result.hasMore);
+      } catch {
+        // Silently fail — empty state will show
+      }
+    },
+    [entityType, entityId, sortBy, token],
+  );
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetchComments(0, false).finally(() => setIsLoading(false));
+  }, [fetchComments, refreshKey]);
+
+  const handleLoadMore = useCallback(async () => {
+    setIsLoadingMore(true);
+    await fetchComments(comments.length, true);
+    setIsLoadingMore(false);
+  }, [fetchComments, comments.length]);
+
+  const handleSortChange = useCallback(
+    (_: React.MouseEvent<HTMLElement>, newSort: SortMode | null) => {
+      if (newSort) {
+        setSortBy(newSort);
+      }
+    },
+    [],
+  );
+
+  const handleCommentUpdated = useCallback((updated: CommentType) => {
+    setComments((prev) => prev.map((c) => (c.uuid === updated.uuid ? updated : c)));
+  }, []);
+
+  const handleCommentDeleted = useCallback((uuid: string) => {
+    setComments((prev) => prev.filter((c) => c.uuid !== uuid));
+    setTotalCount((prev) => prev - 1);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Sort controls */}
+      {totalCount > 0 && (
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+          <MuiTypography variant="caption" color="text.secondary">
+            {totalCount} {totalCount === 1 ? 'comment' : 'comments'}
+          </MuiTypography>
+          <ToggleButtonGroup
+            value={sortBy}
+            exclusive
+            onChange={handleSortChange}
+            size="small"
+          >
+            <ToggleButton value="new" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
+              New
+            </ToggleButton>
+            <ToggleButton value="top" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
+              Top
+            </ToggleButton>
+            <ToggleButton value="controversial" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
+              Controversial
+            </ToggleButton>
+            <ToggleButton value="hot" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
+              Hot
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      )}
+
+      {/* Comments */}
+      {comments.length === 0 ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 4, gap: 1 }}>
+          <ChatBubbleOutlineOutlined sx={{ fontSize: 32, color: themeTokens.neutral[300] }} />
+          <MuiTypography variant="body2" color="text.secondary">
+            No comments yet. Be the first!
+          </MuiTypography>
+        </Box>
+      ) : (
+        <>
+          {comments.map((comment) => (
+            <CommentItem
+              key={comment.uuid}
+              comment={comment}
+              onCommentUpdated={handleCommentUpdated}
+              onCommentDeleted={handleCommentDeleted}
+              entityType={entityType}
+              entityId={entityId}
+            />
+          ))}
+          {hasMore && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+              <MuiButton
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+                size="small"
+                sx={{ textTransform: 'none' }}
+              >
+                {isLoadingMore ? <CircularProgress size={16} /> : 'Load more'}
+              </MuiButton>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/comment-section.tsx
+++ b/packages/web/app/components/social/comment-section.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  ADD_COMMENT,
+  type AddCommentMutationVariables,
+  type AddCommentMutationResponse,
+} from '@/app/lib/graphql/operations';
+import CommentForm from './comment-form';
+import CommentList from './comment-list';
+
+interface CommentSectionProps {
+  entityType: SocialEntityType;
+  entityId: string;
+  title?: string;
+}
+
+export default function CommentSection({ entityType, entityId, title = 'Discussion' }: CommentSectionProps) {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const { token, isAuthenticated } = useWsAuthToken();
+  const { showMessage } = useSnackbar();
+
+  const handleAddComment = useCallback(
+    async (body: string) => {
+      if (!token) return;
+      try {
+        const client = createGraphQLHttpClient(token);
+        await client.request<AddCommentMutationResponse, AddCommentMutationVariables>(
+          ADD_COMMENT,
+          { input: { entityType, entityId, body } },
+        );
+        setRefreshKey((prev) => prev + 1);
+      } catch {
+        showMessage('Failed to post comment', 'error');
+        throw new Error('Failed to post comment');
+      }
+    },
+    [token, entityType, entityId, showMessage],
+  );
+
+  return (
+    <Box>
+      <MuiTypography variant="h6" sx={{ mb: 2 }}>
+        {title}
+      </MuiTypography>
+
+      {isAuthenticated ? (
+        <Box sx={{ mb: 2 }}>
+          <CommentForm onSubmit={handleAddComment} placeholder="Share your thoughts..." />
+        </Box>
+      ) : (
+        <MuiTypography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Sign in to leave a comment.
+        </MuiTypography>
+      )}
+
+      <CommentList entityType={entityType} entityId={entityId} refreshKey={refreshKey} />
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/comment-section.tsx
+++ b/packages/web/app/components/social/comment-section.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback } from 'react';
 import Box from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import type { SocialEntityType } from '@boardsesh/shared-schema';
+import { useSession } from 'next-auth/react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -23,7 +24,9 @@ interface CommentSectionProps {
 
 export default function CommentSection({ entityType, entityId, title = 'Discussion' }: CommentSectionProps) {
   const [refreshKey, setRefreshKey] = useState(0);
+  const { data: session } = useSession();
   const { token, isAuthenticated } = useWsAuthToken();
+  const currentUserId = session?.user?.id ?? null;
   const { showMessage } = useSnackbar();
 
   const handleAddComment = useCallback(
@@ -60,7 +63,7 @@ export default function CommentSection({ entityType, entityId, title = 'Discussi
         </MuiTypography>
       )}
 
-      <CommentList entityType={entityType} entityId={entityId} refreshKey={refreshKey} />
+      <CommentList entityType={entityType} entityId={entityId} refreshKey={refreshKey} currentUserId={currentUserId} />
     </Box>
   );
 }

--- a/packages/web/app/components/social/vote-button.tsx
+++ b/packages/web/app/components/social/vote-button.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import MuiTypography from '@mui/material/Typography';
+import ArrowUpwardOutlined from '@mui/icons-material/ArrowUpwardOutlined';
+import ArrowDownwardOutlined from '@mui/icons-material/ArrowDownwardOutlined';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  VOTE,
+  type VoteMutationVariables,
+  type VoteMutationResponse,
+} from '@/app/lib/graphql/operations';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
+
+interface VoteButtonProps {
+  entityType: SocialEntityType;
+  entityId: string;
+  initialUpvotes?: number;
+  initialDownvotes?: number;
+  initialUserVote?: number;
+  layout?: 'vertical' | 'horizontal';
+  onVoteChange?: (summary: { upvotes: number; downvotes: number; voteScore: number; userVote: number }) => void;
+}
+
+export default function VoteButton({
+  entityType,
+  entityId,
+  initialUpvotes = 0,
+  initialDownvotes = 0,
+  initialUserVote = 0,
+  layout = 'horizontal',
+  onVoteChange,
+}: VoteButtonProps) {
+  const [upvotes, setUpvotes] = useState(initialUpvotes);
+  const [downvotes, setDownvotes] = useState(initialDownvotes);
+  const [userVote, setUserVote] = useState(initialUserVote);
+  const [isLoading, setIsLoading] = useState(false);
+  const { token, isAuthenticated } = useWsAuthToken();
+  const { showMessage } = useSnackbar();
+
+  const handleVote = useCallback(
+    async (value: 1 | -1) => {
+      if (!isAuthenticated || !token) {
+        showMessage('Sign in to vote', 'info');
+        return;
+      }
+
+      // Optimistic update
+      const prevUpvotes = upvotes;
+      const prevDownvotes = downvotes;
+      const prevUserVote = userVote;
+
+      let newUserVote: number;
+      let newUpvotes = upvotes;
+      let newDownvotes = downvotes;
+
+      if (userVote === value) {
+        // Toggle off
+        newUserVote = 0;
+        if (value === 1) newUpvotes--;
+        else newDownvotes--;
+      } else {
+        // Remove previous vote if exists
+        if (userVote === 1) newUpvotes--;
+        if (userVote === -1) newDownvotes--;
+        // Add new vote
+        newUserVote = value;
+        if (value === 1) newUpvotes++;
+        else newDownvotes++;
+      }
+
+      setUpvotes(newUpvotes);
+      setDownvotes(newDownvotes);
+      setUserVote(newUserVote);
+      onVoteChange?.({
+        upvotes: newUpvotes,
+        downvotes: newDownvotes,
+        voteScore: newUpvotes - newDownvotes,
+        userVote: newUserVote,
+      });
+
+      setIsLoading(true);
+      try {
+        const client = createGraphQLHttpClient(token);
+        const response = await client.request<VoteMutationResponse, VoteMutationVariables>(
+          VOTE,
+          { input: { entityType, entityId, value } },
+        );
+
+        // Use server response as source of truth
+        const s = response.vote;
+        setUpvotes(s.upvotes);
+        setDownvotes(s.downvotes);
+        setUserVote(s.userVote);
+        onVoteChange?.(s);
+      } catch {
+        // Revert optimistic update
+        setUpvotes(prevUpvotes);
+        setDownvotes(prevDownvotes);
+        setUserVote(prevUserVote);
+        onVoteChange?.({
+          upvotes: prevUpvotes,
+          downvotes: prevDownvotes,
+          voteScore: prevUpvotes - prevDownvotes,
+          userVote: prevUserVote,
+        });
+        showMessage('Failed to vote', 'error');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [upvotes, downvotes, userVote, isAuthenticated, token, entityType, entityId, onVoteChange, showMessage],
+  );
+
+  const score = upvotes - downvotes;
+  const isVertical = layout === 'vertical';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: isVertical ? 'column' : 'row',
+        alignItems: 'center',
+        gap: 0,
+      }}
+    >
+      <IconButton
+        size="small"
+        onClick={() => handleVote(1)}
+        disabled={isLoading}
+        aria-label="Upvote"
+        sx={{
+          color: userVote === 1 ? themeTokens.colors.success : themeTokens.neutral[400],
+          p: 0.5,
+        }}
+      >
+        <ArrowUpwardOutlined sx={{ fontSize: 20 }} />
+      </IconButton>
+      <MuiTypography
+        variant="body2"
+        fontWeight={600}
+        sx={{
+          minWidth: 20,
+          textAlign: 'center',
+          color:
+            userVote === 1
+              ? themeTokens.colors.success
+              : userVote === -1
+                ? themeTokens.colors.error
+                : themeTokens.neutral[600],
+        }}
+      >
+        {score}
+      </MuiTypography>
+      <IconButton
+        size="small"
+        onClick={() => handleVote(-1)}
+        disabled={isLoading}
+        aria-label="Downvote"
+        sx={{
+          color: userVote === -1 ? themeTokens.colors.error : themeTokens.neutral[400],
+          p: 0.5,
+        }}
+      >
+        <ArrowDownwardOutlined sx={{ fontSize: 20 }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/vote-button.tsx
+++ b/packages/web/app/components/social/vote-button.tsx
@@ -6,6 +6,8 @@ import IconButton from '@mui/material/IconButton';
 import MuiTypography from '@mui/material/Typography';
 import ArrowUpwardOutlined from '@mui/icons-material/ArrowUpwardOutlined';
 import ArrowDownwardOutlined from '@mui/icons-material/ArrowDownwardOutlined';
+import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
+import FavoriteOutlined from '@mui/icons-material/FavoriteOutlined';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -24,6 +26,7 @@ interface VoteButtonProps {
   initialDownvotes?: number;
   initialUserVote?: number;
   layout?: 'vertical' | 'horizontal';
+  likeOnly?: boolean;
   onVoteChange?: (summary: { upvotes: number; downvotes: number; voteScore: number; userVote: number }) => void;
 }
 
@@ -34,6 +37,7 @@ export default function VoteButton({
   initialDownvotes = 0,
   initialUserVote = 0,
   layout = 'horizontal',
+  likeOnly = false,
   onVoteChange,
 }: VoteButtonProps) {
   const [upvotes, setUpvotes] = useState(initialUpvotes);
@@ -119,6 +123,41 @@ export default function VoteButton({
 
   const score = upvotes - downvotes;
   const isVertical = layout === 'vertical';
+  const isLiked = userVote === 1;
+
+  if (likeOnly) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <IconButton
+          size="small"
+          onClick={() => handleVote(1)}
+          disabled={isLoading}
+          aria-label={isLiked ? 'Unlike' : 'Like'}
+          sx={{
+            color: isLiked ? themeTokens.colors.error : themeTokens.neutral[400],
+            p: 0.5,
+          }}
+        >
+          {isLiked ? (
+            <FavoriteOutlined sx={{ fontSize: 18 }} />
+          ) : (
+            <FavoriteBorderOutlined sx={{ fontSize: 18 }} />
+          )}
+        </IconButton>
+        {upvotes > 0 && (
+          <MuiTypography
+            variant="body2"
+            sx={{
+              color: isLiked ? themeTokens.colors.error : themeTokens.neutral[500],
+              fontSize: themeTokens.typography.fontSize.xs,
+            }}
+          >
+            {upvotes}
+          </MuiTypography>
+        )}
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/packages/web/app/lib/graphql/operations/comments-votes.ts
+++ b/packages/web/app/lib/graphql/operations/comments-votes.ts
@@ -1,0 +1,223 @@
+import { gql } from 'graphql-request';
+import type {
+  Comment,
+  CommentConnection,
+  VoteSummary,
+  SocialEntityType,
+  SortMode,
+  TimePeriod,
+} from '@boardsesh/shared-schema';
+
+// ============================================
+// Comment Queries
+// ============================================
+
+export const GET_COMMENTS = gql`
+  query GetComments($input: CommentsInput!) {
+    comments(input: $input) {
+      comments {
+        uuid
+        userId
+        userDisplayName
+        userAvatarUrl
+        entityType
+        entityId
+        parentCommentUuid
+        body
+        isDeleted
+        replyCount
+        upvotes
+        downvotes
+        voteScore
+        userVote
+        createdAt
+        updatedAt
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+// ============================================
+// Vote Queries
+// ============================================
+
+export const GET_VOTE_SUMMARY = gql`
+  query GetVoteSummary($entityType: SocialEntityType!, $entityId: String!) {
+    voteSummary(entityType: $entityType, entityId: $entityId) {
+      entityType
+      entityId
+      upvotes
+      downvotes
+      voteScore
+      userVote
+    }
+  }
+`;
+
+export const GET_BULK_VOTE_SUMMARIES = gql`
+  query GetBulkVoteSummaries($input: BulkVoteSummaryInput!) {
+    bulkVoteSummaries(input: $input) {
+      entityType
+      entityId
+      upvotes
+      downvotes
+      voteScore
+      userVote
+    }
+  }
+`;
+
+// ============================================
+// Comment Mutations
+// ============================================
+
+export const ADD_COMMENT = gql`
+  mutation AddComment($input: AddCommentInput!) {
+    addComment(input: $input) {
+      uuid
+      userId
+      userDisplayName
+      userAvatarUrl
+      entityType
+      entityId
+      parentCommentUuid
+      body
+      isDeleted
+      replyCount
+      upvotes
+      downvotes
+      voteScore
+      userVote
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const UPDATE_COMMENT = gql`
+  mutation UpdateComment($input: UpdateCommentInput!) {
+    updateComment(input: $input) {
+      uuid
+      userId
+      userDisplayName
+      userAvatarUrl
+      entityType
+      entityId
+      parentCommentUuid
+      body
+      isDeleted
+      replyCount
+      upvotes
+      downvotes
+      voteScore
+      userVote
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const DELETE_COMMENT = gql`
+  mutation DeleteComment($commentUuid: ID!) {
+    deleteComment(commentUuid: $commentUuid)
+  }
+`;
+
+export const VOTE = gql`
+  mutation Vote($input: VoteInput!) {
+    vote(input: $input) {
+      entityType
+      entityId
+      upvotes
+      downvotes
+      voteScore
+      userVote
+    }
+  }
+`;
+
+// ============================================
+// Query/Mutation Variable Types
+// ============================================
+
+export interface GetCommentsQueryVariables {
+  input: {
+    entityType: SocialEntityType;
+    entityId: string;
+    parentCommentUuid?: string;
+    sortBy?: SortMode;
+    timePeriod?: TimePeriod;
+    limit?: number;
+    offset?: number;
+  };
+}
+
+export interface GetCommentsQueryResponse {
+  comments: CommentConnection;
+}
+
+export interface GetVoteSummaryQueryVariables {
+  entityType: SocialEntityType;
+  entityId: string;
+}
+
+export interface GetVoteSummaryQueryResponse {
+  voteSummary: VoteSummary;
+}
+
+export interface GetBulkVoteSummariesQueryVariables {
+  input: {
+    entityType: SocialEntityType;
+    entityIds: string[];
+  };
+}
+
+export interface GetBulkVoteSummariesQueryResponse {
+  bulkVoteSummaries: VoteSummary[];
+}
+
+export interface AddCommentMutationVariables {
+  input: {
+    entityType: SocialEntityType;
+    entityId: string;
+    parentCommentUuid?: string;
+    body: string;
+  };
+}
+
+export interface AddCommentMutationResponse {
+  addComment: Comment;
+}
+
+export interface UpdateCommentMutationVariables {
+  input: {
+    commentUuid: string;
+    body: string;
+  };
+}
+
+export interface UpdateCommentMutationResponse {
+  updateComment: Comment;
+}
+
+export interface DeleteCommentMutationVariables {
+  commentUuid: string;
+}
+
+export interface DeleteCommentMutationResponse {
+  deleteComment: boolean;
+}
+
+export interface VoteMutationVariables {
+  input: {
+    entityType: SocialEntityType;
+    entityId: string;
+    value: number;
+  };
+}
+
+export interface VoteMutationResponse {
+  vote: VoteSummary;
+}

--- a/packages/web/app/lib/graphql/operations/index.ts
+++ b/packages/web/app/lib/graphql/operations/index.ts
@@ -3,3 +3,4 @@ export * from './favorites';
 export * from './ticks';
 export * from './playlists';
 export * from './social';
+export * from './comments-votes';

--- a/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-detail-content.tsx
@@ -42,6 +42,7 @@ import BackButton from '@/app/components/back-button';
 import { PlaylistGeneratorDrawer } from '@/app/components/playlist-generator';
 import PlaylistEditDrawer from '@/app/components/library/playlist-edit-drawer';
 import PlaylistClimbsList from './playlist-climbs-list';
+import CommentSection from '@/app/components/social/comment-section';
 import styles from '@/app/components/library/playlist-view.module.css';
 
 // Validate hex color format
@@ -298,6 +299,17 @@ export default function PlaylistDetailContent({
             <Typography variant="body2" color="text.secondary">
               Unable to load climb previews for this board configuration.
             </Typography>
+          </div>
+        )}
+
+        {/* Discussion */}
+        {playlist.isPublic && (
+          <div className={styles.discussionSection}>
+            <CommentSection
+              entityType="playlist_climb"
+              entityId={`${playlistUuid}:_all`}
+              title="Discussion"
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Adds full-stack comments and voting functionality as Milestone 2 of the social features roadmap
- Implements threaded comments (1-level deep) with 4 sort modes: new, top, controversial, hot
- Implements upvote/downvote toggle system with optimistic UI updates
- Integrates discussion sections into climb detail views, activity feed items, and public playlists

## Changes

### Database
- New `comments` table with soft-delete support and self-referencing FK for threading
- New `votes` table with unique constraint per user/entity and check constraint for +1/-1 values
- `social_entity_type` enum supporting: climb, tick, comment, playlist_climb, proposal, board

### Backend
- Comment resolvers: `addComment`, `updateComment`, `deleteComment` (soft/hard), `comments` query
- Vote resolvers: `vote` (toggle logic), `voteSummary`, `bulkVoteSummaries`
- Entity validation helper to verify target entities exist before commenting/voting
- Zod validation schemas for all inputs
- Rate limiting on all mutations

### Frontend
- `VoteButton` — upvote/downvote with optimistic updates, auth-gated
- `CommentForm` — reusable for top-level, reply, and edit modes with character counter
- `CommentItem` — single comment with inline edit/reply, vote, and delete actions
- `CommentList` — paginated list with sort toggle (New/Top/Controversial/Hot)
- `CommentSection` — container combining form + list with auth-gating
- `ClimbSocialSection` — wrapper combining VoteButton + CommentSection for climb views

### Integration
- Climb detail page: added `ClimbSocialSection` in sidebar
- Activity feed items: added `VoteButton` for tick entities
- Playlist detail: added `CommentSection` for public playlists

## Test plan

- [ ] Run `npm run db:migrate` — verify comments and votes tables created
- [ ] Typecheck passes: `npm run typecheck` (backend, shared, db clean; web has pre-existing validator errors only)
- [ ] Test comment CRUD: add, edit, delete comments on a climb
- [ ] Test threading: reply to a comment, verify 1-level indent
- [ ] Test sort modes: switch between New/Top/Controversial/Hot
- [ ] Test vote toggle: upvote → same arrow → removed, upvote → downvote → switched
- [ ] Test auth-gating: unauthenticated users see content but can't interact
- [ ] Test soft delete: delete a comment with replies → body shows [deleted], thread preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)