### PR TITLE
Fix QueueContext type: convert undefined to null in useOptionalQueueContext

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -1004,7 +1004,7 @@ export const useGraphQLQueueContext = (): GraphQLQueueContextType => {
 };
 
 export const useOptionalQueueContext = (): GraphQLQueueContextType | null => {
-  return useContext(QueueContext);
+  return useContext(QueueContext) ?? null;
 };
 
 // Re-export the hook with the standard name for easier migration


### PR DESCRIPTION
useContext returns undefined when no provider is found, but the return
type declares null. Use nullish coalescing to convert undefined to null.

https://claude.ai/code/session_01Q2FDFnb1Y6L7mDMJGcQ1de