### PR TITLE
Add global header and sesh settings drawer

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -17,7 +17,6 @@ import { UISearchParamsProvider } from '@/app/components/queue-control/ui-search
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
 import LastUsedBoardTracker from '@/app/components/board-page/last-used-board-tracker';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
 
 export async function generateMetadata(props: { params: Promise<BoardRouteParameters> }): Promise<Metadata> {
   const params = await props.params;
@@ -70,11 +69,8 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   const { angle } = parsedParams;
 
-  // Fetch the board details and board configs server-side
-  const [boardDetails, boardConfigs] = await Promise.all([
-    Promise.resolve(getBoardDetailsForBoard(parsedParams)),
-    getAllBoardConfigs(),
-  ]);
+  // Fetch the board details server-side
+  const boardDetails = getBoardDetailsForBoard(parsedParams);
 
   // Compute the list URL for last-used-board tracking
   const listUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
@@ -106,7 +102,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               <BluetoothProvider boardDetails={boardDetails}>
                 <UISearchParamsProvider>
                   <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
-                  <BoardSeshHeader boardDetails={boardDetails} angle={angle} boardConfigs={boardConfigs} />
+                  <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
                   <main
                     id="content-for-scrollable"

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -110,7 +110,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                       flex: 1,
                       paddingLeft: `${themeTokens.spacing[2]}px`,
                       paddingRight: `${themeTokens.spacing[2]}px`,
-                      paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
+                      paddingTop: 'var(--global-header-height)',
                       paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
                     }}
                   >

--- a/packages/web/app/about/about.module.css
+++ b/packages/web/app/about/about.module.css
@@ -2,6 +2,7 @@
 
 .pageLayout {
   min-height: 100vh;
+  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
   background: var(--neutral-50);
 }
 

