### PR TITLE
Fix infinite page-fetching loop in ClimbsList on desktop

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -122,18 +122,29 @@ export default function LikedClimbsList({
     return allClimbs.map((climb) => ({ ...climb, angle }));
   }, [allClimbs, angle]);
 
+  // Refs for observer callback values — prevents observer recreation on every page load
+  const fetchNextPageRef = useRef(fetchNextPage);
+  const hasNextPageRef = useRef(hasNextPage);
+  const isFetchingNextPageRef = useRef(isFetchingNextPage);
+  const allClimbsLengthRef = useRef(allClimbs.length);
+  fetchNextPageRef.current = fetchNextPage;
+  hasNextPageRef.current = hasNextPage;
+  isFetchingNextPageRef.current = isFetchingNextPage;
+  allClimbsLengthRef.current = allClimbs.length;
+
+  // Intersection Observer callback for infinite scroll — stable ref, never recreated
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries;
-      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
+      if (target.isIntersecting && hasNextPageRef.current && !isFetchingNextPageRef.current) {
         track('Liked Climbs Infinite Scroll Load More', {
-          currentCount: allClimbs.length,
-          hasMore: hasNextPage,
+          currentCount: allClimbsLengthRef.current,
+          hasMore: hasNextPageRef.current,
         });
-        fetchNextPage();
+        fetchNextPageRef.current();
       }
     },
