### PR TITLE
Fix /my-library production errors and show public playlists

### DIFF
--- a/packages/web/app/components/board-provider/board-provider-context.tsx
+++ b/packages/web/app/components/board-provider/board-provider-context.tsx
@@ -355,5 +355,9 @@ export function useBoardProvider() {
   return context;
 }
 
+export function useOptionalBoardProvider(): BoardContextType | null {
+  return useContext(BoardContext) ?? null;
+}
+
 export type { BoardContextType };
 export { BoardContext };

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -230,6 +230,23 @@
   background: linear-gradient(135deg, var(--color-error), #D87F7A);
 }
 
+/* Sign-in Banner (compact, non-blocking) */
+.signInBanner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  background-color: var(--semantic-surface);
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 20px;
+}
+
+.signInBannerText {
+  flex: 1;
+  min-width: 0;
+}
+
 /* Empty/Loading/Error States */
 .emptyContainer {
   display: flex;

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { PAGE_LIMIT } from '../../board-page/constants';
 import { ClimbQueue } from '../types';
 import { ParsedBoardRouteParameters, SearchRequestPagination, SearchClimbsResult } from '@/app/lib/types';
-import { useBoardProvider } from '../../board-provider/board-provider-context';
+import { useOptionalBoardProvider } from '../../board-provider/board-provider-context';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { SEARCH_CLIMBS, type ClimbSearchResponse } from '@/app/lib/graphql/operations/climb-search';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -23,7 +23,7 @@ export const useQueueDataFetching = ({
   hasDoneFirstFetch,
   setHasDoneFirstFetch,
 }: UseQueueDataFetchingProps) => {
-  const { getLogbook } = useBoardProvider();
+  const getLogbook = useOptionalBoardProvider()?.getLogbook;
   // Use wsAuthToken for GraphQL backend auth (NextAuth session token)
   const { token: wsAuthToken } = useWsAuthToken();
   const fetchedUuidsRef = useRef<string>('');
@@ -162,7 +162,7 @@ export const useQueueDataFetching = ({
     }
 
     const climbUuids = JSON.parse(climbUuidsString);
-    if (climbUuids.length > 0) {
+    if (climbUuids.length > 0 && getLogbook) {
       // Only mark as fetched if the fetch actually succeeded
       // This ensures we retry when wsAuthToken becomes available
       getLogbook(climbUuids).then((success) => {

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -28,7 +28,7 @@ import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
 import { ClimbQueueItem } from './types';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
-import { useBoardProvider } from '../board-provider/board-provider-context';
+import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
@@ -53,7 +53,9 @@ type QueueListItemProps = {
 };
 
 export const AscentStatus = ({ climbUuid, fontSize }: { climbUuid: ClimbUuid; fontSize?: number }) => {
-  const { logbook, boardName } = useBoardProvider();
+  const boardProvider = useOptionalBoardProvider();
+  const logbook = boardProvider?.logbook ?? [];
+  const boardName = boardProvider?.boardName ?? 'kilter';
 
   const ascentsForClimb = useMemo(
     () => logbook.filter((ascent) => ascent.climb_uuid === climbUuid),

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -19,7 +19,7 @@ import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { themeTokens } from '@/app/theme/theme-config';
 import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
-import { useBoardProvider } from '../board-provider/board-provider-context';
+import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 import { LogAscentDrawer } from '../logbook/log-ascent-drawer';
 import AuthModal from '../auth/auth-modal';
 import styles from './queue-list.module.css';
@@ -55,7 +55,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
     removeFromQueue,
   } = useQueueContext();
 
-  const { isAuthenticated } = useBoardProvider();
+  const isAuthenticated = useOptionalBoardProvider()?.isAuthenticated ?? false;
 
   // Tick drawer state
   const [tickDrawerVisible, setTickDrawerVisible] = useState(false);


### PR DESCRIPTION
## Summary
- **Fix hydration mismatch (React #418)**: Added `hasMounted` state guard in `library-page-content.tsx` so SSR and initial client render produce identical HTML (loading state)
- **Fix playlist fetch error**: Switched `useClimbActionsData` from `GET_USER_PLAYLISTS` (requires `boardType`/`layoutId`) to `GET_ALL_USER_PLAYLISTS` (no required params), added guards for `boardName`-dependent queries
- **Fix `useBoardProvider` outside `BoardProvider`**: Added `useOptionalBoardProvider()` hook that returns `null` instead of throwing; updated `queue-list.tsx`, `queue-list-item.tsx`, and `use-queue-data-fetching.tsx`
- **Show public playlists for non-auth users**: Replaced full-page sign-in block with compact banner; Discover section is now always visible

## Test plan
- [ ] Visit `/my-library` when NOT logged in — see compact sign-in banner + Discover section with public playlists
- [ ] Visit `/my-library/playlist/[uuid]` when NOT logged in — public playlist detail page loads
- [ ] Visit `/my-library` when logged in — see personal playlists + Jump Back In + Discover
- [ ] No hydration error (#418) in console
- [ ] No `useBoardProvider` error in console
- [ ] On a board page, "Add to Playlist" shows all playlists (not just current board's)
- [ ] Queue functionality on board routes still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)