### PR TITLE
Add difficulty ID support to grade distribution labels

### DIFF
--- a/packages/backend/src/__tests__/session-feed-attempt-counting.test.ts
+++ b/packages/backend/src/__tests__/session-feed-attempt-counting.test.ts
@@ -60,7 +60,7 @@ describe('buildGradeDistributionFromTicks', () => {
     ];
     const result = buildGradeDistributionFromTicks(rows);
     expect(result).toEqual([
-      { grade: 'V10', flash: 1, send: 1, attempt: 4 }, // 2 from send (3-1) + 2 from attempt
+      { grade: 'V10', difficulty: 10, flash: 1, send: 1, attempt: 4 }, // 2 from send (3-1) + 2 from attempt
     ]);
   });
 
@@ -72,8 +72,8 @@ describe('buildGradeDistributionFromTicks', () => {
     const result = buildGradeDistributionFromTicks(rows);
     // Sorted by difficulty descending
     expect(result).toEqual([
-      { grade: 'V10', flash: 0, send: 1, attempt: 1 },
-      { grade: 'V5', flash: 1, send: 0, attempt: 0 },
+      { grade: 'V10', difficulty: 10, flash: 0, send: 1, attempt: 1 },
+      { grade: 'V5', difficulty: 5, flash: 1, send: 0, attempt: 0 },
     ]);
   });
 
@@ -81,7 +81,7 @@ describe('buildGradeDistributionFromTicks', () => {
     const rows = [makeTick('send', 1, 5)];
     const result = buildGradeDistributionFromTicks(rows);
     expect(result).toEqual([
-      { grade: 'V5', flash: 0, send: 1, attempt: 0 },
+      { grade: 'V5', difficulty: 5, flash: 0, send: 1, attempt: 0 },
     ]);
   });
 

