### PR TITLE
Fix notification errors and add click-through navigation

### DIFF
--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -1617,6 +1617,8 @@ export const typeDefs = /* GraphQL */ `
     climbUuid: String
     "Board type (for navigation)"
     boardType: String
+    "Proposal UUID (for proposal notifications, to deep-link to the specific proposal)"
+    proposalUuid: String
     "Whether the notification has been read"
     isRead: Boolean!
     "When the notification was created (ISO 8601)"
@@ -1673,6 +1675,8 @@ export const typeDefs = /* GraphQL */ `
     climbUuid: String
     "Board type"
     boardType: String
+    "Proposal UUID (for deep-linking to a specific proposal)"
+    proposalUuid: String
     "Whether all notifications in the group are read"
     isRead: Boolean!
     "When the most recent notification was created"

--- a/packages/shared-schema/src/types.ts
+++ b/packages/shared-schema/src/types.ts
@@ -695,6 +695,7 @@ export type Notification = {
   climbName?: string | null;
   climbUuid?: string | null;
   boardType?: string | null;
+  proposalUuid?: string | null;
   isRead: boolean;
   createdAt: string;
 };
@@ -723,6 +724,7 @@ export type GroupedNotification = {
   climbName?: string | null;
   climbUuid?: string | null;
   boardType?: string | null;
+  proposalUuid?: string | null;
   isRead: boolean;
   createdAt: string;
 };

--- a/packages/web/app/api/internal/climb-redirect/route.ts
+++ b/packages/web/app/api/internal/climb-redirect/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+/**
+ * GET /api/internal/climb-redirect?boardType=...&climbUuid=...&proposalUuid=...
+ *
+ * Resolves a climb's full view URL from minimal data (boardType + climbUuid).
+ * Returns JSON with the resolved URL so the client can navigate.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const boardType = searchParams.get('boardType');
+  const climbUuid = searchParams.get('climbUuid');
+  const proposalUuid = searchParams.get('proposalUuid');
+
+  if (!boardType || !climbUuid) {
+    return NextResponse.json({ error: 'Missing boardType or climbUuid' }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+
+    // Look up the climb to get layoutId and angle
+    const [climb] = await db
+      .select({
+        layoutId: schema.boardClimbs.layoutId,
+        angle: schema.boardClimbs.angle,
+      })
+      .from(schema.boardClimbs)
+      .where(
+        and(
+          eq(schema.boardClimbs.uuid, climbUuid),
+          eq(schema.boardClimbs.boardType, boardType),
+        ),
+      )
+      .limit(1);
+
+    if (!climb) {
+      return NextResponse.json({ error: 'Climb not found' }, { status: 404 });
+    }
+
+    const angle = climb.angle ?? 0;
+
+    // Look up a default product size and set for this layout
+    const [psls] = await db
+      .select({
+        productSizeId: schema.boardProductSizesLayoutsSets.productSizeId,
+        setId: schema.boardProductSizesLayoutsSets.setId,
+      })
+      .from(schema.boardProductSizesLayoutsSets)
+      .where(
+        and(
+          eq(schema.boardProductSizesLayoutsSets.boardType, boardType),
+          eq(schema.boardProductSizesLayoutsSets.layoutId, climb.layoutId),
+        ),
+      )
+      .limit(1);
+
+    if (!psls || !psls.productSizeId || !psls.setId) {
+      return NextResponse.json({ error: 'No board configuration found for this climb' }, { status: 404 });
+    }
+
+    // Collect all set IDs for this product size + layout combination
+    const setRows = await db
+      .select({ setId: schema.boardProductSizesLayoutsSets.setId })
+      .from(schema.boardProductSizesLayoutsSets)
+      .where(
+        and(
+          eq(schema.boardProductSizesLayoutsSets.boardType, boardType),
+          eq(schema.boardProductSizesLayoutsSets.layoutId, climb.layoutId),
+          eq(schema.boardProductSizesLayoutsSets.productSizeId, psls.productSizeId),
+        ),
+      );
+
+    const setIds = setRows
+      .map((r) => r.setId)
+      .filter((id): id is number => id != null)
+      .join(',');
+
+    let url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIds}/${angle}/view/${climbUuid}`;
+
+    if (proposalUuid) {
+      url += `?proposalUuid=${encodeURIComponent(proposalUuid)}`;
+    }
+
+    return NextResponse.json({ url });
+  } catch (error) {
+    console.error('[climb-redirect] Error resolving climb URL:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import type { CollapsibleSectionConfig } from '@/app/components/collapsible-section/collapsible-section';
 import BetaVideos from '@/app/components/beta-videos/beta-videos';
 import { LogbookSection, useLogbookSummary } from '@/app/components/logbook/logbook-section';
@@ -71,6 +72,8 @@ export function useBuildClimbDetailSections({
   currentClimbDifficulty,
   boardName,
 }: BuildClimbDetailSectionsProps): CollapsibleSectionConfig[] {
+  const searchParams = useSearchParams();
+  const highlightProposalUuid = searchParams.get('proposalUuid') ?? undefined;
   const betaLinks = useClimbBetaLinks({ boardType, climbUuid, initialBetaLinks });
   const logbookSummary = useLogbookSummary(climb.uuid);
 
@@ -115,6 +118,7 @@ export function useBuildClimbDetailSections({
       defaultSummary: 'Votes, comments, proposals',
       getSummary: () => ['Votes', 'Comments', 'Proposals'],
       lazy: true,
+      defaultActive: !!highlightProposalUuid,
       content: (
         <ClimbSocialSection
           climbUuid={climbUuid}
@@ -122,6 +126,7 @@ export function useBuildClimbDetailSections({
           angle={angle}
           currentClimbDifficulty={currentClimbDifficulty}
           boardName={boardName}
+          highlightProposalUuid={highlightProposalUuid}
         />
       ),
     },

--- a/packages/web/app/components/collapsible-section/collapsible-section.tsx
+++ b/packages/web/app/components/collapsible-section/collapsible-section.tsx
@@ -12,6 +12,8 @@ export interface CollapsibleSectionConfig {
   content: React.ReactNode;
   /** When true, content is only mounted while this section is the active one. */
   lazy?: boolean;
