### PR TITLE
fix: add slide animation to drawers and standardize on SwipeableDrawer

### DIFF
--- a/packages/web/app/components/board-entity/board-creation-banner.tsx
+++ b/packages/web/app/components/board-entity/board-creation-banner.tsx
@@ -7,7 +7,6 @@ import CardContent from '@mui/material/CardContent';
 import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
-import Drawer from '@mui/material/Drawer';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -15,6 +14,7 @@ import { usePathname } from 'next/navigation';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { themeTokens } from '@/app/theme/theme-config';
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import { useRouter } from 'next/navigation';
 import CreateBoardForm from './create-board-form';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -111,18 +111,12 @@ export default function BoardCreationBanner({
         </CardContent>
       </Card>
 
-      <Drawer
-        anchor="bottom"
+      <SwipeableDrawer
+        placement="bottom"
         open={isDrawerOpen}
         onClose={() => setIsDrawerOpen(false)}
-        PaperProps={{
-          sx: {
-            maxHeight: '80dvh',
-            borderTopLeftRadius: themeTokens.borderRadius.xl,
-            borderTopRightRadius: themeTokens.borderRadius.xl,
-            p: 2,
-          },
-        }}
+        title="Save Board"
+        styles={{ wrapper: { maxHeight: '80dvh' } }}
       >
         <CreateBoardForm
           boardType={boardType}
@@ -133,7 +127,7 @@ export default function BoardCreationBanner({
           onSuccess={handleBoardCreated}
           onCancel={() => setIsDrawerOpen(false)}
         />
-      </Drawer>
+      </SwipeableDrawer>
     </>
   );
 }

--- a/packages/web/app/components/board-entity/board-detail.tsx
+++ b/packages/web/app/components/board-entity/board-detail.tsx
@@ -2,8 +2,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Box from '@mui/material/Box';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
 import Avatar from '@mui/material/Avatar';
 import MuiTypography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
@@ -12,7 +10,6 @@ import Tabs from '@mui/material/Tabs';
 import Divider from '@mui/material/Divider';
 import MuiButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
-import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
@@ -45,6 +42,7 @@ import FollowButton from '@/app/components/ui/follow-button';
 import BoardLeaderboard from './board-leaderboard';
 import EditBoardForm from './edit-board-form';
 import CommentSection from '@/app/components/social/comment-section';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import GymDetail from '@/app/components/gym-entity/gym-detail';
 import GymSelector from '@/app/components/gym-entity/gym-selector';
 
@@ -151,47 +149,14 @@ export default function BoardDetail({ boardUuid, open, onClose, onDeleted, ancho
   };
 
   return (
-    <Drawer
-      anchor={anchor}
+    <SwipeableDrawer
+      placement={anchor}
       open={open}
       onClose={onClose}
-      PaperProps={{
-        sx: {
-          height: '90dvh',
-          ...(anchor === 'bottom'
-            ? {
-                borderTopLeftRadius: themeTokens.borderRadius.xl,
-                borderTopRightRadius: themeTokens.borderRadius.xl,
-              }
-            : {
-                borderBottomLeftRadius: themeTokens.borderRadius.xl,
-                borderBottomRightRadius: themeTokens.borderRadius.xl,
-              }),
-        },
-      }}
+      height="90dvh"
+      keepMounted={false}
+      styles={{ body: { padding: 0, overflow: 'hidden' } }}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-        {/* Handle bar (top for bottom-anchored, bottom for top-anchored) */}
-        {anchor === 'bottom' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', pt: 1 }}>
-            <Box
-              sx={{
-                width: 36,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: 'var(--neutral-300)',
-              }}
-            />
-          </Box>
-        )}
-
-        {/* Close button */}
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 1 }}>
-          <IconButton onClick={onClose} size="small">
-            <CloseOutlined />
-          </IconButton>
-        </Box>
-
         {isLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
             <CircularProgress />
@@ -367,7 +332,7 @@ export default function BoardDetail({ boardUuid, open, onClose, onDeleted, ancho
             </Box>
 
             {/* Gym detail drawer */}
-            {board.gymUuid && showGymDetail && (
+            {board.gymUuid && (
               <GymDetail
                 gymUuid={board.gymUuid}
                 open={showGymDetail}
@@ -377,21 +342,7 @@ export default function BoardDetail({ boardUuid, open, onClose, onDeleted, ancho
             )}
           </>
         )}
-
-        {anchor === 'top' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', pb: 1 }}>
-            <Box
-              sx={{
-                width: 36,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: 'var(--neutral-300)',
-              }}
-            />
-          </Box>
-        )}
-      </Box>
-    </Drawer>
+    </SwipeableDrawer>
   );
 }
 

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -227,25 +227,24 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
         </div>
       </div>
 
-      {/* Actions Drawer - only mount when open */}
-      {isActionsOpen && (
-        <SwipeableDrawer
-          title={<DrawerClimbHeader climb={climb} boardDetails={boardDetails} />}
-          placement="bottom"
-          open={isActionsOpen}
-          onClose={() => setIsActionsOpen(false)}
-          styles={drawerStyles}
-        >
-          <ClimbActions
-            climb={climb}
-            boardDetails={boardDetails}
-            angle={climb.angle}
-            viewMode="list"
-            exclude={excludeActions}
-            onActionComplete={() => setIsActionsOpen(false)}
-          />
-        </SwipeableDrawer>
-      )}
+      {/* Actions Drawer */}
+      <SwipeableDrawer
+        title={<DrawerClimbHeader climb={climb} boardDetails={boardDetails} />}
+        placement="bottom"
+        open={isActionsOpen}
+        onClose={() => setIsActionsOpen(false)}
+        styles={drawerStyles}
+        keepMounted={false}
+      >
+        <ClimbActions
+          climb={climb}
+          boardDetails={boardDetails}
+          angle={climb.angle}
+          viewMode="list"
+          exclude={excludeActions}
+          onActionComplete={() => setIsActionsOpen(false)}
+        />
+      </SwipeableDrawer>
     </>
   );
 }, (prev, next) => {

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -2,8 +2,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Box from '@mui/material/Box';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
 import Avatar from '@mui/material/Avatar';
 import MuiTypography from '@mui/material/Typography';
 import Tab from '@mui/material/Tab';
@@ -16,7 +14,6 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import CircularProgress from '@mui/material/CircularProgress';
-import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
@@ -25,6 +22,7 @@ import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import ChatBubbleOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import type { Gym } from '@boardsesh/shared-schema';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -121,38 +119,15 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
   };
 
   return (
-    <Drawer
-      anchor={anchor}
+    <>
+    <SwipeableDrawer
+      placement={anchor}
       open={open}
       onClose={onClose}
-      PaperProps={{
-        sx: {
-          height: '90dvh',
-          ...(anchor === 'bottom'
-            ? {
-                borderTopLeftRadius: themeTokens.borderRadius.xl,
-                borderTopRightRadius: themeTokens.borderRadius.xl,
-              }
-            : {
-                borderBottomLeftRadius: themeTokens.borderRadius.xl,
-                borderBottomRightRadius: themeTokens.borderRadius.xl,
-              }),
-        },
-      }}
+      height="90dvh"
+      keepMounted={false}
+      styles={{ body: { padding: 0, overflow: 'hidden' } }}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-        {anchor === 'bottom' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', pt: 1 }}>
-            <Box sx={{ width: 36, height: 4, borderRadius: 2, backgroundColor: 'var(--neutral-300)' }} />
-          </Box>
-        )}
-
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 1 }}>
-          <IconButton onClick={onClose} size="small">
-            <CloseOutlined />
-          </IconButton>
-        </Box>
-
         {isLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
             <CircularProgress />
@@ -286,13 +261,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
             </Box>
           </>
         )}
