### PR TITLE
Fix useGraphQLQueueContext crash on playlist route

### DIFF
--- a/packages/web/app/components/climb-actions/actions/mirror-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/mirror-action.tsx
@@ -6,7 +6,7 @@ import { ActionTooltip } from '../action-tooltip';
 import SwapHorizOutlined from '@mui/icons-material/SwapHorizOutlined';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
-import { useQueueContext } from '../../graphql-queue';
+import { useOptionalQueueContext } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export function MirrorAction({
@@ -19,18 +19,18 @@ export function MirrorAction({
   className,
   onComplete,
 }: ClimbActionProps): ClimbActionResult {
-  const { mirrorClimb, currentClimb } = useQueueContext();
+  const queueContext = useOptionalQueueContext();
 
-  const canMirror = boardDetails.supportsMirroring === true;
-  const isMirrored = currentClimb?.mirrored ?? climb.mirrored ?? false;
+  const canMirror = boardDetails.supportsMirroring === true && !!queueContext;
+  const isMirrored = queueContext?.currentClimb?.mirrored ?? climb.mirrored ?? false;
 
   const handleClick = useCallback((e?: React.MouseEvent) => {
     e?.stopPropagation();
     e?.preventDefault();
 
-    if (!canMirror) return;
+    if (!canMirror || !queueContext) return;
 
-    mirrorClimb();
+    queueContext.mirrorClimb();
 
     track('Mirror Climb', {
       boardName: boardDetails.board_name,
@@ -39,7 +39,7 @@ export function MirrorAction({
     });
 
     onComplete?.();
-  }, [canMirror, mirrorClimb, boardDetails.board_name, climb.uuid, isMirrored, onComplete]);
+  }, [canMirror, queueContext, boardDetails.board_name, climb.uuid, isMirrored, onComplete]);
 
   const label = isMirrored ? 'Mirrored' : 'Mirror';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');

--- a/packages/web/app/components/climb-actions/actions/queue-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/queue-action.tsx
@@ -7,7 +7,7 @@ import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
-import { useQueueContext } from '../../graphql-queue';
+import { useOptionalQueueContext } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export function QueueAction({
@@ -20,20 +20,20 @@ export function QueueAction({
   className,
   onComplete,
 }: ClimbActionProps): ClimbActionResult {
-  const { addToQueue, queue } = useQueueContext();
+  const queueContext = useOptionalQueueContext();
   const [recentlyAdded, setRecentlyAdded] = useState(false);
 
   const handleClick = useCallback((e?: React.MouseEvent) => {
     e?.stopPropagation();
     e?.preventDefault();
 
-    if (!addToQueue || recentlyAdded) return;
+    if (!queueContext?.addToQueue || recentlyAdded) return;
 
-    addToQueue(climb);
+    queueContext.addToQueue(climb);
 
     track('Add to Queue', {
       boardLayout: boardDetails.layout_name || '',
-      queueLength: queue.length + 1,
+      queueLength: (queueContext.queue?.length ?? 0) + 1,
     });
 
     setRecentlyAdded(true);
@@ -42,7 +42,7 @@ export function QueueAction({
     }, 5000);
 
     onComplete?.();
-  }, [addToQueue, recentlyAdded, climb, boardDetails.layout_name, queue.length, onComplete]);
+  }, [queueContext, recentlyAdded, climb, boardDetails.layout_name, onComplete]);
 
   const label = recentlyAdded ? 'Added' : 'Add to Queue';
   const shortLabel = recentlyAdded ? 'Added' : 'Queue';
@@ -133,7 +133,7 @@ export function QueueAction({
     element,
     menuItem,
     key: 'queue',
-    available: true,
+    available: !!queueContext,
   };
 }
 

--- a/packages/web/app/components/climb-actions/actions/set-active-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/set-active-action.tsx
@@ -6,7 +6,7 @@ import { ActionTooltip } from '../action-tooltip';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
-import { useQueueContext } from '../../graphql-queue';
+import { useOptionalQueueContext } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export function SetActiveAction({
@@ -19,17 +19,17 @@ export function SetActiveAction({
   className,
   onComplete,
 }: ClimbActionProps): ClimbActionResult {
-  const { setCurrentClimb, currentClimb } = useQueueContext();
+  const queueContext = useOptionalQueueContext();
 
-  const isCurrentClimb = currentClimb?.uuid === climb.uuid;
+  const isCurrentClimb = queueContext?.currentClimb?.uuid === climb.uuid;
 
   const handleClick = useCallback((e?: React.MouseEvent) => {
     e?.stopPropagation();
     e?.preventDefault();
 
-    if (isCurrentClimb) return;
+    if (!queueContext || isCurrentClimb) return;
 
-    setCurrentClimb(climb);
+    queueContext.setCurrentClimb(climb);
 
     track('Set Active Climb', {
       boardLayout: boardDetails.layout_name || '',
@@ -37,7 +37,7 @@ export function SetActiveAction({
     });
 
     onComplete?.();
-  }, [isCurrentClimb, setCurrentClimb, climb, boardDetails.layout_name, onComplete]);
+  }, [queueContext, isCurrentClimb, climb, boardDetails.layout_name, onComplete]);
 
   const label = isCurrentClimb ? 'Active' : 'Set Active';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
@@ -126,7 +126,7 @@ export function SetActiveAction({
     element,
     menuItem,
     key: 'setActive',
-    available: true,
+    available: !!queueContext,
   };
 }
 

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -13,7 +13,7 @@ import ClimbThumbnail from './climb-thumbnail';
 import DrawerClimbHeader from './drawer-climb-header';
 import { AscentStatus } from '../queue-control/queue-list-item';
 import { ClimbActions } from '../climb-actions';
-import { useQueueContext } from '../graphql-queue';
+import { useOptionalQueueContext } from '../graphql-queue';
 import { useFavorite } from '../climb-actions';
 import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
@@ -32,13 +32,14 @@ type ClimbListItemProps = {
 
 const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDetails, selected, onSelect }) => {
   const [isActionsOpen, setIsActionsOpen] = useState(false);
-  const { addToQueue } = useQueueContext();
+  const queueContext = useOptionalQueueContext();
+  const addToQueue = queueContext?.addToQueue;
   const { isFavorited, toggleFavorite } = useFavorite({ climbUuid: climb.uuid });
   const { ref: doubleTapRef, onDoubleClick: handleDoubleClick } = useDoubleTap(onSelect);
 
   const handleSwipeLeft = useCallback(() => {
     // Swipe left = add to queue
-    addToQueue(climb);
+    addToQueue?.(climb);
   }, [climb, addToQueue]);
 
   const handleSwipeRight = useCallback(() => {

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -1003,5 +1003,9 @@ export const useGraphQLQueueContext = (): GraphQLQueueContextType => {
   return context;
 };
 
+export const useOptionalQueueContext = (): GraphQLQueueContextType | null => {
+  return useContext(QueueContext);
+};
+
 // Re-export the hook with the standard name for easier migration
 export { useGraphQLQueueContext as useQueueContext };

--- a/packages/web/app/components/graphql-queue/index.ts
+++ b/packages/web/app/components/graphql-queue/index.ts
@@ -5,4 +5,4 @@ export type { Client } from './graphql-client';
 export { useQueueSession } from './use-queue-session';
 export type { UseQueueSessionOptions, UseQueueSessionReturn, Session } from './use-queue-session';
 
-export { GraphQLQueueProvider, useGraphQLQueueContext, useQueueContext, QueueContext } from './QueueContext';
+export { GraphQLQueueProvider, useGraphQLQueueContext, useQueueContext, useOptionalQueueContext, QueueContext } from './QueueContext';


### PR DESCRIPTION
Components using useQueueContext (ClimbListItem, QueueAction,
SetActiveAction, MirrorAction) threw when rendered outside
GraphQLQueueProvider, which happens on /my-library/playlist routes.

Add useOptionalQueueContext hook that returns null instead of throwing,
and update affected components to gracefully degrade queue-related
features when no provider exists.

https://claude.ai/code/session_01FNv3KgCTSwptMRuNShr5Qj