### PR TITLE
Add option to hide end message in climbs list

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -26,6 +26,7 @@ export type ClimbsListProps = {
   onLoadMore: () => void;
   header?: React.ReactNode;
   headerInline?: React.ReactNode;
+  hideEndMessage?: boolean;
 };
 
 const ClimbsListSkeleton = ({ aspectRatio, viewMode }: { aspectRatio: number; viewMode: ViewMode }) => {
@@ -51,6 +52,7 @@ const ClimbsList = ({
   onLoadMore,
   header,
   headerInline,
+  hideEndMessage,
 }: ClimbsListProps) => {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
 
@@ -260,7 +262,7 @@ const ClimbsList = ({
             <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} viewMode="list" />
           )
         )}
-        {!hasMore && climbs.length > 0 && (
+        {!hasMore && climbs.length > 0 && !hideEndMessage && (
           <Box sx={noMoreClimbsBoxSx}>
             No more climbs
           </Box>

--- a/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/my-library/playlist/[playlist_uuid]/playlist-detail-content.tsx
@@ -380,6 +380,7 @@ export default function PlaylistDetailContent({
               onClimbSelect={handleClimbSelect}
               onLoadMore={handleLoadMore}
               header={climbsHeader}
+              hideEndMessage
             />
           </PlaylistsProvider>
         </FavoritesProvider>


### PR DESCRIPTION
## Summary
Added a new optional prop `hideEndMessage` to the `ClimbsList` component to allow consumers to conditionally hide the "No more climbs" message that appears when all climbs have been loaded.

## Changes
- Added `hideEndMessage?: boolean` prop to `ClimbsListProps` type definition
- Updated `ClimbsList` component to accept and use the `hideEndMessage` prop
- Modified the render condition for the end-of-list message to respect the new prop: `{!hasMore && climbs.length > 0 && !hideEndMessage && ...}`
- Updated `PlaylistDetailContent` to pass `hideEndMessage` prop when rendering the climbs list in playlist view

## Implementation Details
The `hideEndMessage` prop is optional and defaults to `false`, maintaining backward compatibility with existing implementations. When set to `true`, the "No more climbs" message will not be displayed even when all climbs have been loaded, providing a cleaner UI for specific use cases like playlists.

https://claude.ai/code/session_01EKb3FFbzuiNV9pitRKATHi