### PR TITLE
Enable swipe actions on climb list items in proposal feed

### DIFF
--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -195,7 +195,6 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
             <ClimbListItem
               climb={climbAndBoardDetails.climb}
               boardDetails={climbAndBoardDetails.boardDetails}
-              disableSwipe
             />
           )}
 

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -33,6 +33,7 @@ import { VOTE_ON_PROPOSAL, RESOLVE_PROPOSAL, DELETE_PROPOSAL } from '@/app/lib/g
 import type { Proposal } from '@boardsesh/shared-schema';
 import type { Climb, BoardDetails, BoardName } from '@/app/lib/types';
 import ClimbListItem from '@/app/components/climb-card/climb-list-item';
+import { useOptionalQueueContext } from '@/app/components/graphql-queue';
 import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
@@ -61,6 +62,7 @@ interface ProposalCardProps {
 
 export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDelete, highlight }: ProposalCardProps) {
   const { token } = useWsAuthToken();
+  const queueContext = useOptionalQueueContext();
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState('');
   const [localProposal, setLocalProposal] = useState(proposal);
@@ -174,6 +176,12 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
     return { climb, boardDetails };
   }, [localProposal]);
 
+  const handleSetActive = useCallback(() => {
+    if (climbAndBoardDetails && queueContext) {
+      queueContext.setCurrentClimb(climbAndBoardDetails.climb);
+    }
+  }, [climbAndBoardDetails, queueContext]);
+
   const typeColor = TYPE_COLORS[localProposal.type] || themeTokens.neutral[500];
 
   return (
@@ -195,6 +203,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
             <ClimbListItem
               climb={climbAndBoardDetails.climb}
               boardDetails={climbAndBoardDetails.boardDetails}
+              onSelect={queueContext ? handleSetActive : undefined}
             />
           )}
 


### PR DESCRIPTION
Remove the disableSwipe prop from ClimbListItem in ProposalCard so users
can swipe right to favorite and swipe left to add to queue directly from
the proposals feed.

https://claude.ai/code/session_01NmGGnHDYGNjvZ1VLSnz5Bz