-    [hasNextPage, isFetchingNextPage, fetchNextPage, allClimbs.length],
+    [],
   );
 
   useEffect(() => {

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -84,25 +84,33 @@ const ClimbsList = ({ boardDetails, initialClimbs, board_name, layout_id, size_i
   // Ref for the intersection observer sentinel element
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
+  // Refs for observer callback values — prevents observer recreation on every page load
+  const fetchMoreClimbsRef = useRef(fetchMoreClimbs);
+  const hasMoreResultsRef = useRef(hasMoreResults);
+  const climbsCountRef = useRef(climbs.length);
+  fetchMoreClimbsRef.current = fetchMoreClimbs;
+  hasMoreResultsRef.current = hasMoreResults;
+  climbsCountRef.current = climbs.length;
+
   useEffect(() => {
     if (page === '0' && hasDoneFirstFetch && isFetchingClimbs) {
       window.scrollTo({ top: 0, behavior: 'instant' });
     }
   }, [page, hasDoneFirstFetch, isFetchingClimbs]);
 
-  // Intersection Observer callback for infinite scroll
+  // Intersection Observer callback for infinite scroll — stable ref, never recreated
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries;
-      if (target.isIntersecting && hasMoreResults) {
+      if (target.isIntersecting && hasMoreResultsRef.current) {
         track('Infinite Scroll Load More', {
-          currentCount: climbs.length,
-          hasMore: hasMoreResults,
+          currentCount: climbsCountRef.current,
+          hasMore: hasMoreResultsRef.current,
         });
-        fetchMoreClimbs();
+        fetchMoreClimbsRef.current();
       }
     },
-    [hasMoreResults, fetchMoreClimbs, climbs.length],
+    [],
   );
 
   // Memoized handler for climb card double-click

--- a/packages/web/app/components/queue-control/persistent-queue-provider.tsx
+++ b/packages/web/app/components/queue-control/persistent-queue-provider.tsx
@@ -6,8 +6,20 @@ import { QueueContext, type GraphQLQueueContextType } from '../graphql-queue/Que
 import { usePersistentSession } from '../persistent-session';
 import { FavoritesProvider } from '../climb-actions/favorites-batch-context';
 import { PlaylistsProvider } from '../climb-actions/playlists-batch-context';
+import type { Playlist } from '../climb-actions/playlists-batch-context';
 import type { ClimbQueueItem } from './types';
 import type { Climb, BoardDetails, Angle, ParsedBoardRouteParameters } from '@/app/lib/types';
+
+// Module-level constants to avoid defeating memoization with new references each render
+const EMPTY_FAVORITES = new Set<string>();
+const EMPTY_PLAYLISTS: Playlist[] = [];
+const EMPTY_MEMBERSHIPS = new Map<string, Set<string>>();
+const NOOP_IS_FAVORITED = () => false;
+const NOOP_TOGGLE_FAVORITE = async () => false;
+const NOOP_ADD_TO_PLAYLIST = async () => {};
+const NOOP_REMOVE_FROM_PLAYLIST = async () => {};
+const NOOP_CREATE_PLAYLIST = async (): Promise<Playlist> => { throw new Error('Not available'); };
+const NOOP_REFRESH_PLAYLISTS = async () => {};
 
 interface PersistentQueueProviderProps {
   boardDetails: BoardDetails;
@@ -238,21 +250,21 @@ export const PersistentQueueProvider: React.FC<PersistentQueueProviderProps> = (
   return (
     <QueueContext.Provider value={contextValue}>
       <FavoritesProvider
-        favorites={new Set<string>()}
-        isFavorited={() => false}
-        toggleFavorite={async () => false}
+        favorites={EMPTY_FAVORITES}
+        isFavorited={NOOP_IS_FAVORITED}
+        toggleFavorite={NOOP_TOGGLE_FAVORITE}
         isLoading={false}
         isAuthenticated={false}
       >
         <PlaylistsProvider
-          playlists={[]}
-          playlistMemberships={new Map()}
-          addToPlaylist={async () => {}}
-          removeFromPlaylist={async () => {}}
-          createPlaylist={async () => { throw new Error('Not available'); }}
+          playlists={EMPTY_PLAYLISTS}
+          playlistMemberships={EMPTY_MEMBERSHIPS}
+          addToPlaylist={NOOP_ADD_TO_PLAYLIST}
+          removeFromPlaylist={NOOP_REMOVE_FROM_PLAYLIST}
+          createPlaylist={NOOP_CREATE_PLAYLIST}
           isLoading={false}
           isAuthenticated={false}
-          refreshPlaylists={async () => {}}
+          refreshPlaylists={NOOP_REFRESH_PLAYLISTS}
         >
           {children}
         </PlaylistsProvider>

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -122,21 +122,31 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
   // Ref for the intersection observer sentinel element
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  // Intersection Observer callback for infinite scroll
+  // Refs for observer callback values — prevents observer recreation on every page load
+  const fetchMoreClimbsRef = useRef(fetchMoreClimbs);
+  const hasMoreResultsRef = useRef(hasMoreResults);
+  const isFetchingNextPageRef = useRef(isFetchingNextPage);
+  const suggestedClimbsLengthRef = useRef(suggestedClimbs.length);
+  fetchMoreClimbsRef.current = fetchMoreClimbs;
+  hasMoreResultsRef.current = hasMoreResults;
+  isFetchingNextPageRef.current = isFetchingNextPage;
+  suggestedClimbsLengthRef.current = suggestedClimbs.length;
+
+  // Intersection Observer callback for infinite scroll — stable ref, never recreated
   // Skip if suggestions are below threshold - proactive fetch in QueueContext handles that case
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries;
       if (
         target.isIntersecting &&
-        hasMoreResults &&
-        !isFetchingNextPage &&
-        suggestedClimbs.length >= SUGGESTIONS_THRESHOLD
+        hasMoreResultsRef.current &&
+        !isFetchingNextPageRef.current &&
+        suggestedClimbsLengthRef.current >= SUGGESTIONS_THRESHOLD
       ) {
-        fetchMoreClimbs();
+        fetchMoreClimbsRef.current();
       }
     },
-    [hasMoreResults, isFetchingNextPage, fetchMoreClimbs, suggestedClimbs.length],
+    [],
   );
 
   // Set up Intersection Observer for infinite scroll

--- a/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-climbs-list.tsx
+++ b/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-climbs-list.tsx
@@ -128,14 +128,23 @@ export default function PlaylistClimbsList({
     return { visibleClimbs: visible, hiddenCount: hidden };
   }, [allClimbs, boardDetails.layout_id, angle]);
 
+  // Refs for observer callback values — prevents observer recreation on every page load
+  const fetchNextPageRef = useRef(fetchNextPage);
+  const hasNextPageRef = useRef(hasNextPage);
+  const isFetchingNextPageRef = useRef(isFetchingNextPage);
+  fetchNextPageRef.current = fetchNextPage;
+  hasNextPageRef.current = hasNextPage;
+  isFetchingNextPageRef.current = isFetchingNextPage;
+
+  // Intersection Observer callback for infinite scroll — stable ref, never recreated
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries;
-      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage();
+      if (target.isIntersecting && hasNextPageRef.current && !isFetchingNextPageRef.current) {
+        fetchNextPageRef.current();
       }
     },
-    [hasNextPage, isFetchingNextPage, fetchNextPage],
+    [],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Fix runaway IntersectionObserver loop** in `climbs-list.tsx` that caused 8GB+ memory usage and 2.6MB/s network traffic on desktop — the observer was being destroyed and recreated on every page load due to unstable `useCallback` dependencies, immediately re-triggering itself while the sentinel element remained visible in the wider viewport
- **Apply the same ref-stabilization pattern** to `queue-list.tsx`, `liked-climbs-list.tsx`, and `playlist-climbs-list.tsx` which had the same vulnerable pattern
- **Hoist inline object/function literals** in `PersistentQueueProvider` to module-level constants (`EMPTY_FAVORITES`, `NOOP_*`, etc.) to stop defeating memoization in `FavoritesProvider` and `PlaylistsProvider`

## Test plan

- [ ] Open the app on desktop in a board route (e.g., `/kilter/.../40/`)
- [ ] Open DevTools Network tab — verify page fetches stop after the viewport is filled
- [ ] Open DevTools Memory tab — verify memory stays stable (not growing continuously)
- [ ] Scroll down to verify infinite scroll still works (loads next page when sentinel enters view)
- [ ] Test on mobile viewport — verify behavior is unchanged
- [ ] Test the queue list drawer — verify infinite scroll still works there too
- [ ] Test liked climbs page — verify infinite scroll works
- [ ] Test playlist climbs page — verify infinite scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)