### PR TITLE
fix: show climb card for all proposal types including classic proposals

### DIFF
--- a/packages/web/app/components/social/__tests__/proposal-card.test.tsx
+++ b/packages/web/app/components/social/__tests__/proposal-card.test.tsx
@@ -219,9 +219,15 @@ describe('ProposalCard', () => {
       expect(screen.queryByTestId('climb-list-item-mock')).toBeNull();
     });
 
-    it('does not render ClimbListItem when angle is null', () => {
+    it('renders ClimbListItem when angle is null (classic proposals)', () => {
       render(<ProposalCard proposal={makeProposal({ angle: null })} />);
-      expect(screen.queryByTestId('climb-list-item-mock')).toBeNull();
+      expect(screen.getByTestId('climb-list-item-mock')).toBeTruthy();
+      // Should use 0 as fallback angle
+      expect(mockClimbListItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          climb: expect.objectContaining({ angle: 0 }),
+        }),
+      );
     });
 
     it('handles missing optional climb fields gracefully', () => {

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -131,7 +131,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
   const climbAndBoardDetails = useMemo(() => {
     const { climbUuid, climbName, frames, layoutId, boardType, angle } = localProposal;
     if (!climbName && !frames) return null;
-    if (!layoutId || !boardType || angle == null) return null;
+    if (!layoutId || !boardType) return null;
 
     const boardName = boardType as BoardName;
     const config = getDefaultBoardConfig(boardName, layoutId);
@@ -159,7 +159,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
       setter_username: localProposal.climbSetterUsername || '',
       description: '',
       frames: frames || '',
-      angle,
+      angle: angle ?? 0,
       ascensionist_count: localProposal.climbAscensionistCount ?? 0,
       difficulty: localProposal.climbDifficulty || '',
       quality_average: localProposal.climbQualityAverage || '0',


### PR DESCRIPTION
Classic proposals have angle=null by design, but ProposalCard blocked card
rendering when angle was null. This also prevented stats from being fetched
for classic proposals in the backend.

Frontend: Remove angle==null guard from card display, use 0 as fallback.
Backend: Use climb's default angle to fetch stats when proposal angle is null.

https://claude.ai/code/session_01X5pxe7GvV21QRaU2CttocK