### PR TITLE
Waveshare 7" settings, captive portal, and BLE fixes

### DIFF
--- a/embedded/libs/ble-proxy/src/ble_proxy.h
+++ b/embedded/libs/ble-proxy/src/ble_proxy.h
@@ -12,7 +12,7 @@ enum class BLEProxyState {
     PROXY_DISABLED,         // Proxy mode not enabled
     IDLE,                   // Waiting to scan
     SCANNING,               // Scanning for boards
-    SCAN_COMPLETE_NONE,     // Scan completed but no boards found (won't auto-retry)
+    SCAN_COMPLETE_NONE,     // Scan completed but no boards found (will auto-retry after delay)
     WAIT_BEFORE_CONNECT,    // Non-blocking wait after scan before connecting
     CONNECTING,             // Connecting to board
     WAIT_BEFORE_ADVERTISE,  // Non-blocking wait after connect before advertising

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -199,13 +199,7 @@ void initializeBLE() {
     }
 
     Logger.logln("Initializing BLE as '%s'...", BLE_DEVICE_NAME);
-#ifdef ENABLE_BLE_PROXY
-    // When proxy is enabled, don't advertise yet - connect to board first
-    // Advertising will start after successful connection to real board
-    BLE.begin(BLE_DEVICE_NAME, false);
-#else
     BLE.begin(BLE_DEVICE_NAME, true);
-#endif
     BLE.setConnectCallback(onBLEConnect);
     BLE.setDataCallback(onBLEData);
     BLE.setLedDataCallback(onBLELedData);

--- a/embedded/test/lib/mocks/src/DNSServer.h
+++ b/embedded/test/lib/mocks/src/DNSServer.h
@@ -1,0 +1,46 @@
+/**
+ * DNSServer Mock Header for Native Unit Testing
+ *
+ * Provides a mock ESP32 DNSServer implementation to satisfy compilation
+ * of wifi_utils and esp_web_server during native tests.
+ */
+
+#ifndef DNSSERVER_MOCK_H
+#define DNSSERVER_MOCK_H
+
+#include "Arduino.h"
+#include "WiFi.h"
+
+#include <cstdint>
+
+class DNSServer {
+  public:
+    DNSServer() : running_(false), port_(0) {}
+
+    void start(uint16_t port, const char* domain, IPAddress ip) {
+        running_ = true;
+        port_ = port;
+    }
+
+    void processNextRequest() {
+        // No-op in mock
+    }
+
+    void stop() {
+        running_ = false;
+    }
+
+    // Test helpers
+    bool mockIsRunning() const { return running_; }
+    uint16_t mockGetPort() const { return port_; }
+    void mockReset() {
+        running_ = false;
+        port_ = 0;
+    }
+
+  private:
+    bool running_;
+    uint16_t port_;
+};
+
+#endif  // DNSSERVER_MOCK_H

--- a/embedded/test/platformio.ini
+++ b/embedded/test/platformio.ini
@@ -34,6 +34,8 @@ lib_deps =
 lib_extra_dirs =
     lib
 test_framework = unity
+; Only run our test_* directories, exclude Unity's bundled examples
+test_filter = test_*
 
 ; Coverage support (uncomment for coverage reports)
 ; build_flags = ${env:native.build_flags} -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
## Summary
- Add settings screen, WiFi join QR code, and captive portal for the Waveshare 7" device
- Fix BLE advertising not starting immediately in proxy mode — device is now discoverable without a real board nearby
- Add automatic BLE proxy scan retry (every 10s) when no boards are found, instead of permanently stopping after the first failed 30s scan

## BLE Fix Details
- **Always advertise**: Removed `#ifdef ENABLE_BLE_PROXY` conditional that delayed BLE advertising until proxy connected to a real board. ESP32-S3 supports multi-role BLE (advertising + scanning simultaneously), and all callbacks safely no-op when proxy isn't connected.
- **Auto-retry scan**: `SCAN_COMPLETE_NONE` was a dead-end state with no way out except reboot. Now it automatically transitions back to `IDLE` after a 10-second delay to rescan.

## Test plan
- [ ] Flash Waveshare 7" device with updated firmware
- [ ] Verify "Kilter Boardsesh" appears in BLE device picker immediately (without a real board nearby)
- [ ] Verify proxy scan retries and eventually connects when a real Kilter board is powered on nearby
- [ ] Verify proxy data forwarding works normally once connected
- [ ] Verify settings screen and captive portal work on the Waveshare display

🤖 Generated with [Claude Code](https://claude.com/claude-code)