--- a/packages/web/app/about/about.module.css
+++ b/packages/web/app/about/about.module.css
@@ -2,7 +2,7 @@
 
 .pageLayout {
   min-height: 100vh;
-  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
+  padding-top: var(--global-header-height);
   background: var(--neutral-50);
 }
 

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -45,7 +45,7 @@ export default function AdminPage() {
 
   if (!token) {
     return (
-      <Container maxWidth="md" sx={{ py: 4 }}>
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
         <Alert severity="warning">Please sign in to access the admin panel.</Alert>
       </Container>
     );
@@ -53,14 +53,14 @@ export default function AdminPage() {
 
   if (!isAdmin) {
     return (
-      <Container maxWidth="md" sx={{ py: 4 }}>
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
         <Alert severity="error">You do not have admin access.</Alert>
       </Container>
     );
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
       <Typography variant="h5" sx={{ fontWeight: 700, mb: 3, color: themeTokens.neutral[800] }}>
         Admin Panel
       </Typography>

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -45,7 +45,7 @@ export default function AdminPage() {
 
   if (!token) {
     return (
-      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
         <Alert severity="warning">Please sign in to access the admin panel.</Alert>
       </Container>
     );
@@ -53,14 +53,14 @@ export default function AdminPage() {
 
   if (!isAdmin) {
     return (
-      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
         <Alert severity="error">You do not have admin access.</Alert>
       </Container>
     );
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 32px)' }}>
+    <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
       <Typography variant="h5" sx={{ fontWeight: 700, mb: 3, color: themeTokens.neutral[800] }}>
         Admin Panel
       </Typography>

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -15,7 +15,7 @@ import { UISearchParamsProvider } from '@/app/components/queue-control/ui-search
 import { BoardProvider } from '@/app/components/board-provider/board-provider-context';
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
 import LastUsedBoardTracker from '@/app/components/board-page/last-used-board-tracker';
-import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
+
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -53,10 +53,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
   const angle = Number(params.angle);
   const parsedParams = boardToRouteParams(board, angle);
 
-  const [boardDetails, boardConfigs] = await Promise.all([
-    Promise.resolve(getBoardDetailsForBoard(parsedParams)),
-    getAllBoardConfigs(),
-  ]);
+  const boardDetails = getBoardDetailsForBoard(parsedParams);
 
   const listUrl = constructBoardSlugListUrl(board.slug, angle);
 
@@ -79,7 +76,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                 <BluetoothProvider boardDetails={boardDetails}>
                   <UISearchParamsProvider>
                     <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
-                    <BoardSeshHeader boardDetails={boardDetails} angle={angle} boardConfigs={boardConfigs} isAngleAdjustable={board.isAngleAdjustable} />
+                    <BoardSeshHeader boardDetails={boardDetails} angle={angle} isAngleAdjustable={board.isAngleAdjustable} />
 
                     <main
                       id="content-for-scrollable"

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -84,7 +84,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                         flex: 1,
                         paddingLeft: `${themeTokens.spacing[2]}px`,
                         paddingRight: `${themeTokens.spacing[2]}px`,
-                        paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))',
+                        paddingTop: 'var(--global-header-height)',
                         paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
                       }}
                     >

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -24,9 +24,10 @@ type AngleSelectorProps = {
   currentAngle: number;
   currentClimb: Climb | null;
   isAngleAdjustable?: boolean;
+  onAngleChange?: (angle: number) => void;
 };
 
-export default function AngleSelector({ boardName, boardDetails, currentAngle, currentClimb, isAngleAdjustable = true }: AngleSelectorProps) {
+export default function AngleSelector({ boardName, boardDetails, currentAngle, currentClimb, isAngleAdjustable = true, onAngleChange: onAngleChangeProp }: AngleSelectorProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
@@ -67,14 +68,18 @@ export default function AngleSelector({ boardName, boardDetails, currentAngle, c
       angle: newAngle,
     });
 
-    // Replace the current angle in the URL with the new one
-    const pathSegments = pathname.split('/');
-    const angleIndex = pathSegments.findIndex((segment) => segment === currentAngle.toString());
+    if (onAngleChangeProp) {
+      onAngleChangeProp(newAngle);
+    } else {
+      // Replace the current angle in the URL with the new one
+      const pathSegments = pathname.split('/');
+      const angleIndex = pathSegments.findIndex((segment) => segment === currentAngle.toString());
 
-    if (angleIndex !== -1) {
-      pathSegments[angleIndex] = newAngle.toString();
-      const newPath = pathSegments.join('/');
-      router.push(newPath);
+      if (angleIndex !== -1) {
+        pathSegments[angleIndex] = newAngle.toString();
+        const newPath = pathSegments.join('/');
+        router.push(newPath);
+      }
     }
 
     setIsDrawerOpen(false);

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -1,0 +1,61 @@
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 8dvh;
+  min-height: 48px;
+  padding: 0 16px;
+  padding-top: env(safe-area-inset-top, 0px);
+  background: var(--semantic-surface);
+  border-bottom: 1px solid var(--neutral-200);
+  touch-action: manipulation;
+}
+
+.header button,
+.header a,
+.header input {
+  touch-action: manipulation;
+}
+
+.searchPillButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-200);
+  cursor: pointer;
+  transition: box-shadow 200ms ease;
+  font-size: 14px;
+  color: var(--neutral-500);
+  line-height: 1.4;
+}
+
+.searchPillButton:hover {
+  box-shadow: var(--shadow-sm);
+}
+
+.searchPillButton:active {
+  background: var(--neutral-100);
+}
+
+.searchPillIcon {
+  flex-shrink: 0;
+  font-size: 14px;
+  color: var(--neutral-400);
+}
+
+.searchPillText {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -7,8 +7,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 8dvh;
-  min-height: 48px;
+  height: var(--global-header-height);
   padding: 0 16px;
   padding-top: env(safe-area-inset-top, 0px);
   background: var(--semantic-surface);

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useState } from 'react';
+import Button from '@mui/material/Button';
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
+import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
+import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
+import UserDrawer from '@/app/components/user-drawer/user-drawer';
+import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
+import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
+import { usePersistentSession, useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
+import { BoardConfigData } from '@/app/lib/server-board-configs';
+import { themeTokens } from '@/app/theme/theme-config';
+import styles from './global-header.module.css';
+
+interface GlobalHeaderProps {
+  boardConfigs: BoardConfigData;
+}
+
+export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [startSeshOpen, setStartSeshOpen] = useState(false);
+  const [seshSettingsOpen, setSeshSettingsOpen] = useState(false);
+  const { activeSession } = usePersistentSession();
+  const isOnBoardRoute = useIsOnBoardRoute();
+
+  const hasActiveSession = !!activeSession;
+
+  const handleSeshClick = () => {
+    if (hasActiveSession) {
+      setSeshSettingsOpen(true);
+    } else {
+      setStartSeshOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <header className={styles.header}>
+        <UserDrawer boardConfigs={boardConfigs} />
+
+        <button
+          className={styles.searchPillButton}
+          onClick={() => setSearchOpen(true)}
+          type="button"
+        >
+          <SearchOutlined className={styles.searchPillIcon} />
+          <span className={styles.searchPillText}>Search</span>
+        </button>
+
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={hasActiveSession ? <SettingsOutlined /> : <PlayCircleOutlineOutlined />}
+          onClick={handleSeshClick}
+          sx={hasActiveSession ? {
+            backgroundColor: themeTokens.colors.success,
+            '&:hover': { backgroundColor: themeTokens.colors.successHover },
+          } : undefined}
+        >
+          Sesh
+        </Button>
+      </header>
+
+      <UnifiedSearchDrawer
+        open={searchOpen}
+        onClose={() => setSearchOpen(false)}
+        defaultCategory={isOnBoardRoute ? 'climbs' : 'boards'}
+      />
+
+      <StartSeshDrawer
+        open={startSeshOpen}
+        onClose={() => setStartSeshOpen(false)}
+        boardConfigs={boardConfigs}
+      />
+
+      <SeshSettingsDrawer
+        open={seshSettingsOpen}
+        onClose={() => setSeshSettingsOpen(false)}
+      />
+    </>
+  );
+}

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -43,6 +43,9 @@
 
   /* Borders */
   --border-subtle: rgba(0, 0, 0, 0.06);
+
+  /* Layout */
+  --global-header-height: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
 }
 
 /* Dark mode overrides */

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import { PartyProfileProvider } from '../party-manager/party-profile-context';
-import { PersistentSessionProvider } from '../persistent-session';
+import { PersistentSessionProvider, usePersistentSession } from '../persistent-session';
 import { QueueBridgeProvider, useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
 import { useQueueContext } from '../graphql-queue';
 import QueueControlBar from '../queue-control/queue-control-bar';
@@ -16,6 +16,8 @@ import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import ErrorBoundary from '../error-boundary';
 import bottomBarStyles from '../bottom-tab-bar/bottom-bar-wrapper.module.css';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
+import GlobalHeader from '../global-header/global-header';
+import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 
 interface PersistentSessionWrapperProps {
   children: React.ReactNode;
@@ -34,12 +36,24 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
     <PartyProfileProvider>
       <PersistentSessionProvider>
         <QueueBridgeProvider>
+          <GlobalHeader boardConfigs={boardConfigs} />
           {children}
           <RootBottomBar boardConfigs={boardConfigs} />
+          <RootSessionSummaryDialog />
         </QueueBridgeProvider>
       </PersistentSessionProvider>
     </PartyProfileProvider>
   );
+}
+
+/**
+ * Root-level session summary dialog.
+ * Consumes sessionSummary/dismissSessionSummary from PersistentSessionContext
+ * so session ending works from any page (not just board routes).
+ */
+function RootSessionSummaryDialog() {
+  const { sessionSummary, dismissSessionSummary } = usePersistentSession();
+  return <SessionSummaryDialog summary={sessionSummary} onDismiss={dismissSessionSummary} />;
 }
 
 /**

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
+import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import AngleSelector from '@/app/components/board-page/angle-selector';
+import { usePersistentSession } from '@/app/components/persistent-session/persistent-session-context';
+import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
+import { useRouter, usePathname } from 'next/navigation';
+import { themeTokens } from '@/app/theme/theme-config';
+
+interface SeshSettingsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawerProps) {
+  const { activeSession, session, users, endSessionWithSummary } = usePersistentSession();
+  const { boardDetails, angle } = useQueueBridgeBoardInfo();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleAngleChange = useCallback((newAngle: number) => {
+    if (!activeSession || !boardDetails) return;
+
+    // Navigate to the board route with the new angle
+    const boardPath = activeSession.boardPath;
+    // Replace angle in the board path
+    const pathParts = boardPath.split('/');
+    // For slug-based routes like /b/board-slug/angle, the angle is the last segment
+    if (pathParts.length > 0) {
+      pathParts[pathParts.length - 1] = newAngle.toString();
+    }
+    const newPath = pathParts.join('/');
+    router.push(`${newPath}/list`);
+  }, [activeSession, boardDetails, router]);
+
+  const handleStopSession = useCallback(() => {
+    endSessionWithSummary();
+
+    // Remove session from URL if on a board route
+    if (pathname.includes('session=')) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('session');
+      router.replace(url.pathname + (url.search || ''), { scroll: false });
+    }
+
+    onClose();
+  }, [endSessionWithSummary, pathname, router, onClose]);
+
+  if (!activeSession) return null;
+
+  const sessionName = session?.name || activeSession.sessionName || 'Session';
+  const participantCount = users.length;
+  const sessionGoal = session?.goal;
+  const startedAt = session?.startedAt;
+
+  // Calculate duration
+  let durationText = '';
+  if (startedAt) {
+    const startDate = new Date(startedAt);
+    const now = new Date();
+    const diffMs = now.getTime() - startDate.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 60) {
+      durationText = `${diffMins}m`;
+    } else {
+      const hours = Math.floor(diffMins / 60);
+      const mins = diffMins % 60;
+      durationText = `${hours}h ${mins}m`;
+    }
+  }
+
+  return (
+    <SwipeableDrawer
+      title="Sesh Settings"
+      placement="right"
+      open={open}
+      onClose={onClose}
+      styles={{ wrapper: { width: '90%', maxWidth: 400 } }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, p: 1 }}>
+        {/* Session info */}
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+            {sessionName}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {participantCount > 0 && (
+              <Chip
+                icon={<PeopleOutlined />}
+                label={`${participantCount} participant${participantCount !== 1 ? 's' : ''}`}
+                size="small"
+                variant="outlined"
+              />
+            )}
+            {durationText && (
+              <Chip label={durationText} size="small" variant="outlined" />
+            )}
+          </Box>
+          {sessionGoal && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Goal: {sessionGoal}
+            </Typography>
+          )}
+        </Box>
+
+        {/* Angle selector */}
+        {boardDetails && angle !== undefined && (
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+              Angle
+            </Typography>
+            <AngleSelector
+              boardName={boardDetails.board_name}
+              boardDetails={boardDetails}
+              currentAngle={angle}
+              currentClimb={null}
+              onAngleChange={handleAngleChange}
+            />
+          </Box>
+        )}
+
+        {/* Stop Session */}
+        <Button
+          variant="outlined"
+          color="error"
+          startIcon={<StopCircleOutlined />}
+          onClick={handleStopSession}
+          fullWidth
+          sx={{
+            mt: 2,
+            borderColor: themeTokens.colors.error,
+            color: themeTokens.colors.error,
+            '&:hover': {
+              borderColor: themeTokens.colors.error,
+              backgroundColor: `${themeTokens.colors.error}10`,
+            },
+          }}
+        >
+          Stop Session
+        </Button>
+      </Box>
+    </SwipeableDrawer>
+  );
+}

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -5,6 +5,7 @@
 
 .layout {
   min-height: 100vh;
+  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
   background: var(--semantic-background, #F9FAFB);
 }
 

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -5,7 +5,7 @@
 
 .layout {
   min-height: 100vh;
-  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
+  padding-top: var(--global-header-height);
   background: var(--semantic-background, #F9FAFB);
 }
 

--- a/packages/web/app/docs/docs.module.css
+++ b/packages/web/app/docs/docs.module.css
@@ -2,6 +2,7 @@
 
 .docsContainer {
   padding: 24px;
+  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 24px);
   max-width: 1400px;
   margin: 0 auto;
 }

--- a/packages/web/app/docs/docs.module.css
+++ b/packages/web/app/docs/docs.module.css
@@ -2,7 +2,7 @@
 
 .docsContainer {
   padding: 24px;
-  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 24px);
+  padding-top: calc(var(--global-header-height) + 24px);
   max-width: 1400px;
   margin: 0 auto;
 }

