### PR TITLE
Add trending and hot climbs feed tabs and search sort options

### DIFF
--- a/packages/backend/src/__tests__/trending-feed-resolver.test.ts
+++ b/packages/backend/src/__tests__/trending-feed-resolver.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Shared mock state
+const mockState = vi.hoisted(() => ({
+  executeResults: [] as any[],
+  executeCallIndex: 0,
+  selectResult: null as any,
+}));
+
+// Mock the database client
+vi.mock('../db/client', () => ({
+  db: new Proxy(
+    {},
+    {
+      get(_, prop) {
+        if (prop === 'execute') {
+          return () => {
+            const result = mockState.executeResults[mockState.executeCallIndex] ?? { rows: [] };
+            mockState.executeCallIndex++;
+            return Promise.resolve(result);
+          };
+        }
+        if (prop === 'select') {
+          // For resolveBoardFilter's db.select().from().where().limit().then()
+          const chainableMock: any = {};
+          for (const method of ['select', 'from', 'where', 'limit']) {
+            chainableMock[method] = () => chainableMock;
+          }
+          chainableMock.then = (resolve: any, reject: any) =>
+            Promise.resolve(mockState.selectResult ? [mockState.selectResult] : []).then(resolve, reject);
+          return () => chainableMock;
+        }
+      },
+    },
+  ),
+}));
+
+vi.mock('@boardsesh/db/schema', () => ({
+  userBoards: { boardType: {}, layoutId: {}, uuid: {} },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: () => ({}),
+  sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }),
+}));
+
+vi.mock('../validation/schemas', () => ({
+  TrendingClimbFeedInputSchema: {
+    parse: (input: any) => ({
+      limit: input?.limit ?? 20,
+      offset: input?.offset ?? 0,
+      timePeriodDays: input?.timePeriodDays ?? 7,
+      boardUuid: input?.boardUuid ?? null,
+    }),
+  },
+}));
+
+vi.mock('../graphql/resolvers/shared/helpers', () => ({
+  validateInput: (_schema: any, input: any) => ({
+    limit: input?.limit ?? 20,
+    offset: input?.offset ?? 0,
+    timePeriodDays: input?.timePeriodDays ?? 7,
+    boardUuid: input?.boardUuid ?? null,
+  }),
+}));
+
+import { trendingFeedQueries } from '../graphql/resolvers/social/trending-feed';
+
+describe('trendingFeedQueries', () => {
+  beforeEach(() => {
+    mockState.executeCallIndex = 0;
+    mockState.executeResults = [];
+    mockState.selectResult = null;
+  });
+
+  describe('trendingClimbs', () => {
+    it('returns empty results when no history data exists', async () => {
+      mockState.executeResults = [{ rows: [] }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('maps rows to TrendingClimbItem correctly', async () => {
+      mockState.executeResults = [{
+        rows: [{
+          climb_uuid: 'climb-1',
+          angle: 40,
+          board_type: 'kilter',
+          current_ascents: 100,
+          ascent_delta: 15,
+          ascent_pct_change: 17.6,
+          climb_name: 'Test Climb',
+          setter_username: 'setter1',
+          layout_id: 1,
+          frames: 'p1r12',
+          quality_average: 4.2,
+          difficulty_name: 'V5',
+          total_count: 1,
+        }],
+      }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(1);
+      const item = result.items[0];
+      expect(item.climbUuid).toBe('climb-1');
+      expect(item.climbName).toBe('Test Climb');
+      expect(item.setterUsername).toBe('setter1');
+      expect(item.boardType).toBe('kilter');
+      expect(item.layoutId).toBe(1);
+      expect(item.angle).toBe(40);
+      expect(item.frames).toBe('p1r12');
+      expect(item.difficultyName).toBe('V5');
+      expect(item.qualityAverage).toBe(4.2);
+      expect(item.currentAscents).toBe(100);
+      expect(item.ascentDelta).toBe(15);
+      expect(item.ascentPctChange).toBe(17.6);
+    });
+
+    it('handles null pct change (climbs that started at 0)', async () => {
+      mockState.executeResults = [{
+        rows: [{
+          climb_uuid: 'climb-2',
+          angle: 40,
+          board_type: 'kilter',
+          current_ascents: 5,
+          ascent_delta: 5,
+          ascent_pct_change: null,
+          climb_name: 'New Climb',
+          setter_username: null,
+          layout_id: 1,
+          frames: null,
+          quality_average: null,
+          difficulty_name: null,
+          total_count: 1,
+        }],
+      }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items[0].ascentPctChange).toBeNull();
+      expect(result.items[0].setterUsername).toBeNull();
+      expect(result.items[0].frames).toBeNull();
+      expect(result.items[0].qualityAverage).toBeNull();
+      expect(result.items[0].difficultyName).toBeNull();
+    });
+
+    it('uses climb name fallback when name is null', async () => {
+      mockState.executeResults = [{
+        rows: [{
+          climb_uuid: 'climb-3',
+          angle: 40,
+          board_type: 'kilter',
+          current_ascents: 10,
+          ascent_delta: 5,
+          ascent_pct_change: 100,
+          climb_name: null,
+          setter_username: null,
+          layout_id: 1,
+          frames: null,
+          quality_average: null,
+          difficulty_name: null,
+          total_count: 1,
+        }],
+      }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items[0].climbName).toBe('Unknown');
+    });
+
+    it('detects hasMore when rows exceed limit', async () => {
+      // With limit=2, returning 3 rows means hasMore=true
+      const rows = Array.from({ length: 3 }, (_, i) => ({
+        climb_uuid: `climb-${i}`,
+        angle: 40,
+        board_type: 'kilter',
+        current_ascents: 100 - i * 10,
+        ascent_delta: 20 - i * 5,
+        ascent_pct_change: 25 - i * 5,
+        climb_name: `Climb ${i}`,
+        setter_username: 'setter',
+        layout_id: 1,
+        frames: 'f',
+        quality_average: 4.0,
+        difficulty_name: 'V5',
+        total_count: 10,
+      }));
+
+      mockState.executeResults = [{ rows }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: { limit: 2 } },
+      );
+
+      expect(result.hasMore).toBe(true);
+      expect(result.items).toHaveLength(2);
+      expect(result.totalCount).toBe(10);
+    });
+
+    it('sets hasMore to false when rows within limit', async () => {
+      mockState.executeResults = [{
+        rows: [{
+          climb_uuid: 'climb-1',
+          angle: 40,
+          board_type: 'kilter',
+          current_ascents: 50,
+          ascent_delta: 10,
+          ascent_pct_change: 25,
+          climb_name: 'Only Climb',
+          setter_username: 'setter',
+          layout_id: 1,
+          frames: 'f',
+          quality_average: 3.5,
+          difficulty_name: 'V3',
+          total_count: 1,
+        }],
+      }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: { limit: 20 } },
+      );
+
+      expect(result.hasMore).toBe(false);
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('resolves board filter when boardUuid is provided', async () => {
+      mockState.selectResult = { boardType: 'tension', layoutId: 8 };
+      mockState.executeResults = [{ rows: [] }];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: { boardUuid: 'board-uuid-123' } },
+      );
+
+      expect(result.items).toHaveLength(0);
+      // Verify the select mock was used (board lookup happened)
+      expect(mockState.executeCallIndex).toBe(1);
+    });
+  });
+
+  describe('hotClimbs', () => {
+    it('returns results sorted by absolute ascent delta', async () => {
+      const rows = [
+        {
+          climb_uuid: 'hot-1',
+          angle: 40,
+          board_type: 'kilter',
+          current_ascents: 200,
+          ascent_delta: 50,
+          ascent_pct_change: 33.3,
+          climb_name: 'Hot Climb',
+          setter_username: 'setter',
+          layout_id: 1,
+          frames: 'f',
+          quality_average: 4.5,
+          difficulty_name: 'V6',
+          total_count: 1,
+        },
+      ];
+
+      mockState.executeResults = [{ rows }];
+
+      const result = await trendingFeedQueries.hotClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].ascentDelta).toBe(50);
+      expect(result.items[0].climbName).toBe('Hot Climb');
+    });
+
+    it('returns empty results for empty history', async () => {
+      mockState.executeResults = [{ rows: [] }];
+
+      const result = await trendingFeedQueries.hotClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe('extractRows safety', () => {
+    it('handles malformed execute result gracefully', async () => {
+      // Simulate a driver returning something unexpected
+      mockState.executeResults = [null];
+
+      const result = await trendingFeedQueries.trendingClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('handles result without rows property', async () => {
+      mockState.executeResults = [{ notRows: [] }];
+
+      const result = await trendingFeedQueries.hotClimbs(
+        undefined,
+        { input: {} },
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
+  });
+});

--- a/packages/backend/src/__tests__/trending-feed-validation.test.ts
+++ b/packages/backend/src/__tests__/trending-feed-validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { TrendingClimbFeedInputSchema } from '../validation/schemas';
+
+describe('TrendingClimbFeedInputSchema', () => {
+  it('should accept empty input with defaults', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+      expect(result.data.offset).toBe(0);
+      expect(result.data.timePeriodDays).toBe(7);
+      expect(result.data.boardUuid).toBeUndefined();
+    }
+  });
+
+  it('should accept custom limit', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ limit: 50 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it('should reject limit exceeding max (100)', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject limit less than 1', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ limit: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid offset', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ offset: 40 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(40);
+    }
+  });
+
+  it('should reject negative offset', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid timePeriodDays values', () => {
+    for (const days of [1, 7, 14, 30, 90]) {
+      const result = TrendingClimbFeedInputSchema.safeParse({ timePeriodDays: days });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.timePeriodDays).toBe(days);
+      }
+    }
+  });
+
+  it('should reject timePeriodDays exceeding max (90)', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ timePeriodDays: 91 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject timePeriodDays less than 1', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ timePeriodDays: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept a valid boardUuid', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ boardUuid: 'board-uuid-123' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.boardUuid).toBe('board-uuid-123');
+    }
+  });
+
+  it('should accept null boardUuid', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ boardUuid: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject boardUuid exceeding max length', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({ boardUuid: 'a'.repeat(101) });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept full valid input', () => {
+    const result = TrendingClimbFeedInputSchema.safeParse({
+      limit: 10,
+      offset: 20,
+      boardUuid: 'my-board',
+      timePeriodDays: 30,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        limit: 10,
+        offset: 20,
+        boardUuid: 'my-board',
+        timePeriodDays: 30,
+      });
+    }
+  });
+});

