### PR TITLE
fix: reduce whitespace between global header and filter pills

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -102,7 +102,6 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
               <BluetoothProvider boardDetails={boardDetails}>
                 <UISearchParamsProvider>
                   <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
-                  <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
 
                   <main
                     id="content-for-scrollable"
@@ -114,6 +113,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                       paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
                     }}
                   >
+                    <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
                     <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
                       {children}
                     </Suspense>

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -76,7 +76,6 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                 <BluetoothProvider boardDetails={boardDetails}>
                   <UISearchParamsProvider>
                     <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
-                    <BoardSeshHeader boardDetails={boardDetails} angle={angle} isAngleAdjustable={board.isAngleAdjustable} />
 
                     <main
                       id="content-for-scrollable"
@@ -88,6 +87,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                         paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
                       }}
                     >
+                      <BoardSeshHeader boardDetails={boardDetails} angle={angle} isAngleAdjustable={board.isAngleAdjustable} />
                       <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
                         {children}
                       </Suspense>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -135,7 +135,7 @@ const ClimbsList = ({
     display: 'flex',
     alignItems: 'center',
     position: 'relative' as const,
-    padding: `${themeTokens.spacing[1]}px 60px ${themeTokens.spacing[2]}px ${themeTokens.spacing[1]}px`,
+    padding: `0px 60px ${themeTokens.spacing[1]}px ${themeTokens.spacing[1]}px`,
     minWidth: 0,
   }), []);
 
@@ -175,7 +175,7 @@ const ClimbsList = ({
   }), []);
 
   return (
-    <Box sx={{ pt: `${themeTokens.spacing[1]}px` }}>
+    <Box>
       {/* Optional header content (e.g. BoardCreationBanner) */}
       {header}
       {/* View mode toggle + optional inline header content */}


### PR DESCRIPTION
Move BoardSeshHeader inside <main> to eliminate the double offset caused by it sitting in the flow before main while main also has paddingTop: var(--global-header-height). Also tighten ClimbsList container and header box padding.

https://claude.ai/code/session_016LMRegRb8Y2AXmzj4zLceE