### PR TITLE
refactor: use React Query cache for session live updates instead of s…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ We are using next.js app router, it's important we try to use server side compon
 #### Data Flow
 
 1. **Server Components**: Initial data fetching in page components
-2. **Client Components**: Interactive features with SWR for data fetching
+2. **Client Components**: Interactive features with React Query (`@tanstack/react-query`) for data fetching
 3. **API Routes**: Two patterns:
    - `/api/internal/...` - Server-side data operations
    - `/api/v1/[board]/proxy/...` - Aurora API proxies

--- a/packages/web/app/components/graphql-queue/__tests__/offline-mutations.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/offline-mutations.test.tsx
@@ -66,7 +66,6 @@ const mockPersistentSession = {
   subscribeToSessionEvents: vi.fn(() => vi.fn()),
   triggerResync: vi.fn(),
   endSessionWithSummary: vi.fn(),
-  liveSessionStats: null,
   sessionSummary: null,
   sessionSummaryBoardType: null,
   sessionSummaryHealthKitWorkoutId: null,

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEventProcessor } from '../hooks/use-event-processor';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import type { Climb } from '@/app/lib/types';
@@ -44,10 +46,16 @@ function createRefs(offlineBuffer: LocalClimbQueueItem[] = []) {
   };
 }
 
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
 describe('useEventProcessor - offline FullSync merge', () => {
   it('FullSync with no offline buffer behaves normally', () => {
     const refs = createRefs([]);
-    const { result } = renderHook(() => useEventProcessor({ refs }));
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -71,7 +79,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
   it('FullSync merges offline buffer items into server queue', () => {
     const offlineItem = createItem('offline-1');
     const refs = createRefs([offlineItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }));
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -97,7 +105,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
   it('FullSync does not duplicate items with same UUID', () => {
     const sharedItem = createItem('shared-1');
     const refs = createRefs([sharedItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }));
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
     act(() => {
       result.current.handleQueueEvent({
@@ -120,7 +128,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
   it('FullSync still filters null/corrupted items with merge', () => {
     const offlineItem = createItem('offline-1');
     const refs = createRefs([offlineItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }));
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -146,7 +154,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
   it('non-FullSync events still work normally', () => {
     const refs = createRefs([]);
     refs.lastReceivedSequenceRef.current = 4;
-    const { result } = renderHook(() => useEventProcessor({ refs }));
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
     const addedItem = createItem('added-1');
 

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEventProcessor } from '../hooks/use-event-processor';
+import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
+import type { SessionEvent, SessionDetail, SessionDetailTick } from '@boardsesh/shared-schema';
+import type { SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import { SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
+
+function createRefs() {
+  return {
+    lastReceivedSequenceRef: { current: null as number | null },
+    triggerResyncRef: { current: null as (() => void) | null },
+    lastCorruptionResyncRef: { current: 0 },
+    isFilteringCorruptedItemsRef: { current: false },
+    queueEventSubscribersRef: { current: new Set<(event: SubscriptionQueueEvent) => void>() },
+    sessionEventSubscribersRef: { current: new Set() } as never,
+    offlineBufferRef: { current: [] as LocalClimbQueueItem[] },
+  };
+}
+
+function createStatsEvent(overrides: Partial<Extract<SessionEvent, { __typename: 'SessionStatsUpdated' }>> = {}): SessionEvent {
+  return {
+    __typename: 'SessionStatsUpdated',
+    sessionId: 'session-abc',
+    totalSends: 3,
+    totalFlashes: 1,
+    totalAttempts: 2,
+    tickCount: 5,
+    participants: [],
+    gradeDistribution: [],
+    boardTypes: ['kilter'],
+    hardestGrade: 'V5',
+    durationMinutes: 45,
+    goal: 'Send V5',
+    ticks: [],
+    ...overrides,
+  };
+}
+
+function createTick(climbedAt: string): SessionDetailTick {
+  return {
+    uuid: `tick-${climbedAt}`,
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    angle: 40,
+    status: 'send',
+    attemptCount: 1,
+    isMirror: false,
+    isBenchmark: false,
+    isNoMatch: false,
+    climbedAt,
+    boardType: 'kilter',
+    userId: 'user-1',
+    upvotes: 0,
+  };
+}
+
+describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => {
+  let queryClient: QueryClient;
+
+  function createWrapper() {
+    return ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  it('seeds cache when no existing data', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent());
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached).not.toBeNull();
+    expect(cached!.totalSends).toBe(3);
+    expect(cached!.totalFlashes).toBe(1);
+    expect(cached!.totalAttempts).toBe(2);
+    expect(cached!.tickCount).toBe(5);
+    expect(cached!.boardTypes).toEqual(['kilter']);
+    expect(cached!.hardestGrade).toBe('V5');
+    expect(cached!.durationMinutes).toBe(45);
+    expect(cached!.goal).toBe('Send V5');
+  });
+
+  it('defaults sessionType to party when seeding', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent());
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.sessionType).toBe('party');
+  });
+
+  it('sets firstTickAt/lastTickAt to empty string when no ticks and no prev data', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks: [] }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.firstTickAt).toBe('');
+    expect(cached!.lastTickAt).toBe('');
+  });
+
+  it('derives firstTickAt/lastTickAt from ticks when present', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    const ticks = [
+      createTick('2026-04-30T10:00:00Z'),
+      createTick('2026-04-30T09:30:00Z'),
+      createTick('2026-04-30T09:00:00Z'),
+    ];
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.lastTickAt).toBe('2026-04-30T10:00:00Z');
+    expect(cached!.firstTickAt).toBe('2026-04-30T09:00:00Z');
+  });
+
+  it('merges into existing cached data, preserving sessionType and ownerUserId', () => {
+    const existingData: SessionDetail = {
+      sessionId: 'session-abc',
+      sessionType: 'inferred',
+      sessionName: 'My Inferred Session',
+      ownerUserId: 'owner-123',
+      participants: [],
+      totalSends: 1,
+      totalFlashes: 0,
+      totalAttempts: 1,
+      tickCount: 1,
+      gradeDistribution: [],
+      boardTypes: ['kilter'],
+      hardestGrade: 'V3',
+      firstTickAt: '2026-04-30T08:00:00Z',
+      lastTickAt: '2026-04-30T08:00:00Z',
+      durationMinutes: 10,
+      goal: null,
+      ticks: [],
+      upvotes: 5,
+      downvotes: 1,
+      voteScore: 4,
+      commentCount: 3,
+    };
+
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), existingData);
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(
+        createStatsEvent({
+          totalSends: 5,
+          totalFlashes: 2,
+          hardestGrade: 'V6',
+          ticks: [createTick('2026-04-30T11:00:00Z')],
+        }),
+      );
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.sessionType).toBe('inferred');
+    expect(cached!.ownerUserId).toBe('owner-123');
+    expect(cached!.sessionName).toBe('My Inferred Session');
+    expect(cached!.upvotes).toBe(5);
+    expect(cached!.commentCount).toBe(3);
+    expect(cached!.totalSends).toBe(5);
+    expect(cached!.totalFlashes).toBe(2);
+    expect(cached!.hardestGrade).toBe('V6');
+  });
+
+  it('preserves prev firstTickAt/lastTickAt when merging with no ticks', () => {
+    const existingData: SessionDetail = {
+      sessionId: 'session-abc',
+      sessionType: 'party',
+      sessionName: null,
+      ownerUserId: null,
+      participants: [],
+      totalSends: 0,
+      totalFlashes: 0,
+      totalAttempts: 0,
+      tickCount: 0,
+      gradeDistribution: [],
+      boardTypes: [],
+      hardestGrade: null,
+      firstTickAt: '2026-04-30T08:00:00Z',
+      lastTickAt: '2026-04-30T09:00:00Z',
+      durationMinutes: null,
+      goal: null,
+      ticks: [],
+      upvotes: 0,
+      downvotes: 0,
+      voteScore: 0,
+      commentCount: 0,
+    };
+
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), existingData);
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks: [] }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.firstTickAt).toBe('2026-04-30T08:00:00Z');
+    expect(cached!.lastTickAt).toBe('2026-04-30T09:00:00Z');
+  });
+
+  it('notifies session event subscribers', () => {
+    const refs = createRefs();
+    const subscriberCalls: SessionEvent[] = [];
+    (refs.sessionEventSubscribersRef as { current: Set<(event: SessionEvent) => void> }).current.add((e) =>
+      subscriberCalls.push(e),
+    );
+
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    const event = createStatsEvent();
+    act(() => {
+      result.current.handleSessionEvent(event);
+    });
+
+    expect(subscriberCalls).toHaveLength(1);
+    expect(subscriberCalls[0]).toBe(event);
+  });
+
+  it('handles non-SessionStatsUpdated events without touching cache', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent({
+        __typename: 'UserJoined',
+        user: { id: 'user-1', username: 'test', isLeader: false },
+      });
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached).toBeUndefined();
+  });
+});

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -4,8 +4,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEventProcessor } from '../hooks/use-event-processor';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import type { SessionEvent, SessionDetail, SessionDetailTick } from '@boardsesh/shared-schema';
-import type { SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import type { SessionEvent, SessionDetail, SessionDetailTick, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
 import { SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
 
 function createRefs() {
@@ -15,12 +14,14 @@ function createRefs() {
     lastCorruptionResyncRef: { current: 0 },
     isFilteringCorruptedItemsRef: { current: false },
     queueEventSubscribersRef: { current: new Set<(event: SubscriptionQueueEvent) => void>() },
-    sessionEventSubscribersRef: { current: new Set() } as never,
+    sessionEventSubscribersRef: { current: new Set<(event: SessionEvent) => void>() },
     offlineBufferRef: { current: [] as LocalClimbQueueItem[] },
   };
 }
 
-function createStatsEvent(overrides: Partial<Extract<SessionEvent, { __typename: 'SessionStatsUpdated' }>> = {}): SessionEvent {
+function createStatsEvent(
+  overrides: Partial<Extract<SessionEvent, { __typename: 'SessionStatsUpdated' }>> = {},
+): SessionEvent {
   return {
     __typename: 'SessionStatsUpdated',
     sessionId: 'session-abc',
@@ -57,6 +58,33 @@ function createTick(climbedAt: string): SessionDetailTick {
   };
 }
 
+function createExistingSession(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    sessionId: 'session-abc',
+    sessionType: 'party',
+    sessionName: null,
+    ownerUserId: null,
+    participants: [],
+    totalSends: 0,
+    totalFlashes: 0,
+    totalAttempts: 0,
+    tickCount: 0,
+    gradeDistribution: [],
+    boardTypes: [],
+    hardestGrade: null,
+    firstTickAt: '2026-04-30T08:00:00Z',
+    lastTickAt: '2026-04-30T09:00:00Z',
+    durationMinutes: null,
+    goal: null,
+    ticks: [],
+    upvotes: 0,
+    downvotes: 0,
+    voteScore: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}
+
 describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => {
   let queryClient: QueryClient;
 
@@ -69,7 +97,21 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   });
 
-  it('seeds cache when no existing data', () => {
+  it('does not seed cache when no existing data (waits for HTTP fetch)', () => {
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent());
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached).toBeUndefined();
+  });
+
+  it('updates stats in existing cached data', () => {
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
+
     const refs = createRefs();
     const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
 
@@ -89,76 +131,19 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     expect(cached!.goal).toBe('Send V5');
   });
 
-  it('defaults sessionType to party when seeding', () => {
-    const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
-
-    act(() => {
-      result.current.handleSessionEvent(createStatsEvent());
-    });
-
-    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
-    expect(cached!.sessionType).toBe('party');
-  });
-
-  it('sets firstTickAt/lastTickAt to empty string when no ticks and no prev data', () => {
-    const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
-
-    act(() => {
-      result.current.handleSessionEvent(createStatsEvent({ ticks: [] }));
-    });
-
-    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
-    expect(cached!.firstTickAt).toBe('');
-    expect(cached!.lastTickAt).toBe('');
-  });
-
-  it('derives firstTickAt/lastTickAt from ticks when present', () => {
-    const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
-
-    const ticks = [
-      createTick('2026-04-30T10:00:00Z'),
-      createTick('2026-04-30T09:30:00Z'),
-      createTick('2026-04-30T09:00:00Z'),
-    ];
-
-    act(() => {
-      result.current.handleSessionEvent(createStatsEvent({ ticks }));
-    });
-
-    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
-    expect(cached!.lastTickAt).toBe('2026-04-30T10:00:00Z');
-    expect(cached!.firstTickAt).toBe('2026-04-30T09:00:00Z');
-  });
-
-  it('merges into existing cached data, preserving sessionType and ownerUserId', () => {
-    const existingData: SessionDetail = {
-      sessionId: 'session-abc',
-      sessionType: 'inferred',
-      sessionName: 'My Inferred Session',
-      ownerUserId: 'owner-123',
-      participants: [],
-      totalSends: 1,
-      totalFlashes: 0,
-      totalAttempts: 1,
-      tickCount: 1,
-      gradeDistribution: [],
-      boardTypes: ['kilter'],
-      hardestGrade: 'V3',
-      firstTickAt: '2026-04-30T08:00:00Z',
-      lastTickAt: '2026-04-30T08:00:00Z',
-      durationMinutes: 10,
-      goal: null,
-      ticks: [],
-      upvotes: 5,
-      downvotes: 1,
-      voteScore: 4,
-      commentCount: 3,
-    };
-
-    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), existingData);
+  it('preserves sessionType, ownerUserId, and social fields when merging', () => {
+    queryClient.setQueryData(
+      SESSION_DETAIL_QUERY_KEY('session-abc'),
+      createExistingSession({
+        sessionType: 'inferred',
+        sessionName: 'My Inferred Session',
+        ownerUserId: 'owner-123',
+        upvotes: 5,
+        downvotes: 1,
+        voteScore: 4,
+        commentCount: 3,
+      }),
+    );
 
     const refs = createRefs();
     const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
@@ -185,32 +170,29 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     expect(cached!.hardestGrade).toBe('V6');
   });
 
-  it('preserves prev firstTickAt/lastTickAt when merging with no ticks', () => {
-    const existingData: SessionDetail = {
-      sessionId: 'session-abc',
-      sessionType: 'party',
-      sessionName: null,
-      ownerUserId: null,
-      participants: [],
-      totalSends: 0,
-      totalFlashes: 0,
-      totalAttempts: 0,
-      tickCount: 0,
-      gradeDistribution: [],
-      boardTypes: [],
-      hardestGrade: null,
-      firstTickAt: '2026-04-30T08:00:00Z',
-      lastTickAt: '2026-04-30T09:00:00Z',
-      durationMinutes: null,
-      goal: null,
-      ticks: [],
-      upvotes: 0,
-      downvotes: 0,
-      voteScore: 0,
-      commentCount: 0,
-    };
+  it('derives firstTickAt/lastTickAt from ticks when present', () => {
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
-    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), existingData);
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    const ticks = [
+      createTick('2026-04-30T10:00:00Z'),
+      createTick('2026-04-30T09:30:00Z'),
+      createTick('2026-04-30T09:00:00Z'),
+    ];
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.lastTickAt).toBe('2026-04-30T10:00:00Z');
+    expect(cached!.firstTickAt).toBe('2026-04-30T09:00:00Z');
+  });
+
+  it('preserves prev firstTickAt/lastTickAt when merging with no ticks', () => {
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
     const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -180,37 +180,16 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
       if (event.__typename === 'SessionStatsUpdated') {
         const queryKey = SESSION_DETAIL_QUERY_KEY(event.sessionId);
         queryClient.setQueryData<SessionDetail | null>(queryKey, (prev) => {
+          if (!prev) return prev;
+
+          // ticks are ordered newest-first (descending by climbedAt)
           const ticks = event.ticks;
           const firstTickAt = ticks.length > 0
             ? ticks[ticks.length - 1].climbedAt
-            : prev?.firstTickAt;
+            : prev.firstTickAt;
           const lastTickAt = ticks.length > 0
             ? ticks[0].climbedAt
-            : prev?.lastTickAt;
-
-          if (!prev) {
-            return {
-              sessionId: event.sessionId,
-              sessionType: 'party' as const,
-              participants: event.participants,
-              totalSends: event.totalSends,
-              totalFlashes: event.totalFlashes,
-              totalAttempts: event.totalAttempts,
-              tickCount: event.tickCount,
-              gradeDistribution: event.gradeDistribution,
-              boardTypes: event.boardTypes,
-              hardestGrade: event.hardestGrade,
-              firstTickAt: firstTickAt ?? '',
-              lastTickAt: lastTickAt ?? '',
-              durationMinutes: event.durationMinutes,
-              goal: event.goal,
-              ticks,
-              upvotes: 0,
-              downvotes: 0,
-              voteScore: 0,
-              commentCount: 0,
-            };
-          }
+            : prev.lastTickAt;
 
           return {
             ...prev,
@@ -225,8 +204,8 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
             durationMinutes: event.durationMinutes,
             goal: event.goal,
             ticks,
-            firstTickAt: firstTickAt ?? prev.firstTickAt,
-            lastTickAt: lastTickAt ?? prev.lastTickAt,
+            firstTickAt,
+            lastTickAt,
           };
         });
       }

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -1,8 +1,10 @@
 import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
-import type { SubscriptionQueueEvent, SessionEvent, SessionLiveStats } from '@boardsesh/shared-schema';
+import { useQueryClient } from '@tanstack/react-query';
+import type { SubscriptionQueueEvent, SessionEvent, SessionDetail } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { evaluateQueueEventSequence, insertQueueItemIdempotent } from '../event-utils';
 import { type SharedRefs, DEBUG } from '../types';
+import { SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
 
 type UseEventProcessorArgs = {
   refs: Pick<
@@ -21,7 +23,6 @@ export type EventProcessorState = {
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
   lastReceivedStateHash: string | null;
-  liveSessionStats: SessionLiveStats | null;
 };
 
 export type EventProcessorActions = {
@@ -29,7 +30,6 @@ export type EventProcessorActions = {
   handleSessionEvent: (event: SessionEvent) => void;
   setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
   setCurrentClimbQueueItem: Dispatch<SetStateAction<LocalClimbQueueItem | null>>;
-  setLiveSessionStats: Dispatch<SetStateAction<SessionLiveStats | null>>;
   notifyQueueSubscribers: (event: SubscriptionQueueEvent) => void;
   notifySessionSubscribers: (event: SessionEvent) => void;
 };
@@ -45,10 +45,11 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
     offlineBufferRef,
   } = refs;
 
+  const queryClient = useQueryClient();
+
   const [queue, setQueueState] = useState<LocalClimbQueueItem[]>([]);
   const [currentClimbQueueItem, setCurrentClimbQueueItem] = useState<LocalClimbQueueItem | null>(null);
   const [lastReceivedStateHash, setLastReceivedStateHash] = useState<string | null>(null);
-  const [liveSessionStats, setLiveSessionStats] = useState<SessionLiveStats | null>(null);
 
   // Notify queue event subscribers
   const notifyQueueSubscribers = useCallback(
@@ -176,39 +177,72 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
   // Handle session events internally
   const handleSessionEvent = useCallback(
     (event: SessionEvent) => {
-      // This is handled externally by the session lifecycle hook via setSession
-      // We only handle stats updates here and forward to subscribers
       if (event.__typename === 'SessionStatsUpdated') {
-        setLiveSessionStats({
-          sessionId: event.sessionId,
-          totalSends: event.totalSends,
-          totalFlashes: event.totalFlashes,
-          totalAttempts: event.totalAttempts,
-          tickCount: event.tickCount,
-          participants: event.participants,
-          gradeDistribution: event.gradeDistribution,
-          boardTypes: event.boardTypes,
-          hardestGrade: event.hardestGrade,
-          durationMinutes: event.durationMinutes,
-          goal: event.goal,
-          ticks: event.ticks,
+        const queryKey = SESSION_DETAIL_QUERY_KEY(event.sessionId);
+        queryClient.setQueryData<SessionDetail | null>(queryKey, (prev) => {
+          const ticks = event.ticks;
+          const firstTickAt = ticks.length > 0
+            ? ticks[ticks.length - 1].climbedAt
+            : prev?.firstTickAt;
+          const lastTickAt = ticks.length > 0
+            ? ticks[0].climbedAt
+            : prev?.lastTickAt;
+
+          if (!prev) {
+            return {
+              sessionId: event.sessionId,
+              sessionType: 'party' as const,
+              participants: event.participants,
+              totalSends: event.totalSends,
+              totalFlashes: event.totalFlashes,
+              totalAttempts: event.totalAttempts,
+              tickCount: event.tickCount,
+              gradeDistribution: event.gradeDistribution,
+              boardTypes: event.boardTypes,
+              hardestGrade: event.hardestGrade,
+              firstTickAt: firstTickAt ?? '',
+              lastTickAt: lastTickAt ?? '',
+              durationMinutes: event.durationMinutes,
+              goal: event.goal,
+              ticks,
+              upvotes: 0,
+              downvotes: 0,
+              voteScore: 0,
+              commentCount: 0,
+            };
+          }
+
+          return {
+            ...prev,
+            participants: event.participants,
+            totalSends: event.totalSends,
+            totalFlashes: event.totalFlashes,
+            totalAttempts: event.totalAttempts,
+            tickCount: event.tickCount,
+            gradeDistribution: event.gradeDistribution,
+            boardTypes: event.boardTypes,
+            hardestGrade: event.hardestGrade,
+            durationMinutes: event.durationMinutes,
+            goal: event.goal,
+            ticks,
+            firstTickAt: firstTickAt ?? prev.firstTickAt,
+            lastTickAt: lastTickAt ?? prev.lastTickAt,
+          };
         });
       }
       notifySessionSubscribers(event);
     },
-    [notifySessionSubscribers],
+    [queryClient, notifySessionSubscribers],
   );
 
   return {
     queue,
     currentClimbQueueItem,
     lastReceivedStateHash,
-    liveSessionStats,
     handleQueueEvent,
     handleSessionEvent,
     setQueueState,
     setCurrentClimbQueueItem,
-    setLiveSessionStats,
     notifyQueueSubscribers,
     notifySessionSubscribers,
   };

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -1,18 +1,15 @@
 import { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
-import type { SubscriptionQueueEvent, SessionEvent, SessionLiveStats } from '@boardsesh/shared-schema';
+import type { SubscriptionQueueEvent, SessionEvent } from '@boardsesh/shared-schema';
 import { computeQueueStateHash } from '@/app/utils/hash';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import { type Session, type ActiveSessionInfo, type SharedRefs, CORRUPTION_RESYNC_COOLDOWN_MS, DEBUG } from '../types';
+import { type Session, type SharedRefs, CORRUPTION_RESYNC_COOLDOWN_MS, DEBUG } from '../types';
 
 type UseSessionSubscriptionsArgs = {
   session: Session | null;
-  activeSession: ActiveSessionInfo | null;
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
   lastReceivedStateHash: string | null;
-  liveSessionStats: { sessionId: string } | null;
   setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
-  setLiveSessionStats: Dispatch<SetStateAction<SessionLiveStats | null>>;
   refs: Pick<
     SharedRefs,
     | 'triggerResyncRef'
@@ -31,13 +28,10 @@ export type SessionSubscriptionsActions = {
 
 export function useSessionSubscriptions({
   session,
-  activeSession,
   queue,
   currentClimbQueueItem,
   lastReceivedStateHash,
-  liveSessionStats: _liveSessionStats,
   setQueueState,
-  setLiveSessionStats,
   refs,
 }: UseSessionSubscriptionsArgs): SessionSubscriptionsActions {
   const {
@@ -136,14 +130,6 @@ export function useSessionSubscriptions({
       }
     }
   }, [session, currentClimbQueueItem, queue, triggerResyncRef]);
-
-  // Reset live stats when active session changes or clears
-  useEffect(() => {
-    setLiveSessionStats((prev: SessionLiveStats | null) => {
-      if (!activeSession) return null;
-      return prev?.sessionId === activeSession.sessionId ? prev : null;
-    });
-  }, [activeSession, setLiveSessionStats]);
 
   // Event subscription functions
   const subscribeToQueueEvents = useCallback(

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -139,13 +139,10 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   // 5. Session subscriptions: periodic verification, event subscriptions, corruption checks
   const subscriptions = useSessionSubscriptions({
     session: lifecycle.session,
-    activeSession: lifecycle.activeSession,
     queue: eventProcessor.queue,
     currentClimbQueueItem: eventProcessor.currentClimbQueueItem,
     lastReceivedStateHash: eventProcessor.lastReceivedStateHash,
-    liveSessionStats: eventProcessor.liveSessionStats,
     setQueueState: eventProcessor.setQueueState,
-    setLiveSessionStats: eventProcessor.setLiveSessionStats,
     refs,
   });
 
@@ -209,7 +206,6 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
       isLocalQueueLoaded: queueStorage.isLocalQueueLoaded,
       offlineBufferRef,
       lastReceivedSequenceRef,
-      liveSessionStats: eventProcessor.liveSessionStats,
       sessionSummary: lifecycle.sessionSummary,
       sessionSummaryBoardType: lifecycle.sessionSummaryBoardType ?? null,
       sessionSummaryHealthKitWorkoutId: lifecycle.sessionSummaryHealthKitWorkoutId ?? null,
@@ -225,7 +221,6 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
       lifecycle.sessionSummaryHealthKitWorkoutId,
       eventProcessor.currentClimbQueueItem,
       eventProcessor.queue,
-      eventProcessor.liveSessionStats,
       queueStorage.localQueue,
       queueStorage.localCurrentClimbQueueItem,
       queueStorage.localBoardPath,

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -4,7 +4,6 @@ import type {
   SessionUser,
   SubscriptionQueueEvent,
   SessionEvent,
-  SessionLiveStats,
   SessionSummary,
   QueueState,
 } from '@boardsesh/shared-schema';
@@ -121,7 +120,6 @@ export type PersistentSessionStateType = {
   // Ref for last received sequence number (used by reconciliation to detect server changes)
   lastReceivedSequenceRef: MutableRefObject<number | null>;
 
-  liveSessionStats: SessionLiveStats | null;
   sessionSummary: SessionSummary | null;
   sessionSummaryBoardType: string | null;
   sessionSummaryHealthKitWorkoutId: string | null;

--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -20,28 +20,26 @@ const mockDeactivateSession = vi.fn();
 let mockAngle: number | undefined = 40;
 let mockBoardDetails: Record<string, unknown> | null = { board_name: 'kilter' };
 let mockSessionDetail: Record<string, unknown> | null = {
-  sessionDetail: {
-    sessionId: 'session-123',
-    sessionType: 'party',
-    sessionName: 'Morning Sesh',
-    participants: [],
-    totalSends: 0,
-    totalFlashes: 0,
-    totalAttempts: 0,
-    tickCount: 0,
-    gradeDistribution: [],
-    boardTypes: [],
-    hardestGrade: null,
-    durationMinutes: 30,
-    goal: 'Send V5',
-    ticks: [],
-    upvotes: 0,
-    downvotes: 0,
-    voteScore: 0,
-    commentCount: 0,
-    firstTickAt: new Date().toISOString(),
-    lastTickAt: new Date().toISOString(),
-  },
+  sessionId: 'session-123',
+  sessionType: 'party',
+  sessionName: 'Morning Sesh',
+  participants: [],
+  totalSends: 0,
+  totalFlashes: 0,
+  totalAttempts: 0,
+  tickCount: 0,
+  gradeDistribution: [],
+  boardTypes: [],
+  hardestGrade: null,
+  durationMinutes: 30,
+  goal: 'Send V5',
+  ticks: [],
+  upvotes: 0,
+  downvotes: 0,
+  voteScore: 0,
+  commentCount: 0,
+  firstTickAt: new Date().toISOString(),
+  lastTickAt: new Date().toISOString(),
 };
 
 vi.mock('next/navigation', () => ({
@@ -58,13 +56,11 @@ vi.mock('@/app/components/persistent-session/persistent-session-context', () => 
     session: mockSession,
     users: [],
     deactivateSession: mockDeactivateSession,
-    liveSessionStats: null,
   }),
   usePersistentSessionState: () => ({
     activeSession: mockActiveSession,
     session: mockSession,
     users: [],
-    liveSessionStats: null,
   }),
   usePersistentSessionActions: () => ({
     deactivateSession: mockDeactivateSession,
@@ -83,16 +79,16 @@ vi.mock('@/app/lib/climb-session-cookie', () => ({
   clearClimbSessionCookie: (...args: unknown[]) => mockClearClimbSessionCookie(...args),
 }));
 
-vi.mock('@/app/hooks/use-ws-auth-token', () => ({
-  useWsAuthToken: () => ({ token: null }),
-}));
-
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: () => ({
-    data: mockSessionDetail,
+vi.mock('@/app/hooks/use-session-detail', () => ({
+  useSessionDetail: () => ({
+    session: mockSessionDetail,
     isLoading: false,
     isError: false,
+    updateSession: { mutateAsync: vi.fn(), isPending: false },
+    addUser: { mutateAsync: vi.fn(), isPending: false },
+    removeUser: { mutateAsync: vi.fn(), isPending: false },
   }),
+  SESSION_DETAIL_QUERY_KEY: (id: string) => ['sessionDetail', id],
 }));
 
 vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
@@ -131,13 +127,6 @@ vi.mock('@/app/hooks/use-session-timer', () => ({
   useSessionTimer: () => null,
 }));
 
-vi.mock('@/app/lib/graphql/client', () => ({
-  createGraphQLHttpClient: () => ({ request: vi.fn() }),
-}));
-
-vi.mock('@/app/lib/graphql/operations/activity-feed', () => ({
-  GET_SESSION_DETAIL: 'query GetSessionDetail',
-}));
 
 vi.mock('@/app/lib/share-utils', () => ({
   shareWithFallback: vi.fn(),
@@ -205,28 +194,26 @@ describe('SeshSettingsDrawer', () => {
     mockAngle = 40;
     mockBoardDetails = { board_name: 'kilter' };
     mockSessionDetail = {
-      sessionDetail: {
-        sessionId: 'session-123',
-        sessionType: 'party',
-        sessionName: 'Morning Sesh',
-        participants: [],
-        totalSends: 0,
-        totalFlashes: 0,
-        totalAttempts: 0,
-        tickCount: 0,
-        gradeDistribution: [],
-        boardTypes: [],
-        hardestGrade: null,
-        durationMinutes: 30,
-        goal: 'Send V5',
-        ticks: [],
-        upvotes: 0,
-        downvotes: 0,
-        voteScore: 0,
-        commentCount: 0,
-        firstTickAt: new Date().toISOString(),
-        lastTickAt: new Date().toISOString(),
-      },
+      sessionId: 'session-123',
+      sessionType: 'party',
+      sessionName: 'Morning Sesh',
+      participants: [],
+      totalSends: 0,
+      totalFlashes: 0,
+      totalAttempts: 0,
+      tickCount: 0,
+      gradeDistribution: [],
+      boardTypes: [],
+      hardestGrade: null,
+      durationMinutes: 30,
+      goal: 'Send V5',
+      ticks: [],
+      upvotes: 0,
+      downvotes: 0,
+      voteScore: 0,
+      commentCount: 0,
+      firstTickAt: new Date().toISOString(),
+      lastTickAt: new Date().toISOString(),
     };
   });
 

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -11,7 +11,6 @@ import IosShare from '@mui/icons-material/IosShare';
 import QrCode2Outlined from '@mui/icons-material/QrCode2Outlined';
 import IconButton from '@mui/material/IconButton';
 import { QRCodeSVG } from 'qrcode.react';
-import { useQuery } from '@tanstack/react-query';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import drawerCss from '@/app/components/swipeable-drawer/swipeable-drawer.module.css';
 import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';
@@ -20,10 +19,8 @@ import { usePersistentSession } from '@/app/components/persistent-session/persis
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { useRouter, usePathname } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSessionTimer } from '@/app/hooks/use-session-timer';
-import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
-import { GET_SESSION_DETAIL, type GetSessionDetailQueryResponse } from '@/app/lib/graphql/operations/activity-feed';
+import { useSessionDetail } from '@/app/hooks/use-session-detail';
 import { clearClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { shareWithFallback } from '@/app/lib/share-utils';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -69,9 +66,8 @@ export default function SeshSettingsDrawer({
   tourMockSession,
   tourActiveSection,
 }: SeshSettingsDrawerProps) {
-  const { activeSession, session, users, deactivateSession, liveSessionStats } = usePersistentSession();
+  const { activeSession, session, users, deactivateSession } = usePersistentSession();
   const { boardDetails, angle } = useQueueBridgeBoardInfo();
-  const { token: authToken } = useWsAuthToken();
   const router = useRouter();
   const pathname = usePathname();
   const sessionId = activeSession?.sessionId ?? null;
@@ -128,22 +124,10 @@ export default function SeshSettingsDrawer({
     onClose();
   }, [onClose]);
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['activeSessionDetail', sessionId],
-    queryFn: async () => {
-      const client = createGraphQLHttpClient(authToken);
-      return client.request<GetSessionDetailQueryResponse>(GET_SESSION_DETAIL, { sessionId });
-    },
-    enabled: open && !!sessionId && !!authToken && !tourMockSession,
-    staleTime: 5000,
-    refetchOnWindowFocus: false,
+  const { session: sessionDetail, isLoading, isError } = useSessionDetail({
+    sessionId: sessionId ?? undefined,
+    enabled: open && !!sessionId && !tourMockSession,
   });
-
-  const sessionDetail = data?.sessionDetail ?? null;
-  const mergedStats = useMemo(() => {
-    if (liveSessionStats?.sessionId !== sessionId) return null;
-    return liveSessionStats;
-  }, [liveSessionStats, sessionId]);
 
   // Capture a stable timestamp once when the active session first becomes
   // relevant, so that unrelated dep changes don't regenerate different values.
@@ -208,33 +192,7 @@ export default function SeshSettingsDrawer({
     boardDetails?.board_name,
   ]);
 
-  const sessionForView = useMemo<SessionDetail | null>(() => {
-    const base = sessionDetail ?? fallbackSession;
-    if (!base) return null;
-
-    if (!mergedStats) return base;
-
-    const mergedTicks = mergedStats.ticks;
-    const firstTickAt = mergedTicks.length > 0 ? mergedTicks[mergedTicks.length - 1].climbedAt : base.firstTickAt;
-    const lastTickAt = mergedTicks.length > 0 ? mergedTicks[0].climbedAt : base.lastTickAt;
-
-    return {
-      ...base,
-      participants: mergedStats.participants,
-      totalSends: mergedStats.totalSends,
-      totalFlashes: mergedStats.totalFlashes,
-      totalAttempts: mergedStats.totalAttempts,
-      tickCount: mergedStats.tickCount,
-      gradeDistribution: mergedStats.gradeDistribution,
-      boardTypes: mergedStats.boardTypes,
-      hardestGrade: mergedStats.hardestGrade,
-      durationMinutes: mergedStats.durationMinutes,
-      goal: mergedStats.goal,
-      firstTickAt,
-      lastTickAt,
-      ticks: mergedTicks,
-    };
-  }, [sessionDetail, fallbackSession, mergedStats]);
+  const sessionForView = sessionDetail ?? fallbackSession;
 
   if (sessionForView) {
     lastSessionRef.current = sessionForView;

--- a/packages/web/app/hooks/use-session-detail.ts
+++ b/packages/web/app/hooks/use-session-detail.ts
@@ -104,6 +104,7 @@ export function useSessionDetail({ sessionId, initialData, enabled = true }: Use
   return {
     session: enabled ? (query.data ?? null) : (initialData ?? null),
     isLoading: query.isLoading,
+    isError: query.isError,
     updateSession,
     addUser,
     removeUser,

--- a/packages/web/app/hooks/use-session-detail.ts
+++ b/packages/web/app/hooks/use-session-detail.ts
@@ -39,6 +39,7 @@ export function useSessionDetail({ sessionId, initialData, enabled = true }: Use
     },
     enabled: enabled && !!sessionId && isAuthenticated && !!token,
     staleTime: 30_000,
+    refetchOnWindowFocus: false,
     ...(initialData
       ? {
           initialData,


### PR DESCRIPTION
…eparate state

Replace liveSessionStats React state with React Query cache updates in persistent-session-context. SessionStatsUpdated WebSocket events now flow directly into the ['sessionDetail', sessionId] query cache via queryClient.setQueryData(), following the notification subscription pattern.

This eliminates the dual data source (React state + React Query), removes manual merge logic from sesh-settings-drawer, and unifies on a single query key for session detail data.

https://claude.ai/code/session_01N6woHqDMK7oWE93QzqByR9