### PR TITLE
Use GitHub Deployments API for branch deploy previews

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DEPLOYMENT_ID=$(printf '{"ref":"%s","environment":"preview-pr-%s","description":"Preview deployment for PR #%s","auto_merge":false,"required_contexts":[]}' \
+          DEPLOYMENT_ID=$(printf '{"ref":"%s","environment":"preview-pr-%s","description":"Preview deployment for PR #%s","auto_merge":false,"required_contexts":[],"transient_environment":true}' \
             "${{ github.sha }}" "${{ env.PR_NUMBER }}" "${{ env.PR_NUMBER }}" | \
             gh api repos/${{ github.repository }}/deployments \
               --method POST --input - --jq '.id')

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -162,7 +162,9 @@ jobs:
           gh api repos/${{ github.repository }}/deployments/${{ steps.create.outputs.deployment_id }}/statuses \
             --method POST \
             --field state="in_progress" \
-            --field description="Building and deploying preview..."
+            --field environment_url="https://${{ env.PR_NUMBER }}.preview.boardsesh.com" \
+            --field log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --field description="Deploying preview..."
 
   deployment-status:
     needs: [deploy, create-deployment]
@@ -179,6 +181,7 @@ jobs:
             --method POST \
             --field state="success" \
             --field environment_url="https://${{ env.PR_NUMBER }}.preview.boardsesh.com" \
+            --field log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --field description="Preview is live" \
             --field auto_inactive=true
 
@@ -196,4 +199,5 @@ jobs:
           gh api repos/${{ github.repository }}/deployments/${{ needs.create-deployment.outputs.deployment_id }}/statuses \
             --method POST \
             --field state="failure" \
+            --field log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --field description="Deployment failed"


### PR DESCRIPTION
## Summary

- Replace PR bot comment with GitHub's native Deployments API for branch deploy previews
- PRs now show a "Deployments" sidebar with clickable preview links instead of a comment from github-actions[bot]
- Mark environments as transient so they auto-remove from the sidebar when the PR is closed
- Add `log_url` on all deployment statuses linking to the Actions run
- Deactivate deployments on PR close (cleanup workflow)

## Changes

**`branch-deploy.yml`**:
- Remove `comment` job (peter-evans/find-comment + create-or-update-comment)
- Add `create-deployment` job: creates GitHub deployment with `in_progress` status after images build
- Add `deployment-status` job: marks deployment as `success` with `environment_url` after deploy
- Add `deployment-failure` job: marks deployment as `failure` if deploy fails
- Job chain: `build-images` → `create-deployment` → `deploy` → `deployment-status`/`deployment-failure`
- `workflow_dispatch` still works (skips deployment tracking, no PR to attach to)

**`branch-deploy-cleanup.yml`**:
- Add `deactivate-deployment` job to mark all deployments as `inactive` when PR closes

## Test plan

- [ ] Open a test PR with a code change and verify the "Deployments" section appears on the PR with a clickable preview link
- [ ] Verify the deployment status transitions: in_progress → success
- [ ] Verify log_url links to the correct Actions run
- [ ] Close the PR and verify the deployment is marked inactive and removed from the sidebar
- [ ] Trigger a `workflow_dispatch` deploy and verify it still works without deployment tracking

https://claude.ai/code/session_013WoC1FECHmPY5PAg3TX7gF