### PR TITLE
fix: disable OAuth buttons in Capacitor app, same as Bluefy

### DIFF
--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -9,6 +9,7 @@ import Collapse from '@mui/material/Collapse';
 import Typography from '@mui/material/Typography';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { signIn } from 'next-auth/react';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
 // Note: OAuth provider icons and button colors use brand-specific colors
 // per Google/Apple/Facebook brand guidelines, not design system tokens
@@ -64,12 +65,14 @@ export default function SocialLoginButtons({
   const [providers, setProviders] = useState<ProvidersConfig | null>(null);
   const [loading, setLoading] = useState(true);
   const [isBluefy, setIsBluefy] = useState(false);
-  const [showBluefyInfo, setShowBluefyInfo] = useState(false);
+  const [isCapacitorApp, setIsCapacitorApp] = useState(false);
+  const [showOAuthInfo, setShowOAuthInfo] = useState(false);
 
   useEffect(() => {
     if (typeof navigator !== 'undefined') {
       setIsBluefy(/Bluefy/i.test(navigator.userAgent));
     }
+    setIsCapacitorApp(isNativeApp());
   }, []);
 
   useEffect(() => {
@@ -103,7 +106,8 @@ export default function SocialLoginButtons({
     return null;
   }
 
-  if (isBluefy) {
+  if (isBluefy || isCapacitorApp) {
+    const appName = isCapacitorApp ? 'the Boardsesh app' : 'Bluefy';
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <Button
@@ -111,17 +115,17 @@ export default function SocialLoginButtons({
           size="large"
           variant="outlined"
           startIcon={<InfoOutlined />}
-          onClick={() => setShowBluefyInfo((prev) => !prev)}
+          onClick={() => setShowOAuthInfo((prev) => !prev)}
         >
-          Sign-in options unavailable in Bluefy
+          Sign-in options unavailable in {appName}
         </Button>
-        <Collapse in={showBluefyInfo}>
+        <Collapse in={showOAuthInfo}>
           <Alert severity="info" sx={{ mt: 1 }}>
             <Typography variant="body2" component="div">
-              Google, Apple, and Facebook sign-in are not supported in the Bluefy browser.
+              Google, Apple, and Facebook sign-in are not supported in {appName}.
             </Typography>
             <Typography variant="body2" component="div" sx={{ mt: 1 }}>
-              To use Boardsesh in Bluefy, open <strong>boardsesh.com</strong> in
+              To sign in, open <strong>boardsesh.com</strong> in
               Safari, sign in with your preferred provider, then go
               to <strong>Settings</strong> and set a password. You can then use
               that email and password to log in here.


### PR DESCRIPTION
OAuth redirects open in the system browser which breaks the WebView auth flow. Show an info message directing users to set a password via Safari first, matching the existing Bluefy behavior.