### PR TITLE
Remove unused 'stale' connection state and extract shared test FakeCl…

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -857,8 +857,7 @@ graphql-ws Client(s)
 | `idle` | No clients registered |
 | `connecting` | Client is establishing a WebSocket connection |
 | `connected` | Client connected and receiving keep-alive pongs |
-| `reconnecting` | Connection lost — `graphql-ws` is retrying |
-| `stale` | No activity received within `STALE_GRACE_MS` |
+| `reconnecting` | Connection lost or stale — `graphql-ws` is retrying |
 | `error` | Client reported an error event |
 
 ### Health Check
@@ -894,7 +893,7 @@ On the server (`typeof window === 'undefined'`), the exported `connectionManager
 
 ### Reconnect UX
 
-The `QueueControlBar` reads connection state from the provider. When `state` is `reconnecting`, `stale`, or `error`:
+The `QueueControlBar` reads connection state from the provider. When `state` is `reconnecting` or `error`:
 
 1. The normal climb info is replaced with a spinner and "Reconnecting..." / "Connection error – retrying..." message.
 2. A "Cancel" button reveals a confirmation row: "Leave session" (calls `endSession` or `disconnect`) vs "Keep reconnecting".

--- a/packages/web/app/components/connection-manager/__tests__/fake-client.ts
+++ b/packages/web/app/components/connection-manager/__tests__/fake-client.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+
+export class FakeClient {
+  listeners = new Map<string, (...args: any[]) => void>();
+  terminate = vi.fn();
+  dispose = vi.fn();
+
+  on(event: string, listener: (...args: any[]) => void) {
+    this.listeners.set(event, listener);
+    return () => this.listeners.delete(event);
+  }
+
+  emit(event: string, ...args: any[]) {
+    const handler = this.listeners.get(event);
+    if (handler) handler(...args);
+  }
+}

--- a/packages/web/app/components/connection-manager/__tests__/websocket-connection-manager.test.ts
+++ b/packages/web/app/components/connection-manager/__tests__/websocket-connection-manager.test.ts
@@ -1,21 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { connectionManager, STALE_GRACE_MS } from '../websocket-connection-manager';
-
-class FakeClient {
-  listeners = new Map<string, (...args: any[]) => void>();
-  terminate = vi.fn();
-  dispose = vi.fn();
-
-  on(event: string, listener: (...args: any[]) => void) {
-    this.listeners.set(event, listener);
-    return () => this.listeners.delete(event);
-  }
-
-  emit(event: string, ...args: any[]) {
-    const handler = this.listeners.get(event);
-    if (handler) handler(...args);
-  }
-}
+import { FakeClient } from './fake-client';
 
 describe('WebSocketConnectionManager', () => {
   let originalVisibilityState: PropertyDescriptor | undefined;

--- a/packages/web/app/components/connection-manager/__tests__/websocket-connection-provider.test.tsx
+++ b/packages/web/app/components/connection-manager/__tests__/websocket-connection-provider.test.tsx
@@ -3,22 +3,7 @@ import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import { connectionManager } from '../websocket-connection-manager';
 import { WebSocketConnectionProvider, useWebSocketConnection } from '../websocket-connection-provider';
-
-class FakeClient {
-  listeners = new Map<string, (...args: any[]) => void>();
-  terminate = vi.fn();
-  dispose = vi.fn();
-
-  on(event: string, listener: (...args: any[]) => void) {
-    this.listeners.set(event, listener);
-    return () => this.listeners.delete(event);
-  }
-
-  emit(event: string, ...args: any[]) {
-    const handler = this.listeners.get(event);
-    if (handler) handler(...args);
-  }
-}
+import { FakeClient } from './fake-client';
 
 function TestConsumer() {
   const { state, name } = useWebSocketConnection();

--- a/packages/web/app/components/connection-manager/websocket-connection-manager.ts
+++ b/packages/web/app/components/connection-manager/websocket-connection-manager.ts
@@ -1,6 +1,6 @@
 import { Client, Event as WsEvent, EventListener as WsEventListener } from 'graphql-ws';
 
-export type ConnectionState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'stale' | 'error';
+export type ConnectionState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error';
 
 type ConnectionSnapshot = {
   name: string | null;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -114,7 +114,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const isDark = mode === 'dark';
   const gradeTintColor = useMemo(() => getGradeTintColor(currentClimb?.difficulty, 'default', isDark), [currentClimb?.difficulty, isDark]);
 
-  const isReconnecting = !!sessionId && (connectionState === 'reconnecting' || connectionState === 'stale' || connectionState === 'error');
+  const isReconnecting = !!sessionId && (connectionState === 'reconnecting' || connectionState === 'error');
 
   const nextClimb = getNextClimbQueueItem();
   const previousClimb = getPreviousClimbQueueItem();


### PR DESCRIPTION
…ient

The 'stale' value in ConnectionState was never assigned anywhere in the state machine — staleness detection always transitioned directly to 'reconnecting'. This removes the dead type variant and the unreachable check in queue-control-bar. Also extracts the duplicated FakeClient test helper into a shared module.

https://claude.ai/code/session_01ELk1C1ABsSUaTgnBRmvoFv