### PR TITLE
fix: correct climb card drawer preview layout - thumbnail left, grade…

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -148,6 +148,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
     () => ({
       wrapper: { height: 'auto', width: '100%' },
       body: { padding: `${themeTokens.spacing[2]}px 0` },
+      header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
     }),
     [],
   );

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -117,7 +117,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
           ...userStyles?.header,
         }}
       >
-        <Typography variant="h6" component="div" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, fontSize: themeTokens.typography.fontSize.base }}>
+        <Typography variant="h6" component="div" sx={{ flex: 1, minWidth: 0, fontWeight: themeTokens.typography.fontWeight.semibold, fontSize: themeTokens.typography.fontSize.base }}>
           {userTitle}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>


### PR DESCRIPTION
… right

The SwipeableDrawer title Typography wasn't stretching to fill available width, preventing ClimbTitle's grade from floating to the far right. Added flex: 1 and minWidth: 0 to the title wrapper, and reduced the drawer header horizontal padding for the climb action drawer.

https://claude.ai/code/session_01YYHs7sNym1Akh8bNCBKJXV