### PR TITLE
Optimize playlist memberships fetching with batched GraphQL query

### DIFF
--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -438,6 +438,12 @@ export const GetPlaylistsForClimbInputSchema = z.object({
   climbUuid: ExternalUUIDSchema,
 });
 
+export const GetPlaylistMembershipsForClimbsInputSchema = z.object({
+  boardType: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+  climbUuids: z.array(ExternalUUIDSchema).min(1).max(200),
+});
+
 export const GetPlaylistClimbsInputSchema = z.object({
   playlistId: z.string().min(1),
   boardName: BoardNameSchema,

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -932,6 +932,28 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
+  Input for batch-fetching playlist memberships for multiple climbs.
+  """
+  input GetPlaylistMembershipsForClimbsInput {
+    "Board type"
+    boardType: String!
+    "Layout ID"
+    layoutId: Int!
+    "Climb UUIDs to check memberships for"
+    climbUuids: [String!]!
+  }
+
+  """
+  A single climb's playlist membership entry.
+  """
+  type PlaylistMembershipEntry {
+    "The climb UUID"
+    climbUuid: String!
+    "Playlist UUIDs containing this climb"
+    playlistIds: [ID!]!
+  }
+
+  """
   Input for getting climbs in a playlist with full data.
   """
   input GetPlaylistClimbsInput {
@@ -2624,6 +2646,12 @@ export const typeDefs = /* GraphQL */ `
     Get IDs of playlists that contain a specific climb.
     """
     playlistsForClimb(input: GetPlaylistsForClimbInput!): [ID!]!
+
+    """
+    Batch-fetch playlist memberships for multiple climbs in a single query.
+    Returns which playlists each climb belongs to.
+    """
+    playlistMembershipsForClimbs(input: GetPlaylistMembershipsForClimbsInput!): [PlaylistMembershipEntry!]!
 
     """
     Get climbs in a playlist with full climb data.

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -57,6 +57,16 @@ export const GET_PLAYLISTS_FOR_CLIMB = gql`
   }
 `;
 
+// Batch-fetch playlist memberships for multiple climbs in a single query
+export const GET_PLAYLIST_MEMBERSHIPS_FOR_CLIMBS = gql`
+  query GetPlaylistMembershipsForClimbs($input: GetPlaylistMembershipsForClimbsInput!) {
+    playlistMembershipsForClimbs(input: $input) {
+      climbUuid
+      playlistIds
+    }
+  }
+`;
+
 // Create new playlist
 export const CREATE_PLAYLIST = gql`
   ${PLAYLIST_FIELDS}
@@ -195,6 +205,25 @@ export interface GetPlaylistsForClimbQueryVariables {
 
 export interface GetPlaylistsForClimbQueryResponse {
   playlistsForClimb: string[];
+}
+
+export interface GetPlaylistMembershipsForClimbsInput {
+  boardType: string;
+  layoutId: number;
+  climbUuids: string[];
+}
+
+export interface GetPlaylistMembershipsForClimbsQueryVariables {
+  input: GetPlaylistMembershipsForClimbsInput;
+}
+
+export interface PlaylistMembershipEntry {
+  climbUuid: string;
+  playlistIds: string[];
+}
+
+export interface GetPlaylistMembershipsForClimbsQueryResponse {
+  playlistMembershipsForClimbs: PlaylistMembershipEntry[];
 }
 
 export interface CreatePlaylistInput {


### PR DESCRIPTION
## Summary
Refactored playlist data fetching to use React Query for state management and introduced a new batched GraphQL query to fetch playlist memberships for multiple climbs in a single request, replacing N separate queries with one optimized call.

## Key Changes

**Frontend (packages/web/app/hooks/use-climb-actions-data.tsx):**
- Removed local `useState` hooks for `playlists`, `playlistMemberships`, and `playlistsLoading`
- Migrated to `useQuery` for both user playlists and playlist memberships, providing automatic caching and consistency
- Replaced individual `playlistsForClimb` queries with a single batched `GET_PLAYLIST_MEMBERSHIPS_FOR_CLIMBS` query
- Updated optimistic updates to use `queryClient.setQueryData()` instead of state setters
- Improved mutation callbacks to properly handle cache updates with immutable Set operations
- Simplified `refreshPlaylists()` to use `queryClient.invalidateQueries()`

**Backend (packages/backend/src/graphql/resolvers/playlists/queries.ts):**
- Added new `playlistMembershipsForClimbs` resolver that accepts multiple climb UUIDs
- Executes a single database query to fetch all playlist memberships for all requested climbs
- Returns results grouped by climb UUID with empty arrays for climbs with no memberships

**GraphQL Schema (packages/shared-schema/src/schema.ts):**
- Added `GetPlaylistMembershipsForClimbsInput` input type for batch requests
- Added `PlaylistMembershipEntry` type to represent climb-to-playlists mapping
- Added `playlistMembershipsForClimbs` query field to the Query type

**GraphQL Operations (packages/web/app/lib/graphql/operations/playlists.ts):**
- Added `GET_PLAYLIST_MEMBERSHIPS_FOR_CLIMBS` query definition
- Added TypeScript interfaces for the new query and its response types

**Validation (packages/backend/src/validation/schemas.ts):**
- Added `GetPlaylistMembershipsForClimbsInputSchema` with validation for board type, layout ID, and climb UUIDs (max 200)

## Notable Implementation Details

- Query keys are memoized to prevent unnecessary re-renders and cache invalidations
- Stale time set to 5 minutes for both playlists and memberships queries
- Window focus refetching disabled to avoid unnecessary network requests
- Optimistic updates create new Set instances to avoid stale closure mutations
- Batch query supports up to 200 climb UUIDs per request
- Gracefully handles empty climb lists and missing memberships

https://claude.ai/code/session_013FeKjWGrgDj3N2oq9kvU6R