### PR TITLE
feat: restore session and queue state on all routes including /

### DIFF
--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -1,0 +1,312 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { getPreference, setPreference, removePreference } from '@/app/lib/user-preferences-db';
+import { saveQueueState } from '@/app/lib/queue-storage-db';
+import type { ClimbQueueItem } from '../../queue-control/types';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+// ---------------------------------------------------------------------------
+// Mock heavy dependencies that PersistentSessionProvider relies on
+// ---------------------------------------------------------------------------
+
+// Mock the WebSocket/GraphQL layer — we don't want real connections in tests
+vi.mock('../../graphql-queue/graphql-client', () => ({
+  createGraphQLClient: vi.fn(() => ({
+    dispose: vi.fn(),
+  })),
+  execute: vi.fn(),
+  subscribe: vi.fn(() => vi.fn()),
+}));
+
+// Mock auth token hook
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isLoading: false }),
+}));
+
+// Mock party profile
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => ({
+    profile: { id: 'test-user' },
+    username: 'tester',
+    avatarUrl: null,
+  }),
+  PartyProfileProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+// Mock hash utility
+vi.mock('@/app/utils/hash', () => ({
+  computeQueueStateHash: () => 'mock-hash',
+}));
+
+// Import AFTER mocks are set up
+import { PersistentSessionProvider, usePersistentSession } from '../persistent-session-context';
+
+// ---------------------------------------------------------------------------
+// Constants matching the source
+// ---------------------------------------------------------------------------
+const ACTIVE_SESSION_KEY = 'activeSession';
+const PREFS_DB_NAME = 'boardsesh-user-preferences';
+const PREFS_STORE_NAME = 'preferences';
+const QUEUE_DB_NAME = 'boardsesh-queue';
+const QUEUE_STORE_NAME = 'queues';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    layout_name: 'Original',
+    size_name: '12x12',
+    ...overrides,
+  } as BoardDetails;
+}
+
+function createTestClimbQueueItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: `climb-${uuid}`,
+      name: `Climb ${uuid}`,
+      setter_username: 'tester',
+      description: '',
+      frames: '',
+      angle: 40,
+      ascensionist_count: 10,
+      difficulty: '5',
+      quality_average: '3',
+      stars: 3,
+      difficulty_error: '',
+      litUpHoldsMap: {},
+      mirrored: false,
+      benchmark_difficulty: null,
+      userAscents: 0,
+      userAttempts: 0,
+    } as Climb,
+    addedBy: null,
+    suggested: false,
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <PersistentSessionProvider>{children}</PersistentSessionProvider>;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  // Clear preferences DB
+  try {
+    const prefsDb = await openDB(PREFS_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(PREFS_STORE_NAME)) {
+          db.createObjectStore(PREFS_STORE_NAME);
+        }
+      },
+    });
+    await prefsDb.clear(PREFS_STORE_NAME);
+    prefsDb.close();
+  } catch {
+    // DB may not exist yet
+  }
+
+  // Clear queue DB
+  try {
+    const queueDb = await openDB(QUEUE_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(QUEUE_STORE_NAME)) {
+          db.createObjectStore(QUEUE_STORE_NAME);
+        }
+      },
+    });
+    await queueDb.clear(QUEUE_STORE_NAME);
+    queueDb.close();
+  } catch {
+    // DB may not exist yet
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Session persistence via user-preferences-db
+// ---------------------------------------------------------------------------
+
+describe('Active session persistence', () => {
+  it('stores and retrieves ActiveSessionInfo via user-preferences-db', async () => {
+    const sessionInfo = {
+      sessionId: 'session-123',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: { board_name: 'kilter' as const, layout_id: 1, size_id: 10, set_ids: [1, 2], angle: 40 },
+    };
+
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+    const result = await getPreference(ACTIVE_SESSION_KEY);
+
+    expect(result).toEqual(sessionInfo);
+  });
+
+  it('returns null after clearing', async () => {
+    await setPreference(ACTIVE_SESSION_KEY, { sessionId: 'test' });
+    await removePreference(ACTIVE_SESSION_KEY);
+
+    const result = await getPreference(ACTIVE_SESSION_KEY);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PersistentSessionProvider mount restore behavior
+// ---------------------------------------------------------------------------
+
+describe('PersistentSessionProvider auto-restore on mount', () => {
+  it('sets isLocalQueueLoaded=true when no stored data exists', async () => {
+    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLocalQueueLoaded).toBe(true);
+    });
+
+    expect(result.current.localQueue).toEqual([]);
+    expect(result.current.localBoardDetails).toBeNull();
+    expect(result.current.activeSession).toBeNull();
+  });
+
+  it('restores local queue from IndexedDB on mount', async () => {
+    const boardDetails = createTestBoardDetails();
+    const item = createTestClimbQueueItem('restored');
+
+    // Save a queue to IndexedDB before mounting the provider
+    await saveQueueState({
+      boardPath: '/kilter/1/10/1,2/40',
+      queue: [item],
+      currentClimbQueueItem: item,
+      boardDetails,
+      updatedAt: Date.now(),
+    });
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLocalQueueLoaded).toBe(true);
+    });
+
+    expect(result.current.localQueue).toHaveLength(1);
+    expect(result.current.localQueue[0].uuid).toBe('restored');
+    expect(result.current.localCurrentClimbQueueItem?.uuid).toBe('restored');
+    expect(result.current.localBoardPath).toBe('/kilter/1/10/1,2/40');
+    expect(result.current.localBoardDetails).toEqual(boardDetails);
+  });
+
+  it('restores persisted party session on mount (takes priority over local queue)', async () => {
+    const boardDetails = createTestBoardDetails();
+    const sessionInfo = {
+      sessionId: 'session-abc',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails,
+      parsedParams: { board_name: 'kilter' as const, layout_id: 1, size_id: 10, set_ids: [1, 2], angle: 40 },
+    };
+
+    // Save both a party session AND a local queue
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+    await saveQueueState({
+      boardPath: '/kilter/1/10/1,2/40',
+      queue: [createTestClimbQueueItem('local')],
+      currentClimbQueueItem: null,
+      boardDetails,
+      updatedAt: Date.now(),
+    });
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLocalQueueLoaded).toBe(true);
+    });
+
+    // Party session should be active
+    expect(result.current.activeSession).toEqual(sessionInfo);
+    // Local queue should NOT be loaded (party session takes priority)
+    expect(result.current.localQueue).toEqual([]);
+  });
+
+  it('activateSession persists to IndexedDB', async () => {
+    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLocalQueueLoaded).toBe(true);
+    });
+
+    const sessionInfo = {
+      sessionId: 'new-session',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: { board_name: 'kilter' as const, layout_id: 1, size_id: 10, set_ids: [1, 2], angle: 40 },
+    };
+
+    act(() => {
+      result.current.activateSession(sessionInfo);
+    });
+
+    // Wait for the async persistence to complete
+    await waitFor(async () => {
+      const stored = await getPreference(ACTIVE_SESSION_KEY);
+      expect(stored).toEqual(sessionInfo);
+    });
+  });
+
+  it('deactivateSession clears from IndexedDB', async () => {
+    // Pre-populate a persisted session
+    const sessionInfo = {
+      sessionId: 'to-deactivate',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: { board_name: 'kilter' as const, layout_id: 1, size_id: 10, set_ids: [1, 2], angle: 40 },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.activeSession).toEqual(sessionInfo);
+    });
+
+    act(() => {
+      result.current.deactivateSession();
+    });
+
+    expect(result.current.activeSession).toBeNull();
+
+    // Verify IndexedDB was cleared
+    await waitFor(async () => {
+      const stored = await getPreference(ACTIVE_SESSION_KEY);
+      expect(stored).toBeNull();
+    });
+  });
+});

