### PR TITLE
Fix notification item typography and unread indicator rendering

### DIFF
--- a/packages/web/app/components/notifications/notification-item.tsx
+++ b/packages/web/app/components/notifications/notification-item.tsx
@@ -157,6 +157,7 @@ export default function NotificationItem({ notification, onClick }: Notification
         )}
       </ListItemAvatar>
       <ListItemText
+        disableTypography
         primary={
           <MuiTypography
             variant="body2"
@@ -178,6 +179,7 @@ export default function NotificationItem({ notification, onClick }: Notification
             </MuiTypography>
             {!notification.isRead && (
               <Box
+                component="span"
                 sx={{
                   width: 6,
                   height: 6,


### PR DESCRIPTION
## Summary
This PR fixes rendering issues in the notification item component by properly configuring the ListItemText component and ensuring the unread indicator renders as an inline element.

## Key Changes
- Added `disableTypography` prop to `ListItemText` to prevent default typography wrapping, allowing custom `MuiTypography` component to handle text styling
- Added `component="span"` prop to the unread indicator `Box` to render it as an inline element instead of a block element, ensuring proper layout alignment with the notification text

## Implementation Details
These changes ensure that:
1. The notification text styling is controlled by the explicit `MuiTypography` component rather than being overridden by ListItemText's default typography behavior
2. The unread indicator dot displays inline with the notification content, maintaining proper visual alignment and spacing

https://claude.ai/code/session_017zhWTgQrsxBbRrWUTLzMXg