### PR TITLE
Implement chunked Aurora JSON imports to handle large exports

### DIFF
--- a/packages/web/app/api/internal/aurora-import/route.ts
+++ b/packages/web/app/api/internal/aurora-import/route.ts
@@ -5,11 +5,12 @@ import { authOptions } from '@/app/lib/auth/auth-options';
 import { auroraExportSchema, importJsonExportData } from '@/app/lib/data-sync/aurora/json-import';
 import type { ImportResult, ImportProgressEvent } from '@/app/lib/data-sync/aurora/json-import';
 
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 const requestSchema = z.object({
   boardType: z.enum(['kilter', 'tension']),
   data: auroraExportSchema,
+  skipSessionBuild: z.boolean().optional().default(false),
 });
 
 export interface AuroraImportResponse {
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { boardType, data } = parsed.data;
+    const { boardType, data, skipSessionBuild } = parsed.data;
 
     const encoder = new TextEncoder();
 
@@ -51,6 +52,7 @@ export async function POST(request: NextRequest) {
             boardType,
             data,
             send,
+            { skipSessionBuild },
           );
 
           send({ type: 'complete', results });

--- a/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
+++ b/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
@@ -246,12 +246,12 @@ describe('BoardImportPrompt', () => {
       });
 
       const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
-      const largeFile = new File(['x'.repeat(11 * 1024 * 1024)], 'big.json', { type: 'application/json' });
+      const largeFile = new File(['x'.repeat(201 * 1024 * 1024)], 'big.json', { type: 'application/json' });
 
       fireEvent.change(fileInput, { target: { files: [largeFile] } });
 
       expect(mockShowMessage).toHaveBeenCalledWith(
-        'File is too large (max 10MB). Please check you selected the correct file.',
+        'File is too large (max 200MB). Please check you selected the correct file.',
         'error',
       );
     });

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -416,10 +416,10 @@ export default function AuroraCredentialsSection() {
     const file = event.target.files?.[0];
     if (!file || !importingBoard) return;
 
-    // Guard against very large files (10MB limit)
-    const maxSizeBytes = 10 * 1024 * 1024;
+    // Guard against very large files (200MB limit - exports can be large due to climb data)
+    const maxSizeBytes = 200 * 1024 * 1024;
     if (file.size > maxSizeBytes) {
-      showMessage('File is too large (max 10MB). Please check you selected the correct file.', 'error');
+      showMessage('File is too large (max 200MB). Please check you selected the correct file.', 'error');
       setImportingBoard(null);
       event.target.value = '';
       return;
@@ -454,11 +454,22 @@ export default function AuroraCredentialsSection() {
           }
         }
 
-        setImportRawData(json);
+        // Strip heavy unused fields before storing - only keep what the import uses.
+        // The full export can be 50MB+ due to the climbs array containing all climb
+        // definitions with hold data. We only need user, ascents, attempts, and circuits.
+        // TODO: Import user's own climbs (drafts) once the export format is verified.
+        const strippedData = {
+          user: json.user,
+          ascents: Array.isArray(json.ascents) ? json.ascents : [],
+          attempts: Array.isArray(json.attempts) ? json.attempts : [],
+          circuits: Array.isArray(json.circuits) ? json.circuits : [],
+        };
+
+        setImportRawData(strippedData);
         setImportPreview({
-          ascents: Array.isArray(json.ascents) ? json.ascents.length : 0,
-          attempts: Array.isArray(json.attempts) ? json.attempts.length : 0,
-          circuits: Array.isArray(json.circuits) ? json.circuits.length : 0,
+          ascents: strippedData.ascents.length,
+          attempts: strippedData.attempts.length,
+          circuits: strippedData.circuits.length,
           username: json.user.username,
         });
         setImportPhase('preview');

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -36,7 +36,7 @@ import type { AuroraCredentialStatus } from '@/app/api/internal/aurora-credentia
 import type { UnsyncedCounts } from '@/app/api/internal/aurora-credentials/unsynced/route';
 import type { ImportResult } from '@/app/lib/data-sync/aurora/json-import';
 import { streamImport } from '@/app/lib/data-sync/aurora/json-import-stream';
-import { parseAuroraExport, type AuroraExportPreview } from '@/app/lib/data-sync/aurora/parse-aurora-export';
+import { parseAuroraExport, type AuroraExportPreview, type StrippedExportData } from '@/app/lib/data-sync/aurora/parse-aurora-export';
 import styles from './aurora-credentials-section.module.css';
 
 interface BoardUnsyncedCounts {
@@ -288,7 +288,7 @@ export default function AuroraCredentialsSection() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importingBoard, setImportingBoard] = useState<'kilter' | 'tension' | null>(null);
   const [importPreview, setAuroraExportPreview] = useState<AuroraExportPreview | null>(null);
-  const [importRawData, setImportRawData] = useState<unknown>(null);
+  const [importRawData, setImportRawData] = useState<StrippedExportData | null>(null);
   const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -36,18 +36,12 @@ import type { AuroraCredentialStatus } from '@/app/api/internal/aurora-credentia
 import type { UnsyncedCounts } from '@/app/api/internal/aurora-credentials/unsynced/route';
 import type { ImportResult } from '@/app/lib/data-sync/aurora/json-import';
 import { streamImport } from '@/app/lib/data-sync/aurora/json-import-stream';
+import { parseAuroraExport, type AuroraExportPreview } from '@/app/lib/data-sync/aurora/parse-aurora-export';
 import styles from './aurora-credentials-section.module.css';
 
 interface BoardUnsyncedCounts {
   ascents: number;
   climbs: number;
-}
-
-export interface ImportPreview {
-  ascents: number;
-  attempts: number;
-  circuits: number;
-  username: string;
 }
 
 export type ImportPhase = 'preview' | 'importing' | 'complete' | 'error';
@@ -293,7 +287,7 @@ export default function AuroraCredentialsSection() {
   // Import state
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importingBoard, setImportingBoard] = useState<'kilter' | 'tension' | null>(null);
-  const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
+  const [importPreview, setAuroraExportPreview] = useState<AuroraExportPreview | null>(null);
   const [importRawData, setImportRawData] = useState<unknown>(null);
   const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
@@ -400,7 +394,7 @@ export default function AuroraCredentialsSection() {
   const resetImportState = () => {
     setImportPhase(null);
     setImportProgress(null);
-    setImportPreview(null);
+    setAuroraExportPreview(null);
     setImportRawData(null);
     setImportingBoard(null);
     setImportResult(null);
@@ -429,52 +423,20 @@ export default function AuroraCredentialsSection() {
     reader.onload = (e) => {
       try {
         const json = JSON.parse(e.target?.result as string);
+        const parsed = parseAuroraExport(json, importingBoard);
 
-        // Quick validation
-        if (!json.user?.username) {
-          showMessage('Invalid file: missing user data. Please select an Aurora JSON export file.', 'error');
-          setImportingBoard(null);
-          return;
+        if (parsed.boardWarning) {
+          showMessage(parsed.boardWarning, 'warning');
         }
 
-        // Board type validation: check if the export contains climbs with layout info
-        // that doesn't match the selected board type
-        if (Array.isArray(json.climbs) && json.climbs.length > 0) {
-          const layout = json.climbs[0]?.layout?.toLowerCase() ?? '';
-          const selectedBrd = importingBoard;
-          const layoutMatchesBoard =
-            (selectedBrd === 'kilter' && layout.includes('kilter')) ||
-            (selectedBrd === 'tension' && layout.includes('tension'));
-
-          if (!layoutMatchesBoard && layout) {
-            showMessage(
-              `Warning: This export appears to be from "${json.climbs[0].layout}" but you're importing to ${selectedBrd.charAt(0).toUpperCase() + selectedBrd.slice(1)}. Climbs may not match.`,
-              'warning',
-            );
-          }
-        }
-
-        // Strip heavy unused fields before storing - only keep what the import uses.
-        // The full export can be 50MB+ due to the climbs array containing all climb
-        // definitions with hold data. We only need user, ascents, attempts, and circuits.
-        // TODO: Import user's own climbs (drafts) once the export format is verified.
-        const strippedData = {
-          user: json.user,
-          ascents: Array.isArray(json.ascents) ? json.ascents : [],
-          attempts: Array.isArray(json.attempts) ? json.attempts : [],
-          circuits: Array.isArray(json.circuits) ? json.circuits : [],
-        };
-
-        setImportRawData(strippedData);
-        setImportPreview({
-          ascents: strippedData.ascents.length,
-          attempts: strippedData.attempts.length,
-          circuits: strippedData.circuits.length,
-          username: json.user.username,
-        });
+        setImportRawData(parsed.data);
+        setAuroraExportPreview(parsed.preview);
         setImportPhase('preview');
-      } catch {
-        showMessage('Failed to parse JSON file. Please check the file format.', 'error');
+      } catch (err) {
+        showMessage(
+          err instanceof Error ? err.message : 'Failed to parse JSON file. Please check the file format.',
+          'error',
+        );
         setImportingBoard(null);
       }
     };
@@ -493,7 +455,7 @@ export default function AuroraCredentialsSection() {
 
     setImportPhase('importing');
     setImportProgress(null);
-    setImportPreview(null);
+    setAuroraExportPreview(null);
     receivedCompleteRef.current = false;
 
     try {

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -158,9 +158,9 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
     const file = event.target.files?.[0];
     if (!file) return;
 
-    const maxSizeBytes = 10 * 1024 * 1024;
+    const maxSizeBytes = 200 * 1024 * 1024;
     if (file.size > maxSizeBytes) {
-      showMessage('File is too large (max 10MB). Please check you selected the correct file.', 'error');
+      showMessage('File is too large (max 200MB). Please check you selected the correct file.', 'error');
       event.target.value = '';
       return;
     }
@@ -189,11 +189,22 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
           }
         }
 
-        setImportRawData(json);
+        // Strip heavy unused fields before storing - only keep what the import uses.
+        // The full export can be 50MB+ due to the climbs array containing all climb
+        // definitions with hold data. We only need user, ascents, attempts, and circuits.
+        // TODO: Import user's own climbs (drafts) once the export format is verified.
+        const strippedData = {
+          user: json.user,
+          ascents: Array.isArray(json.ascents) ? json.ascents : [],
+          attempts: Array.isArray(json.attempts) ? json.attempts : [],
+          circuits: Array.isArray(json.circuits) ? json.circuits : [],
+        };
+
+        setImportRawData(strippedData);
         setImportPreview({
-          ascents: Array.isArray(json.ascents) ? json.ascents.length : 0,
-          attempts: Array.isArray(json.attempts) ? json.attempts.length : 0,
-          circuits: Array.isArray(json.circuits) ? json.circuits.length : 0,
+          ascents: strippedData.ascents.length,
+          attempts: strippedData.attempts.length,
+          circuits: strippedData.circuits.length,
           username: json.user.username,
         });
         setImportPhase('preview');

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -24,8 +24,8 @@ import {
   ImportProgressSteps,
   type ImportPhase,
   type ImportProgress,
-  type ImportPreview,
 } from './aurora-credentials-section';
+import { parseAuroraExport, type AuroraExportPreview } from '@/app/lib/data-sync/aurora/parse-aurora-export';
 import styles from './aurora-credentials-section.module.css';
 
 interface BoardImportPromptProps {
@@ -46,7 +46,7 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
 
   // Import state
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
+  const [importPreview, setImportPreview] = useState<AuroraExportPreview | null>(null);
   const [importRawData, setImportRawData] = useState<Record<string, unknown> | null>(null);
   const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
@@ -169,47 +169,20 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
     reader.onload = (e) => {
       try {
         const json = JSON.parse(e.target?.result as string);
+        const parsed = parseAuroraExport(json, boardType);
 
-        if (!json.user?.username) {
-          showMessage('Invalid file: missing user data. Please select an Aurora JSON export file.', 'error');
-          return;
+        if (parsed.boardWarning) {
+          showMessage(parsed.boardWarning, 'warning');
         }
 
-        if (Array.isArray(json.climbs) && json.climbs.length > 0) {
-          const layout = json.climbs[0]?.layout?.toLowerCase() ?? '';
-          const layoutMatchesBoard =
-            (boardType === 'kilter' && layout.includes('kilter')) ||
-            (boardType === 'tension' && layout.includes('tension'));
-
-          if (!layoutMatchesBoard && layout) {
-            showMessage(
-              `Warning: This export appears to be from "${json.climbs[0].layout}" but you're importing to ${boardName}. Climbs may not match.`,
-              'warning',
-            );
-          }
-        }
-
-        // Strip heavy unused fields before storing - only keep what the import uses.
-        // The full export can be 50MB+ due to the climbs array containing all climb
-        // definitions with hold data. We only need user, ascents, attempts, and circuits.
-        // TODO: Import user's own climbs (drafts) once the export format is verified.
-        const strippedData = {
-          user: json.user,
-          ascents: Array.isArray(json.ascents) ? json.ascents : [],
-          attempts: Array.isArray(json.attempts) ? json.attempts : [],
-          circuits: Array.isArray(json.circuits) ? json.circuits : [],
-        };
-
-        setImportRawData(strippedData);
-        setImportPreview({
-          ascents: strippedData.ascents.length,
-          attempts: strippedData.attempts.length,
-          circuits: strippedData.circuits.length,
-          username: json.user.username,
-        });
+        setImportRawData(parsed.data);
+        setImportPreview(parsed.preview);
         setImportPhase('preview');
-      } catch {
-        showMessage('Failed to parse JSON file. Please check the file format.', 'error');
+      } catch (err) {
+        showMessage(
+          err instanceof Error ? err.message : 'Failed to parse JSON file. Please check the file format.',
+          'error',
+        );
       }
     };
     reader.onerror = () => {

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -25,7 +25,7 @@ import {
   type ImportPhase,
   type ImportProgress,
 } from './aurora-credentials-section';
-import { parseAuroraExport, type AuroraExportPreview } from '@/app/lib/data-sync/aurora/parse-aurora-export';
+import { parseAuroraExport, type AuroraExportPreview, type StrippedExportData } from '@/app/lib/data-sync/aurora/parse-aurora-export';
 import styles from './aurora-credentials-section.module.css';
 
 interface BoardImportPromptProps {
@@ -47,7 +47,7 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
   // Import state
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importPreview, setImportPreview] = useState<AuroraExportPreview | null>(null);
-  const [importRawData, setImportRawData] = useState<Record<string, unknown> | null>(null);
+  const [importRawData, setImportRawData] = useState<StrippedExportData | null>(null);
   const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
@@ -193,6 +193,26 @@ describe('streamImport', () => {
 
       expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream buffer:', 'not json at all');
     });
+
+    it('throws when server stream ends without a complete or error event', async () => {
+      // Stream with only progress events, no complete/error
+      const progressOnly: ImportProgressEvent = { type: 'progress', step: 'resolving', message: 'working...' };
+      const stream = createMockReadableStream([JSON.stringify(progressOnly) + '\n']);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+
+      await expect(
+        streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, vi.fn()),
+      ).rejects.toThrow('Import was interrupted: server response ended without a result');
+    });
+
+    it('throws when server stream is completely empty', async () => {
+      const stream = createMockReadableStream([]);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+
+      await expect(
+        streamImport('kilter', { user: { username: 'test' } }, vi.fn()),
+      ).rejects.toThrow('Import was interrupted: server response ended without a result');
+    });
   });
 
   describe('chunking', () => {

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ImportProgressEvent } from '../json-import';
+import type { ImportProgressEvent, ImportResult } from '../json-import';
 
 // ---------------------------------------------------------------------------
 // Helpers to build a mock ReadableStream from chunks
@@ -33,6 +33,27 @@ function mockFetchResponse(
   } as unknown as Response;
 }
 
+const emptyResult: ImportResult = {
+  ascents: { imported: 0, skipped: 0, failed: 0 },
+  attempts: { imported: 0, skipped: 0, failed: 0 },
+  circuits: { imported: 0, skipped: 0, failed: 0 },
+  unresolvedClimbs: [],
+};
+
+function makeResult(overrides: Partial<ImportResult> = {}): ImportResult {
+  return { ...emptyResult, ...overrides };
+}
+
+/**
+ * Creates a stream that returns a complete event with the given result.
+ */
+function makeCompleteStream(result: ImportResult): ReadableStream<Uint8Array> {
+  const events: ImportProgressEvent[] = [
+    { type: 'complete', results: result },
+  ];
+  return createMockReadableStream([events.map((e) => JSON.stringify(e)).join('\n') + '\n']);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -42,154 +63,287 @@ describe('streamImport', () => {
 
   beforeEach(async () => {
     vi.restoreAllMocks();
-    // Dynamic import to pick up fresh mocks each time
     const mod = await import('../json-import-stream');
     streamImport = mod.streamImport;
   });
 
-  it('parses newline-delimited JSON events from stream', async () => {
-    const events: ImportProgressEvent[] = [
-      { type: 'progress', step: 'resolving', message: 'Resolving 5 climb names...' },
-      { type: 'progress', step: 'dedup', message: 'Checking for duplicates...' },
-      { type: 'progress', step: 'ascents', current: 10, total: 10 },
-      {
-        type: 'complete',
-        results: {
-          ascents: { imported: 10, skipped: 0, failed: 0 },
-          attempts: { imported: 0, skipped: 0, failed: 0 },
-          circuits: { imported: 0, skipped: 0, failed: 0 },
-          unresolvedClimbs: [],
-        },
-      },
-    ];
+  describe('basic streaming', () => {
+    it('parses newline-delimited JSON events from a single-chunk import', async () => {
+      const result = makeResult({ ascents: { imported: 5, skipped: 0, failed: 0 } });
+      const events: ImportProgressEvent[] = [
+        { type: 'progress', step: 'resolving', message: 'Resolving 5 climb names...' },
+        { type: 'progress', step: 'dedup', message: 'Checking for duplicates...' },
+        { type: 'progress', step: 'ascents', current: 5, total: 5 },
+        { type: 'complete', results: result },
+      ];
 
-    const chunks = [events.map((e) => JSON.stringify(e)).join('\n') + '\n'];
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+      const chunks = [events.map((e) => JSON.stringify(e)).join('\n') + '\n'];
+      const stream = createMockReadableStream(chunks);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-    const received: ImportProgressEvent[] = [];
-    await streamImport('kilter', {}, (e) => received.push(e));
+      const received: ImportProgressEvent[] = [];
+      // Small data set: single user with few ascents -> single chunk
+      await streamImport('kilter', { user: { username: 'test' }, ascents: [1, 2, 3, 4, 5] }, (e) => received.push(e));
 
-    expect(received).toEqual(events);
-  });
+      // Should receive the batch progress event + forwarded progress events + complete
+      const completeEvent = received.find((e) => e.type === 'complete');
+      expect(completeEvent).toBeDefined();
+    });
 
-  it('handles events split across multiple chunks', async () => {
-    const event1 = JSON.stringify({ type: 'progress', step: 'resolving', message: 'hi' });
-    const event2 = JSON.stringify({ type: 'progress', step: 'dedup', message: 'dup' });
+    it('handles events split across multiple stream chunks', async () => {
+      const event1 = JSON.stringify({ type: 'progress', step: 'resolving', message: 'hi' } satisfies ImportProgressEvent);
+      const complete = JSON.stringify({ type: 'complete', results: emptyResult } satisfies ImportProgressEvent);
 
-    // Split event1 across two chunks, event2 in a third
-    const half = Math.floor(event1.length / 2);
-    const chunks = [
-      event1.slice(0, half),
-      event1.slice(half) + '\n',
-      event2 + '\n',
-    ];
+      // Split event1 across two chunks
+      const half = Math.floor(event1.length / 2);
+      const streamChunks = [
+        event1.slice(0, half),
+        event1.slice(half) + '\n',
+        complete + '\n',
+      ];
 
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+      const stream = createMockReadableStream(streamChunks);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-    const received: ImportProgressEvent[] = [];
-    await streamImport('tension', {}, (e) => received.push(e));
+      const received: ImportProgressEvent[] = [];
+      await streamImport('tension', { user: { username: 'test' } }, (e) => received.push(e));
 
-    expect(received).toHaveLength(2);
-    expect(received[0]).toEqual({ type: 'progress', step: 'resolving', message: 'hi' });
-    expect(received[1]).toEqual({ type: 'progress', step: 'dedup', message: 'dup' });
-  });
+      const progressEvents = received.filter((e) => e.type === 'progress' && e.step === 'resolving');
+      expect(progressEvents.length).toBeGreaterThanOrEqual(1);
+    });
 
-  it('processes remaining buffer data after stream ends (no trailing newline)', async () => {
-    const event = { type: 'complete', results: { ascents: { imported: 1, skipped: 0, failed: 0 }, attempts: { imported: 0, skipped: 0, failed: 0 }, circuits: { imported: 0, skipped: 0, failed: 0 }, unresolvedClimbs: [] } };
-    // No trailing newline — data stays in buffer until stream ends
-    const chunks = [JSON.stringify(event)];
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+    it('processes remaining buffer data after stream ends (no trailing newline)', async () => {
+      const result = makeResult({ ascents: { imported: 1, skipped: 0, failed: 0 } });
+      const completeEvent: ImportProgressEvent = { type: 'complete', results: result };
+      // No trailing newline — data stays in buffer until stream ends
+      const stream = createMockReadableStream([JSON.stringify(completeEvent)]);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-    const received: ImportProgressEvent[] = [];
-    await streamImport('kilter', {}, (e) => received.push(e));
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, (e) => received.push(e));
 
-    expect(received).toHaveLength(1);
-    expect(received[0]).toEqual(event);
-  });
-
-  it('throws on non-ok response with JSON error body', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      mockFetchResponse(null, { ok: false, status: 400, jsonBody: { error: 'Bad request data' } }),
-    );
-
-    await expect(streamImport('kilter', {}, vi.fn())).rejects.toThrow('Bad request data');
-  });
-
-  it('throws generic message on non-ok response with non-JSON body', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: () => Promise.reject(new Error('not json')),
-      body: null,
-    } as unknown as Response);
-
-    await expect(streamImport('kilter', {}, vi.fn())).rejects.toThrow('Import failed');
-  });
-
-  it('throws when response has no body', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(null));
-
-    await expect(streamImport('kilter', {}, vi.fn())).rejects.toThrow('No response body');
-  });
-
-  it('skips malformed JSON lines without throwing', async () => {
-    const validEvent = { type: 'progress', step: 'resolving', message: 'ok' };
-    const chunks = [
-      'not valid json\n' + JSON.stringify(validEvent) + '\n',
-    ];
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
-
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const received: ImportProgressEvent[] = [];
-    await streamImport('kilter', {}, (e) => received.push(e));
-
-    expect(received).toHaveLength(1);
-    expect(received[0]).toEqual(validEvent);
-    expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream line:', 'not valid json');
-  });
-
-  it('skips malformed JSON in remaining buffer without throwing', async () => {
-    // Buffer with invalid JSON and no trailing newline
-    const chunks = ['not json at all'];
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
-
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const received: ImportProgressEvent[] = [];
-    await streamImport('kilter', {}, (e) => received.push(e));
-
-    expect(received).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream buffer:', 'not json at all');
-  });
-
-  it('sends correct fetch request with board type and data', async () => {
-    const stream = createMockReadableStream([]);
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
-
-    const testData = { ascents: [], attempts: [], circuits: [] };
-    await streamImport('tension', testData, vi.fn());
-
-    expect(fetchSpy).toHaveBeenCalledWith('/api/internal/aurora-import', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ boardType: 'tension', data: testData }),
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
     });
   });
 
-  it('skips empty lines between events', async () => {
-    const event = { type: 'progress', step: 'resolving', message: 'test' };
-    const chunks = ['\n\n' + JSON.stringify(event) + '\n\n'];
-    const stream = createMockReadableStream(chunks);
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+  describe('error handling', () => {
+    it('throws on non-ok response with JSON error body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        mockFetchResponse(null, { ok: false, status: 400, jsonBody: { error: 'Bad request data' } }),
+      );
 
-    const received: ImportProgressEvent[] = [];
-    await streamImport('kilter', {}, (e) => received.push(e));
+      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('Bad request data');
+    });
 
-    expect(received).toHaveLength(1);
-    expect(received[0]).toEqual(event);
+    it('throws generic message on non-ok response with non-JSON body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error('not json')),
+        body: null,
+      } as unknown as Response);
+
+      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('Import failed');
+    });
+
+    it('throws when response has no body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(null));
+
+      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('No response body');
+    });
+
+    it('skips malformed JSON lines without throwing', async () => {
+      const validEvent: ImportProgressEvent = { type: 'progress', step: 'resolving', message: 'ok' };
+      const completeEvent: ImportProgressEvent = { type: 'complete', results: emptyResult };
+      const streamChunks = [
+        'not valid json\n' + JSON.stringify(validEvent) + '\n' + JSON.stringify(completeEvent) + '\n',
+      ];
+      const stream = createMockReadableStream(streamChunks);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      const progressEvents = received.filter((e) => e.type === 'progress' && e.step === 'resolving');
+      expect(progressEvents.length).toBeGreaterThanOrEqual(1);
+      expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream line:', 'not valid json');
+    });
+
+    it('propagates server error events from stream', async () => {
+      const errorEvent: ImportProgressEvent = { type: 'error', error: 'Database connection failed' };
+      const stream = createMockReadableStream([JSON.stringify(errorEvent) + '\n']);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+
+      await expect(
+        streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, vi.fn()),
+      ).rejects.toThrow('Database connection failed');
+    });
+
+    it('skips malformed JSON in remaining buffer without throwing', async () => {
+      // First chunk completes fine, but buffer has garbage
+      const completeEvent: ImportProgressEvent = { type: 'complete', results: emptyResult };
+      const stream = createMockReadableStream([JSON.stringify(completeEvent) + '\nnot json at all']);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream buffer:', 'not json at all');
+    });
+  });
+
+  describe('chunking', () => {
+    it('sends multiple requests when data exceeds chunk size', async () => {
+      // 600 ascents should produce 2 chunks (500 + 100)
+      const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+      const result = makeResult({ ascents: { imported: 500, skipped: 0, failed: 0 } });
+      const result2 = makeResult({ ascents: { imported: 100, skipped: 0, failed: 0 } });
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result)))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result2)));
+
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents }, (e) => received.push(e));
+
+      // Should have made 2 fetch calls (2 ascent chunks)
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // First chunk should have skipSessionBuild: true
+      const firstBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(firstBody.skipSessionBuild).toBe(true);
+      expect(firstBody.data.ascents).toHaveLength(500);
+
+      // Last chunk should have skipSessionBuild: false
+      const lastBody = JSON.parse(fetchSpy.mock.calls[1][1]!.body as string);
+      expect(lastBody.skipSessionBuild).toBe(false);
+      expect(lastBody.data.ascents).toHaveLength(100);
+    });
+
+    it('merges results across chunks', async () => {
+      const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+      const result1 = makeResult({
+        ascents: { imported: 400, skipped: 50, failed: 50 },
+        unresolvedClimbs: ['climb-a'],
+      });
+      const result2 = makeResult({
+        ascents: { imported: 80, skipped: 10, failed: 10 },
+        unresolvedClimbs: ['climb-b', 'climb-a'], // duplicate should be deduped
+      });
+
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result1)))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result2)));
+
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents }, (e) => received.push(e));
+
+      const completeEvent = received.find((e) => e.type === 'complete');
+      expect(completeEvent).toBeDefined();
+      if (completeEvent?.type === 'complete') {
+        expect(completeEvent.results.ascents.imported).toBe(480);
+        expect(completeEvent.results.ascents.skipped).toBe(60);
+        expect(completeEvent.results.ascents.failed).toBe(60);
+        // Unresolved climbs should be deduped
+        expect(completeEvent.results.unresolvedClimbs).toEqual(['climb-a', 'climb-b']);
+      }
+    });
+
+    it('sends ascents and attempts in separate chunk groups', async () => {
+      const ascents = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+      const attempts = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(
+          makeResult({ ascents: { imported: 100, skipped: 0, failed: 0 } }),
+        )))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(
+          makeResult({ attempts: { imported: 100, skipped: 0, failed: 0 } }),
+        )));
+
+      await streamImport('kilter', { user: { username: 'test' }, ascents, attempts }, vi.fn());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // First call: ascents only
+      const body1 = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(body1.data.ascents).toHaveLength(100);
+      expect(body1.data.attempts).toHaveLength(0);
+
+      // Second call: attempts only
+      const body2 = JSON.parse(fetchSpy.mock.calls[1][1]!.body as string);
+      expect(body2.data.ascents).toHaveLength(0);
+      expect(body2.data.attempts).toHaveLength(100);
+    });
+
+    it('sends circuits in the last chunk', async () => {
+      const ascents = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+      const circuits = [{ name: 'My Circuit', color: 'ff0000', created_at: '2024-01-01', climbs: [] }];
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)));
+
+      await streamImport('kilter', { user: { username: 'test' }, ascents, circuits }, vi.fn());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // Last call should contain circuits and have skipSessionBuild: false
+      const lastBody = JSON.parse(fetchSpy.mock.calls[1][1]!.body as string);
+      expect(lastBody.data.circuits).toHaveLength(1);
+      expect(lastBody.skipSessionBuild).toBe(false);
+    });
+
+    it('sends a single request for small data sets', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)));
+
+      await streamImport('kilter', {
+        user: { username: 'test' },
+        ascents: [{ id: 1 }],
+        attempts: [],
+        circuits: [],
+      }, vi.fn());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(body.skipSessionBuild).toBe(false);
+    });
+
+    it('handles empty data by sending a single empty chunk', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)));
+
+      await streamImport('kilter', { user: { username: 'test' } }, vi.fn());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(body.skipSessionBuild).toBe(false);
+      expect(body.data.ascents).toHaveLength(0);
+      expect(body.data.attempts).toHaveLength(0);
+      expect(body.data.circuits).toHaveLength(0);
+    });
+
+    it('stops and throws on chunk error without sending remaining chunks', async () => {
+      const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+
+      // First chunk succeeds, second fails
+      const errorEvent: ImportProgressEvent = { type: 'error', error: 'Server overloaded' };
+      const errorStream = createMockReadableStream([JSON.stringify(errorEvent) + '\n']);
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)))
+        .mockResolvedValueOnce(mockFetchResponse(errorStream));
+
+      await expect(
+        streamImport('kilter', { user: { username: 'test' }, ascents }, vi.fn()),
+      ).rejects.toThrow('Server overloaded');
+
+      // Only 2 calls made (stopped at the error)
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
@@ -55,7 +55,7 @@ function mergeResults(a: ImportResult, b: ImportResult): ImportResult {
 async function sendChunk(
   payload: ChunkPayload,
   onEvent: (event: ImportProgressEvent) => void,
-): Promise<ImportResult | null> {
+): Promise<ImportResult> {
   const response = await fetch('/api/internal/aurora-import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -116,6 +116,9 @@ async function sendChunk(
       event = JSON.parse(buffer);
     } catch {
       console.warn('Failed to parse import stream buffer:', buffer);
+      if (!result) {
+        throw new Error('Import was interrupted: server response ended without a result');
+      }
       return result;
     }
     if (event.type === 'complete') {
@@ -123,6 +126,10 @@ async function sendChunk(
     } else if (event.type === 'error') {
       throw new Error(event.error);
     }
+  }
+
+  if (!result) {
+    throw new Error('Import was interrupted: server response ended without a result');
   }
 
   return result;
@@ -212,9 +219,7 @@ export async function streamImport(
     });
 
     const chunkResult = await sendChunk(allChunks[i], onEvent);
-    if (chunkResult) {
-      merged = mergeResults(merged, chunkResult);
-    }
+    merged = mergeResults(merged, chunkResult);
   }
 
   onEvent({ type: 'complete', results: merged });

