### PR TITLE
Fix Box component rendering in notification unread indicator

### DIFF
--- a/packages/web/app/components/notifications/notification-item.tsx
+++ b/packages/web/app/components/notifications/notification-item.tsx
@@ -178,6 +178,7 @@ export default function NotificationItem({ notification, onClick }: Notification
             </MuiTypography>
             {!notification.isRead && (
               <Box
+                component="span"
                 sx={{
                   width: 6,
                   height: 6,


### PR DESCRIPTION
## Summary
Updated the unread indicator Box component in the notification item to explicitly render as a `span` element instead of relying on the default div rendering.

## Changes
- Added `component="span"` prop to the Box component wrapping the unread notification indicator dot
- This ensures the indicator renders as an inline `span` element, which is more semantically appropriate for a small visual indicator within text content

## Details
The unread indicator is a small circular dot displayed next to unread notifications. By explicitly setting the component to render as a `span`, this improves the semantic HTML structure and may prevent potential layout issues that could arise from using a block-level `div` in certain contexts.

https://claude.ai/code/session_01BW8ztA5TRSzbQNLQNk7Wyt