### PR TITLE
fix: use current board angle when setting proposal climb as active

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -654,7 +654,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
 
       // Actions
       addToQueue: (climb: Climb) => {
-        const newItem = createClimbQueueItem(climb, clientId, currentUserInfo);
+        const newItem = createClimbQueueItem({ ...climb, angle: parsedParams.angle }, clientId, currentUserInfo);
 
         // Optimistic update
         dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item: newItem } });
@@ -680,7 +680,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
       },
 
       setCurrentClimb: async (climb: Climb) => {
-        const newItem = createClimbQueueItem(climb, clientId, currentUserInfo);
+        const newItem = createClimbQueueItem({ ...climb, angle: parsedParams.angle }, clientId, currentUserInfo);
 
         // Optimistic update
         dispatch({ type: 'SET_CURRENT_CLIMB', payload: newItem });

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -114,7 +114,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       if (!boardDetails) return;
       const newItem: ClimbQueueItem = {
-        climb,
+        climb: { ...climb, angle },
         addedBy: null,
         uuid: uuidv4(),
         suggested: false,
@@ -123,7 +123,7 @@ function usePersistentSessionQueueAdapter(): {
       const current = currentClimbQueueItem ?? newItem;
       ps.setLocalQueueState(newQueue, current, baseBoardPath, boardDetails);
     },
-    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps],
+    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle],
   );
 
   const removeFromQueue = useCallback(
@@ -166,7 +166,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       if (!boardDetails) return;
       const newItem: ClimbQueueItem = {
-        climb,
+        climb: { ...climb, angle },
         addedBy: null,
         uuid: uuidv4(),
         suggested: false,
@@ -183,7 +183,7 @@ function usePersistentSessionQueueAdapter(): {
       }
       ps.setLocalQueueState(newQueue, newItem, baseBoardPath, boardDetails);
     },
-    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps],
+    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle],
   );
 
   // No-op functions for fields not used by the bottom bar — each matches its exact type signature

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -64,6 +64,9 @@ function usePersistentSessionQueueAdapter(): {
   const angle: Angle = isParty
     ? ps.activeSession!.parsedParams.angle
     : (ps.localCurrentClimbQueueItem?.climb?.angle ?? 0);
+  // Whether the angle comes from a real source (party session or existing queue item)
+  // vs the fallback 0 when the local queue is empty.
+  const hasAngleSource = isParty || !!ps.localCurrentClimbQueueItem;
 
   const baseBoardPath = useMemo(() => {
     if (isParty && ps.activeSession?.boardPath) {
@@ -114,7 +117,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       if (!boardDetails) return;
       const newItem: ClimbQueueItem = {
-        climb: { ...climb, angle },
+        climb: hasAngleSource ? { ...climb, angle } : climb,
         addedBy: null,
         uuid: uuidv4(),
         suggested: false,
@@ -123,7 +126,7 @@ function usePersistentSessionQueueAdapter(): {
       const current = currentClimbQueueItem ?? newItem;
       ps.setLocalQueueState(newQueue, current, baseBoardPath, boardDetails);
     },
-    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle],
+    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle, hasAngleSource],
   );
 
   const removeFromQueue = useCallback(
@@ -166,7 +169,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       if (!boardDetails) return;
       const newItem: ClimbQueueItem = {
-        climb: { ...climb, angle },
+        climb: hasAngleSource ? { ...climb, angle } : climb,
         addedBy: null,
         uuid: uuidv4(),
         suggested: false,
@@ -183,7 +186,7 @@ function usePersistentSessionQueueAdapter(): {
       }
       ps.setLocalQueueState(newQueue, newItem, baseBoardPath, boardDetails);
     },
-    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle],
+    [queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, angle, hasAngleSource],
   );
 
   // No-op functions for fields not used by the bottom bar — each matches its exact type signature


### PR DESCRIPTION
When a proposal climb was set as the active climb via "Set Active",
the climb's angle would be set to 0 or the proposal's stored angle
instead of the current board/queue angle. This happened because the
climb object from the proposal card carried the proposal's angle.

Override the climb's angle with the current board angle in both
addToQueue and setCurrentClimb in the GraphQL QueueContext (party mode)
and the persistent session queue adapter (local mode).

https://claude.ai/code/session_01Na4cZifibvzbqcjysHmDiE