### PR TITLE
Fix nested drawer swipe-to-close propagating to parent

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -210,11 +210,12 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   }, [isOpen, setActiveDrawer]);
 
   const handleClose = useCallback(() => {
+    if (isActionsOpen || isQueueOpen) return;
     setActiveDrawer('none');
     if (window.location.hash === '#playing') {
       window.history.back();
     }
-  }, [setActiveDrawer]);
+  }, [setActiveDrawer, isActionsOpen, isQueueOpen]);
 
   // Card-swipe navigation
   const nextItem = getNextClimbQueueItem();


### PR DESCRIPTION
## Summary
- Guard the parent play-view drawer's `onClose` so it's a no-op while a child drawer (queue or actions) is open
- Fixes an issue where swiping to close the nested queue/actions drawer also closes the parent play-view drawer
- MUI's internal swipe tracking can fire the parent's `onClose` during the child's close animation, bypassing the `swipeEnabled` check

## Test plan
- [ ] Open play view, open queue drawer, swipe queue closed — parent stays open
- [ ] Open play view, open actions drawer, swipe actions closed — parent stays open
- [ ] Tapping a climb in the queue list still closes both drawers correctly
- [ ] Closing a child drawer then swiping parent closed still works normally
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)