### PR TITLE
feat: optimize search bar filter display

### DIFF
--- a/packages/web/app/components/search-drawer/recent-search-pills.tsx
+++ b/packages/web/app/components/search-drawer/recent-search-pills.tsx
@@ -5,6 +5,8 @@ import HistoryOutlined from '@mui/icons-material/HistoryOutlined';
 import { getRecentSearches, getFilterKey, RecentSearch, RECENT_SEARCHES_CHANGED_EVENT } from './recent-searches-storage';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import { SearchRequestPagination } from '@/app/lib/types';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import { getSearchPillFullSummary } from './search-summary-utils';
 import styles from './recent-search-pills.module.css';
 
 const RecentSearchPills: React.FC = () => {
@@ -39,13 +41,16 @@ const RecentSearchPills: React.FC = () => {
       <div className={styles.pillList}>
         {searches.map((search) => {
           const isActive = getFilterKey(search.filters) === currentFilterKey;
+          // Compute full summary for tooltip (shows all filters without truncation)
+          const fullFilters = { ...DEFAULT_SEARCH_PARAMS, ...search.filters } as SearchRequestPagination;
+          const tooltipText = getSearchPillFullSummary(fullFilters);
           return (
             <button
               key={search.id}
               type="button"
               className={`${styles.pill} ${isActive ? styles.pillActive : ''}`}
               onClick={() => handleApply(search.filters)}
-              title={search.label}
+              title={tooltipText}
             >
               <HistoryOutlined className={styles.pillIcon} />
               <span className={styles.pillLabel}>{search.label}</span>

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -66,13 +66,23 @@ export function getQualityPanelSummary(params: SearchRequestPagination): string[
 }
 
 export function getProgressPanelSummary(params: SearchRequestPagination): string[] {
+  // Merge "Hide" filters into single entry
+  const hideFilters: string[] = [];
+  if (params.hideAttempted) hideFilters.push('attempted');
+  if (params.hideCompleted) hideFilters.push('completed');
+
+  // Merge "Only" filters into single entry
+  const onlyFilters: string[] = [];
+  if (params.showOnlyAttempted) onlyFilters.push('attempted');
+  if (params.showOnlyCompleted) onlyFilters.push('completed');
+
   const parts: string[] = [];
-
-  if (params.hideAttempted) parts.push('Hide attempted');
-  if (params.hideCompleted) parts.push('Hide completed');
-  if (params.showOnlyAttempted) parts.push('Only attempted');
-  if (params.showOnlyCompleted) parts.push('Only completed');
-
+  if (hideFilters.length > 0) {
+    parts.push(`Hide ${hideFilters.join(', ')}`);
+  }
+  if (onlyFilters.length > 0) {
+    parts.push(`Only ${onlyFilters.join(', ')}`);
+  }
   return parts;
 }
 
@@ -82,7 +92,33 @@ export function getHoldsPanelSummary(params: SearchRequestPagination): string[] 
   return [`${holdsCount} hold${holdsCount !== 1 ? 's' : ''}`];
 }
 
+/**
+ * Get compact search pill summary (max 2 items + "+N more")
+ * Used for display in the search bar and recent search pills
+ */
 export function getSearchPillSummary(params: SearchRequestPagination): string {
+  const allParts = [
+    ...getClimbPanelSummary(params),
+    ...getQualityPanelSummary(params),
+    ...getProgressPanelSummary(params),
+    ...getHoldsPanelSummary(params),
+  ];
+
+  if (allParts.length === 0) return 'Search climbs...';
+
+  // Show max 2 items, append "+N more" if more
+  if (allParts.length <= 2) {
+    return allParts.join(' \u00B7 ');
+  }
+  const remaining = allParts.length - 2;
+  return allParts.slice(0, 2).join(' \u00B7 ') + ` \u00B7 +${remaining} more`;
+}
+
+/**
+ * Get full search pill summary (all items, no truncation)
+ * Used for tooltips to show the complete filter list
+ */
+export function getSearchPillFullSummary(params: SearchRequestPagination): string {
   const allParts = [
     ...getClimbPanelSummary(params),
     ...getQualityPanelSummary(params),


### PR DESCRIPTION
- Merge related progress filters (e.g., "Hide attempted, completed")
- Limit display to max 2 filter items with "+N more" suffix
- Add full filter list tooltip on recent search pills hover
- Add getSearchPillFullSummary() for untruncated filter display

<img width="466" height="248" alt="image" src="https://github.com/user-attachments/assets/5826869f-a0f4-422b-a85c-4d7617f2664e" />
