### PR TITLE
Security audit: fix high/medium severity findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2960,6 +2960,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/@escape.tech/graphql-armor-cost-limit": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-cost-limit/-/graphql-armor-cost-limit-2.4.3.tgz",
+      "integrity": "sha512-fLZTlJjrjinpNhbv5VP6f8Ce4MiQzbcHtCNaCPVaHqArTEbN7vDnlVLiH+VcmZBmOwU6Si97lKdlOXWNgB5ytw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^16.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^5.2.3",
+        "@escape.tech/graphql-armor-types": "0.7.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-depth": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-depth/-/graphql-armor-max-depth-2.4.2.tgz",
+      "integrity": "sha512-J9fbW1+W4u3GAcf19wwS0zrNGICCbWn/glvopCoC11Ga0reXvGwgr8EcyuHjTFLL7+pPvWAeVhP4qo6hybcB9w==",
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^16.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^5.2.3",
+        "@escape.tech/graphql-armor-types": "0.7.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-types/-/graphql-armor-types-0.7.0.tgz",
+      "integrity": "sha512-RHxyyp6PDgS6NAPnnmB6JdmUJ6oqhpSHFbsglGWeCcnNzceA5AkQFpir7VIDbVyS8LNC1xhipOtk7f9ycrIemQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graphql": "^16.0.0"
+      }
+    },
     "node_modules/@faker-js/faker": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
@@ -4898,7 +4940,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.57.0"
@@ -8392,7 +8434,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11877,7 +11919,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.57.0"
@@ -11896,7 +11938,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -12234,6 +12276,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12253,6 +12296,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -12786,6 +12830,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -15492,6 +15537,8 @@
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
         "@boardsesh/shared-schema": "*",
+        "@escape.tech/graphql-armor-cost-limit": "^2.4.3",
+        "@escape.tech/graphql-armor-max-depth": "^2.4.2",
         "@graphql-tools/schema": "^10.0.30",
         "@panva/hkdf": "^1.2.1",
         "@whatwg-node/fetch": "^0.10.13",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,6 +26,8 @@
     "@boardsesh/crypto": "*",
     "@boardsesh/db": "*",
     "@boardsesh/shared-schema": "*",
+    "@escape.tech/graphql-armor-cost-limit": "^2.4.3",
+    "@escape.tech/graphql-armor-max-depth": "^2.4.2",
     "@graphql-tools/schema": "^10.0.30",
     "@panva/hkdf": "^1.2.1",
     "@whatwg-node/fetch": "^0.10.13",