--- a/packages/backend/src/db/queries/climbs/search-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/search-climbs.ts
@@ -4,7 +4,7 @@ import { getBoardTables, type BoardName } from '../util/table-select';
 import { createClimbFilters, type ClimbSearchParams, type ParsedBoardRouteParameters } from './create-climb-filters';
 import { getSizeEdges } from '../util/product-sizes-data';
 import type { Climb, ClimbSearchResult } from '@boardsesh/shared-schema';
-import { boardClimbStats, boardClimbStatsHistory } from '@boardsesh/db/schema';
+import { boardClimbStats } from '@boardsesh/db/schema';
 import { convertLitUpHoldsStringToMap } from '../util/hold-state';
 
 export const searchClimbs = async (
@@ -40,53 +40,29 @@ export const searchClimbs = async (
       WHERE cs.board_type = ${params.board_name} AND cs.climb_uuid = ${tables.climbs.uuid}
     )`,
     // Trending: % increase in ascents over last 7 days
-    trending: sql`(
+    // Uses a single aggregation subquery instead of correlated per-row subqueries.
+    // The existing (board_type, climb_uuid, angle) index covers this efficiently.
+    trending: sql`COALESCE((
       SELECT CASE
-        WHEN earliest.ascensionist_count > 0
-        THEN ((latest.ascensionist_count - earliest.ascensionist_count)::float / earliest.ascensionist_count) * 100
+        WHEN MIN(h.ascensionist_count) > 0
+        THEN ((MAX(h.ascensionist_count) - MIN(h.ascensionist_count))::float / MIN(h.ascensionist_count)) * 100
         ELSE 0
       END
-      FROM (
-        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
-        FROM ${boardClimbStatsHistory}
-        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
-          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
-          AND ${boardClimbStatsHistory.angle} = ${params.angle}
-          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
-        ORDER BY ${boardClimbStatsHistory.createdAt} ASC LIMIT 1
-      ) earliest,
-      (
-        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
-        FROM ${boardClimbStatsHistory}
-        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
-          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
-          AND ${boardClimbStatsHistory.angle} = ${params.angle}
-          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
-        ORDER BY ${boardClimbStatsHistory.createdAt} DESC LIMIT 1
-      ) latest
-    )`,
+      FROM board_climb_stats_history h
+      WHERE h.board_type = ${params.board_name}
+        AND h.climb_uuid = ${tables.climbs.uuid}
+        AND h.angle = ${params.angle}
+        AND h.created_at >= NOW() - INTERVAL '7 days'
+    ), 0)`,
     // Hot: absolute increase in ascents over last 7 days
-    hot: sql`(
-      SELECT COALESCE(latest.ascensionist_count - earliest.ascensionist_count, 0)
-      FROM (
-        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
-        FROM ${boardClimbStatsHistory}
-        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
-          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
-          AND ${boardClimbStatsHistory.angle} = ${params.angle}
-          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
-        ORDER BY ${boardClimbStatsHistory.createdAt} ASC LIMIT 1
-      ) earliest,
-      (
-        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
-        FROM ${boardClimbStatsHistory}
-        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
-          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
-          AND ${boardClimbStatsHistory.angle} = ${params.angle}
-          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
-        ORDER BY ${boardClimbStatsHistory.createdAt} DESC LIMIT 1
-      ) latest
-    )`,
+    hot: sql`COALESCE((
+      SELECT MAX(h.ascensionist_count) - MIN(h.ascensionist_count)
+      FROM board_climb_stats_history h
+      WHERE h.board_type = ${params.board_name}
+        AND h.climb_uuid = ${tables.climbs.uuid}
+        AND h.angle = ${params.angle}
+        AND h.created_at >= NOW() - INTERVAL '7 days'
+    ), 0)`,
   };
 
   // Get the selected sort column or fall back to ascensionist_count

--- a/packages/backend/src/db/queries/climbs/search-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/search-climbs.ts
@@ -4,7 +4,7 @@ import { getBoardTables, type BoardName } from '../util/table-select';
 import { createClimbFilters, type ClimbSearchParams, type ParsedBoardRouteParameters } from './create-climb-filters';
 import { getSizeEdges } from '../util/product-sizes-data';
 import type { Climb, ClimbSearchResult } from '@boardsesh/shared-schema';
-import { boardClimbStats } from '@boardsesh/db/schema';
+import { boardClimbStats, boardClimbStatsHistory } from '@boardsesh/db/schema';
 import { convertLitUpHoldsStringToMap } from '../util/hold-state';
 
 export const searchClimbs = async (
@@ -38,6 +38,54 @@ export const searchClimbs = async (
       SELECT COALESCE(SUM(cs.ascensionist_count), 0)
       FROM ${boardClimbStats} cs
       WHERE cs.board_type = ${params.board_name} AND cs.climb_uuid = ${tables.climbs.uuid}
+    )`,
+    // Trending: % increase in ascents over last 7 days
+    trending: sql`(
+      SELECT CASE
+        WHEN earliest.ascensionist_count > 0
+        THEN ((latest.ascensionist_count - earliest.ascensionist_count)::float / earliest.ascensionist_count) * 100
+        ELSE 0
+      END
+      FROM (
+        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
+        FROM ${boardClimbStatsHistory}
+        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
+          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
+          AND ${boardClimbStatsHistory.angle} = ${params.angle}
+          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
+        ORDER BY ${boardClimbStatsHistory.createdAt} ASC LIMIT 1
+      ) earliest,
+      (
+        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
+        FROM ${boardClimbStatsHistory}
+        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
+          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
+          AND ${boardClimbStatsHistory.angle} = ${params.angle}
+          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
+        ORDER BY ${boardClimbStatsHistory.createdAt} DESC LIMIT 1
+      ) latest
+    )`,
+    // Hot: absolute increase in ascents over last 7 days
+    hot: sql`(
+      SELECT COALESCE(latest.ascensionist_count - earliest.ascensionist_count, 0)
+      FROM (
+        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
+        FROM ${boardClimbStatsHistory}
+        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
+          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
+          AND ${boardClimbStatsHistory.angle} = ${params.angle}
+          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
+        ORDER BY ${boardClimbStatsHistory.createdAt} ASC LIMIT 1
+      ) earliest,
+      (
+        SELECT ${boardClimbStatsHistory.ascensionistCount} as ascensionist_count
+        FROM ${boardClimbStatsHistory}
+        WHERE ${boardClimbStatsHistory.boardType} = ${params.board_name}
+          AND ${boardClimbStatsHistory.climbUuid} = ${tables.climbs.uuid}
+          AND ${boardClimbStatsHistory.angle} = ${params.angle}
+          AND ${boardClimbStatsHistory.createdAt} >= NOW() - INTERVAL '7 days'
+        ORDER BY ${boardClimbStatsHistory.createdAt} DESC LIMIT 1
+      ) latest
     )`,
   };
 

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -42,6 +42,7 @@ import { socialRoleQueries, socialRoleMutations } from './social/roles';
 import { socialCommunitySettingsQueries, socialCommunitySettingsMutations } from './social/community-settings';
 import { newClimbSubscriptionResolvers } from './social/new-climb-subscriptions';
 import { newClimbFeedSubscription } from './social/new-climb-feed-subscription';
