### PR TITLE
Fix board session redirect missing /list segment

### DIFF
--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -13,7 +13,7 @@ import { useCreateSession } from '@/app/hooks/use-create-session';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { constructBoardSlugUrl } from '@/app/lib/url-utils';
+import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import AuthModal from '../auth/auth-modal';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
@@ -52,7 +52,7 @@ export default function StartSeshDrawer({ open, onClose }: StartSeshDrawerProps)
       const sessionId = await createSession(formData, boardPath);
 
       // Navigate to board page with session
-      const boardUrl = constructBoardSlugUrl(selectedBoard.slug, selectedBoard.angle);
+      const boardUrl = constructBoardSlugListUrl(selectedBoard.slug, selectedBoard.angle);
       router.push(`${boardUrl}?session=${sessionId}`);
 
       onClose();


### PR DESCRIPTION
Use constructBoardSlugListUrl instead of constructBoardSlugUrl when redirecting after session creation, so the URL includes the /list view segment (e.g. /b/josh-caz/40/list?session=...) instead of stopping at the angle (e.g. /b/josh-caz/40?session=...).

https://claude.ai/code/session_01RzqUytjC116V2L1tt7VYmv