### PR TITLE
Add frosted glass effect with gradient to global header

### DIFF
--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -10,8 +10,10 @@
   height: var(--global-header-height);
   padding: 0 16px;
   padding-top: env(safe-area-inset-top, 0px);
-  background: var(--semantic-surface);
-  border-bottom: 1px solid var(--neutral-200);
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.6));
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   touch-action: manipulation;
 }
 
@@ -65,4 +67,11 @@
   border-radius: 50%;
   background-color: var(--color-primary);
   flex-shrink: 0;
+}
+
+:global(html[data-theme="dark"]) .header {
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.4));
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }


### PR DESCRIPTION
Replace the solid background on the top header with a glassmorphism effect matching the bottom tab bar. Uses a top-to-bottom gradient (more opaque at top, more transparent at bottom) with backdrop-filter blur. Includes dark mode variant with stronger blur and darker tint.

https://claude.ai/code/session_019g2pxtHTsEHrXdz2bXJnZV