### PR TITLE
fix: use isomorphic useLayoutEffect to avoid SSR warnings and update …

### DIFF
--- a/docs/social-features-plan.md
+++ b/docs/social-features-plan.md
@@ -2245,7 +2245,7 @@ packages/web/app/components/search-drawer/
   playlist-search-results.tsx # NEW: Playlist search result list
   search-dropdown.tsx        # MODIFIED: Add category pill at top, switch form per category
   accordion-search-form.tsx  # MODIFIED: Only render when category = 'climbs'
-  search-pill.tsx            # MODIFIED: Show active category in pill summary
+  search-drawer-bridge-context.tsx # EXISTING: Bridge context that exposes search drawer open/summary/filter state to GlobalHeader
 
 packages/web/app/components/board-page/
   header.tsx                 # MODIFIED: Search bar also appears on home page
@@ -2378,7 +2378,7 @@ The search drawer is extended with a **search category pill bar** at the top, al
 #### Current Architecture (reference)
 
 The existing search system consists of:
-- `SearchPill` (in `header.tsx`) -- triggers `SearchDropdown`
+- `SearchDrawerBridgeInjector` (in `header.tsx`) -- registers the search drawer opener with `GlobalHeader` via bridge context
 - `SearchDropdown` -- full-screen swipeable drawer with `AccordionSearchForm`
 - `AccordionSearchForm` -- 4 collapsible filter panels (Climb, Quality, Progress, Holds)
 - `UISearchParamsProvider` -- manages filter state with 500ms debounce
@@ -2472,10 +2472,10 @@ The playlist search category shows a simplified form:
 #### Home Page Integration
 
 The home page (`packages/web/app/(app)/page.tsx` or equivalent) is modified to:
-1. Include the `SearchPill` component in the page header (same as climb list page)
+1. Use the `SearchDrawerBridgeInjector` to register a search drawer opener with `GlobalHeader` via the bridge context
 2. Pass `defaultCategory="users"` to the search drawer
-3. The search pill shows "Search users..." as placeholder text when on the home page
-4. Tapping the pill opens the unified search drawer with the Users category pre-selected
+3. The search summary in `GlobalHeader` shows "Search users..." as placeholder text when on the home page
+4. Tapping the search area in the header opens the unified search drawer with the Users category pre-selected
 
 #### Climb List Page Integration
 

--- a/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
+++ b/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
@@ -2,6 +2,9 @@
 
 import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useLayoutEffect, useEffect } from 'react';
 
+// useLayoutEffect emits SSR warnings in Next.js; fall back to useEffect on the server.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 // -------------------------------------------------------------------
 // State context (consumed by GlobalHeader)
 // -------------------------------------------------------------------
@@ -122,7 +125,7 @@ export function SearchDrawerBridgeInjector({
   activeRef.current = active;
 
   // Register/deregister based on whether we're on the list page
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (isOnListPage) {
       register(() => openDrawerRef.current(), summaryRef.current, activeRef.current);
     } else {


### PR DESCRIPTION
…docs

Replace useLayoutEffect with a useIsomorphicLayoutEffect wrapper that falls back to useEffect on the server, preventing Next.js hydration warnings. Update social-features-plan.md to replace deleted SearchPill references with the current SearchDrawerBridge architecture.

https://claude.ai/code/session_011oaALoRPAYV5BfnAFLeFbR