--- a/packages/backend/src/graphql/resolvers/social/session-feed-utils.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed-utils.ts
@@ -52,5 +52,5 @@ export function buildGradeDistributionFromTicks(
 
   return [...gradeMap.values()]
     .sort((a, b) => b.difficulty - a.difficulty)
-    .map(({ grade, flash, send, attempt }) => ({ grade, flash, send, attempt }));
+    .map(({ grade, difficulty, flash, send, attempt }) => ({ grade, difficulty, flash, send, attempt }));
 }

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -661,7 +661,7 @@ async function fetchGradeDistributionBatch(
   for (const r of rows) {
     if (r.grade == null) continue;
     const distribution = map.get(r.effective_session_id) ?? [];
-    distribution.push({ grade: r.grade, flash: r.flash, send: r.send, attempt: r.attempt });
+    distribution.push({ grade: r.grade, difficulty: r.diff_num, flash: r.flash, send: r.send, attempt: r.attempt });
     map.set(r.effective_session_id, distribution);
   }
   return map;

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -235,6 +235,7 @@ export const SESSION_UPDATES = `
         }
         gradeDistribution {
           grade
+          difficulty
           flash
           send
           attempt

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -317,6 +317,7 @@ export const activityFeedTypeDefs = /* GraphQL */ `
   """
   type SessionGradeDistributionItem {
     grade: String!
+    difficulty: Int
     flash: Int!
     send: Int!
     attempt: Int!

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -94,6 +94,7 @@ export type SessionFeedParticipant = {
 
 export type SessionGradeDistributionItem = {
   grade: string;
+  difficulty?: number;
   flash: number;
   send: number;
   attempt: number;

--- a/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
+++ b/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
@@ -32,8 +32,7 @@ describe('formatGradeLabels', () => {
     ])).toEqual(['V2', 'V3', 'V3+', 'V4']);
   });
 
-  it('falls back to original string when no V-grade is found and no lookup match', () => {
-    // MoonBoard uppercase Font grades not in the Kilter/Tension BOULDER_GRADES lookup
+  it('converts MoonBoard uppercase Font grades to V-grades via case-insensitive lookup', () => {
     expect(formatGradeLabels([{ grade: '6A' }, { grade: '7A+' }])).toEqual(['V3', 'V7']);
   });
 

--- a/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
+++ b/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
@@ -15,40 +15,55 @@ import GradeDistributionBar, { formatGradeLabels } from '../grade-distribution-b
 
 describe('formatGradeLabels', () => {
   it('extracts V-grade from combined Font/V-grade strings', () => {
-    expect(formatGradeLabels(['6a/V3', '6b/V4'])).toEqual(['V3', 'V4']);
+    expect(formatGradeLabels([{ grade: '6a/V3' }, { grade: '6b/V4' }])).toEqual(['V3', 'V4']);
   });
 
   it('passes through bare V-grade strings', () => {
-    expect(formatGradeLabels(['V3', 'V5'])).toEqual(['V3', 'V5']);
+    expect(formatGradeLabels([{ grade: 'V3' }, { grade: 'V5' }])).toEqual(['V3', 'V5']);
   });
 
   it('adds "+" when Font grade has "+" suffix (e.g., 6c+ → V5+)', () => {
-    expect(formatGradeLabels(['6c/V5', '6c+/V5'])).toEqual(['V5', 'V5+']);
+    expect(formatGradeLabels([{ grade: '6c/V5' }, { grade: '6c+/V5' }])).toEqual(['V5', 'V5+']);
   });
 
   it('handles mix of single and dual Font grades per V-grade', () => {
-    expect(formatGradeLabels(['5c/V2', '6a/V3', '6a+/V3', '6b/V4'])).toEqual([
-      'V2', 'V3', 'V3+', 'V4',
-    ]);
+    expect(formatGradeLabels([
+      { grade: '5c/V2' }, { grade: '6a/V3' }, { grade: '6a+/V3' }, { grade: '6b/V4' },
+    ])).toEqual(['V2', 'V3', 'V3+', 'V4']);
   });
 
-  it('falls back to original string when no V-grade is found', () => {
-    expect(formatGradeLabels(['6A', '7A+'])).toEqual(['6A', '7A+']);
+  it('falls back to original string when no V-grade is found and no lookup match', () => {
+    // MoonBoard uppercase Font grades not in the Kilter/Tension BOULDER_GRADES lookup
+    expect(formatGradeLabels([{ grade: '6A' }, { grade: '7A+' }])).toEqual(['V3', 'V7']);
   });
 
   it('only adds "+" when V-grade has multiple Font grades', () => {
     // 7a+/V7: V7 has only one Font grade (7a+), so no "+" needed
-    expect(formatGradeLabels(['7a/V6', '7a+/V7'])).toEqual(['V6', 'V7']);
+    expect(formatGradeLabels([{ grade: '7a/V6' }, { grade: '7a+/V7' }])).toEqual(['V6', 'V7']);
     // 6b+/V4: V4 has two Font grades (6b, 6b+), so "+" is added
-    expect(formatGradeLabels(['6b/V4', '6b+/V4'])).toEqual(['V4', 'V4+']);
+    expect(formatGradeLabels([{ grade: '6b/V4' }, { grade: '6b+/V4' }])).toEqual(['V4', 'V4+']);
   });
 
   it('handles empty array', () => {
     expect(formatGradeLabels([])).toEqual([]);
   });
 
-  it('handles numeric-only grades that lack V prefix', () => {
-    expect(formatGradeLabels(['0', '1', '2'])).toEqual(['0', '1', '2']);
+  it('converts numeric difficulty IDs to V-grades via BOULDER_GRADES lookup', () => {
+    // difficulty_id 10 → V0, 13 → V1, 15 → V2
+    expect(formatGradeLabels([
+      { grade: '0', difficulty: 10 },
+      { grade: '1', difficulty: 13 },
+      { grade: '2', difficulty: 15 },
+    ])).toEqual(['V0', 'V1', 'V2']);
+  });
+
+  it('converts font-grade-only strings to V-grades', () => {
+    // "5a" → V1, "5c" → V2 via font grade lookup
+    expect(formatGradeLabels([{ grade: '5a' }, { grade: '5c' }])).toEqual(['V1', 'V2']);
+  });
+
+  it('falls back to original string for unknown grades without difficulty', () => {
+    expect(formatGradeLabels([{ grade: 'unknown' }])).toEqual(['unknown']);
   });
 });
 
@@ -120,5 +135,17 @@ describe('GradeDistributionBar', () => {
     const data = JSON.parse(chartEl.getAttribute('data-data') || '{}');
     // V7 has only one Font grade (7a+), so no "+" is added
     expect(data.labels).toEqual(['V6', 'V7']);
+  });
+
+  it('renders V-grade labels from numeric difficulty IDs', () => {
+    const gradeDistribution = [
+      { grade: '2', difficulty: 15, flash: 1, send: 0, attempt: 0 },
+      { grade: '0', difficulty: 10, flash: 0, send: 1, attempt: 0 },
+    ];
+
+    render(<GradeDistributionBar gradeDistribution={gradeDistribution} />);
+    const chartEl = screen.getByTestId('chart-bar');
+    const data = JSON.parse(chartEl.getAttribute('data-data') || '{}');
+    expect(data.labels).toEqual(['V0', 'V2']);
   });
 });

--- a/packages/web/app/components/charts/grade-distribution-bar.tsx
+++ b/packages/web/app/components/charts/grade-distribution-bar.tsx
@@ -4,9 +4,19 @@ import React from 'react';
 import { Bar } from 'react-chartjs-2';
 import './chart-registry'; // Ensure Chart.js components are registered
 import { formatVGrade } from '@/app/lib/grade-colors';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
+
+// Build lookup maps from BOULDER_GRADES for V-grade conversion
+const DIFFICULTY_ID_TO_VGRADE = new Map<number, string>(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.v_grade]),
+);
+const FONT_GRADE_TO_VGRADE = new Map<string, string>(
+  BOULDER_GRADES.map((g) => [g.font_grade.toLowerCase(), g.v_grade]),
+);
 
 export interface GradeDistributionItem {
   grade: string;
+  difficulty?: number;
   flash?: number;
   send?: number;
   attempt?: number;
@@ -25,12 +35,37 @@ interface GradeDistributionBarProps {
 }
 
 /**
- * Format grade strings to V-grade labels for chart display.
- * Uses formatVGrade which appends "+" when the Font grade has a "+"
- * (e.g., "6c+/V5" → "V5+").
+ * Resolve a single grade item to a V-grade display label.
+ * Tries multiple strategies:
+ * 1. Extract V-grade from combined Font/V-grade string (e.g., "6c+/V5" → "V5+")
+ * 2. Look up by difficulty ID in BOULDER_GRADES (e.g., difficulty 15 → "V2")
+ * 3. Look up by font grade name (e.g., "5c" → "V2")
+ * 4. Fallback to the original grade string
  */
-export function formatGradeLabels(grades: string[]): string[] {
-  return grades.map((g) => formatVGrade(g) ?? g);
+function resolveVGrade(grade: string, difficulty?: number): string {
+  // 1. Standard V-grade extraction (handles "5a/V2", "V3", etc.)
+  const vGrade = formatVGrade(grade);
+  if (vGrade) return vGrade;
+
+  // 2. Look up by difficulty ID
+  if (difficulty != null) {
+    const fromId = DIFFICULTY_ID_TO_VGRADE.get(difficulty);
+    if (fromId) return fromId;
+  }
+
+  // 3. Try font grade lookup (case-insensitive)
+  const fromFont = FONT_GRADE_TO_VGRADE.get(grade.toLowerCase());
+  if (fromFont) return fromFont;
+
+  // 4. Fallback
+  return grade;
+}
+
+/**
+ * Format grade distribution items to V-grade labels for chart display.
+ */
+export function formatGradeLabels(items: GradeDistributionItem[]): string[] {
+  return items.map((item) => resolveVGrade(item.grade, item.difficulty));
 }
 
 // Match profile page "Ascents by Difficulty" colors
@@ -50,7 +85,7 @@ export default function GradeDistributionBar({
   // Data comes sorted hardest-first from backend; reverse to show lowest→highest on x-axis
   const sorted = [...gradeDistribution].reverse();
 
-  const labels = formatGradeLabels(sorted.map((g) => g.grade));
+  const labels = formatGradeLabels(sorted);
 
   // In compact mode, use near-full width bars for a dense chart
   const barPct = compact ? 0.95 : 0.8;

--- a/packages/web/app/lib/graphql/operations/activity-feed.ts
+++ b/packages/web/app/lib/graphql/operations/activity-feed.ts
@@ -24,6 +24,7 @@ const SESSION_FEED_ITEM_FIELDS = `
   tickCount
   gradeDistribution {
     grade
+    difficulty
     flash
     send
     attempt


### PR DESCRIPTION
## Summary
Enhanced the grade distribution chart to support multiple strategies for resolving V-grade labels, including lookup by difficulty ID. This allows proper grade conversion for climbing platforms (like MoonBoard) that use numeric difficulty IDs instead of traditional Font grades.

## Key Changes
- **Updated `GradeDistributionItem` interface** to include optional `difficulty` field for numeric difficulty IDs
- **Enhanced grade resolution logic** with a new `resolveVGrade()` function that tries multiple strategies:
  1. Extract V-grade from combined Font/V-grade strings (e.g., "6c+/V5")
  2. Look up by difficulty ID using `BOULDER_GRADES` mapping
  3. Look up by font grade name (case-insensitive)
  4. Fall back to original grade string
- **Updated GraphQL schema and types** to include `difficulty` field in `SessionGradeDistributionItem`
- **Modified backend resolvers** to include `difficulty` when building grade distributions from ticks
- **Updated test cases** to reflect new input format and test difficulty ID conversion scenarios

## Implementation Details
- Created lookup maps (`DIFFICULTY_ID_TO_VGRADE` and `FONT_GRADE_TO_VGRADE`) from `BOULDER_GRADES` for efficient grade conversion
- The resolution strategy is ordered by specificity: combined grades → difficulty ID → font grade → fallback
- Maintains backward compatibility with existing grade string formats while adding support for numeric difficulty IDs
- All grade distribution data now flows through the enhanced resolution logic consistently across frontend and backend

https://claude.ai/code/session_01FFhSGnpa49SE99umFmh6SY