### PR TITLE
Add clear button to climb search input

### DIFF
--- a/packages/web/app/components/search-drawer/search-climb-name-input.tsx
+++ b/packages/web/app/components/search-drawer/search-climb-name-input.tsx
@@ -3,7 +3,9 @@
 import React from 'react';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import ClearIcon from '@mui/icons-material/Clear';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
 
 const SearchClimbNameInput = () => {
@@ -22,6 +24,18 @@ const SearchClimbNameInput = () => {
               <SearchOutlined color="action" />
             </InputAdornment>
           ),
+          endAdornment: uiSearchParams.name ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                aria-label="Clear search"
+                onClick={() => updateFilters({ name: '' })}
+                edge="end"
+              >
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
         },
       }}
       onChange={(e) => {


### PR DESCRIPTION
Show a small X icon on the right side of the search bar when there's
an active search filter. Clicking it clears the search name.

https://claude.ai/code/session_01UYoNJMzgzDMi2p26NsQLaG