### PR TITLE
feat: filter playlists by board layout and auto-select board on detai…

### DIFF
--- a/packages/backend/src/__tests__/all-user-playlists.test.ts
+++ b/packages/backend/src/__tests__/all-user-playlists.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    execute: vi.fn(),
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+  };
+  return { mockDb };
+});
+
+vi.mock('../db/client', () => ({
+  db: mockDb,
+}));
+
+vi.mock('../events/index', () => ({
+  publishSocialEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/rate-limiter', () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock('../utils/redis-rate-limiter', () => ({
+  checkRateLimitRedis: vi.fn(),
+}));
+
+vi.mock('../db/queries/util/table-select', () => ({
+  getBoardTables: vi.fn().mockReturnValue({
+    climbs: { uuid: 'uuid', layoutId: 'layoutId', boardType: 'boardType', setterUsername: 'setterUsername', name: 'name', description: 'description', frames: 'frames', createdAt: 'createdAt', edgeLeft: 'edgeLeft', edgeRight: 'edgeRight', edgeBottom: 'edgeBottom', edgeTop: 'edgeTop' },
+    climbStats: { climbUuid: 'climbUuid', boardType: 'boardType', angle: 'angle', ascensionistCount: 'ascensionistCount', qualityAverage: 'qualityAverage', difficultyAverage: 'difficultyAverage', displayDifficulty: 'displayDifficulty', benchmarkDifficulty: 'benchmarkDifficulty' },
+    difficultyGrades: { boardType: 'boardType', difficulty: 'difficulty', boulderName: 'boulderName' },
+  }),
+  isValidBoardName: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../db/queries/util/hold-state', () => ({
+  convertLitUpHoldsStringToMap: vi.fn().mockReturnValue([{}]),
+}));
+
+vi.mock('../db/queries/util/product-sizes-data', () => ({
+  getSizeEdges: vi.fn().mockReturnValue({ edgeLeft: 0, edgeRight: 100, edgeBottom: 0, edgeTop: 100 }),
+}));
+
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: 'user-123',
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+const NOW = new Date('2026-01-15T12:00:00Z');
+
+/**
+ * Creates a mock Drizzle query chain that tracks method calls.
+ */
+function createMockChain(resolveValue: unknown = []) {
+  const calls: Record<string, unknown[][]> = {};
+  const chain: Record<string, unknown> = {};
+  const methods = [
+    'select', 'from', 'where', 'leftJoin', 'innerJoin',
+    'groupBy', 'orderBy', 'limit', 'offset',
+    'insert', 'values', 'onConflictDoNothing', 'returning',
+    'delete', 'update', 'set',
+  ];
+
+  chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
+
+  for (const method of methods) {
+    calls[method] = [];
+    chain[method] = vi.fn((...args: unknown[]) => {
+      calls[method].push(args);
+      return chain;
+    });
+  }
+
+  return { chain, calls };
+}
+
+function makePlaylistRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BigInt(1),
+    uuid: 'pl-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    name: 'Test Playlist',
+    description: 'A test playlist',
+    isPublic: true,
+    color: '#FF0000',
+    icon: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastAccessedAt: null,
+    role: 'owner',
+    ...overrides,
+  };
+}
+
+describe('allUserPlaylists resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should require authentication', async () => {
+    const ctx = makeCtx({ isAuthenticated: false, userId: null });
+
+    await expect(
+      playlistQueries.allUserPlaylists(null, { input: {} }, ctx),
+    ).rejects.toThrow('Authentication required');
+  });
+
+  it('should return all playlists when no filters provided', async () => {
+    const ctx = makeCtx();
+
+    // Main query
+    const { chain: mainChain, calls: mainCalls } = createMockChain([
+      makePlaylistRow({ uuid: 'pl-1', boardType: 'kilter', layoutId: 1 }),
+      makePlaylistRow({ uuid: 'pl-2', boardType: 'tension', layoutId: 2, id: BigInt(2) }),
+    ]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    // Climb counts query
+    const { chain: countChain } = createMockChain([
+      { playlistId: BigInt(1), count: 5 },
+      { playlistId: BigInt(2), count: 3 },
+    ]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    // Follow stats: follower counts
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    // Follow stats: is followed by me
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(null, { input: {} }, ctx);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ uuid: 'pl-1', boardType: 'kilter', climbCount: 5 });
+    expect(result[1]).toMatchObject({ uuid: 'pl-2', boardType: 'tension', climbCount: 3 });
+
+    // Verify main query used where() and innerJoin()
+    expect(mainCalls.where.length).toBe(1);
+    expect(mainCalls.innerJoin.length).toBe(1);
+  });
+
+  it('should filter by boardType only when only boardType provided', async () => {
+    const ctx = makeCtx();
+
+    const { chain: mainChain, calls: mainCalls } = createMockChain([
+      makePlaylistRow({ uuid: 'pl-1', boardType: 'kilter' }),
+    ]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    const { chain: countChain } = createMockChain([
+      { playlistId: BigInt(1), count: 10 },
+    ]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(
+      null,
+      { input: { boardType: 'kilter' } },
+      ctx,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ uuid: 'pl-1', boardType: 'kilter' });
+
+    // Verify where() was called with conditions (userId + boardType)
+    expect(mainCalls.where.length).toBe(1);
+  });
+
+  it('should filter by both boardType and layoutId when both provided', async () => {
+    const ctx = makeCtx();
+
+    const { chain: mainChain, calls: mainCalls } = createMockChain([
+      makePlaylistRow({ uuid: 'pl-1', boardType: 'kilter', layoutId: 8 }),
+    ]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    const { chain: countChain } = createMockChain([
+      { playlistId: BigInt(1), count: 7 },
+    ]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 8 } },
+      ctx,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ uuid: 'pl-1', boardType: 'kilter', layoutId: 8 });
+
+    // Verify where() was called (userId + boardType + layoutId or null)
+    expect(mainCalls.where.length).toBe(1);
+  });
+
+  it('should include playlists with null layoutId when filtering by layoutId', async () => {
+    const ctx = makeCtx();
+
+    // Simulate returning a playlist with null layoutId (Aurora-synced circuit)
+    const { chain: mainChain } = createMockChain([
+      makePlaylistRow({ uuid: 'pl-1', boardType: 'kilter', layoutId: 8 }),
+      makePlaylistRow({ uuid: 'pl-circuit', boardType: 'kilter', layoutId: null, id: BigInt(2) }),
+    ]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    const { chain: countChain } = createMockChain([
+      { playlistId: BigInt(1), count: 5 },
+      { playlistId: BigInt(2), count: 3 },
+    ]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 8 } },
+      ctx,
+    );
+
+    // Both playlists should be returned (layoutId=8 match + layoutId=null circuit)
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ uuid: 'pl-1', layoutId: 8 });
+    expect(result[1]).toMatchObject({ uuid: 'pl-circuit', layoutId: null });
+  });
+
+  it('should return empty array when no playlists match', async () => {
+    const ctx = makeCtx();
+
+    const { chain: mainChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    // No climb counts or follow stats queries needed for empty result
+
+    const result = await playlistQueries.allUserPlaylists(
+      null,
+      { input: { boardType: 'tension', layoutId: 99 } },
+      ctx,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should return playlists ordered by last accessed/updated', async () => {
+    const ctx = makeCtx();
+
+    const { chain: mainChain, calls: mainCalls } = createMockChain([
+      makePlaylistRow({ uuid: 'pl-recent', lastAccessedAt: new Date('2026-01-15') }),
+      makePlaylistRow({ uuid: 'pl-old', lastAccessedAt: new Date('2026-01-01'), id: BigInt(2) }),
+    ]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    const { chain: countChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(null, { input: {} }, ctx);
+
+    expect(result).toHaveLength(2);
+    // Verify orderBy was called
+    expect(mainCalls.orderBy.length).toBe(1);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/queries.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries.ts
@@ -171,7 +171,7 @@ export const playlistQueries = {
    */
   allUserPlaylists: async (
     _: unknown,
-    { input }: { input: { boardType?: string } },
+    { input }: { input: { boardType?: string; layoutId?: number } },
     ctx: ConnectionContext
   ): Promise<unknown[]> => {
     requireAuthenticated(ctx);
@@ -183,6 +183,16 @@ export const playlistQueries = {
 
     if (input.boardType) {
       conditions.push(eq(dbSchema.playlists.boardType, input.boardType));
+    }
+
+    if (input.layoutId != null) {
+      // Include playlists with matching layoutId OR null layoutId (Aurora-synced circuits)
+      conditions.push(
+        or(
+          eq(dbSchema.playlists.layoutId, input.layoutId),
+          isNull(dbSchema.playlists.layoutId)
+        )!,
+      );
     }
 
     const userPlaylists = await db

--- a/packages/backend/src/graphql/resolvers/playlists/queries.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries.ts
@@ -187,12 +187,13 @@ export const playlistQueries = {
 
     if (input.layoutId != null) {
       // Include playlists with matching layoutId OR null layoutId (Aurora-synced circuits)
-      conditions.push(
-        or(
-          eq(dbSchema.playlists.layoutId, input.layoutId),
-          isNull(dbSchema.playlists.layoutId)
-        )!,
+      const layoutCondition = or(
+        eq(dbSchema.playlists.layoutId, input.layoutId),
+        isNull(dbSchema.playlists.layoutId),
       );
+      if (layoutCondition) {
+        conditions.push(layoutCondition);
+      }
     }
 
     const userPlaylists = await db

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -430,6 +430,7 @@ export const GetUserPlaylistsInputSchema = z.object({
 
 export const GetAllUserPlaylistsInputSchema = z.object({
   boardType: BoardNameSchema.optional(),
+  layoutId: z.number().int().positive().optional(),
 });
 
 export const GetPlaylistsForClimbInputSchema = z.object({

--- a/packages/shared-schema/src/schema.ts
+++ b/packages/shared-schema/src/schema.ts
@@ -923,6 +923,8 @@ export const typeDefs = /* GraphQL */ `
   input GetAllUserPlaylistsInput {
     "Optional filter by board type"
     boardType: String
+    "Optional filter by layout ID (includes playlists with null layoutId)"
+    layoutId: Int
   }
 
   """

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { BoardRouteParameters } from '@/app/lib/types';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { Metadata } from 'next';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -22,14 +24,24 @@ export default async function PlaylistDetailPage(props: {
 
   try {
     // Validate route params (throws if invalid board/layout/size/set combination)
-    await parseBoardRouteParamsWithSlugs(params);
+    const parsed = await parseBoardRouteParamsWithSlugs(params);
     const playlistsBasePath = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/playlists`;
+
+    // Fetch user's boards server-side for instant board filter selection
+    const authToken = await getServerAuthToken();
+    const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
 
     return (
       <div className={styles.pageContainer}>
         <PlaylistDetailContent
           playlistUuid={params.playlist_uuid}
           playlistsBasePath={playlistsBasePath}
+          boardConfig={{
+            boardType: parsed.board_name,
+            layoutId: parsed.layout_id,
+            sizeId: parsed.size_id,
+          }}
+          initialMyBoards={initialMyBoards}
         />
       </div>
     );

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { BoardRouteParameters } from '@/app/lib/types';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { Metadata } from 'next';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from '@/app/playlists/library-page-content';
 import styles from '@/app/components/library/library.module.css';
 
@@ -18,13 +20,26 @@ export default async function PlaylistsPage(props: { params: Promise<BoardRouteP
 
   try {
     // Validate route params (throws if invalid board/layout/size/set combination)
-    await parseBoardRouteParamsWithSlugs(params);
+    const parsed = await parseBoardRouteParamsWithSlugs(params);
     const playlistsBasePath = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/playlists`;
+
+    // SSR: fetch boards, playlists, and discover data in parallel
+    const authToken = await getServerAuthToken();
+    const playlistFilter = { boardType: parsed.board_name, layoutId: parsed.layout_id };
+
+    const [initialMyBoards, initialPlaylists, initialDiscoverPlaylists] = await Promise.all([
+      authToken ? serverMyBoards(authToken) : null,
+      authToken ? serverUserPlaylists(authToken, playlistFilter) : null,
+      cachedDiscoverPlaylists(playlistFilter),
+    ]);
 
     return (
       <div className={styles.pageContainer}>
         <LibraryPageContent
           playlistsBasePath={playlistsBasePath}
+          initialMyBoards={initialMyBoards}
+          initialPlaylists={initialPlaylists}
+          initialDiscoverPlaylists={initialDiscoverPlaylists}
         />
       </div>
     );

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -25,11 +27,17 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
 
   const playlistsBasePath = constructBoardSlugPlaylistsUrl(params.board_slug, Number(params.angle));
 
+  // Fetch user's boards server-side for instant board filter selection
+  const authToken = await getServerAuthToken();
+  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+
   return (
     <div className={styles.pageContainer}>
       <PlaylistDetailContent
         playlistUuid={params.playlist_uuid}
         playlistsBasePath={playlistsBasePath}
+        boardSlug={params.board_slug}
+        initialMyBoards={initialMyBoards}
       />
     </div>
   );

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from '@/app/playlists/library-page-content';
 import styles from '@/app/components/library/library.module.css';
 
@@ -25,11 +27,24 @@ export default async function BoardSlugPlaylistsPage(props: PlaylistsPageProps) 
     return notFound();
   }
 
+  // SSR: fetch boards, playlists, and discover data in parallel
+  const authToken = await getServerAuthToken();
+  const playlistFilter = { boardType: board.boardType, layoutId: board.layoutId };
+
+  const [initialMyBoards, initialPlaylists, initialDiscoverPlaylists] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    authToken ? serverUserPlaylists(authToken, playlistFilter) : null,
+    cachedDiscoverPlaylists(playlistFilter),
+  ]);
+
   return (
     <div className={styles.pageContainer}>
       <LibraryPageContent
         boardSlug={params.board_slug}
         playlistsBasePath={constructBoardSlugPlaylistsUrl(params.board_slug, Number(params.angle))}
+        initialMyBoards={initialMyBoards}
+        initialPlaylists={initialPlaylists}
+        initialDiscoverPlaylists={initialDiscoverPlaylists}
       />
     </div>
   );

--- a/packages/web/app/lib/__tests__/find-matching-board.test.ts
+++ b/packages/web/app/lib/__tests__/find-matching-board.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { findMatchingBoard } from '../find-matching-board';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const makeBoard = (overrides: Partial<UserBoard> = {}): UserBoard => ({
+  uuid: 'board-1',
+  slug: 'my-kilter',
+  ownerId: 'user-1',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 12,
+  setIds: '1,2',
+  name: 'My Kilter',
+  isPublic: true,
+  isOwned: true,
+  angle: 40,
+  isAngleAdjustable: true,
+  createdAt: '2026-01-01',
+  totalAscents: 0,
+  uniqueClimbers: 0,
+  followerCount: 0,
+  commentCount: 0,
+  isFollowedByMe: false,
+  ...overrides,
+});
+
+describe('findMatchingBoard', () => {
+  const kilterBoard = makeBoard({ uuid: 'b-1', slug: 'my-kilter', boardType: 'kilter', layoutId: 1, sizeId: 12 });
+  const tensionBoard = makeBoard({ uuid: 'b-2', slug: 'my-tension', boardType: 'tension', layoutId: 2, sizeId: 8 });
+  const boards = [kilterBoard, tensionBoard];
+
+  it('should return null for null boards', () => {
+    expect(findMatchingBoard(null, 'my-kilter')).toBeNull();
+  });
+
+  it('should return null for undefined boards', () => {
+    expect(findMatchingBoard(undefined, 'my-kilter')).toBeNull();
+  });
+
+  it('should return null for empty boards array', () => {
+    expect(findMatchingBoard([], 'my-kilter')).toBeNull();
+  });
+
+  it('should return null when neither slug nor config provided', () => {
+    expect(findMatchingBoard(boards)).toBeNull();
+  });
+
+  it('should match by slug', () => {
+    expect(findMatchingBoard(boards, 'my-kilter')).toBe(kilterBoard);
+    expect(findMatchingBoard(boards, 'my-tension')).toBe(tensionBoard);
+  });
+
+  it('should return null for non-matching slug', () => {
+    expect(findMatchingBoard(boards, 'nonexistent')).toBeNull();
+  });
+
+  it('should match by boardConfig', () => {
+    expect(findMatchingBoard(boards, undefined, { boardType: 'kilter', layoutId: 1, sizeId: 12 })).toBe(kilterBoard);
+    expect(findMatchingBoard(boards, undefined, { boardType: 'tension', layoutId: 2, sizeId: 8 })).toBe(tensionBoard);
+  });
+
+  it('should return null for non-matching boardConfig', () => {
+    expect(findMatchingBoard(boards, undefined, { boardType: 'kilter', layoutId: 1, sizeId: 999 })).toBeNull();
+    expect(findMatchingBoard(boards, undefined, { boardType: 'kilter', layoutId: 999, sizeId: 12 })).toBeNull();
+    expect(findMatchingBoard(boards, undefined, { boardType: 'moonboard', layoutId: 1, sizeId: 12 })).toBeNull();
+  });
+
+  it('should prefer slug over boardConfig when both provided', () => {
+    // Slug matches kilter, config matches tension — slug wins
+    const result = findMatchingBoard(boards, 'my-kilter', { boardType: 'tension', layoutId: 2, sizeId: 8 });
+    expect(result).toBe(kilterBoard);
+  });
+
+  it('should fall back to boardConfig when slug is undefined', () => {
+    const result = findMatchingBoard(boards, undefined, { boardType: 'tension', layoutId: 2, sizeId: 8 });
+    expect(result).toBe(tensionBoard);
+  });
+});

--- a/packages/web/app/lib/find-matching-board.ts
+++ b/packages/web/app/lib/find-matching-board.ts
@@ -1,0 +1,26 @@
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+export type BoardConfig = { boardType: string; layoutId: number; sizeId: number };
+
+/**
+ * Find a UserBoard matching by slug, board config, or both.
+ * Returns null if no match is found or if boards is empty/nullish.
+ */
+export function findMatchingBoard(
+  boards: UserBoard[] | null | undefined,
+  boardSlug?: string,
+  boardConfig?: BoardConfig,
+): UserBoard | null {
+  if (!boards || boards.length === 0) return null;
+  if (boardSlug) {
+    return boards.find((b) => b.slug === boardSlug) ?? null;
+  }
+  if (boardConfig) {
+    return boards.find((b) =>
+      b.boardType === boardConfig.boardType &&
+      b.layoutId === boardConfig.layoutId &&
+      b.sizeId === boardConfig.sizeId,
+    ) ?? null;
+  }
+  return null;
+}

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -157,6 +157,7 @@ export interface Playlist {
 
 export interface GetAllUserPlaylistsInput {
   boardType?: string;
+  layoutId?: number;
 }
 
 export interface GetAllUserPlaylistsQueryVariables {

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -209,6 +209,66 @@ export async function cachedSessionGroupedFeed(
 }
 
 /**
+ * Server-side fetch of the user's playlists (authenticated, not cached).
+ */
+export async function serverUserPlaylists(
+  authToken: string,
+  input: { boardType?: string; layoutId?: number } = {},
+): Promise<import('@/app/lib/graphql/operations/playlists').Playlist[] | null> {
+  const { GET_ALL_USER_PLAYLISTS } = await import('@/app/lib/graphql/operations/playlists');
+  type Response = import('@/app/lib/graphql/operations/playlists').GetAllUserPlaylistsQueryResponse;
+
+  try {
+    const response = await executeAuthenticatedGraphQL<Response>(
+      GET_ALL_USER_PLAYLISTS,
+      { input },
+      authToken,
+    );
+    return response.allUserPlaylists;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Server-side cached fetch of discover playlists (public, no auth needed).
+ */
+export async function cachedDiscoverPlaylists(
+  input: { boardType?: string; layoutId?: number } = {},
+): Promise<{
+  popular: import('@/app/lib/graphql/operations/playlists').DiscoverablePlaylist[];
+  recent: import('@/app/lib/graphql/operations/playlists').DiscoverablePlaylist[];
+} | null> {
+  const { DISCOVER_PLAYLISTS } = await import('@/app/lib/graphql/operations/playlists');
+  type Response = import('@/app/lib/graphql/operations/playlists').DiscoverPlaylistsQueryResponse;
+
+  try {
+    const popularQuery = createCachedGraphQLQuery<Response>(
+      DISCOVER_PLAYLISTS,
+      'discover-playlists-popular',
+      300, // 5 min cache
+    );
+    const recentQuery = createCachedGraphQLQuery<Response>(
+      DISCOVER_PLAYLISTS,
+      'discover-playlists-recent',
+      300,
+    );
+
+    const [popularRes, recentRes] = await Promise.all([
+      popularQuery({ input: { ...input, pageSize: 10, sortBy: 'popular' } }),
+      recentQuery({ input: { ...input, pageSize: 10, sortBy: 'recent' } }),
+    ]);
+
+    return {
+      popular: popularRes.discoverPlaylists.playlists,
+      recent: recentRes.discoverPlaylists.playlists,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetch the first page of grouped notifications server-side.
  * Returns null on failure so the client can fall back to client-side fetching.
  */

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -55,6 +55,7 @@ import PlaylistEditDrawer from '@/app/components/library/playlist-edit-drawer';
 import CommentSection from '@/app/components/social/comment-section';
 import MultiboardClimbList from '@/app/components/climb-list/multiboard-climb-list';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
+import { findMatchingBoard, type BoardConfig } from '@/app/lib/find-matching-board';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -81,32 +82,10 @@ type PlaylistDetailContentProps = {
   /** When set from a board slug route, auto-selects the matching board filter. */
   boardSlug?: string;
   /** When set from a legacy route, auto-selects the matching board filter by config. */
-  boardConfig?: { boardType: string; layoutId: number; sizeId: number };
+  boardConfig?: BoardConfig;
   /** SSR-fetched user boards for instant board filter selection (avoids flash). */
   initialMyBoards?: UserBoard[] | null;
 };
-
-/**
- * Find the initial board from SSR-provided boards or return null.
- */
-function findInitialBoard(
-  boards: UserBoard[] | null | undefined,
-  boardSlug?: string,
-  boardConfig?: { boardType: string; layoutId: number; sizeId: number },
-): UserBoard | null {
-  if (!boards || boards.length === 0) return null;
-  if (boardSlug) {
-    return boards.find((b) => b.slug === boardSlug) ?? null;
-  }
-  if (boardConfig) {
-    return boards.find((b) =>
-      b.boardType === boardConfig.boardType &&
-      b.layoutId === boardConfig.layoutId &&
-      b.sizeId === boardConfig.sizeId,
-    ) ?? null;
-  }
-  return null;
-}
 
 export default function PlaylistDetailContent({
   playlistUuid,
@@ -126,7 +105,7 @@ export default function PlaylistDetailContent({
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   // Initialize selectedBoard from SSR data immediately (avoids flash from "All" to selected board)
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
-    () => findInitialBoard(initialMyBoards, boardSlug, boardConfig),
+    () => findMatchingBoard(initialMyBoards, boardSlug, boardConfig),
   );
   const lastAccessedUpdatedRef = useRef(false);
   const defaultBoardAppliedRef = useRef(!!selectedBoard);
@@ -140,7 +119,7 @@ export default function PlaylistDetailContent({
     if (defaultBoardAppliedRef.current || boardsLoading || myBoards.length === 0) return;
     if (!boardSlug && !boardConfig) return;
 
-    const match = findInitialBoard(myBoards, boardSlug, boardConfig);
+    const match = findMatchingBoard(myBoards, boardSlug, boardConfig);
     if (match) {
       setSelectedBoard(match);
     }

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -54,6 +54,7 @@ import { PlaylistGeneratorDrawer } from '@/app/components/playlist-generator';
 import PlaylistEditDrawer from '@/app/components/library/playlist-edit-drawer';
 import CommentSection from '@/app/components/social/comment-section';
 import MultiboardClimbList from '@/app/components/climb-list/multiboard-climb-list';
+import { useMyBoards } from '@/app/hooks/use-my-boards';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -77,11 +78,42 @@ type PlaylistDetailContentProps = {
   playlistUuid: string;
   /** Base path for navigating back to the playlists library (e.g. "/b/my-kilter/40/playlists"). Defaults to "/playlists". */
   playlistsBasePath?: string;
+  /** When set from a board slug route, auto-selects the matching board filter. */
+  boardSlug?: string;
+  /** When set from a legacy route, auto-selects the matching board filter by config. */
+  boardConfig?: { boardType: string; layoutId: number; sizeId: number };
+  /** SSR-fetched user boards for instant board filter selection (avoids flash). */
+  initialMyBoards?: UserBoard[] | null;
 };
+
+/**
+ * Find the initial board from SSR-provided boards or return null.
+ */
+function findInitialBoard(
+  boards: UserBoard[] | null | undefined,
+  boardSlug?: string,
+  boardConfig?: { boardType: string; layoutId: number; sizeId: number },
+): UserBoard | null {
+  if (!boards || boards.length === 0) return null;
+  if (boardSlug) {
+    return boards.find((b) => b.slug === boardSlug) ?? null;
+  }
+  if (boardConfig) {
+    return boards.find((b) =>
+      b.boardType === boardConfig.boardType &&
+      b.layoutId === boardConfig.layoutId &&
+      b.sizeId === boardConfig.sizeId,
+    ) ?? null;
+  }
+  return null;
+}
 
 export default function PlaylistDetailContent({
   playlistUuid,
   playlistsBasePath = '/playlists',
+  boardSlug,
+  boardConfig,
+  initialMyBoards,
 }: PlaylistDetailContentProps) {
   const router = useRouter();
   const { showMessage } = useSnackbar();
@@ -92,9 +124,28 @@ export default function PlaylistDetailContent({
   const [generatorOpen, setGeneratorOpen] = useState(false);
   const [listRefreshKey, setListRefreshKey] = useState(0);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
-  const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
+  // Initialize selectedBoard from SSR data immediately (avoids flash from "All" to selected board)
+  const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
+    () => findInitialBoard(initialMyBoards, boardSlug, boardConfig),
+  );
   const lastAccessedUpdatedRef = useRef(false);
+  const defaultBoardAppliedRef = useRef(!!selectedBoard);
   const { token, isLoading: tokenLoading } = useWsAuthToken();
+
+  // Fetch user's boards (with SSR initial data to avoid loading skeleton)
+  const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(true, 50, initialMyBoards);
+
+  // Auto-select the matching board when boards load (fallback for non-SSR paths)
+  useEffect(() => {
+    if (defaultBoardAppliedRef.current || boardsLoading || myBoards.length === 0) return;
+    if (!boardSlug && !boardConfig) return;
+
+    const match = findInitialBoard(myBoards, boardSlug, boardConfig);
+    if (match) {
+      setSelectedBoard(match);
+    }
+    defaultBoardAppliedRef.current = true;
+  }, [myBoards, boardsLoading, boardSlug, boardConfig]);
 
   const fetchPlaylist = useCallback(async () => {
     if (tokenLoading) return;

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -27,6 +27,7 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
+import { findMatchingBoard } from '@/app/lib/find-matching-board';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import AuthModal from '@/app/components/auth/auth-modal';
 import PlaylistCardGrid from '@/app/components/library/playlist-card-grid';
@@ -36,34 +37,6 @@ import BoardScrollSection from '@/app/components/board-scroll/board-scroll-secti
 import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
 import styles from '@/app/components/library/library.module.css';
 import boardScrollStyles from '@/app/components/board-scroll/board-scroll.module.css';
-
-/**
- * Find the UserBoard that best matches a board identified by type + layout + size.
- */
-function findMatchingBoard(
-  boards: UserBoard[],
-  boardName: string | undefined,
-  layoutId: number | undefined,
-  sizeId: number | undefined,
-): UserBoard | null {
-  if (!boardName) return null;
-  return boards.find((b) =>
-    b.boardType === boardName &&
-    b.layoutId === layoutId &&
-    b.sizeId === sizeId,
-  ) ?? null;
-}
-
-/**
- * Find the initial board from SSR-provided boards by slug.
- */
-function findInitialBoardBySlug(
-  boards: UserBoard[] | null | undefined,
-  boardSlug?: string,
-): UserBoard | null {
-  if (!boards || !boardSlug) return null;
-  return boards.find((b) => b.slug === boardSlug) ?? null;
-}
 
 type LibraryPageContentProps = {
   /** When set, the page was rendered from a board route and this board is pre-selected. */
@@ -97,7 +70,7 @@ export default function LibraryPageContent({
   const [hasMounted, setHasMounted] = useState(false);
   // Initialize selectedBoard from SSR data immediately when boardSlug is provided
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
-    () => findInitialBoardBySlug(initialMyBoards, boardSlug),
+    () => findMatchingBoard(initialMyBoards, boardSlug),
   );
   const [showAuthModal, setShowAuthModal] = useState(false);
   const defaultBoardAppliedRef = useRef(!!selectedBoard);
@@ -132,12 +105,15 @@ export default function LibraryPageContent({
       // Wait if there's an active queue but board details haven't loaded yet
       if (!currentBoardDetails && hasActiveQueue) return;
 
-      const match = findMatchingBoard(
+      const match = currentBoardDetails ? findMatchingBoard(
         myBoards,
-        currentBoardDetails?.board_name,
-        currentBoardDetails?.layout_id,
-        currentBoardDetails?.size_id,
-      );
+        undefined,
+        {
+          boardType: currentBoardDetails.board_name,
+          layoutId: currentBoardDetails.layout_id,
+          sizeId: currentBoardDetails.size_id,
+        },
+      ) : null;
       if (match) {
         setSelectedBoard(match);
       }
@@ -325,13 +301,8 @@ export default function LibraryPageContent({
   const isLoading = (!hasMounted && !hasInitialPlaylistData) || playlistsLoading || tokenLoading || sessionStatus === 'loading';
   const discoverItems = getDiscoverPlaylists();
 
-  // Filter playlists by selected board (boardType + layoutId)
-  const filteredPlaylists = selectedBoard
-    ? playlists.filter((p) =>
-        p.boardType === selectedBoard.boardType &&
-        (p.layoutId == null || p.layoutId === selectedBoard.layoutId)
-      )
-    : playlists;
+  // Server query already filters by boardType + layoutId; no client-side filter needed
+  const filteredPlaylists = playlists;
 
   return (
     <>
@@ -387,7 +358,7 @@ export default function LibraryPageContent({
       )}
 
       {/* Authenticated: Recent Playlists Grid */}
-      {(isAuthenticated || hasInitialPlaylistData) && (
+      {isAuthenticated && (
         <PlaylistCardGrid
           playlists={filteredPlaylists}
           getPlaylistUrl={getPlaylistUrl}
@@ -409,7 +380,7 @@ export default function LibraryPageContent({
       )}
 
       {/* Jump Back In (authenticated only) */}
-      {(isAuthenticated || hasInitialPlaylistData) && (isLoading || filteredPlaylists.length > 0) && (
+      {isAuthenticated && (isLoading || filteredPlaylists.length > 0) && (
         <PlaylistScrollSection title="Jump Back In" loading={isLoading}>
           {filteredPlaylists.slice(0, 10).map((p, i) => (
             <PlaylistCard

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -133,7 +133,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
       setError(null);
 
       const input: GetAllUserPlaylistsInput = selectedBoard
-        ? { boardType: selectedBoard.boardType }
+        ? { boardType: selectedBoard.boardType, layoutId: selectedBoard.layoutId }
         : {};
 
       const playlistsRes = await executeGraphQL<GetAllUserPlaylistsQueryResponse, { input: GetAllUserPlaylistsInput }>(
@@ -272,9 +272,12 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
   const isLoading = !hasMounted || playlistsLoading || tokenLoading || sessionStatus === 'loading';
   const discoverItems = getDiscoverPlaylists();
 
-  // Filter playlists by selected board
+  // Filter playlists by selected board (boardType + layoutId)
   const filteredPlaylists = selectedBoard
-    ? playlists.filter((p) => p.boardType === selectedBoard.boardType)
+    ? playlists.filter((p) =>
+        p.boardType === selectedBoard.boardType &&
+        (p.layoutId == null || p.layoutId === selectedBoard.layoutId)
+      )
     : playlists;
 
   return (

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -54,26 +54,60 @@ function findMatchingBoard(
   ) ?? null;
 }
 
+/**
+ * Find the initial board from SSR-provided boards by slug.
+ */
+function findInitialBoardBySlug(
+  boards: UserBoard[] | null | undefined,
+  boardSlug?: string,
+): UserBoard | null {
+  if (!boards || !boardSlug) return null;
+  return boards.find((b) => b.slug === boardSlug) ?? null;
+}
+
 type LibraryPageContentProps = {
   /** When set, the page was rendered from a board route and this board is pre-selected. */
   boardSlug?: string;
   /** Base path for playlist detail links (e.g. "/b/my-kilter/40/playlists" or "/kilter/original/12x12/default/45/playlists"). Defaults to "/playlists". */
   playlistsBasePath?: string;
+  /** SSR-fetched user boards for instant rendering. */
+  initialMyBoards?: UserBoard[] | null;
+  /** SSR-fetched user playlists for instant rendering. */
+  initialPlaylists?: Playlist[] | null;
+  /** SSR-fetched discover playlists for instant rendering. */
+  initialDiscoverPlaylists?: { popular: DiscoverablePlaylist[]; recent: DiscoverablePlaylist[] } | null;
 };
 
-export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/playlists' }: LibraryPageContentProps) {
+export default function LibraryPageContent({
+  boardSlug,
+  playlistsBasePath = '/playlists',
+  initialMyBoards,
+  initialPlaylists,
+  initialDiscoverPlaylists,
+}: LibraryPageContentProps) {
   const { data: session, status: sessionStatus } = useSession();
   const { token, isLoading: tokenLoading } = useWsAuthToken();
   const router = useRouter();
   const isAuthenticated = sessionStatus === 'authenticated';
 
-  const [hasMounted, setHasMounted] = useState(false);
-  const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
-  const [showAuthModal, setShowAuthModal] = useState(false);
-  const defaultBoardAppliedRef = useRef(false);
+  const hasInitialBoardData = initialMyBoards != null && initialMyBoards.length > 0;
+  const hasInitialPlaylistData = initialPlaylists != null;
+  const hasInitialDiscoverData = initialDiscoverPlaylists != null;
 
-  // Fetch user's boards for the board selector
-  const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(hasMounted);
+  const [hasMounted, setHasMounted] = useState(false);
+  // Initialize selectedBoard from SSR data immediately when boardSlug is provided
+  const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
+    () => findInitialBoardBySlug(initialMyBoards, boardSlug),
+  );
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const defaultBoardAppliedRef = useRef(!!selectedBoard);
+
+  // Fetch user's boards for the board selector (with SSR initial data)
+  const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(
+    hasMounted || hasInitialBoardData,
+    50,
+    initialMyBoards,
+  );
 
   // Get current session/queue board info to use as default selection (global route only)
   const { boardDetails: currentBoardDetails, hasActiveQueue } = useQueueBridgeBoardInfo();
@@ -82,7 +116,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
     setHasMounted(true);
   }, []);
 
-  // Auto-select the matching board once boards finish loading
+  // Auto-select the matching board once boards finish loading (fallback for non-SSR paths)
   useEffect(() => {
     if (defaultBoardAppliedRef.current || boardsLoading || myBoards.length === 0) return;
 
@@ -111,15 +145,23 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
     }
   }, [myBoards, boardsLoading, currentBoardDetails, hasActiveQueue, boardSlug]);
 
-  // Data states
-  const [playlists, setPlaylists] = useState<Playlist[]>([]);
-  const [popularPlaylists, setPopularPlaylists] = useState<DiscoverablePlaylist[]>([]);
-  const [recentPlaylists, setRecentPlaylists] = useState<DiscoverablePlaylist[]>([]);
+  // Data states — initialized from SSR data when available
+  const [playlists, setPlaylists] = useState<Playlist[]>(initialPlaylists ?? []);
+  const [popularPlaylists, setPopularPlaylists] = useState<DiscoverablePlaylist[]>(
+    initialDiscoverPlaylists?.popular ?? [],
+  );
+  const [recentPlaylists, setRecentPlaylists] = useState<DiscoverablePlaylist[]>(
+    initialDiscoverPlaylists?.recent ?? [],
+  );
 
-  // Loading states
-  const [playlistsLoading, setPlaylistsLoading] = useState(true);
-  const [discoverLoading, setDiscoverLoading] = useState(true);
+  // Loading states — skip loading when SSR data is available
+  const [playlistsLoading, setPlaylistsLoading] = useState(!hasInitialPlaylistData);
+  const [discoverLoading, setDiscoverLoading] = useState(!hasInitialDiscoverData);
   const [error, setError] = useState<string | null>(null);
+
+  // Track whether we already have data to avoid re-showing loading skeleton on refetches
+  const hasPlaylistDataRef = useRef(hasInitialPlaylistData);
+  const hasDiscoverDataRef = useRef(hasInitialDiscoverData);
 
   // Fetch user data
   const fetchUserData = useCallback(async () => {
@@ -129,7 +171,10 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
     }
 
     try {
-      setPlaylistsLoading(true);
+      // Only show loading if we don't already have data
+      if (!hasPlaylistDataRef.current) {
+        setPlaylistsLoading(true);
+      }
       setError(null);
 
       const input: GetAllUserPlaylistsInput = selectedBoard
@@ -143,6 +188,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
       );
 
       setPlaylists(playlistsRes.allUserPlaylists);
+      hasPlaylistDataRef.current = true;
     } catch (err) {
       console.error('Error fetching user data:', err);
       setError('Failed to load your library');
@@ -154,7 +200,10 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
   // Fetch discover playlists (works for both "All" and specific board)
   const fetchDiscoverData = useCallback(async () => {
     try {
-      setDiscoverLoading(true);
+      // Only show loading if we don't already have data
+      if (!hasDiscoverDataRef.current) {
+        setDiscoverLoading(true);
+      }
 
       const baseInput: DiscoverPlaylistsInput = {
         pageSize: 10,
@@ -177,6 +226,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
 
       setPopularPlaylists(popularRes.discoverPlaylists.playlists);
       setRecentPlaylists(recentRes.discoverPlaylists.playlists);
+      hasDiscoverDataRef.current = true;
     } catch (err) {
       console.error('Error fetching discover playlists:', err);
     } finally {
@@ -215,6 +265,9 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
 
   const handleBoardSelect = useCallback((board: UserBoard | null) => {
     setSelectedBoard(board);
+    // Reset data refs so loading skeletons show for new board filter
+    hasPlaylistDataRef.current = false;
+    hasDiscoverDataRef.current = false;
 
     // When rendered from a board route, switching boards navigates to the correct URL
     if (boardSlug || playlistsBasePath !== '/playlists') {
@@ -269,7 +322,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
     );
   }
 
-  const isLoading = !hasMounted || playlistsLoading || tokenLoading || sessionStatus === 'loading';
+  const isLoading = (!hasMounted && !hasInitialPlaylistData) || playlistsLoading || tokenLoading || sessionStatus === 'loading';
   const discoverItems = getDiscoverPlaylists();
 
   // Filter playlists by selected board (boardType + layoutId)
@@ -334,7 +387,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
       )}
 
       {/* Authenticated: Recent Playlists Grid */}
-      {isAuthenticated && (
+      {(isAuthenticated || hasInitialPlaylistData) && (
         <PlaylistCardGrid
           playlists={filteredPlaylists}
           getPlaylistUrl={getPlaylistUrl}
@@ -356,7 +409,7 @@ export default function LibraryPageContent({ boardSlug, playlistsBasePath = '/pl
       )}
 
       {/* Jump Back In (authenticated only) */}
-      {isAuthenticated && (isLoading || filteredPlaylists.length > 0) && (
+      {(isAuthenticated || hasInitialPlaylistData) && (isLoading || filteredPlaylists.length > 0) && (
         <PlaylistScrollSection title="Jump Back In" loading={isLoading}>
           {filteredPlaylists.slice(0, 10).map((p, i) => (
             <PlaylistCard

--- a/packages/web/app/playlists/page.tsx
+++ b/packages/web/app/playlists/page.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from './library-page-content';
 import styles from '@/app/components/library/library.module.css';
 
@@ -9,9 +11,22 @@ export const metadata: Metadata = {
 };
 
 export default async function PlaylistsPage() {
+  // SSR: fetch boards, playlists (unfiltered), and discover data in parallel
+  const authToken = await getServerAuthToken();
+
+  const [initialMyBoards, initialPlaylists, initialDiscoverPlaylists] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    authToken ? serverUserPlaylists(authToken) : null,
+    cachedDiscoverPlaylists(),
+  ]);
+
   return (
     <div className={styles.pageContainer}>
-      <LibraryPageContent />
+      <LibraryPageContent
+        initialMyBoards={initialMyBoards}
+        initialPlaylists={initialPlaylists}
+        initialDiscoverPlaylists={initialDiscoverPlaylists}
+      />
     </div>
   );
 }


### PR DESCRIPTION
…l page

When viewing playlists from a board-scoped route, the list page now filters by both boardType and layoutId (previously only boardType). The playlist detail page now auto-selects the matching board filter using SSR-fetched board data to avoid a flash from "All" to the selected board.

- Add optional layoutId to GetAllUserPlaylistsInput GraphQL schema
- Update allUserPlaylists resolver to filter by layoutId (includes playlists with null layoutId for Aurora-synced circuits)
- Pass layoutId from library-page-content when board is selected
- Pass boardSlug/boardConfig to PlaylistDetailContent from both board slug and legacy route pages
- Fetch initialMyBoards server-side for instant board filter selection

https://claude.ai/code/session_018EN9pUTJVfWkza7fiicjuW