### PR TITLE
Fix board-slug climb detail URLs on /b routes

### DIFF
--- a/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
+++ b/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
@@ -4,8 +4,10 @@ import { renderHook, act } from '@testing-library/react';
 // --- Mocks ---
 
 const mockPush = vi.fn();
+let mockPathname = '/kilter/original/12x12/default/40/list';
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
 }));
 
 const mockTrack = vi.fn();
@@ -39,8 +41,7 @@ vi.mock('../use-favorite', () => ({
 }));
 
 vi.mock('@/app/lib/url-utils', () => ({
-  constructClimbViewUrl: vi.fn(() => '/climb/view'),
-  constructClimbViewUrlWithSlugs: vi.fn(() => '/climb/view-slug'),
+  getContextAwareClimbViewUrl: vi.fn(() => '/climb/view-context'),
   constructCreateClimbUrl: vi.fn(() => '/climb/create'),
   constructClimbInfoUrl: vi.fn(() => '/climb/info'),
 }));
@@ -79,6 +80,7 @@ describe('useClimbActions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockPathname = '/kilter/original/12x12/default/40/list';
 
     // Provide navigator.share and clipboard mocks
     Object.defineProperty(global, 'navigator', {
@@ -117,7 +119,7 @@ describe('useClimbActions', () => {
     expect(mockTrack).toHaveBeenCalledWith('Climb Info Viewed', expect.objectContaining({
       climbUuid: 'climb-1',
     }));
-    expect(mockPush).toHaveBeenCalledWith('/climb/view-slug');
+    expect(mockPush).toHaveBeenCalledWith('/climb/view-context');
     expect(defaultOptions.onActionComplete).toHaveBeenCalledWith('viewDetails');
   });
 
@@ -297,7 +299,7 @@ describe('useClimbActions', () => {
   it('viewDetailsUrl uses slug URL when names available', () => {
     const { result } = renderHook(() => useClimbActions(defaultOptions));
 
-    expect(result.current.viewDetailsUrl).toBe('/climb/view-slug');
+    expect(result.current.viewDetailsUrl).toBe('/climb/view-context');
   });
 
   it('forkUrl is null when canFork is false', () => {

--- a/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
@@ -10,8 +10,7 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('@/app/lib/url-utils', () => ({
-  constructClimbViewUrl: vi.fn(() => '/id-based-url'),
-  constructClimbViewUrlWithSlugs: vi.fn(() => '/slug-based-url'),
+  getContextAwareClimbViewUrl: vi.fn(() => '/context-aware-url'),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -34,7 +33,7 @@ vi.mock('../../action-tooltip', () => ({
 }));
 
 import { ViewDetailsAction } from '../view-details-action';
-import { constructClimbViewUrl, constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
@@ -115,61 +114,32 @@ describe('ViewDetailsAction', () => {
   });
 
   describe('URL construction strategy', () => {
-    it('uses slug-based URL when layout_name, size_name, and set_names all present', () => {
+    it('delegates URL generation to getContextAwareClimbViewUrl', () => {
       const props = createTestProps();
       ViewDetailsAction(props);
 
-      expect(constructClimbViewUrlWithSlugs).toHaveBeenCalledWith(
-        'kilter',
-        'Original',
-        '12x12',
-        'Full Size',
-        ['Standard', 'Extended'],
+      expect(getContextAwareClimbViewUrl).toHaveBeenCalledWith(
+        '',
+        props.boardDetails,
         40,
         'test-uuid-456',
         'Test Climb',
       );
-      expect(constructClimbViewUrl).not.toHaveBeenCalled();
     });
 
-    it('falls back to ID-based URL when layout_name is missing', () => {
+    it('passes current pathname when provided', () => {
       const props = createTestProps({
-        boardDetails: createTestBoardDetails({ layout_name: undefined }),
+        currentPathname: '/b/my-board/40/list',
       });
       ViewDetailsAction(props);
 
-      expect(constructClimbViewUrl).toHaveBeenCalledWith(
-        {
-          board_name: 'kilter',
-          layout_id: 1,
-          size_id: 10,
-          set_ids: '1,2',
-          angle: 40,
-        },
+      expect(getContextAwareClimbViewUrl).toHaveBeenCalledWith(
+        '/b/my-board/40/list',
+        props.boardDetails,
+        40,
         'test-uuid-456',
         'Test Climb',
       );
-      expect(constructClimbViewUrlWithSlugs).not.toHaveBeenCalled();
-    });
-
-    it('falls back to ID-based URL when size_name is missing', () => {
-      const props = createTestProps({
-        boardDetails: createTestBoardDetails({ size_name: undefined }),
-      });
-      ViewDetailsAction(props);
-
-      expect(constructClimbViewUrl).toHaveBeenCalled();
-      expect(constructClimbViewUrlWithSlugs).not.toHaveBeenCalled();
-    });
-
-    it('falls back to ID-based URL when set_names is missing', () => {
-      const props = createTestProps({
-        boardDetails: createTestBoardDetails({ set_names: undefined }),
-      });
-      ViewDetailsAction(props);
-
-      expect(constructClimbViewUrl).toHaveBeenCalled();
-      expect(constructClimbViewUrlWithSlugs).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -6,8 +6,7 @@ import ShareOutlined from '@mui/icons-material/ShareOutlined';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import {
-  constructClimbViewUrl,
-  constructClimbViewUrlWithSlugs,
+  getContextAwareClimbViewUrl,
 } from '@/app/lib/url-utils';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
 
@@ -15,6 +14,7 @@ export function ShareAction({
   climb,
   boardDetails,
   angle,
+  currentPathname,
   viewMode,
   size = 'default',
   showLabel,
@@ -25,28 +25,13 @@ export function ShareAction({
   const { showMessage } = useSnackbar();
   const { iconSize } = computeActionDisplay(viewMode, size, showLabel);
 
-  const viewUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-    ? constructClimbViewUrlWithSlugs(
-        boardDetails.board_name,
-        boardDetails.layout_name,
-        boardDetails.size_name,
-        boardDetails.size_description,
-        boardDetails.set_names,
-        angle,
-        climb.uuid,
-        climb.name,
-      )
-    : constructClimbViewUrl(
-        {
-          board_name: boardDetails.board_name,
-          layout_id: boardDetails.layout_id,
-          size_id: boardDetails.size_id,
-          set_ids: boardDetails.set_ids,
-          angle,
-        },
-        climb.uuid,
-        climb.name,
-      );
+  const viewUrl = getContextAwareClimbViewUrl(
+    currentPathname ?? '',
+    boardDetails,
+    angle,
+    climb.uuid,
+    climb.name,
+  );
 
   const handleClick = useCallback(async (e?: React.MouseEvent) => {
     e?.stopPropagation();

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -8,8 +8,7 @@ import Link from 'next/link';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import {
-  constructClimbViewUrl,
-  constructClimbViewUrlWithSlugs,
+  getContextAwareClimbViewUrl,
 } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
@@ -20,6 +19,7 @@ export function ViewDetailsAction({
   climb,
   boardDetails,
   angle,
+  currentPathname,
   viewMode,
   size = 'default',
   showLabel,
@@ -29,28 +29,13 @@ export function ViewDetailsAction({
 }: ClimbActionProps): ClimbActionResult {
   const { iconSize, shouldShowLabel } = computeActionDisplay(viewMode, size, showLabel);
 
-  const url = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-    ? constructClimbViewUrlWithSlugs(
-        boardDetails.board_name,
-        boardDetails.layout_name,
-        boardDetails.size_name,
-        boardDetails.size_description,
-        boardDetails.set_names,
-        angle,
-        climb.uuid,
-        climb.name,
-      )
-    : constructClimbViewUrl(
-        {
-          board_name: boardDetails.board_name,
-          layout_id: boardDetails.layout_id,
-          size_id: boardDetails.size_id,
-          set_ids: boardDetails.set_ids,
-          angle,
-        },
-        climb.uuid,
-        climb.name,
-      );
+  const url = getContextAwareClimbViewUrl(
+    currentPathname ?? '',
+    boardDetails,
+    angle,
+    climb.uuid,
+    climb.name,
+  );
 
   const handleClick = () => {
     track('Climb Info Viewed', {

--- a/packages/web/app/components/climb-actions/climb-actions.tsx
+++ b/packages/web/app/components/climb-actions/climb-actions.tsx
@@ -94,6 +94,7 @@ export function ClimbActions({
   climb,
   boardDetails,
   angle,
+  currentPathname,
   viewMode,
   include,
   exclude = [],
@@ -116,11 +117,12 @@ export function ClimbActions({
       climb,
       boardDetails,
       angle,
+      currentPathname,
       viewMode,
       size,
       auroraAppUrl,
     }),
-    [climb, boardDetails, angle, viewMode, size, auroraAppUrl]
+    [climb, boardDetails, angle, currentPathname, viewMode, size, auroraAppUrl]
   );
 
   // Memoize action complete handler to prevent creating new functions on every render

--- a/packages/web/app/components/climb-actions/types.ts
+++ b/packages/web/app/components/climb-actions/types.ts
@@ -36,6 +36,8 @@ export interface ClimbActionBaseProps {
   climb: Climb;
   boardDetails: BoardDetails;
   angle: number;
+  /** Current route pathname for context-aware URL construction (e.g. preserving /b/{slug}/{angle}). */
+  currentPathname?: string;
 }
 
 /**

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -1,16 +1,15 @@
 'use client';
 
 import { useState, useCallback, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { track } from '@vercel/analytics';
 import { useQueueContext } from '../graphql-queue';
 import { useFavorite } from './use-favorite';
 import {
-  constructClimbViewUrl,
-  constructClimbViewUrlWithSlugs,
   constructCreateClimbUrl,
   constructClimbInfoUrl,
+  getContextAwareClimbViewUrl,
 } from '@/app/lib/url-utils';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import { UseClimbActionsReturn } from './types';
@@ -31,6 +30,7 @@ export function useClimbActions({
   onActionComplete,
 }: UseClimbActionsOptions): UseClimbActionsReturn {
   const router = useRouter();
+  const pathname = usePathname();
   const { addToQueue, queue, mirrorClimb } = useQueueContext();
   const { showMessage } = useSnackbar();
 
@@ -53,32 +53,14 @@ export function useClimbActions({
   // URLs
   const viewDetailsUrl = useMemo(() => {
     if (!climb) return '';
-
-    if (boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names) {
-      return constructClimbViewUrlWithSlugs(
-        boardDetails.board_name,
-        boardDetails.layout_name,
-        boardDetails.size_name,
-        boardDetails.size_description,
-        boardDetails.set_names,
-        angle,
-        climb.uuid,
-        climb.name,
-      );
-    }
-
-    return constructClimbViewUrl(
-      {
-        board_name: boardDetails.board_name,
-        layout_id: boardDetails.layout_id,
-        size_id: boardDetails.size_id,
-        set_ids: boardDetails.set_ids,
-        angle,
-      },
+    return getContextAwareClimbViewUrl(
+      pathname,
+      boardDetails,
+      angle,
       climb.uuid,
       climb.name,
     );
-  }, [climb, boardDetails, angle]);
+  }, [climb, pathname, boardDetails, angle]);
 
   const forkUrl = useMemo(() => {
     if (!climb || !canFork) return null;

--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -5,6 +5,10 @@ import type { Climb, BoardDetails } from '@/app/lib/types';
 
 // --- Mocks ---
 
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/original/12x12/default/40/list',
+}));
+
 vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));

--- a/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+let mockPathname = '/b/moonrise-gym/40/list';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+vi.mock('../../board-renderer/board-renderer', () => ({
+  default: () => <div data-testid="board-renderer" />,
+}));
+
+import ClimbThumbnail from '../climb-thumbnail';
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 2,
+  set_ids: [3, 4],
+  images_to_holds: {},
+  holdsData: [],
+  edge_left: 0,
+  edge_right: 100,
+  edge_bottom: 0,
+  edge_top: 100,
+  boardHeight: 100,
+  boardWidth: 100,
+  layout_name: 'Homewall',
+  size_name: '8x12 Full Ride',
+  size_description: 'Main',
+  set_names: ['Main Kicker', 'Aux Kicker'],
+} as BoardDetails;
+
+const climb = {
+  uuid: 'ABC123',
+  name: 'Moon Landing',
+  angle: 40,
+  setter_username: 'setter',
+  description: '',
+  frames: '',
+  ascensionist_count: 0,
+  difficulty: 'V4',
+  quality_average: '3',
+  stars: 0,
+  difficulty_error: '0',
+  litUpHoldsMap: {},
+  benchmark_difficulty: null,
+} as Climb;
+
+describe('ClimbThumbnail', () => {
+  it('preserves board-slug URL context on /b routes', () => {
+    mockPathname = '/b/moonrise-gym/40/list';
+
+    render(
+      <ClimbThumbnail
+        boardDetails={boardDetails}
+        currentClimb={climb}
+        enableNavigation
+      />,
+    );
+
+    const link = screen.getByTestId('climb-thumbnail-link');
+    expect(link.getAttribute('href')).toBe('/b/moonrise-gym/40/view/moon-landing-ABC123');
+  });
+
+  it('falls back to canonical route format outside /b routes', () => {
+    mockPathname = '/kilter/homewall/8x12-main/main-kicker_aux-kicker/40/list';
+
+    render(
+      <ClimbThumbnail
+        boardDetails={boardDetails}
+        currentClimb={climb}
+        enableNavigation
+      />,
+    );
+
+    const link = screen.getByTestId('climb-thumbnail-link');
+    expect(link.getAttribute('href')).toBe('/kilter/homewall/8x12-main/main-kicker_aux-kicker/40/view/moon-landing-ABC123');
+  });
+});

--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -5,6 +5,7 @@ import MuiCard from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
 import CardActions from '@mui/material/CardActions';
+import { usePathname } from 'next/navigation';
 
 import ClimbCardCover from './climb-card-cover';
 import ClimbTitle from './climb-title';
@@ -71,6 +72,7 @@ function ClimbCardWithActions({
   selected?: boolean;
   unsupported?: boolean;
 }) {
+  const pathname = usePathname();
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
   const cover = <ClimbCardCover climb={climb} boardDetails={boardDetails} onClick={onCoverClick} onDoubleClick={onCoverDoubleClick} />;
@@ -106,6 +108,7 @@ function ClimbCardWithActions({
             climb={climb}
             boardDetails={boardDetails}
             angle={climb.angle}
+            currentPathname={pathname}
             viewMode="icon"
             exclude={excludeActions}
           />

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import IconButton from '@mui/material/IconButton';
+import { usePathname } from 'next/navigation';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
@@ -37,6 +38,7 @@ type ClimbListItemProps = {
 };
 
 const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDetails, selected, unsupported, disableSwipe, onSelect }) => {
+  const pathname = usePathname();
   const isDark = useIsDarkMode();
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const queueContext = useOptionalQueueContext();
@@ -240,6 +242,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({ climb, boardDe
           climb={climb}
           boardDetails={boardDetails}
           angle={climb.angle}
+          currentPathname={pathname}
           viewMode="list"
           exclude={excludeActions}
           onActionComplete={() => setIsActionsOpen(false)}

--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { BoardDetails, Climb } from '@/app/lib/types';
 import BoardRenderer from '../board-renderer/board-renderer';
-import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, parseBoardRouteParams } from '@/app/lib/url-utils';
+import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 
 type ClimbThumbnailProps = {
   currentClimb: Climb | null;
@@ -14,30 +15,16 @@ type ClimbThumbnailProps = {
 };
 
 const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, onNavigate, maxHeight }: ClimbThumbnailProps) => {
+  const pathname = usePathname();
+
   if (enableNavigation && currentClimb) {
-    // Use slug-based URL construction if slug names are available
-    const climbViewUrl =
-      boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-        ? constructClimbViewUrlWithSlugs(
-            boardDetails.board_name,
-            boardDetails.layout_name,
-            boardDetails.size_name,
-            boardDetails.size_description,
-            boardDetails.set_names,
-            currentClimb.angle,
-            currentClimb.uuid,
-            currentClimb.name,
-          )
-        : (() => {
-            const routeParams = parseBoardRouteParams({
-              board_name: boardDetails.board_name,
-              layout_id: boardDetails.layout_id.toString(),
-              size_id: boardDetails.size_id.toString(),
-              set_ids: boardDetails.set_ids.join(','),
-              angle: currentClimb.angle.toString(),
-            });
-            return constructClimbViewUrl(routeParams, currentClimb.uuid, currentClimb.name);
-          })();
+    const climbViewUrl = getContextAwareClimbViewUrl(
+      pathname,
+      boardDetails,
+      currentClimb.angle,
+      currentClimb.uuid,
+      currentClimb.name,
+    );
 
     return (
       <Link href={climbViewUrl} onClick={() => onNavigate?.()} data-testid="climb-thumbnail-link">

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { usePathname } from 'next/navigation';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import styles from './climb-view-actions.module.css';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
@@ -15,6 +16,8 @@ type ClimbViewActionsProps = {
 };
 
 const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbViewActionsProps) => {
+  const pathname = usePathname();
+
   const getBackToListUrl = () => {
     const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
 
@@ -40,6 +43,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             climb={climb}
             boardDetails={boardDetails}
             angle={angle}
+            currentPathname={pathname}
             viewMode="button"
             include={['favorite', 'queue']}
             size="default"
@@ -49,6 +53,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             climb={climb}
             boardDetails={boardDetails}
             angle={angle}
+            currentPathname={pathname}
             viewMode="dropdown"
             include={['tick', 'share', 'openInApp']}
             auroraAppUrl={auroraAppUrl}
@@ -65,6 +70,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             climb={climb}
             boardDetails={boardDetails}
             angle={angle}
+            currentPathname={pathname}
             viewMode="button"
             include={['favorite', 'tick', 'queue', 'share', 'openInApp']}
             auroraAppUrl={auroraAppUrl}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -17,6 +17,7 @@ import EditOutlined from '@mui/icons-material/EditOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import HistoryOutlined from '@mui/icons-material/HistoryOutlined';
 import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
 import { useQueueContext } from '../graphql-queue';
 import { useFavorite, ClimbActions } from '../climb-actions';
 import { ShareBoardButton } from '../board-page/share-button';
@@ -83,6 +84,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const [showHistory, setShowHistory] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [queueDrawerHeight, setQueueDrawerHeight] = useState<string>('60%');
+  const pathname = usePathname();
   const queueListRef = useRef<QueueListHandle>(null);
   const queueScrollRef = useRef<HTMLDivElement>(null);
   const [queueScrollEl, setQueueScrollEl] = useState<HTMLDivElement | null>(null);
@@ -383,6 +385,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               climb={currentClimb}
               boardDetails={boardDetails}
               angle={typeof angle === 'string' ? parseInt(angle, 10) : angle}
+              currentPathname={pathname}
               viewMode="list"
               onActionComplete={() => setIsActionsOpen(false)}
             />

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
-import { parseBoardRouteParams, constructClimbViewUrlWithSlugs, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
+import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
 import { track } from '@vercel/analytics';
@@ -42,22 +42,33 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
   };
 
   if (!viewOnlyMode && navigate && nextClimb) {
-    const urlConstructor = isPlayPage ? constructPlayUrlWithSlugs : constructClimbViewUrlWithSlugs;
-    const fallbackPath = isPlayPage ? 'play' : 'view';
+    let climbUrl = '';
 
-    let climbUrl =
-      boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-        ? urlConstructor(
-            boardDetails.board_name,
-            boardDetails.layout_name,
-            boardDetails.size_name,
-            boardDetails.size_description,
-            boardDetails.set_names,
-            angle,
-            nextClimb.climb.uuid,
-            nextClimb.climb.name,
-          )
-        : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/${fallbackPath}/${nextClimb.climb.uuid}`;
+    if (isPlayPage) {
+      climbUrl =
+        boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
+          ? constructPlayUrlWithSlugs(
+              boardDetails.board_name,
+              boardDetails.layout_name,
+              boardDetails.size_name,
+              boardDetails.size_description,
+              boardDetails.set_names,
+              angle,
+              nextClimb.climb.uuid,
+              nextClimb.climb.name,
+            )
+          : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${nextClimb.climb.uuid}`;
+    } else if (boardDetails) {
+      climbUrl = getContextAwareClimbViewUrl(
+        pathname,
+        boardDetails,
+        angle,
+        nextClimb.climb.uuid,
+        nextClimb.climb.name,
+      );
+    } else {
+      climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/view/${nextClimb.climb.uuid}`;
+    }
 
     // Preserve search params in play mode to maintain filter state for back navigation
     if (isPlayPage) {

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
 import { useParams } from 'next/navigation';
-import { parseBoardRouteParams, constructClimbViewUrlWithSlugs, constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
+import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
 import { track } from '@vercel/analytics';
@@ -43,22 +43,33 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
   };
 
   if (!viewOnlyMode && navigate && previousClimb) {
-    const urlConstructor = isPlayPage ? constructPlayUrlWithSlugs : constructClimbViewUrlWithSlugs;
-    const fallbackPath = isPlayPage ? 'play' : 'view';
+    let climbUrl = '';
 
-    let climbUrl =
-      boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-        ? urlConstructor(
-            boardDetails.board_name,
-            boardDetails.layout_name,
-            boardDetails.size_name,
-            boardDetails.size_description,
-            boardDetails.set_names,
-            angle,
-            previousClimb.climb.uuid,
-            previousClimb.climb.name,
-          )
-        : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/${fallbackPath}/${previousClimb.climb.uuid}`;
+    if (isPlayPage) {
+      climbUrl =
+        boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
+          ? constructPlayUrlWithSlugs(
+              boardDetails.board_name,
+              boardDetails.layout_name,
+              boardDetails.size_name,
+              boardDetails.size_description,
+              boardDetails.set_names,
+              angle,
+              previousClimb.climb.uuid,
+              previousClimb.climb.name,
+            )
+          : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${previousClimb.climb.uuid}`;
+    } else if (boardDetails) {
+      climbUrl = getContextAwareClimbViewUrl(
+        pathname,
+        boardDetails,
+        angle,
+        previousClimb.climb.uuid,
+        previousClimb.climb.name,
+      );
+    } else {
+      climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/view/${previousClimb.climb.uuid}`;
+    }
 
     // Preserve search params in play mode to maintain filter state for back navigation
     if (isPlayPage) {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -15,7 +15,7 @@ import { useQueueContext } from '../graphql-queue';
 import NextClimbButton from './next-climb-button';
 import { usePathname, useParams, useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { constructPlayUrlWithSlugs, constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { BoardRouteParameters, BoardDetails, Angle } from '@/app/lib/types';
 import PreviousClimbButton from './previous-climb-button';
 import QueueList, { QueueListHandle } from './queue-list';
@@ -100,23 +100,32 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   // Build URL for a climb item (for navigation on view/play pages)
   const buildClimbUrl = useCallback((climb: { uuid: string; name: string }) => {
-    const urlConstructor = isPlayPage ? constructPlayUrlWithSlugs : constructClimbViewUrlWithSlugs;
-    const fallbackPath = isPlayPage ? 'play' : 'view';
+    let climbUrl: string | null = null;
 
-    let climbUrl = boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-      ? urlConstructor(
-          boardDetails.board_name,
-          boardDetails.layout_name,
-          boardDetails.size_name,
-          boardDetails.size_description,
-          boardDetails.set_names,
-          angle,
-          climb.uuid,
-          climb.name,
-        )
-      : params.board_name
-        ? `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/${fallbackPath}/${climb.uuid}`
-        : null;
+    if (isPlayPage) {
+      climbUrl = boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
+        ? constructPlayUrlWithSlugs(
+            boardDetails.board_name,
+            boardDetails.layout_name,
+            boardDetails.size_name,
+            boardDetails.size_description,
+            boardDetails.set_names,
+            angle,
+            climb.uuid,
+            climb.name,
+          )
+        : params.board_name
+          ? `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`
+          : null;
+    } else {
+      climbUrl = getContextAwareClimbViewUrl(
+        pathname,
+        boardDetails,
+        angle,
+        climb.uuid,
+        climb.name,
+      );
+    }
 
     if (!climbUrl) return null;
 
@@ -128,7 +137,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       }
     }
     return climbUrl;
-  }, [boardDetails, angle, params, searchParams, isPlayPage]);
+  }, [pathname, boardDetails, angle, params, searchParams, isPlayPage]);
 
   // Handle swipe navigation
   const handleSwipeNext = useCallback(() => {

--- a/packages/web/app/components/queue-control/queue-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-list-item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import MuiTooltip from '@mui/material/Tooltip';
 import MuiAvatar from '@mui/material/Avatar';
 import MuiCheckbox from '@mui/material/Checkbox';
@@ -32,7 +32,7 @@ import { useOptionalBoardProvider } from '../board-provider/board-provider-conte
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
-import { constructClimbViewUrl, constructClimbViewUrlWithSlugs, parseBoardRouteParams, constructClimbInfoUrl } from '@/app/lib/url-utils';
+import { constructClimbInfoUrl, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import styles from './queue-list-item.module.css';
 
@@ -117,6 +117,7 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
   onToggleSelect,
 }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
@@ -126,32 +127,17 @@ const QueueListItem: React.FC<QueueListItemProps> = ({
   const handleViewClimb = useCallback(() => {
     if (!item.climb) return;
 
-    const climbViewUrl =
-      boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-        ? constructClimbViewUrlWithSlugs(
-            boardDetails.board_name,
-            boardDetails.layout_name,
-            boardDetails.size_name,
-            boardDetails.size_description,
-            boardDetails.set_names,
-            item.climb.angle,
-            item.climb.uuid,
-            item.climb.name,
-          )
-        : (() => {
-            const routeParams = parseBoardRouteParams({
-              board_name: boardDetails.board_name,
-              layout_id: boardDetails.layout_id.toString(),
-              size_id: boardDetails.size_id.toString(),
-              set_ids: boardDetails.set_ids.join(','),
-              angle: item.climb.angle.toString(),
-            });
-            return constructClimbViewUrl(routeParams, item.climb.uuid, item.climb.name);
-          })();
+    const climbViewUrl = getContextAwareClimbViewUrl(
+      pathname,
+      boardDetails,
+      item.climb.angle,
+      item.climb.uuid,
+      item.climb.name,
+    );
 
     onClimbNavigate?.();
     router.push(climbViewUrl);
-  }, [item.climb, boardDetails, onClimbNavigate, router]);
+  }, [item.climb, pathname, boardDetails, onClimbNavigate, router]);
 
   const handleSwipeLeft = useCallback(() => {
     // Swipe left = remove from queue

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -18,6 +18,8 @@ import {
   getBaseBoardPath,
   getPlaylistsBasePath,
   getContextAwarePlaylistUrl,
+  getContextAwareClimbViewUrl,
+  constructBoardSlugViewUrl,
   constructBoardSlugPlaylistsUrl,
   DEFAULT_SEARCH_PARAMS
 } from '../url-utils';
@@ -978,6 +980,44 @@ describe('constructBoardSlugPlaylistsUrl', () => {
 
   it('should handle angle 0', () => {
     expect(constructBoardSlugPlaylistsUrl('my-board', 0)).toBe('/b/my-board/0/playlists');
+  });
+});
+
+describe('constructBoardSlugViewUrl', () => {
+  it('should construct board-slug view URL with UUID when no climb name is provided', () => {
+    expect(constructBoardSlugViewUrl('my-kilter', 40, 'ABC123')).toBe('/b/my-kilter/40/view/ABC123');
+  });
+
+  it('should construct board-slug view URL with climb slug and UUID when climb name is provided', () => {
+    expect(constructBoardSlugViewUrl('my-kilter', 40, 'ABC123', 'Moon Landing')).toBe('/b/my-kilter/40/view/moon-landing-ABC123');
+  });
+});
+
+describe('getContextAwareClimbViewUrl', () => {
+  const boardDetails = {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 2,
+    set_ids: [3, 4],
+    layout_name: 'Homewall',
+    size_name: '8x12 Full Ride',
+    size_description: 'Main',
+    set_names: ['Main Kicker', 'Aux Kicker'],
+  } as any;
+
+  it('should preserve /b/{slug}/{angle} context from list routes', () => {
+    expect(getContextAwareClimbViewUrl('/b/moonrise-gym/40/list', boardDetails, 40, 'ABC123', 'Moon Landing'))
+      .toBe('/b/moonrise-gym/40/view/moon-landing-ABC123');
+  });
+
+  it('should preserve /b/{slug}/{angle} context from play routes', () => {
+    expect(getContextAwareClimbViewUrl('/b/moonrise-gym/40/play/some-climb', boardDetails, 40, 'ABC123', 'Moon Landing'))
+      .toBe('/b/moonrise-gym/40/view/moon-landing-ABC123');
+  });
+
+  it('should fall back to canonical URL outside /b routes', () => {
+    expect(getContextAwareClimbViewUrl('/kilter/homewall/8x12/main_aux/40/list', boardDetails, 40, 'ABC123', 'Moon Landing'))
+      .toBe('/kilter/homewall/8x12-main/main-kicker_aux-kicker/40/view/moon-landing-ABC123');
   });
 });
 

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -568,8 +568,20 @@ export const constructBoardSlugPlayUrl = (slug: string, angle: number, climbUuid
  * Construct a board slug URL for the climb view.
  * /b/{board-slug}/{angle}/view/{climb_uuid}
  */
-export const constructBoardSlugViewUrl = (slug: string, angle: number, climbUuid: string) =>
-  constructBoardSlugUrl(slug, angle, `view/${climbUuid}`);
+export const constructBoardSlugViewUrl = (
+  slug: string,
+  angle: number,
+  climbUuid: string,
+  climbName?: string,
+) => {
+  if (climbName && climbName.trim()) {
+    const climbSlug = generateSlugFromText(climbName.trim());
+    if (climbSlug) {
+      return constructBoardSlugUrl(slug, angle, `view/${climbSlug}-${climbUuid}`);
+    }
+  }
+  return constructBoardSlugUrl(slug, angle, `view/${climbUuid}`);
+};
 
 /**
  * Construct a board slug URL for the playlists library.
@@ -577,6 +589,59 @@ export const constructBoardSlugViewUrl = (slug: string, angle: number, climbUuid
  */
 export const constructBoardSlugPlaylistsUrl = (slug: string, angle: number) =>
   constructBoardSlugUrl(slug, angle, 'playlists');
+
+const getBoardSlugRouteContext = (pathname: string): { slug: string; angle: number } | null => {
+  const match = pathname.match(/^\/b\/([^/]+)\/(-?\d+)(?:\/|$)/);
+  if (!match) return null;
+
+  const angle = Number(match[2]);
+  if (Number.isNaN(angle)) return null;
+
+  return { slug: match[1], angle };
+};
+
+/**
+ * Build a climb-view URL that preserves board-slug routing context when present.
+ * - On /b/{slug}/{angle}/... routes, returns /b/{slug}/{angle}/view/{slug-uuid|uuid}
+ * - Otherwise, falls back to canonical board URLs.
+ */
+export const getContextAwareClimbViewUrl = (
+  pathname: string,
+  boardDetails: BoardDetails,
+  angle: number,
+  climbUuid: string,
+  climbName?: string,
+): string => {
+  const boardSlugRoute = getBoardSlugRouteContext(pathname);
+  if (boardSlugRoute) {
+    return constructBoardSlugViewUrl(boardSlugRoute.slug, boardSlugRoute.angle, climbUuid, climbName);
+  }
+
+  if (boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names) {
+    return constructClimbViewUrlWithSlugs(
+      boardDetails.board_name,
+      boardDetails.layout_name,
+      boardDetails.size_name,
+      boardDetails.size_description,
+      boardDetails.set_names,
+      angle,
+      climbUuid,
+      climbName,
+    );
+  }
+
+  return constructClimbViewUrl(
+    {
+      board_name: boardDetails.board_name,
+      layout_id: boardDetails.layout_id,
+      size_id: boardDetails.size_id,
+      set_ids: boardDetails.set_ids,
+      angle,
+    },
+    climbUuid,
+    climbName,
+  );
+};
 
 /**
  * Extract the playlists base path from the current pathname.


### PR DESCRIPTION
## Summary
- fix issue #898 by preserving  when navigating to climb detail URLs
- add a shared  helper and use it across list, queue, and climb action link paths
- keep canonical URL behavior for non- routes
- add regression tests for URL utilities and climb thumbnail/detail link generation

## Testing
- npm run test:run --workspace=@boardsesh/web -- app/lib/__tests__/url-utils.test.ts app/components/climb-card/__tests__/climb-thumbnail.test.tsx app/components/climb-actions/__tests__/use-climb-actions.test.ts app/components/climb-actions/actions/__tests__/view-details-action.test.ts app/components/climb-card/__tests__/climb-list-item.test.tsx
- npm run typecheck --workspace=@boardsesh/web

Closes #898