### PR TITLE
Modernize search form elements with filled-background inputs and refined styling

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -92,11 +92,21 @@
   padding: 16px 24px 24px;
 }
 
-/* Panel content sections (reused from before) */
+/* Panel content sections */
 .panelContent {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
+}
+
+/* Modern form label */
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--neutral-400, #9CA3AF);
+  margin-bottom: 2px;
 }
 
 .inputGroup {
@@ -108,11 +118,77 @@
 .compactInputGroup {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .fullWidth {
   width: 100%;
+}
+
+/* Grade range row */
+.gradeRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+/* Quality metrics row */
+.qualityRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+/* Sort controls row */
+.sortRow {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 8px;
+}
+
+/* Scoped MUI input overrides for modern filled-background look */
+.panelContent :global(.MuiOutlinedInput-root) {
+  background-color: var(--neutral-50, #F9FAFB);
+  border-radius: 12px;
+  transition: background-color 200ms ease, box-shadow 200ms ease;
+}
+
+.panelContent :global(.MuiOutlinedInput-root:hover) {
+  background-color: var(--neutral-100, #F3F4F6);
+}
+
+.panelContent :global(.MuiOutlinedInput-root.Mui-focused) {
+  background-color: var(--semantic-surface, #FFFFFF);
+  box-shadow: 0 0 0 2px var(--color-primary, #8C4A52);
+}
+
+.panelContent :global(.MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
+}
+
+.panelContent :global(.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
+}
+
+.panelContent :global(.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
+}
+
+/* Hide number input spinners for cleaner look */
+.panelContent :global(input[type="number"]::-webkit-outer-spin-button),
+.panelContent :global(input[type="number"]::-webkit-inner-spin-button) {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.panelContent :global(input[type="number"]) {
+  -moz-appearance: textfield;
+}
+
+/* Autocomplete overrides */
+.panelContent :global(.MuiAutocomplete-root .MuiOutlinedInput-root) {
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 /* Switch groups */
@@ -120,7 +196,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  background-color: var(--semantic-background, #F9FAFB);
+  background-color: var(--neutral-50, #F9FAFB);
   border-radius: 12px;
   padding: 4px 0;
 }
@@ -129,12 +205,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 10px 16px;
   transition: background-color 150ms ease;
 }
 
 .switchRow:hover {
   background-color: var(--neutral-100, #F3F4F6);
+}
+
+/* Subtle divider between switch rows */
+.switchRow + .switchRow {
+  border-top: 1px solid var(--neutral-200, #E5E7EB);
 }
 
 /* Sort toggle */
@@ -148,6 +229,7 @@
 /* Progress alert */
 .progressAlert {
   margin: 0;
+  border-radius: 12px;
 }
 
 /* Hold search container */
@@ -164,7 +246,11 @@
 
 .gradeSelectColored :global(.MuiSelect-select) {
   background-color: var(--grade-bg);
-  border-radius: 4px;
+  border-radius: 8px;
+}
+
+.gradeSelectColored:global(.MuiOutlinedInput-root) {
+  background-color: var(--grade-bg);
 }
 
 /* Mobile adjustments */
@@ -190,10 +276,10 @@
   }
 
   .switchRow {
-    padding: 10px 14px;
+    padding: 8px 14px;
   }
 
   .panelContent {
-    gap: 14px;
+    gap: 16px;
   }
 }

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -5,7 +5,6 @@ import MuiAlert from '@mui/material/Alert';
 import MuiTooltip from '@mui/material/Tooltip';
 import MuiTypography from '@mui/material/Typography';
 import MuiButton from '@mui/material/Button';
-import Box from '@mui/material/Box';
 import MuiSelect, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import MuiSwitch from '@mui/material/Switch';
@@ -90,46 +89,44 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
       content: (
         <div className={styles.panelContent}>
           <div className={styles.inputGroup}>
-            <MuiTypography variant="body2" component="span" fontWeight={600}>Climb Name</MuiTypography>
+            <span className={styles.fieldLabel}>Climb Name</span>
             <SearchClimbNameInput />
           </div>
 
           <div className={styles.inputGroup}>
-            <MuiTypography variant="body2" component="span" fontWeight={600}>Grade Range</MuiTypography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0px 8px' }}>
-              <Box sx={{ width: '50%' }}>
-                <MuiSelect
-                  value={uiSearchParams.minGrade || 0}
-                  onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', e.target.value as number || undefined)}
-                  className={`${styles.fullWidth} ${minGradeBg ? styles.gradeSelectColored : ''}`}
-                  sx={minGradeBg ? { '--grade-bg': minGradeBg } as React.CSSProperties : undefined}
-                  size="small"
-                >
-                  <MenuItem value={0}>Any</MenuItem>
-                  {grades.map((grade) => (
-                    <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
-                      {grade.difficulty_name}
-                    </MenuItem>
-                  ))}
-                </MuiSelect>
-              </Box>
-              <Box sx={{ width: '50%' }}>
-                <MuiSelect
-                  value={uiSearchParams.maxGrade || 0}
-                  onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', e.target.value as number || undefined)}
-                  className={`${styles.fullWidth} ${maxGradeBg ? styles.gradeSelectColored : ''}`}
-                  sx={maxGradeBg ? { '--grade-bg': maxGradeBg } as React.CSSProperties : undefined}
-                  size="small"
-                >
-                  <MenuItem value={0}>Any</MenuItem>
-                  {grades.map((grade) => (
-                    <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
-                      {grade.difficulty_name}
-                    </MenuItem>
-                  ))}
-                </MuiSelect>
-              </Box>
-            </Box>
+            <span className={styles.fieldLabel}>Grade Range</span>
+            <div className={styles.gradeRow}>
+              <MuiSelect
+                value={uiSearchParams.minGrade || 0}
+                onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', e.target.value as number || undefined)}
+                className={`${styles.fullWidth} ${minGradeBg ? styles.gradeSelectColored : ''}`}
+                sx={minGradeBg ? { '--grade-bg': minGradeBg } as React.CSSProperties : undefined}
+                size="small"
+                displayEmpty
+              >
+                <MenuItem value={0}>Min</MenuItem>
+                {grades.map((grade) => (
+                  <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
+                    {grade.difficulty_name}
+                  </MenuItem>
+                ))}
+              </MuiSelect>
+              <MuiSelect
+                value={uiSearchParams.maxGrade || 0}
+                onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', e.target.value as number || undefined)}
+                className={`${styles.fullWidth} ${maxGradeBg ? styles.gradeSelectColored : ''}`}
+                sx={maxGradeBg ? { '--grade-bg': maxGradeBg } as React.CSSProperties : undefined}
+                size="small"
+                displayEmpty
+              >
+                <MenuItem value={0}>Max</MenuItem>
+                {grades.map((grade) => (
+                  <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
+                    {grade.difficulty_name}
+                  </MenuItem>
+                ))}
+              </MuiSelect>
+            </div>
           </div>
 
           {showTallClimbsFilter && (
@@ -140,6 +137,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 </MuiTooltip>
                 <MuiSwitch
                   size="small"
+                  color="primary"
                   checked={uiSearchParams.onlyTallClimbs}
                   onChange={(_, checked) => updateFilters({ onlyTallClimbs: checked })}
                 />
@@ -148,7 +146,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
           )}
 
           <div className={styles.inputGroup}>
-            <MuiTypography variant="body2" component="span" fontWeight={600}>Setter</MuiTypography>
+            <span className={styles.fieldLabel}>Setter</span>
             <SetterNameSelect />
           </div>
 
@@ -164,33 +162,29 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
 
           {showSort && (
             <div className={styles.inputGroup}>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0px 8px' }}>
-                <Box sx={{ width: '58.33%' }}>
-                  <MuiSelect
-                    value={uiSearchParams.sortBy}
-                    onChange={(e) => updateFilters({ sortBy: e.target.value as typeof uiSearchParams.sortBy })}
-                    className={styles.fullWidth}
-                    size="small"
-                  >
-                    <MenuItem value="ascents">Ascents</MenuItem>
-                    <MenuItem value="popular">Popular</MenuItem>
-                    <MenuItem value="difficulty">Difficulty</MenuItem>
-                    <MenuItem value="name">Name</MenuItem>
-                    <MenuItem value="quality">Quality</MenuItem>
-                  </MuiSelect>
-                </Box>
-                <Box sx={{ width: '41.67%' }}>
-                  <MuiSelect
-                    value={uiSearchParams.sortOrder}
-                    onChange={(e) => updateFilters({ sortOrder: e.target.value as typeof uiSearchParams.sortOrder })}
-                    className={styles.fullWidth}
-                    size="small"
-                  >
-                    <MenuItem value="desc">Desc</MenuItem>
-                    <MenuItem value="asc">Asc</MenuItem>
-                  </MuiSelect>
-                </Box>
-              </Box>
+              <div className={styles.sortRow}>
+                <MuiSelect
+                  value={uiSearchParams.sortBy}
+                  onChange={(e) => updateFilters({ sortBy: e.target.value as typeof uiSearchParams.sortBy })}
+                  className={styles.fullWidth}
+                  size="small"
+                >
+                  <MenuItem value="ascents">Ascents</MenuItem>
+                  <MenuItem value="popular">Popular</MenuItem>
+                  <MenuItem value="difficulty">Difficulty</MenuItem>
+                  <MenuItem value="name">Name</MenuItem>
+                  <MenuItem value="quality">Quality</MenuItem>
+                </MuiSelect>
+                <MuiSelect
+                  value={uiSearchParams.sortOrder}
+                  onChange={(e) => updateFilters({ sortOrder: e.target.value as typeof uiSearchParams.sortOrder })}
+                  className={styles.fullWidth}
+                  size="small"
+                >
+                  <MenuItem value="desc">Desc</MenuItem>
+                  <MenuItem value="asc">Asc</MenuItem>
+                </MuiSelect>
+              </div>
             </div>
           )}
 
@@ -205,39 +199,35 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
       getSummary: () => getQualityPanelSummary(uiSearchParams),
       content: (
         <div className={styles.panelContent}>
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '12px 12px' }}>
-            <Box sx={{ width: '50%' }}>
-              <div className={styles.compactInputGroup}>
-                <MuiTypography variant="body2" component="span">Min Ascents</MuiTypography>
-                <TextField
-                  type="number"
-                  slotProps={{ htmlInput: { min: 1 } }}
-                  value={uiSearchParams.minAscents ?? ''}
-                  onChange={(e) => updateFilters({ minAscents: Number(e.target.value) || undefined })}
-                  className={styles.fullWidth}
-                  placeholder="Any"
-                  size="small"
-                />
-              </div>
-            </Box>
-            <Box sx={{ width: '50%' }}>
-              <div className={styles.compactInputGroup}>
-                <MuiTypography variant="body2" component="span">Min Rating</MuiTypography>
-                <TextField
-                  type="number"
-                  slotProps={{ htmlInput: { min: 1.0, max: 3.0, step: 0.1 } }}
-                  value={uiSearchParams.minRating ?? ''}
-                  onChange={(e) => updateFilters({ minRating: Number(e.target.value) || undefined })}
-                  className={styles.fullWidth}
-                  placeholder="Any"
-                  size="small"
-                />
-              </div>
-            </Box>
-          </Box>
+          <div className={styles.qualityRow}>
+            <div className={styles.compactInputGroup}>
+              <span className={styles.fieldLabel}>Min Ascents</span>
+              <TextField
+                type="number"
+                slotProps={{ htmlInput: { min: 1 } }}
+                value={uiSearchParams.minAscents ?? ''}
+                onChange={(e) => updateFilters({ minAscents: Number(e.target.value) || undefined })}
+                className={styles.fullWidth}
+                placeholder="Any"
+                size="small"
+              />
+            </div>
+            <div className={styles.compactInputGroup}>
+              <span className={styles.fieldLabel}>Min Rating</span>
+              <TextField
+                type="number"
+                slotProps={{ htmlInput: { min: 1.0, max: 3.0, step: 0.1 } }}
+                value={uiSearchParams.minRating ?? ''}
+                onChange={(e) => updateFilters({ minRating: Number(e.target.value) || undefined })}
+                className={styles.fullWidth}
+                placeholder="Any"
+                size="small"
+              />
+            </div>
+          </div>
 
           <div className={styles.inputGroup}>
-            <MuiTypography variant="body2" component="span">Grade Accuracy</MuiTypography>
+            <span className={styles.fieldLabel}>Grade Accuracy</span>
             <MuiSelect
               value={uiSearchParams.gradeAccuracy ?? 0}
               onChange={(e) => updateFilters({ gradeAccuracy: (e.target.value as number) || undefined })}
@@ -256,6 +246,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
               <MuiTypography variant="body2" component="span">Classics Only</MuiTypography>
               <MuiSwitch
                 size="small"
+                color="primary"
                 checked={uiSearchParams.onlyClassics}
                 onChange={(_, checked) => updateFilters({ onlyClassics: checked })}
               />
@@ -297,6 +288,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <MuiTypography variant="body2" component="span">Hide Attempted</MuiTypography>
                 <MuiSwitch
                   size="small"
+                  color="primary"
                   checked={uiSearchParams.hideAttempted}
                   onChange={(_, checked) => updateFilters({ hideAttempted: checked })}
                 />
@@ -305,6 +297,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <MuiTypography variant="body2" component="span">Hide Completed</MuiTypography>
                 <MuiSwitch
                   size="small"
+                  color="primary"
                   checked={uiSearchParams.hideCompleted}
                   onChange={(_, checked) => updateFilters({ hideCompleted: checked })}
                 />
@@ -313,6 +306,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <MuiTypography variant="body2" component="span">Only Attempted</MuiTypography>
                 <MuiSwitch
                   size="small"
+                  color="primary"
                   checked={uiSearchParams.showOnlyAttempted}
                   onChange={(_, checked) => updateFilters({ showOnlyAttempted: checked })}
                 />
@@ -321,6 +315,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 <MuiTypography variant="body2" component="span">Only Completed</MuiTypography>
                 <MuiSwitch
                   size="small"
+                  color="primary"
                   checked={uiSearchParams.showOnlyCompleted}
                   onChange={(_, checked) => updateFilters({ showOnlyCompleted: checked })}
                 />

--- a/packages/web/app/components/search-drawer/climb-hold-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-hold-search-form.tsx
@@ -57,7 +57,7 @@ const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails 
   return (
     <div className={styles.holdSearchForm}>
       <div className={styles.holdSearchHeaderCompact}>
-        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
           <MuiTypography variant="body2" component="span" color="text.secondary">Tap to:</MuiTypography>
           <MuiSelect
             value={selectedState}
@@ -70,19 +70,19 @@ const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails 
               });
             }}
             size="small"
-            sx={{ width: 110 }}
+            sx={{ minWidth: 120 }}
           >
             {stateItems.map(item => (
               <MenuItem key={item.value} value={item.value}>
-                <Stack direction="row" spacing={0.5}>
+                <Stack direction="row" spacing={0.5} alignItems="center">
                   {item.icon}
                   {item.label}
                 </Stack>
               </MenuItem>
             ))}
           </MuiSelect>
-          {anyHoldsCount > 0 && <Chip label={`${anyHoldsCount} in`} size="small" sx={{ bgcolor: themeTokens.colors.primary, color: 'common.white', margin: 0 }} />}
-          {notHoldsCount > 0 && <Chip label={`${notHoldsCount} out`} size="small" sx={{ bgcolor: themeTokens.colors.error, color: 'common.white', margin: 0 }} />}
+          {anyHoldsCount > 0 && <Chip label={`${anyHoldsCount} included`} size="small" sx={{ bgcolor: themeTokens.colors.primary, color: 'common.white' }} />}
+          {notHoldsCount > 0 && <Chip label={`${notHoldsCount} excluded`} size="small" sx={{ bgcolor: themeTokens.colors.error, color: 'common.white' }} />}
         </Stack>
       </div>
 

--- a/packages/web/app/components/search-drawer/search-climb-name-input.tsx
+++ b/packages/web/app/components/search-drawer/search-climb-name-input.tsx
@@ -5,14 +5,13 @@ import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
-import { themeTokens } from '@/app/theme/theme-config';
 
 const SearchClimbNameInput = () => {
   const { uiSearchParams, updateFilters } = useUISearchParams();
 
   return (
     <TextField
-      placeholder="Search by climb name..."
+      placeholder="Search climbs..."
       variant="outlined"
       size="small"
       fullWidth
@@ -20,7 +19,7 @@ const SearchClimbNameInput = () => {
         input: {
           startAdornment: (
             <InputAdornment position="start">
-              <SearchOutlined sx={{ color: themeTokens.neutral[400] }} />
+              <SearchOutlined color="action" />
             </InputAdornment>
           ),
         },

--- a/packages/web/app/components/search-drawer/search-form.module.css
+++ b/packages/web/app/components/search-drawer/search-form.module.css
@@ -89,13 +89,41 @@
 .holdSearchForm {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
 .holdSearchHeaderCompact {
   display: flex;
   align-items: center;
-  padding: 8px 0;
+  padding: 4px 0;
+}
+
+/* Scoped MUI overrides for hold search select */
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-root) {
+  background-color: var(--neutral-50, #F9FAFB);
+  border-radius: 12px;
+  transition: background-color 200ms ease, box-shadow 200ms ease;
+}
+
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-root:hover) {
+  background-color: var(--neutral-100, #F3F4F6);
+}
+
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-root.Mui-focused) {
+  background-color: var(--semantic-surface, #FFFFFF);
+  box-shadow: 0 0 0 2px var(--color-primary, #8C4A52);
+}
+
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
+}
+
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
+}
+
+.holdSearchHeaderCompact :global(.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline) {
+  border-color: transparent;
 }
 
 .boardContainer {

--- a/packages/web/app/components/search-drawer/setter-name-select.tsx
+++ b/packages/web/app/components/search-drawer/setter-name-select.tsx
@@ -101,13 +101,13 @@ const SetterNameSelect = () => {
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder={selectedOptions.length === 0 ? 'Select setters...' : ''}
+          placeholder={selectedOptions.length === 0 ? 'Search setters...' : ''}
           slotProps={{
             input: {
               ...params.InputProps,
               endAdornment: (
                 <>
-                  {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                  {isLoading ? <CircularProgress color="inherit" size={16} /> : null}
                   {params.InputProps.endAdornment}
                 </>
               ),


### PR DESCRIPTION
Replace dated outlined inputs with a modern filled-background look: subtle
neutral background, 12px border-radius, transparent borders, primary-color
focus ring. Add uppercase micro-labels, CSS grid layouts for grade/quality/sort
rows, hidden number spinners, dividers between switch rows, and primary-colored
switches. Remove unused Box imports in favor of semantic CSS grid classes.

https://claude.ai/code/session_019RSLtJ1ie1HTrnWRZkpnP2