### PR TITLE
Improve session creation form error handling and reset behavior

### DIFF
--- a/packages/web/app/components/session-creation/session-creation-form.tsx
+++ b/packages/web/app/components/session-creation/session-creation-form.tsx
@@ -48,20 +48,24 @@ export default function SessionCreationForm({
   const [discoverable, setDiscoverable] = useState(true);
 
   const handleSubmit = async () => {
-    await onSubmit({
-      name: name.trim() || undefined,
-      goal: goal.trim() || undefined,
-      color,
-      isPermanent,
-      discoverable,
-    });
+    try {
+      await onSubmit({
+        name: name.trim() || undefined,
+        goal: goal.trim() || undefined,
+        color,
+        isPermanent,
+        discoverable,
+      });
 
-    // Reset form state after successful submit
-    setName('');
-    setGoal('');
-    setColor(undefined);
-    setIsPermanent(false);
-    setDiscoverable(true);
+      // Reset form state only after successful submit
+      setName('');
+      setGoal('');
+      setColor(undefined);
+      setIsPermanent(false);
+      setDiscoverable(true);
+    } catch {
+      // Don't reset on error — preserve form data for retry
+    }
   };
 
   return (

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -29,8 +29,15 @@ export default function StartSeshDrawer({ open, onClose }: StartSeshDrawerProps)
   const { createSession, isCreating } = useCreateSession();
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
   const [showAuthModal, setShowAuthModal] = useState(false);
+  const [formKey, setFormKey] = useState(0);
 
   const isLoggedIn = status === 'authenticated';
+
+  const handleClose = useCallback(() => {
+    onClose();
+    setSelectedBoard(null);
+    setFormKey((k) => k + 1);
+  }, [onClose]);
 
   const handleBoardSelect = (board: UserBoard) => {
     setSelectedBoard(board);
@@ -55,11 +62,12 @@ export default function StartSeshDrawer({ open, onClose }: StartSeshDrawerProps)
       const boardUrl = constructBoardSlugUrl(selectedBoard.slug, selectedBoard.angle);
       router.push(`${boardUrl}?session=${sessionId}`);
 
-      onClose();
+      handleClose();
       showMessage('Session started!', 'success');
     } catch (error) {
       console.error('Failed to create session:', error);
       showMessage('Failed to start session', 'error');
+      throw error;
     }
   };
 
@@ -87,7 +95,7 @@ export default function StartSeshDrawer({ open, onClose }: StartSeshDrawerProps)
         title="Start Sesh"
         placement="top"
         open={open}
-        onClose={onClose}
+        onClose={handleClose}
       >
         {!isLoggedIn ? (
           <Box
@@ -116,6 +124,7 @@ export default function StartSeshDrawer({ open, onClose }: StartSeshDrawerProps)
               Start a session to track your climbing and invite others to join.
             </Typography>
             <SessionCreationForm
+              key={formKey}
               onSubmit={handleSubmit}
               isSubmitting={isCreating}
               submitLabel="Start Sesh"


### PR DESCRIPTION
## Summary
Enhanced the session creation flow to properly handle errors and preserve form data when submission fails, while ensuring the form resets cleanly on successful submission.

## Key Changes
- **Error handling in SessionCreationForm**: Wrapped the submit handler in a try-catch block to only reset form state after successful submission. On error, form data is preserved to allow users to retry without losing their input.
- **Form reset on drawer close**: Added a `handleClose` callback in StartSeshDrawer that resets the form by incrementing a `formKey` state variable, which forces a remount of the SessionCreationForm component.
- **Error propagation**: Added explicit error re-throw in the session creation handler to ensure errors bubble up to the form's error boundary.
- **Improved drawer close handling**: Consolidated close logic into a memoized `handleClose` callback that clears selected board state and resets the form.

## Implementation Details
- Used React's `useCallback` hook to memoize the close handler and prevent unnecessary re-renders
- Leveraged React's `key` prop to force form component remounting, providing a clean reset mechanism
- Maintained backward compatibility with existing error messaging and user feedback

https://claude.ai/code/session_018iLQsQG3oc4eTyV48EHtZW