-
-        {anchor === 'top' && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', pb: 1 }}>
-            <Box sx={{ width: 36, height: 4, borderRadius: 2, backgroundColor: 'var(--neutral-300)' }} />
-          </Box>
-        )}
-      </Box>
+    </SwipeableDrawer>
 
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
@@ -309,7 +278,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
           </MuiButton>
         </DialogActions>
       </Dialog>
-    </Drawer>
+    </>
   );
 }
 

--- a/packages/web/app/components/social/board-search-results.tsx
+++ b/packages/web/app/components/social/board-search-results.tsx
@@ -98,14 +98,12 @@ export default function BoardSearchResults({ query, authToken }: BoardSearchResu
       <Box ref={sentinelRef} sx={{ display: 'flex', justifyContent: 'center', py: 2, minHeight: 20 }}>
         {isFetchingNextPage && <CircularProgress size={24} />}
       </Box>
-      {selectedBoardUuid && (
-        <BoardDetail
-          boardUuid={selectedBoardUuid}
-          open={!!selectedBoardUuid}
-          onClose={() => setSelectedBoardUuid(null)}
-          anchor="top"
-        />
-      )}
+      <BoardDetail
+        boardUuid={selectedBoardUuid ?? ''}
+        open={!!selectedBoardUuid}
+        onClose={() => setSelectedBoardUuid(null)}
+        anchor="top"
+      />
     </>
   );
 }

--- a/packages/web/app/components/social/gym-search-results.tsx
+++ b/packages/web/app/components/social/gym-search-results.tsx
@@ -98,14 +98,12 @@ export default function GymSearchResults({ query, authToken }: GymSearchResultsP
       <Box ref={sentinelRef} sx={{ display: 'flex', justifyContent: 'center', py: 2, minHeight: 20 }}>
         {isFetchingNextPage && <CircularProgress size={24} />}
       </Box>
-      {selectedGymUuid && (
-        <GymDetail
-          gymUuid={selectedGymUuid}
-          open={!!selectedGymUuid}
-          onClose={() => setSelectedGymUuid(null)}
-          anchor="top"
-        />
-      )}
+      <GymDetail
+        gymUuid={selectedGymUuid ?? ''}
+        open={!!selectedGymUuid}
+        onClose={() => setSelectedGymUuid(null)}
+        anchor="top"
+      />
     </>
   );
 }


### PR DESCRIPTION
The climb list actions drawer had no opening animation because it was conditionally rendered ({isActionsOpen && <SwipeableDrawer open={...}>}), mounting already in the open state so MUI's Slide transition had no "from" state. Fix by always rendering with open prop control and keepMounted={false} for list performance.

Also convert 3 components using raw MUI Drawer to the shared SwipeableDrawer for consistent swipe-to-close, responsive drag handles, and animation behavior:
- gym-detail.tsx
- board-detail.tsx
- board-creation-banner.tsx

Fix conditional rendering in gym-search-results and board-search-results that coupled data availability with open state, preventing animation.

https://claude.ai/code/session_01KR9PpCUWDVkV33uu3eUuRp