--- a/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
@@ -1,18 +1,65 @@
-import type { ImportProgressEvent } from './json-import';
+import type { ImportProgressEvent, ImportResult } from './json-import';
+
+const CHUNK_SIZE = 500;
+
+interface ChunkPayload {
+  boardType: 'kilter' | 'tension';
+  data: {
+    user: { username: string; email_address?: string; created_at?: string };
+    ascents: unknown[];
+    attempts: unknown[];
+    circuits: unknown[];
+  };
+  skipSessionBuild: boolean;
+}
 
 /**
- * Streams an Aurora JSON import request, calling onEvent for each
- * newline-delimited JSON progress event from the server.
+ * Splits an array into chunks of the given size.
  */
-export async function streamImport(
-  boardType: 'kilter' | 'tension',
-  data: unknown,
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Merges two ImportResult objects by summing their counts.
+ */
+function mergeResults(a: ImportResult, b: ImportResult): ImportResult {
+  return {
+    ascents: {
+      imported: a.ascents.imported + b.ascents.imported,
+      skipped: a.ascents.skipped + b.ascents.skipped,
+      failed: a.ascents.failed + b.ascents.failed,
+    },
+    attempts: {
+      imported: a.attempts.imported + b.attempts.imported,
+      skipped: a.attempts.skipped + b.attempts.skipped,
+      failed: a.attempts.failed + b.attempts.failed,
+    },
+    circuits: {
+      imported: a.circuits.imported + b.circuits.imported,
+      skipped: a.circuits.skipped + b.circuits.skipped,
+      failed: a.circuits.failed + b.circuits.failed,
+    },
+    unresolvedClimbs: [...new Set([...a.unresolvedClimbs, ...b.unresolvedClimbs])],
+  };
+}
+
+/**
+ * Sends a single chunk to the import endpoint and reads the streaming response.
+ * Returns the ImportResult from the 'complete' event, or throws on error.
+ */
+async function sendChunk(
+  payload: ChunkPayload,
   onEvent: (event: ImportProgressEvent) => void,
-): Promise<void> {
+): Promise<ImportResult | null> {
   const response = await fetch('/api/internal/aurora-import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ boardType, data }),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
@@ -33,6 +80,7 @@ export async function streamImport(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  let result: ImportResult | null = null;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -46,21 +94,128 @@ export async function streamImport(
       if (line.trim()) {
         try {
           const event: ImportProgressEvent = JSON.parse(line);
-          onEvent(event);
-        } catch {
+          if (event.type === 'complete') {
+            result = event.results;
+          } else if (event.type === 'error') {
+            throw new Error(event.error);
+          }
+          // Forward progress events but not complete/error (we aggregate those)
+          if (event.type === 'progress') {
+            onEvent(event);
+          }
+        } catch (e) {
+          if (e instanceof Error && e.message !== 'Import failed') throw e;
           console.warn('Failed to parse import stream line:', line);
         }
       }
     }
   }
 
-  // Process any remaining data in buffer
   if (buffer.trim()) {
     try {
       const event: ImportProgressEvent = JSON.parse(buffer);
-      onEvent(event);
-    } catch {
+      if (event.type === 'complete') {
+        result = event.results;
+      } else if (event.type === 'error') {
+        throw new Error(event.error);
+      }
+    } catch (e) {
+      if (e instanceof Error && e.message !== 'Import failed') throw e;
       console.warn('Failed to parse import stream buffer:', buffer);
     }
   }
+
+  return result;
+}
+
+/**
+ * Streams an Aurora JSON import, splitting data into chunks to stay within
+ * Vercel's request body size limits. Each chunk is sent as a separate request
+ * and results are merged client-side.
+ */
+export async function streamImport(
+  boardType: 'kilter' | 'tension',
+  data: unknown,
+  onEvent: (event: ImportProgressEvent) => void,
+): Promise<void> {
+  const typedData = data as {
+    user: { username: string; email_address?: string; created_at?: string };
+    ascents?: unknown[];
+    attempts?: unknown[];
+    circuits?: unknown[];
+  };
+
+  const user = typedData.user;
+  const ascents = typedData.ascents ?? [];
+  const attempts = typedData.attempts ?? [];
+  const circuits = typedData.circuits ?? [];
+
+  // Build list of chunks to send
+  const ascentChunks = chunk(ascents, CHUNK_SIZE);
+  const attemptChunks = chunk(attempts, CHUNK_SIZE);
+
+  // Circuits are typically small, send them all in one chunk
+  const allChunks: ChunkPayload[] = [];
+
+  for (const batch of ascentChunks) {
+    allChunks.push({
+      boardType,
+      data: { user, ascents: batch, attempts: [], circuits: [] },
+      skipSessionBuild: true,
+    });
+  }
+
+  for (const batch of attemptChunks) {
+    allChunks.push({
+      boardType,
+      data: { user, ascents: [], attempts: batch, circuits: [] },
+      skipSessionBuild: true,
+    });
+  }
+
+  // Circuits go in the last chunk (or as a standalone if no other data)
+  if (circuits.length > 0) {
+    allChunks.push({
+      boardType,
+      data: { user, ascents: [], attempts: [], circuits },
+      skipSessionBuild: true,
+    });
+  }
+
+  // If no data at all, send a single empty chunk
+  if (allChunks.length === 0) {
+    allChunks.push({
+      boardType,
+      data: { user, ascents: [], attempts: [], circuits: [] },
+      skipSessionBuild: false,
+    });
+  }
+
+  // The last chunk triggers session building
+  allChunks[allChunks.length - 1].skipSessionBuild = false;
+
+  const emptyResult: ImportResult = {
+    ascents: { imported: 0, skipped: 0, failed: 0 },
+    attempts: { imported: 0, skipped: 0, failed: 0 },
+    circuits: { imported: 0, skipped: 0, failed: 0 },
+    unresolvedClimbs: [],
+  };
+
+  let merged = emptyResult;
+  const totalChunks = allChunks.length;
+
+  for (let i = 0; i < totalChunks; i++) {
+    onEvent({
+      type: 'progress',
+      step: 'resolving',
+      message: `Processing batch ${i + 1} of ${totalChunks}...`,
+    });
+
+    const chunkResult = await sendChunk(allChunks[i], onEvent);
+    if (chunkResult) {
+      merged = mergeResults(merged, chunkResult);
+    }
+  }
+
+  onEvent({ type: 'complete', results: merged });
 }

--- a/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
@@ -92,36 +92,36 @@ async function sendChunk(
 
     for (const line of lines) {
       if (line.trim()) {
+        let event: ImportProgressEvent;
         try {
-          const event: ImportProgressEvent = JSON.parse(line);
-          if (event.type === 'complete') {
-            result = event.results;
-          } else if (event.type === 'error') {
-            throw new Error(event.error);
-          }
-          // Forward progress events but not complete/error (we aggregate those)
-          if (event.type === 'progress') {
-            onEvent(event);
-          }
-        } catch (e) {
-          if (e instanceof Error && e.message !== 'Import failed') throw e;
+          event = JSON.parse(line);
+        } catch {
           console.warn('Failed to parse import stream line:', line);
+          continue;
+        }
+        if (event.type === 'complete') {
+          result = event.results;
+        } else if (event.type === 'error') {
+          throw new Error(event.error);
+        } else if (event.type === 'progress') {
+          onEvent(event);
         }
       }
     }
   }
 
   if (buffer.trim()) {
+    let event: ImportProgressEvent;
     try {
-      const event: ImportProgressEvent = JSON.parse(buffer);
-      if (event.type === 'complete') {
-        result = event.results;
-      } else if (event.type === 'error') {
-        throw new Error(event.error);
-      }
-    } catch (e) {
-      if (e instanceof Error && e.message !== 'Import failed') throw e;
+      event = JSON.parse(buffer);
+    } catch {
       console.warn('Failed to parse import stream buffer:', buffer);
+      return result;
+    }
+    if (event.type === 'complete') {
+      result = event.results;
+    } else if (event.type === 'error') {
+      throw new Error(event.error);
     }
   }
 

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -277,6 +277,7 @@ export async function importJsonExportData(
   boardType: BoardType,
   data: AuroraExportData,
   onProgress?: (event: ImportProgressEvent) => void,
+  options?: { skipSessionBuild?: boolean },
 ): Promise<ImportResult> {
   const result: ImportResult = {
     ascents: { imported: 0, skipped: 0, failed: 0 },
@@ -507,16 +508,19 @@ export async function importJsonExportData(
       onProgress?.({ type: 'progress', step: 'circuits', current: ci + 1, total: data.circuits.length });
     }
 
-    // Step 7: Build inferred sessions for imported ticks
-    onProgress?.({ type: 'progress', step: 'sessions', message: 'Building sessions...' });
-    if (result.ascents.imported > 0 || result.attempts.imported > 0) {
-      try {
-        const assigned = await buildInferredSessionsForUser(userId);
-        if (assigned > 0) {
-          console.log(`Built inferred sessions: assigned ${assigned} ticks for user ${userId}`);
+    // Step 7: Build inferred sessions for imported ticks (skipped during chunked imports
+    // until the final chunk to avoid rebuilding sessions on every batch)
+    if (!options?.skipSessionBuild) {
+      onProgress?.({ type: 'progress', step: 'sessions', message: 'Building sessions...' });
+      if (result.ascents.imported > 0 || result.attempts.imported > 0) {
+        try {
+          const assigned = await buildInferredSessionsForUser(userId);
+          if (assigned > 0) {
+            console.log(`Built inferred sessions: assigned ${assigned} ticks for user ${userId}`);
+          }
+        } catch (error) {
+          console.error('Error building inferred sessions after JSON import:', error);
         }
-      } catch (error) {
-        console.error('Error building inferred sessions after JSON import:', error);
       }
     }
 

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -509,18 +509,18 @@ export async function importJsonExportData(
     }
 
     // Step 7: Build inferred sessions for imported ticks (skipped during chunked imports
-    // until the final chunk to avoid rebuilding sessions on every batch)
+    // until the final chunk to avoid rebuilding sessions on every batch).
+    // Always run on the final chunk — earlier chunks may have imported ticks even if
+    // this chunk only contains circuits.
     if (!options?.skipSessionBuild) {
       onProgress?.({ type: 'progress', step: 'sessions', message: 'Building sessions...' });
-      if (result.ascents.imported > 0 || result.attempts.imported > 0) {
-        try {
-          const assigned = await buildInferredSessionsForUser(userId);
-          if (assigned > 0) {
-            console.log(`Built inferred sessions: assigned ${assigned} ticks for user ${userId}`);
-          }
-        } catch (error) {
-          console.error('Error building inferred sessions after JSON import:', error);
+      try {
+        const assigned = await buildInferredSessionsForUser(userId);
+        if (assigned > 0) {
+          console.log(`Built inferred sessions: assigned ${assigned} ticks for user ${userId}`);
         }
+      } catch (error) {
+        console.error('Error building inferred sessions after JSON import:', error);
       }
     }
 

--- a/packages/web/app/lib/data-sync/aurora/parse-aurora-export.ts
+++ b/packages/web/app/lib/data-sync/aurora/parse-aurora-export.ts
@@ -1,0 +1,80 @@
+/**
+ * Utilities for parsing and preparing Aurora JSON export files for import.
+ */
+
+export interface AuroraExportPreview {
+  ascents: number;
+  attempts: number;
+  circuits: number;
+  username: string;
+}
+
+export interface StrippedExportData {
+  user: { username: string; email_address?: string; created_at?: string };
+  ascents: unknown[];
+  attempts: unknown[];
+  circuits: unknown[];
+}
+
+export interface ParsedExportResult {
+  data: StrippedExportData;
+  preview: AuroraExportPreview;
+  boardWarning?: string;
+}
+
+/**
+ * Parses an Aurora JSON export, validates required fields, strips heavy unused
+ * fields (climbs, walls, blocks, etc.), and returns the data ready for import.
+ *
+ * The full export can be 50MB+ due to the climbs array containing all climb
+ * definitions with hold data. We only need user, ascents, attempts, and circuits.
+ *
+ * TODO: Import user's own climbs (drafts) once the export format is verified.
+ *
+ * @throws {Error} If the JSON is missing required user data.
+ */
+export function parseAuroraExport(
+  json: Record<string, unknown>,
+  boardType: 'kilter' | 'tension',
+): ParsedExportResult {
+  const user = json.user as { username?: string; email_address?: string; created_at?: string } | undefined;
+
+  if (!user?.username) {
+    throw new Error('Invalid file: missing user data. Please select an Aurora JSON export file.');
+  }
+
+  // Check if the export's board type matches the target board
+  let boardWarning: string | undefined;
+  const climbs = json.climbs;
+  if (Array.isArray(climbs) && climbs.length > 0) {
+    const layout = (climbs[0]?.layout as string | undefined)?.toLowerCase() ?? '';
+    const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
+    const layoutMatchesBoard =
+      (boardType === 'kilter' && layout.includes('kilter')) ||
+      (boardType === 'tension' && layout.includes('tension'));
+
+    if (!layoutMatchesBoard && layout) {
+      boardWarning = `Warning: This export appears to be from "${climbs[0].layout}" but you're importing to ${boardName}. Climbs may not match.`;
+    }
+  }
+
+  const ascents = Array.isArray(json.ascents) ? (json.ascents as unknown[]) : [];
+  const attempts = Array.isArray(json.attempts) ? (json.attempts as unknown[]) : [];
+  const circuits = Array.isArray(json.circuits) ? (json.circuits as unknown[]) : [];
+
+  return {
+    data: {
+      user: user as StrippedExportData['user'],
+      ascents,
+      attempts,
+      circuits,
+    },
+    preview: {
+      ascents: ascents.length,
+      attempts: attempts.length,
+      circuits: circuits.length,
+      username: user.username,
+    },
+    boardWarning,
+  };
+}


### PR DESCRIPTION
## Summary
This PR refactors the Aurora JSON import process to handle large export files by splitting data into chunks and sending them as separate requests. This works around Vercel's request body size limits while keeping the import experience seamless for users.

## Key Changes

- **Chunked import strategy**: Split ascents and attempts into 500-item chunks, with circuits sent in a final batch. Each chunk is sent as a separate API request with results merged client-side.

- **Session building optimization**: Added `skipSessionBuild` option to defer session building until the final chunk, avoiding redundant rebuilds during multi-batch imports.

- **File size limit increase**: Raised the client-side file upload limit from 10MB to 200MB to accommodate large Aurora exports (which can exceed 50MB due to embedded climb definitions).

- **Data stripping on client**: Before storing imported data, strip unused fields (especially the large `climbs` array) to keep only what's needed: `user`, `ascents`, `attempts`, and `circuits`.

- **API timeout extension**: Increased `maxDuration` from 60s to 300s to handle longer import operations.

- **Result merging**: Implemented `mergeResults()` helper to aggregate import statistics across chunks, with deduplication of unresolved climbs.

## Implementation Details

- New `sendChunk()` function handles individual chunk uploads and response streaming
- `chunk()` utility splits arrays into fixed-size batches
- Progress events are forwarded to the UI for each batch, with a final aggregated `complete` event
- The last chunk always has `skipSessionBuild: false` to trigger session building once all data is imported
- Error handling distinguishes between parse errors (logged as warnings) and import failures (thrown)

https://claude.ai/code/session_01BbfeshYURfmreUWnSdnCRw