### PR TITLE
Fix createSession "Client not registered" error

### DIFF
--- a/packages/db/drizzle/0052_broad_red_ghost.sql
+++ b/packages/db/drizzle/0052_broad_red_ghost.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "esp32_controllers" (
+CREATE TABLE IF NOT EXISTS "esp32_controllers" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"user_id" text,
 	"api_key" varchar(64) NOT NULL,
@@ -13,9 +13,16 @@ CREATE TABLE "esp32_controllers" (
 	CONSTRAINT "esp32_controllers_api_key_unique" UNIQUE("api_key")
 );
 --> statement-breakpoint
-DROP INDEX "board_climbs_holds_hash_idx";--> statement-breakpoint
-ALTER TABLE "esp32_controllers" ADD CONSTRAINT "esp32_controllers_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "esp32_controllers_user_idx" ON "esp32_controllers" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "esp32_controllers_api_key_idx" ON "esp32_controllers" USING btree ("api_key");--> statement-breakpoint
-CREATE INDEX "esp32_controllers_session_idx" ON "esp32_controllers" USING btree ("authorized_session_id");--> statement-breakpoint
-ALTER TABLE "board_climbs" DROP COLUMN "holds_hash";
+DROP INDEX IF EXISTS "board_climbs_holds_hash_idx";--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'esp32_controllers'::regclass AND contype = 'f'
+  ) THEN
+    ALTER TABLE "esp32_controllers" ADD CONSTRAINT "esp32_controllers_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "esp32_controllers_user_idx" ON "esp32_controllers" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "esp32_controllers_api_key_idx" ON "esp32_controllers" USING btree ("api_key");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "esp32_controllers_session_idx" ON "esp32_controllers" USING btree ("authorized_session_id");--> statement-breakpoint
+ALTER TABLE "board_climbs" DROP COLUMN IF EXISTS "holds_hash";

--- a/packages/db/drizzle/0053_add_vote_counts.sql
+++ b/packages/db/drizzle/0053_add_vote_counts.sql
@@ -50,7 +50,7 @@ BEGIN
   -- receiving their first vote).
   SELECT COALESCE(
     (SELECT fi."created_at" FROM feed_items fi
-     WHERE fi."entity_type" = v_entity_type::text AND fi."entity_id" = v_entity_id
+     WHERE fi."entity_type" = v_entity_type AND fi."entity_id" = v_entity_id
      LIMIT 1),
     NOW()
   ) INTO v_created_at;
@@ -92,13 +92,13 @@ SELECT
   SIGN(SUM(v.value)) * LN(GREATEST(ABS(SUM(v.value)), 1))
     + EXTRACT(EPOCH FROM COALESCE(
         (SELECT fi."created_at" FROM feed_items fi
-         WHERE fi."entity_type" = v.entity_type::text AND fi."entity_id" = v.entity_id
+         WHERE fi."entity_type" = v.entity_type AND fi."entity_id" = v.entity_id
          LIMIT 1),
         MIN(v.created_at)
       )) / 45000.0 as hot_score,
   COALESCE(
     (SELECT fi."created_at" FROM feed_items fi
-     WHERE fi."entity_type" = v.entity_type::text AND fi."entity_id" = v.entity_id
+     WHERE fi."entity_type" = v.entity_type AND fi."entity_id" = v.entity_id
      LIMIT 1),
     MIN(v.created_at)
   ) as created_at


### PR DESCRIPTION
## Summary

- **Fix "Client not registered" error** when creating sessions via the Start Sesh drawer. The `createSession` mutation was called via HTTP (`graphql-request`), but the backend's `roomManager.joinSession()` requires a registered WebSocket client. HTTP requests generate a transient `http-{uuid}` connectionId that is never registered in the RoomManager.
- **Skip `joinSession` for HTTP requests** — the session is created in the DB, and the creator joins via WebSocket when they navigate to the board page (via `BoardSessionBridge` → `activateSession` → WebSocket `joinSession`).
- **Make migration 0052 idempotent** (`IF NOT EXISTS` / `IF EXISTS`) so it can be safely replayed when migration tracking rows are missing.
- **Fix enum type casts in migration 0053** — remove `::text` casts when comparing `social_entity_type` enum columns (Neon PG doesn't implicitly cast enum=text).

## Test plan

- [ ] Create a session via Start Sesh drawer — should succeed without "Client not registered" error
- [ ] After creation, verify the board page loads with `?session=` param and WebSocket connection establishes
- [ ] Verify session appears in nearby sessions for other users
- [ ] Verify existing WebSocket-based session creation (if any) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)