### PR TITLE
Enforce strict no-any types across all packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ We are using next.js app router, it's important we try to use server side compon
 - Always use CSS media queries for mobile/responsive design
 - For rendering avoid JavaScript breakpoint detection & Grid.useBreakpoint()
 - While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
+- **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
 
 ### Component Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@types/node": "^25.3.3",
         "@types/ws": "^8.18.1",
+        "oxlint": "^1.50.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
       },
@@ -64,6 +65,7 @@
         "@types/node": "^25.3.3",
         "@types/ws": "^8.18.1",
         "drizzle-kit": "^0.31.9",
+        "oxlint": "^1.50.0",
         "postgres": "^3.4.8",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
@@ -74,6 +76,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^25",
+        "oxlint": "^1.50.0",
         "typescript": "^5.9.3",
       },
     },
@@ -93,6 +96,7 @@
         "@types/ws": "^8.18.1",
         "dotenv": "^17.3.1",
         "drizzle-kit": "^0.31.9",
+        "oxlint": "^1.50.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
       },
@@ -107,7 +111,7 @@
       "name": "@boardsesh/moonboard-ocr",
       "version": "0.2.0",
       "bin": {
-        "moonboard-ocr": "dist/cli.js",
+        "moonboard-ocr": "./dist/cli.js",
       },
       "dependencies": {
         "commander": "^14.0.3",
@@ -116,6 +120,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.3.3",
+        "oxlint": "^1.50.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
@@ -131,6 +136,7 @@
         "graphql": "^16.13.0",
       },
       "devDependencies": {
+        "oxlint": "^1.50.0",
         "typescript": "^5.9.3",
       },
     },
@@ -2088,15 +2094,7 @@
 
     "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "@atlaskit/app-provider/@atlaskit/tokens": ["@atlaskit/tokens@11.0.1", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-3W9TncNs3TKQmJXSm2oIBoLhh9FnudLKHspT/NxlHWkVEqSWZX0gAbECMbH9wVItgaK+zqo5DyxqAPUtGRdCWg=="],
-
-    "@atlaskit/css/@atlaskit/tokens": ["@atlaskit/tokens@11.0.1", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-3W9TncNs3TKQmJXSm2oIBoLhh9FnudLKHspT/NxlHWkVEqSWZX0gAbECMbH9wVItgaK+zqo5DyxqAPUtGRdCWg=="],
-
     "@atlaskit/focus-ring/@atlaskit/tokens": ["@atlaskit/tokens@9.1.2", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-3JXke1jwMUUWF5nW0YGUEmQa9byg1h6yjF4m5gL4sKJJ0qt6Q/jmaugIFpPyuptwZGov+mBZlVbuwcoMVJDKow=="],
-
-    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/@atlaskit/tokens": ["@atlaskit/tokens@11.0.1", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-3W9TncNs3TKQmJXSm2oIBoLhh9FnudLKHspT/NxlHWkVEqSWZX0gAbECMbH9wVItgaK+zqo5DyxqAPUtGRdCWg=="],
-
-    "@atlaskit/skeleton/@atlaskit/tokens": ["@atlaskit/tokens@11.0.1", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-3W9TncNs3TKQmJXSm2oIBoLhh9FnudLKHspT/NxlHWkVEqSWZX0gAbECMbH9wVItgaK+zqo5DyxqAPUtGRdCWg=="],
 
     "@auth/core/preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
@@ -2121,8 +2119,6 @@
     "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA=="],
 
     "@graphql-tools/executor/@graphql-tools/utils": ["@graphql-tools/utils@10.11.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q=="],
-
-    "@graphql-tools/merge/@graphql-tools/utils": ["@graphql-tools/utils@11.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA=="],
 
     "@neondatabase/serverless/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
 
@@ -2154,8 +2150,6 @@
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "cosmiconfig/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 
     "cssstyle/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
@@ -2170,15 +2164,11 @@
 
     "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
-    "make-dir/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "next-auth/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "next-auth/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "next-auth/uuid": ["uuid@8.3.2", "", { "bin": "dist/bin/uuid" }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
-
-    "node-abi/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -2213,8 +2203,6 @@
     "tree-sitter/node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
 
     "tree-sitter-json/node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
-
-    "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -2280,8 +2268,6 @@
 
     "@swagger-api/apidom-parser-adapter-yaml-1-2/tree-sitter/node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
 
-    "bl/buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "drizzle-kit/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -2337,58 +2323,6 @@
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
-
-    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
-
-    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
-
-    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
-
-    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
-
-    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
-
-    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
-
-    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
-
-    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
-
-    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
-
-    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
-
-    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
-
-    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
-
-    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
-
-    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
-
-    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
-
-    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
-
-    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
-
-    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
-
-    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
-
-    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
-
-    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
-
-    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
-
-    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
-
-    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
-
-    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:shared": "bun run --filter=@boardsesh/shared-schema build",
     "build:crypto": "bun run --filter=@boardsesh/crypto build",
     "build:db": "bun run --filter=@boardsesh/db build",
-    "lint": "bun run --filter=@boardsesh/web lint",
+    "lint": "bun run --filter='*' lint",
     "typecheck": "bun run --filter='*' typecheck",
     "typecheck:web": "bun run --filter=@boardsesh/web typecheck",
     "typecheck:backend": "bun run --filter=boardsesh-backend typecheck",

--- a/packages/aurora-sync/oxlint.json
+++ b/packages/aurora-sync/oxlint.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-    "node_modules/**",
-    "board-controller/**"
+    "dist/**",
+    "node_modules/**"
   ]
 }

--- a/packages/aurora-sync/package.json
+++ b/packages/aurora-sync/package.json
@@ -34,6 +34,8 @@
     "dev": "tsx watch src/cli/index.ts",
     "build": "tsc",
     "start": "node dist/cli/index.js",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix .",
     "sync:all": "tsx src/cli/index.ts all",
     "sync:user": "tsx src/cli/index.ts user"
   },
@@ -49,6 +51,7 @@
   "devDependencies": {
     "@types/node": "^25.3.3",
     "@types/ws": "^8.18.1",
+    "oxlint": "^1.50.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -32,14 +32,15 @@ interface UpsertResult {
   skippedReason?: string;
 }
 
