### PR TITLE
Fix queue drawer positioning in play view

### DIFF
--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -197,7 +197,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
 
   // Compute paper dimensions from height/width/styles.wrapper
   const paperSx = useMemo(() => {
-    const sx: Record<string, unknown> = { position: 'relative' };
+    const sx: Record<string, unknown> = {};
 
     // Apply wrapper styles (styles.wrapper → MUI PaperProps.sx)
     if (userStyles?.wrapper) {
@@ -319,7 +319,9 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
       slotProps={slotProps}
       PaperProps={muiPaperProps}
     >
-      {bodyContent}
+      <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        {bodyContent}
+      </Box>
     </MuiSwipeableDrawer>
   );
 };


### PR DESCRIPTION
## Summary
- Removed `position: relative` from the SwipeableDrawer's `paperSx` which was overriding MUI's native `position: fixed; bottom: 0` anchoring on the Paper element
- Added an inner `<Box>` content wrapper with `position: relative` to preserve the positioning context needed by the absolutely-positioned close button
- This fixes partial-height bottom drawers (e.g. the 60% queue drawer) anchoring to the top of the modal instead of the bottom

## Test plan
- [ ] Open the play view drawer, tap the queue icon — confirm the queue drawer anchors to the **bottom** of the screen (filling the bottom 60%)
- [ ] Drag up to expand to 100%, drag down to collapse back to 60%, drag down again to close
- [ ] Verify the close button on other drawers (e.g., climb actions drawer) still positions correctly
- [ ] Verify the main play view drawer (100% height) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)