### PR TITLE
Fix infinite connect/disconnect loop from stale generation guard

### DIFF
--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -805,10 +805,9 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
 
         const sessionData = await joinSession(graphqlClient);
 
-        // Bail if a newer connection superseded this one (React Strict Mode re-mount)
+        // Bail if a newer connection superseded this one (React Strict Mode re-mount).
+        // Cleanup already disposed the client and reset refs — just return.
         if (connectionGenerationRef.current !== connectionGeneration) {
-          graphqlClient.dispose();
-          isConnectingRef.current = false;
           return;
         }
 


### PR DESCRIPTION
## Summary

- Fixes the connection generation bail-out that was calling `graphqlClient.dispose()` on a null reference, causing a TypeError that cascaded into clearing the active session

## Root cause

The generation counter guard added in #901 had a bug: when the connection effect re-runs (e.g., because a `useCallback` dependency changes), cleanup sets `graphqlClient = null` and schedules disposal. The stale `connect()` closure then resumes after `await joinSession()` and hits `graphqlClient.dispose()` — but `graphqlClient` is already `null`. The resulting TypeError falls into the catch block, which calls `setActiveSession(null)`, disconnecting the *new* connection too. This creates an infinite connect/disconnect loop visible in the backend logs as rapid connect/disconnect pairs with no `joinSession` operations.

## Fix

Remove `graphqlClient.dispose()` and `isConnectingRef.current = false` from the generation bail-out — cleanup already handles both. The bail-out now just returns.

## Test plan

- [ ] Deploy and verify sessions connect successfully (no infinite spinner)
- [ ] Backend logs show `UserJoined` events instead of rapid connect/disconnect cycles
- [ ] No "completed without data" errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)