### PR TITLE
feat: align climb rendering with grade floated right across queue bar…

### DIFF
--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/app/lib/hooks/use-double-tap', () => ({
 
 vi.mock('@/app/lib/grade-colors', () => ({
   getSoftGradeColor: () => '#888',
+  getSoftVGradeColor: () => '#888',
   getGradeTintColor: () => null,
   formatVGrade: (d: string) => (d.startsWith('V') ? d : null),
 }));
@@ -73,7 +74,7 @@ vi.mock('@/app/theme/theme-config', () => ({
     neutral: { 200: '#E5E7EB', 400: '#9CA3AF', 500: '#6B7280' },
     typography: {
       fontSize: { xs: 12, sm: 14, xl: 20, '2xl': 24 },
-      fontWeight: { semibold: 600, bold: 700 },
+      fontWeight: { normal: 400, semibold: 600, bold: 700 },
     },
   },
 }));

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// --- Mocks ---
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  getSoftVGradeColor: (vGrade: string) => `#color-${vGrade}`,
+  formatVGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+    colors: { primary: '#8C4A52' },
+    typography: {
+      fontSize: { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 },
+      fontWeight: { normal: 400, medium: 500, semibold: 600, bold: 700 },
+    },
+  },
+}));
+
+import ClimbTitle, { ClimbTitleData } from '../climb-title';
+
+// --- Helpers ---
+
+function makeClimb(overrides: Partial<ClimbTitleData> = {}): ClimbTitleData {
+  return {
+    name: 'Test Boulder',
+    difficulty: '6a/V3',
+    quality_average: '3.5',
+    benchmark_difficulty: null,
+    angle: 40,
+    setter_username: 'setter_joe',
+    ascensionist_count: 10,
+    ...overrides,
+  };
+}
+
+describe('ClimbTitle', () => {
+  // --- No climb / null handling ---
+
+  describe('no climb', () => {
+    it('renders "No climb selected" when climb is null', () => {
+      render(<ClimbTitle climb={null} />);
+      expect(screen.getByText('No climb selected')).toBeTruthy();
+    });
+
+    it('renders "No climb selected" when climb is undefined', () => {
+      render(<ClimbTitle />);
+      expect(screen.getByText('No climb selected')).toBeTruthy();
+    });
+  });
+
+  // --- Stacked layout (default) ---
+
+  describe('stacked layout (default)', () => {
+    it('renders climb name', () => {
+      render(<ClimbTitle climb={makeClimb({ name: 'Cool Route' })} />);
+      expect(screen.getByText('Cool Route')).toBeTruthy();
+    });
+
+    it('renders difficulty and quality as inline text', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3', quality_average: '3.5' })} />);
+      expect(screen.getByText('6a/V3 3.5★')).toBeTruthy();
+    });
+
+    it('renders "project" when quality_average is "0"', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '0' })} />);
+      expect(screen.getByText('project')).toBeTruthy();
+    });
+
+    it('renders angle when showAngle is true', () => {
+      render(<ClimbTitle climb={makeClimb()} showAngle />);
+      expect(screen.getByText('6a/V3 3.5★ @ 40°')).toBeTruthy();
+    });
+
+    it('does not render angle when showAngle is false', () => {
+      render(<ClimbTitle climb={makeClimb()} />);
+      expect(screen.queryByText(/@ 40°/)).toBeNull();
+    });
+
+    it('renders setter info when showSetterInfo is true', () => {
+      render(<ClimbTitle climb={makeClimb()} showSetterInfo />);
+      expect(screen.getByText('By setter_joe - 10 ascents')).toBeTruthy();
+    });
+
+    it('does not render setter info when showSetterInfo is false', () => {
+      render(<ClimbTitle climb={makeClimb()} />);
+      expect(screen.queryByText(/setter_joe/)).toBeNull();
+    });
+
+    it('renders benchmark icon when benchmark_difficulty is positive', () => {
+      render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: '15' })} />);
+      expect(screen.getByTestId('CopyrightOutlinedIcon')).toBeTruthy();
+    });
+
+    it('does not render benchmark icon when benchmark_difficulty is null', () => {
+      render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: null })} />);
+      expect(screen.queryByTestId('CopyrightOutlinedIcon')).toBeNull();
+    });
+
+    it('renders nameAddon after name', () => {
+      render(<ClimbTitle climb={makeClimb()} nameAddon={<span data-testid="addon">✓</span>} />);
+      expect(screen.getByTestId('addon')).toBeTruthy();
+    });
+  });
+
+  // --- Horizontal layout ---
+
+  describe('horizontal layout', () => {
+    it('renders large V-grade element', () => {
+      render(<ClimbTitle climb={makeClimb()} layout="horizontal" />);
+      expect(screen.getByText('V3')).toBeTruthy();
+    });
+
+    it('renders subtitle with quality joined by middle dot', () => {
+      render(<ClimbTitle climb={makeClimb()} layout="horizontal" showSetterInfo />);
+      expect(screen.getByText(/6a\/V3 3\.5★/)).toBeTruthy();
+      expect(screen.getByText(/setter_joe/)).toBeTruthy();
+    });
+
+    it('renders "project" when no grade quality', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '0', difficulty: null, ascensionist_count: undefined })} layout="horizontal" />);
+      expect(screen.getByText('project')).toBeTruthy();
+    });
+
+    it('renders rightAddon', () => {
+      render(<ClimbTitle climb={makeClimb()} layout="horizontal" rightAddon={<span data-testid="right-addon">tick</span>} />);
+      expect(screen.getByTestId('right-addon')).toBeTruthy();
+    });
+  });
+
+  // --- gradePosition='right' layout ---
+
+  describe('gradePosition="right"', () => {
+    it('renders climb name', () => {
+      render(<ClimbTitle climb={makeClimb({ name: 'Solstice' })} gradePosition="right" />);
+      expect(screen.getByText('Solstice')).toBeTruthy();
+    });
+
+    it('renders colorized V-grade on the right', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6c+/V5' })} gradePosition="right" />);
+      expect(screen.getByText('V5')).toBeTruthy();
+    });
+
+    it('renders quality stars in subtitle', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '4.2' })} gradePosition="right" />);
+      expect(screen.getByText('4.2★')).toBeTruthy();
+    });
+
+    it('renders setter name in subtitle when showSetterInfo is true', () => {
+      render(<ClimbTitle climb={makeClimb({ setter_username: 'DanielBolts' })} gradePosition="right" showSetterInfo />);
+      expect(screen.getByText(/4\.2|3\.5/)).toBeTruthy(); // stars present
+      expect(screen.getByText(/DanielBolts/)).toBeTruthy();
+    });
+
+    it('renders subtitle as "stars · setter_name" format', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '3.5', setter_username: 'alice' })} gradePosition="right" showSetterInfo />);
+      expect(screen.getByText('3.5★ · alice')).toBeTruthy();
+    });
+
+    it('renders only stars when showSetterInfo is false', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '3.5' })} gradePosition="right" />);
+      expect(screen.getByText('3.5★')).toBeTruthy();
+      expect(screen.queryByText(/setter_joe/)).toBeNull();
+    });
+
+    it('renders only stars when setter_username is missing', () => {
+      render(<ClimbTitle climb={makeClimb({ setter_username: undefined })} gradePosition="right" showSetterInfo />);
+      expect(screen.getByText('3.5★')).toBeTruthy();
+    });
+
+    it('does not render angle even when showAngle is true', () => {
+      render(<ClimbTitle climb={makeClimb()} gradePosition="right" showAngle />);
+      expect(screen.queryByText(/@ 40°/)).toBeNull();
+    });
+
+    it('does not render ascent count', () => {
+      render(<ClimbTitle climb={makeClimb({ ascensionist_count: 72 })} gradePosition="right" showSetterInfo />);
+      expect(screen.queryByText(/72 ascents/)).toBeNull();
+    });
+
+    it('renders "project" when no grade quality', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '0' })} gradePosition="right" />);
+      expect(screen.getByText('project')).toBeTruthy();
+    });
+
+    it('renders "project" when difficulty is null', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: null, quality_average: null })} gradePosition="right" />);
+      expect(screen.getByText('project')).toBeTruthy();
+    });
+
+    it('renders benchmark icon after climb name', () => {
+      render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: '10' })} gradePosition="right" />);
+      expect(screen.getByTestId('CopyrightOutlinedIcon')).toBeTruthy();
+    });
+
+    it('renders nameAddon in the name row', () => {
+      render(<ClimbTitle climb={makeClimb()} gradePosition="right" nameAddon={<span data-testid="name-addon">✓</span>} />);
+      expect(screen.getByTestId('name-addon')).toBeTruthy();
+    });
+
+    it('renders rightAddon before the grade on the right', () => {
+      render(<ClimbTitle climb={makeClimb()} gradePosition="right" rightAddon={<span data-testid="right-addon">status</span>} />);
+      expect(screen.getByTestId('right-addon')).toBeTruthy();
+    });
+
+    it('renders raw difficulty as fallback when V-grade cannot be parsed', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a+' })} gradePosition="right" />);
+      // formatVGrade returns null for '6a+' (no V-grade match), so fallback renders raw difficulty
+      expect(screen.getByText('6a+')).toBeTruthy();
+    });
+
+    it('uses communityGrade when available', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3', communityGrade: '6b/V4' })} gradePosition="right" />);
+      expect(screen.getByText('V4')).toBeTruthy();
+    });
+
+    it('renders with custom titleFontSize', () => {
+      const { container } = render(<ClimbTitle climb={makeClimb()} gradePosition="right" titleFontSize={20} />);
+      // Name should be rendered (basic rendering check with custom size)
+      expect(screen.getByText('Test Boulder')).toBeTruthy();
+      expect(container.firstChild).toBeTruthy();
+    });
+  });
+
+  // --- Edge cases ---
+
+  describe('edge cases', () => {
+    it('handles climb with empty name', () => {
+      render(<ClimbTitle climb={makeClimb({ name: '' })} />);
+      // Should render without crashing
+      expect(screen.queryByText('No climb selected')).toBeNull();
+    });
+
+    it('handles climb with null difficulty', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: null })} />);
+      expect(screen.getByText('Test Boulder')).toBeTruthy();
+    });
+
+    it('handles benchmark_difficulty as numeric value', () => {
+      // benchmark_difficulty might come as number from some code paths
+      render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: '0' })} />);
+      expect(screen.queryByTestId('CopyrightOutlinedIcon')).toBeNull();
+    });
+
+    it('handles benchmark_difficulty as "0" string (not benchmark)', () => {
+      render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: '0' })} />);
+      expect(screen.queryByTestId('CopyrightOutlinedIcon')).toBeNull();
+    });
+
+    it('renders both name and grade in stacked layout', () => {
+      render(<ClimbTitle climb={makeClimb()} />);
+      expect(screen.getByText('Test Boulder')).toBeTruthy();
+      expect(screen.getByText('6a/V3 3.5★')).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import IconButton from '@mui/material/IconButton';
-import Typography from '@mui/material/Typography';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
@@ -10,6 +9,7 @@ import Favorite from '@mui/icons-material/Favorite';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbThumbnail from './climb-thumbnail';
+import ClimbTitle from './climb-title';
 import DrawerClimbHeader from './drawer-climb-header';
 import { AscentStatus } from '../queue-control/queue-list-item';
 import { ClimbActions } from '../climb-actions';
@@ -18,7 +18,7 @@ import { useFavorite } from '../climb-actions';
 import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getSoftGradeColor, getGradeTintColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 
@@ -59,10 +59,6 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
     onSwipeRight: handleSwipeRight,
     disabled: disableSwipe,
   });