+  /** When true, this section should be the initially active one (overrides defaultActiveKey). */
+  defaultActive?: boolean;
 }
 
 interface CollapsibleSectionProps {
@@ -23,7 +25,10 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   sections,
   defaultActiveKey,
 }) => {
-  const [activeKey, setActiveKey] = useState<string | null>(defaultActiveKey ?? null);
+  const sectionDefaultActive = sections.find((s) => s.defaultActive);
+  const [activeKey, setActiveKey] = useState<string | null>(
+    sectionDefaultActive?.key ?? defaultActiveKey ?? null,
+  );
 
   return (
     <div className={styles.steppedContainer}>

--- a/packages/web/app/components/notifications/notification-item.tsx
+++ b/packages/web/app/components/notifications/notification-item.tsx
@@ -11,6 +11,8 @@ import Box from '@mui/material/Box';
 import PersonAddOutlined from '@mui/icons-material/PersonAddOutlined';
 import ChatBubbleOutline from '@mui/icons-material/ChatBubbleOutline';
 import ThumbUpOutlined from '@mui/icons-material/ThumbUpOutlined';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
+import AddCircleOutline from '@mui/icons-material/AddCircleOutline';
 import type { GroupedNotification, NotificationType } from '@boardsesh/shared-schema';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -72,6 +74,17 @@ function getNotificationText(notification: GroupedNotification): string {
       return `${actorSummary} liked your ascent`;
     case 'vote_on_comment':
       return `${actorSummary} liked your comment`;
+    case 'proposal_created':
+      return `${actorSummary} created a new proposal`;
+    case 'proposal_approved':
+      return `${actorSummary}'s proposal was approved`;
+    case 'proposal_rejected':
+      return `${actorSummary}'s proposal was rejected`;
+    case 'proposal_vote':
+      return `${actorSummary} voted on your proposal`;
+    case 'new_climb':
+    case 'new_climb_global':
+      return `${actorSummary} created a new climb`;
     default:
       return 'You have a new notification';
   }
@@ -88,6 +101,14 @@ function getNotificationIcon(type: NotificationType) {
     case 'vote_on_tick':
     case 'vote_on_comment':
       return <ThumbUpOutlined fontSize="small" />;
+    case 'proposal_created':
+    case 'proposal_approved':
+    case 'proposal_rejected':
+    case 'proposal_vote':
+      return <LightbulbOutlined fontSize="small" />;
+    case 'new_climb':
+    case 'new_climb_global':
+      return <AddCircleOutline fontSize="small" />;
     default:
       return null;
   }

--- a/packages/web/app/components/social/climb-social-section.tsx
+++ b/packages/web/app/components/social/climb-social-section.tsx
@@ -12,9 +12,10 @@ interface ClimbSocialSectionProps {
   angle?: number;
   currentClimbDifficulty?: string;
   boardName?: string;
+  highlightProposalUuid?: string;
 }
 
-export default function ClimbSocialSection({ climbUuid, boardType, angle, currentClimbDifficulty, boardName }: ClimbSocialSectionProps) {
+export default function ClimbSocialSection({ climbUuid, boardType, angle, currentClimbDifficulty, boardName, highlightProposalUuid }: ClimbSocialSectionProps) {
   return (
     <Box>
       {boardType && angle != null && (
@@ -24,6 +25,7 @@ export default function ClimbSocialSection({ climbUuid, boardType, angle, curren
           angle={angle}
           currentClimbDifficulty={currentClimbDifficulty}
           boardName={boardName}
+          highlightProposalUuid={highlightProposalUuid}
         />
       )}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -51,15 +51,23 @@ interface ProposalCardProps {
   isAdminOrLeader?: boolean;
   onUpdate?: (updated: Proposal) => void;
   onDelete?: (proposalUuid: string) => void;
+  highlight?: boolean;
 }
 
-export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDelete }: ProposalCardProps) {
+export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDelete, highlight }: ProposalCardProps) {
   const { token } = useWsAuthToken();
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState('');
   const [localProposal, setLocalProposal] = useState(proposal);
   const [showComments, setShowComments] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (highlight && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlight]);
 
   const handleVote = useCallback(async (value: number) => {
     if (!token) {
@@ -120,10 +128,12 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
   return (
     <>
       <Card
+        ref={cardRef}
         variant="outlined"
         sx={{
           mb: 1.5,
-          borderColor: themeTokens.neutral[200],
+          borderColor: highlight ? themeTokens.colors.primary : themeTokens.neutral[200],
+          boxShadow: highlight ? `0 0 0 1px ${themeTokens.colors.primary}` : undefined,
           '&:hover': { borderColor: themeTokens.neutral[300] },
         }}
       >

--- a/packages/web/app/components/social/proposal-section.tsx
+++ b/packages/web/app/components/social/proposal-section.tsx
@@ -34,9 +34,10 @@ interface ProposalSectionProps {
   angle: number;
   currentClimbDifficulty?: string;
   boardName?: string;
+  highlightProposalUuid?: string;
 }
 
-export default function ProposalSection({ climbUuid, boardType, angle, currentClimbDifficulty, boardName }: ProposalSectionProps) {
+export default function ProposalSection({ climbUuid, boardType, angle, currentClimbDifficulty, boardName, highlightProposalUuid }: ProposalSectionProps) {
   const { token } = useWsAuthToken();
   const [communityStatus, setCommunityStatus] = useState<ClimbCommunityStatusType | null>(null);
   const [proposals, setProposals] = useState<Proposal[]>([]);
@@ -167,6 +168,7 @@ export default function ProposalSection({ climbUuid, boardType, angle, currentCl
                 proposal={proposal}
                 isAdminOrLeader={isAdminOrLeader}
                 onUpdate={handleProposalUpdated}
+                highlight={proposal.uuid === highlightProposalUuid}
               />
             ))
           ) : (

--- a/packages/web/app/lib/graphql/operations/notifications.ts
+++ b/packages/web/app/lib/graphql/operations/notifications.ts
@@ -27,6 +27,7 @@ export const GET_NOTIFICATIONS = gql`
         climbName
         climbUuid
         boardType
+        proposalUuid
         isRead
         createdAt
       }
@@ -55,6 +56,7 @@ export const GET_GROUPED_NOTIFICATIONS = gql`
         climbName
         climbUuid
         boardType
+        proposalUuid
         isRead
         createdAt
       }
@@ -112,6 +114,7 @@ export const NOTIFICATION_RECEIVED_SUBSCRIPTION = `
         climbName
         climbUuid
         boardType
+        proposalUuid
         isRead
         createdAt
       }


### PR DESCRIPTION
## Summary

- **Fix follow notifications DB error**: `handleFollowCreated` was passing `'user'` as `entity_type`, which is not a valid `social_entity_type` enum value, causing a `22P02` error on every follow event. Changed to `null` (the column is nullable).
- **Add missing notification type rendering**: `getNotificationText()` and `getNotificationIcon()` now handle all 12 notification types including `proposal_created`, `proposal_approved`, `proposal_rejected`, `proposal_vote`, `new_climb`, and `new_climb_global`.
- **Enrich proposal/climb notifications**: The backend now populates `climbUuid`, `boardType`, `climbName`, and `proposalUuid` for proposal and new-climb notification types (both real-time and grouped query).
- **Add notification click navigation**: Clicking a proposal or new-climb notification navigates to the climb view page via a new `/api/internal/climb-redirect` route that resolves the full URL from minimal data.
- **Proposal deep-linking**: When navigating from a proposal notification, the community section auto-expands and the specific proposal card is highlighted with a primary-color border and scrolled into view.

## Test plan

- [ ] Create a follow event in a party session — verify no DB error in backend logs
- [ ] Create a proposal — verify the notification renders with "created a new proposal" text and lightbulb icon
- [ ] Click a proposal notification — verify navigation to the climb view page with the proposal highlighted
- [ ] Click a new-climb notification — verify navigation to the climb view page
- [ ] Verify existing notification types (comments, votes, follows) still render and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)