--- a/packages/backend/src/graphql/query-depth.ts
+++ b/packages/backend/src/graphql/query-depth.ts
@@ -1,0 +1,50 @@
+import { DocumentNode, Kind, type DefinitionNode, type SelectionSetNode } from 'graphql';
+
+const MAX_QUERY_DEPTH = 10;
+
+/**
+ * Calculate the maximum depth of a GraphQL document.
+ * Used for both HTTP (via graphql-armor plugin) and WebSocket (via onSubscribe) paths.
+ */
+function calculateDepth(selectionSet: SelectionSetNode, currentDepth: number): number {
+  let maxDepth = currentDepth;
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD && selection.selectionSet) {
+      const fieldDepth = calculateDepth(selection.selectionSet, currentDepth + 1);
+      if (fieldDepth > maxDepth) {
+        maxDepth = fieldDepth;
+      }
+    } else if (
+      (selection.kind === Kind.INLINE_FRAGMENT || selection.kind === Kind.FRAGMENT_SPREAD) &&
+      'selectionSet' in selection &&
+      selection.selectionSet
+    ) {
+      const fragmentDepth = calculateDepth(selection.selectionSet, currentDepth);
+      if (fragmentDepth > maxDepth) {
+        maxDepth = fragmentDepth;
+      }
+    }
+  }
+
+  return maxDepth;
+}
+
+/**
+ * Validate that a GraphQL document does not exceed the maximum allowed depth.
+ * Returns an error message if the depth is exceeded, or null if valid.
+ */
+export function validateQueryDepth(document: DocumentNode): string | null {
+  for (const definition of document.definitions) {
+    if (
+      definition.kind === Kind.OPERATION_DEFINITION &&
+      definition.selectionSet
+    ) {
+      const depth = calculateDepth(definition.selectionSet, 0);
+      if (depth > MAX_QUERY_DEPTH) {
+        return `Query depth ${depth} exceeds maximum allowed depth of ${MAX_QUERY_DEPTH}`;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -4,6 +4,8 @@ import { schema } from './index';
 import { validateNextAuthToken } from '../middleware/auth';
 import { createContext } from './context';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
+import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
 
 /**
  * Create and configure the GraphQL Yoga instance
@@ -16,6 +18,10 @@ export function createYogaInstance() {
   const yoga = createYoga({
     schema,
     graphqlEndpoint: '/graphql',
+    plugins: [
+      maxDepthPlugin({ n: 10 }),
+      costLimitPlugin({ maxCost: 5000 }),
+    ],
     // Context function - extract auth from HTTP requests
     context: async ({ request }): Promise<ConnectionContext> => {
       // Extract Authorization header

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -1,8 +1,8 @@
 import { createYoga } from 'graphql-yoga';
 import type { IncomingMessage } from 'http';
+import { v4 as uuidv4 } from 'uuid';
 import { schema } from './index';
 import { validateNextAuthToken } from '../middleware/auth';
-import { createContext } from './context';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
@@ -25,6 +25,8 @@ export function createYogaInstance() {
       costLimitPlugin({ maxCost: 5000 }),
     ],
     // Context function - extract auth from HTTP requests
+    // HTTP requests are stateless and don't need to be tracked in the connections Map.
+    // Only WebSocket connections are stored there (they have onDisconnect cleanup).
     context: async ({ request }): Promise<ConnectionContext> => {
       // Extract Authorization header
       const authHeader = request.headers.get('authorization');
@@ -34,13 +36,21 @@ export function createYogaInstance() {
         const authResult = await validateNextAuthToken(token);
 
         if (authResult) {
-          // Create authenticated context
-          return createContext(undefined, true, authResult.userId);
+          return {
+            connectionId: `http-${uuidv4()}`,
+            sessionId: undefined,
+            userId: authResult.userId,
+            isAuthenticated: true,
+          };
         }
       }
 
-      // Return unauthenticated context
-      return createContext(undefined, false, undefined);
+      return {
+        connectionId: `http-${uuidv4()}`,
+        sessionId: undefined,
+        userId: undefined,
+        isAuthenticated: false,
+      };
     },
     // Disable GraphiQL in production
     graphiql: process.env.NODE_ENV !== 'production'

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -18,6 +18,8 @@ export function createYogaInstance() {
   const yoga = createYoga({
     schema,
     graphqlEndpoint: '/graphql',
+    // Depth/cost limiting for HTTP GraphQL requests.
+    // WebSocket subscriptions are protected separately via onSubscribe in websocket/setup.ts
     plugins: [
       maxDepthPlugin({ n: 10 }),
       costLimitPlugin({ maxCost: 5000 }),

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -26,7 +26,7 @@ export async function handleStaticAvatar(req: IncomingMessage, res: ServerRespon
   if (!applyCorsHeaders(req, res)) return;
 
   // Security: validate filename to prevent path traversal
-  if (fileName.includes('..') || fileName.includes('/') || fileName.includes('\\')) {
+  if (!fileName || fileName !== path.basename(fileName)) {
     res.writeHead(400, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Invalid path' }));
     return;

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -48,7 +48,13 @@ export const SessionNameSchema = z.string().max(100, 'Session name too long').op
 /**
  * Avatar URL validation schema
  */
-export const AvatarUrlSchema = z.string().max(500, 'Avatar URL too long').optional();
+export const AvatarUrlSchema = z.string()
+  .max(500, 'Avatar URL too long')
+  .refine(
+    (url) => url.startsWith('http://') || url.startsWith('https://') || url.startsWith('/'),
+    'Avatar URL must use http(s) or be a relative path'
+  )
+  .optional();
 
 /**
  * Create session input validation schema

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -12,6 +12,8 @@ import { validateNextAuthToken, extractAuthToken, extractControllerApiKey, valid
 import { isOriginAllowed } from '../handlers/cors';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
+const DEBUG = process.env.NODE_ENV === 'development';
+
 // Extend Extra type with our custom context
 interface CustomExtra extends WsExtra {
   context?: ConnectionContext;
@@ -129,7 +131,9 @@ export function setupWebSocketServer(httpServer: HttpServer): WebSocketServer {
           throw new Error(`Connection context lost for ${extra.context.connectionId}`);
         }
 
-        console.log(`[Context] Retrieved context: ${latestContext.connectionId}, sessionId: ${latestContext.sessionId}`);
+        if (DEBUG) {
+          console.log(`[Context] Retrieved context: ${latestContext.connectionId}, sessionId: ${latestContext.sessionId}`);
+        }
         return latestContext;
       },
       onDisconnect: async (ctx: ServerContext, code?: number) => {
@@ -168,7 +172,9 @@ export function setupWebSocketServer(httpServer: HttpServer): WebSocketServer {
         }
       },
       onSubscribe: (_ctx: ServerContext, _id: string, payload) => {
-        console.log(`Subscription started: ${payload.operationName || 'anonymous'}`);
+        if (DEBUG) {
+          console.log(`Subscription started: ${payload.operationName || 'anonymous'}`);
+        }
 
         // Validate query depth to prevent DoS via deeply nested subscriptions
         if (payload.query) {
@@ -183,7 +189,9 @@ export function setupWebSocketServer(httpServer: HttpServer): WebSocketServer {
         console.error('GraphQL error:', errors);
       },
       onComplete: (_ctx: ServerContext, _id: string, payload) => {
-        console.log(`Subscription completed: ${payload.operationName || 'anonymous'}`);
+        if (DEBUG) {
+          console.log(`Subscription completed: ${payload.operationName || 'anonymous'}`);
+        }
       },
     },
     wss,

--- a/packages/web/app/api/internal/shared-sync/[board_name]/route.ts
+++ b/packages/web/app/api/internal/shared-sync/[board_name]/route.ts
@@ -77,9 +77,9 @@ export async function GET(request: Request, props: { params: Promise<SharedSyncR
 
     console.log(`Starting shared sync for ${board_name}`);
 
-    // Basic auth check
+    // Auth check - always require valid CRON_SECRET
     const authHeader = request.headers.get('authorization');
-    if (process.env.VERCEL_ENV !== 'development' && authHeader !== `Bearer ${CRON_SECRET}`) {
+    if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/packages/web/app/api/v1/[board_name]/proxy/login/route.ts
+++ b/packages/web/app/api/v1/[board_name]/proxy/login/route.ts
@@ -72,9 +72,10 @@ async function login(boardName: AuroraBoardName, username: string, password: str
 export async function POST(request: Request, props: { params: Promise<BoardOnlyRouteParameters> }) {
   const params = await props.params;
 
-  // MoonBoard doesn't use Aurora APIs
-  if (params.board_name === 'moonboard') {
-    return NextResponse.json({ error: 'MoonBoard does not support this endpoint' }, { status: 400 });
+  // Only kilter and tension use Aurora APIs
+  const VALID_AURORA_BOARDS: AuroraBoardName[] = ['kilter', 'tension'];
+  if (!VALID_AURORA_BOARDS.includes(params.board_name as AuroraBoardName)) {
+    return NextResponse.json({ error: 'Unsupported board for this endpoint' }, { status: 400 });
   }
 
   const board_name = params.board_name as AuroraBoardName;

--- a/packages/web/app/lib/session.ts
+++ b/packages/web/app/lib/session.ts
@@ -41,7 +41,6 @@ interface CookieStore {
 interface BoardSessionData {
   token: string;
   username: string;
-  password: string;
   userId: number;
 }
 
@@ -53,5 +52,10 @@ export const getSession = async (cookies: CookieStore, boardName: BoardName) => 
   return getIronSession<BoardSessionData>(cookies, {
     password,
     cookieName: `${boardName}_session`,
+    cookieOptions: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax' as const,
+    },
   });
 };

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -19,6 +19,19 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: [],
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       // Redirect old board-scoped playlist routes to /my-library


### PR DESCRIPTION
## Summary

- **[HIGH] Remove plaintext password from session cookies** — `password` field removed from `BoardSessionData` interface and login route; was redundant since credentials are stored encrypted in DB
- **[HIGH] Add GraphQL depth/complexity limiting** — Added `graphql-armor` max-depth (10) and cost-limit (5000) plugins to prevent DoS via deeply nested queries
- **[HIGH] Add input validation to user-board-mapping** — Added Zod schema; removed unsafe `as BoardName` cast and raw `parseInt()`
- **[HIGH] Fix cron endpoint auth bypass** — Removed `VERCEL_ENV !== 'development'` check; always requires valid `CRON_SECRET`
- **[MEDIUM] Replace `sql.unsafe()` with Drizzle ORM** — Now uses `dbz.insert(boardUsers)` with unified `board_users` table (legacy tables were dropped in migration 0038)
- **[MEDIUM] Add security headers** — X-Frame-Options, X-Content-Type-Options, HSTS, Referrer-Policy
- **[MEDIUM] Validate avatar URL scheme** — Blocks `javascript:` and `data:` URIs in avatar URLs
- **[MEDIUM] Remove Zod error details from responses** — No longer exposes internal field names/validation rules to clients
- **[LOW] Improve path traversal check** — Uses `path.basename()` instead of fragile string checks
- **[LOW] Add explicit cookie options** — `httpOnly`, `secure` (prod only), `sameSite: 'lax'`

## Test plan

- [ ] Run `npm run typecheck` — passes cleanly
- [ ] Test Aurora login flow (credentials fetched from DB, not cookie)
- [ ] Verify `session.password` is no longer set (grep confirms zero references)
- [ ] Send deeply nested GraphQL query and verify rejection
- [ ] POST invalid data to `/api/internal/user-board-mapping` and verify 400
- [ ] GET shared-sync endpoint without auth header and verify 401 in all environments
- [ ] Check response headers via `curl -I`

🤖 Generated with [Claude Code](https://claude.com/claude-code)