### PR TITLE
feat: add board-scoped playlist routes for proper SSR context

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -20,7 +20,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { track } from '@vercel/analytics';
 import { BoardDetails } from '@/app/lib/types';
-import { constructClimbListWithSlugs, generateLayoutSlug, generateSizeSlug, generateSetSlug, searchParamsToUrlParams, getContextAwarePlaylistUrl } from '@/app/lib/url-utils';
+import { constructClimbListWithSlugs, generateLayoutSlug, generateSizeSlug, generateSetSlug, searchParamsToUrlParams, getContextAwarePlaylistUrl, getPlaylistsBasePath } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { PlaylistsContext } from '../climb-actions/playlists-batch-context';
@@ -190,17 +190,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     track('Bottom Tab Bar', { tab: 'climbs' });
   };
 
-  const playlistsUrl = (() => {
-    // If on a /b/ slug route, construct board-scoped playlists URL
-    if (pathname.startsWith('/b/')) {
-      const segments = pathname.split('/');
-      if (segments.length >= 4) {
-        return `/b/${segments[2]}/${segments[3]}/playlists`;
-      }
-    }
-    // No board context — global playlists
-    return '/playlists';
-  })();
+  const playlistsUrl = getPlaylistsBasePath(pathname);
 
   const handleLibraryTab = () => {
     setIsCreateOpen(false);

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -23,8 +23,9 @@ import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 
 import { useSession, signOut } from 'next-auth/react';
 import { useColorMode } from '@/app/hooks/use-color-mode';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { getPlaylistsBasePath } from '@/app/lib/url-utils';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import AuthModal from '../auth/auth-modal';
 import { HoldClassificationWizard } from '../hold-classification';
@@ -48,6 +49,7 @@ interface UserDrawerProps {
 export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerProps) {
   const { data: session } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showHoldClassification, setShowHoldClassification] = useState(false);
@@ -84,7 +86,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
     handleClose();
   };
 
-  const playlistsUrl = '/playlists';
+  const playlistsUrl = getPlaylistsBasePath(pathname);
 
   const userAvatar = session?.user?.image ?? undefined;
   const userName = session?.user?.name;


### PR DESCRIPTION
Playlists are now viewable under board-specific routes:
- /[board]/[layout]/[size]/[sets]/[angle]/playlists - listing
- /[board]/[layout]/[size]/[sets]/[angle]/playlists/[uuid] - detail
- /b/[slug]/[angle]/playlists/[uuid] - detail (board slug route)

The global /playlists route is preserved for "all boards" mode.

Navigation components (bottom tab bar, user drawer, library page, playlist detail) now generate board-context-aware playlist URLs when rendered within a board route.

https://claude.ai/code/session_01GhzgwqCryu6w2ShTphdMfM