### PR TITLE
Fix climb title wrapping in queue control bar by adding minWidth: 0

### DIFF
--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -197,7 +197,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         {/* Left: Name + subtitle */}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: 1, minWidth: 0 }}>
           {/* Row 1: Name with addon */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px` }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px`, minWidth: 0 }}>
             {nameElement}
             {nameAddon}
           </Box>


### PR DESCRIPTION
The name row in the gradePosition="right" layout was missing minWidth: 0, which prevented the CSS text-overflow: ellipsis from working in the flex context. Long climb names now truncate with "…" instead of breaking to a new line.

https://claude.ai/code/session_01UY31QWqyZNwmZeFqZ9crj4