### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: boardsesh


### PR DESCRIPTION
## Summary
Added GitHub Sponsors funding configuration to enable sponsorship support for the project.

## Changes
- Created `.github/FUNDING.yml` with GitHub Sponsors configuration pointing to the `boardsesh` account

## Details
This configuration file enables the GitHub Sponsors button on the repository, allowing users to support the project through GitHub's sponsorship platform.

https://claude.ai/code/session_01Rw4WUwb6r6zWn6JpW7t4eC