### PR TITLE
fix: only show V-grade "+" suffix when multiple Font grades share the…

### DIFF
--- a/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
+++ b/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
@@ -36,9 +36,11 @@ describe('formatGradeLabels', () => {
     expect(formatGradeLabels(['6A', '7A+'])).toEqual(['6A', '7A+']);
   });
 
-  it('adds "+" when Font grade has "+" suffix regardless of context', () => {
-    // 7a+ has "+" in Font grade, so V7 gets "+" even as the only entry
-    expect(formatGradeLabels(['7a/V6', '7a+/V7'])).toEqual(['V6', 'V7+']);
+  it('only adds "+" when V-grade has multiple Font grades', () => {
+    // 7a+/V7: V7 has only one Font grade (7a+), so no "+" needed
+    expect(formatGradeLabels(['7a/V6', '7a+/V7'])).toEqual(['V6', 'V7']);
+    // 6b+/V4: V4 has two Font grades (6b, 6b+), so "+" is added
+    expect(formatGradeLabels(['6b/V4', '6b+/V4'])).toEqual(['V4', 'V4+']);
   });
 
   it('handles empty array', () => {
@@ -107,7 +109,7 @@ describe('GradeDistributionBar', () => {
     expect(data.labels).toEqual(['V3', 'V3+']);
   });
 
-  it('renders V-grade labels with "+" when Font grade has "+" suffix', () => {
+  it('does not add "+" when V-grade has only one Font grade mapping', () => {
     const gradeDistribution = [
       { grade: '7a+/V7', flash: 0, send: 1, attempt: 0 },
       { grade: '7a/V6', flash: 1, send: 0, attempt: 0 },
@@ -116,7 +118,7 @@ describe('GradeDistributionBar', () => {
     render(<GradeDistributionBar gradeDistribution={gradeDistribution} />);
     const chartEl = screen.getByTestId('chart-bar');
     const data = JSON.parse(chartEl.getAttribute('data-data') || '{}');
-    // Reversed: V6 first, V7+ second (7a+ has "+" in Font grade)
-    expect(data.labels).toEqual(['V6', 'V7+']);
+    // V7 has only one Font grade (7a+), so no "+" is added
+    expect(data.labels).toEqual(['V6', 'V7']);
   });
 });

--- a/packages/web/app/lib/__tests__/grade-colors.test.ts
+++ b/packages/web/app/lib/__tests__/grade-colors.test.ts
@@ -173,10 +173,19 @@ describe('Grade Colors', () => {
       expect(formatVGrade('6b/V4')).toBe('V4');
     });
 
-    it('adds "+" when Font grade has "+" suffix', () => {
-      expect(formatVGrade('6a+/V3')).toBe('V3+');
-      expect(formatVGrade('6c+/V5')).toBe('V5+');
-      expect(formatVGrade('7a+/V7')).toBe('V7+');
+    it('adds "+" when Font grade has "+" and V-grade has multiple Font grades', () => {
+      expect(formatVGrade('6a+/V3')).toBe('V3+');  // V3 has 6a and 6a+
+      expect(formatVGrade('6c+/V5')).toBe('V5+');  // V5 has 6c and 6c+
+      expect(formatVGrade('6b+/V4')).toBe('V4+');  // V4 has 6b and 6b+
+      expect(formatVGrade('7b+/V8')).toBe('V8+');  // V8 has 7b and 7b+
+    });
+
+    it('does not add "+" when V-grade has only one Font grade', () => {
+      expect(formatVGrade('7a+/V7')).toBe('V7');   // V7 only has 7a+
+      expect(formatVGrade('7c+/V10')).toBe('V10'); // V10 only has 7c+
+      expect(formatVGrade('8a+/V12')).toBe('V12'); // V12 only has 8a+
+      expect(formatVGrade('8b+/V14')).toBe('V14'); // V14 only has 8b+
+      expect(formatVGrade('8c+/V16')).toBe('V16'); // V16 only has 8c+
     });
 
     it('returns plain V-grade when Font grade has no "+"', () => {

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -10,6 +10,8 @@
  * - V11+: Purple/magenta
  */
 
+import { BOULDER_GRADES } from './board-data';
+
 // V-grade to hex color mapping
 export const V_GRADE_COLORS: Record<string, string> = {
   'V0': '#FFEB3B',   // Yellow
@@ -108,32 +110,50 @@ export function getGradeColor(difficulty: string | null | undefined): string | u
 
 /**
  * Extract V-grade from a difficulty string (e.g., "6a/V3" -> "V3")
+ * Internal helper - not exported.
  * @param difficulty - Difficulty string that may contain V-grade
  * @returns Uppercase V-grade string (e.g., "V3") or null if not found
  */
-export function extractVGrade(difficulty: string | null | undefined): string | null {
+function extractVGrade(difficulty: string | null | undefined): string | null {
   if (!difficulty) return null;
   const vGradeMatch = difficulty.match(/V\d+/i);
   return vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
 }
 
+// Build set of V-grades that have more than one Font grade mapping.
+// Only these V-grades should show "+" to disambiguate (e.g., V3 vs V3+).
+// V-grades with a single Font grade (e.g., V7 from 7a+) don't need "+".
+const V_GRADES_WITH_MULTIPLE_FONT_GRADES: Set<string> = (() => {
+  const countByVGrade = new Map<string, number>();
+  for (const g of BOULDER_GRADES) {
+    countByVGrade.set(g.v_grade, (countByVGrade.get(g.v_grade) ?? 0) + 1);
+  }
+  const result = new Set<string>();
+  for (const [vGrade, count] of countByVGrade) {
+    if (count > 1) result.add(vGrade);
+  }
+  return result;
+})();
+
 /**
  * Format a difficulty string to a V-grade display label.
- * When the Font grade has a "+" suffix (e.g., "6c+" in "6c+/V5"),
- * the result includes "+" (e.g., "V5+").
- * @param difficulty - Difficulty string (e.g., "6c+/V5", "6a/V3", "V3")
- * @returns Formatted V-grade string (e.g., "V5+", "V3") or null if not found
+ * When the Font grade has a "+" suffix AND the V-grade has multiple Font grade
+ * mappings (e.g., "6c+/V5" where V5 maps from both 6c and 6c+), the result
+ * includes "+" for disambiguation (e.g., "V5+").
+ * When a V-grade has only one Font grade (e.g., V7 from 7a+), no "+" is added.
+ * @param difficulty - Difficulty string (e.g., "6c+/V5", "7a+/V7", "V3")
+ * @returns Formatted V-grade string (e.g., "V5+", "V7", "V3") or null if not found
  */
 export function formatVGrade(difficulty: string | null | undefined): string | null {
   if (!difficulty) return null;
   const vGrade = extractVGrade(difficulty);
   if (!vGrade) return null;
 
-  // Check if the font grade part (before "/") has a "+" suffix
+  // Only add "+" when the Font grade has "+" AND the V-grade has multiple Font grades
   const slashIndex = difficulty.indexOf('/');
   if (slashIndex > 0) {
     const fontPart = difficulty.substring(0, slashIndex);
-    if (fontPart.endsWith('+')) {
+    if (fontPart.endsWith('+') && V_GRADES_WITH_MULTIPLE_FONT_GRADES.has(vGrade)) {
       return `${vGrade}+`;
     }
   }


### PR DESCRIPTION
… same V-grade

Previously, formatVGrade always added "+" when the Font grade had a "+" suffix (e.g., 7a+/V7 → "V7+"). This was misleading because V7 only maps from 7a+, so the "+" added no disambiguation value. Now "+" is only added when the V-grade has multiple Font grade mappings (e.g., V3 from 6a/6a+, V4 from 6b/6b+, V5 from 6c/6c+, V8 from 7b/7b+).

Also removes the extractVGrade export since it was only used internally.

https://claude.ai/code/session_01BGRQt4wSk9JWN2tP2EVjqA