### PR TITLE
Fix play view board rendering too large after unify shell merge

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -1,15 +1,8 @@
 .drawerContent {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior-y: contain;
-}
-
-.aboveFold {
-  height: 100%;
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 .boardSection {
@@ -32,12 +25,6 @@
   align-items: center;
   padding: 8px 16px 12px;
   flex-shrink: 0;
-}
-
-.extrasSection {
-  flex-shrink: 0;
-  border-top: 1px solid var(--neutral-200);
-  padding-top: 8px;
 }
 
 .swipeCardContainer {


### PR DESCRIPTION
The merge of PR #801 wrapped the play view content in a new
.mobileScrollLayout container from ClimbDetailShellClient, but
.drawerContent was not a flex container, so .mobileScrollLayout's
flex:1 had no effect. The board rendered at its natural (unconstrained)
height, pushing the action bar below the fold.

Fix by making .drawerContent a proper flex column container and removing
scroll properties now handled by .mobileScrollLayout. Also remove dead
.aboveFold and .extrasSection classes that are no longer referenced.

https://claude.ai/code/session_012UCvmZyBxTqPjrP1xccPVu