### PR TITLE
feat: add reusable FeedCommentButton for inline comments on feed items

### DIFF
--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -14,12 +14,12 @@ import FlashOnOutlined from '@mui/icons-material/FlashOnOutlined';
 import CheckCircleOutlineOutlined from '@mui/icons-material/CheckCircleOutlineOutlined';
 import ErrorOutlineOutlined from '@mui/icons-material/ErrorOutlineOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
-import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import Link from 'next/link';
 import type { SessionFeedItem } from '@boardsesh/shared-schema';
 import GradeDistributionBar from '@/app/components/charts/grade-distribution-bar';
 import OutcomeDoughnut from '@/app/components/charts/outcome-doughnut';
 import VoteButton from '@/app/components/social/vote-button';
+import FeedCommentButton from '@/app/components/social/feed-comment-button';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeColor, getGradeTextColor } from '@/app/lib/grade-colors';
 
@@ -303,14 +303,11 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
           initialUserVote={0}
           likeOnly
         />
-        {commentCount > 0 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-            <ChatBubbleOutlineOutlined sx={{ fontSize: 14, color: 'text.secondary' }} />
-            <Typography variant="caption" color="text.secondary">
-              {commentCount} comment{commentCount !== 1 ? 's' : ''}
-            </Typography>
-          </Box>
-        )}
+        <FeedCommentButton
+          entityType="session"
+          entityId={sessionId}
+          commentCount={commentCount}
+        />
       </Box>
     </Card>
   );

