### PR TITLE
Fix collapsible sections showing above the fold in play view

### DIFF
--- a/packages/web/app/components/climb-detail/climb-detail-shell.module.css
+++ b/packages/web/app/components/climb-detail/climb-detail-shell.module.css
@@ -12,7 +12,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  flex-shrink: 0;
 }
 
 .belowFold {


### PR DESCRIPTION
The .aboveFold container inside the flex-column scroll container (.mobileScrollLayout) had default flex-shrink: 1 while .belowFold had flex-shrink: 0. When total content exceeded the container, flex shrank .aboveFold to accommodate .belowFold, pulling the collapsible sections into the viewport.

Fix by adding flex-shrink: 0 to .aboveFold so it keeps its full 100% height, forcing .belowFold below the fold where it's only visible on scroll.

https://claude.ai/code/session_012UCvmZyBxTqPjrP1xccPVu