### PR TITLE
Fix bottom nav bar positioning for non-Safari browsers

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.module.css
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.module.css
@@ -1,6 +1,6 @@
 .bottomBarWrapper {
   position: fixed;
-  bottom: 2dvh;
+  bottom: 0;
   left: 2dvw;
   right: 2dvw;
   z-index: 10;
@@ -15,5 +15,16 @@
     bottom: 0;
     padding-bottom: 16px;
     border-radius: 0;
+  }
+}
+
+/* Mobile Safari renders a grey rectangle under the chrome when bottom: 0,
+   so offset with 2dvh. -webkit-touch-callout is only supported by iOS Safari
+   (all iOS browsers use WebKit), and the media query limits to touch devices. */
+@supports (-webkit-touch-callout: none) {
+  @media (hover: none) and (pointer: coarse) {
+    .bottomBarWrapper {
+      bottom: 2dvh;
+    }
   }
 }


### PR DESCRIPTION
The bottom bar was using bottom: 2dvh on all browsers to work around a mobile Safari issue where bottom: 0 causes a grey rectangle under the chrome. This offset is unnecessary on other browsers and shifts the nav bar up from where it should be.

Default to bottom: 0 and only apply the 2dvh workaround on mobile Safari using @supports (-webkit-touch-callout: none) combined with touch device media queries.

https://claude.ai/code/session_016hnfZcVGmCAqFBPuHBxtc2