--- a/packages/web/app/components/social/__tests__/feed-comment-button.test.tsx
+++ b/packages/web/app/components/social/__tests__/feed-comment-button.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// --- Mocks ---
+
+const mockCommentSection = vi.fn();
+vi.mock('../comment-section', () => ({
+  default: (props: { entityType: string; entityId: string; title: string }) => {
+    mockCommentSection(props);
+    return (
+      <div
+        data-testid="comment-section"
+        data-entity-type={props.entityType}
+        data-entity-id={props.entityId}
+        data-title={props.title}
+      />
+    );
+  },
+}));
+
+import FeedCommentButton from '../feed-comment-button';
+
+describe('FeedCommentButton', () => {
+  describe('Initial rendering', () => {
+    it('renders the comment icon button', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+      expect(screen.getByRole('button', { name: /show comments/i })).toBeTruthy();
+    });
+
+    it('shows comment count when greater than 0', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" commentCount={5} />);
+      expect(screen.getByText('5')).toBeTruthy();
+    });
+
+    it('does not show count text when commentCount is 0', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" commentCount={0} />);
+      expect(screen.queryByText('0')).toBeNull();
+    });
+
+    it('does not show count text when commentCount is not provided', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+      expect(screen.queryByText('0')).toBeNull();
+    });
+
+    it('does not render CommentSection initially', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+      expect(screen.queryByTestId('comment-section')).toBeNull();
+    });
+  });
+
+  describe('Toggle behavior', () => {
+    it('shows CommentSection when icon button is clicked', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      expect(screen.getByTestId('comment-section')).toBeTruthy();
+    });
+
+    it('toggles aria-label back to Show comments when clicked again', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+
+      // Open
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+      expect(screen.getByRole('button', { name: /hide comments/i })).toBeTruthy();
+
+      // Close — the aria-label should switch back
+      fireEvent.click(screen.getByRole('button', { name: /hide comments/i }));
+      expect(screen.getByRole('button', { name: /show comments/i })).toBeTruthy();
+    });
+
+    it('changes aria-label based on open state', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" />);
+
+      expect(screen.getByRole('button', { name: /show comments/i })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: /hide comments/i })).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      expect(screen.getByRole('button', { name: /hide comments/i })).toBeTruthy();
+    });
+
+    it('stops event propagation on click', () => {
+      const parentHandler = vi.fn();
+      render(
+        <div onClick={parentHandler}>
+          <FeedCommentButton entityType="session" entityId="session-1" />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      expect(parentHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CommentSection props', () => {
+    it('passes entityType and entityId to CommentSection', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-42" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      const section = screen.getByTestId('comment-section');
+      expect(section.getAttribute('data-entity-type')).toBe('session');
+      expect(section.getAttribute('data-entity-id')).toBe('session-42');
+    });
+
+    it('passes "Comments" as title to CommentSection', () => {
+      render(<FeedCommentButton entityType="proposal" entityId="prop-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      const section = screen.getByTestId('comment-section');
+      expect(section.getAttribute('data-title')).toBe('Comments');
+    });
+
+    it('works with proposal entity type', () => {
+      render(<FeedCommentButton entityType="proposal" entityId="proposal-abc" commentCount={3} />);
+
+      expect(screen.getByText('3')).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      const section = screen.getByTestId('comment-section');
+      expect(section.getAttribute('data-entity-type')).toBe('proposal');
+      expect(section.getAttribute('data-entity-id')).toBe('proposal-abc');
+    });
+
+    it('works with climb entity type', () => {
+      render(<FeedCommentButton entityType="climb" entityId="climb-xyz" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /show comments/i }));
+
+      const section = screen.getByTestId('comment-section');
+      expect(section.getAttribute('data-entity-type')).toBe('climb');
+      expect(section.getAttribute('data-entity-id')).toBe('climb-xyz');
+    });
+  });
+
+  describe('Large comment counts', () => {
+    it('renders large comment counts', () => {
+      render(<FeedCommentButton entityType="session" entityId="session-1" commentCount={999} />);
+      expect(screen.getByText('999')).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/app/components/social/__tests__/proposal-card.test.tsx
+++ b/packages/web/app/components/social/__tests__/proposal-card.test.tsx
@@ -66,8 +66,19 @@ vi.mock('../proposal-vote-bar', () => ({
   default: () => <div data-testid="proposal-vote-bar" />,
 }));
 
-vi.mock('../comment-section', () => ({
-  default: () => <div data-testid="comment-section" />,
+const mockFeedCommentButton = vi.fn();
+vi.mock('../feed-comment-button', () => ({
+  default: (props: { entityType: string; entityId: string; commentCount?: number }) => {
+    mockFeedCommentButton(props);
+    return (
+      <div
+        data-testid="feed-comment-button"
+        data-entity-type={props.entityType}
+        data-entity-id={props.entityId}
+        data-comment-count={props.commentCount ?? 0}
+      />
+    );
+  },
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -347,17 +358,19 @@ describe('ProposalCard', () => {
   });
 
   describe('Comments', () => {
-    it('toggles comment section on button click', () => {
+    it('renders FeedCommentButton with proposal entity type', () => {
       render(<ProposalCard proposal={makeProposal()} />);
 
-      // Comment section should not be visible initially
-      expect(screen.queryByTestId('comment-section')).toBeNull();
+      const commentButton = screen.getByTestId('feed-comment-button');
+      expect(commentButton.getAttribute('data-entity-type')).toBe('proposal');
+      expect(commentButton.getAttribute('data-entity-id')).toBe('proposal-1');
+    });
 
-      // Click comments button
-      fireEvent.click(screen.getByText('Comments'));
+    it('passes correct entity id from local proposal state', () => {
+      render(<ProposalCard proposal={makeProposal({ uuid: 'custom-uuid' })} />);
 
-      // Comment section should now be visible
-      expect(screen.getByTestId('comment-section')).toBeTruthy();
+      const commentButton = screen.getByTestId('feed-comment-button');
+      expect(commentButton.getAttribute('data-entity-id')).toBe('custom-uuid');
     });
   });
 

--- a/packages/web/app/components/social/feed-comment-button.tsx
+++ b/packages/web/app/components/social/feed-comment-button.tsx
@@ -30,27 +30,23 @@ export default function FeedCommentButton({
 
   return (
     <Box>
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', gap: 0.25, cursor: 'pointer' }}
+      <IconButton
+        size="small"
+        aria-label={open ? 'Hide comments' : 'Show comments'}
+        sx={{ p: 0.5, color: open ? 'text.primary' : 'text.secondary' }}
         onClick={handleToggle}
-        role="button"
-        tabIndex={0}
       >
-        <IconButton
-          size="small"
-          aria-label={open ? 'Hide comments' : 'Show comments'}
-          sx={{ p: 0.5, color: open ? 'text.primary' : 'text.secondary' }}
-          onClick={handleToggle}
-        >
-          <ChatBubbleOutlineOutlined sx={{ fontSize: 18 }} />
-        </IconButton>
-        <Typography
-          variant="caption"
-          sx={{ color: open ? 'text.primary' : 'text.secondary', userSelect: 'none' }}
-        >
-          {commentCount > 0 ? commentCount : ''}
-        </Typography>
-      </Box>
+        <ChatBubbleOutlineOutlined sx={{ fontSize: 18 }} />
+        {commentCount > 0 && (
+          <Typography
+            variant="caption"
+            component="span"
+            sx={{ ml: 0.5, color: 'inherit', userSelect: 'none', fontSize: 12 }}
+          >
+            {commentCount}
+          </Typography>
+        )}
+      </IconButton>
 
       <Collapse in={open} unmountOnExit>
         <Box sx={{ mt: 1 }}>

--- a/packages/web/app/components/social/feed-comment-button.tsx
+++ b/packages/web/app/components/social/feed-comment-button.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Collapse from '@mui/material/Collapse';
+import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
+import CommentSection from './comment-section';
+
+interface FeedCommentButtonProps {
+  entityType: SocialEntityType;
+  entityId: string;
+  commentCount?: number;
+}
+
+export default function FeedCommentButton({
+  entityType,
+  entityId,
+  commentCount = 0,
+}: FeedCommentButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <Box>
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.25, cursor: 'pointer' }}
+        onClick={handleToggle}
+        role="button"
+        tabIndex={0}
+      >
+        <IconButton
+          size="small"
+          aria-label={open ? 'Hide comments' : 'Show comments'}
+          sx={{ p: 0.5, color: open ? 'text.primary' : 'text.secondary' }}
+          onClick={handleToggle}
+        >
+          <ChatBubbleOutlineOutlined sx={{ fontSize: 18 }} />
+        </IconButton>
+        <Typography
+          variant="caption"
+          sx={{ color: open ? 'text.primary' : 'text.secondary', userSelect: 'none' }}
+        >
+          {commentCount > 0 ? commentCount : ''}
+        </Typography>
+      </Box>
+
+      <Collapse in={open} unmountOnExit>
+        <Box sx={{ mt: 1 }}>
+          <CommentSection entityType={entityType} entityId={entityId} title="Comments" />
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -9,13 +9,11 @@ import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Avatar from '@mui/material/Avatar';
 import Tooltip from '@mui/material/Tooltip';
-import Collapse from '@mui/material/Collapse';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpOutlinedIcon from '@mui/icons-material/ThumbUpOutlined';
 import ThumbDownOutlinedIcon from '@mui/icons-material/ThumbDownOutlined';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -37,7 +35,7 @@ import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/ut
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import ProposalVoteBar from './proposal-vote-bar';
-import CommentSection from './comment-section';
+import FeedCommentButton from './feed-comment-button';
 
 const TYPE_LABELS: Record<string, string> = {
   grade: 'Grade',
@@ -64,7 +62,6 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState('');
   const [localProposal, setLocalProposal] = useState(proposal);
-  const [showComments, setShowComments] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -345,25 +342,12 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
           )}
 
           {/* Comments toggle */}
-          <Button
-            size="small"
-            startIcon={<ChatBubbleOutlineIcon />}
-            onClick={() => setShowComments((prev) => !prev)}
-            sx={{
-              mt: 1.5,
-              color: themeTokens.neutral[500],
-              textTransform: 'none',
-              fontSize: 12,
-            }}
-          >
-            Comments
-          </Button>
-
-          <Collapse in={showComments} unmountOnExit>
-            <Box sx={{ mt: 1 }}>
-              <CommentSection entityType="proposal" entityId={localProposal.uuid} title="Comments" />
-            </Box>
-          </Collapse>
+          <Box sx={{ mt: 1.5 }}>
+            <FeedCommentButton
+              entityType="proposal"
+              entityId={localProposal.uuid}
+            />
+          </Box>
 
           {/* Timestamp */}
           <Typography variant="caption" sx={{ color: themeTokens.neutral[400], mt: 1, display: 'block' }}>


### PR DESCRIPTION
Replace static comment count display on session feed cards with an
interactive comment button that expands a full comment section inline.
Reuse the same component in proposal cards, replacing the previous
inline toggle/collapse implementation with the shared FeedCommentButton.

https://claude.ai/code/session_015q9qGSCH3Q9Jbgvp5fhRwg