-
-  const vGrade = formatVGrade(climb.difficulty);
-  const gradeColor = getSoftGradeColor(climb.difficulty, isDark);
-  const hasQuality = climb.quality_average && climb.quality_average !== '0';
 
   const excludeActions = getExcludedClimbActions(boardDetails.board_name, 'list');
 
@@ -143,57 +139,6 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
     [],
   );
 
-  const nameStyle = useMemo(
-    () => ({
-      fontSize: themeTokens.typography.fontSize.xl,
-      fontWeight: themeTokens.typography.fontWeight.semibold,
-      whiteSpace: 'nowrap' as const,
-      overflow: 'hidden' as const,
-      textOverflow: 'ellipsis' as const,
-      display: 'block' as const,
-    }),
-    [],
-  );
-
-  const subtitleStyle = useMemo(
-    () => ({
-      fontSize: themeTokens.typography.fontSize.xs,
-      whiteSpace: 'nowrap' as const,
-      overflow: 'hidden' as const,
-      textOverflow: 'ellipsis' as const,
-      display: 'block' as const,
-    }),
-    [],
-  );
-
-  const rightContentStyle = useMemo(
-    () => ({
-      display: 'flex' as const,
-      alignItems: 'center' as const,
-      gap: themeTokens.spacing[1],
-      flexShrink: 0,
-    }),
-    [],
-  );
-
-  const vGradeStyle = useMemo(
-    () => ({
-      fontSize: themeTokens.typography.fontSize['2xl'],
-      fontWeight: themeTokens.typography.fontWeight.bold,
-      lineHeight: 1,
-      color: gradeColor ?? 'var(--neutral-500)',
-    }),
-    [gradeColor],
-  );
-
-  const difficultyStyle = useMemo(
-    () => ({
-      fontSize: themeTokens.typography.fontSize.sm,
-      fontWeight: themeTokens.typography.fontWeight.semibold,
-    }),
-    [],
-  );
-
   const iconButtonStyle = useMemo(
     () => ({ flexShrink: 0, color: 'var(--neutral-400)' }),
     [],
@@ -256,48 +201,15 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
             />
           </div>
 
-          {/* Center: Name, quality, setter */}
+          {/* Center + Right: Name, stars, setter, colorized grade */}
           <div style={centerStyle}>
-            <Typography
-              variant="body2"
-              component="span"
-              style={nameStyle}
-            >
-              {climb.name}
-            </Typography>
-            <Typography
-              variant="body2"
-              component="span"
-              color="text.secondary"
-              style={subtitleStyle}
-            >
-              {hasQuality ? `${climb.quality_average}\u2605` : ''}{' '}
-              {climb.setter_username && `${climb.setter_username}`}
-            </Typography>
-          </div>
-
-          {/* Right: Ascent status + V-grade colorized */}
-          <div style={rightContentStyle}>
-            <AscentStatus climbUuid={climb.uuid} fontSize={20} />
-            {vGrade && (
-              <Typography
-                variant="body2"
-                component="span"
-                style={vGradeStyle}
-              >
-                {vGrade}
-              </Typography>
-            )}
-            {!vGrade && climb.difficulty && (
-              <Typography
-                variant="body2"
-                component="span"
-                color="text.secondary"
-                style={difficultyStyle}
-              >
-                {climb.difficulty}
-              </Typography>
-            )}
+            <ClimbTitle
+              climb={climb}
+              gradePosition="right"
+              showSetterInfo
+              titleFontSize={themeTokens.typography.fontSize.xl}
+              rightAddon={<AscentStatus climbUuid={climb.uuid} fontSize={20} />}
+            />
           </div>
 
           {/* Ellipsis menu button */}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -39,6 +39,9 @@ type ClimbTitleProps = {
   centered?: boolean;
   /** Font size for the climb name. Use a design token, e.g. themeTokens.typography.fontSize.lg */
   titleFontSize?: number;
+  /** Grade position: 'inline' (default) keeps grade in subtitle, 'right' floats colorized grade to the far right.
+   *  When 'right', renders name + stars/setter on left and large colorized V-grade on right. Overrides layout prop. */
+  gradePosition?: 'inline' | 'right';
 };
 
 /**
@@ -56,6 +59,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   layout = 'stacked',
   centered = false,
   titleFontSize,
+  gradePosition = 'inline',
 }) => {
   const isDark = useIsDarkMode();
 
@@ -174,6 +178,65 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
       By {climb.setter_username} - {climb.ascensionist_count ?? 0} ascents
     </Typography>
   );
+
+  if (gradePosition === 'right') {
+    const subtitleParts: string[] = [];
+    if (hasGrade) {
+      subtitleParts.push(`${climb.quality_average}\u2605`);
+    }
+    if (showSetterInfo && climb.setter_username) {
+      subtitleParts.push(climb.setter_username);
+    }
+
+    const subtitleContent = subtitleParts.length > 0
+      ? subtitleParts.join(' \u00b7 ')
+      : <Box component="span" sx={{ fontStyle: 'italic' }}>project</Box>;
+
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px`, width: '100%' }} className={className}>
+        {/* Left: Name + subtitle */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: 1, minWidth: 0 }}>
+          {/* Row 1: Name with addon */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px` }}>
+            {nameElement}
+            {nameAddon}
+          </Box>
+          {/* Row 2: Stars + setter */}
+          <Typography
+            variant="body2"
+            component="span"
+            color="text.secondary"
+            sx={{
+              fontSize: themeTokens.typography.fontSize.xs,
+              fontWeight: themeTokens.typography.fontWeight.normal,
+              ...textOverflowStyles,
+            }}
+          >
+            {subtitleContent}
+          </Typography>
+        </Box>
+        {/* Right: rightAddon + colorized grade */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px`, flexShrink: 0 }}>
+          {rightAddon}
+          {largeGradeElement}
+          {!vGrade && displayDifficulty && (
+            <Typography
+              variant="body2"
+              component="span"
+              color="text.secondary"
+              sx={{
+                fontSize: nameFontSize,
+                fontWeight: themeTokens.typography.fontWeight.semibold,
+                lineHeight: 1,
+              }}
+            >
+              {displayDifficulty}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    );
+  }
 
   if (layout === 'horizontal') {
     const secondLineContent = [];

--- a/packages/web/app/components/climb-card/drawer-climb-header.tsx
+++ b/packages/web/app/components/climb-card/drawer-climb-header.tsx
@@ -16,7 +16,7 @@ export default function DrawerClimbHeader({ climb, boardDetails }: DrawerClimbHe
       <div style={{ flexShrink: 0, maxWidth: 56 }}>
         <ClimbThumbnail boardDetails={boardDetails} currentClimb={climb} maxHeight="80px" />
       </div>
-      <ClimbTitle climb={climb} layout="horizontal" titleFontSize={themeTokens.typography.fontSize.xl} showSetterInfo />
+      <ClimbTitle climb={climb} gradePosition="right" titleFontSize={themeTokens.typography.fontSize.xl} showSetterInfo />
     </div>
   );
 }

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -306,7 +306,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                     >
                       <ClimbTitle
                         climb={currentClimb}
-                        showAngle
+                        gradePosition="right"
+                        showSetterInfo
                       />
                     </div>
 
@@ -321,7 +322,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       >
                         <ClimbTitle
                           climb={peekClimbData}
-                          showAngle
+                          gradePosition="right"
+                          showSetterInfo
                         />
                       </div>
                     )}


### PR DESCRIPTION
…, drawer header, and list items

Add gradePosition='right' prop to ClimbTitle that renders colorized V-grade on the right with stars and setter below the name. Unify the layout across QueueControlBar, DrawerClimbHeader, and ClimbListItem using the same shared component, eliminating duplicated rendering code in ClimbListItem.

Includes 38 new tests for ClimbTitle covering all layout variants.

https://claude.ai/code/session_01GwrueU5c5j7vRxZLEWebEi