### PR TITLE
Replace double-tap with thumbnail click handler

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -244,6 +244,8 @@ export default function LikedClimbsList({
               boardDetails={boardDetails}
               selected={selectedClimbUuid === climb.uuid}
               onSelect={climbHandlersMap.get(climb.uuid)}
+              onThumbnailClick={climbHandlersMap.get(climb.uuid)}
+              disableThumbnailNavigation
             />
           ))}
         </Box>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -137,10 +137,10 @@ const ClimbsList = ({
     isFetching,
   });
 
-  const handleClimbDoubleClick = useCallback(
+  const handleClimbClick = useCallback(
     (climb: Climb) => {
       onClimbSelectRef.current?.(climb);
-      track('Climb List Card Clicked', { climbUuid: climb.uuid });
+      track('Climb List Item Clicked', { climbUuid: climb.uuid });
     },
     [],
   );
@@ -148,10 +148,10 @@ const ClimbsList = ({
   const climbHandlersMap = useMemo(() => {
     const map = new Map<string, () => void>();
     climbs.forEach(climb => {
-      map.set(climb.uuid, () => handleClimbDoubleClick(climb));
+      map.set(climb.uuid, () => handleClimbClick(climb));
     });
     return map;
-  }, [climbs, handleClimbDoubleClick]);
+  }, [climbs, handleClimbClick]);
 
   const resolveBoardDetails = useCallback(
     (climb: Climb): BoardDetails => {
@@ -308,6 +308,8 @@ const ClimbsList = ({
                       boardDetails={resolveBoardDetails(climb)}
                       selected={selectedClimbUuid === climb.uuid}
                       onSelect={climbHandlersMap.get(climb.uuid)}
+                      onThumbnailClick={climbHandlersMap.get(climb.uuid)}
+                      disableThumbnailNavigation
                       unsupported={unsupportedClimbs?.has(climb.uuid)}
                     />
                   </div>

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -19,7 +19,6 @@ import PlaylistSelectionContent from '../climb-actions/playlist-selection-conten
 import { useOptionalQueueContext } from '../graphql-queue';
 import { useFavorite } from '../climb-actions';
 import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
-import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
@@ -67,6 +66,8 @@ type ClimbListItemProps = {
   contentOpacity?: number;
   /** When true, disables thumbnail click-to-navigate (e.g., in edit mode) */
   disableThumbnailNavigation?: boolean;
+  /** Handler for thumbnail clicks. When set, stops propagation so the row onClick doesn't also fire. */
+  onThumbnailClick?: () => void;
 };
 
 const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
@@ -84,6 +85,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
   backgroundColor,
   contentOpacity,
   disableThumbnailNavigation,
+  onThumbnailClick,
 }) => {
   const pathname = usePathname();
   const isDark = useIsDarkMode();
@@ -93,7 +95,6 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
   const queueContext = useOptionalQueueContext();
   const addToQueue = queueContext?.addToQueue;
   const { isFavorited, toggleFavorite } = useFavorite({ climbUuid: climb.uuid });
-  const { ref: doubleTapRef, onDoubleClick: handleDoubleClick } = useDoubleTap(onSelect);
 
   const hasSwipeOverrides = Boolean(swipeLeftAction || swipeRightAction);
 
@@ -371,17 +372,16 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
         <div
           {...(disableSwipe ? {} : swipeHandlers)}
           ref={(node: HTMLDivElement | null) => {
-            doubleTapRef(node);
             if (!disableSwipe) {
               swipeHandlers.ref(node);
               contentRef(node);
             }
           }}
-          onDoubleClick={handleDoubleClick}
+          onClick={onSelect}
           style={swipeableContentStyle}
         >
           {/* Thumbnail */}
-          <div style={thumbnailStyle}>
+          <div style={thumbnailStyle} onClick={onThumbnailClick ? (e) => { e.stopPropagation(); onThumbnailClick(); } : undefined}>
             <ClimbThumbnail
               boardDetails={boardDetails}
               currentClimb={climb}
@@ -479,7 +479,8 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
     && prev.titleProps === next.titleProps
     && prev.backgroundColor === next.backgroundColor
     && prev.contentOpacity === next.contentOpacity
-    && prev.disableThumbnailNavigation === next.disableThumbnailNavigation;
+    && prev.disableThumbnailNavigation === next.disableThumbnailNavigation
+    && prev.onThumbnailClick === next.onThumbnailClick;
 });
 
 ClimbListItem.displayName = 'ClimbListItem';


### PR DESCRIPTION
## Summary
Replaced the `useDoubleTap` hook with a new `onThumbnailClick` prop to handle thumbnail interactions more explicitly. This change simplifies the click handling logic and provides better control over event propagation.

## Key Changes
- Removed `useDoubleTap` hook import and usage from `ClimbListItem`
- Added `onThumbnailClick` optional prop to `ClimbListItem` component with event propagation control
- Changed main container click handler from `onDoubleClick` to `onClick` for `onSelect`
- Updated thumbnail div to conditionally handle clicks with `stopPropagation()` when `onThumbnailClick` is provided
- Renamed `handleClimbDoubleClick` to `handleClimbClick` in `ClimbsList` for clarity
- Updated event tracking label from "Climb List Card Clicked" to "Climb List Item Clicked"
- Applied `onThumbnailClick` and `disableThumbnailNavigation` props in both `ClimbsList` and `LikedClimbsList` components
- Updated `ClimbListItem` memo comparison to include the new `onThumbnailClick` prop

## Implementation Details
- The thumbnail click handler now explicitly stops event propagation to prevent the row's `onClick` from firing
- This provides a cleaner separation of concerns between thumbnail interactions and row selection
- The change maintains backward compatibility by making `onThumbnailClick` optional

https://claude.ai/code/session_01FApuKvuJhUX4iyC5x42gLN