### PR TITLE
ui: reorder party mode tabs and use lightbulb icon

### DIFF
--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import GroupOutlined from '@mui/icons-material/GroupOutlined';
 import ContentCopyOutlined from '@mui/icons-material/ContentCopyOutlined';
 import EmojiEvents from '@mui/icons-material/EmojiEvents';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -196,7 +195,7 @@ export const ShareBoardButton = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [joinSessionId, setJoinSessionId] = useState('');
   const [showAuthModal, setShowAuthModal] = useState(false);
-  const [activeNoSessionTab, setActiveNoSessionTab] = useState('start');
+  const [activeNoSessionTab, setActiveNoSessionTab] = useState('led');
   const [activeSessionTab, setActiveSessionTab] = useState('session');
 
   const isLoggedIn = authStatus === 'authenticated';
@@ -489,7 +488,7 @@ export const ShareBoardButton = () => {
           onClick={showDrawer}
           color={isSessionActive ? 'primary' : 'default'}
         >
-          {isConnecting ? <CircularProgress size={16} /> : <GroupOutlined />}
+          {isConnecting ? <CircularProgress size={16} /> : <LightbulbOutlined />}
         </IconButton>
       </Badge>
       <SwipeableDrawer
@@ -535,18 +534,18 @@ export const ShareBoardButton = () => {
               {!isSessionActive && !isConnecting && (
                 <>
                   <Tabs value={activeNoSessionTab} onChange={(_, v) => setActiveNoSessionTab(v)}>
+                    <Tab label="Connect to Board" value="led" />
                     <Tab label="Start Session" value="start" />
                     <Tab label="Join Session" value="join" />
-                    <Tab label="Connect to Board" value="led" />
                   </Tabs>
+                  <TabPanel value={activeNoSessionTab} index="led">
+                    {ledTabContent}
+                  </TabPanel>
                   <TabPanel value={activeNoSessionTab} index="start">
                     {startTabContent}
                   </TabPanel>
                   <TabPanel value={activeNoSessionTab} index="join">
                     {joinTabContent}
-                  </TabPanel>
-                  <TabPanel value={activeNoSessionTab} index="led">
-                    {ledTabContent}
                   </TabPanel>
                 </>
               )}

--- a/packages/web/app/help/help-content.tsx
+++ b/packages/web/app/help/help-content.tsx
@@ -132,8 +132,8 @@ const helpSections = [
               <Typography variant="body2" component="span" fontWeight={600}>To start a session:</Typography>
             </Typography>
             <ol>
-              <li>Tap the group icon in the queue bar at the bottom</li>
-              <li>Sign in if not already logged in</li>
+              <li>Tap the lightbulb icon in the queue bar at the bottom</li>
+              <li>Go to the &quot;Start Session&quot; tab and sign in if not already logged in</li>
               <li>Click &quot;Start Party Mode&quot; to create a new session</li>
               <li>Share the session with friends using QR code or link</li>
             </ol>
@@ -371,7 +371,7 @@ const helpSections = [
               <Typography variant="body2" component="span" fontWeight={600}>To connect:</Typography>
             </Typography>
             <ol>
-              <li>Tap the group icon in the queue bar, then go to the &quot;Connect to Board&quot; tab</li>
+              <li>Tap the lightbulb icon in the queue bar</li>
               <li>Select your board from the device list</li>
               <li>Once connected, LEDs automatically show the current climb</li>
             </ol>

--- a/packages/web/e2e/help-screenshots.spec.ts
+++ b/packages/web/e2e/help-screenshots.spec.ts
@@ -174,7 +174,8 @@ test.describe('Help Page Screenshots - Authenticated', () => {
     await page.locator('[data-testid="queue-control-bar"]').getByLabel('Party Mode').click();
     await page.locator('[data-swipeable-drawer="true"]:visible').first().waitFor({ timeout: 10000 });
 
-    // Start a party session
+    // Switch to Start Session tab and start a party session
+    await page.getByRole('tab', { name: 'Start Session' }).click();
     await page.getByRole('button', { name: 'Start Party Mode' }).click();
 
     // Wait for session to be active - WebSocket connection needs time to establish


### PR DESCRIPTION
## Summary
- Move "Connect to Board" to be the first (default) tab in the party mode drawer — it's the most common action
- Change the party mode button icon from a people icon (`GroupOutlined`) to a light bulb (`LightbulbOutlined`) in the queue control bar
- Remove unused `GroupOutlined` import

## Test plan
- [ ] Open party mode drawer — "Connect to Board" should be the first tab and selected by default
- [ ] Verify the queue control bar shows a light bulb icon for the party mode button

🤖 Generated with [Claude Code](https://claude.com/claude-code)