### PR TITLE
fix: preserve session when navigating via Climbs tab

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { BoardDetails } from '@/app/lib/types';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
@@ -7,6 +7,14 @@ import type { BoardConfigData } from '@/app/lib/server-board-configs';
 const mockPush = vi.fn();
 const mockShowMessage = vi.fn();
 const mockCreatePlaylist = vi.fn();
+
+let mockPathname = '/kilter/original/12x12-square/screw_bolt/40/list';
+let mockActiveSession: {
+  sessionId: string;
+  boardPath: string;
+  boardDetails: BoardDetails;
+  parsedParams: { angle: number };
+} | null = null;
 
 const mockBoardConfig = {
   board: 'kilter',
@@ -19,7 +27,7 @@ const mockBoardConfig = {
 };
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/kilter/original/12x12-square/screw_bolt/40/list',
+  usePathname: () => mockPathname,
   useRouter: () => ({ push: mockPush }),
 }));
 
@@ -85,7 +93,7 @@ vi.mock('@/app/components/providers/snackbar-provider', () => ({
 
 vi.mock('../../persistent-session', () => ({
   usePersistentSession: () => ({
-    activeSession: null,
+    activeSession: mockActiveSession,
     localBoardDetails: null,
     localCurrentClimbQueueItem: null,
   }),
@@ -98,6 +106,14 @@ vi.mock('@/app/hooks/use-climb-actions-data', () => ({
       isAuthenticated: true,
     },
   }),
+}));
+
+vi.mock('@/app/lib/last-used-board-db', () => ({
+  getLastUsedBoard: () => Promise.resolve(null),
+}));
+
+vi.mock('@/app/components/search-drawer/recent-searches-storage', () => ({
+  getRecentSearches: () => Promise.resolve([]),
 }));
 
 import BottomTabBar from '../bottom-tab-bar';
@@ -123,9 +139,68 @@ const boardDetails = {
 
 const boardConfigs = {} as BoardConfigData;
 
+describe('BottomTabBar session preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/';
+    mockActiveSession = null;
+  });
+
+  it('includes session param when navigating to climbs with active session on /b/ board', async () => {
+    mockActiveSession = {
+      sessionId: 'test-session-123',
+      boardPath: '/b/my-board/35/list',
+      boardDetails,
+      parsedParams: { angle: 35 },
+    };
+
+    render(<BottomTabBar boardConfigs={boardConfigs} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Climb' }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining('session=test-session-123'),
+      );
+    });
+  });
+
+  it('uses /b/ slug URL from active session when on home page', async () => {
+    mockActiveSession = {
+      sessionId: 'test-session-123',
+      boardPath: '/b/my-board/35/list',
+      boardDetails,
+      parsedParams: { angle: 35 },
+    };
+
+    render(<BottomTabBar boardConfigs={boardConfigs} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Climb' }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining('/b/my-board/35/list'),
+      );
+    });
+  });
+
+  it('does not include session param when no active session', async () => {
+    mockPathname = '/kilter/original/12x12-square/screw_bolt/40/list';
+
+    render(<BottomTabBar boardDetails={boardDetails} angle={40} boardConfigs={boardConfigs} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Climb' }));
+
+    await waitFor(() => {
+      if (mockPush.mock.calls.length > 0) {
+        expect(mockPush.mock.calls[0][0]).not.toContain('session=');
+      }
+    });
+  });
+});
+
 describe('BottomTabBar create flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPathname = '/kilter/original/12x12-square/screw_bolt/40/list';
+    mockActiveSession = null;
   });
 
   it('opens create drawer without immediate navigation', () => {

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -151,6 +151,13 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         return `/b/${segments[2]}/${segments[3]}/list`;
       }
     }
+    // Fallback: use active session's board path if it's a /b/ slug route
+    if (activeSession?.boardPath?.startsWith('/b/')) {
+      const segments = activeSession.boardPath.split('/');
+      if (segments.length >= 4) {
+        return `/b/${segments[2]}/${segments[3]}/list`;
+      }
+    }
     if (!effectiveBoardDetails) return null;
     const { board_name, layout_name, size_name, size_description, set_names } = effectiveBoardDetails;
     if (layout_name && size_name && set_names) {
@@ -231,6 +238,12 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       }
     } catch {
       // Ignore errors loading recent searches
+    }
+
+    // Preserve active session param so BoardSessionBridge can re-activate the session
+    if (activeSession?.sessionId && url) {
+      const separator = url.includes('?') ? '&' : '?';
+      url = `${url}${separator}session=${activeSession.sessionId}`;
     }
 
     const currentUrl = pathname + (typeof window !== 'undefined' ? window.location.search : '');


### PR DESCRIPTION
## Summary
- When a user has an active session on a named board (`/b/` route) and clicks the "Climbs" tab from the home page, the session was lost
- Root cause: the Climbs tab constructed a generic URL (`/kilter/homewall/...`) instead of the named board URL (`/b/slug/angle/list`), and omitted the `?session=` query parameter
- Fix: `listUrl` now derives from `activeSession.boardPath` when available, and `handleClimbsTab` appends the session param to the navigation URL

## Test plan
- [x] TypeScript typecheck passes
- [x] Unit tests pass (3 new tests added)
- [ ] Manual test: start a session on a named board, go to home, click "Climbs" — session should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)