### PR TITLE
Replace session button with Bluetooth fallback drawer when Web Blueto…

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/bluetooth-fallback-button.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-fallback-button.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useState } from 'react';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
+import AppleOutlined from '@mui/icons-material/Apple';
+import IconButton from '@mui/material/IconButton';
+import MuiButton from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import { useBluetoothContext } from './bluetooth-context';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export const BluetoothFallbackButton = () => {
+  const { isIOS } = useBluetoothContext();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton
+        aria-label="Bluetooth not supported"
+        onClick={() => setIsDrawerOpen(true)}
+        color="error"
+      >
+        <LightbulbOutlined />
+      </IconButton>
+      <SwipeableDrawer
+        title="Connect to Board"
+        placement="bottom"
+        onClose={() => setIsDrawerOpen(false)}
+        open={isDrawerOpen}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+              padding: '12px',
+              background: 'var(--color-warning-bg)',
+              border: `1px solid ${themeTokens.colors.warning}`,
+              borderRadius: themeTokens.borderRadius.md,
+            }}
+          >
+            <Typography variant="body2">
+              Your browser does not support Web Bluetooth, which means you
+              won&#39;t be able to illuminate routes on the board.
+            </Typography>
+            {isIOS ? (
+              <>
+                <Typography variant="body2">
+                  To control your board from an iOS device, install the Bluefy
+                  browser:
+                </Typography>
+                <MuiButton
+                  variant="contained"
+                  startIcon={<AppleOutlined />}
+                  href="https://apps.apple.com/us/app/bluefy-web-ble-browser/id1492822055"
+                  target="_blank"
+                >
+                  Download Bluefy from the App Store
+                </MuiButton>
+              </>
+            ) : (
+              <Typography variant="body2">
+                For the best experience, please use Chrome or another
+                Chromium-based browser.
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      </SwipeableDrawer>
+    </>
+  );
+};

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -25,6 +25,8 @@ import ClimbTitle from '../climb-card/climb-title';
 import { themeTokens } from '@/app/theme/theme-config';
 import { TOUR_DRAWER_EVENT } from '../onboarding/onboarding-tour';
 import { ShareBoardButton } from '../board-page/share-button';
+import { BluetoothFallbackButton } from '../board-bluetooth-control/bluetooth-fallback-button';
+import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMATION_DURATION } from '@/app/hooks/use-card-swipe-navigation';
 import PlayViewDrawer from '../play-view/play-view-drawer';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
@@ -89,6 +91,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const isListPage = pathname.includes('/list');
   const isPlayPage = pathname.includes('/play/');
   const { currentClimb, mirrorClimb, queue, setQueue, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode } = useQueueContext();
+  const { isBluetoothSupported } = useBluetoothContext();
 
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
@@ -388,8 +391,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                     </Stack>
                   </span>
-                  {/* Party button */}
-                  <ShareBoardButton />
+                  {/* Party button or Bluetooth fallback */}
+                  {isBluetoothSupported ? <ShareBoardButton /> : <BluetoothFallbackButton />}
                   {/* Tick button */}
                   <TickButton currentClimb={currentClimb} angle={angle} boardDetails={boardDetails} />
                 </Stack>


### PR DESCRIPTION
…oth unsupported

When the browser doesn't support Web Bluetooth, the party mode button in the queue control bar is replaced with a lightbulb icon button that opens a drawer explaining the limitation and recommending Bluefy for iOS users or Chrome for others.

https://claude.ai/code/session_01F3W6NGWS6rfCTF6VbrPvX7