### PR TITLE
Add embedded architecture docs and improve config persistence error handling

### DIFF
--- a/docs/embedded-architecture.md
+++ b/docs/embedded-architecture.md
@@ -1,0 +1,199 @@
+# Embedded Architecture
+
+This document describes the ESP32 firmware that powers BoardSesh's physical board controllers. The firmware provides BLE communication with climbing boards, real-time backend sync via WebSocket, a captive portal for device setup, and optional display support for queue navigation.
+
+## Directory Structure
+
+```
+embedded/
+├── libs/                          # Shared PlatformIO libraries
+│   ├── aurora-protocol/           # Kilter/Tension BLE protocol codec
+│   ├── ble-proxy/                 # BLE proxy for app↔board forwarding
+│   ├── board-data/                # Generated board images & hold mappings
+│   ├── climb-history/             # Circular buffer for recent climbs (NVS)
+│   ├── config-manager/            # NVS key-value persistence wrapper
+│   ├── display-base/              # Abstract base class for display drivers
+│   ├── display-ui/                # Shared UI components (grades, QR, colors)
+│   ├── esp-web-server/            # HTTP config server & captive portal
+│   ├── graphql-types/             # Auto-generated C++ types from GraphQL schema
+│   ├── graphql-ws-client/         # WebSocket GraphQL subscriptions client
+│   ├── led-controller/            # FastLED abstraction for WS2812B LEDs
+│   ├── lilygo-display/            # LilyGo T-Display-S3 driver (170x320)
+│   ├── log-buffer/                # Ring buffer logger (2KB)
+│   ├── nordic-uart-ble/           # BLE GATT server (Nordic UART Service)
+│   ├── waveshare-display/         # Waveshare 7" touch driver (480x800)
+│   └── wifi-utils/                # WiFi manager with AP mode & auto-reconnect
+├── projects/
+│   └── board-controller/          # Main firmware project
+│       ├── src/
+│       │   ├── main.cpp           # Entry point & state machine
+│       │   └── config/            # Board-specific defaults
+│       └── platformio.ini         # Build environments & variants
+├── test/                          # Native unit tests (no hardware)
+│   ├── lib/mocks/                 # Hardware API mocks (Arduino, BLE, WiFi, etc.)
+│   └── test_*/                    # Test suites per library
+└── scripts/
+    ├── prebuild.py                # Triggers codegen before build
+    ├── generate-graphql-types.mjs # GraphQL schema → C++ header
+    └── generate-board-data.mjs    # Board image & hold data codegen
+```
+
+## Build Variants
+
+The project uses PlatformIO with multiple build environments defined in `embedded/projects/board-controller/platformio.ini`:
+
+| Environment | Target Hardware | Display | BLE Proxy | Board Image |
+|---|---|---|---|---|
+| `esp32s3dev` | ESP32-S3 DevKit | No | No | No |
+| `esp32s3dev-proxy` | ESP32-S3 DevKit | No | Yes | No |
+| `tdisplay-s3` | LilyGo T-Display-S3 | 170x320 LCD | Yes | No |
+| `waveshare-7inch` | Waveshare 7" Touch LCD | 480x800 RGB | Yes | Yes |
+| `esp32dev` | Original ESP32 (legacy) | No | No | No |
+
+Feature flags are controlled via build defines: `ENABLE_BLE_PROXY`, `ENABLE_DISPLAY`, `ENABLE_WAVESHARE_DISPLAY`, `ENABLE_BOARD_IMAGE`.
+
+## Operating Modes
+
+### Direct Mode (Default)
+
+The ESP32 acts as a drop-in board controller:
+
+1. Exposes a BLE GATT server (Nordic UART Service) compatible with official Kilter/Tension apps
+2. Receives LED commands from the app via BLE and drives WS2812B LEDs directly
+3. Optionally forwards BLE LED data to the BoardSesh backend for climb identification
+
+### Proxy Mode
+
+The ESP32 bridges between the official app and an existing board:
+
+1. Acts as a BLE server (appears as "Kilter Boardsesh" to the app)
+2. Acts as a BLE client connected to the actual climbing board
+3. Forwards all BLE traffic bidirectionally between app and board
+4. Additionally syncs with the BoardSesh backend via WebSocket
+
+The proxy's state machine:
+```
+DISABLED → IDLE → SCANNING → CONNECTING → CONNECTED
+                                  ↑              ↓
+                                  └── RECONNECTING
+```
+
+## Captive Portal & WiFi Setup
+
+When no WiFi credentials are stored (first boot or after reset), the device enters AP mode:
+
+1. Creates a WiFi access point named "Boardsesh-Setup"
+2. Starts a DNS server that redirects all requests to `192.168.4.1`
+3. Serves a configuration web page via the built-in HTTP server
+4. User connects to the AP, gets redirected to the setup page, and enters WiFi credentials
+5. On successful connection, credentials are persisted to NVS and the device reconnects automatically on future boots
+
+The web server (`esp-web-server`) provides these endpoints in both AP and station modes:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/` | GET | Configuration web page |
+| `/api/config` | GET/POST | Read/write device settings |
+| `/api/wifi/scan` | GET | Scan available networks |
+| `/api/wifi/connect` | POST | Connect to a WiFi network |
+| `/api/wifi/status` | GET | Current connection state |
+| `/api/restart` | POST | Reboot the device |
+| `/api/firmware/version` | GET | Current firmware version |
+| `/api/firmware/upload` | POST | OTA firmware update |
+
+## Settings Screen (Waveshare Display)
+
+The Waveshare 7" touch display includes an interactive settings screen accessible via a touch gesture from the main climb view. The settings screen displays:
+
+- **Current WiFi SSID** and IP address
+- **Reset WiFi** button — clears stored credentials and restarts in AP mode for reconfiguration
+- **BLE Proxy toggle** — enables/disables proxy mode with immediate effect
+
+Settings changes are persisted to NVS via `ConfigManager`. On the LilyGo display (which lacks touch), a long press (3s) on Button 1 performs a full configuration reset instead.
+
+## Configuration Persistence
+
+All device settings are stored in ESP32 NVS (Non-Volatile Storage) via the `ConfigManager` class, which wraps the ESP32 `Preferences` API under the `"boardsesh"` namespace.
+
+Key stored values:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `wifi_ssid` | String | WiFi network name |
+| `wifi_pass` | String | WiFi password |
+| `backend_host` | String | GraphQL WebSocket server host |
+| `backend_port` | Int | Server port |
+| `backend_path` | String | Server path |
+| `api_key` | String | Authentication key |
+| `session_id` | String | BoardSesh session ID |
+| `proxy_en` | Bool | BLE proxy enabled |
+| `proxy_mac` | String | Target board MAC address |
+| `brightness` | Int | LED brightness |
+| `disp_br` | Int | Display brightness |
+
+All setter methods (`setString`, `setBool`, `setInt`, `setBytes`) return `bool` indicating whether the write succeeded, allowing callers to detect and log persistence failures.
+
+## Backend Integration
+
+The device connects to the BoardSesh backend via a WebSocket GraphQL subscription (`graphql-ws-client`):
+
+1. **Connection**: Establishes WebSocket to the configured backend with API key in `connection_init`
+2. **Subscription**: Subscribes to `controllerEvents` for the configured session ID
+3. **Events received**:
+   - `LedUpdate` — LED commands, climb metadata, navigation context
+   - `ControllerQueueSync` — Full queue state (up to 150 items with current index)
+   - `ControllerPing` — Keepalive
+4. **Mutations sent**:
+   - `navigateQueue` — Queue navigation (previous/next) triggered by touch or buttons
+   - `sendLedPositions` — Forward BLE-received LED data for climb identification
+
+Navigation mutations are debounced (100ms) to coalesce rapid button presses into a single backend call. The display updates optimistically while the mutation is in flight.
+
+## Display Architecture
+
+Display support uses an abstract base class (`DisplayBase`) with two concrete implementations:
+
+### LilyGo T-Display-S3 (170x320)
+- Parallel 8-bit interface via LovyanGFX
+- Layout: status bar, climb info, QR code, navigation indicator, history
+- Input: 2 physical buttons (GPIO 0 & GPIO 14) with debouncing
+
+### Waveshare 7" Touch (480x800)
+- RGB bus interface with bounce buffer for DMA transfers
+- GT911 capacitive touch via I2C with CH422G IO expander
+- All LilyGo features plus: touch navigation, settings screen, board image rendering
+- Board image: JPEG decoded to PSRAM sprite with LED hold overlay
+
+Both displays share common state management in `DisplayBase`:
+- Current climb (name, grade, color, angle)
+- Queue state (local copy of 150 items, current index)
+- Navigation context (previous/next climb previews)
+- Climb history (last 5 climbs)
+- Status indicators (WiFi, BLE, backend connection)
+- QR code (session URL, Version 6)
+
+## Memory Budget
+
+| Component | Size | Notes |
+|---|---|---|
+| Queue buffer | ~13 KB | 150 items x ~88 bytes (static allocation) |
+| Log buffer | 2 KB | Circular ring buffer |
+| Climb history | ~1 KB | 5 entries |
+| QR code | 211 bytes | 41x41 module grid |
+| Board image sprite | ~768 KB | PSRAM only (Waveshare) |
+
+## Testing
+
+Native unit tests run on the host machine without hardware, using mock implementations of Arduino, BLE, WiFi, and other ESP32 APIs. Test suites exist for all core libraries.
+
+Run tests from `embedded/test/`:
+```bash
+pio test -e native
+```
+
+## Code Generation
+
+The prebuild script (`scripts/prebuild.py`) runs before each firmware build:
+
+1. **GraphQL types**: Converts `packages/shared-schema/src/schema.ts` into `libs/graphql-types/src/graphql_types.h`
+2. **Board data** (if `ENABLE_BOARD_IMAGE`): Generates board images and hold position mappings from the web package's database into `libs/board-data/src/board_hold_data.h`

--- a/embedded/libs/config-manager/src/config_manager.cpp
+++ b/embedded/libs/config-manager/src/config_manager.cpp
@@ -23,9 +23,9 @@ String ConfigManager::getString(const char* key, const String& defaultValue) {
     return prefs.getString(key, defaultValue);
 }
 
-void ConfigManager::setString(const char* key, const String& value) {
+bool ConfigManager::setString(const char* key, const String& value) {
     begin();
-    prefs.putString(key, value);
+    return prefs.putString(key, value) > 0 || value.length() == 0;
 }
 
 int32_t ConfigManager::getInt(const char* key, int32_t defaultValue) {
@@ -33,9 +33,9 @@ int32_t ConfigManager::getInt(const char* key, int32_t defaultValue) {
     return prefs.getInt(key, defaultValue);
 }
 
-void ConfigManager::setInt(const char* key, int32_t value) {
+bool ConfigManager::setInt(const char* key, int32_t value) {
     begin();
-    prefs.putInt(key, value);
+    return prefs.putInt(key, value) > 0;
 }
 
 bool ConfigManager::getBool(const char* key, bool defaultValue) {
@@ -43,9 +43,9 @@ bool ConfigManager::getBool(const char* key, bool defaultValue) {
     return prefs.getBool(key, defaultValue);
 }
 
-void ConfigManager::setBool(const char* key, bool value) {
+bool ConfigManager::setBool(const char* key, bool value) {
     begin();
-    prefs.putBool(key, value);
+    return prefs.putBool(key, value) > 0;
 }
 
 size_t ConfigManager::getBytes(const char* key, uint8_t* buffer, size_t maxLen) {
@@ -53,9 +53,9 @@ size_t ConfigManager::getBytes(const char* key, uint8_t* buffer, size_t maxLen) 
     return prefs.getBytes(key, buffer, maxLen);
 }
 
-void ConfigManager::setBytes(const char* key, const uint8_t* buffer, size_t len) {
+bool ConfigManager::setBytes(const char* key, const uint8_t* buffer, size_t len) {
     begin();
-    prefs.putBytes(key, buffer, len);
+    return prefs.putBytes(key, buffer, len) > 0 || len == 0;
 }
 
 void ConfigManager::clear() {

--- a/embedded/libs/config-manager/src/config_manager.h
+++ b/embedded/libs/config-manager/src/config_manager.h
@@ -15,19 +15,19 @@ class ConfigManager {
 
     // String values
     String getString(const char* key, const String& defaultValue = "");
-    void setString(const char* key, const String& value);
+    bool setString(const char* key, const String& value);
 
     // Integer values
     int32_t getInt(const char* key, int32_t defaultValue = 0);
-    void setInt(const char* key, int32_t value);
+    bool setInt(const char* key, int32_t value);
 
     // Boolean values
     bool getBool(const char* key, bool defaultValue = false);
-    void setBool(const char* key, bool value);
+    bool setBool(const char* key, bool value);
 
     // Byte arrays
     size_t getBytes(const char* key, uint8_t* buffer, size_t maxLen);
-    void setBytes(const char* key, const uint8_t* buffer, size_t len);
+    bool setBytes(const char* key, const uint8_t* buffer, size_t len);
 
     // Clear all config
     void clear();

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -176,6 +176,9 @@ void navigateNext();
 void sendNavigationMutation(const char* queueItemUuid);
 #endif
 void startupAnimation();
+#ifdef ENABLE_WAVESHARE_DISPLAY
+void updateSettingsDisplay(bool proxyEnabled);
+#endif
 
 #ifdef ENABLE_BLE_PROXY
 void onBLERawForward(const uint8_t* data, size_t len);
@@ -333,6 +336,20 @@ void setup() {
 #endif
 }
 
+#ifdef ENABLE_WAVESHARE_DISPLAY
+/**
+ * Update the settings display with current WiFi/proxy state.
+ * Centralizes the IP retrieval logic to avoid duplication.
+ */
+void updateSettingsDisplay(bool proxyEnabled) {
+    const char* ssid = WiFiMgr.isConnected() ? WiFiMgr.getSSID().c_str() : "";
+    const char* ip = WiFiMgr.isConnected() ? WiFiMgr.getIP().c_str()
+                     : WiFiMgr.isAPMode()   ? WiFiMgr.getAPIP().c_str()
+                                             : "";
+    Display.setSettingsData(ssid, ip, proxyEnabled);
+}
+#endif
+
 void loop() {
     // Process WiFi
     WiFiMgr.loop();
@@ -387,39 +404,37 @@ void loop() {
             break;
         case TouchAction::OPEN_SETTINGS:
             Logger.logln("Touch: open settings");
-            Display.setSettingsData(
-                WiFiMgr.isConnected() ? WiFiMgr.getSSID().c_str() : "",
-                WiFiMgr.isConnected() ? WiFiMgr.getIP().c_str() : WiFiMgr.isAPMode() ? WiFiMgr.getAPIP().c_str() : "",
-                Config.getBool("proxy_en", false)
-            );
+            updateSettingsDisplay(Config.getBool("proxy_en", false));
             Display.showSettingsScreen();
             break;
         case TouchAction::SETTINGS_BACK:
             Logger.logln("Touch: settings back");
             Display.hideSettingsScreen();
             break;
-        case TouchAction::SETTINGS_RESET_WIFI:
+        case TouchAction::SETTINGS_RESET_WIFI: {
             Logger.logln("Touch: reset WiFi");
-            Config.setString("wifi_ssid", "");
-            Config.setString("wifi_pass", "");
+            bool wifiResetOk = Config.setString("wifi_ssid", "")
+                            && Config.setString("wifi_pass", "");
+            if (!wifiResetOk) {
+                Logger.logln("WARNING: Failed to persist WiFi reset");
+            }
             WiFiMgr.disconnect();
             Display.hideSettingsScreen();
             if (WiFiMgr.startAP()) {
                 Display.showSetupScreen(DEFAULT_AP_NAME);
             }
             break;
+        }
         case TouchAction::SETTINGS_TOGGLE_PROXY: {
             Logger.logln("Touch: toggle BLE proxy");
             bool newProxyState = !Config.getBool("proxy_en", false);
-            Config.setBool("proxy_en", newProxyState);
+            if (!Config.setBool("proxy_en", newProxyState)) {
+                Logger.logln("WARNING: Failed to persist proxy toggle");
+            }
 #ifdef ENABLE_BLE_PROXY
             Proxy.setEnabled(newProxyState);
 #endif
-            Display.setSettingsData(
-                WiFiMgr.isConnected() ? WiFiMgr.getSSID().c_str() : "",
-                WiFiMgr.isConnected() ? WiFiMgr.getIP().c_str() : WiFiMgr.isAPMode() ? WiFiMgr.getAPIP().c_str() : "",
-                newProxyState
-            );
+            updateSettingsDisplay(newProxyState);
             Display.showSettingsScreen();
             break;
         }
@@ -454,10 +469,13 @@ void loop() {
             Display.showError("Resetting...");
             button1LongPressTriggered = true;
 
-            Config.setString("wifi_ssid", "");
-            Config.setString("wifi_pass", "");
-            Config.setString("api_key", "");
-            Config.setString("session_id", "");
+            bool resetOk = Config.setString("wifi_ssid", "")
+                        && Config.setString("wifi_pass", "")
+                        && Config.setString("api_key", "")
+                        && Config.setString("session_id", "");
+            if (!resetOk) {
+                Logger.logln("WARNING: Failed to persist config reset");
+            }
 
             delay(1000);
             ESP.restart();


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the ESP32 firmware architecture and improves error handling in the configuration persistence layer by making setter methods return success/failure status.

## Key Changes

**Documentation**
- Added `embedded-architecture.md` with complete overview of the firmware including:
  - Directory structure and library organization
  - Build variants and feature flags
  - Operating modes (Direct and Proxy)
  - Captive portal and WiFi setup flow
  - Settings screen functionality
  - Configuration persistence details
  - Backend GraphQL integration
  - Display architecture for both LilyGo and Waveshare implementations
  - Memory budget breakdown
  - Testing and code generation processes

**Configuration Manager**
- Changed all setter methods (`setString`, `setInt`, `setBool`, `setBytes`) to return `bool` indicating success/failure
- Implementation now checks the return value from underlying `Preferences` API calls
- Handles edge cases (e.g., empty strings/arrays return true even if putX returns 0)

**Main Firmware**
- Added `updateSettingsDisplay()` helper function to centralize WiFi/IP retrieval logic and eliminate duplication
- Updated all configuration setter calls to check return values and log warnings on persistence failures
- Added error handling for:
  - WiFi reset operations
  - BLE proxy toggle persistence
  - Full configuration reset on button long-press
- Improved code organization by extracting repeated WiFi state retrieval into the helper function

## Implementation Details

The configuration setter changes follow the ESP32 Preferences API pattern where `putX()` returns the number of bytes written (>0 on success, 0 on failure). The implementation accounts for special cases where empty values are valid (empty strings, zero-length byte arrays) and should return true even if the underlying API returns 0.

All callers now have visibility into persistence failures, enabling proper error logging and user feedback when NVS operations fail.

https://claude.ai/code/session_012TGYovzEaFfHSFcGk1NZ6K