### PR TITLE
Harden WebSocket session connection with state machine, error classification, and tab suspend/resume

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -6,13 +6,14 @@ This document describes the WebSocket implementation used for real-time party se
 
 1. [Architecture Overview](#architecture-overview)
 2. [Technology Stack](#technology-stack)
-3. [Connection Flow](#connection-flow)
-4. [Session Management](#session-management)
-5. [Queue State Synchronization](#queue-state-synchronization)
-6. [Multi-Instance Support](#multi-instance-support)
-7. [Failure States and Recovery](#failure-states-and-recovery)
-8. [Client-Side Connection Supervisor](#client-side-connection-supervisor)
-9. [Data Persistence Strategy](#data-persistence-strategy)
+3. [Frontend Connection Architecture](#frontend-connection-architecture)
+4. [Connection Flow](#connection-flow)
+5. [Session Management](#session-management)
+6. [Queue State Synchronization](#queue-state-synchronization)
+7. [Multi-Instance Support](#multi-instance-support)
+8. [Failure States and Recovery](#failure-states-and-recovery)
+9. [Client-Side Connection Supervisor](#client-side-connection-supervisor)
+10. [Data Persistence Strategy](#data-persistence-strategy)
 
 ---
 
@@ -87,6 +88,75 @@ The party session system uses a GraphQL-over-WebSocket architecture with the fol
 1. **Publisher** — shared by RoomManager, RedisSessionStore, DistributedState, EventBroker (non-blocking ops like `xadd`, `xack`)
 2. **Subscriber** — dedicated to ioredis pub/sub mode (enters special subscribe-only mode)
 3. **Stream Consumer** — dedicated to EventBroker's blocking `XREADGROUP BLOCK 5000` loop, preventing it from starving the publisher connection
+
+---
+
+## Frontend Connection Architecture
+
+The frontend connection layer uses a 3-class separation of concerns:
+
+```
+ConnectionStateMachine (state)  <-  SessionConnection (orchestration)  <-  PersistentSessionContext (React)
+```
+
+### ConnectionStateMachine
+
+A finite state machine (`connection-state-machine.ts`) that replaces 6+ scattered boolean flags with explicit states and transitions:
+
+```
+IDLE -> CONNECTING -> CONNECTED -> RECONNECTING -> CONNECTED
+                  \-> FAILED                    \-> FAILED
+```
+
+**States:**
+| State | Description |
+|-------|-------------|
+| `IDLE` | Initial state, no connection attempted |
+| `CONNECTING` | First connection in progress |
+| `CONNECTED` | Active WebSocket connection with subscriptions |
+| `RECONNECTING` | Lost connection, attempting to restore |
+| `FAILED` | Permanent failure (max retries exhausted or non-transient error) |
+
+**Derived flags** (exposed via `flags` getter):
+- `isConnecting` -- true when `CONNECTING`
+- `hasConnected` -- true once `CONNECTED` has been reached (persists through `RECONNECTING`)
+- `isWebSocketConnected` -- true only when currently `CONNECTED`
+
+Invalid transitions log warnings instead of silently corrupting state.
+
+### SessionConnection
+
+The `SessionConnection` class (`session-connection.ts`) encapsulates all WebSocket orchestration:
+
+- **Client lifecycle**: Creates/disposes `graphql-ws` client
+- **Session join/leave**: Executes `joinSession` mutation with initial queue support
+- **Subscriptions**: Sets up queue and session update subscriptions; automatically re-establishes them on subscription error
+- **Reconnection**: Uses an async lock to prevent overlapping resync calls; delegates state transitions to `ConnectionStateMachine`
+- **Delta/full sync**: See [Reconnection Sync Strategy](#reconnection-sync-strategy) below
+- **Retry logic**: Exponential backoff for transient failures, immediate fail for permanent ones (auth errors, session-not-found)
+- **Suspend/resume**: Background tabs are suspended after 60s hidden, resumed on foreground return
+- **Resync throttling**: Non-forced resyncs throttled to prevent spamming from rapid tab switches
+- **Disposal**: Sends `LEAVE_SESSION` on microtask, then nulls client synchronously
+
+### Reconnection Sync Strategy
+
+When reconnecting after a WebSocket drop, `SessionConnection` calculates the sequence gap and chooses:
+
+| Condition | Strategy |
+|-----------|----------|
+| Gap > 100 events | Full sync via `joinSession` response |
+| 0 < Gap <= 100 | Delta sync via `eventsReplay` query; falls back to full sync if no events returned |
+| Gap = 0 | Verify state hash; full sync if mismatch |
+| First connection (`lastSeq` is null) | Full sync |
+
+### PersistentSessionContext
+
+The React context layer (`persistent-session-context.tsx`) retains:
+- Queue state management (reducer pattern for event processing)
+- Sequence tracking and gap detection
+- Corruption detection with cooldown-based resync
+- Periodic hash verification (every 60 seconds)
+- iOS foreground recovery (visibility change handler with 300ms debounce)
 
 ---
 

--- a/packages/web/app/components/climb-actions/favorites-batch-context.tsx
+++ b/packages/web/app/components/climb-actions/favorites-batch-context.tsx
@@ -20,6 +20,7 @@ interface FavoritesProviderProps {
   isFavorited: (uuid: string) => boolean;
   toggleFavorite: (uuid: string) => Promise<boolean>;
   isLoading: boolean;
+  error: Error | null;
   isAuthenticated: boolean;
   children: React.ReactNode;
 }

--- a/packages/web/app/components/climb-actions/playlists-batch-context.tsx
+++ b/packages/web/app/components/climb-actions/playlists-batch-context.tsx
@@ -40,6 +40,7 @@ interface PlaylistsProviderProps {
     icon?: string
   ) => Promise<Playlist>;
   isLoading: boolean;
+  error: Error | null;
   isAuthenticated: boolean;
   refreshPlaylists: () => Promise<void>;
   children: React.ReactNode;

--- a/packages/web/app/components/graphql-queue/__tests__/graphql-client.test.ts
+++ b/packages/web/app/components/graphql-queue/__tests__/graphql-client.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let capturedOnHandlers: {
+  connected?: () => void;
+  closed?: (event: unknown) => void;
+  error?: (error: unknown) => void;
+} = {};
+let capturedShouldRetry: ((errorOrCloseEvent: unknown) => boolean) | undefined;
+
+const mockDispose = vi.fn();
+const mockSubscribe = vi.fn();
+
+vi.mock('graphql-ws', () => ({
+  createClient: vi.fn((options: { on?: typeof capturedOnHandlers, shouldRetry?: typeof capturedShouldRetry }) => {
+    capturedOnHandlers = options.on || {};
+    capturedShouldRetry = options.shouldRetry;
+    return {
+      subscribe: mockSubscribe,
+      dispose: mockDispose,
+    };
+  }),
+}));
+
+vi.mock('../../connection-manager/websocket-connection-manager', () => ({
+  connectionManager: {
+    registerClient: vi.fn(() => vi.fn()),
+  },
+  KEEP_ALIVE_MS: 10000,
+}));
+
+import { createGraphQLClient, execute } from '../graphql-client';
+
+describe('createGraphQLClient', () => {
+  beforeEach(() => {
+    capturedOnHandlers = {};
+    capturedShouldRetry = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('creates a client with the given URL', () => {
+    const client = createGraphQLClient({ url: 'ws://test' });
+    expect(client).toBeDefined();
+    expect(client.subscribe).toBeDefined();
+  });
+
+  describe('onConnectionStateChange', () => {
+    it('calls onConnectionStateChange(true, false) on first connect', () => {
+      const onChange = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onConnectionStateChange: onChange });
+      capturedOnHandlers.connected?.();
+      expect(onChange).toHaveBeenCalledWith(true, false);
+    });
+
+    it('calls onConnectionStateChange(true, true) on reconnect', () => {
+      const onChange = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onConnectionStateChange: onChange });
+      capturedOnHandlers.connected?.();
+      onChange.mockClear();
+      capturedOnHandlers.connected?.();
+      expect(onChange).toHaveBeenCalledWith(true, true);
+    });
+
+    it('calls onConnectionStateChange(false, true) on close after connect', () => {
+      const onChange = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onConnectionStateChange: onChange });
+      capturedOnHandlers.connected?.();
+      onChange.mockClear();
+      capturedOnHandlers.closed?.({});
+      expect(onChange).toHaveBeenCalledWith(false, true);
+    });
+
+    it('does not call onConnectionStateChange on close before first connect', () => {
+      const onChange = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onConnectionStateChange: onChange });
+      capturedOnHandlers.closed?.({});
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onReconnect', () => {
+    it('does not call onReconnect on first connect', () => {
+      const onReconnect = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onReconnect });
+      capturedOnHandlers.connected?.();
+      expect(onReconnect).not.toHaveBeenCalled();
+    });
+
+    it('calls onReconnect on subsequent connects', () => {
+      const onReconnect = vi.fn();
+      createGraphQLClient({ url: 'ws://test', onReconnect });
+      capturedOnHandlers.connected?.();
+      capturedOnHandlers.connected?.();
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shouldRetry', () => {
+    it('does not retry definitive auth/protocol close codes', () => {
+      createGraphQLClient({ url: 'ws://test' });
+      expect(capturedShouldRetry?.({ code: 4401 })).toBe(false);
+      expect(capturedShouldRetry?.({ code: 4403 })).toBe(false);
+      expect(capturedShouldRetry?.({ code: 1008 })).toBe(false);
+    });
+
+    it('retries transient close codes', () => {
+      createGraphQLClient({ url: 'ws://test' });
+      expect(capturedShouldRetry?.({ code: 1006 })).toBe(true);
+      expect(capturedShouldRetry?.({ code: 1012 })).toBe(true);
+    });
+  });
+});
+
+describe('execute timeout behavior', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('unsubscribes the in-flight operation when timeout elapses', async () => {
+    vi.useFakeTimers();
+
+    const unsubscribe = vi.fn();
+    const client = {
+      subscribe: vi.fn(() => unsubscribe),
+    } as any;
+
+    const promise = execute(client, { query: 'mutation Test { test }' }, 50);
+    const assertion = expect(promise).rejects.toThrow("GraphQL mutation 'Test' timed out after 50ms");
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores late completion after timeout and does not double-unsubscribe', async () => {
+    vi.useFakeTimers();
+
+    const unsubscribe = vi.fn();
+    let sink: { complete?: () => void } | null = null;
+    const client = {
+      subscribe: vi.fn((_op: unknown, currentSink: { complete?: () => void }) => {
+        sink = currentSink;
+        return unsubscribe;
+      }),
+    } as any;
+
+    const promise = execute(client, { query: 'mutation Test { test }' }, 50);
+    const assertion = expect(promise).rejects.toThrow();
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+
+    // Operation eventually completes after timeout; should be ignored.
+    (sink as { complete?: () => void } | null)?.complete?.();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -9,6 +9,7 @@ const MUTATION_TIMEOUT_MS = 30_000; // 30 second timeout for mutations
 import { INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, BACKOFF_MULTIPLIER } from './retry-constants';
 
 let clientCounter = 0;
+const NON_RETRYABLE_CLOSE_CODES = new Set([4400, 4401, 4403, 4404, 1002, 1003, 1008]);
 
 // Cache for parsed operation names to avoid regex on every call
 const operationNameCache = new WeakMap<{ query: string }, string>();
@@ -26,6 +27,26 @@ function getOperationName(operation: { query: string }, type: 'mutation' | 'quer
   return name;
 }
 
+function shouldRetrySocket(errorOrCloseEvent: unknown): boolean {
+  const eventWithCode = errorOrCloseEvent as { code?: number; reason?: string; message?: string };
+  const code = eventWithCode?.code;
+  if (typeof code === 'number' && NON_RETRYABLE_CLOSE_CODES.has(code)) {
+    return false;
+  }
+
+  const message = `${eventWithCode?.reason ?? ''} ${eventWithCode?.message ?? ''}`.toLowerCase();
+  if (
+    message.includes('unauthorized') ||
+    message.includes('forbidden') ||
+    message.includes('authentication') ||
+    message.includes('invalid token')
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export interface ExtendedClient extends Client {
   onReconnect?: (callback: () => void) => void;
 }
@@ -34,6 +55,7 @@ export interface GraphQLClientOptions {
   url: string;
   authToken?: string | null;
   onReconnect?: () => void;
+  onConnectionStateChange?: (connected: boolean, isReconnect: boolean) => void;
   connectionName?: string;
 }
 
@@ -55,7 +77,7 @@ export function createGraphQLClient(
     ? { url: urlOrOptions, onReconnect }
     : urlOrOptions;
 
-  const { url, authToken, onReconnect: onReconnectCallback, connectionName } = options;
+  const { url, authToken, onReconnect: onReconnectCallback, onConnectionStateChange, connectionName } = options;
   const managerConnectionName = connectionName ?? 'primary';
 
   const clientId = ++clientCounter;
@@ -67,7 +89,7 @@ export function createGraphQLClient(
   const client = createClient({
     url,
     retryAttempts: 10, // More attempts with exponential backoff
-    shouldRetry: () => true,
+    shouldRetry: shouldRetrySocket,
     // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
     retryWait: async (retryCount) => {
       const delay = Math.min(
@@ -85,15 +107,20 @@ export function createGraphQLClient(
     connectionParams: authToken ? { authToken } : undefined,
     on: {
       connected: () => {
+        const isReconnect = hasConnectedOnce;
         if (DEBUG) console.log(`[GraphQL] Client #${clientId} connected (first: ${!hasConnectedOnce})`);
-        if (hasConnectedOnce && onReconnectCallback) {
+        hasConnectedOnce = true;
+        onConnectionStateChange?.(true, isReconnect);
+        if (isReconnect && onReconnectCallback) {
           if (DEBUG) console.log(`[GraphQL] Client #${clientId} reconnected, calling onReconnect`);
           onReconnectCallback();
         }
-        hasConnectedOnce = true;
       },
       closed: (event) => {
         if (DEBUG) console.log(`[GraphQL] Client #${clientId} closed`, event);
+        if (hasConnectedOnce) {
+          onConnectionStateChange?.(false, true);
+        }
       },
       error: (error) => {
         if (DEBUG) console.log(`[GraphQL] Client #${clientId} error`, error);
@@ -127,11 +154,20 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
 
   if (DEBUG) console.log(`[GraphQL] execute START: ${opName}`);
 
-  const executionPromise = new Promise<TData>((resolve, reject) => {
-    let result: TData | undefined;
-    let hasResolved = false;
+  let result: TData | undefined;
+  let hasSettled = false;
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let unsubscribe: (() => void) | null = null;
 
-    const unsubscribe = client.subscribe<TData>(
+  const unsubscribeSafely = () => {
+    if (!unsubscribe) return;
+    const fn = unsubscribe;
+    unsubscribe = null;
+    fn();
+  };
+
+  const executionPromise = new Promise<TData>((resolve, reject) => {
+    unsubscribe = client.subscribe<TData>(
       { query: operation.query, variables: operation.variables as Record<string, unknown> },
       {
         next: (data) => {
@@ -141,26 +177,26 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
             result = data.data as TData;
           }
           if (data.errors) {
-            if (!hasResolved) {
-              hasResolved = true;
-              unsubscribe();
+            if (!hasSettled) {
+              hasSettled = true;
+              unsubscribeSafely();
               reject(new Error(data.errors.map((e) => e.message).join(', ')));
             }
           }
         },
         error: (err) => {
           if (DEBUG) console.log(`[GraphQL] execute ERROR: ${opName}`, err);
-          if (!hasResolved) {
-            hasResolved = true;
-            unsubscribe();
+          if (!hasSettled) {
+            hasSettled = true;
+            unsubscribeSafely();
             reject(err);
           }
         },
         complete: () => {
           if (DEBUG) console.log(`[GraphQL] execute COMPLETE: ${opName}`);
-          if (!hasResolved) {
-            hasResolved = true;
-            unsubscribe();
+          if (!hasSettled) {
+            hasSettled = true;
+            unsubscribeSafely();
             if (result === undefined) {
               reject(new Error(`GraphQL operation '${opName}' completed without data`));
               return;
@@ -174,12 +210,17 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
 
   // Add timeout to prevent mutations from hanging forever
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
+    timeoutId = setTimeout(() => {
+      if (hasSettled) return;
+      hasSettled = true;
+      unsubscribeSafely();
       reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
 
-  return Promise.race([executionPromise, timeoutPromise]);
+  return Promise.race([executionPromise, timeoutPromise]).finally(() => {
+    clearTimeout(timeoutId);
+  });
 }
 
 /**

--- a/packages/web/app/components/persistent-session/__tests__/connection-state-machine.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/connection-state-machine.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConnectionStateMachine } from '../connection-state-machine';
+
+describe('ConnectionStateMachine', () => {
+  it('starts in IDLE state', () => {
+    const sm = new ConnectionStateMachine();
+    expect(sm.state).toBe('IDLE');
+    expect(sm.hasEverConnected).toBe(false);
+  });
+
+  it('derives correct flags for IDLE', () => {
+    const sm = new ConnectionStateMachine();
+    expect(sm.flags).toEqual({
+      isConnecting: false,
+      hasConnected: false,
+      isWebSocketConnected: false,
+      isReconnecting: false,
+    });
+  });
+
+  describe('valid transitions', () => {
+    it('IDLE -> CONNECTING', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      expect(sm.state).toBe('CONNECTING');
+      expect(sm.flags.isConnecting).toBe(true);
+    });
+
+    it('CONNECTING -> CONNECTED', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      expect(sm.state).toBe('CONNECTED');
+      expect(sm.hasEverConnected).toBe(true);
+      expect(sm.flags).toEqual({
+        isConnecting: false,
+        hasConnected: true,
+        isWebSocketConnected: true,
+        isReconnecting: false,
+      });
+    });
+
+    it('CONNECTING -> FAILED', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('FAILED');
+      expect(sm.state).toBe('FAILED');
+    });
+
+    it('CONNECTING -> IDLE (cancelled)', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('IDLE');
+      expect(sm.state).toBe('IDLE');
+    });
+
+    it('CONNECTED -> RECONNECTING', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      sm.transition('RECONNECTING');
+      expect(sm.state).toBe('RECONNECTING');
+      expect(sm.flags).toEqual({
+        isConnecting: false,
+        hasConnected: true,
+        isWebSocketConnected: false,
+        isReconnecting: true,
+      });
+    });
+
+    it('CONNECTED -> IDLE (disconnect)', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      sm.transition('IDLE');
+      expect(sm.state).toBe('IDLE');
+    });
+
+    it('RECONNECTING -> CONNECTED', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      sm.transition('RECONNECTING');
+      sm.transition('CONNECTED');
+      expect(sm.state).toBe('CONNECTED');
+      expect(sm.flags.isReconnecting).toBe(false);
+      expect(sm.flags.isWebSocketConnected).toBe(true);
+    });
+
+    it('RECONNECTING -> FAILED', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      sm.transition('RECONNECTING');
+      sm.transition('FAILED');
+      expect(sm.state).toBe('FAILED');
+    });
+
+    it('FAILED -> CONNECTING (retry)', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('FAILED');
+      sm.transition('CONNECTING');
+      expect(sm.state).toBe('CONNECTING');
+    });
+
+    it('FAILED -> IDLE (give up)', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('FAILED');
+      sm.transition('IDLE');
+      expect(sm.state).toBe('IDLE');
+    });
+  });
+
+  describe('invalid transitions', () => {
+    it('IDLE -> CONNECTED is ignored', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTED');
+      expect(sm.state).toBe('IDLE');
+    });
+
+    it('IDLE -> RECONNECTING is ignored', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('RECONNECTING');
+      expect(sm.state).toBe('IDLE');
+    });
+
+    it('CONNECTED -> CONNECTING is ignored', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      sm.transition('CONNECTING');
+      expect(sm.state).toBe('CONNECTED');
+    });
+  });
+
+  describe('same-state transitions', () => {
+    it('does not fire listener for same-state transition', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      sm.onStateChange(listener);
+      sm.transition('IDLE'); // already IDLE
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasEverConnected', () => {
+    it('stays true after reconnection', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      expect(sm.hasEverConnected).toBe(true);
+
+      sm.transition('RECONNECTING');
+      expect(sm.hasEverConnected).toBe(true);
+
+      sm.transition('CONNECTED');
+      expect(sm.hasEverConnected).toBe(true);
+    });
+
+    it('is false after failed first connection', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('FAILED');
+      expect(sm.hasEverConnected).toBe(false);
+    });
+  });
+
+  describe('listeners', () => {
+    it('notifies listeners on transition', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      sm.onStateChange(listener);
+
+      sm.transition('CONNECTING');
+      expect(listener).toHaveBeenCalledWith('CONNECTING', 'IDLE');
+
+      sm.transition('CONNECTED');
+      expect(listener).toHaveBeenCalledWith('CONNECTED', 'CONNECTING');
+    });
+
+    it('unsubscribe stops notifications', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      const unsubscribe = sm.onStateChange(listener);
+
+      sm.transition('CONNECTING');
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      sm.transition('CONNECTED');
+      expect(listener).toHaveBeenCalledTimes(1); // No additional call
+    });
+
+    it('supports multiple listeners', () => {
+      const sm = new ConnectionStateMachine();
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      sm.onStateChange(listener1);
+      sm.onStateChange(listener2);
+
+      sm.transition('CONNECTING');
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('resets to IDLE and clears hasEverConnected', () => {
+      const sm = new ConnectionStateMachine();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+      expect(sm.hasEverConnected).toBe(true);
+
+      sm.reset();
+      expect(sm.state).toBe('IDLE');
+      expect(sm.hasEverConnected).toBe(false);
+    });
+
+    it('fires listener on reset', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+
+      sm.onStateChange(listener);
+      sm.reset();
+      expect(listener).toHaveBeenCalledWith('IDLE', 'CONNECTED');
+    });
+
+    it('does not fire listener if already IDLE', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      sm.onStateChange(listener);
+      sm.reset();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears all listeners', () => {
+      const sm = new ConnectionStateMachine();
+      const listener = vi.fn();
+      sm.onStateChange(listener);
+
+      sm.dispose();
+      sm.transition('CONNECTING');
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('full lifecycle simulation', () => {
+    it('handles connect -> disconnect -> reconnect -> connected', () => {
+      const sm = new ConnectionStateMachine();
+      const states: string[] = [];
+      sm.onStateChange((state) => states.push(state));
+
+      // Initial connection
+      sm.transition('CONNECTING');
+      sm.transition('CONNECTED');
+
+      // Network drop
+      sm.transition('RECONNECTING');
+
+      // Reconnection succeeds
+      sm.transition('CONNECTED');
+
+      expect(states).toEqual(['CONNECTING', 'CONNECTED', 'RECONNECTING', 'CONNECTED']);
+      expect(sm.flags).toEqual({
+        isConnecting: false,
+        hasConnected: true,
+        isWebSocketConnected: true,
+        isReconnecting: false,
+      });
+    });
+
+    it('handles connect -> fail -> retry -> connect', () => {
+      const sm = new ConnectionStateMachine();
+
+      sm.transition('CONNECTING');
+      sm.transition('FAILED');
+      sm.transition('CONNECTING'); // retry
+      sm.transition('CONNECTED');
+
+      expect(sm.state).toBe('CONNECTED');
+      expect(sm.hasEverConnected).toBe(true);
+    });
+  });
+});

--- a/packages/web/app/components/persistent-session/__tests__/session-connection.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-connection.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionConnection, type SessionConnectionCallbacks, type SessionData } from '../session-connection';
+
+const mockCreateGraphQLClient = vi.fn();
+const mockExecute = vi.fn();
+const mockSubscribe = vi.fn();
+
+vi.mock('../../graphql-queue/graphql-client', () => ({
+  createGraphQLClient: (...args: unknown[]) => mockCreateGraphQLClient(...args),
+  execute: (...args: unknown[]) => mockExecute(...args),
+  subscribe: (...args: unknown[]) => mockSubscribe(...args),
+}));
+
+vi.mock('@/app/utils/hash', () => ({
+  computeQueueStateHash: () => 'hash',
+}));
+
+function buildSessionData(sequence = 1): SessionData {
+  return {
+    id: 'session-1',
+    name: 'Test Session',
+    boardPath: '/kilter/1/10/1,2/40',
+    users: [],
+    queueState: {
+      sequence,
+      stateHash: 'abc123',
+      queue: [],
+      currentClimbQueueItem: null,
+    },
+    isLeader: true,
+    clientId: 'client-1',
+  };
+}
+
+function buildCallbacks(overrides?: Partial<SessionConnectionCallbacks>): SessionConnectionCallbacks {
+  return {
+    onConnectionFlagsChange: vi.fn(),
+    onSessionJoined: vi.fn(),
+    onSessionCleared: vi.fn(),
+    onQueueEvent: vi.fn(),
+    onSessionEvent: vi.fn(),
+    onError: vi.fn(),
+    onClientCreated: vi.fn(),
+    getQueueState: () => ({ queue: [], currentItemUuid: null }),
+    getLastSequence: () => 1,
+    toClimbQueueItemInput: (item) => item,
+    getPendingInitialQueue: () => null,
+    clearPendingInitialQueue: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('SessionConnection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockCreateGraphQLClient.mockReturnValue({
+      subscribe: vi.fn(),
+      dispose: vi.fn(),
+    });
+    mockSubscribe.mockReturnValue(vi.fn());
+    // Default: resolve execute calls (e.g. LEAVE_SESSION on dispose)
+    mockExecute.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('handles reconnect with transient join failure without clearing session', async () => {
+    const callbacks = buildCallbacks();
+    mockExecute.mockResolvedValueOnce({ joinSession: buildSessionData() });
+
+    const conn = new SessionConnection({
+      backendUrl: 'ws://test',
+      sessionId: 'session-1',
+      boardPath: '/kilter/1/10/1,2/40',
+      callbacks,
+    });
+
+    await conn.connect();
+    expect(callbacks.onSessionJoined).toHaveBeenCalledTimes(1);
+
+    // Reconnect fails with transient error
+    mockExecute.mockRejectedValueOnce(new Error('network timeout'));
+    conn.triggerResync(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onSessionCleared).not.toHaveBeenCalled();
+    expect(conn.flags.isReconnecting).toBe(true);
+
+    conn.dispose();
+  });
+
+  it('clears session on definitive auth failure during reconnect', async () => {
+    const callbacks = buildCallbacks();
+    mockExecute.mockResolvedValueOnce({ joinSession: buildSessionData() });
+
+    const conn = new SessionConnection({
+      backendUrl: 'ws://test',
+      sessionId: 'session-1',
+      boardPath: '/kilter/1/10/1,2/40',
+      callbacks,
+    });
+
+    await conn.connect();
+
+    // Reconnect fails with auth error
+    mockExecute.mockRejectedValueOnce(new Error('Unauthorized: invalid token'));
+    conn.triggerResync(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onSessionCleared).toHaveBeenCalled();
+    expect(conn.flags.isReconnecting).toBe(false);
+
+    conn.dispose();
+  });
+
+  it('suspends and resumes with a fresh client', async () => {
+    const callbacks = buildCallbacks();
+    mockExecute.mockResolvedValue({ joinSession: buildSessionData() });
+
+    const conn = new SessionConnection({
+      backendUrl: 'ws://test',
+      sessionId: 'session-1',
+      boardPath: '/kilter/1/10/1,2/40',
+      callbacks,
+    });
+
+    await conn.connect();
+    expect(callbacks.onClientCreated).toHaveBeenCalledTimes(1);
+
+    conn.suspend();
+    expect(callbacks.onClientCreated).toHaveBeenCalledWith(null);
+
+    conn.resume();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockCreateGraphQLClient).toHaveBeenCalledTimes(2);
+
+    conn.dispose();
+  });
+
+  it('retries transient initial join failure from IDLE and eventually connects', async () => {
+    const callbacks = buildCallbacks();
+
+    // First attempt fails with transient error
+    mockExecute.mockRejectedValueOnce(new Error('network timeout'));
+    // Second attempt succeeds
+    mockExecute.mockResolvedValueOnce({ joinSession: buildSessionData() });
+
+    const conn = new SessionConnection({
+      backendUrl: 'ws://test',
+      sessionId: 'session-1',
+      boardPath: '/kilter/1/10/1,2/40',
+      callbacks,
+    });
+
+    await conn.connect();
+    expect(callbacks.onSessionJoined).not.toHaveBeenCalled();
+    expect(callbacks.onError).toHaveBeenCalledTimes(1);
+
+    // Advance past retry delay
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(callbacks.onSessionJoined).toHaveBeenCalledTimes(1);
+
+    conn.dispose();
+  });
+});

--- a/packages/web/app/components/persistent-session/connection-state-machine.ts
+++ b/packages/web/app/components/persistent-session/connection-state-machine.ts
@@ -1,0 +1,122 @@
+/**
+ * Finite state machine for WebSocket connection lifecycle.
+ *
+ * Replaces scattered boolean state variables (isConnecting, hasConnected,
+ * isWebSocketConnected, isReconnectingRef) with explicit states and transitions.
+ *
+ * States:
+ *   IDLE → CONNECTING → CONNECTED → RECONNECTING → CONNECTED
+ *                  ↘ FAILED → IDLE
+ */
+
+export type ConnectionState =
+  | 'IDLE'
+  | 'CONNECTING'
+  | 'CONNECTED'
+  | 'RECONNECTING'
+  | 'FAILED';
+
+export type ConnectionStateListener = (state: ConnectionState, prev: ConnectionState) => void;
+
+/**
+ * Derived boolean flags for React consumers.
+ * These match the existing PersistentSessionContext interface.
+ */
+export interface ConnectionFlags {
+  isConnecting: boolean;
+  hasConnected: boolean;
+  isWebSocketConnected: boolean;
+  isReconnecting: boolean;
+}
+
+// Valid state transitions
+const VALID_TRANSITIONS: Record<ConnectionState, ConnectionState[]> = {
+  IDLE: ['CONNECTING'],
+  CONNECTING: ['CONNECTED', 'FAILED', 'IDLE'],
+  CONNECTED: ['RECONNECTING', 'IDLE'],
+  RECONNECTING: ['CONNECTED', 'FAILED', 'IDLE'],
+  FAILED: ['CONNECTING', 'IDLE'],
+};
+
+export class ConnectionStateMachine {
+  private _state: ConnectionState = 'IDLE';
+  private _hasEverConnected = false;
+  private _listeners = new Set<ConnectionStateListener>();
+
+  get state(): ConnectionState {
+    return this._state;
+  }
+
+  get hasEverConnected(): boolean {
+    return this._hasEverConnected;
+  }
+
+  /**
+   * Derive the boolean flags that the React context expects.
+   */
+  get flags(): ConnectionFlags {
+    return {
+      isConnecting: this._state === 'CONNECTING',
+      hasConnected: this._hasEverConnected,
+      isWebSocketConnected: this._state === 'CONNECTED',
+      isReconnecting: this._state === 'RECONNECTING',
+    };
+  }
+
+  /**
+   * Transition to a new state. Throws if the transition is invalid.
+   */
+  transition(to: ConnectionState): void {
+    const from = this._state;
+    if (from === to) return;
+
+    if (!VALID_TRANSITIONS[from].includes(to)) {
+      console.warn(
+        `[ConnectionStateMachine] Invalid transition: ${from} → ${to}. Allowed: ${VALID_TRANSITIONS[from].join(', ')}`,
+      );
+      return;
+    }
+
+    this._state = to;
+
+    if (to === 'CONNECTED') {
+      this._hasEverConnected = true;
+    }
+
+    for (const listener of this._listeners) {
+      listener(to, from);
+    }
+  }
+
+  /**
+   * Subscribe to state changes. Returns an unsubscribe function.
+   */
+  onStateChange(listener: ConnectionStateListener): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Reset the state machine to IDLE (e.g. on disconnect or dispose).
+   * Does not trigger listeners if already IDLE.
+   */
+  reset(): void {
+    const from = this._state;
+    if (from === 'IDLE') return;
+
+    this._state = 'IDLE';
+    this._hasEverConnected = false;
+    for (const listener of this._listeners) {
+      listener('IDLE', from);
+    }
+  }
+
+  /**
+   * Remove all listeners (for cleanup).
+   */
+  dispose(): void {
+    this._listeners.clear();
+  }
+}

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import type { SubscriptionQueueEvent, SessionEvent, SessionLiveStats } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { evaluateQueueEventSequence, insertQueueItemIdempotent } from '../event-utils';
@@ -16,6 +16,8 @@ export interface EventProcessorState {
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
   lastReceivedStateHash: string | null;
+  serverStateHash: string | null;
+  localStateHash: string | null;
   liveSessionStats: SessionLiveStats | null;
 }
 
@@ -24,6 +26,9 @@ export interface EventProcessorActions {
   handleSessionEvent: (event: SessionEvent) => void;
   setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
   setCurrentClimbQueueItem: Dispatch<SetStateAction<LocalClimbQueueItem | null>>;
+  setLocalStateHash: Dispatch<SetStateAction<string | null>>;
+  setServerStateHash: Dispatch<SetStateAction<string | null>>;
+  shouldRefreshServerHashRef: MutableRefObject<boolean>;
   setLiveSessionStats: Dispatch<SetStateAction<SessionLiveStats | null>>;
   notifyQueueSubscribers: (event: SubscriptionQueueEvent) => void;
   notifySessionSubscribers: (event: SessionEvent) => void;
@@ -41,7 +46,9 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
 
   const [queue, setQueueState] = useState<LocalClimbQueueItem[]>([]);
   const [currentClimbQueueItem, setCurrentClimbQueueItem] = useState<LocalClimbQueueItem | null>(null);
-  const [lastReceivedStateHash, setLastReceivedStateHash] = useState<string | null>(null);
+  const [serverStateHash, setServerStateHash] = useState<string | null>(null);
+  const [localStateHash, setLocalStateHash] = useState<string | null>(null);
+  const shouldRefreshServerHashRef = useRef(false);
   const [liveSessionStats, setLiveSessionStats] = useState<SessionLiveStats | null>(null);
 
   // Notify queue event subscribers
@@ -82,9 +89,7 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           `[PersistentSession] Sequence gap detected: expected ${lastSeq! + 1}, got ${event.sequence}. ` +
           `Triggering resync.`
         );
-        if (triggerResyncRef.current) {
-          triggerResyncRef.current();
-        }
+        triggerResyncRef.current?.(true);
         return;
       }
     }
@@ -94,7 +99,8 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
         setQueueState((event.state.queue as LocalClimbQueueItem[]).filter(item => item != null));
         setCurrentClimbQueueItem(event.state.currentClimbQueueItem as LocalClimbQueueItem | null);
         updateLastReceivedSequence(event.sequence);
-        setLastReceivedStateHash(event.state.stateHash);
+        shouldRefreshServerHashRef.current = false;
+        setServerStateHash(event.state.stateHash);
         break;
       case 'QueueItemAdded':
         if (event.addedItem == null) {
@@ -110,23 +116,34 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           );
         });
         updateLastReceivedSequence(event.sequence);
+        shouldRefreshServerHashRef.current = true;
         break;
       case 'QueueItemRemoved':
         setQueueState((prev) => prev.filter((item) => item.uuid !== event.uuid));
         updateLastReceivedSequence(event.sequence);
+        shouldRefreshServerHashRef.current = true;
         break;
       case 'QueueReordered':
         setQueueState((prev) => {
+          if (event.oldIndex < 0 || event.oldIndex >= prev.length || event.newIndex < 0 || event.newIndex >= prev.length) {
+            console.warn(
+              `[PersistentSession] QueueReordered indices out of bounds: oldIndex=${event.oldIndex}, newIndex=${event.newIndex}, queue length=${prev.length}. Triggering resync.`
+            );
+            triggerResyncRef.current?.(true);
+            return prev;
+          }
           const newQueue = [...prev];
           const [item] = newQueue.splice(event.oldIndex, 1);
           newQueue.splice(event.newIndex, 0, item);
           return newQueue;
         });
         updateLastReceivedSequence(event.sequence);
+        shouldRefreshServerHashRef.current = true;
         break;
       case 'CurrentClimbChanged':
         setCurrentClimbQueueItem(event.currentItem as LocalClimbQueueItem | null);
         updateLastReceivedSequence(event.sequence);
+        shouldRefreshServerHashRef.current = true;
         break;
       case 'ClimbMirrored':
         setCurrentClimbQueueItem((prev) => {
@@ -140,6 +157,7 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           };
         });
         updateLastReceivedSequence(event.sequence);
+        shouldRefreshServerHashRef.current = true;
         break;
     }
 
@@ -173,12 +191,17 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
   return {
     queue,
     currentClimbQueueItem,
-    lastReceivedStateHash,
+    lastReceivedStateHash: serverStateHash,
+    serverStateHash,
+    localStateHash,
+    shouldRefreshServerHashRef,
     liveSessionStats,
     handleQueueEvent,
     handleSessionEvent,
     setQueueState,
     setCurrentClimbQueueItem,
+    setLocalStateHash,
+    setServerStateHash,
     setLiveSessionStats,
     notifyQueueSubscribers,
     notifySessionSubscribers,

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -1,60 +1,20 @@
 import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
-import { createGraphQLClient, execute, subscribe, Client } from '../../graphql-queue/graphql-client';
-import {
-  INITIAL_RETRY_DELAY_MS,
-  MAX_RETRY_DELAY_MS,
-  BACKOFF_MULTIPLIER,
-  MAX_TRANSIENT_RETRIES,
-} from '../../graphql-queue/retry-constants';
-import {
-  JOIN_SESSION,
-  LEAVE_SESSION,
-  QUEUE_UPDATES,
-  SESSION_UPDATES,
-  EVENTS_REPLAY,
-  type SubscriptionQueueEvent,
-  type SessionEvent,
-  type QueueEvent,
-  type EventsReplayResponse,
-} from '@boardsesh/shared-schema';
+import type { Client } from '../../graphql-queue/graphql-client';
+import type { SubscriptionQueueEvent, SessionEvent, SessionSummary } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import { computeQueueStateHash } from '@/app/utils/hash';
 import { setPreference, removePreference } from '@/app/lib/user-preferences-db';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   END_SESSION as END_SESSION_GQL,
   type EndSessionResponse,
 } from '@/app/lib/graphql/operations/sessions';
-import type { SessionSummary } from '@boardsesh/shared-schema';
 import { upsertSessionUser } from '../event-utils';
-import { TransientJoinError } from '../errors';
+import { SessionConnection, type SessionData } from '../session-connection';
 import type { Session, ActiveSessionInfo, PendingInitialQueue, SharedRefs } from '../types';
 import { toClimbQueueItemInput, ACTIVE_SESSION_KEY, DEFAULT_BACKEND_URL, DEBUG } from '../types';
 
-/**
- * Transform QueueEvent (from eventsReplay) to SubscriptionQueueEvent format.
- */
-function transformToSubscriptionEvent(event: QueueEvent): SubscriptionQueueEvent {
-  switch (event.__typename) {
-    case 'QueueItemAdded':
-      return {
-        __typename: 'QueueItemAdded',
-        sequence: event.sequence,
-        addedItem: event.item,
-        position: event.position,
-      };
-    case 'CurrentClimbChanged':
-      return {
-        __typename: 'CurrentClimbChanged',
-        sequence: event.sequence,
-        currentItem: event.item,
-        clientId: event.clientId,
-        correlationId: event.correlationId,
-      };
-    default:
-      return event as SubscriptionQueueEvent;
-  }
-}
+const VISIBILITY_RESYNC_DEBOUNCE_MS = 300;
+const HIDDEN_TAB_SUSPEND_DELAY_MS = 60_000;
 
 interface UseSessionLifecycleArgs {
   isAuthLoading: boolean;
@@ -64,9 +24,7 @@ interface UseSessionLifecycleArgs {
   refs: Pick<SharedRefs,
     'wsAuthTokenRef' | 'usernameRef' | 'avatarUrlRef' | 'sessionRef' |
     'activeSessionRef' | 'queueRef' | 'currentClimbQueueItemRef' |
-    'mountedRef' | 'isConnectingRef' | 'isReconnectingRef' |
-    'connectionGenerationRef' | 'triggerResyncRef' | 'lastReceivedSequenceRef' |
-    'queueUnsubscribeRef' | 'sessionUnsubscribeRef'
+    'triggerResyncRef' | 'lastReceivedSequenceRef'
   >;
 }
 
@@ -76,6 +34,7 @@ export interface SessionLifecycleState {
   session: Session | null;
   isConnecting: boolean;
   hasConnected: boolean;
+  isWebSocketConnected: boolean;
   error: Error | null;
   sessionSummary: SessionSummary | null;
 }
@@ -105,9 +64,7 @@ export function useSessionLifecycle({
     wsAuthTokenRef, usernameRef, avatarUrlRef,
     sessionRef, activeSessionRef,
     queueRef, currentClimbQueueItemRef,
-    mountedRef, isConnectingRef, isReconnectingRef,
-    connectionGenerationRef, triggerResyncRef, lastReceivedSequenceRef,
-    queueUnsubscribeRef, sessionUnsubscribeRef,
+    triggerResyncRef, lastReceivedSequenceRef,
   } = refs;
 
   const [activeSession, setActiveSession] = useState<ActiveSessionInfo | null>(null);
@@ -115,11 +72,17 @@ export function useSessionLifecycle({
   const [session, setSessionLocal] = useState<Session | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [hasConnected, setHasConnected] = useState(false);
+  const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [sessionSummary, setSessionSummary] = useState<SessionSummary | null>(null);
 
   // Pending initial queue for new sessions
   const [pendingInitialQueue, setPendingInitialQueue] = useState<PendingInitialQueue | null>(null);
+  const pendingInitialQueueRef = useRef<PendingInitialQueue | null>(null);
+  useEffect(() => { pendingInitialQueueRef.current = pendingInitialQueue; }, [pendingInitialQueue]);
+
+  // SessionConnection instance
+  const connectionRef = useRef<SessionConnection | null>(null);
 
   // Combined setter that updates both local and external state
   const setSession = useCallback((value: SetStateAction<Session | null>) => {
@@ -185,7 +148,7 @@ export function useSessionLifecycle({
     }
   }, [activeSession, deactivateSession, wsAuthTokenRef]);
 
-  // Connect to session when activeSession changes
+  // Connect to session via SessionConnection when activeSession changes
   useEffect(() => {
     if (!activeSession) {
       if (DEBUG) console.log('[PersistentSession] No active session, skipping connection');
@@ -197,7 +160,7 @@ export function useSessionLifecycle({
       return;
     }
 
-    const { sessionId, boardPath } = activeSession;
+    const { sessionId, boardPath, sessionName } = activeSession;
     const backendUrl = DEFAULT_BACKEND_URL;
 
     if (!backendUrl) {
@@ -205,354 +168,189 @@ export function useSessionLifecycle({
       return;
     }
 
-    mountedRef.current = true;
-    const connectionGeneration = ++connectionGenerationRef.current;
-    let graphqlClient: Client | null = null;
-    let retryConnectTimeout: ReturnType<typeof setTimeout> | null = null;
-    let transientRetryCount = 0;
-
-    async function joinSession(clientToUse: Client): Promise<Session | null> {
-      if (DEBUG) console.log('[PersistentSession] Calling joinSession mutation...');
-      try {
-        const initialQueueData =
-          pendingInitialQueue?.sessionId === sessionId
-            ? pendingInitialQueue
-            : null;
-
-        if (DEBUG && initialQueueData) {
-          console.log('[PersistentSession] Sending initial queue with', initialQueueData.queue.length, 'items');
-        }
-
-        const sessionName = activeSession?.sessionName || initialQueueData?.sessionName;
-        const variables = {
-          sessionId,
-          boardPath,
-          username: usernameRef.current,
-          avatarUrl: avatarUrlRef.current,
-          ...(initialQueueData && {
-            initialQueue: initialQueueData.queue.map(toClimbQueueItemInput),
-            initialCurrentClimb: initialQueueData.currentClimb ? toClimbQueueItemInput(initialQueueData.currentClimb) : null,
-          }),
-          ...(sessionName && { sessionName }),
-        };
-
-        const response = await execute<{ joinSession: Session }>(clientToUse, {
-          query: JOIN_SESSION,
-          variables,
-        });
-
-        const joinedSession = response?.joinSession;
-        if (!joinedSession) {
-          console.error('[PersistentSession] JoinSession returned no session payload');
-          return null;
-        }
-
-        if (initialQueueData) {
-          setPendingInitialQueue(null);
-        }
-
-        return joinedSession;
-      } catch (err) {
-        console.error('[PersistentSession] JoinSession failed:', err);
-        return null;
-      }
-    }
-
-    async function handleReconnect() {
-      if (!mountedRef.current || !graphqlClient) return;
-      if (connectionGenerationRef.current !== connectionGeneration) return;
-      if (isReconnectingRef.current) {
-        if (DEBUG) console.log('[PersistentSession] Reconnection already in progress');
-        return;
-      }
-
-      isReconnectingRef.current = true;
-      try {
-        if (DEBUG) console.log('[PersistentSession] Reconnecting...');
-
-        const lastSeq = lastReceivedSequenceRef.current;
-        const sessionData = await joinSession(graphqlClient);
-        if (!sessionData || !mountedRef.current) return;
-
-        const currentSeq = sessionData.queueState.sequence;
-        const gap = lastSeq !== null ? currentSeq - lastSeq : 0;
-
-        if (DEBUG) console.log(`[PersistentSession] Reconnected. Last seq: ${lastSeq}, Current seq: ${currentSeq}, Gap: ${gap}`);
-
-        if (gap > 0 && gap <= 100 && lastSeq !== null && sessionId) {
-          try {
-            if (DEBUG) console.log(`[PersistentSession] Attempting delta sync for ${gap} missed events...`);
-
-            const response = await execute<{ eventsReplay: EventsReplayResponse }>(graphqlClient, {
-              query: EVENTS_REPLAY,
-              variables: { sessionId, sinceSequence: lastSeq },
+    const conn = new SessionConnection({
+      backendUrl,
+      sessionId,
+      boardPath,
+      sessionName,
+      callbacks: {
+        onConnectionFlagsChange: (flags) => {
+          setIsConnecting(flags.isConnecting);
+          setHasConnected(flags.hasConnected);
+          setIsWebSocketConnected(flags.isWebSocketConnected);
+        },
+        onSessionJoined: (sessionData: SessionData) => {
+          // Handle session state updates (UserJoined/Left/etc. happen via onSessionEvent)
+          setSession(sessionData as unknown as Session);
+        },
+        onSessionCleared: () => {
+          removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+          setActiveSession(null);
+        },
+        onQueueEvent: handleQueueEvent,
+        onSessionEvent: (event: SessionEvent) => {
+          // Handle UserJoined/UserLeft/LeaderChanged/SessionEnded in session state
+          if (event.__typename !== 'SessionStatsUpdated') {
+            setSession((prev) => {
+              if (!prev) return prev;
+              switch (event.__typename) {
+                case 'UserJoined':
+                  return { ...prev, users: upsertSessionUser(prev.users, event.user) };
+                case 'UserLeft':
+                  return { ...prev, users: prev.users.filter((u) => u.id !== event.userId) };
+                case 'LeaderChanged':
+                  return {
+                    ...prev,
+                    isLeader: event.leaderId === prev.clientId,
+                    users: prev.users.map((u) => ({ ...u, isLeader: u.id === event.leaderId })),
+                  };
+                case 'SessionEnded':
+                  if (DEBUG) console.log('[PersistentSession] Session ended:', event.reason);
+                  removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+                  return prev;
+                default:
+                  return prev;
+              }
             });
-
-            const replay = response?.eventsReplay;
-            if (!replay) {
-              throw new Error('eventsReplay payload missing');
-            }
-
-            if (replay.events.length > 0) {
-              if (DEBUG) console.log(`[PersistentSession] Replaying ${replay.events.length} events`);
-              replay.events.forEach(event => {
-                handleQueueEvent(transformToSubscriptionEvent(event));
-              });
-              if (DEBUG) console.log('[PersistentSession] Delta sync completed successfully');
-            } else {
-              if (DEBUG) console.log('[PersistentSession] No events to replay');
-            }
-          } catch (err) {
-            console.warn('[PersistentSession] Delta sync failed, falling back to full sync:', err);
-            applyFullSync(sessionData);
           }
-        } else if (gap > 100) {
-          if (DEBUG) console.log(`[PersistentSession] Gap too large (${gap}), using full sync`);
-          applyFullSync(sessionData);
-        } else if (lastSeq === null) {
-          if (DEBUG) console.log('[PersistentSession] First connection, applying initial state');
-          applyFullSync(sessionData);
-        } else if (gap === 0) {
-          const localHash = computeQueueStateHash(queueRef.current, currentClimbQueueItemRef.current?.uuid || null);
-          if (localHash !== sessionData.queueState.stateHash) {
-            if (DEBUG) console.log('[PersistentSession] Hash mismatch on reconnect despite gap=0, applying full sync');
-            applyFullSync(sessionData);
-          } else {
-            if (DEBUG) console.log('[PersistentSession] No missed events, already in sync');
-          }
-        }
+          handleSessionEvent(event);
+        },
+        onError: (err) => {
+          setError(err);
+        },
+        onClientCreated: (newClient) => {
+          setClient(newClient);
+        },
+        getQueueState: () => ({
+          queue: queueRef.current,
+          currentItemUuid: currentClimbQueueItemRef.current?.uuid || null,
+        }),
+        getLastSequence: () => lastReceivedSequenceRef.current,
+        toClimbQueueItemInput: (item: unknown) => toClimbQueueItemInput(item as LocalClimbQueueItem),
+        getPendingInitialQueue: () => pendingInitialQueueRef.current,
+        clearPendingInitialQueue: () => setPendingInitialQueue(null),
+      },
+    });
 
-        setSession(sessionData);
-        if (DEBUG) console.log('[PersistentSession] Reconnection complete, clientId:', sessionData.clientId);
-      } finally {
-        isReconnectingRef.current = false;
-      }
-    }
+    connectionRef.current = conn;
 
-    triggerResyncRef.current = handleReconnect;
+    // Wire up triggerResync ref for use by other hooks (event processor, subscriptions)
+    triggerResyncRef.current = (force?: boolean) => conn.triggerResync(force);
 
-    function applyFullSync(sessionData: any) {
-      if (sessionData.queueState) {
-        handleQueueEvent({
-          __typename: 'FullSync',
-          sequence: sessionData.queueState.sequence,
-          state: sessionData.queueState,
-        });
-      }
-    }
-
-    async function connect() {
-      if (connectionGenerationRef.current !== connectionGeneration) return;
-      if (isConnectingRef.current) {
-        if (DEBUG) console.log('[PersistentSession] Connection already in progress, skipping');
-        return;
-      }
-      isConnectingRef.current = true;
-
-      if (DEBUG) console.log('[PersistentSession] Connecting to session:', sessionId);
-      setIsConnecting(true);
-      setError(null);
-
-      try {
-        graphqlClient = createGraphQLClient({
-          url: backendUrl!,
-          authToken: wsAuthTokenRef.current,
-          onReconnect: handleReconnect,
-          connectionName: 'session',
-        });
-
-        if (!mountedRef.current) {
-          graphqlClient.dispose();
-          isConnectingRef.current = false;
-          return;
-        }
-
-        setClient(graphqlClient);
-
-        const sessionData = await joinSession(graphqlClient);
-
-        if (connectionGenerationRef.current !== connectionGeneration) {
-          return;
-        }
-
-        if (!mountedRef.current) {
-          graphqlClient.dispose();
-          return;
-        }
-
-        if (!sessionData) {
-          throw new TransientJoinError('JoinSession returned no payload');
-        }
-
-        if (DEBUG) console.log('[PersistentSession] Joined session, clientId:', sessionData.clientId);
-
-        transientRetryCount = 0;
-        setSession(sessionData);
-        setHasConnected(true);
-        setIsConnecting(false);
-
-        if (sessionData.queueState) {
-          handleQueueEvent({
-            __typename: 'FullSync',
-            sequence: sessionData.queueState.sequence,
-            state: sessionData.queueState,
-          });
-        }
-
-        // Subscribe to queue updates
-        queueUnsubscribeRef.current = subscribe<{ queueUpdates: SubscriptionQueueEvent }>(
-          graphqlClient,
-          { query: QUEUE_UPDATES, variables: { sessionId } },
-          {
-            next: (data) => {
-              if (data.queueUpdates) {
-                handleQueueEvent(data.queueUpdates);
-              }
-            },
-            error: (err) => {
-              console.error('[PersistentSession] Queue subscription error:', err);
-              queueUnsubscribeRef.current = null;
-              if (mountedRef.current) {
-                setError(err instanceof Error ? err : new Error(String(err)));
-              }
-            },
-            complete: () => {
-              if (DEBUG) console.log('[PersistentSession] Queue subscription completed');
-              queueUnsubscribeRef.current = null;
-            },
-          },
-        );
-
-        // Subscribe to session updates
-        sessionUnsubscribeRef.current = subscribe<{ sessionUpdates: SessionEvent }>(
-          graphqlClient,
-          { query: SESSION_UPDATES, variables: { sessionId } },
-          {
-            next: (data) => {
-              if (data.sessionUpdates) {
-                // Handle UserJoined/UserLeft/LeaderChanged/SessionEnded in session state
-                const event = data.sessionUpdates;
-                if (event.__typename !== 'SessionStatsUpdated') {
-                  setSession((prev) => {
-                    if (!prev) return prev;
-                    switch (event.__typename) {
-                      case 'UserJoined':
-                        return { ...prev, users: upsertSessionUser(prev.users, event.user) };
-                      case 'UserLeft':
-                        return { ...prev, users: prev.users.filter((u) => u.id !== event.userId) };
-                      case 'LeaderChanged':
-                        return {
-                          ...prev,
-                          isLeader: event.leaderId === prev.clientId,
-                          users: prev.users.map((u) => ({ ...u, isLeader: u.id === event.leaderId })),
-                        };
-                      case 'SessionEnded':
-                        if (DEBUG) console.log('[PersistentSession] Session ended:', event.reason);
-                        removePreference(ACTIVE_SESSION_KEY).catch(() => {});
-                        return prev;
-                      default:
-                        return prev;
-                    }
-                  });
-                }
-                handleSessionEvent(event);
-              }
-            },
-            error: (err) => {
-              console.error('[PersistentSession] Session subscription error:', err);
-              sessionUnsubscribeRef.current = null;
-            },
-            complete: () => {
-              if (DEBUG) console.log('[PersistentSession] Session subscription completed');
-              sessionUnsubscribeRef.current = null;
-            },
-          },
-        );
-
-        isConnectingRef.current = false;
-      } catch (err) {
-        console.error('[PersistentSession] Connection failed:', err);
-        isConnectingRef.current = false;
-        const isTransientJoinFailure = err instanceof TransientJoinError;
-
-        if (mountedRef.current) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-          setIsConnecting(false);
-          if (isTransientJoinFailure) {
-            transientRetryCount++;
-            if (transientRetryCount > MAX_TRANSIENT_RETRIES) {
-              console.warn(
-                `[PersistentSession] Exhausted ${MAX_TRANSIENT_RETRIES} transient retries, clearing session`,
-              );
-              transientRetryCount = 0;
-              removePreference(ACTIVE_SESSION_KEY).catch(() => {});
-              setActiveSession(null);
-            } else {
-              const delay = Math.min(
-                INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, transientRetryCount - 1),
-                MAX_RETRY_DELAY_MS,
-              );
-              if (DEBUG) console.log(`[PersistentSession] Transient retry ${transientRetryCount}/${MAX_TRANSIENT_RETRIES} in ${delay}ms`);
-              retryConnectTimeout = setTimeout(() => {
-                if (
-                  connectionGenerationRef.current === connectionGeneration &&
-                  mountedRef.current &&
-                  activeSessionRef.current?.sessionId === sessionId &&
-                  !isConnectingRef.current
-                ) {
-                  connect();
-                }
-              }, delay);
-            }
-          } else {
-            removePreference(ACTIVE_SESSION_KEY).catch(() => {});
-            setActiveSession(null);
-          }
-        }
-        if (graphqlClient) {
-          graphqlClient.dispose();
-        }
-      }
-    }
-
-    connect();
+    // Set initial credentials and connect
+    conn.updateCredentials(wsAuthTokenRef.current, usernameRef.current, avatarUrlRef.current);
+    conn.connect();
 
     return () => {
       if (DEBUG) console.log('[PersistentSession] Cleaning up connection');
-      mountedRef.current = false;
-      isConnectingRef.current = false;
-
-      const clientToCleanup = graphqlClient;
-      graphqlClient = null;
-
-      queueUnsubscribeRef.current?.();
-      queueUnsubscribeRef.current = null;
-      sessionUnsubscribeRef.current?.();
-      sessionUnsubscribeRef.current = null;
-
-      if (clientToCleanup) {
-        Promise.resolve().then(() => {
-          if (sessionRef.current) {
-            execute(clientToCleanup, { query: LEAVE_SESSION }).catch(() => {});
-          }
-          clientToCleanup.dispose();
-        });
-      }
+      conn.dispose();
+      connectionRef.current = null;
+      triggerResyncRef.current = null;
 
       setClient(null);
       setSession(null);
       setHasConnected(false);
       setIsConnecting(false);
-      if (retryConnectTimeout) {
-        clearTimeout(retryConnectTimeout);
+      setIsWebSocketConnected(false);
+      lastReceivedSequenceRef.current = null;
+    };
+  // Note: credentials are accessed via refs to prevent reconnection on changes
+  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setSession,
+      wsAuthTokenRef, usernameRef, avatarUrlRef, sessionRef, activeSessionRef,
+      queueRef, currentClimbQueueItemRef, triggerResyncRef, lastReceivedSequenceRef]);
+
+  // Sync credentials to SessionConnection when they change
+  useEffect(() => {
+    connectionRef.current?.updateCredentials(wsAuthTokenRef.current, usernameRef.current, avatarUrlRef.current);
+  }, [wsAuthTokenRef, usernameRef, avatarUrlRef]);
+
+  // Background-tab handling: suspend socket after inactivity and recover on foreground
+  useEffect(() => {
+    if (!activeSession || !hasConnected) return;
+
+    let resyncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let hiddenSuspendTimer: ReturnType<typeof setTimeout> | null = null;
+    let suspendedForHiddenTab = false;
+
+    const clearTimers = () => {
+      if (resyncDebounceTimer) {
+        clearTimeout(resyncDebounceTimer);
+        resyncDebounceTimer = null;
+      }
+      if (hiddenSuspendTimer) {
+        clearTimeout(hiddenSuspendTimer);
+        hiddenSuspendTimer = null;
       }
     };
-  // Note: username, avatarUrl, wsAuthToken are accessed via refs to prevent reconnection on changes
-  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setSession,
-      mountedRef, connectionGenerationRef, isConnectingRef, isReconnectingRef,
-      wsAuthTokenRef, usernameRef, avatarUrlRef, sessionRef, activeSessionRef,
-      queueRef, currentClimbQueueItemRef, triggerResyncRef, lastReceivedSequenceRef,
-      queueUnsubscribeRef, sessionUnsubscribeRef, pendingInitialQueue]);
+
+    const scheduleResync = () => {
+      if (resyncDebounceTimer) clearTimeout(resyncDebounceTimer);
+      resyncDebounceTimer = setTimeout(() => {
+        connectionRef.current?.triggerResync();
+      }, VISIBILITY_RESYNC_DEBOUNCE_MS);
+    };
+
+    const resumeIfNeeded = () => {
+      if (hiddenSuspendTimer) {
+        clearTimeout(hiddenSuspendTimer);
+        hiddenSuspendTimer = null;
+      }
+      if (suspendedForHiddenTab) {
+        if (DEBUG) console.log('[PersistentSession] Foreground return, resuming suspended connection');
+        connectionRef.current?.resume();
+        suspendedForHiddenTab = false;
+        return;
+      }
+      scheduleResync();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        if (hiddenSuspendTimer) clearTimeout(hiddenSuspendTimer);
+        hiddenSuspendTimer = setTimeout(() => {
+          if (document.visibilityState !== 'hidden') return;
+          if (DEBUG) {
+            console.log('[PersistentSession] Tab hidden beyond threshold, suspending connection');
+          }
+          connectionRef.current?.suspend();
+          suspendedForHiddenTab = true;
+        }, HIDDEN_TAB_SUSPEND_DELAY_MS);
+        return;
+      }
+
+      if (document.visibilityState === 'visible') {
+        if (DEBUG) console.log('[PersistentSession] Page became visible, triggering connection health check');
+        resumeIfNeeded();
+      }
+    };
+
+    const handleFocus = () => {
+      if (document.visibilityState !== 'visible') return;
+      resumeIfNeeded();
+    };
+
+    const handleOnline = () => {
+      if (DEBUG) console.log('[PersistentSession] Network online, validating session connection');
+      resumeIfNeeded();
+    };
+
+    const handleOffline = () => {
+      if (DEBUG) console.log('[PersistentSession] Network offline');
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      clearTimers();
+    };
+  }, [activeSession, hasConnected]);
 
   return {
     activeSession,
@@ -560,6 +358,7 @@ export function useSessionLifecycle({
     session,
     isConnecting,
     hasConnected,
+    isWebSocketConnected,
     error,
     sessionSummary,
     activateSession,

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
+import React, { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
 import type { SubscriptionQueueEvent, SessionEvent, SessionLiveStats } from '@boardsesh/shared-schema';
 import { computeQueueStateHash } from '@/app/utils/hash';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
@@ -10,7 +10,11 @@ interface UseSessionSubscriptionsArgs {
   activeSession: ActiveSessionInfo | null;
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
-  lastReceivedStateHash: string | null;
+  serverStateHash: string | null;
+  localStateHash: string | null;
+  shouldRefreshServerHashRef: React.MutableRefObject<boolean>;
+  setLocalStateHash: Dispatch<SetStateAction<string | null>>;
+  setServerStateHash: Dispatch<SetStateAction<string | null>>;
   liveSessionStats: { sessionId: string } | null;
   setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
   setLiveSessionStats: Dispatch<SetStateAction<SessionLiveStats | null>>;
@@ -31,7 +35,11 @@ export function useSessionSubscriptions({
   activeSession,
   queue,
   currentClimbQueueItem,
-  lastReceivedStateHash,
+  serverStateHash,
+  localStateHash,
+  shouldRefreshServerHashRef,
+  setLocalStateHash,
+  setServerStateHash,
   liveSessionStats,
   setQueueState,
   setLiveSessionStats,
@@ -74,39 +82,42 @@ export function useSessionSubscriptions({
 
       console.error('[PersistentSession] Detected null/undefined items in queue, triggering resync');
       lastCorruptionResyncRef.current = now;
-      if (triggerResyncRef.current) {
-        triggerResyncRef.current();
-      }
+      triggerResyncRef.current?.(true);
       return;
     }
-    // Note: hash is computed in the main provider via the event processor
-  }, [session, queue, currentClimbQueueItem, setQueueState, triggerResyncRef, lastCorruptionResyncRef, isFilteringCorruptedItemsRef]);
+
+    // Compute local hash and conditionally update server hash
+    const newHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
+    setLocalStateHash(newHash);
+    if (shouldRefreshServerHashRef.current) {
+      shouldRefreshServerHashRef.current = false;
+      setServerStateHash(newHash);
+    }
+  }, [session, queue, currentClimbQueueItem, setQueueState, setLocalStateHash, setServerStateHash, shouldRefreshServerHashRef, triggerResyncRef, lastCorruptionResyncRef, isFilteringCorruptedItemsRef]);
 
   // Periodic state hash verification (every 60 seconds)
   useEffect(() => {
-    if (!session || !lastReceivedStateHash || queue.length === 0) {
+    if (!session || !serverStateHash || queue.length === 0) {
       return;
     }
 
     const verifyInterval = setInterval(() => {
-      const localHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
+      const currentLocalHash = localStateHash ?? computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
 
-      if (localHash !== lastReceivedStateHash) {
+      if (currentLocalHash !== serverStateHash) {
         console.warn(
           '[PersistentSession] State hash mismatch detected!',
-          `Local: ${localHash}, Server: ${lastReceivedStateHash}`,
+          `Local: ${currentLocalHash}, Server: ${serverStateHash}`,
           'Triggering automatic resync...'
         );
-        if (triggerResyncRef.current) {
-          triggerResyncRef.current();
-        }
+        triggerResyncRef.current?.(true);
       } else {
         if (DEBUG) console.log('[PersistentSession] State hash verification passed');
       }
     }, 60000);
 
     return () => clearInterval(verifyInterval);
-  }, [session, lastReceivedStateHash, queue, currentClimbQueueItem, triggerResyncRef]);
+  }, [session, serverStateHash, localStateHash, queue, currentClimbQueueItem, triggerResyncRef]);
 
   // Defensive state consistency check
   useEffect(() => {
@@ -120,9 +131,7 @@ export function useSessionSubscriptions({
       console.warn(
         '[PersistentSession] Current climb not found in queue - state inconsistency detected. Triggering resync.'
       );
-      if (triggerResyncRef.current) {
-        triggerResyncRef.current();
-      }
+      triggerResyncRef.current?.(true);
     }
   }, [session, currentClimbQueueItem, queue, triggerResyncRef]);
 

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -39,7 +39,7 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   const isConnectingRef = useRef(false);
   const isReconnectingRef = useRef(false);
   const connectionGenerationRef = useRef(0);
-  const triggerResyncRef = useRef<(() => void) | null>(null);
+  const triggerResyncRef = useRef<((force?: boolean) => void) | null>(null);
   const lastReceivedSequenceRef = useRef<number | null>(null);
   const lastCorruptionResyncRef = useRef<number>(0);
   const isFilteringCorruptedItemsRef = useRef(false);
@@ -59,6 +59,8 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   // destabilize the lifecycle effect's dependency array and cause infinite reconnects.
   const noopSetSession = useCallback(() => {}, []);
 
+  // SharedRefs: some refs are still used by non-lifecycle hooks (event processor, subscriptions, storage).
+  // The lifecycle hook only uses a subset since SessionConnection manages its own state internally.
   const refs: SharedRefs = {
     wsAuthTokenRef, usernameRef, avatarUrlRef,
     sessionRef, activeSessionRef,
@@ -108,7 +110,11 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     activeSession: lifecycle.activeSession,
     queue: eventProcessor.queue,
     currentClimbQueueItem: eventProcessor.currentClimbQueueItem,
-    lastReceivedStateHash: eventProcessor.lastReceivedStateHash,
+    serverStateHash: eventProcessor.serverStateHash,
+    localStateHash: eventProcessor.localStateHash,
+    shouldRefreshServerHashRef: eventProcessor.shouldRefreshServerHashRef,
+    setLocalStateHash: eventProcessor.setLocalStateHash,
+    setServerStateHash: eventProcessor.setServerStateHash,
     liveSessionStats: eventProcessor.liveSessionStats,
     setQueueState: eventProcessor.setQueueState,
     setLiveSessionStats: eventProcessor.setLiveSessionStats,

--- a/packages/web/app/components/persistent-session/session-connection.ts
+++ b/packages/web/app/components/persistent-session/session-connection.ts
@@ -1,0 +1,712 @@
+/**
+ * SessionConnection encapsulates all WebSocket connection orchestration:
+ * - graphql-ws client lifecycle (create, connect, dispose)
+ * - Session join/leave mutations
+ * - Queue and session subscription setup/teardown
+ * - Reconnection with delta sync / full sync fallback
+ * - Transient retry logic with exponential backoff
+ *
+ * This class replaces the inline connection logic in use-session-lifecycle.ts.
+ * It emits events via callbacks rather than calling React setState directly,
+ * making it independently testable and free from stale closure issues.
+ */
+
+import { createGraphQLClient, execute, subscribe, Client } from '../graphql-queue/graphql-client';
+import {
+  INITIAL_RETRY_DELAY_MS,
+  MAX_RETRY_DELAY_MS,
+  BACKOFF_MULTIPLIER,
+  MAX_TRANSIENT_RETRIES,
+} from '../graphql-queue/retry-constants';
+import {
+  JOIN_SESSION,
+  LEAVE_SESSION,
+  QUEUE_UPDATES,
+  SESSION_UPDATES,
+  EVENTS_REPLAY,
+  type SubscriptionQueueEvent,
+  type SessionEvent,
+} from '@boardsesh/shared-schema';
+import { ConnectionStateMachine, type ConnectionFlags } from './connection-state-machine';
+import { TransientJoinError } from './errors';
+import { computeQueueStateHash } from '@/app/utils/hash';
+
+const DEBUG = process.env.NODE_ENV === 'development';
+
+/** Session data returned from joinSession mutation */
+export interface SessionData {
+  id: string;
+  name: string | null;
+  boardPath: string;
+  users: Array<{
+    id: string;
+    username: string;
+    isLeader: boolean;
+    avatarUrl?: string;
+  }>;
+  queueState: {
+    sequence: number;
+    stateHash: string;
+    queue: unknown[];
+    currentClimbQueueItem: unknown;
+  };
+  isLeader: boolean;
+  clientId: string;
+  goal?: string | null;
+  isPublic?: boolean;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  isPermanent?: boolean;
+  color?: string | null;
+}
+
+/** Initial queue data to seed a new session */
+export interface InitialQueueData {
+  sessionId: string;
+  queue: Array<{ uuid: string }>;
+  currentClimb: { uuid: string } | null;
+  sessionName?: string;
+}
+
+/** Callbacks for the React layer to receive events */
+export interface SessionConnectionCallbacks {
+  onConnectionFlagsChange: (flags: ConnectionFlags) => void;
+  onSessionJoined: (session: SessionData) => void;
+  onSessionCleared: () => void;
+  onQueueEvent: (event: SubscriptionQueueEvent) => void;
+  onSessionEvent: (event: SessionEvent) => void;
+  onError: (error: Error) => void;
+  onClientCreated: (client: Client | null) => void;
+  /** Called to read current queue state for hash verification during reconnect */
+  getQueueState: () => { queue: Array<{ uuid: string }>, currentItemUuid: string | null };
+  /** Called to read current sequence number for delta sync */
+  getLastSequence: () => number | null;
+  /** Called to convert queue items to GraphQL input format */
+  toClimbQueueItemInput: (item: unknown) => unknown;
+  /** Called to get current pending initial queue data */
+  getPendingInitialQueue: () => InitialQueueData | null;
+  /** Called after initial queue is consumed */
+  clearPendingInitialQueue: () => void;
+}
+
+/** Configuration for creating a SessionConnection */
+export interface SessionConnectionConfig {
+  backendUrl: string;
+  sessionId: string;
+  boardPath: string;
+  sessionName?: string;
+  callbacks: SessionConnectionCallbacks;
+}
+
+// Minimum interval between resyncs to prevent spamming (e.g., rapid visibility changes)
+const MIN_RESYNC_INTERVAL_MS = 5_000;
+const DEFINITIVE_AUTH_PATTERNS = [
+  'unauthorized',
+  'forbidden',
+  'authentication',
+  'auth token',
+  'invalid token',
+  'permission denied',
+];
+const DEFINITIVE_SESSION_PATTERNS = [
+  'session not found',
+  'invalid session',
+  'session expired',
+  'session ended',
+];
+const TRANSIENT_PATTERNS = [
+  'timeout',
+  'timed out',
+  'network',
+  'fetch',
+  'econn',
+  'closed',
+  'unavailable',
+  'temporarily',
+  'gateway',
+  'too many requests',
+];
+
+type JoinErrorKind = 'auth' | 'session-invalid' | 'transient' | 'unknown';
+
+type EventsReplayAliasedResponse = {
+  events: SubscriptionQueueEvent[];
+  currentSequence: number;
+};
+
+class JoinSessionError extends Error {
+  constructor(
+    public readonly kind: JoinErrorKind,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'JoinSessionError';
+  }
+}
+
+export class SessionConnection {
+  private readonly config: SessionConnectionConfig;
+  private readonly stateMachine = new ConnectionStateMachine();
+
+  private client: Client | null = null;
+  private queueUnsubscribe: (() => void) | null = null;
+  private sessionUnsubscribe: (() => void) | null = null;
+  private retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  private transientRetryCount = 0;
+  private disposed = false;
+  private suspended = false;
+  private reconnectInProgress: Promise<void> | null = null;
+  private lastResyncTimestamp = 0;
+
+  // Mutable credentials that can be updated without reconnecting
+  private authToken: string | null = null;
+  private username: string | undefined = '';
+  private avatarUrl: string | undefined;
+
+  constructor(config: SessionConnectionConfig) {
+    this.config = config;
+
+    // Wire up state machine to emit flag changes
+    this.stateMachine.onStateChange(() => {
+      if (!this.disposed) {
+        this.config.callbacks.onConnectionFlagsChange(this.stateMachine.flags);
+      }
+    });
+  }
+
+  /** Update auth credentials without triggering reconnect */
+  updateCredentials(authToken: string | null, username: string | undefined, avatarUrl: string | undefined): void {
+    this.authToken = authToken;
+    this.username = username;
+    this.avatarUrl = avatarUrl;
+  }
+
+  /** Get the current connection state flags */
+  get flags(): ConnectionFlags {
+    return this.stateMachine.flags;
+  }
+
+  /** Get the underlying graphql-ws client (for mutations) */
+  get graphqlClient(): Client | null {
+    return this.client;
+  }
+
+  /**
+   * Start the connection. Creates the graphql-ws client, joins the session,
+   * and sets up subscriptions.
+   */
+  async connect(): Promise<void> {
+    if (this.disposed) return;
+    if (this.suspended) return;
+
+    // Prevent duplicate connections
+    if (this.stateMachine.state === 'CONNECTING') {
+      if (DEBUG) console.log('[SessionConnection] Connection already in progress, skipping');
+      return;
+    }
+
+    this.clearRetryTimeout();
+    this.stateMachine.transition('CONNECTING');
+
+    try {
+      this.ensureClient();
+      const sessionData = await this.joinSession();
+
+      if (this.disposed || this.suspended) {
+        this.clearClient(false);
+        return;
+      }
+
+      if (DEBUG) console.log('[SessionConnection] Joined session, clientId:', sessionData.clientId);
+
+      this.transientRetryCount = 0;
+      this.lastResyncTimestamp = Date.now();
+      this.stateMachine.transition('CONNECTED');
+      this.config.callbacks.onSessionJoined(sessionData);
+
+      // Send initial queue state via FullSync
+      if (sessionData.queueState) {
+        this.config.callbacks.onQueueEvent({
+          __typename: 'FullSync',
+          sequence: sessionData.queueState.sequence,
+          state: sessionData.queueState,
+        } as SubscriptionQueueEvent);
+      }
+
+      this.setupSubscriptions();
+    } catch (err) {
+      if (this.disposed || this.suspended) return;
+
+      console.error('[SessionConnection] Connection failed:', err);
+      this.handleConnectionFailure(err, 'connect');
+    }
+  }
+
+  /**
+   * Handle WebSocket reconnection: rejoin session, delta sync or full sync.
+   * Uses an async lock to prevent overlapping resync calls.
+   */
+  private handleReconnect(): Promise<void> {
+    if (this.disposed || this.suspended || !this.client) return Promise.resolve();
+
+    // If a reconnect is already in progress, return the existing promise
+    // to prevent overlapping resync calls
+    if (this.reconnectInProgress) {
+      if (DEBUG) console.log('[SessionConnection] Reconnect already in progress, waiting for it to complete');
+      return this.reconnectInProgress;
+    }
+
+    this.reconnectInProgress = this.doReconnect().finally(() => {
+      this.reconnectInProgress = null;
+    });
+    return this.reconnectInProgress;
+  }
+
+  private async doReconnect(): Promise<void> {
+    const { callbacks } = this.config;
+
+    // Transition to RECONNECTING if not already (e.g., when called from triggerResync while CONNECTED)
+    if (
+      !this.disposed &&
+      this.stateMachine.state !== 'RECONNECTING' &&
+      this.stateMachine.state !== 'FAILED'
+    ) {
+      this.stateMachine.transition('RECONNECTING');
+    }
+
+    try {
+      if (DEBUG) console.log('[SessionConnection] Reconnecting...');
+
+      const lastSeq = callbacks.getLastSequence();
+      const sessionData = await this.joinSession();
+
+      if (this.disposed || this.suspended) return;
+
+      this.lastResyncTimestamp = Date.now();
+
+      // Calculate sequence gap
+      const currentSeq = sessionData.queueState.sequence;
+      const gap = lastSeq !== null ? currentSeq - lastSeq : 0;
+
+      if (DEBUG) console.log(`[SessionConnection] Reconnected. Last seq: ${lastSeq}, Current seq: ${currentSeq}, Gap: ${gap}`);
+
+      if (gap > 0 && gap <= 100 && lastSeq !== null) {
+        await this.attemptDeltaSync(lastSeq, sessionData);
+      } else if (gap > 100) {
+        if (DEBUG) console.log(`[SessionConnection] Gap too large (${gap}), using full sync`);
+        this.applyFullSync(sessionData);
+      } else if (lastSeq === null) {
+        if (DEBUG) console.log('[SessionConnection] First connection, applying initial state');
+        this.applyFullSync(sessionData);
+      } else if (gap === 0) {
+        this.verifyHashAndSync(sessionData);
+      } else if (gap < 0) {
+        // Client is ahead of server (e.g., subscription delivered events during joinSession)
+        if (DEBUG) console.log(`[SessionConnection] Client ahead of server (gap=${gap}), verifying hash`);
+        this.verifyHashAndSync(sessionData);
+      }
+
+      callbacks.onSessionJoined(sessionData);
+
+      // Re-establish subscriptions if they were lost (e.g., due to subscription error)
+      if (!this.queueUnsubscribe || !this.sessionUnsubscribe) {
+        if (DEBUG) console.log('[SessionConnection] Re-establishing lost subscriptions');
+        this.setupSubscriptions();
+      }
+
+      if (DEBUG) console.log('[SessionConnection] Reconnection complete, clientId:', sessionData.clientId);
+      this.transientRetryCount = 0;
+      this.stateMachine.transition('CONNECTED');
+    } catch (err) {
+      if (this.disposed || this.suspended) return;
+      console.error('[SessionConnection] Reconnect failed:', err);
+      this.handleConnectionFailure(err, 'reconnect');
+    }
+  }
+
+  /**
+   * Trigger a manual resync (e.g. from corruption detection or visibility change).
+   * Throttled to prevent excessive resyncs from rapid triggers.
+   * @param force - Bypass throttle (e.g., for corruption detection)
+   */
+  triggerResync(force = false): void {
+    if (this.disposed || this.suspended || !this.client) return;
+    if (this.stateMachine.state !== 'CONNECTED' && this.stateMachine.state !== 'RECONNECTING') return;
+
+    // Throttle non-forced resyncs to prevent spamming (e.g., rapid tab switches)
+    if (!force) {
+      const timeSinceLastResync = Date.now() - this.lastResyncTimestamp;
+      if (timeSinceLastResync < MIN_RESYNC_INTERVAL_MS) {
+        if (DEBUG) console.log(`[SessionConnection] Resync throttled (${Math.round(timeSinceLastResync / 1000)}s since last)`);
+        return;
+      }
+    }
+
+    if (DEBUG) console.log(`[SessionConnection] Manual resync triggered (force=${force})`);
+    this.handleReconnect();
+  }
+
+  /**
+   * Suspend active networking without disposing the whole SessionConnection instance.
+   * Used for long inactive-tab periods.
+   */
+  suspend(): void {
+    if (this.disposed || this.suspended) return;
+    this.suspended = true;
+    this.clearRetryTimeout();
+    this.clearSubscriptions();
+    this.clearClient(false);
+    this.stateMachine.transition('IDLE');
+  }
+
+  /**
+   * Resume networking after a prior suspend().
+   */
+  resume(): void {
+    if (this.disposed || !this.suspended) return;
+    this.suspended = false;
+    void this.connect();
+  }
+
+  /**
+   * Execute a GraphQL mutation on the connected client.
+   */
+  async executeMutation<TData = unknown>(
+    query: string,
+    variables?: Record<string, unknown>,
+  ): Promise<TData> {
+    if (!this.client) throw new Error('Not connected to session');
+    return execute<TData>(this.client, { query, variables });
+  }
+
+  /**
+   * Disconnect and clean up all resources.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.suspended = false;
+
+    if (DEBUG) console.log('[SessionConnection] Disposing');
+
+    this.clearRetryTimeout();
+    this.clearSubscriptions();
+    this.clearClient(true);
+
+    this.stateMachine.reset();
+    this.stateMachine.dispose();
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────
+
+  private ensureClient(): void {
+    if (this.client || this.disposed || this.suspended) return;
+
+    const { backendUrl, callbacks } = this.config;
+    const newClient = createGraphQLClient({
+      url: backendUrl,
+      authToken: this.authToken,
+      onReconnect: () => this.handleReconnect(),
+      onConnectionStateChange: (connected, isReconnect) => {
+        if (this.disposed || this.suspended) return;
+        if (connected && isReconnect) {
+          // On reconnection, don't transition to CONNECTED yet.
+          // handleReconnect will do it after resync completes.
+          return;
+        }
+        if (!connected && this.stateMachine.state === 'CONNECTED') {
+          this.stateMachine.transition('RECONNECTING');
+        }
+      },
+    });
+
+    this.client = newClient;
+    callbacks.onClientCreated(newClient);
+  }
+
+  private normalizeError(err: unknown): Error {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+
+  private classifyJoinError(err: unknown): JoinErrorKind {
+    const message = this.normalizeError(err).message.toLowerCase();
+
+    if (DEFINITIVE_AUTH_PATTERNS.some((pattern) => message.includes(pattern))) {
+      return 'auth';
+    }
+    if (DEFINITIVE_SESSION_PATTERNS.some((pattern) => message.includes(pattern))) {
+      return 'session-invalid';
+    }
+    if (TRANSIENT_PATTERNS.some((pattern) => message.includes(pattern))) {
+      return 'transient';
+    }
+    if (err instanceof TransientJoinError) {
+      return 'transient';
+    }
+    return 'unknown';
+  }
+
+  private handleConnectionFailure(err: unknown, mode: 'connect' | 'reconnect'): void {
+    const error = this.normalizeError(err);
+    const wrappedError = err instanceof JoinSessionError
+      ? err
+      : new JoinSessionError(this.classifyJoinError(err), error.message, err);
+
+    this.config.callbacks.onError(wrappedError);
+
+    const isDefinitive =
+      wrappedError.kind === 'auth' || wrappedError.kind === 'session-invalid';
+    if (isDefinitive) {
+      this.transientRetryCount = 0;
+      this.stateMachine.transition('FAILED');
+      this.config.callbacks.onSessionCleared();
+      this.clearClient(false);
+      return;
+    }
+
+    this.transientRetryCount++;
+    if (this.transientRetryCount > MAX_TRANSIENT_RETRIES) {
+      console.warn(`[SessionConnection] Exhausted ${MAX_TRANSIENT_RETRIES} transient retries`);
+      this.transientRetryCount = 0;
+      this.stateMachine.transition('FAILED');
+      this.config.callbacks.onSessionCleared();
+      this.clearClient(false);
+      return;
+    }
+
+    if (mode === 'connect') {
+      this.stateMachine.transition('IDLE');
+      this.clearClient(false);
+    } else {
+      this.stateMachine.transition('RECONNECTING');
+    }
+
+    this.scheduleRetry(mode);
+  }
+
+  private clearRetryTimeout(): void {
+    if (!this.retryTimeout) return;
+    clearTimeout(this.retryTimeout);
+    this.retryTimeout = null;
+  }
+
+  private clearSubscriptions(): void {
+    this.queueUnsubscribe?.();
+    this.queueUnsubscribe = null;
+    this.sessionUnsubscribe?.();
+    this.sessionUnsubscribe = null;
+  }
+
+  private clearClient(sendLeave: boolean): void {
+    const clientToCleanup = this.client;
+    this.client = null;
+    this.config.callbacks.onClientCreated(null);
+
+    if (!clientToCleanup) return;
+
+    Promise.resolve().then(() => {
+      if (sendLeave) {
+        execute(clientToCleanup, { query: LEAVE_SESSION }).catch(() => {});
+      }
+      clientToCleanup.dispose();
+    });
+  }
+
+  private async joinSession(): Promise<SessionData> {
+    if (!this.client) {
+      throw new JoinSessionError('transient', 'Cannot join session without an active websocket client');
+    }
+
+    if (DEBUG) console.log('[SessionConnection] Calling joinSession mutation...');
+
+    try {
+      const { sessionId, boardPath, sessionName, callbacks } = this.config;
+
+      const initialQueueData = callbacks.getPendingInitialQueue();
+      const isForThisSession = initialQueueData?.sessionId === sessionId;
+      const queueData = isForThisSession ? initialQueueData : null;
+
+      if (DEBUG && queueData) {
+        console.log('[SessionConnection] Sending initial queue with', queueData.queue.length, 'items');
+      }
+
+      const effectiveSessionName = sessionName || queueData?.sessionName;
+      const variables: Record<string, unknown> = {
+        sessionId,
+        boardPath,
+        username: this.username,
+        avatarUrl: this.avatarUrl,
+      };
+
+      if (queueData) {
+        variables.initialQueue = queueData.queue.map(callbacks.toClimbQueueItemInput);
+        variables.initialCurrentClimb = queueData.currentClimb
+          ? callbacks.toClimbQueueItemInput(queueData.currentClimb)
+          : null;
+      }
+
+      if (effectiveSessionName) {
+        variables.sessionName = effectiveSessionName;
+      }
+
+      const response = await execute<{ joinSession: SessionData }>(this.client, {
+        query: JOIN_SESSION,
+        variables,
+      });
+
+      const joinedSession = response?.joinSession;
+      if (!joinedSession) {
+        throw new TransientJoinError('JoinSession returned no session payload');
+      }
+
+      // Clear pending queue only after confirmed successful join payload
+      if (queueData) {
+        callbacks.clearPendingInitialQueue();
+      }
+
+      return joinedSession;
+    } catch (err) {
+      console.error('[SessionConnection] JoinSession failed:', err);
+      const error = this.normalizeError(err);
+      throw new JoinSessionError(this.classifyJoinError(err), error.message, err);
+    }
+  }
+
+  private setupSubscriptions(): void {
+    if (!this.client || this.disposed) return;
+
+    const { sessionId, callbacks } = this.config;
+
+    // Subscribe to queue updates
+    this.queueUnsubscribe = subscribe<{ queueUpdates: SubscriptionQueueEvent }>(
+      this.client,
+      { query: QUEUE_UPDATES, variables: { sessionId } },
+      {
+        next: (data) => {
+          if (data.queueUpdates) {
+            callbacks.onQueueEvent(data.queueUpdates);
+          }
+        },
+        error: (err) => {
+          console.error('[SessionConnection] Queue subscription error:', err);
+          this.queueUnsubscribe = null;
+          if (!this.disposed) {
+            callbacks.onError(this.normalizeError(err));
+            this.handleReconnect();
+          }
+        },
+        complete: () => {
+          if (DEBUG) console.log('[SessionConnection] Queue subscription completed');
+          this.queueUnsubscribe = null;
+        },
+      },
+    );
+
+    // Subscribe to session updates
+    this.sessionUnsubscribe = subscribe<{ sessionUpdates: SessionEvent }>(
+      this.client,
+      { query: SESSION_UPDATES, variables: { sessionId } },
+      {
+        next: (data) => {
+          if (data.sessionUpdates) {
+            callbacks.onSessionEvent(data.sessionUpdates);
+          }
+        },
+        error: (err) => {
+          console.error('[SessionConnection] Session subscription error:', err);
+          this.sessionUnsubscribe = null;
+          if (!this.disposed) {
+            callbacks.onError(this.normalizeError(err));
+            this.handleReconnect();
+          }
+        },
+        complete: () => {
+          if (DEBUG) console.log('[SessionConnection] Session subscription completed');
+          this.sessionUnsubscribe = null;
+        },
+      },
+    );
+  }
+
+  private async attemptDeltaSync(lastSeq: number, sessionData: SessionData): Promise<void> {
+    if (!this.client) return;
+
+    const { sessionId, callbacks } = this.config;
+
+    try {
+      if (DEBUG) console.log(`[SessionConnection] Attempting delta sync for missed events...`);
+
+      const response = await execute<{ eventsReplay: EventsReplayAliasedResponse }>(this.client, {
+        query: EVENTS_REPLAY,
+        variables: { sessionId, sinceSequence: lastSeq },
+      });
+
+      const replay = response?.eventsReplay;
+      if (!replay) {
+        throw new Error('eventsReplay payload missing');
+      }
+
+      if (replay.events.length > 0) {
+        if (DEBUG) console.log(`[SessionConnection] Replaying ${replay.events.length} events`);
+        replay.events.forEach(event => {
+          callbacks.onQueueEvent(event);
+        });
+        if (DEBUG) console.log('[SessionConnection] Delta sync completed successfully');
+      } else {
+        // Gap > 0 but no events returned — server may have purged old events.
+        if (DEBUG) console.log('[SessionConnection] No events to replay despite gap > 0, falling back to full sync');
+        this.applyFullSync(sessionData);
+      }
+    } catch (err) {
+      console.warn('[SessionConnection] Delta sync failed, falling back to full sync:', err);
+      this.applyFullSync(sessionData);
+    }
+  }
+
+  private applyFullSync(sessionData: SessionData): void {
+    if (sessionData.queueState) {
+      this.config.callbacks.onQueueEvent({
+        __typename: 'FullSync',
+        sequence: sessionData.queueState.sequence,
+        state: sessionData.queueState,
+      } as SubscriptionQueueEvent);
+    }
+  }
+
+  private verifyHashAndSync(sessionData: SessionData): void {
+    const { queue, currentItemUuid } = this.config.callbacks.getQueueState();
+    const localHash = computeQueueStateHash(queue, currentItemUuid);
+
+    if (localHash !== sessionData.queueState.stateHash) {
+      if (DEBUG) console.log('[SessionConnection] Hash mismatch on reconnect despite gap=0, applying full sync');
+      this.applyFullSync(sessionData);
+    } else {
+      if (DEBUG) console.log('[SessionConnection] No missed events, already in sync');
+    }
+  }
+
+  private scheduleRetry(mode: 'connect' | 'reconnect'): void {
+    this.clearRetryTimeout();
+
+    const delay = Math.min(
+      INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, this.transientRetryCount - 1),
+      MAX_RETRY_DELAY_MS,
+    );
+
+    if (DEBUG) {
+      console.log(
+        `[SessionConnection] Transient retry ${this.transientRetryCount}/${MAX_TRANSIENT_RETRIES} in ${delay}ms`,
+      );
+    }
+
+    this.retryTimeout = setTimeout(() => {
+      if (this.disposed || this.suspended) return;
+      if (mode === 'connect') {
+        void this.connect();
+      } else {
+        void this.handleReconnect();
+      }
+    }, delay);
+  }
+}

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -154,7 +154,7 @@ export interface SharedRefs {
   isConnectingRef: MutableRefObject<boolean>;
   isReconnectingRef: MutableRefObject<boolean>;
   connectionGenerationRef: MutableRefObject<number>;
-  triggerResyncRef: MutableRefObject<(() => void) | null>;
+  triggerResyncRef: MutableRefObject<((force?: boolean) => void) | null>;
   lastReceivedSequenceRef: MutableRefObject<number | null>;
   lastCorruptionResyncRef: MutableRefObject<number>;
   isFilteringCorruptedItemsRef: MutableRefObject<boolean>;

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -100,6 +100,7 @@ export function useClimbActionsData({
   const {
     data: favorites,
     isLoading: isLoadingFavorites,
+    error: favoritesError,
     cancelFetches: cancelFavFetches,
   } = useIncrementalQuery<Set<string>>(
     climbUuids,
@@ -215,6 +216,7 @@ export function useClimbActionsData({
 
   const {
     data: membershipsData,
+    error: membershipsError,
     cancelFetches: cancelMemFetches,
   } = useIncrementalQuery<Map<string, Set<string>>>(
     climbUuids,
@@ -315,6 +317,7 @@ export function useClimbActionsData({
       isFavorited,
       toggleFavorite,
       isLoading: isLoadingFavorites,
+      error: favoritesError,
       isAuthenticated,
     },
     playlistsProviderProps: {
@@ -324,6 +327,7 @@ export function useClimbActionsData({
       removeFromPlaylist,
       createPlaylist,
       isLoading: playlistsLoading,
+      error: membershipsError,
       isAuthenticated,
       refreshPlaylists,
     },

--- a/packages/web/app/hooks/use-incremental-query.ts
+++ b/packages/web/app/hooks/use-incremental-query.ts
@@ -31,6 +31,8 @@ interface UseIncrementalQueryOptions<T> {
 interface UseIncrementalQueryResult<T> {
   data: T;
   isLoading: boolean;
+  /** The error from the most recent failed fetch, or null if the last fetch succeeded. */
+  error: Error | null;
   /**
    * Cancel all in-flight fetch queries for this incremental query.
    * Useful for optimistic mutations that need to prevent stale fetch results
@@ -130,9 +132,28 @@ export function useIncrementalQuery<T>(
         return fetchChunk(chunks[0]);
       }
 
-      // Parallel fetch for multiple chunks, then merge
-      const results = await Promise.all(chunks.map((chunk) => fetchChunk(chunk)));
-      return results.reduce((acc, result) => merge(acc, result), initialValue);
+      // Parallel fetch for multiple chunks — use allSettled to save partial results
+      const settled = await Promise.allSettled(chunks.map((chunk) => fetchChunk(chunk)));
+      const fulfilled: T[] = [];
+      let failCount = 0;
+      for (const result of settled) {
+        if (result.status === 'fulfilled') {
+          fulfilled.push(result.value as T);
+        } else {
+          failCount++;
+        }
+      }
+      if (fulfilled.length === 0) {
+        // All chunks failed — rethrow the first error
+        const firstRejected = settled.find((r) => r.status === 'rejected') as PromiseRejectedResult | undefined;
+        throw firstRejected?.reason ?? new Error('All fetch chunks failed');
+      }
+      if (failCount > 0) {
+        console.warn(
+          `[useIncrementalQuery] ${failCount}/${settled.length} chunks failed, using partial results`,
+        );
+      }
+      return fulfilled.reduce((acc, result) => merge(acc, result), initialValue);
     },
     enabled: enabled && newUuids.length > 0,
     // Each batch is fetched once; accumulation handles deduplication
@@ -172,6 +193,11 @@ export function useIncrementalQuery<T>(
   const lastCacheWriteRef = useRef<T | undefined>(undefined);
   useEffect(() => {
     if (!fetchQuery.data || fetchQuery.data === lastMergedRef.current) return;
+
+    // Guard against stale fetch results from a previous context (e.g., board/angle changed mid-fetch).
+    // If the key has changed since this fetch started, discard the results.
+    if (prevKeyRef.current !== currentKeyStr) return;
+
     lastMergedRef.current = fetchQuery.data;
 
     // Mark these UUIDs as fetched (including those with no results)
@@ -183,7 +209,7 @@ export function useIncrementalQuery<T>(
       lastCacheWriteRef.current = merged;
       queryClient.setQueryData(accumulatedKey, merged);
     }
-  }, [fetchQuery.data, newUuids, accumulated, merge, hasChanged, accumulatedKey, queryClient]);
+  }, [fetchQuery.data, newUuids, accumulated, merge, hasChanged, accumulatedKey, queryClient, currentKeyStr]);
 
   // Subscribe to cache changes for the accumulated key only.
   // Handles two scenarios:
@@ -238,6 +264,7 @@ export function useIncrementalQuery<T>(
   return {
     data: accumulated,
     isLoading: fetchQuery.isLoading && !hasChanged(initialValue, accumulated),
+    error: fetchQuery.error instanceof Error ? fetchQuery.error : fetchQuery.error ? new Error(String(fetchQuery.error)) : null,
     cancelFetches,
   };
 }


### PR DESCRIPTION
## Summary

- **ConnectionStateMachine**: Explicit FSM (`IDLE → CONNECTING → CONNECTED → RECONNECTING → FAILED`) replaces 6+ scattered boolean flags, eliminating inconsistent state combinations
- **SessionConnection class**: Encapsulates all WebSocket orchestration (client lifecycle, join/leave, subscriptions, reconnection, retry) — replaces ~400 lines of inline logic in `use-session-lifecycle.ts`
- **Error classification**: `JoinSessionError` categorizes failures as `auth`/`session-invalid`/`transient`/`unknown` for smarter retry vs fail-fast behavior
- **Background tab handling**: Suspends socket after 60s hidden, resumes on foreground return with resync
- **Resync throttling**: 5s minimum interval prevents spamming from rapid tab switches; forced resyncs bypass throttle
- **graphql-client hardening**: `shouldRetrySocket()` skips retries for definitive close codes (4401, 4403, 1008); fixed `execute()` timeout to properly unsubscribe and prevent double-settle
- **Split state hash tracking**: Server vs local hash for more precise periodic verification
- **QueueReordered bounds checking**: Triggers resync instead of corrupting state on out-of-bounds indices
- **useIncrementalQuery improvements**: Exposes `error` field, uses `Promise.allSettled` for partial chunk failure resilience, guards against stale context results

## Context

The previous branch (`claude/websocket-state-machine-session`) applied these improvements against a monolithic `persistent-session-context.tsx`. Main has since been refactored into 5 modular hooks. This PR re-applies all improvements into main's module structure rather than attempting a mechanical rebase.

## Test plan

- [x] `tsc --noEmit` passes clean across all packages
- [x] 50 tests pass across 4 test files (connection-state-machine, session-connection, event-utils, graphql-client)
- [ ] Manual test: join a party session, verify connection and queue sync
- [ ] Manual test: switch tabs for >60s, return and verify resume + resync
- [ ] Manual test: kill backend, verify reconnection with delta sync
- [ ] Manual test: verify auth failure clears session instead of retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)