--- a/packages/web/app/help/help.module.css
+++ b/packages/web/app/help/help.module.css
@@ -2,6 +2,7 @@
 
 .pageLayout {
   min-height: 100vh;
+  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
   background: var(--semantic-background);
 }
 

--- a/packages/web/app/help/help.module.css
+++ b/packages/web/app/help/help.module.css
@@ -2,7 +2,7 @@
 
 .pageLayout {
   min-height: 100vh;
-  padding-top: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
+  padding-top: var(--global-header-height);
   background: var(--semantic-background);
 }
 

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -4,20 +4,12 @@ import React, { useState, useCallback } from 'react';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import SearchOutlined from '@mui/icons-material/SearchOutlined';
-import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
-import Button from '@mui/material/Button';
 import ActivityFeed from '@/app/components/activity-feed/activity-feed';
 import ProposalFeed from '@/app/components/activity-feed/proposal-feed';
 import CommentFeed from '@/app/components/activity-feed/comment-feed';
-import searchPillStyles from '@/app/components/search-drawer/search-pill.module.css';
-import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
-import UserDrawer from '@/app/components/user-drawer/user-drawer';
-import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { BoardConfigData } from '@/app/lib/server-board-configs';
 import BoardScrollSection from '@/app/components/board-scroll/board-scroll-section';
 import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
 import type { SessionFeedResult } from '@boardsesh/shared-schema';
