### PR TITLE
Fix proposals with angle=0 stored as NULL

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/proposals.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals.ts
@@ -861,7 +861,7 @@ export const socialProposalMutations = {
         uuid,
         climbUuid,
         boardType,
-        angle: angle || null,
+        angle: angle ?? null,
         proposerId,
         type,
         proposedValue,
@@ -882,7 +882,7 @@ export const socialProposalMutations = {
       });
 
     // Check auto-approval (atomic: only transition if still 'open')
-    const shouldApprove = await checkAutoApproval(proposal.id, boardType, climbUuid, angle || null);
+    const shouldApprove = await checkAutoApproval(proposal.id, boardType, climbUuid, angle ?? null);
     if (shouldApprove) {
       const [approved] = await db
         .update(dbSchema.climbProposals)


### PR DESCRIPTION
## Summary
- Replace `||` with `??` (nullish coalescing) in proposal creation to preserve angle `0` as a valid value
- The `||` operator treated `0` as falsy, converting it to `NULL` in the database, causing proposals at angle 0 to disappear after creation since the query filters by `eq(angle, 0)` which doesn't match `NULL`

## Test plan
- [ ] Create a grade proposal at angle 0 — it should persist after creation and appear in the proposals list
- [ ] Create a grade proposal at a non-zero angle — should continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)