### PR TITLE
fix: use internal Docker URL for branch deploy SSR requests

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -109,6 +109,7 @@ jobs:
             -e NEXTAUTH_SECRET=branch-deploy-secret-${PR_NUM} \
             -e NEXTAUTH_URL=https://${PR_NUM}.preview.boardsesh.com \
             -e IRON_SESSION_PASSWORD='{"1":"branch-deploy-session-must-be-32-chars!!"}' \
+            -e BACKEND_INTERNAL_URL=ws://backend-pr-${PR_NUM}:8080/graphql \
             -e VERCEL_ENV=preview \
             -e NODE_ENV=production \
             --label "traefik.enable=true" \

--- a/packages/web/app/lib/backend-url.ts
+++ b/packages/web/app/lib/backend-url.ts
@@ -44,9 +44,9 @@ export function deriveWsUrlFromHost(hostname: string, secure: boolean): string |
  * files). On the server side it returns the build-time env var directly.
  */
 export function getBackendWsUrl(): string | null {
-  // Server-side: env var is the only source of truth
+  // Server-side: prefer internal URL for Docker networking, fall back to public URL
   if (typeof window === 'undefined') {
-    return process.env.NEXT_PUBLIC_WS_URL || null;
+    return process.env.BACKEND_INTERNAL_URL || process.env.NEXT_PUBLIC_WS_URL || null;
   }
 
   // 1. Host-derived URL for known domain patterns


### PR DESCRIPTION
## Summary
- Add `BACKEND_INTERNAL_URL` env var to web containers in branch deploys, pointing to the backend's Docker network hostname (`ws://backend-pr-{N}:8080/graphql`)
- Update `getBackendWsUrl()` to prefer `BACKEND_INTERNAL_URL` on the server side, fixing 10s connect timeouts on SSR GraphQL requests that were trying to reach the external public URL from inside Docker

## Test plan
- [x] Deployed and verified on PR #945 preview — pages load without SSR timeouts
- [x] Verify `https://929.preview.boardsesh.com/` loads with data
- [x] Verify `https://929.ws.preview.boardsesh.com/health` returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)