@@ -29,7 +21,6 @@ type FeedTab = 'sessions' | 'proposals' | 'comments';
 const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
 
 interface HomePageContentProps {
-  boardConfigs: BoardConfigData;
   initialTab?: FeedTab;
   initialBoardUuid?: string;
   initialFeedResult?: SessionFeedResult | null;
@@ -38,7 +29,6 @@ interface HomePageContentProps {
 }
 
 export default function HomePageContent({
-  boardConfigs,
   initialTab = 'sessions',
   initialBoardUuid,
   initialFeedResult,
@@ -48,9 +38,7 @@ export default function HomePageContent({
   const { status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [startSeshOpen, setStartSeshOpen] = useState(false);
-  const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
+  const [_selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
 
   // Trust the SSR hint during the loading phase to prevent flash of unauthenticated content
   const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
@@ -96,41 +84,8 @@ export default function HomePageContent({
 
   return (
     <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: '60px' }}>
-      {/* Header */}
-      <Box
-        component="header"
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1.5,
-          px: 2,
-          py: 1.5,
-          borderBottom: '1px solid var(--neutral-200)',
-        }}
-      >
-        <UserDrawer boardConfigs={boardConfigs} />
-        <button
-          className={searchPillStyles.pill}
-          onClick={() => setSearchOpen(true)}
-          type="button"
-        >
-          <SearchOutlined className={searchPillStyles.icon} />
-          <span className={searchPillStyles.text}>Search</span>
-        </button>
-        <Box sx={{ ml: 'auto' }}>
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<PlayCircleOutlineOutlined />}
-            onClick={() => setStartSeshOpen(true)}
-          >
-            Sesh
-          </Button>
-        </Box>
-      </Box>
-
       {/* Feed */}
-      <Box component="main" sx={{ flex: 1, px: 2, py: 2 }}>
+      <Box component="main" sx={{ flex: 1, px: 2, py: 2, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 16px)' }}>
         {isAuthenticated && (myBoards.length > 0 || isLoadingBoards) && (
           <BoardScrollSection loading={isLoadingBoards} size="small">
             <div
@@ -174,7 +129,6 @@ export default function HomePageContent({
           <ActivityFeed
             isAuthenticated={isAuthenticated}
             boardUuid={selectedBoardUuid}
-            onFindClimbers={() => setSearchOpen(true)}
             initialFeedResult={initialFeedResult}
           />
         )}
@@ -193,18 +147,6 @@ export default function HomePageContent({
           />
         )}
       </Box>
-
-      <UnifiedSearchDrawer
-        open={searchOpen}
-        onClose={() => setSearchOpen(false)}
-        defaultCategory="boards"
-      />
-
-      <StartSeshDrawer
-        open={startSeshOpen}
-        onClose={() => setStartSeshOpen(false)}
-        boardConfigs={boardConfigs}
-      />
     </Box>
   );
 }

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
@@ -38,7 +38,6 @@ export default function HomePageContent({
   const { status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [_selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
 
   // Trust the SSR hint during the loading phase to prevent flash of unauthenticated content
   const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
@@ -72,27 +71,22 @@ export default function HomePageContent({
 
   const handleBoardFilter = useCallback((boardUuid: string | null) => {
     updateParam('board', boardUuid);
-    if (!boardUuid) {
-      setSelectedBoard(null);
-    }
   }, [updateParam]);
 
   const handleBoardSelect = useCallback((board: UserBoard) => {
-    setSelectedBoard(board);
     updateParam('board', board.uuid);
   }, [updateParam]);
 
   return (
     <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: '60px' }}>
       {/* Feed */}
-      <Box component="main" sx={{ flex: 1, px: 2, py: 2, pt: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px) + 16px)' }}>
+      <Box component="main" sx={{ flex: 1, px: 2, py: 2, pt: 'calc(var(--global-header-height) + 16px)' }}>
         {isAuthenticated && (myBoards.length > 0 || isLoadingBoards) && (
           <BoardScrollSection loading={isLoadingBoards} size="small">
             <div
               className={`${boardScrollStyles.cardScroll} ${boardScrollStyles.cardScrollSmall}`}
               onClick={() => {
                 handleBoardFilter(null);
-                setSelectedBoard(null);
               }}
             >
               <div className={`${boardScrollStyles.cardSquare} ${boardScrollStyles.filterSquare} ${!selectedBoardUuid ? boardScrollStyles.cardSquareSelected : ''}`}>

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -6,7 +6,7 @@ export default function NotificationsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
     </div>
   );

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -6,7 +6,7 @@ export default function NotificationsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
     </div>
   );

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -53,7 +53,6 @@ export default async function Home({ searchParams }: HomeProps) {
 
   return (
     <HomePageContent
-      boardConfigs={boardConfigs}
       initialTab={tab}
       initialBoardUuid={boardUuid}
       initialFeedResult={initialFeedResult}

--- a/packages/web/app/playlists/layout.tsx
+++ b/packages/web/app/playlists/layout.tsx
@@ -6,7 +6,7 @@ export default function MyLibraryLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
     </div>
   );

--- a/packages/web/app/playlists/layout.tsx
+++ b/packages/web/app/playlists/layout.tsx
@@ -6,7 +6,7 @@ export default function MyLibraryLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
     </div>
   );

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -249,7 +249,7 @@ export default function SettingsPageContent() {
 
   if (status === 'loading' || loading) {
     return (
-      <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+      <Box sx={{ minHeight: '100vh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', background: 'var(--semantic-background)' }}>
         <Box component="main" sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
           <CircularProgress size={48} />
         </Box>
@@ -262,7 +262,7 @@ export default function SettingsPageContent() {
   }
 
   return (
-    <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+    <Box sx={{ minHeight: '100vh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', background: 'var(--semantic-background)' }}>
       <Box
         component="header"
         sx={{

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -249,7 +249,7 @@ export default function SettingsPageContent() {
 
   if (status === 'loading' || loading) {
     return (
-      <Box sx={{ minHeight: '100vh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', background: 'var(--semantic-background)' }}>
+      <Box sx={{ minHeight: '100vh', paddingTop: 'var(--global-header-height)', background: 'var(--semantic-background)' }}>
         <Box component="main" sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
           <CircularProgress size={48} />
         </Box>
@@ -262,7 +262,7 @@ export default function SettingsPageContent() {
   }
 
   return (
-    <Box sx={{ minHeight: '100vh', paddingTop: 'calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px))', background: 'var(--semantic-background)' }}>
+    <Box sx={{ minHeight: '100vh', paddingTop: 'var(--global-header-height)', background: 'var(--semantic-background)' }}>
       <Box
         component="header"
         sx={{


### PR DESCRIPTION
## Summary
- Unified persistent global header across all pages (home, board, notifications, library, profile, settings, etc.) with UserDrawer, search pill, and context-aware Sesh button
- New SeshSettingsDrawer with session info (name, participants, duration, goal), angle selector, and stop session button
- Elevated session ending to root-level PersistentSessionContext so ending a session works from any page (not just board routes)
- Simplified board page header by removing UserDrawer and fixed positioning (now a contextual toolbar)
- Added `onAngleChange` callback prop to AngleSelector for non-URL-based angle changes

## Key Changes
| File | Change |
|------|--------|
| `global-header/global-header.tsx` | New persistent header component |
| `global-header/global-header.module.css` | Header styles |
| `sesh-settings/sesh-settings-drawer.tsx` | New sesh settings drawer |
| `persistent-session-context.tsx` | Added `endSessionWithSummary`, `sessionSummary`, `dismissSessionSummary` |
| `persistent-session-wrapper.tsx` | Renders GlobalHeader + root SessionSummaryDialog |
| `home-page-content.tsx` | Removed inline header, drawers, boardConfigs prop |
| `board-page/header.tsx` | Removed UserDrawer, AngleSelector; simplified to toolbar |
| `board-page/angle-selector.tsx` | Added optional `onAngleChange` prop |
| Board route layouts | Removed unused `boardConfigs` fetch |
| All page layouts/CSS | Added `paddingTop` for fixed global header |

## Test plan
- [ ] Global header appears on `/`, board pages, notifications, library, profile, settings
- [ ] Search pill opens UnifiedSearchDrawer (climbs on board routes, boards elsewhere)
- [ ] Sesh button is blue with no session, opens StartSeshDrawer
- [ ] Start a session, Sesh button turns sage green
- [ ] Tap sage green Sesh, opens SeshSettingsDrawer with angle selector
- [ ] Stop session from drawer, session saved, summary dialog appears
- [ ] Navigate between pages, header persists, bottom tab bar still works
- [ ] Test on mobile viewport (responsive behavior, safe area insets)
- [ ] Board page contextual toolbar still shows back button, search pill, angle selector, create button

🤖 Generated with [Claude Code](https://claude.com/claude-code)