### PR TITLE
Remove unnecessary session polling interval

### DIFF
--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -13,7 +13,6 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
     <SessionProvider
       refetchOnWindowFocus={false}
       refetchWhenOffline={false}
-      refetchInterval={5 * 60}
     >
       {children}
     </SessionProvider>


### PR DESCRIPTION
## Summary

- Remove `refetchInterval={5 * 60}` from NextAuth `SessionProvider`, eliminating background `/api/auth/session` polling every 5 minutes
- Session uses JWT strategy with 30-day expiry — tokens are self-contained and validated server-side without polling
- Keeps `refetchOnWindowFocus={false}` and `refetchWhenOffline={false}` unchanged

## Test plan

- [ ] Start dev server, open Network tab, filter for `/api/auth/session`
- [ ] Confirm only a single request on page load
- [ ] Leave tab open 10+ minutes and confirm no additional requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)