### PR TITLE
Suppress noisy Yoga debug logs

### DIFF
--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -60,12 +60,12 @@ export function createYogaInstance() {
       : false,
     // Disable CORS - we handle it manually in the request router
     cors: false,
-    // Logging - disable debug in production to reduce noise
+    // Logging - suppress debug entirely (Yoga internals like "Parsing request" are noisy)
     logging: {
-      debug: process.env.NODE_ENV === 'production' ? () => {} : (...args) => console.log('[Yoga Debug]', ...args),
-      info: (...args) => console.log('[Yoga Info]', ...args),
-      warn: (...args) => console.warn('[Yoga Warn]', ...args),
-      error: (...args) => console.error('[Yoga Error]', ...args),
+      debug: () => {},
+      info: (...args: unknown[]) => console.log('[Yoga]', ...args),
+      warn: (...args: unknown[]) => console.warn('[Yoga]', ...args),
+      error: (...args: unknown[]) => console.error('[Yoga]', ...args),
     },
     // In development/test, show all errors
     // In production, errors will be masked by default


### PR DESCRIPTION
## Summary

- Disable GraphQL Yoga's debug-level logger entirely. It emits high-frequency internal messages on every request (`Parsing request to extract GraphQL parameters`, `Processing GraphQL Parameters done`) that clutter logs in all environments without providing useful application-level insight.
- Info, warn, and error loggers remain active with a `[Yoga]` prefix.

## Test plan

- [ ] Start backend with `npm run backend:dev`, make GraphQL requests — no more `[Yoga Debug]` lines in output
- [ ] Verify `[Yoga]` info/warn/error logs still appear when relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)