### PR TITLE
feat: hide OAuth buttons in Bluefy, show setup instructions

### DIFF
--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -4,6 +4,10 @@ import React, { useEffect, useState } from 'react';
 import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import Collapse from '@mui/material/Collapse';
+import Typography from '@mui/material/Typography';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { signIn } from 'next-auth/react';
 
 // Note: OAuth provider icons and button colors use brand-specific colors
@@ -59,6 +63,14 @@ export default function SocialLoginButtons({
 }: SocialLoginButtonsProps) {
   const [providers, setProviders] = useState<ProvidersConfig | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isBluefy, setIsBluefy] = useState(false);
+  const [showBluefyInfo, setShowBluefyInfo] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      setIsBluefy(/Bluefy/i.test(navigator.userAgent));
+    }
+  }, []);
 
   useEffect(() => {
     fetch('/api/auth/providers-config')
@@ -89,6 +101,35 @@ export default function SocialLoginButtons({
 
   if (!hasAnyProvider) {
     return null;
+  }
+
+  if (isBluefy) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <Button
+          fullWidth
+          size="large"
+          variant="outlined"
+          startIcon={<InfoOutlined />}
+          onClick={() => setShowBluefyInfo((prev) => !prev)}
+        >
+          Sign-in options unavailable in Bluefy
+        </Button>
+        <Collapse in={showBluefyInfo}>
+          <Alert severity="info" sx={{ mt: 1 }}>
+            <Typography variant="body2" component="div">
+              Google, Apple, and Facebook sign-in are not supported in the Bluefy browser.
+            </Typography>
+            <Typography variant="body2" component="div" sx={{ mt: 1 }}>
+              To use Boardsesh in Bluefy, open <strong>boardsesh.com</strong> in
+              Safari, sign in with your preferred provider, then go
+              to <strong>Settings</strong> and set a password. You can then use
+              that email and password to log in here.
+            </Typography>
+          </Alert>
+        </Collapse>
+      </Box>
+    );
   }
 
   // Apple button needs custom colors per brand guidelines


### PR DESCRIPTION
## Summary
- Detects Bluefy browser via user agent on the login screen
- Replaces non-functional OAuth buttons (Google, Apple, Facebook) with an expandable info button
- Guides users to set a password via Safari Settings so they can log in with email/password in Bluefy
- Works on both the login page and auth modal (both use `SocialLoginButtons`)

## Test plan
- [ ] Visit `/auth/login` in a normal browser — OAuth buttons appear as before
- [ ] Spoof Bluefy user agent (Chrome DevTools > Network Conditions) — OAuth buttons replaced with "Sign-in options unavailable in Bluefy" button
- [ ] Click the info button — expands to show instructions about setting a password via Safari
- [ ] Trigger the auth modal in-app — same Bluefy behavior applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)