### PR TITLE
Fix bottom nav hidden by queue bar on my-library and notifications pages

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-with-queue.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-with-queue.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { usePersistentSession } from '@/app/components/persistent-session';
+import { PersistentQueueProvider } from '@/app/components/queue-control/persistent-queue-provider';
+import { BoardProvider } from '@/app/components/board-provider/board-provider-context';
+import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
+import QueueControlBar from '@/app/components/queue-control/queue-control-bar';
+import BottomTabBar from './bottom-tab-bar';
+import ErrorBoundary from '@/app/components/error-boundary';
+import bottomBarStyles from './bottom-bar-wrapper.module.css';
+import { BoardConfigData } from '@/app/lib/server-board-configs';
+
+interface BottomBarWithQueueProps {
+  boardConfigs: BoardConfigData;
+}
+
+/**
+ * Combined bottom bar that renders QueueControlBar (when there's an active queue)
+ * stacked above the BottomTabBar. Used on non-board pages (my-library, notifications)
+ * that need both components in a single fixed container.
+ */
+export default function BottomBarWithQueue({ boardConfigs }: BottomBarWithQueueProps) {
+  const {
+    activeSession,
+    localQueue,
+    localCurrentClimbQueueItem,
+    localBoardDetails,
+  } = usePersistentSession();
+
+  const isPartyMode = !!activeSession;
+  const queueBoardDetails = isPartyMode ? activeSession.boardDetails : localBoardDetails;
+  const queueAngle = isPartyMode
+    ? activeSession.parsedParams.angle
+    : (localCurrentClimbQueueItem?.climb?.angle ?? 0);
+  const hasActiveQueue = (localQueue.length > 0 || !!localCurrentClimbQueueItem || !!activeSession) && !!queueBoardDetails;
+
+  return (
+    <div className={bottomBarStyles.bottomBarWrapper}>
+      {hasActiveQueue && queueBoardDetails && (
+        <ErrorBoundary>
+          <BoardProvider boardName={queueBoardDetails.board_name}>
+            <PersistentQueueProvider boardDetails={queueBoardDetails} angle={queueAngle}>
+              <BluetoothProvider boardDetails={queueBoardDetails}>
+                <QueueControlBar boardDetails={queueBoardDetails} angle={queueAngle} />
+              </BluetoothProvider>
+            </PersistentQueueProvider>
+          </BoardProvider>
+        </ErrorBoundary>
+      )}
+      <BottomTabBar boardConfigs={boardConfigs} />
+    </div>
+  );
+}

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -39,6 +39,8 @@ function OffBoardQueueBar() {
   const isOnBoardRoute = useIsOnBoardRoute();
   const pathname = usePathname();
   const isHomePage = pathname === '/';
+  // Pages with their own layout that includes BottomBarWithQueue handle the queue bar themselves
+  const hasOwnBottomBar = pathname.startsWith('/my-library') || pathname.startsWith('/notifications');
   const {
     activeSession,
     localQueue,
@@ -53,9 +55,9 @@ function OffBoardQueueBar() {
     : (localCurrentClimbQueueItem?.climb?.angle ?? 0);
 
   // Only show when off board routes and there's something to show
-  // Home page handles its own bottom bar with QueueControlBar integration
+  // Home page and pages with BottomBarWithQueue handle their own QueueControlBar integration
   const hasContent = localQueue.length > 0 || !!localCurrentClimbQueueItem || !!activeSession;
-  if (!hasContent || isOnBoardRoute || isHomePage || !boardDetails) {
+  if (!hasContent || isOnBoardRoute || isHomePage || hasOwnBottomBar || !boardDetails) {
     return null;
   }
 

--- a/packages/web/app/my-library/layout.tsx
+++ b/packages/web/app/my-library/layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import BottomTabBar from '@/app/components/bottom-tab-bar/bottom-tab-bar';
+import BottomBarWithQueue from '@/app/components/bottom-tab-bar/bottom-bar-with-queue';
 import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
-import bottomBarStyles from '@/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css';
 
 export default async function MyLibraryLayout({
   children,
@@ -13,9 +12,7 @@ export default async function MyLibraryLayout({
   return (
     <div style={{ minHeight: '100dvh', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
-      <div className={bottomBarStyles.bottomBarWrapper}>
-        <BottomTabBar boardConfigs={boardConfigs} />
-      </div>
+      <BottomBarWithQueue boardConfigs={boardConfigs} />
     </div>
   );
 }

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import BottomTabBar from '@/app/components/bottom-tab-bar/bottom-tab-bar';
+import BottomBarWithQueue from '@/app/components/bottom-tab-bar/bottom-bar-with-queue';
 import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
-import bottomBarStyles from '@/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css';
 
 export default async function NotificationsLayout({
   children,
@@ -13,9 +12,7 @@ export default async function NotificationsLayout({
   return (
     <div style={{ minHeight: '100dvh', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
-      <div className={bottomBarStyles.bottomBarWrapper}>
-        <BottomTabBar boardConfigs={boardConfigs} />
-      </div>
+      <BottomBarWithQueue boardConfigs={boardConfigs} />
     </div>
   );
 }


### PR DESCRIPTION
The OffBoardQueueBar (z-index: 999, position: fixed) was covering the BottomTabBar (z-index: 10) on these routes. Created BottomBarWithQueue component that stacks both QueueControlBar and BottomTabBar in a single fixed container, matching the pattern used on the home page. Excluded my-library and notifications from OffBoardQueueBar since their layouts now handle the queue bar themselves.

https://claude.ai/code/session_01LaZ9bfiZQcoPU5dws3esdS