+type AuroraApiRow = Record<string, string>;
+
 async function upsertTableData(
   db: NeonDatabase<Record<string, never>>,
   boardName: AuroraBoardName,
   tableName: string,
   auroraUserId: number,
   nextAuthUserId: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any[],
+  data: AuroraApiRow[],
   log: (message: string) => void = console.log,
 ): Promise<UpsertResult> {
   if (data.length === 0) return { synced: 0, skipped: 0 };
@@ -174,7 +175,7 @@ async function upsertTableData(
             isMirror: Boolean(item.is_mirror),
             status: (Number(item.attempt_id) === 1 ? 'flash' : 'send') as 'flash' | 'send' | 'attempt',
             attemptCount: Number(item.bid_count || 1),
-            quality: convertQuality(item.quality),
+            quality: convertQuality(item.quality ? Number(item.quality) : null),
             difficulty: item.difficulty ? Number(item.difficulty) : null,
             isBenchmark: Boolean(item.is_benchmark || 0),
             comment: item.comment || '',

--- a/packages/backend/oxlint.json
+++ b/packages/backend/oxlint.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-    "node_modules/**",
-    "board-controller/**"
+    "dist/**",
+    "node_modules/**"
   ]
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,6 +12,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix .",
     "test:db:up": "docker-compose up -d db",
     "test:db:migrate": "DATABASE_URL=postgresql://postgres:postgres@localhost:5433/boardsesh_backend_test drizzle-kit migrate",
     "test:integration": "vitest run src/__tests__/integration.test.ts",
@@ -53,6 +55,7 @@
     "drizzle-kit": "^0.31.9",
     "postgres": "^3.4.8",
     "typescript": "^5.9.3",
+    "oxlint": "^1.50.0",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/backend/src/__tests__/graphql-resolvers.test.ts
+++ b/packages/backend/src/__tests__/graphql-resolvers.test.ts
@@ -284,7 +284,7 @@ describe('GraphQL Resolver Input Validation', () => {
       `;
 
       // This should succeed (not throw)
-      const result = await execute<{ searchClimbs: { climbs: any[]; hasMore: boolean } }>(client, {
+      const result = await execute<{ searchClimbs: { climbs: Array<{ uuid: string }>; hasMore: boolean } }>(client, {
         query,
         variables: {
           input: {

--- a/packages/backend/src/__tests__/integration.test.ts
+++ b/packages/backend/src/__tests__/integration.test.ts
@@ -5,6 +5,51 @@ import { v4 as uuidv4 } from 'uuid';
 import { startServer } from '../server';
 import type { ClimbQueueItem } from '@boardsesh/shared-schema';
 
+interface JoinSessionResult {
+  id: string;
+  boardPath: string;
+  isLeader: boolean;
+  clientId: string;
+  users: Array<{ id: string; username: string; isLeader: boolean }>;
+  queueState: { queue: Array<{ uuid: string }>; currentClimbQueueItem: { uuid: string } | null };
+}
+
+interface AddQueueItemResult {
+  uuid: string;
+  climb: { name: string };
+}
+
+interface SetCurrentClimbResult {
+  uuid: string;
+  climb: { name: string; mirrored: boolean };
+}
+
+interface MirrorCurrentClimbResult {
+  uuid: string;
+  climb: { mirrored: boolean };
+}
+
+interface SessionQueryResult {
+  queueState: { queue: Array<{ uuid: string }>; currentClimbQueueItem: { uuid: string } | null };
+  users: Array<{ id: string }>;
+}
+
+interface QueueEvent {
+  __typename: string;
+  state?: { queue: Array<{ uuid: string }>; currentClimbQueueItem?: { uuid: string } | null };
+  item?: { uuid: string; climb?: { name: string } };
+  uuid?: string;
+  oldIndex?: number;
+  newIndex?: number;
+}
+
+interface SessionEvent {
+  __typename: string;
+  user?: { id: string; username: string };
+  userId?: string;
+  leaderId?: string;
+}
+
 // Test fixtures
 const TEST_BOARD_PATH = '/kilter/1/2/3/40';
 const TEST_PORT = 8082;
@@ -89,7 +134,8 @@ function waitForEvent<T>(
       { query },
       {
         next: (data) => {
-          const event = (data.data as any)?.queueUpdates || (data.data as any)?.sessionUpdates;
+          const d = data.data as Record<string, T> | null | undefined;
+          const event = d?.queueUpdates || d?.sessionUpdates;
           if (event && predicate(event)) {
             clearTimeout(timeoutId);
             unsubscribe();
@@ -123,7 +169,8 @@ function collectEvents<T>(
       { query },
       {
         next: (data) => {
-          const event = (data.data as any)?.queueUpdates || (data.data as any)?.sessionUpdates;
+          const d = data.data as Record<string, T> | null | undefined;
+          const event = d?.queueUpdates || d?.sessionUpdates;
           if (event) {
             events.push(event);
             if (events.length >= count) {
@@ -183,7 +230,7 @@ describe('Daemon Integration Tests', () => {
       const sessionId = createTestSessionId();
       const client = createTestClient();
 
-      const result = await execute<{ joinSession: any }>(client, {
+      const result = await execute<{ joinSession: JoinSessionResult }>(client, {
         query: `
           mutation JoinSession($sessionId: ID!, $boardPath: String!, $username: String) {
             joinSession(sessionId: $sessionId, boardPath: $boardPath, username: $username) {
@@ -215,7 +262,7 @@ describe('Daemon Integration Tests', () => {
       const sessionId = createTestSessionId();
       const client = createTestClient();
 
-      const result = await execute<{ joinSession: any }>(client, {
+      const result = await execute<{ joinSession: JoinSessionResult }>(client, {
         query: `
           mutation {
             joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Leader") {
@@ -234,12 +281,12 @@ describe('Daemon Integration Tests', () => {
       const client2 = createTestClient();
 
       // First client joins
-      const result1 = await execute<{ joinSession: any }>(client1, {
+      const result1 = await execute<{ joinSession: JoinSessionResult }>(client1, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Leader") { isLeader clientId } }`,
       });
 
       // Second client joins
-      const result2 = await execute<{ joinSession: any }>(client2, {
+      const result2 = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Follower") { isLeader clientId users { id isLeader } } }`,
       });
 
@@ -248,7 +295,7 @@ describe('Daemon Integration Tests', () => {
       expect(result2.joinSession.users).toHaveLength(2);
 
       // Verify one user is leader
-      const leader = result2.joinSession.users.find((u: any) => u.isLeader);
+      const leader = result2.joinSession.users.find((u) => u.isLeader);
       expect(leader).toBeDefined();
       expect(leader.id).toBe(result1.joinSession.clientId);
     });
@@ -265,7 +312,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Subscribe and wait for initial FullSync
-      const event = await waitForEvent<any>(
+      const event = await waitForEvent<QueueEvent | SessionEvent>(
         client,
         `subscription { queueUpdates(sessionId: "${sessionId}") { __typename ... on FullSync { state { queue { uuid } } } } }`,
         (e) => e.__typename === 'FullSync'
@@ -288,7 +335,7 @@ describe('Daemon Integration Tests', () => {
 
       // Add a queue item
       const testClimb = createTestClimb('test-climb-1');
-      const result = await execute<{ addQueueItem: any }>(client, {
+      const result = await execute<{ addQueueItem: AddQueueItemResult }>(client, {
         query: `
           mutation AddQueueItem($item: ClimbQueueItemInput!) {
             addQueueItem(item: $item) { uuid climb { name } }
@@ -312,7 +359,7 @@ describe('Daemon Integration Tests', () => {
 
       // Set current climb
       const testClimb = createTestClimb('current-test');
-      const result = await execute<{ setCurrentClimb: any }>(client, {
+      const result = await execute<{ setCurrentClimb: SetCurrentClimbResult }>(client, {
         query: `
           mutation SetCurrentClimb($item: ClimbQueueItemInput) {
             setCurrentClimb(item: $item, shouldAddToQueue: true) { uuid climb { name } }
@@ -341,7 +388,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Mirror the climb
-      const result = await execute<{ mirrorCurrentClimb: any }>(client, {
+      const result = await execute<{ mirrorCurrentClimb: MirrorCurrentClimbResult }>(client, {
         query: `mutation { mirrorCurrentClimb(mirrored: true) { uuid climb { mirrored } } }`,
       });
 
@@ -403,7 +450,7 @@ describe('Daemon Integration Tests', () => {
       expect(result.reorderQueueItem).toBe(true);
 
       // Verify the order by querying the session
-      const sessionResult = await execute<{ session: any }>(client, {
+      const sessionResult = await execute<{ session: SessionQueryResult }>(client, {
         query: `query { session(sessionId: "${sessionId}") { queueState { queue { uuid } } } }`,
       });
 
@@ -428,7 +475,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Client 2 subscribes to queue updates
-      const eventPromise = collectEvents<any>(
+      const eventPromise = collectEvents<QueueEvent>(
         client2,
         `subscription { queueUpdates(sessionId: "${sessionId}") { __typename ... on FullSync { state { queue { uuid } } } ... on QueueItemAdded { item { uuid climb { name } } } } }`,
         2 // FullSync + QueueItemAdded
@@ -465,7 +512,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Client 2 subscribes to queue updates
-      const eventPromise = collectEvents<any>(
+      const eventPromise = collectEvents<QueueEvent>(
         client2,
         `subscription { queueUpdates(sessionId: "${sessionId}") { __typename ... on FullSync { state { currentClimbQueueItem { uuid } } } ... on CurrentClimbChanged { item { uuid } } } }`,
         2 // FullSync + CurrentClimbChanged
@@ -509,7 +556,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Client 2 subscribes
-      const eventPromise = waitForEvent<any>(
+      const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client2,
         `subscription { queueUpdates(sessionId: "${sessionId}") { __typename ... on FullSync { state { queue { uuid } } } ... on QueueReordered { uuid oldIndex newIndex } } }`,
         (e) => e.__typename === 'QueueReordered'
@@ -538,19 +585,19 @@ describe('Daemon Integration Tests', () => {
       const client2 = createTestClient();
 
       // Client 1 joins first (becomes leader)
-      const result1 = await execute<{ joinSession: any }>(client1, {
+      const result1 = await execute<{ joinSession: JoinSessionResult }>(client1, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Leader") { isLeader clientId } }`,
       });
       expect(result1.joinSession.isLeader).toBe(true);
 
       // Client 2 joins second (not leader)
-      const result2 = await execute<{ joinSession: any }>(client2, {
+      const result2 = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Follower") { isLeader clientId } }`,
       });
       expect(result2.joinSession.isLeader).toBe(false);
 
       // Client 2 subscribes to session updates
-      const eventPromise = waitForEvent<any>(
+      const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client2,
         `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on LeaderChanged { leaderId } ... on UserLeft { userId } } }`,
         (e) => e.__typename === 'LeaderChanged'
@@ -574,7 +621,7 @@ describe('Daemon Integration Tests', () => {
       const client2 = createTestClient();
 
       // Client 1 joins first (becomes leader)
-      const result1 = await execute<{ joinSession: any }>(client1, {
+      const result1 = await execute<{ joinSession: JoinSessionResult }>(client1, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Leader") { isLeader clientId } }`,
       });
       expect(result1.joinSession.isLeader).toBe(true);
@@ -585,7 +632,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Client 1 subscribes to session updates to detect UserLeft
-      const eventPromise = waitForEvent<any>(
+      const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client1,
         `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } ... on LeaderChanged { leaderId } } }`,
         (e) => e.__typename === 'UserLeft'
@@ -614,7 +661,7 @@ describe('Daemon Integration Tests', () => {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "First") { id } }`,
       });
 
-      const eventPromise = waitForEvent<any>(
+      const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client1,
         `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserJoined { user { id username } } } }`,
         (e) => e.__typename === 'UserJoined'
@@ -642,12 +689,12 @@ describe('Daemon Integration Tests', () => {
       await execute(client1, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "First") { id } }`,
       });
-      const result2 = await execute<{ joinSession: any }>(client2, {
+      const result2 = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Second") { clientId } }`,
       });
 
       // Client 1 subscribes to session updates
-      const eventPromise = waitForEvent<any>(
+      const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client1,
         `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } } }`,
         (e) => e.__typename === 'UserLeft'
@@ -672,17 +719,17 @@ describe('Daemon Integration Tests', () => {
       const client2 = createTestClient();
 
       // Client 1 joins first (becomes leader)
-      const result1 = await execute<{ joinSession: any }>(client1, {
+      const result1 = await execute<{ joinSession: JoinSessionResult }>(client1, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Leader") { clientId } }`,
       });
 
       // Client 2 joins second
-      const result2 = await execute<{ joinSession: any }>(client2, {
+      const result2 = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Follower") { clientId } }`,
       });
 
       // Client 2 subscribes to session updates
-      const eventPromise = collectEvents<any>(
+      const eventPromise = collectEvents<SessionEvent>(
         client2,
         `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } ... on LeaderChanged { leaderId } } }`,
         2 // UserLeft + LeaderChanged
@@ -732,7 +779,7 @@ describe('Daemon Integration Tests', () => {
 
       // New client joins same session - should get empty state (session was cleaned up)
       const client2 = createTestClient();
-      const result = await execute<{ joinSession: any }>(client2, {
+      const result = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}") { isLeader users { id } queueState { queue { uuid } } } }`,
       });
 
@@ -769,7 +816,7 @@ describe('Daemon Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       // Client 2 should still see the queue item (query session state)
-      const result = await execute<{ session: any }>(client2, {
+      const result = await execute<{ session: SessionQueryResult }>(client2, {
         query: `query { session(sessionId: "${sessionId}") { queueState { queue { uuid } } users { id } } }`,
       });
 

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -216,7 +216,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       await roomManager.leaveSession('client-1');
 
       // Simulate Redis expiry by clearing Redis and resetting room manager
-      const redisHashes = (mockRedis as any)._hashes as Map<string, Record<string, string>>;
+      const redisHashes = mockRedis._hashes;
       redisHashes.clear();
 
       roomManager.reset();
@@ -458,7 +458,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       await roomManager.leaveSession('client-1');
 
       // Clear both in-memory and Redis (simulate TTL expiry)
-      const redisHashes = (mockRedis as any)._hashes as Map<string, Record<string, string>>;
+      const redisHashes = mockRedis._hashes;
       redisHashes.clear();
 
       roomManager.reset();
@@ -568,7 +568,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       await roomManager.flushPendingWrites();
 
       // Verify in Redis
-      const redisHashes = (mockRedis as any)._hashes as Map<string, Record<string, string>>;
+      const redisHashes = mockRedis._hashes;
       const redisSession = redisHashes.get(`boardsesh:session:${sessionId}`);
       expect(redisSession?.queue).toBeDefined();
 
@@ -602,7 +602,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       expect(users.length).toBeGreaterThan(0);
 
       // Session queue state should be in Redis (written by updateQueueState)
-      const redisHashes = (mockRedis as any)._hashes as Map<string, Record<string, string>>;
+      const redisHashes = mockRedis._hashes;
       const redisSession = redisHashes.get(`boardsesh:session:${sessionId}`);
       expect(redisSession).toBeDefined();
     });

--- a/packages/backend/src/__tests__/session-summary.test.ts
+++ b/packages/backend/src/__tests__/session-summary.test.ts
@@ -3,21 +3,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Shared mock state, declared with vi.hoisted to ensure availability before mock setup
 const mockState = vi.hoisted(() => ({
   selectCallIndex: 0,
-  sessionRows: [] as any[],
-  gradeDistRows: [] as any[],
-  hardestRows: [] as any[],
-  participantRows: [] as any[],
+  sessionRows: [] as Record<string, unknown>[],
+  gradeDistRows: [] as Record<string, unknown>[],
+  hardestRows: [] as Record<string, unknown>[],
+  participantRows: [] as Record<string, unknown>[],
 }));
 
 // Chainable mock builder, also hoisted for use in mock factory
 const { createChainableMock } = vi.hoisted(() => ({
-  createChainableMock: (resolveData: any) => {
-    const chain: any = {};
+  createChainableMock: (resolveData: unknown) => {
+    const chain: Record<string, unknown> = {};
     for (const method of ['select', 'from', 'where', 'leftJoin', 'groupBy', 'orderBy', 'limit']) {
-      chain[method] = (..._args: any[]) => chain;
+      chain[method] = (..._args: unknown[]) => chain;
     }
-    // Make it thenable so `await` resolves to the predetermined data
-    chain.then = (resolve: any, reject: any) =>
+    chain.then = (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
       Promise.resolve(resolveData).then(resolve, reject);
     return chain;
   },
@@ -30,7 +29,7 @@ vi.mock('../db/client', () => ({
     {
       get(_, prop) {
         if (prop === 'select') {
-          return (..._args: any[]) => {
+          return (..._args: unknown[]) => {
             const index = mockState.selectCallIndex++;
             const dataByIndex = [
               mockState.sessionRows,
@@ -41,7 +40,7 @@ vi.mock('../db/client', () => ({
           };
         }
         if (prop === 'execute') {
-          return (..._args: any[]) => Promise.resolve(mockState.participantRows);
+          return (..._args: unknown[]) => Promise.resolve(mockState.participantRows);
         }
       },
     },
@@ -58,13 +57,13 @@ vi.mock('@boardsesh/db/schema', () => ({
 
 // Mock drizzle-orm functions to prevent errors from passing mock schema objects
 vi.mock('drizzle-orm', () => ({
-  eq: (..._args: any[]) => ({}),
-  and: (..._args: any[]) => ({}),
-  inArray: (..._args: any[]) => ({}),
-  sql: (_strings: TemplateStringsArray, ..._values: any[]) => ({}),
-  count: (..._args: any[]) => ({}),
-  desc: (..._args: any[]) => ({}),
-  isNotNull: (..._args: any[]) => ({}),
+  eq: (..._args: unknown[]) => ({}),
+  and: (..._args: unknown[]) => ({}),
+  inArray: (..._args: unknown[]) => ({}),
+  sql: (_strings: TemplateStringsArray, ..._values: unknown[]) => ({}),
+  count: (..._args: unknown[]) => ({}),
+  desc: (..._args: unknown[]) => ({}),
+  isNotNull: (..._args: unknown[]) => ({}),
 }));
 
 import { generateSessionSummary } from '../graphql/resolvers/sessions/session-summary';

--- a/packages/backend/src/events/__tests__/event-broker.test.ts
+++ b/packages/backend/src/events/__tests__/event-broker.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { EventBroker } from '../event-broker';
+import type { SocialEvent } from '@boardsesh/shared-schema';
 
-/**
- * Unit tests for EventBroker's parseEvent logic.
- * We test the private method by accessing it through a subclass.
- */
 class TestableEventBroker extends EventBroker {
-  public testParseEvent(fields: string[]) {
-    return (this as any).parseEvent(fields);
+  public testParseEvent(fields: string[]): SocialEvent | null {
+    return (this as unknown as { parseEvent(fields: string[]): SocialEvent | null }).parseEvent(fields);
   }
 }
 

--- a/packages/crypto/oxlint.json
+++ b/packages/crypto/oxlint.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-    "node_modules/**",
-    "board-controller/**"
+    "dist/**",
+    "node_modules/**"
   ]
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -14,10 +14,13 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix ."
   },
   "devDependencies": {
     "@types/node": "^25",
+    "oxlint": "^1.50.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/db/oxlint.json
+++ b/packages/db/oxlint.json
@@ -1,15 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    "dist/**",
     "node_modules/**",
-    "board-controller/**"
+    "drizzle/**"
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,6 +46,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix .",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",
     "test": "tsx --test scripts/**/*.test.ts",
@@ -67,6 +69,7 @@
     "@types/ws": "^8.18.1",
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.31.9",
+    "oxlint": "^1.50.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/packages/moonboard-ocr/oxlint.json
+++ b/packages/moonboard-ocr/oxlint.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-    "node_modules/**",
-    "board-controller/**"
+    "dist/**",
+    "node_modules/**"
   ]
 }

--- a/packages/moonboard-ocr/package.json
+++ b/packages/moonboard-ocr/package.json
@@ -30,7 +30,9 @@
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix ."
   },
   "dependencies": {
     "commander": "^14.0.3",
@@ -39,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.3.3",
+    "oxlint": "^1.50.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/packages/shared-schema/oxlint.json
+++ b/packages/shared-schema/oxlint.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "react", "react-hooks", "nextjs"],
+  "plugins": ["typescript"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "deny"
   },
   "ignorePatterns": [
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-    "node_modules/**",
-    "board-controller/**"
+    "dist/**",
+    "node_modules/**"
   ]
 }

--- a/packages/shared-schema/package.json
+++ b/packages/shared-schema/package.json
@@ -30,12 +30,15 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix ."
   },
   "dependencies": {
     "graphql": "^16.13.0"
   },
   "devDependencies": {
+    "oxlint": "^1.50.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -38,14 +38,14 @@ const mockBoardDetails = {
   size_description: 'Full',
   set_names: ['Standard'],
   supportsMirroring: true,
-} as any;
+} as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
 
 describe('useBoardBluetooth', () => {
-  let originalBluetooth: any;
+  let originalBluetooth: unknown;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalBluetooth = (navigator as any).bluetooth;
+    originalBluetooth = (navigator as unknown as Record<string, unknown>).bluetooth;
 
     // Set up navigator.bluetooth as available
     Object.defineProperty(navigator, 'bluetooth', {
@@ -112,7 +112,7 @@ describe('useBoardBluetooth', () => {
   });
 
   it('sets loading during connect', async () => {
-    let resolveDevice: (value: any) => void;
+    let resolveDevice: (value: unknown) => void;
     const devicePromise = new Promise((resolve) => {
       resolveDevice = resolve;
     });

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-wake-lock.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-wake-lock.test.ts
@@ -8,7 +8,7 @@ function createMockWakeLockSentinel(): WakeLockSentinel {
     released: false,
     type: 'screen' as const,
     release: vi.fn(async function (this: WakeLockSentinel) {
-      (this as any).released = true;
+      (this as unknown as { released: boolean }).released = true;
       // Trigger release listeners
       listeners['release']?.forEach((fn) => fn());
     }),
@@ -63,7 +63,7 @@ describe('useWakeLock', () => {
       configurable: true,
     });
     // Delete the property entirely to make 'wakeLock' in navigator return false
-    delete (navigator as any).wakeLock;
+    delete (navigator as unknown as Record<string, unknown>).wakeLock;
 
     const { result } = renderHook(() => useWakeLock(false));
     expect(result.current.isSupported).toBe(false);

--- a/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
+++ b/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
@@ -55,7 +55,7 @@ const mockClimb = {
   name: 'Test Climb',
   difficulty: 'V5',
   frames: 'p1r42',
-} as any;
+} as unknown as Parameters<typeof useClimbActions>[0]['climb'];
 
 const mockBoardDetails = {
   board_name: 'kilter',
@@ -67,7 +67,7 @@ const mockBoardDetails = {
   size_description: 'Full',
   set_names: ['Standard'],
   supportsMirroring: true,
-} as any;
+} as unknown as Parameters<typeof useClimbActions>[0]['boardDetails'];
 
 const defaultOptions = {
   climb: mockClimb,

--- a/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
@@ -96,7 +96,7 @@ describe('ForkAction', () => {
   describe('availability', () => {
     it('returns available: false when board_name is moonboard', () => {
       const props = createTestProps({
-        boardDetails: createTestBoardDetails({ board_name: 'moonboard' as any }),
+        boardDetails: createTestBoardDetails({ board_name: 'moonboard' }),
       });
       const result = ForkAction(props);
       expect(result.available).toBe(false);
@@ -134,7 +134,7 @@ describe('ForkAction', () => {
 
     it('returns available: true for tension board with all fields', () => {
       const props = createTestProps({
-        boardDetails: createTestBoardDetails({ board_name: 'tension' as any }),
+        boardDetails: createTestBoardDetails({ board_name: 'tension' }),
       });
       const result = ForkAction(props);
       expect(result.available).toBe(true);
@@ -159,7 +159,7 @@ describe('ForkAction', () => {
 
     it('does not call constructCreateClimbUrl when not available', () => {
       const props = createTestProps({
-        boardDetails: createTestBoardDetails({ board_name: 'moonboard' as any }),
+        boardDetails: createTestBoardDetails({ board_name: 'moonboard' }),
       });
       ForkAction(props);
 
@@ -177,7 +177,7 @@ describe('ForkAction', () => {
 
     it('returns a disabled menuItem when not available', () => {
       const props = createTestProps({
-        boardDetails: createTestBoardDetails({ board_name: 'moonboard' as any }),
+        boardDetails: createTestBoardDetails({ board_name: 'moonboard' }),
       });
       const result = ForkAction(props);
       expect(result.menuItem.key).toBe('fork');

--- a/packages/web/app/components/connection-manager/__tests__/websocket-connection-manager.test.ts
+++ b/packages/web/app/components/connection-manager/__tests__/websocket-connection-manager.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client } from 'graphql-ws';
 import { connectionManager, STALE_GRACE_MS } from '../websocket-connection-manager';
 
 class FakeClient {
-  listeners = new Map<string, (...args: any[]) => void>();
+  listeners = new Map<string, (...args: unknown[]) => void>();
   terminate = vi.fn();
   dispose = vi.fn();
 
-  on(event: string, listener: (...args: any[]) => void) {
+  on(event: string, listener: (...args: unknown[]) => void) {
     this.listeners.set(event, listener);
     return () => this.listeners.delete(event);
   }
 
-  emit(event: string, ...args: any[]) {
+  emit(event: string, ...args: unknown[]) {
     const handler = this.listeners.get(event);
     if (handler) handler(...args);
   }
@@ -32,13 +33,13 @@ describe('WebSocketConnectionManager', () => {
     if (originalVisibilityState) {
       Object.defineProperty(document, 'visibilityState', originalVisibilityState);
     } else {
-      delete (document as any).visibilityState;
+      delete (document as unknown as Record<string, unknown>).visibilityState;
     }
   });
 
   it('terminates a stale connection and marks reconnecting', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     // Advance past stale threshold and health check interval
@@ -52,7 +53,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('forces reconnect on visibilitychange to visible', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     // Ensure document reports visible
@@ -68,7 +69,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('exposes error state when client errors', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
 
     client.emit('error', new Error('boom'));
 
@@ -79,7 +80,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('sets state to reconnecting on closed event', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     expect(connectionManager.getSnapshot().state).toBe('connected');
@@ -93,7 +94,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('ping with received=true marks activity, received=false does not', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     const activityAfterConnect = connectionManager.getSnapshot().lastActivity!;
@@ -113,7 +114,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('pong with received=true resets state to connected', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
 
     // Start in connecting state
     expect(connectionManager.getSnapshot().state).toBe('connecting');
@@ -128,8 +129,8 @@ describe('WebSocketConnectionManager', () => {
   it('switches primary with setPrimaryName()', () => {
     const clientA = new FakeClient();
     const clientB = new FakeClient();
-    const unregA = connectionManager.registerClient(clientA as any, 'queue');
-    const unregB = connectionManager.registerClient(clientB as any, 'session');
+    const unregA = connectionManager.registerClient(clientA as unknown as Client, 'queue');
+    const unregB = connectionManager.registerClient(clientB as unknown as Client, 'session');
 
     clientA.emit('connected');
     clientB.emit('connecting');
@@ -149,7 +150,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('unregister cleans up listeners and resets state to idle when last client removed', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     expect(connectionManager.getSnapshot().state).toBe('connected');
@@ -169,7 +170,7 @@ describe('WebSocketConnectionManager', () => {
     const states: string[] = [];
     connectionManager.subscribe((snapshot) => states.push(snapshot.state));
 
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
 
     // connecting → connected
     client.emit('connected');
@@ -201,7 +202,7 @@ describe('WebSocketConnectionManager', () => {
 
   it('pauses health check when tab is hidden and resumes when visible', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
     // Hide the tab
@@ -227,10 +228,10 @@ describe('WebSocketConnectionManager', () => {
 
   it('subscribe delivers initial snapshot immediately', () => {
     const client = new FakeClient();
-    const unregister = connectionManager.registerClient(client as any, 'session');
+    const unregister = connectionManager.registerClient(client as unknown as Client, 'session');
     client.emit('connected');
 
-    const snapshots: any[] = [];
+    const snapshots: ReturnType<typeof connectionManager.getSnapshot>[] = [];
     const unsub = connectionManager.subscribe((snapshot) => snapshots.push(snapshot));
 
     // Should have received exactly one snapshot immediately

--- a/packages/web/app/components/connection-manager/__tests__/websocket-connection-provider.test.tsx
+++ b/packages/web/app/components/connection-manager/__tests__/websocket-connection-provider.test.tsx
@@ -3,18 +3,19 @@ import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import { connectionManager } from '../websocket-connection-manager';
 import { WebSocketConnectionProvider, useWebSocketConnection } from '../websocket-connection-provider';
+import type { Client } from 'graphql-ws';
 
 class FakeClient {
-  listeners = new Map<string, (...args: any[]) => void>();
+  listeners = new Map<string, (...args: unknown[]) => void>();
   terminate = vi.fn();
   dispose = vi.fn();
 
-  on(event: string, listener: (...args: any[]) => void) {
+  on(event: string, listener: (...args: unknown[]) => void) {
     this.listeners.set(event, listener);
     return () => this.listeners.delete(event);
   }
 
-  emit(event: string, ...args: any[]) {
+  emit(event: string, ...args: unknown[]) {
     const handler = this.listeners.get(event);
     if (handler) handler(...args);
   }
@@ -55,7 +56,7 @@ describe('WebSocketConnectionProvider', () => {
     );
 
     act(() => {
-      connectionManager.registerClient(client as any, 'session');
+      connectionManager.registerClient(client as unknown as Client, 'session');
     });
 
     expect(screen.getByTestId('state').textContent).toBe('connecting:session');
@@ -77,7 +78,7 @@ describe('WebSocketConnectionProvider', () => {
     );
 
     act(() => {
-      connectionManager.registerClient(client as any, 'session');
+      connectionManager.registerClient(client as unknown as Client, 'session');
       client.emit('connected');
     });
 
@@ -113,7 +114,7 @@ describe('WebSocketConnectionProvider', () => {
     );
 
     act(() => {
-      unregister = connectionManager.registerClient(client as any, 'session');
+      unregister = connectionManager.registerClient(client as unknown as Client, 'session');
       client.emit('connected');
     });
 
@@ -144,7 +145,7 @@ describe('useWebSocketConnection fallback (no provider)', () => {
   });
 
   it('returns a stable reference across renders without a provider', () => {
-    const refs: any[] = [];
+    const refs: ReturnType<typeof useWebSocketConnection>[] = [];
 
     function RefTracker() {
       const value = useWebSocketConnection();

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-restoration.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-restoration.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, Dispatch } from 'react';
-import type { QueueAction } from '../../queue-control/types';
+import type { QueueAction, ClimbQueue, ClimbQueueItem } from '../../queue-control/types';
 
 interface UseQueueRestorationParams {
   isPersistentSessionActive: boolean;
@@ -72,10 +72,8 @@ export function useQueueRestoration({
       dispatch({
         type: 'INITIAL_QUEUE_DATA',
         payload: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          queue: persistentSession.localQueue as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          currentClimbQueueItem: persistentSession.localCurrentClimbQueueItem as any,
+          queue: persistentSession.localQueue as unknown as ClimbQueue,
+          currentClimbQueueItem: persistentSession.localCurrentClimbQueueItem as unknown as ClimbQueueItem | null,
         },
       });
       setHasRestored(true);
@@ -88,10 +86,8 @@ export function useQueueRestoration({
           dispatch({
             type: 'INITIAL_QUEUE_DATA',
             payload: {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              queue: stored.queue as any,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              currentClimbQueueItem: stored.currentClimbQueueItem as any,
+              queue: stored.queue as unknown as ClimbQueue,
+              currentClimbQueueItem: stored.currentClimbQueueItem as unknown as ClimbQueueItem | null,
             },
           });
         }

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -331,7 +331,7 @@ export function useSessionLifecycle({
 
     triggerResyncRef.current = handleReconnect;
 
-    function applyFullSync(sessionData: any) {
+    function applyFullSync(sessionData: Session) {
       if (sessionData.queueState) {
         handleQueueEvent({
           __typename: 'FullSync',

--- a/packages/web/app/components/search-drawer/__tests__/use-heatmap.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/use-heatmap.test.tsx
@@ -14,7 +14,7 @@ const defaultProps = {
   sizeId: 10,
   setIds: '1,2',
   angle: 40,
-  filters: { minGrade: 1 } as any,
+  filters: { minGrade: 1 } as unknown as Parameters<typeof useHeatmapData>[0]['filters'],
   enabled: true,
 };
 
@@ -99,7 +99,7 @@ describe('useHeatmapData', () => {
   });
 
   it('cancels fetch on unmount (cancelled flag)', async () => {
-    let resolvePromise: (value: any) => void;
+    let resolvePromise: (value: unknown) => void;
     const fetchPromise = new Promise((resolve) => {
       resolvePromise = resolve;
     });

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -294,8 +294,7 @@ export default function AuroraCredentialsSection() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importingBoard, setImportingBoard] = useState<'kilter' | 'tension' | null>(null);
   const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [importRawData, setImportRawData] = useState<any>(null);
+  const [importRawData, setImportRawData] = useState<unknown>(null);
   const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);

--- a/packages/web/app/hooks/__tests__/use-card-swipe-navigation.test.ts
+++ b/packages/web/app/hooks/__tests__/use-card-swipe-navigation.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Capture the config passed to useSwipeable
-let capturedSwipeableConfig: Record<string, any> = {};
+let capturedSwipeableConfig: Record<string, (...args: unknown[]) => unknown> = {};
 vi.mock('react-swipeable', () => ({
-  useSwipeable: (config: Record<string, any>) => {
+  useSwipeable: (config: Record<string, (...args: unknown[]) => unknown>) => {
     capturedSwipeableConfig = config;
     return { ref: vi.fn() };
   },

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -31,6 +31,7 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useClimbActionsData } from '../use-climb-actions-data';
 import { createQueryWrapper } from '@/app/test-utils/test-providers';
+import type { Playlist } from '@/app/lib/graphql/operations/playlists';
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 const mockUseSnackbar = vi.mocked(useSnackbar);
@@ -53,7 +54,7 @@ describe('useClimbActionsData', () => {
       isLoading: false,
       error: null,
     });
-    mockUseSnackbar.mockReturnValue({ showMessage: mockShowMessage } as any);
+    mockUseSnackbar.mockReturnValue({ showMessage: mockShowMessage });
     mockRequest.mockReset();
   });
 
@@ -152,7 +153,7 @@ describe('useClimbActionsData', () => {
     });
 
     // Create a promise we can control to keep mutation pending
-    let resolveMutation: (value: any) => void;
+    let resolveMutation: (value: unknown) => void;
     mockRequest.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveMutation = resolve;
@@ -324,7 +325,7 @@ describe('useClimbActionsData', () => {
     const newPlaylist = { uuid: 'pl-new', name: 'New Playlist', climbCount: 0 };
     mockRequest.mockResolvedValueOnce({ createPlaylist: newPlaylist });
 
-    let created: any;
+    let created: Playlist | undefined;
     await act(async () => {
       created = await result.current.playlistsProviderProps.createPlaylist('New Playlist');
     });
@@ -360,7 +361,7 @@ describe('useClimbActionsData', () => {
     await waitFor(() => {
       const lastCallArgs = mockRequest.mock.calls;
       const hasRefetchCall = lastCallArgs.some(
-        (call: any[]) => call[0] === 'GET_ALL_USER_PLAYLISTS',
+        (call: unknown[]) => call[0] === 'GET_ALL_USER_PLAYLISTS',
       );
       expect(hasRefetchCall).toBe(true);
     });
@@ -399,7 +400,7 @@ describe('useClimbActionsData', () => {
 
     // The favorites fetch should only include climb-3 (not climb-1, climb-2)
     const favCalls = mockRequest.mock.calls.filter(
-      (call: any[]) => call[0] === 'GET_FAVORITES',
+      (call: unknown[]) => call[0] === 'GET_FAVORITES',
     );
     // Second favorites call should only contain the new UUID
     const lastFavCall = favCalls[favCalls.length - 1];

--- a/packages/web/app/hooks/__tests__/use-create-session.test.ts
+++ b/packages/web/app/hooks/__tests__/use-create-session.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/app/lib/graphql/operations/create-session', () => ({
 
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useCreateSession } from '../use-create-session';
+import type { SessionCreationFormData } from '@/app/components/session-creation/session-creation-form';
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
@@ -73,7 +74,7 @@ describe('useCreateSession', () => {
 
     await expect(
       act(async () => {
-        await result.current.createSession(createFormData() as any, '/kilter/1/2/3/40');
+        await result.current.createSession(createFormData() as SessionCreationFormData, '/kilter/1/2/3/40');
       }),
     ).rejects.toThrow('Not authenticated');
   });
@@ -103,7 +104,7 @@ describe('useCreateSession', () => {
     let sessionId: string | undefined;
     await act(async () => {
       sessionId = await result.current.createSession(
-        createFormData({ discoverable: true }) as any,
+        createFormData({ discoverable: true }) as SessionCreationFormData,
         '/kilter/1/2/3/40',
       );
     });
@@ -145,7 +146,7 @@ describe('useCreateSession', () => {
     let sessionId: string | undefined;
     await act(async () => {
       sessionId = await result.current.createSession(
-        createFormData({ discoverable: false }) as any,
+        createFormData({ discoverable: false }) as SessionCreationFormData,
         '/kilter/1/2/3/40',
       );
     });
@@ -183,7 +184,7 @@ describe('useCreateSession', () => {
 
     await act(async () => {
       await result.current.createSession(
-        createFormData({ discoverable: true }) as any,
+        createFormData({ discoverable: true }) as SessionCreationFormData,
         '/kilter/1/2/3/40',
       );
     });
@@ -218,7 +219,7 @@ describe('useCreateSession', () => {
 
     await act(async () => {
       await result.current.createSession(
-        createFormData({ discoverable: true }) as any,
+        createFormData({ discoverable: true }) as SessionCreationFormData,
         '/kilter/1/2/3/40',
       );
     });
@@ -240,7 +241,7 @@ describe('useCreateSession', () => {
 
     let createPromise: Promise<string>;
     act(() => {
-      createPromise = result.current.createSession(createFormData() as any, '/kilter/1/2/3/40');
+      createPromise = result.current.createSession(createFormData() as SessionCreationFormData, '/kilter/1/2/3/40');
     });
 
     expect(result.current.isCreating).toBe(true);
@@ -282,7 +283,7 @@ describe('useCreateSession', () => {
 
     let sessionId: string | undefined;
     await act(async () => {
-      sessionId = await result.current.createSession(createFormData() as any, '/kilter/1/2/3/40');
+      sessionId = await result.current.createSession(createFormData() as SessionCreationFormData, '/kilter/1/2/3/40');
     });
 
     expect(sessionId).toBe('returned-session-id');
@@ -295,7 +296,7 @@ describe('useCreateSession', () => {
 
     await expect(
       act(async () => {
-        await result.current.createSession(createFormData() as any, '/kilter/1/2/3/40');
+        await result.current.createSession(createFormData() as SessionCreationFormData, '/kilter/1/2/3/40');
       }),
     ).rejects.toThrow('Server error');
 

--- a/packages/web/app/hooks/__tests__/use-follow-toggle.test.ts
+++ b/packages/web/app/hooks/__tests__/use-follow-toggle.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/app/lib/graphql/client', () => ({
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useFollowToggle } from '../use-follow-toggle';
 
+type FollowToggleConfig = Parameters<typeof useFollowToggle>[0];
+
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
 function createDefaultConfig(overrides: Record<string, unknown> = {}) {
@@ -47,7 +49,7 @@ describe('useFollowToggle', () => {
 
   it('initial state matches initialIsFollowing', () => {
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ initialIsFollowing: true }) as any),
+      useFollowToggle(createDefaultConfig({ initialIsFollowing: true }) as FollowToggleConfig),
     );
 
     expect(result.current.isFollowing).toBe(true);
@@ -62,7 +64,7 @@ describe('useFollowToggle', () => {
     });
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig() as any),
+      useFollowToggle(createDefaultConfig() as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -76,7 +78,7 @@ describe('useFollowToggle', () => {
     mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as any),
+      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as FollowToggleConfig),
     );
 
     expect(result.current.isFollowing).toBe(false);
@@ -92,7 +94,7 @@ describe('useFollowToggle', () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as any),
+      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -107,7 +109,7 @@ describe('useFollowToggle', () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ initialIsFollowing: true }) as any),
+      useFollowToggle(createDefaultConfig({ initialIsFollowing: true }) as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -122,7 +124,7 @@ describe('useFollowToggle', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as any),
+      useFollowToggle(createDefaultConfig({ initialIsFollowing: false }) as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -139,7 +141,7 @@ describe('useFollowToggle', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig() as any),
+      useFollowToggle(createDefaultConfig() as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -155,7 +157,7 @@ describe('useFollowToggle', () => {
     const onFollowChange = vi.fn();
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig({ onFollowChange, initialIsFollowing: false }) as any),
+      useFollowToggle(createDefaultConfig({ onFollowChange, initialIsFollowing: false }) as FollowToggleConfig),
     );
 
     await act(async () => {
@@ -171,7 +173,7 @@ describe('useFollowToggle', () => {
     mockRequest.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve; }));
 
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig() as any),
+      useFollowToggle(createDefaultConfig() as FollowToggleConfig),
     );
 
     expect(result.current.isLoading).toBe(false);
@@ -191,7 +193,7 @@ describe('useFollowToggle', () => {
 
   it('provides setIsHovered for hover state', () => {
     const { result } = renderHook(() =>
-      useFollowToggle(createDefaultConfig() as any),
+      useFollowToggle(createDefaultConfig() as FollowToggleConfig),
     );
 
     expect(result.current.isHovered).toBe(false);

--- a/packages/web/app/hooks/__tests__/use-mark-notifications-read.test.ts
+++ b/packages/web/app/hooks/__tests__/use-mark-notifications-read.test.ts
@@ -28,6 +28,7 @@ vi.mock('../use-grouped-notifications', () => ({
 
 import { useWsAuthToken } from '../use-ws-auth-token';
 import { useMarkGroupAsRead, useMarkAllAsRead } from '../use-mark-notifications-read';
+import type { GroupedNotification, GroupedNotificationConnection } from '@boardsesh/shared-schema';
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
@@ -82,7 +83,7 @@ describe('useMarkGroupAsRead', () => {
     const { result } = renderHook(() => useMarkGroupAsRead(), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(notification as any);
+      await result.current.mutateAsync(notification as unknown as GroupedNotification);
     });
 
     expect(mockRequest).toHaveBeenCalledWith(
@@ -121,10 +122,10 @@ describe('useMarkGroupAsRead', () => {
     const { result } = renderHook(() => useMarkGroupAsRead(), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(notification as any);
+      await result.current.mutateAsync(notification as unknown as GroupedNotification);
     });
 
-    const cache = queryClient.getQueryData(['notifications', 'grouped']) as any;
+    const cache = queryClient.getQueryData(['notifications', 'grouped']) as { pages: GroupedNotificationConnection[]; pageParams: unknown[] };
     expect(cache.pages[0].groups[0].isRead).toBe(true);
     expect(cache.pages[0].groups[1].isRead).toBe(false);
   });
@@ -141,7 +142,7 @@ describe('useMarkGroupAsRead', () => {
     const { result } = renderHook(() => useMarkGroupAsRead(), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(notification as any);
+      await result.current.mutateAsync(notification as unknown as GroupedNotification);
     });
 
     const count = queryClient.getQueryData(['notifications', 'unreadCount']);
@@ -160,7 +161,7 @@ describe('useMarkGroupAsRead', () => {
     const { result } = renderHook(() => useMarkGroupAsRead(), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(notification as any);
+      await result.current.mutateAsync(notification as unknown as GroupedNotification);
     });
 
     const count = queryClient.getQueryData(['notifications', 'unreadCount']);
@@ -222,8 +223,8 @@ describe('useMarkAllAsRead', () => {
       await result.current.mutateAsync();
     });
 
-    const cache = queryClient.getQueryData(['notifications', 'grouped']) as any;
-    expect(cache.pages[0].groups.every((n: any) => n.isRead === true)).toBe(true);
+    const cache = queryClient.getQueryData(['notifications', 'grouped']) as { pages: GroupedNotificationConnection[]; pageParams: unknown[] };
+    expect(cache.pages[0].groups.every((n: GroupedNotification) => n.isRead === true)).toBe(true);
   });
 
   it('resets unread count to 0', async () => {

--- a/packages/web/app/hooks/__tests__/use-notification-subscription.test.ts
+++ b/packages/web/app/hooks/__tests__/use-notification-subscription.test.ts
@@ -187,8 +187,8 @@ describe('useNotificationSubscription', () => {
     renderHook(() => useNotificationSubscription());
 
     // Get the subscription callbacks
-    const subscribeCall = mockSubscribe.mock.calls[0] as any[];
-    const callbacks = subscribeCall[2] as { next: (data: any) => void; error: (err: any) => void };
+    const subscribeCall = mockSubscribe.mock.calls[0] as unknown[];
+    const callbacks = subscribeCall[2] as { next: (data: unknown) => void; error: (err: unknown) => void };
 
     // Simulate receiving a notification
     callbacks.next({
@@ -218,7 +218,7 @@ describe('useNotificationSubscription', () => {
 
     // Call the updater function to verify it increments
     const updaterFn = mockSetQueryData.mock.calls.find(
-      (call: any[]) => call[0][0] === 'notifications' && call[0][1] === 'unreadCount',
+      (call: unknown[]) => (call[0] as string[])[0] === 'notifications' && (call[0] as string[])[1] === 'unreadCount',
     )?.[1];
 
     if (typeof updaterFn === 'function') {
@@ -237,8 +237,8 @@ describe('useNotificationSubscription', () => {
 
     renderHook(() => useNotificationSubscription());
 
-    const subscribeCall = mockSubscribe.mock.calls[0] as any[];
-    const callbacks = subscribeCall[2] as { next: (data: any) => void; error: (err: any) => void };
+    const subscribeCall = mockSubscribe.mock.calls[0] as unknown[];
+    const callbacks = subscribeCall[2] as { next: (data: unknown) => void; error: (err: unknown) => void };
 
     callbacks.next({
       notificationReceived: {
@@ -274,8 +274,8 @@ describe('useNotificationSubscription', () => {
 
     renderHook(() => useNotificationSubscription());
 
-    const subscribeCall = mockSubscribe.mock.calls[0] as any[];
-    const callbacks = subscribeCall[2] as { next: (data: any) => void; error: (err: any) => void };
+    const subscribeCall = mockSubscribe.mock.calls[0] as unknown[];
+    const callbacks = subscribeCall[2] as { next: (data: unknown) => void; error: (err: unknown) => void };
 
     // Should not throw
     expect(() => {
@@ -300,8 +300,8 @@ describe('useNotificationSubscription', () => {
 
     renderHook(() => useNotificationSubscription());
 
-    const subscribeCall = mockSubscribe.mock.calls[0] as any[];
-    const callbacks = subscribeCall[2] as { next: (data: any) => void; error: (err: any) => void };
+    const subscribeCall = mockSubscribe.mock.calls[0] as unknown[];
+    const callbacks = subscribeCall[2] as { next: (data: unknown) => void; error: (err: unknown) => void };
 
     callbacks.next({
       notificationReceived: {

--- a/packages/web/app/hooks/__tests__/use-save-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-save-tick.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/app/lib/graphql/operations', () => ({
 import { useWsAuthToken } from '../use-ws-auth-token';
 import { useSession } from 'next-auth/react';
 import { useSaveTick, type SaveTickOptions } from '../use-save-tick';
+import type { LogbookEntry } from '../use-logbook';
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 const mockUseSession = vi.mocked(useSession);
@@ -178,7 +179,7 @@ describe('useSaveTick', () => {
 
     // Check that the optimistic entry was added
     await waitFor(() => {
-      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as any[];
+      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as LogbookEntry[];
       expect(data?.length).toBe(1);
       expect(data?.[0].uuid).toMatch(/^temp-/);
       expect(data?.[0].climb_uuid).toBe('climb-1');
@@ -215,7 +216,7 @@ describe('useSaveTick', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as any[];
+    const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as LogbookEntry[];
     if (data && data.length > 0) {
       expect(data[0].uuid).toBe('server-uuid-123');
     }
@@ -239,7 +240,7 @@ describe('useSaveTick', () => {
     });
 
     // The optimistic entry should have been rolled back
-    const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as any[];
+    const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as LogbookEntry[];
     expect(data?.length).toBe(0);
   });
 
@@ -279,7 +280,7 @@ describe('useSaveTick', () => {
     });
 
     await waitFor(() => {
-      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as any[];
+      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as LogbookEntry[];
       expect(data?.length).toBe(1);
       expect(data?.[0].is_ascent).toBe(true);
     });
@@ -308,7 +309,7 @@ describe('useSaveTick', () => {
     });
 
     await waitFor(() => {
-      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as any[];
+      const data = queryClient.getQueryData(['logbook', 'kilter', 'climb-1']) as LogbookEntry[];
       expect(data?.length).toBe(1);
       expect(data?.[0].is_ascent).toBe(false);
     });
@@ -321,8 +322,8 @@ describe('useSaveTick', () => {
   });
 
   it('extracts GraphQL error message from response', async () => {
-    const graphqlError = new Error('GraphQL error');
-    (graphqlError as any).response = {
+    const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
+    graphqlError.response = {
       errors: [{ message: 'Climb not found' }],
     };
     mockRequest.mockRejectedValue(graphqlError);

--- a/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
+++ b/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Capture the config passed to useSwipeable
-let capturedSwipeableConfig: Record<string, any> = {};
+let capturedSwipeableConfig: Record<string, (...args: unknown[]) => unknown> = {};
 vi.mock('react-swipeable', () => ({
-  useSwipeable: (config: Record<string, any>) => {
+  useSwipeable: (config: Record<string, (...args: unknown[]) => unknown>) => {
     capturedSwipeableConfig = config;
     return { ref: vi.fn() };
   },

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from 'vitest';
 import {
   searchParamsToUrlParams,
@@ -23,6 +22,7 @@ import {
   constructBoardSlugPlaylistsUrl,
   DEFAULT_SEARCH_PARAMS
 } from '../url-utils';
+import type { SearchRequestPagination, BoardDetails } from '../types';
 
 describe('searchParamsToUrlParams', () => {
   it('should return empty URLSearchParams when all values are defaults', () => {
@@ -82,7 +82,7 @@ describe('searchParamsToUrlParams', () => {
       holdsFilter: {
         'red': { state: 'include' },
         'blue': { state: 'exclude' },
-      } as any,
+      } as unknown as SearchRequestPagination['holdsFilter'],
     });
     
     const params = result.toString();
@@ -137,14 +137,14 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should convert string numbers to actual numbers', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: '5' as any,
-      maxGrade: '10' as any,
-      minAscents: '20' as any,
-      minRating: '3' as any,
-      gradeAccuracy: '1' as any,
-      page: '2' as any,
-      pageSize: '50' as any,
-    };
+      minGrade: '5',
+      maxGrade: '10',
+      minAscents: '20',
+      minRating: '3',
+      gradeAccuracy: '1',
+      page: '2',
+      pageSize: '50',
+    } as unknown as SearchRequestPagination;
 
     const result = parsedRouteSearchParamsToSearchParams(input);
 
@@ -162,10 +162,10 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should use defaults when values are undefined', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: undefined as any,
-      maxGrade: undefined as any,
+      minGrade: undefined,
+      maxGrade: undefined,
       name: 'test climb',
-    };
+    } as unknown as SearchRequestPagination;
 
     const result = parsedRouteSearchParamsToSearchParams(input);
 
@@ -177,9 +177,9 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should handle null values by using defaults', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: null as any,
-      maxGrade: null as any,
-      page: null as any,
+      minGrade: null as unknown as number,
+      maxGrade: null as unknown as number,
+      page: null as unknown as number,
     };
 
     const result = parsedRouteSearchParamsToSearchParams(input);
@@ -192,9 +192,9 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should handle empty string values by using defaults', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: '' as any,
-      maxGrade: '' as any,
-      minAscents: '' as any,
+      minGrade: '' as unknown as number,
+      maxGrade: '' as unknown as number,
+      minAscents: '' as unknown as number,
     };
 
     const result = parsedRouteSearchParamsToSearchParams(input);
@@ -209,8 +209,8 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
       ...DEFAULT_SEARCH_PARAMS,
       name: 'test climb',
       settername: ['john doe'],
-      sortBy: 'difficulty' as any,
-      sortOrder: 'asc' as any,
+      sortBy: 'difficulty' as SearchRequestPagination['sortBy'],
+      sortOrder: 'asc' as SearchRequestPagination['sortOrder'],
       onlyClassics: true,
       holdsFilter: { red: { state: 'include' } },
     };
@@ -228,10 +228,10 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should handle mixed string and number inputs', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: '5' as any,
+      minGrade: '5' as unknown as number,
       maxGrade: 10, // already a number
       name: 'test',
-      page: '1' as any,
+      page: '1' as unknown as number,
       pageSize: 25, // already a number
     };
 
@@ -251,9 +251,9 @@ describe('parsedRouteSearchParamsToSearchParams', () => {
   it('should handle invalid number strings by falling back to defaults', () => {
     const input = {
       ...DEFAULT_SEARCH_PARAMS,
-      minGrade: 'invalid' as any,
-      maxGrade: 'NaN' as any,
-      page: 'not-a-number' as any,
+      minGrade: 'invalid' as unknown as number,
+      maxGrade: 'NaN' as unknown as number,
+      page: 'not-a-number' as unknown as number,
     };
 
     const result = parsedRouteSearchParamsToSearchParams(input);
@@ -379,13 +379,13 @@ describe('URL construction functions', () => {
   describe('constructClimbInfoUrl', () => {
     it('should construct external info URL for kilter', () => {
       const boardDetails = { board_name: 'kilter' as const };
-      const result = constructClimbInfoUrl(boardDetails as any, 'abc123');
+      const result = constructClimbInfoUrl(boardDetails as unknown as BoardDetails, 'abc123');
       expect(result).toBe('https://kilterboardapp.com/climbs/abc123');
     });
 
     it('should construct external info URL for tension', () => {
       const boardDetails = { board_name: 'tension' as const };
-      const result = constructClimbInfoUrl(boardDetails as any, 'def456');
+      const result = constructClimbInfoUrl(boardDetails as unknown as BoardDetails, 'def456');
       expect(result).toBe('https://tensionboardapp2.com/climbs/def456');
     });
   });
@@ -1003,7 +1003,7 @@ describe('getContextAwareClimbViewUrl', () => {
     size_name: '8x12 Full Ride',
     size_description: 'Main',
     set_names: ['Main Kicker', 'Aux Kicker'],
-  } as any;
+  } as unknown as BoardDetails;
 
   it('should preserve /b/{slug}/{angle} context from list routes', () => {
     expect(getContextAwareClimbViewUrl('/b/moonrise-gym/40/list', boardDetails, 40, 'ABC123', 'Moon Landing'))

--- a/packages/web/app/lib/api-wrappers/aurora/saveAttempt.ts
+++ b/packages/web/app/lib/api-wrappers/aurora/saveAttempt.ts
@@ -2,8 +2,7 @@ import { WEB_HOSTS, SaveAttemptOptions, AuroraBoardName } from './types';
 import { generateUuid } from './util';
 import dayjs from 'dayjs';
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export async function saveAttempt(board: AuroraBoardName, token: string, options: SaveAttemptOptions): Promise<any> {
+export async function saveAttempt(board: AuroraBoardName, token: string, options: SaveAttemptOptions): Promise<unknown> {
   const uuid = generateUuid();
 
   // Convert the ISO date to the required format "YYYY-MM-DD HH:mm:ss"

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -10,8 +10,7 @@ import { eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 
 // Build providers array conditionally based on available env vars
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const providers: any[] = [];
+const providers: NextAuthOptions['providers'] = [];
 
 // Only add Google provider if credentials are configured
 if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -8,7 +8,10 @@ import { UNIFIED_TABLES } from '../../db/queries/util/table-select';
 import { boardseshTicks, auroraCredentials, playlists, playlistClimbs, playlistOwnership } from '../../db/schema';
 import { randomUUID } from 'crypto';
 import { convertQuality } from './convert-quality';
+
 import { buildInferredSessionsForUser } from './inferred-session-builder';
+
+type AuroraRowData = Record<string, string>;
 
 /**
  * Get NextAuth user ID from Aurora user ID
@@ -33,8 +36,7 @@ async function upsertTableData(
   tableName: string,
   auroraUserId: number,
   nextAuthUserId: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any[],
+  data: Record<string, string>[],
 ) {
   if (data.length === 0) return;
 
@@ -150,7 +152,7 @@ async function upsertTableData(
       // Write directly to boardsesh_ticks (requires NextAuth user ID)
       for (const item of data) {
         const status = Number(item.attempt_id) === 1 ? 'flash' : 'send';
-        const convertedQuality = convertQuality(item.quality);
+        const convertedQuality = convertQuality(item.quality ? Number(item.quality) : null);
 
         await db
           .insert(boardseshTicks)


### PR DESCRIPTION
- Change oxlint no-explicit-any rule from warn to deny in web package
- Add oxlint configs with no-explicit-any: deny to all other packages (backend, db, shared-schema, aurora-sync, crypto, moonboard-ocr)
- Add lint and lint-fix scripts to all packages, extend root lint to run across all
- Add oxlint as devDependency to all packages
- Fix all ~125 any usages across the codebase:
  - Replace explicit any annotations with proper types or unknown
  - Replace as-any casts with as-unknown-as-Type pattern in tests
  - Use Record<string, string> for Aurora API row data
  - Use NextAuthOptions['providers'] instead of any[]
- Add no-any rule to CLAUDE.md development guidelines
- Fix oxlint "next" plugin name to "nextjs" for compatibility with v1.50

https://claude.ai/code/session_01EZA2am9kopCvDN5inxBXo8