### PR TITLE
Add safe-area-inset-top padding to drawers for Capacitor webview

### DIFF
--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -229,6 +229,13 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
       sx.backgroundColor = 'var(--semantic-background)';
     }
 
+    // Full-height bottom drawers extend to the top of the screen and need
+    // safe-area-inset-top padding to avoid rendering behind the device notch/pill.
+    // (Top/left/right anchors get this from the MUI theme overrides.)
+    if (isFullHeightDrawer && placement === 'bottom' && !sx.paddingTop) {
+      sx.paddingTop = 'env(safe-area-inset-top, 0px)';
+    }
+
     return sx;
   }, [userStyles?.wrapper, height, width, fullHeightProp]);
 

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -83,12 +83,17 @@ const sharedComponents: Components<Theme> = {
       },
       paperAnchorLeft: {
         borderRadius: `0 ${themeTokens.borderRadius.lg}px ${themeTokens.borderRadius.lg}px 0`,
+        paddingTop: 'env(safe-area-inset-top, 0px)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
       },
       paperAnchorRight: {
         borderRadius: `${themeTokens.borderRadius.lg}px 0 0 ${themeTokens.borderRadius.lg}px`,
+        paddingTop: 'env(safe-area-inset-top, 0px)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
       },
       paperAnchorTop: {
         borderRadius: `0 0 ${themeTokens.borderRadius.lg}px ${themeTokens.borderRadius.lg}px`,
+        paddingTop: 'env(safe-area-inset-top, 0px)',
       },
     },
   },


### PR DESCRIPTION
Drawers that extend to the top of the screen now respect the device's
safe area inset to prevent content from rendering behind the status bar
pill/notch in Capacitor webviews.

- MUI theme: top/left/right anchored drawers get paddingTop via env()
- Left/right drawers also get paddingBottom for home indicator
- SwipeableDrawer: full-height bottom drawers get paddingTop dynamically

https://claude.ai/code/session_019irpVpw2f1TwEq6m6TuqJ9