### PR TITLE
Reuse ClimbListItem for suggested items in queue list

### DIFF
--- a/packages/web/app/components/queue-control/queue-list.module.css
+++ b/packages/web/app/components/queue-control/queue-list.module.css
@@ -12,55 +12,9 @@
   flex-direction: column;
 }
 
-.suggestedItem {
-  display: flex;
-  align-items: center;
-}
-
-.suggestedItemRow {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 8px;
-  width: 100%;
-  align-items: center;
-}
-
-.suggestedThumbnailCol {
-  width: 25%;
-}
-
-.suggestedTitleCol {
-  width: 62.5%;
-}
-
-.suggestedActionCol {
-  width: 12.5%;
-}
-
-@media (min-width: 600px) {
-  .suggestedThumbnailCol {
-    width: 20.83%;
-  }
-
-  .suggestedTitleCol {
-    width: 70.83%;
-  }
-
-  .suggestedActionCol {
-    width: 8.33%;
-  }
-}
-
 .loadMoreContainer {
   display: flex;
   flex-direction: column;
-}
-
-.loadMoreSkeletonRow {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 8px;
-  align-items: center;
 }
 
 .noMoreSuggestions {

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useEffect, useState, useCallback, useRef, useImperativeHandle, forwardRef, useMemo } from 'react';
-import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
@@ -15,8 +14,8 @@ import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/ad
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
 import QueueClimbListItem from './queue-climb-list-item';
-import ClimbThumbnail from '../climb-card/climb-thumbnail';
-import ClimbTitle from '../climb-card/climb-title';
+import ClimbListItem from '../climb-card/climb-list-item';
+import { ClimbListItemSkeleton } from '../board-page/board-page-skeleton';
 import { themeTokens } from '@/app/theme/theme-config';
 import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
@@ -182,27 +181,10 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
   // Show only 2 history items above current, so scroll target is at index (length - 2)
   const scrollToHistoryIndex = historyItems.length > 2 ? historyItems.length - 2 : 0;
 
-  // Memoize inline style objects to prevent recreation on every render
-  const suggestedItemStyle = useMemo(
-    () => ({
-      padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[0]}px`,
-      borderBottom: `1px solid var(--neutral-200)`,
-    }),
-    [],
-  );
-
   const loadMoreContainerStyle = useMemo(
     () => ({
       minHeight: themeTokens.spacing[5],
       marginTop: themeTokens.spacing[2],
-    }),
-    [],
-  );
-
-  const loadMoreSkeletonStyle = useMemo(
-    () => ({
-      gap: `${themeTokens.spacing[2]}px`,
-      padding: `${themeTokens.spacing[2]}px`,
     }),
     [],
   );
@@ -304,28 +286,24 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
           <MuiDivider>Suggested Items</MuiDivider>
           <div className={styles.suggestedColumn}>
             {suggestedClimbs.map((climb: Climb) => (
-              <div
+              <ClimbListItem
                 key={`suggested-${climb.uuid}`}
-                className={styles.suggestedItem}
-                style={suggestedItemStyle}
-              >
-                <div className={styles.suggestedItemRow}>
-                  <div className={styles.suggestedThumbnailCol}>
-                    <ClimbThumbnail
-                      boardDetails={boardDetails}
-                      currentClimb={climb}
-                      enableNavigation={true}
-                      onNavigate={onClimbNavigate}
-                    />
-                  </div>
-                  <div className={styles.suggestedTitleCol}>
-                    <ClimbTitle climb={climb} showAngle centered />
-                  </div>
-                  <div className={styles.suggestedActionCol}>
-                    <IconButton onClick={() => addToQueue(climb)}><AddOutlined /></IconButton>
-                  </div>
-                </div>
-              </div>
+                climb={climb}
+                boardDetails={boardDetails}
+                onSelect={() => addToQueue(climb)}
+                menuSlot={
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      addToQueue(climb);
+                    }}
+                    style={{ flexShrink: 0, color: 'var(--neutral-400)' }}
+                  >
+                    <AddOutlined />
+                  </IconButton>
+                }
+              />
             ))}
           </div>
           {/* Sentinel element for Intersection Observer - only render when needed */}
@@ -336,22 +314,9 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
               style={loadMoreContainerStyle}
             >
               {(isFetchingClimbs || isFetchingNextPage) && (
-                <div
-                  className={styles.loadMoreContainer}
-                  style={loadMoreSkeletonStyle}
-                >
+                <div className={styles.loadMoreContainer}>
                   {[1, 2, 3].map((i) => (
-                    <div key={i} className={styles.loadMoreSkeletonRow}>
-                      <div className={styles.suggestedThumbnailCol}>
-                        <Skeleton variant="rectangular" width="100%" height={60} animation="wave" />
-                      </div>
-                      <div className={styles.suggestedTitleCol}>
-                        <Skeleton variant="text" animation="wave" />
-                      </div>
-                      <div className={styles.suggestedActionCol}>
-                        <Skeleton variant="rectangular" width={32} height={32} animation="wave" />
-                      </div>
-                    </div>
+                    <ClimbListItemSkeleton key={i} />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
Replace the custom inline layout (ClimbThumbnail + ClimbTitle + IconButton) with the reusable ClimbListItem component, keeping a "+" button as the menuSlot for quick add-to-queue. Also replace custom loading skeletons with ClimbListItemSkeleton for visual consistency.

https://claude.ai/code/session_01Mi4EYHj6wivFPfixZjauR2