### PR TITLE
Fix bottom nav bar hidden on iOS Safari

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -11,3 +11,14 @@
     padding-bottom: 16px;
   }
 }
+
+/* Mobile Safari renders a grey rectangle under the chrome when bottom: 0,
+   so offset with 2dvh. -webkit-touch-callout is only supported by iOS Safari
+   (all iOS browsers use WebKit), and the media query limits to touch devices. */
+@supports (-webkit-touch-callout: none) {
+  @media (hover: none) and (pointer: coarse) {
+    .bottomBarWrapper {
+      bottom: 2dvh;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `@supports (-webkit-touch-callout: none)` CSS rule with `bottom: 2dvh` offset to the shared `bottom-bar-wrapper.module.css`
- Matches the pattern already used in board page layouts (`layout.module.css`)
- Fixes the bottom navigation bar being hidden behind iOS Safari browser chrome on My Library, Alerts, and Home pages

## Test plan
- [ ] On iOS Safari, navigate to `/my-library` — bottom tab bar should be visible above the browser chrome
- [ ] On iOS Safari, navigate to `/notifications` — same
- [ ] On iOS Safari, navigate to `/` (home) — same
- [ ] Verify board pages still render correctly (they use their own CSS modules, no regression expected)
- [ ] On desktop browsers, verify no visual change (the `@supports` + `@media` query only targets iOS Safari touch devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)