### PR TITLE
Use pre-built dev-db image for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,11 +23,11 @@ jobs:
 
     services:
       postgres:
-        image: ghcr.io/marcodejongh/boardsesh-postgres-postgis:latest
+        image: ghcr.io/marcodejongh/boardsesh-dev-db:latest
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: boardsesh_test
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: main
         ports:
           - 5432:5432
         options: >-
@@ -35,6 +35,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --shm-size=256m
 
     steps:
     - uses: actions/checkout@v4
@@ -64,13 +65,13 @@ jobs:
         # Provide minimal env vars needed for build
         NEXTAUTH_SECRET: test-secret-for-ci
         NEXTAUTH_URL: http://localhost:3000
-        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+        DATABASE_URL: postgresql://postgres:password@localhost:5432/main
 
     - name: Run database migrations
       run: npx drizzle-kit migrate
-      working-directory: packages/web
+      working-directory: packages/db
       env:
-        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+        DATABASE_URL: postgresql://postgres:password@localhost:5432/main
 
     - name: Start server and run E2E tests
       run: |
@@ -79,7 +80,7 @@ jobs:
         npm run test:e2e --workspace=@boardsesh/web
       env:
         PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
-        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/boardsesh_test
+        DATABASE_URL: postgresql://postgres:password@localhost:5432/main
         NEXTAUTH_SECRET: test-secret-for-ci
         NEXTAUTH_URL: http://localhost:3000
 


### PR DESCRIPTION
## Summary

- Switch E2E CI service container from bare `postgres-postgis` image (no data) to pre-built `boardsesh-dev-db` image (all Kilter/Tension data + migrations)
- Fix migration working directory from `packages/web` to `packages/db` where `drizzle.config.ts` lives
- Update DB credentials and name to match the dev-db image defaults (`password`/`main`)

## Test plan

- [ ] Verify the E2E workflow triggers and the service container starts successfully
- [ ] Verify migrations run idempotently (data already present in image)
- [ ] Verify E2E tests pass with real board data (climb cards, search filters, heatmaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)