--- a/packages/web/app/lib/__tests__/queue-storage-db.test.ts
+++ b/packages/web/app/lib/__tests__/queue-storage-db.test.ts
@@ -1,0 +1,152 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getMostRecentQueue,
+  saveQueueState,
+} from '../queue-storage-db';
+import type { ClimbQueueItem } from '../../components/queue-control/types';
+import type { BoardDetails, Climb } from '../types';
+
+const DB_NAME = 'boardsesh-queue';
+const STORE_NAME = 'queues';
+
+function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    layout_name: 'Original',
+    size_name: '12x12',
+    ...overrides,
+  } as BoardDetails;
+}
+
+function createTestClimb(uuid: string): Climb {
+  return {
+    uuid: `climb-${uuid}`,
+    name: `Climb ${uuid}`,
+    setter_username: 'tester',
+    description: '',
+    frames: '',
+    angle: 40,
+    ascensionist_count: 10,
+    difficulty: '5',
+    quality_average: '3',
+    stars: 3,
+    difficulty_error: '',
+    litUpHoldsMap: {},
+    mirrored: false,
+    benchmark_difficulty: null,
+    userAscents: 0,
+    userAttempts: 0,
+  } as Climb;
+}
+
+function createTestClimbQueueItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: createTestClimb(uuid),
+    addedBy: null,
+    suggested: false,
+  };
+}
+
+beforeEach(async () => {
+  // Clear the store contents using a separate short-lived connection
+  const db = await openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+  await db.clear(STORE_NAME);
+  db.close();
+});
+
+describe('getMostRecentQueue', () => {
+  it('returns null when no queues are stored', async () => {
+    const result = await getMostRecentQueue();
+    expect(result).toBeNull();
+  });
+
+  it('returns the queue with the highest updatedAt', async () => {
+    const boardDetails = createTestBoardDetails();
+
+    await saveQueueState({
+      boardPath: '/kilter/1/10/1,2/40',
+      queue: [createTestClimbQueueItem('a')],
+      currentClimbQueueItem: null,
+      boardDetails,
+      updatedAt: 1000,
+    });
+    await saveQueueState({
+      boardPath: '/tension/1/10/1,2/45',
+      queue: [createTestClimbQueueItem('b')],
+      currentClimbQueueItem: null,
+      boardDetails: createTestBoardDetails({ board_name: 'tension' }),
+      updatedAt: 2000,
+    });
+
+    const result = await getMostRecentQueue();
+    expect(result).not.toBeNull();
+    // saveQueueState overwrites updatedAt with Date.now(), but the second call
+    // has a later Date.now() so it will have the higher timestamp
+    expect(result!.boardPath).toBe('/tension/1/10/1,2/45');
+    expect(result!.queue).toHaveLength(1);
+    expect(result!.queue[0].uuid).toBe('b');
+  });
+
+  it('filters out corrupted items (null/undefined climbs)', async () => {
+    const boardDetails = createTestBoardDetails();
+    const validItem = createTestClimbQueueItem('valid');
+
+    // Save directly to DB with corrupted items to test filtering
+    const db = await openDB(DB_NAME, 1);
+    await db.put(
+      STORE_NAME,
+      {
+        boardPath: '/kilter/1/10/1,2/40',
+        queue: [validItem, null, undefined, { uuid: 'bad', climb: null }],
+        currentClimbQueueItem: validItem,
+        boardDetails,
+        updatedAt: Date.now(),
+      },
+      'queue:/kilter/1/10/1,2/40',
+    );
+    db.close();
+
+    const result = await getMostRecentQueue();
+    expect(result).not.toBeNull();
+    expect(result!.queue).toHaveLength(1);
+    expect(result!.queue[0].uuid).toBe('valid');
+  });
+
+  it('returns the single stored queue when only one exists', async () => {
+    const boardDetails = createTestBoardDetails();
+    const item = createTestClimbQueueItem('only');
+
+    await saveQueueState({
+      boardPath: '/kilter/1/10/1,2/40',
+      queue: [item],
+      currentClimbQueueItem: item,
+      boardDetails,
+      updatedAt: Date.now(),
+    });
+
+    const result = await getMostRecentQueue();
+    expect(result).not.toBeNull();
+    expect(result!.queue).toHaveLength(1);
+    expect(result!.currentClimbQueueItem?.uuid).toBe('only');
+  });
+});


### PR DESCRIPTION
Previously, queue restoration only happened on board-specific routes
(e.g., /kilter/1/1/1,2/40/list) where GraphQLQueueProvider and
BoardSessionBridge mount. This meant landing on / showed no queue
control bar even when the user had an active local queue or party
session.

Changes:
- Add getMostRecentQueue() to queue-storage-db.ts to find the most
  recently updated stored queue without knowing the boardPath
- Add mount effect in PersistentSessionProvider that restores party
  session (priority) or most recent local queue on startup
- Persist ActiveSessionInfo to IndexedDB via user-preferences-db on
  activateSession, clear on deactivateSession/SessionEnded/failure
- Add tests for queue-storage-db and session restoration logic

https://claude.ai/code/session_016jqwd1ye4a89qLVcib9PAH