### PR TITLE
fix: redirect unauthenticated users to login from settings page

### DIFF
--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -59,10 +59,10 @@ export default function SettingsPageContent() {
   const { showMessage } = useSnackbar();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Redirect if not authenticated
+  // Redirect unauthenticated users to login with a return URL
   useEffect(() => {
     if (status === 'unauthenticated') {
-      router.push('/');
+      router.push('/auth/login?callbackUrl=%2Fsettings');
     }
   }, [status, router]);
 


### PR DESCRIPTION
Previously, visiting /settings while logged out redirected to the home page with no indication that login is required. Now redirects to /auth/login with a callbackUrl so users return to settings after logging in or creating an account.