+import { trendingFeedQueries } from './social/trending-feed';
 
 export const resolvers = {
   // Scalar types
@@ -73,6 +74,7 @@ export const resolvers = {
     ...socialRoleQueries,
     ...socialCommunitySettingsQueries,
     ...newClimbSubscriptionResolvers.Query,
+    ...trendingFeedQueries,
   },
 
   Mutation: {

--- a/packages/backend/src/graphql/resolvers/social/trending-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/trending-feed.ts
@@ -1,0 +1,193 @@
+import { eq, sql } from 'drizzle-orm';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { validateInput } from '../shared/helpers';
+import { TrendingClimbFeedInputSchema } from '../../../validation/schemas';
+import type { TrendingClimbItem, TrendingClimbFeedResult } from '@boardsesh/shared-schema';
+
+async function resolveBoardFilter(boardUuid: string | null | undefined) {
+  if (!boardUuid) return { boardTypeFilter: null, layoutIdFilter: null };
+
+  const board = await db
+    .select({ boardType: dbSchema.userBoards.boardType, layoutId: dbSchema.userBoards.layoutId })
+    .from(dbSchema.userBoards)
+    .where(eq(dbSchema.userBoards.uuid, boardUuid))
+    .limit(1)
+    .then(rows => rows[0]);
+
+  return {
+    boardTypeFilter: board?.boardType ?? null,
+    layoutIdFilter: board?.layoutId ?? null,
+  };
+}
+
+async function queryTrendingOrHot(
+  input: Record<string, unknown> | undefined,
+  mode: 'trending' | 'hot',
+): Promise<TrendingClimbFeedResult> {
+  const validated = validateInput(TrendingClimbFeedInputSchema, input || {}, 'input');
+  const limit = validated.limit ?? 20;
+  const offset = validated.offset ?? 0;
+  const days = validated.timePeriodDays ?? 7;
+
+  const { boardTypeFilter, layoutIdFilter } = await resolveBoardFilter(validated.boardUuid);
+
+  const boardFilterSql = boardTypeFilter
+    ? sql`AND h.board_type = ${boardTypeFilter}`
+    : sql``;
+
+  const layoutFilterSql = layoutIdFilter !== null
+    ? sql`AND c.layout_id = ${layoutIdFilter}`
+    : sql``;
+
+  // For trending: exclude climbs that went from 0 ascents (pct change is meaningless)
+  // For hot: include all climbs with increases
+  const trendingFilter = mode === 'trending'
+    ? sql`AND f_ascensionist_count > 0`
+    : sql``;
+
+  const orderBy = mode === 'trending'
+    ? sql`ascent_pct_change DESC NULLS LAST`
+    : sql`ascent_delta DESC`;
+
+  type TrendingRow = {
+    climb_uuid: string;
+    angle: number;
+    board_type: string;
+    current_ascents: number;
+    ascent_delta: number;
+    ascent_pct_change: number | null;
+    climb_name: string | null;
+    setter_username: string | null;
+    layout_id: number;
+    frames: string | null;
+    quality_average: number | null;
+    difficulty_name: string | null;
+  };
+
+  // db.execute() returns QueryResult (neon-serverless) with .rows property
+  const result = await db.execute(sql`
+    WITH stats_window AS (
+      SELECT
+        h.climb_uuid,
+        h.angle,
+        h.ascensionist_count,
+        h.board_type,
+        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at ASC) as rn_first,
+        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at DESC) as rn_last
+      FROM board_climb_stats_history h
+      WHERE h.created_at >= NOW() - (${days} || ' days')::interval
+        ${boardFilterSql}
+    ),
+    deltas AS (
+      SELECT
+        f.climb_uuid,
+        f.angle,
+        f.board_type,
+        l.ascensionist_count AS current_ascents,
+        (l.ascensionist_count - f.ascensionist_count) AS ascent_delta,
+        CASE
+          WHEN f.ascensionist_count > 0
+          THEN ((l.ascensionist_count - f.ascensionist_count)::float / f.ascensionist_count) * 100
+          ELSE NULL
+        END AS ascent_pct_change,
+        f.ascensionist_count AS f_ascensionist_count
+      FROM
+        (SELECT * FROM stats_window WHERE rn_first = 1) f
+        JOIN (SELECT * FROM stats_window WHERE rn_last = 1) l
+          ON f.climb_uuid = l.climb_uuid AND f.angle = l.angle
+      WHERE l.ascensionist_count > f.ascensionist_count
+        AND (l.ascensionist_count - f.ascensionist_count) >= 2
+        ${trendingFilter}
+    )
+    SELECT
+      d.climb_uuid,
+      d.angle,
+      d.board_type,
+      d.current_ascents,
+      d.ascent_delta,
+      d.ascent_pct_change,
+      c.name AS climb_name,
+      c.setter_username,
+      c.layout_id,
+      c.frames,
+      s.quality_average,
+      g.boulder_name AS difficulty_name
+    FROM deltas d
+    JOIN board_climbs c
+      ON c.uuid = d.climb_uuid AND c.board_type = d.board_type
+    LEFT JOIN board_climb_stats s
+      ON s.climb_uuid = d.climb_uuid AND s.angle = d.angle AND s.board_type = d.board_type
+    LEFT JOIN board_difficulty_grades g
+      ON g.board_type = d.board_type AND g.difficulty = s.display_difficulty
+    WHERE 1=1
+      ${layoutFilterSql}
+    ORDER BY ${orderBy}
+    LIMIT ${limit + 1}
+    OFFSET ${offset}
+  `);
+
+  const rows = (result as unknown as { rows: TrendingRow[] }).rows;
+  const hasMore = rows.length > limit;
+  const items: TrendingClimbItem[] = rows.slice(0, limit).map((row) => ({
+    climbUuid: row.climb_uuid,
+    climbName: row.climb_name || 'Unknown',
+    setterUsername: row.setter_username,
+    boardType: row.board_type,
+    layoutId: Number(row.layout_id),
+    angle: Number(row.angle),
+    frames: row.frames,
+    difficultyName: row.difficulty_name,
+    qualityAverage: row.quality_average != null ? Number(row.quality_average) : null,
+    currentAscents: Number(row.current_ascents),
+    ascentDelta: Number(row.ascent_delta),
+    ascentPctChange: row.ascent_pct_change != null ? Number(row.ascent_pct_change) : null,
+  }));
+
+  // Get total count (separate query for efficiency)
+  const countResult = await db.execute(sql`
+    WITH stats_window AS (
+      SELECT
+        h.climb_uuid,
+        h.angle,
+        h.ascensionist_count,
+        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at ASC) as rn_first,
+        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at DESC) as rn_last
+      FROM board_climb_stats_history h
+      WHERE h.created_at >= NOW() - (${days} || ' days')::interval
+        ${boardFilterSql}
+    ),
+    deltas AS (
+      SELECT
+        f.climb_uuid,
+        f.angle,
+        (l.ascensionist_count - f.ascensionist_count) AS ascent_delta,
+        f.ascensionist_count AS f_ascensionist_count
+      FROM
+        (SELECT * FROM stats_window WHERE rn_first = 1) f
+        JOIN (SELECT * FROM stats_window WHERE rn_last = 1) l
+          ON f.climb_uuid = l.climb_uuid AND f.angle = l.angle
+      WHERE l.ascensionist_count > f.ascensionist_count
+        AND (l.ascensionist_count - f.ascensionist_count) >= 2
+        ${trendingFilter}
+    )
+    SELECT COUNT(*) as total FROM deltas
+  `);
+
+  const countRows = (countResult as unknown as { rows: Array<{ total: number }> }).rows;
+  const totalCount = Number(countRows[0]?.total ?? 0);
+
+  return { items, totalCount, hasMore };
+}
+
+export const trendingFeedQueries = {
+  trendingClimbs: async (
+    _: unknown,
+    { input }: { input?: Record<string, unknown> },
+  ) => queryTrendingOrHot(input, 'trending'),
+
+  hotClimbs: async (
+    _: unknown,
+    { input }: { input?: Record<string, unknown> },
+  ) => queryTrendingOrHot(input, 'hot'),
+};

--- a/packages/backend/src/graphql/resolvers/social/trending-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/trending-feed.ts
@@ -48,6 +48,7 @@ interface TrendingRow {
   frames: string | null;
   quality_average: number | null;
   difficulty_name: string | null;
+  total_count: number;
 }
 
 async function queryTrendingOrHot(
@@ -126,7 +127,8 @@ async function queryTrendingOrHot(
       c.layout_id,
       c.frames,
       s.quality_average,
-      g.boulder_name AS difficulty_name
+      g.boulder_name AS difficulty_name,
+      COUNT(*) OVER() AS total_count
     FROM deltas d
     JOIN board_climbs c
       ON c.uuid = d.climb_uuid AND c.board_type = d.board_type
@@ -143,7 +145,9 @@ async function queryTrendingOrHot(
 
   const rows = extractRows<TrendingRow>(result);
   const hasMore = rows.length > limit;
-  const items: TrendingClimbItem[] = rows.slice(0, limit).map((row) => ({
+  const pagedRows = rows.slice(0, limit);
+  const totalCount = Number(pagedRows[0]?.total_count ?? 0);
+  const items: TrendingClimbItem[] = pagedRows.map((row) => ({
     climbUuid: row.climb_uuid,
     climbName: row.climb_name || 'Unknown',
     setterUsername: row.setter_username,
@@ -157,46 +161,6 @@ async function queryTrendingOrHot(
     ascentDelta: Number(row.ascent_delta),
     ascentPctChange: row.ascent_pct_change != null ? Number(row.ascent_pct_change) : null,
   }));
-
-  // Get total count (separate query for efficiency)
-  const countResult = await db.execute(sql`
-    WITH stats_window AS (
-      SELECT
-        h.climb_uuid,
-        h.angle,
-        h.ascensionist_count,
-        h.board_type,
-        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at ASC) as rn_first,
-        ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at DESC) as rn_last
-      FROM board_climb_stats_history h
-      WHERE h.created_at >= NOW() - (${days} || ' days')::interval
-        ${boardFilterSql}
-    ),
-    deltas AS (
-      SELECT
-        f.climb_uuid,
-        f.angle,
-        f.board_type,
-        (l.ascensionist_count - f.ascensionist_count) AS ascent_delta,
-        f.ascensionist_count AS f_ascensionist_count
-      FROM
-        (SELECT * FROM stats_window WHERE rn_first = 1) f
-        JOIN (SELECT * FROM stats_window WHERE rn_last = 1) l
-          ON f.climb_uuid = l.climb_uuid AND f.angle = l.angle
-      WHERE l.ascensionist_count > f.ascensionist_count
-        AND (l.ascensionist_count - f.ascensionist_count) >= 2
-        ${trendingFilter}
-    )
-    SELECT COUNT(*) as total
-    FROM deltas d
-    JOIN board_climbs c
-      ON c.uuid = d.climb_uuid AND c.board_type = d.board_type
-    WHERE 1=1
-      ${layoutFilterSql}
-  `);
-
-  const countRows = extractRows<{ total: number }>(countResult);
-  const totalCount = Number(countRows[0]?.total ?? 0);
 
   return { items, totalCount, hasMore };
 }

--- a/packages/backend/src/graphql/resolvers/social/trending-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/trending-feed.ts
@@ -5,6 +5,20 @@ import { validateInput } from '../shared/helpers';
 import { TrendingClimbFeedInputSchema } from '../../../validation/schemas';
 import type { TrendingClimbItem, TrendingClimbFeedResult } from '@boardsesh/shared-schema';
 
+/**
+ * Extract typed rows from db.execute() result.
+ * db.execute() returns RowList (neon-serverless) or QueryResult (postgres-js),
+ * both of which expose a .rows property. This helper centralizes the cast
+ * so there's a single point to update if the driver return type changes.
+ */
+function extractRows<T>(result: unknown): T[] {
+  const resultObj = result as { rows?: T[] };
+  if (!resultObj || !Array.isArray(resultObj.rows)) {
+    return [];
+  }
+  return resultObj.rows;
+}
+
 async function resolveBoardFilter(boardUuid: string | null | undefined) {
   if (!boardUuid) return { boardTypeFilter: null, layoutIdFilter: null };
 
@@ -19,6 +33,21 @@ async function resolveBoardFilter(boardUuid: string | null | undefined) {
     boardTypeFilter: board?.boardType ?? null,
     layoutIdFilter: board?.layoutId ?? null,
   };
+}
+
+interface TrendingRow {
+  climb_uuid: string;
+  angle: number;
+  board_type: string;
+  current_ascents: number;
+  ascent_delta: number;
+  ascent_pct_change: number | null;
+  climb_name: string | null;
+  setter_username: string | null;
+  layout_id: number;
+  frames: string | null;
+  quality_average: number | null;
+  difficulty_name: string | null;
 }
 
 async function queryTrendingOrHot(
@@ -49,21 +78,6 @@ async function queryTrendingOrHot(
   const orderBy = mode === 'trending'
     ? sql`ascent_pct_change DESC NULLS LAST`
     : sql`ascent_delta DESC`;
-
-  type TrendingRow = {
-    climb_uuid: string;
-    angle: number;
-    board_type: string;
-    current_ascents: number;
-    ascent_delta: number;
-    ascent_pct_change: number | null;
-    climb_name: string | null;
-    setter_username: string | null;
-    layout_id: number;
-    frames: string | null;
-    quality_average: number | null;
-    difficulty_name: string | null;
-  };
 
   // db.execute() returns QueryResult (neon-serverless) with .rows property
   const result = await db.execute(sql`
@@ -127,7 +141,7 @@ async function queryTrendingOrHot(
     OFFSET ${offset}
   `);
 
-  const rows = (result as unknown as { rows: TrendingRow[] }).rows;
+  const rows = extractRows<TrendingRow>(result);
   const hasMore = rows.length > limit;
   const items: TrendingClimbItem[] = rows.slice(0, limit).map((row) => ({
     climbUuid: row.climb_uuid,
@@ -181,7 +195,7 @@ async function queryTrendingOrHot(
       ${layoutFilterSql}
   `);
 
-  const countRows = (countResult as unknown as { rows: Array<{ total: number }> }).rows;
+  const countRows = extractRows<{ total: number }>(countResult);
   const totalCount = Number(countRows[0]?.total ?? 0);
 
   return { items, totalCount, hasMore };

--- a/packages/backend/src/graphql/resolvers/social/trending-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/trending-feed.ts
@@ -151,6 +151,7 @@ async function queryTrendingOrHot(
         h.climb_uuid,
         h.angle,
         h.ascensionist_count,
+        h.board_type,
         ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at ASC) as rn_first,
         ROW_NUMBER() OVER (PARTITION BY h.climb_uuid, h.angle ORDER BY h.created_at DESC) as rn_last
       FROM board_climb_stats_history h
@@ -161,6 +162,7 @@ async function queryTrendingOrHot(
       SELECT
         f.climb_uuid,
         f.angle,
+        f.board_type,
         (l.ascensionist_count - f.ascensionist_count) AS ascent_delta,
         f.ascensionist_count AS f_ascensionist_count
       FROM
@@ -171,7 +173,12 @@ async function queryTrendingOrHot(
         AND (l.ascensionist_count - f.ascensionist_count) >= 2
         ${trendingFilter}
     )
-    SELECT COUNT(*) as total FROM deltas
+    SELECT COUNT(*) as total
+    FROM deltas d
+    JOIN board_climbs c
+      ON c.uuid = d.climb_uuid AND c.board_type = d.board_type
+    WHERE 1=1
+      ${layoutFilterSql}
   `);
 
   const countRows = (countResult as unknown as { rows: Array<{ total: number }> }).rows;

--- a/packages/backend/src/validation/schemas/feeds.ts
+++ b/packages/backend/src/validation/schemas/feeds.ts
@@ -19,6 +19,16 @@ export const GlobalCommentFeedInputSchema = z.object({
 });
 
 /**
+ * Trending/hot climb feed input validation schema
+ */
+export const TrendingClimbFeedInputSchema = z.object({
+  limit: z.number().int().min(1).max(100).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+  boardUuid: z.string().max(100).optional().nullable(),
+  timePeriodDays: z.number().int().min(1).max(90).optional().default(7),
+});
+
+/**
  * Grouped notifications query input validation schema
  */
 export const GroupedNotificationsInputSchema = z.object({

--- a/packages/db/drizzle/0065_supreme_doctor_strange.sql
+++ b/packages/db/drizzle/0065_supreme_doctor_strange.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "board_climb_stats_history_trending_idx" ON "board_climb_stats_history" USING btree ("board_type","created_at");

--- a/packages/db/drizzle/meta/0065_snapshot.json
+++ b/packages/db/drizzle/meta/0065_snapshot.json
@@ -1,0 +1,7845 @@
+{
+  "id": "f957714c-315f-4c07-9173-b560ea312069",
+  "prevId": "8001152f-65a4-49d4-8534-d96ac9271655",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "link"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": [
+            "board_type",
+            "circuit_uuid"
+          ],
+          "columnsTo": [
+            "board_type",
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "circuit_uuid",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_stats_history_trending_idx": {
+          "name": "board_climb_stats_history_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_layout_filter_idx": {
+          "name": "board_climbs_layout_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_edges_idx": {
+          "name": "board_climbs_edges_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": [
+            "board_type",
+            "difficulty"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": [
+            "board_type",
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": [
+            "board_type",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": [
+            "board_type",
+            "entity_uuid",
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": [
+            "board_type",
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inferred_sessions": {
+      "name": "inferred_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_tick_at": {
+          "name": "first_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sends": {
+          "name": "total_sends",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_flashes": {
+          "name": "total_flashes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tick_count": {
+          "name": "tick_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inferred_sessions_user_idx": {
+          "name": "inferred_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_user_last_tick_idx": {
+          "name": "inferred_sessions_user_last_tick_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_last_tick_idx": {
+          "name": "inferred_sessions_last_tick_idx",
+          "columns": [
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inferred_sessions_user_id_users_id_fk": {
+          "name": "inferred_sessions_user_id_users_id_fk",
+          "tableFrom": "inferred_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_member_overrides": {
+      "name": "session_member_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_member_overrides_session_idx": {
+          "name": "session_member_overrides_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_member_overrides_user_idx": {
+          "name": "session_member_overrides_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_member_overrides_session_id_inferred_sessions_id_fk": {
+          "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_user_id_users_id_fk": {
+          "name": "session_member_overrides_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_added_by_user_id_users_id_fk": {
+          "name": "session_member_overrides_added_by_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_member_overrides_session_user_unique": {
+          "name": "session_member_overrides_session_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_session_id": {
+          "name": "inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_inferred_session_id": {
+          "name": "previous_inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_inferred_session_idx": {
+          "name": "boardsesh_ticks_inferred_session_idx",
+          "columns": [
+            {
+              "expression": "inferred_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "inferred_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "previous_inferred_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "user_id",
+            "role",
+            "board_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "set_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": [
+        "jug",
+        "sloper",
+        "pinch",
+        "crimp",
+        "pocket"
+      ]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": [
+        "playlist_climb",
+        "climb",
+        "tick",
+        "comment",
+        "proposal",
+        "board",
+        "gym",
+        "session"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": [
+        "ascent",
+        "new_climb",
+        "comment",
+        "proposal_approved",
+        "session_summary"
+      ]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "community_leader"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": [
+        "grade",
+        "classic",
+        "benchmark"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1772484823930,
       "tag": "0064_useful_nocturne",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1772957530711,
+      "tag": "0065_supreme_doctor_strange",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -323,6 +323,10 @@ export const boardClimbStatsHistory = pgTable('board_climb_stats_history', {
     table.climbUuid,
     table.angle,
   ),
+  trendingIdx: index('board_climb_stats_history_trending_idx').on(
+    table.boardType,
+    table.createdAt,
+  ),
 }));
 
 export const boardBetaLinks = pgTable('board_beta_links', {

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -95,7 +95,7 @@ export const climbTypeDefs = /* GraphQL */ `
     maxGrade: Int
     "Minimum number of ascents"
     minAscents: Int
-    "Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular')"
+    "Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular', 'trending', 'hot')"
     sortBy: String
     "Sort direction ('asc' or 'desc')"
     sortOrder: String

--- a/packages/shared-schema/src/schema/index.ts
+++ b/packages/shared-schema/src/schema/index.ts
@@ -15,6 +15,7 @@ import { notificationsTypeDefs } from './notifications';
 import { proposalsTypeDefs } from './proposals';
 import { socialTypeDefs } from './social';
 import { newClimbFeedTypeDefs } from './new-climb-feed';
+import { trendingTypeDefs } from './trending';
 import { queriesTypeDefs } from './queries';
 import { mutationsTypeDefs } from './mutations';
 import { subscriptionsTypeDefs } from './subscriptions';
@@ -39,6 +40,7 @@ export const typeDefs = [
   proposalsTypeDefs,
   socialTypeDefs,
   newClimbFeedTypeDefs,
+  trendingTypeDefs,
   queriesTypeDefs,
   mutationsTypeDefs,
   subscriptionsTypeDefs,

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -319,6 +319,16 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     myNewClimbSubscriptions: [NewClimbSubscription!]!
 
+    """
+    Get climbs with the biggest percentage increase in ascents over a time period.
+    """
+    trendingClimbs(input: TrendingClimbFeedInput): TrendingClimbFeedResult!
+
+    """
+    Get climbs with the largest absolute increase in ascents over a time period.
+    """
+    hotClimbs(input: TrendingClimbFeedInput): TrendingClimbFeedResult!
+
     # ============================================
     # Board Entity Queries
     # ============================================

--- a/packages/shared-schema/src/schema/trending.ts
+++ b/packages/shared-schema/src/schema/trending.ts
@@ -1,0 +1,33 @@
+export const trendingTypeDefs = /* GraphQL */ `
+  # ============================================
+  # Trending & Hot Climbs Feed
+  # ============================================
+
+  type TrendingClimbItem {
+    climbUuid: String!
+    climbName: String!
+    setterUsername: String
+    boardType: String!
+    layoutId: Int!
+    angle: Int!
+    frames: String
+    difficultyName: String
+    qualityAverage: Float
+    currentAscents: Int!
+    ascentDelta: Int!
+    ascentPctChange: Float
+  }
+
+  type TrendingClimbFeedResult {
+    items: [TrendingClimbItem!]!
+    totalCount: Int!
+    hasMore: Boolean!
+  }
+
+  input TrendingClimbFeedInput {
+    limit: Int
+    offset: Int
+    boardUuid: String
+    timePeriodDays: Int
+  }
+`;

--- a/packages/shared-schema/src/types/index.ts
+++ b/packages/shared-schema/src/types/index.ts
@@ -17,5 +17,6 @@ export * from './activity-feed';
 export * from './proposals';
 export * from './events';
 export * from './new-climb-feed';
+export * from './trending';
 export * from './controller';
 export * from './device-logging';

--- a/packages/shared-schema/src/types/trending.ts
+++ b/packages/shared-schema/src/types/trending.ts
@@ -1,0 +1,27 @@
+export type TrendingClimbItem = {
+  climbUuid: string;
+  climbName: string;
+  setterUsername: string | null;
+  boardType: string;
+  layoutId: number;
+  angle: number;
+  frames: string | null;
+  difficultyName: string | null;
+  qualityAverage: number | null;
+  currentAscents: number;
+  ascentDelta: number;
+  ascentPctChange: number | null;
+};
+
+export type TrendingClimbFeedResult = {
+  items: TrendingClimbItem[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+export type TrendingClimbFeedInput = {
+  limit?: number;
+  offset?: number;
+  boardUuid?: string | null;
+  timePeriodDays?: number;
+};

--- a/packages/web/app/components/activity-feed/__tests__/trending-climb-feed.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/trending-climb-feed.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import type { TrendingClimbItem } from '@boardsesh/shared-schema';
+
+// --- Mocks ---
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  GET_TRENDING_CLIMBS: 'GET_TRENDING_CLIMBS',
+  GET_HOT_CLIMBS: 'GET_HOT_CLIMBS',
+}));
+
+vi.mock('@/app/hooks/use-infinite-scroll', () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null } }),
+}));
+
+const mockReplace = vi.fn();
+const mockSearchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => '/',
+}));
+
+vi.mock('../trending-climb-card', () => ({
+  default: ({ item, mode }: { item: TrendingClimbItem; mode: string }) => (
+    <div data-testid="trending-climb-card" data-mode={mode}>
+      {item.climbName}
+    </div>
+  ),
+}));
+vi.mock('../feed-item-skeleton', () => ({
+  default: () => <div data-testid="feed-item-skeleton" />,
+}));
+
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import TrendingClimbFeed from '../trending-climb-feed';
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+
+// --- Helpers ---
+
+function makeTrendingClimbItem(uuid: string, overrides?: Partial<TrendingClimbItem>): TrendingClimbItem {
+  return {
+    climbUuid: uuid,
+    climbName: `Climb ${uuid}`,
+    setterUsername: 'test-setter',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    frames: 'p1r12',
+    difficultyName: 'V5',
+    qualityAverage: 4.2,
+    currentAscents: 100,
+    ascentDelta: 15,
+    ascentPctChange: 17.6,
+    ...overrides,
+  };
+}
+
+function createWrapper(queryClient?: QueryClient) {
+  const client = queryClient ?? createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('TrendingClimbFeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockReset();
+  });
+
+  describe('Loading state', () => {
+    it('shows skeleton placeholders while loading', () => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: true,
+        error: null,
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(screen.getAllByTestId('feed-item-skeleton')).toHaveLength(3);
+    });
+  });
+
+  describe('Trending mode', () => {
+    beforeEach(() => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('fetches trending climbs and renders cards', async () => {
+      const items = [makeTrendingClimbItem('c1'), makeTrendingClimbItem('c2')];
+      mockRequest.mockResolvedValueOnce({
+        trendingClimbs: { items, totalCount: 2, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('trending-climb-card')).toHaveLength(2);
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith('GET_TRENDING_CLIMBS', expect.objectContaining({
+        input: expect.objectContaining({ timePeriodDays: 7 }),
+      }));
+    });
+
+    it('shows empty state when no results', async () => {
+      mockRequest.mockResolvedValueOnce({
+        trendingClimbs: { items: [], totalCount: 0, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/No trending climbs yet/)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Hot mode', () => {
+    beforeEach(() => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('fetches hot climbs and renders cards', async () => {
+      const items = [makeTrendingClimbItem('h1'), makeTrendingClimbItem('h2')];
+      mockRequest.mockResolvedValueOnce({
+        hotClimbs: { items, totalCount: 2, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="hot" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        const cards = screen.getAllByTestId('trending-climb-card');
+        expect(cards).toHaveLength(2);
+        expect(cards[0].getAttribute('data-mode')).toBe('hot');
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith('GET_HOT_CLIMBS', expect.any(Object));
+    });
+
+    it('shows empty state when no results', async () => {
+      mockRequest.mockResolvedValueOnce({
+        hotClimbs: { items: [], totalCount: 0, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="hot" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/No hot climbs yet/)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Board UUID filtering', () => {
+    beforeEach(() => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('passes boardUuid in query variables', async () => {
+      mockRequest.mockResolvedValueOnce({
+        trendingClimbs: { items: [], totalCount: 0, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" boardUuid="board-123" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith('GET_TRENDING_CLIMBS', expect.objectContaining({
+          input: expect.objectContaining({ boardUuid: 'board-123' }),
+        }));
+      });
+    });
+  });
+
+  describe('Time period selector', () => {
+    it('renders 7d, 14d, 30d toggle buttons', () => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+
+      mockRequest.mockResolvedValueOnce({
+        trendingClimbs: { items: [], totalCount: 0, hasMore: false },
+      });
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(screen.getByText('7d')).toBeTruthy();
+      expect(screen.getByText('14d')).toBeTruthy();
+      expect(screen.getByText('30d')).toBeTruthy();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('shows error state with retry button on fetch failure', async () => {
+      mockUseWsAuthToken.mockReturnValue({
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+
+      mockRequest.mockRejectedValueOnce(new Error('Network error'));
+
+      render(
+        <TrendingClimbFeed isAuthenticated={false} mode="trending" />,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load trending climbs/)).toBeTruthy();
+      });
+
+      expect(screen.getByText('Retry')).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/app/components/activity-feed/trending-climb-card.tsx
+++ b/packages/web/app/components/activity-feed/trending-climb-card.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import TrendingUpOutlined from '@mui/icons-material/TrendingUpOutlined';
+import WhatshotOutlined from '@mui/icons-material/WhatshotOutlined';
+import type { TrendingClimbItem } from '@boardsesh/shared-schema';
+import AscentThumbnail from '@/app/components/activity-feed/ascent-thumbnail';
+import { getDefaultBoardConfig, getDefaultClimbViewPath } from '@/app/lib/default-board-configs';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import type { BoardName } from '@/app/lib/types';
+import Link from 'next/link';
+
+interface TrendingClimbCardProps {
+  item: TrendingClimbItem;
+  mode: 'trending' | 'hot';
+}
+
+export default function TrendingClimbCard({ item, mode }: TrendingClimbCardProps) {
+  const climbViewPath = (() => {
+    const boardName = item.boardType as BoardName;
+    const angle = item.angle;
+
+    const defaultConfig = getDefaultBoardConfig(boardName, item.layoutId);
+    if (defaultConfig) {
+      const details = getBoardDetailsForBoard({
+        board_name: boardName,
+        layout_id: item.layoutId,
+        size_id: defaultConfig.sizeId,
+        set_ids: defaultConfig.setIds,
+      });
+
+      if (details?.layout_name && details.size_name && details.set_names) {
+        return constructClimbViewUrlWithSlugs(
+          boardName,
+          details.layout_name,
+          details.size_name,
+          details.size_description,
+          details.set_names,
+          angle,
+          item.climbUuid,
+          item.climbName || undefined,
+        );
+      }
+    }
+
+    return getDefaultClimbViewPath(boardName, item.layoutId, angle, item.climbUuid);
+  })();
+
+  const metricDisplay = mode === 'trending'
+    ? `+${item.ascentPctChange?.toFixed(0) ?? 0}%`
+    : `+${item.ascentDelta}`;
+
+  const metricSecondary = mode === 'trending'
+    ? `+${item.ascentDelta} ascents`
+    : item.ascentPctChange != null ? `+${item.ascentPctChange.toFixed(0)}%` : '';
+
+  const MetricIcon = mode === 'trending' ? TrendingUpOutlined : WhatshotOutlined;
+
+  return (
+    <Card variant="outlined" sx={{ mb: 1.5 }}>
+      <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+        <Link href={climbViewPath ?? '#'} style={{ textDecoration: 'none', color: 'inherit' }}>
+          <Box sx={{ display: 'flex', gap: 1.25 }}>
+            {item.frames && (
+              <AscentThumbnail
+                boardType={item.boardType}
+                layoutId={item.layoutId}
+                angle={item.angle}
+                climbUuid={item.climbUuid}
+                climbName={item.climbName}
+                frames={item.frames}
+                isMirror={false}
+              />
+            )}
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, flex: 1, minWidth: 0 }}>
+              <Typography variant="subtitle1" fontWeight={700} noWrap>
+                {item.climbName || 'Untitled climb'}
+              </Typography>
+
+              <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
+                {item.difficultyName && <Chip label={item.difficultyName} size="small" color="primary" />}
+                <Chip icon={<LocationOnOutlined />} label={`${item.angle}\u00B0`} size="small" />
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'capitalize' }}>
+                  {item.boardType}
+                </Typography>
+              </Box>
+
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <MetricIcon
+                  fontSize="small"
+                  color={mode === 'trending' ? 'success' : 'error'}
+                />
+                <Typography
+                  variant="body2"
+                  fontWeight={700}
+                  color={mode === 'trending' ? 'success.main' : 'error.main'}
+                >
+                  {metricDisplay}
+                </Typography>
+                {metricSecondary && (
+                  <Typography variant="caption" color="text.secondary">
+                    ({metricSecondary})
+                  </Typography>
+                )}
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+                  {item.currentAscents.toLocaleString()} total
+                </Typography>
+              </Box>
+
+              {item.setterUsername && (
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  Set by {item.setterUsername}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/app/components/activity-feed/trending-climb-feed.tsx
+++ b/packages/web/app/components/activity-feed/trending-climb-feed.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useMemo, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import MuiButton from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ErrorOutline from '@mui/icons-material/ErrorOutline';
+import TrendingUpOutlined from '@mui/icons-material/TrendingUpOutlined';
+import WhatshotOutlined from '@mui/icons-material/WhatshotOutlined';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { EmptyState } from '@/app/components/ui/empty-state';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  GET_TRENDING_CLIMBS,
+  GET_HOT_CLIMBS,
+  type GetTrendingClimbsQueryResponse,
+  type GetHotClimbsQueryResponse,
+} from '@/app/lib/graphql/operations';
+import type { TrendingClimbItem, TrendingClimbFeedResult } from '@boardsesh/shared-schema';
+import TrendingClimbCard from './trending-climb-card';
+import FeedItemSkeleton from './feed-item-skeleton';
+import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+
+const VALID_PERIODS = [7, 14, 30] as const;
+type TimePeriod = typeof VALID_PERIODS[number];
+
+interface TrendingClimbFeedProps {
+  isAuthenticated: boolean;
+  boardUuid?: string | null;
+  mode: 'trending' | 'hot';
+}
+
+export default function TrendingClimbFeed({
+  isAuthenticated,
+  boardUuid,
+  mode,
+}: TrendingClimbFeedProps) {
+  const { token } = useWsAuthToken();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const PAGE_SIZE = 20;
+
+  const periodParam = Number(searchParams.get('period'));
+  const timePeriodDays: TimePeriod = VALID_PERIODS.includes(periodParam as TimePeriod)
+    ? (periodParam as TimePeriod)
+    : 7;
+
+  const handlePeriodChange = useCallback((_: React.MouseEvent<HTMLElement>, newPeriod: TimePeriod | null) => {
+    if (newPeriod === null) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('period', String(newPeriod));
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [searchParams, router, pathname]);
+
+  const queryDocument = mode === 'trending' ? GET_TRENDING_CLIMBS : GET_HOT_CLIMBS;
+  const queryKey = [mode === 'trending' ? 'trendingClimbs' : 'hotClimbs', boardUuid, timePeriodDays] as const;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error, refetch } = useInfiniteQuery<
+    TrendingClimbFeedResult,
+    Error
+  >({
+    queryKey,
+    queryFn: async ({ pageParam }) => {
+      const client = createGraphQLHttpClient(isAuthenticated ? token : null);
+      const variables = {
+        input: {
+          limit: PAGE_SIZE,
+          offset: (pageParam as number) || 0,
+          timePeriodDays,
+          ...(boardUuid ? { boardUuid } : {}),
+        },
+      };
+
+      if (mode === 'trending') {
+        const response = await client.request<GetTrendingClimbsQueryResponse>(queryDocument, variables);
+        return response.trendingClimbs;
+      } else {
+        const response = await client.request<GetHotClimbsQueryResponse>(queryDocument, variables);
+        return response.hotClimbs;
+      }
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined;
+      return allPages.reduce((total, page) => total + page.items.length, 0);
+    },
+    enabled: isAuthenticated ? !!token : true,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const items: TrendingClimbItem[] = useMemo(
+    () => data?.pages.flatMap((p) => p.items) ?? [],
+    [data],
+  );
+
+  const { sentinelRef } = useInfiniteScroll({
+    onLoadMore: fetchNextPage,
+    hasMore: hasNextPage ?? false,
+    isFetching: isFetchingNextPage,
+  });
+
+  const EmptyIcon = mode === 'trending' ? TrendingUpOutlined : WhatshotOutlined;
+
+  return (
+    <Box
+      data-testid={`${mode}-feed`}
+      sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
+    >
+      <ToggleButtonGroup
+        value={timePeriodDays}
+        exclusive
+        onChange={handlePeriodChange}
+        size="small"
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        <ToggleButton value={7}>7d</ToggleButton>
+        <ToggleButton value={14}>14d</ToggleButton>
+        <ToggleButton value={30}>30d</ToggleButton>
+      </ToggleButtonGroup>
+
+      {isLoading && items.length === 0 && (
+        <>
+          <FeedItemSkeleton />
+          <FeedItemSkeleton />
+          <FeedItemSkeleton />
+        </>
+      )}
+
+      {error && (
+        <EmptyState
+          icon={<ErrorOutline fontSize="inherit" />}
+          description={`Failed to load ${mode} climbs. Please try again.`}
+        >
+          <MuiButton variant="contained" onClick={() => refetch()}>
+            Retry
+          </MuiButton>
+        </EmptyState>
+      )}
+
+      {!error && !isLoading && items.length === 0 ? (
+        <EmptyState
+          icon={<EmptyIcon fontSize="inherit" />}
+          description={`No ${mode} climbs yet. Check back after more syncs.`}
+        />
+      ) : (
+        <>
+          {items.map((item) => (
+            <TrendingClimbCard
+              key={`${item.climbUuid}-${item.angle}`}
+              item={item}
+              mode={mode}
+            />
+          ))}
+          <Box
+            ref={sentinelRef}
+            data-testid={`${mode}-feed-sentinel`}
+            sx={{ display: 'flex', flexDirection: 'column', gap: '12px', py: 2, minHeight: 20 }}
+          >
+            {isFetchingNextPage && (
+              <>
+                <FeedItemSkeleton />
+                <FeedItemSkeleton />
+              </>
+            )}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -165,6 +165,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 >
                   <MenuItem value="ascents">Ascents</MenuItem>
                   <MenuItem value="popular">Popular</MenuItem>
+                  <MenuItem value="trending">Trending</MenuItem>
+                  <MenuItem value="hot">Hot</MenuItem>
                   <MenuItem value="difficulty">Difficulty</MenuItem>
                   <MenuItem value="name">Name</MenuItem>
                   <MenuItem value="quality">Quality</MenuItem>

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -7,6 +7,7 @@ import Tab from '@mui/material/Tab';
 import ActivityFeed from '@/app/components/activity-feed/activity-feed';
 import ProposalFeed from '@/app/components/activity-feed/proposal-feed';
 import CommentFeed from '@/app/components/activity-feed/comment-feed';
+import TrendingClimbFeed from '@/app/components/activity-feed/trending-climb-feed';
 import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -18,8 +19,8 @@ import { useMyBoards } from '@/app/hooks/use-my-boards';
 import boardScrollStyles from '@/app/components/board-scroll/board-scroll.module.css';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 
-type FeedTab = 'sessions' | 'proposals' | 'comments';
-const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
+type FeedTab = 'sessions' | 'proposals' | 'comments' | 'trending' | 'hot';
+const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments', 'trending', 'hot'];
 
 interface HomePageContentProps {
   initialTab?: FeedTab;
@@ -112,11 +113,14 @@ export default function HomePageContent({
         <Tabs
           value={activeTab}
           onChange={handleTabChange}
-          variant="fullWidth"
+          variant="scrollable"
+          scrollButtons="auto"
           sx={{ mb: 2 }}
           aria-label="Home feed tabs"
         >
           <Tab label="Sessions" value="sessions" />
+          <Tab label="Trending" value="trending" />
+          <Tab label="Hot" value="hot" />
           <Tab label="Proposals" value="proposals" />
           <Tab label="Comments" value="comments" />
         </Tabs>
@@ -127,6 +131,22 @@ export default function HomePageContent({
             boardUuid={selectedBoardUuid}
             initialFeedResult={initialFeedResult}
             onFindClimbers={() => setFindClimbersOpen(true)}
+          />
+        )}
+
+        {activeTab === 'trending' && (
+          <TrendingClimbFeed
+            isAuthenticated={isAuthenticated}
+            boardUuid={selectedBoardUuid}
+            mode="trending"
+          />
+        )}
+
+        {activeTab === 'hot' && (
+          <TrendingClimbFeed
+            isAuthenticated={isAuthenticated}
+            boardUuid={selectedBoardUuid}
+            mode="hot"
           />
         )}
 

--- a/packages/web/app/lib/graphql/operations/index.ts
+++ b/packages/web/app/lib/graphql/operations/index.ts
@@ -12,3 +12,4 @@ export * from './new-climb-feed';
 export * from './sessions';
 export * from './create-session';
 export * from './climb-stats-history';
+export * from './trending';

--- a/packages/web/app/lib/graphql/operations/trending.ts
+++ b/packages/web/app/lib/graphql/operations/trending.ts
@@ -1,0 +1,61 @@
+import { gql } from 'graphql-request';
+import type {
+  TrendingClimbFeedInput,
+  TrendingClimbFeedResult,
+} from '@boardsesh/shared-schema';
+
+export const GET_TRENDING_CLIMBS = gql`
+  query GetTrendingClimbs($input: TrendingClimbFeedInput) {
+    trendingClimbs(input: $input) {
+      items {
+        climbUuid
+        climbName
+        setterUsername
+        boardType
+        layoutId
+        angle
+        frames
+        difficultyName
+        qualityAverage
+        currentAscents
+        ascentDelta
+        ascentPctChange
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+export const GET_HOT_CLIMBS = gql`
+  query GetHotClimbs($input: TrendingClimbFeedInput) {
+    hotClimbs(input: $input) {
+      items {
+        climbUuid
+        climbName
+        setterUsername
+        boardType
+        layoutId
+        angle
+        frames
+        difficultyName
+        qualityAverage
+        currentAscents
+        ascentDelta
+        ascentPctChange
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+export type GetTrendingClimbsQueryResponse = {
+  trendingClimbs: TrendingClimbFeedResult;
+};
+
+export type GetHotClimbsQueryResponse = {
+  hotClimbs: TrendingClimbFeedResult;
+};
+
+export type { TrendingClimbFeedInput, TrendingClimbFeedResult };

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -84,7 +84,7 @@ export type SearchRequest = {
   minAscents: number;
   minGrade: number;
   minRating: number;
-  sortBy: 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular';
+  sortBy: 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular' | 'trending' | 'hot';
   sortOrder: 'asc' | 'desc';
   name: string;
   onlyClassics: boolean;


### PR DESCRIPTION
Query board_climb_stats_history to derive two new metrics:
- Trending: biggest % increase in ascents over a configurable time period
- Hot: largest absolute increase in ascents over a time period

Changes:
- Add database index on (board_type, created_at) for efficient time-range queries
- Add GraphQL types, queries, and backend resolvers for trendingClimbs/hotClimbs
- Add trending/hot sort options to climb search (correlated subqueries)
- Add Trending and Hot tabs to home page activity feed with time period selector (7d/14d/30d)
- Add TrendingClimbCard component with ascent metrics and board navigation
- Switch home page tabs to scrollable variant for mobile compatibility

https://claude.ai/code/session_0182yMWJM3vhoBrupcV71VZX