### PR TITLE
Refactor: Compute litUpHoldsMap on-the-fly from frames string

### DIFF
--- a/packages/backend/src/__tests__/integration.test.ts
+++ b/packages/backend/src/__tests__/integration.test.ts
@@ -81,10 +81,6 @@ const createTestClimb = (label: string): ClimbQueueItem => ({
     quality_average: '4.5',
     stars: 4.5,
     difficulty_error: '0.5',
-    litUpHoldsMap: {
-      42: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      43: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-    },
     mirrored: false,
     benchmark_difficulty: 'V5',
   },

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -28,7 +28,6 @@ const createTestClimb = (uuid?: string): ClimbQueueItem => ({
     quality_average: '3.5',
     stars: 3.5,
     difficulty_error: '0.5',
-    litUpHoldsMap: {},
     mirrored: false,
     benchmark_difficulty: null,
   },

--- a/packages/backend/src/__tests__/redis-pubsub.test.ts
+++ b/packages/backend/src/__tests__/redis-pubsub.test.ts
@@ -78,7 +78,6 @@ describe('Redis PubSub Adapter', () => {
             quality_average: '4.5',
             stars: 4.5,
             difficulty_error: '0.5',
-            litUpHoldsMap: {},
             mirrored: false,
             benchmark_difficulty: null,
           },

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -21,7 +21,6 @@ const createTestClimb = (): ClimbQueueItem => ({
     quality_average: '3.5',
     stars: 3.5,
     difficulty_error: '0.5',
-    litUpHoldsMap: {},
     mirrored: false,
     benchmark_difficulty: null,
   },

--- a/packages/backend/src/__tests__/websocket-sync.test.ts
+++ b/packages/backend/src/__tests__/websocket-sync.test.ts
@@ -24,7 +24,6 @@ function createTestClimbQueueItem(uuid: string, name: string): ClimbQueueItem {
       quality_average: '4.5',
       stars: 4.5,
       difficulty_error: '0.5',
-      litUpHoldsMap: {},
       mirrored: false,
       benchmark_difficulty: null,
     },

--- a/packages/backend/src/db/queries/climbs/get-climb.ts
+++ b/packages/backend/src/db/queries/climbs/get-climb.ts
@@ -2,7 +2,6 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../client';
 import { getBoardTables, type BoardName } from '../util/table-select';
 import type { Climb } from '@boardsesh/shared-schema';
-import { convertLitUpHoldsStringToMap } from '../util/hold-state';
 
 interface GetClimbParams {
   board_name: BoardName;
@@ -70,7 +69,6 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
       stars: Math.round((Number(row.quality_average) || 0) * 5),
       difficulty_error: row.difficulty_error?.toString() || '0',
       benchmark_difficulty: row.benchmark_difficulty && row.benchmark_difficulty > 0 ? row.benchmark_difficulty.toString() : null,
-      litUpHoldsMap: convertLitUpHoldsStringToMap(row.frames || '', params.board_name)[0] || {},
     };
 
     return climb;

--- a/packages/backend/src/db/queries/climbs/search-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/search-climbs.ts
@@ -5,7 +5,6 @@ import { createClimbFilters, type ClimbSearchParams, type ParsedBoardRouteParame
 import { getSizeEdges } from '../util/product-sizes-data';
 import type { Climb, ClimbSearchResult } from '@boardsesh/shared-schema';
 import { boardClimbStats, boardseshTicks } from '@boardsesh/db/schema';
-import { convertLitUpHoldsStringToMap } from '../util/hold-state';
 
 export const searchClimbs = async (
   params: ParsedBoardRouteParameters,
@@ -140,8 +139,6 @@ export const searchClimbs = async (
       stars: Math.round((Number(result.quality_average) || 0) * 5),
       difficulty_error: result.difficulty_error?.toString() || '0',
       benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-      // TODO: Multiframe support should remove the hardcoded [0]
-      litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', params.board_name)[0],
       // Add user-specific fields if they exist
       userAscents: userId ? Number((result as Record<string, unknown>)?.userAscents || 0) : undefined,
       userAttempts: userId ? Number((result as Record<string, unknown>)?.userAttempts || 0) : undefined,

--- a/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
@@ -6,6 +6,7 @@ import { pubsub } from '../../../pubsub/index';
 import { roomManager } from '../../../services/room-manager';
 import { createAsyncIterator } from '../shared/async-iterators';
 import { getLedPlacements } from '../../../db/queries/util/led-placements-data';
+import { convertLitUpHoldsStringToMap } from '../../../db/queries/util/hold-state';
 import { requireControllerAuth } from '../shared/helpers';
 import { getGradeColor } from './grade-colors';
 import { buildNavigationContext, findClimbIndex } from './navigation-helpers';
@@ -48,15 +49,18 @@ function buildControllerQueueSync(queue: ClimbQueueItem[], currentItemUuid: stri
 }
 
 /**
- * Convert a climb's litUpHoldsMap to LED commands using LED placements data
+ * Convert a climb's frames string to LED commands using LED placements data.
+ * Derives the litUpHoldsMap from the compact frames string on-the-fly.
  */
 function climbToLedCommands(
-  climb: { litUpHoldsMap: Record<number, { state: string }> },
+  climb: { frames: string },
+  boardName: BoardName,
   ledPlacements: Record<number, number>
 ): LedCommand[] {
+  const litUpHoldsMap = convertLitUpHoldsStringToMap(climb.frames || '', boardName)[0] || {};
   const commands: LedCommand[] = [];
 
-  for (const [placementIdStr, holdInfo] of Object.entries(climb.litUpHoldsMap)) {
+  for (const [placementIdStr, holdInfo] of Object.entries(litUpHoldsMap)) {
     const placementId = parseInt(placementIdStr, 10);
     const ledPosition = ledPlacements[placementId];
 
@@ -75,7 +79,7 @@ function climbToLedCommands(
     });
   }
 
-  console.log(`[Controller] Converted ${Object.keys(climb.litUpHoldsMap).length} holds to ${commands.length} LED commands`);
+  console.log(`[Controller] Converted ${Object.keys(litUpHoldsMap).length} holds to ${commands.length} LED commands`);
   return commands;
 }
 
@@ -121,7 +125,7 @@ export const controllerSubscriptions = {
 
       // Helper to build LedUpdate with navigation context
       const buildLedUpdateWithNavigation = async (
-        climb: { uuid: string; name: string; difficulty: string; angle: number; litUpHoldsMap: Record<number, { state: string }> } | null | undefined,
+        climb: { uuid: string; name: string; difficulty: string; angle: number; frames: string } | null | undefined,
         currentItemUuid?: string,
         clientId?: string | null
       ): Promise<LedUpdate> => {
@@ -151,7 +155,7 @@ export const controllerSubscriptions = {
           };
         }
 
-        const commands = climbToLedCommands(climb, ledPlacements);
+        const commands = climbToLedCommands(climb, controller.boardName as BoardName, ledPlacements);
 
         // Get queue state for navigation context
         const queueState = await roomManager.getQueueState(sessionId);

--- a/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
@@ -7,7 +7,6 @@ import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { GetUserFavoriteClimbsInputSchema } from '../../../validation/schemas';
 import { getBoardTables, isValidBoardName } from '../../../db/queries/util/table-select';
 import { getSizeEdges } from '../../../db/queries/util/product-sizes-data';
-import { convertLitUpHoldsStringToMap } from '../../../db/queries/util/hold-state';
 
 export const favoriteClimbsQuery = {
   userFavoriteClimbs: async (
@@ -124,7 +123,6 @@ export const favoriteClimbsQuery = {
       stars: Math.round((Number(result.quality_average) || 0) * 5),
       difficulty_error: result.difficulty_error?.toString() || '0',
       benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-      litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', boardName)[0],
     }));
 
     return {

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -7,7 +7,6 @@ import { validateInput } from '../../shared/helpers';
 import { GetPlaylistClimbsInputSchema } from '../../../../validation/schemas';
 import { getBoardTables, isValidBoardName } from '../../../../db/queries/util/table-select';
 import { getSizeEdges } from '../../../../db/queries/util/product-sizes-data';
-import { convertLitUpHoldsStringToMap } from '../../../../db/queries/util/hold-state';
 import { verifyPlaylistAccess } from '../helpers/enrichment';
 
 export interface PlaylistClimbsInput {
@@ -121,7 +120,6 @@ async function fetchSpecificBoardClimbs(
     stars: Math.round((Number(result.quality_average) || 0) * 5),
     difficulty_error: result.difficulty_error?.toString() || '0',
     benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-    litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', boardName)[0],
     boardType: boardName,
   }));
 
@@ -207,7 +205,6 @@ async function fetchAllBoardsClimbs(
       stars: Math.round((Number(result.quality_average) || 0) * 5),
       difficulty_error: result.difficulty_error?.toString() || '0',
       benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-      litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', bt)[0],
       boardType: bt,
     };
   });

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -189,7 +189,7 @@ export const setterFollowQueries = {
   },
 
   /**
-   * Get climbs created by a setter with full Climb data (including litUpHoldsMap for thumbnails).
+   * Get climbs created by a setter with full Climb data (for thumbnails).
    * Supports multi-board mode when boardType is omitted.
    */
   setterClimbsFull: async (

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -14,7 +14,6 @@ import {
 import { publishSocialEvent } from '../../../events/index';
 import { getBoardTables, isValidBoardName } from '../../../db/queries/util/table-select';
 import { getSizeEdges } from '../../../db/queries/util/product-sizes-data';
-import { convertLitUpHoldsStringToMap } from '../../../db/queries/util/hold-state';
 
 /** Default angle fallback when no angle specified or no stats exist. 40 is the most common training angle. */
 const DEFAULT_ANGLE = 40;
@@ -311,7 +310,6 @@ export const setterFollowQueries = {
         stars: Math.round((Number(result.quality_average) || 0) * 5),
         difficulty_error: result.difficulty_error?.toString() || '0',
         benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-        litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', boardName)[0],
         boardType: boardName,
       }));
 
@@ -411,7 +409,6 @@ export const setterFollowQueries = {
           stars: Math.round((Number(result.quality_average) || 0) * 5),
           difficulty_error: result.difficulty_error?.toString() || '0',
           benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-          litUpHoldsMap: convertLitUpHoldsStringToMap(result.frames || '', bt)[0],
           boardType: bt,
         };
       });

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -16,7 +16,6 @@ export const ClimbInputSchema = z.object({
   quality_average: z.string().max(20).nullish().transform(v => v ?? ''),
   stars: z.number().min(0).max(15).nullish().transform(v => v ?? 0),
   difficulty_error: z.string().max(50).nullish().transform(v => v ?? ''),
-  litUpHoldsMap: z.record(z.string(), z.any()).nullish().transform(v => v ?? {}),
   mirrored: z.boolean().nullish(),
   benchmark_difficulty: z.string().max(50).nullish(),
   userAscents: z.number().min(0).nullish(),

--- a/packages/backend/src/validation/schemas/social.ts
+++ b/packages/backend/src/validation/schemas/social.ts
@@ -61,7 +61,7 @@ export const SetterClimbsInputSchema = z.object({
 });
 
 /**
- * Setter climbs full input validation schema (with litUpHoldsMap for thumbnails)
+ * Setter climbs full input validation schema (with full Climb data for thumbnails)
  */
 export const SetterClimbsFullInputSchema = z.object({
   username: z.string().min(1, 'Username cannot be empty').max(100),

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -14,7 +14,6 @@ const CLIMB_FIELDS = `
   quality_average
   stars
   difficulty_error
-  litUpHoldsMap
   mirrored
   benchmark_difficulty
   userAscents

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -28,8 +28,6 @@ export const climbTypeDefs = /* GraphQL */ `
     stars: Float!
     "Difficulty uncertainty/spread"
     difficulty_error: String!
-    "Map of hold IDs to their lit-up state codes for board display"
-    litUpHoldsMap: JSON!
     "Whether the climb should be displayed mirrored"
     mirrored: Boolean
     "Official benchmark difficulty if this is a benchmark climb"
@@ -57,7 +55,6 @@ export const climbTypeDefs = /* GraphQL */ `
     quality_average: String!
     stars: Float!
     difficulty_error: String!
-    litUpHoldsMap: JSON!
     mirrored: Boolean
     benchmark_difficulty: String
     userAscents: Int

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -267,7 +267,7 @@ export const queriesTypeDefs = /* GraphQL */ `
     setterClimbs(input: SetterClimbsInput!): SetterClimbsConnection!
 
     """
-    Get climbs created by a setter with full Climb data (including litUpHoldsMap for thumbnails).
+    Get climbs created by a setter with full Climb data (for thumbnails).
     Supports multi-board mode when boardType is omitted.
     """
     setterClimbsFull(input: SetterClimbsFullInput!): PlaylistClimbsResult!

--- a/packages/shared-schema/src/schema/social.ts
+++ b/packages/shared-schema/src/schema/social.ts
@@ -233,7 +233,7 @@ export const socialTypeDefs = /* GraphQL */ `
   }
 
   """
-  Input for fetching setter climbs with full Climb data (including litUpHoldsMap).
+  Input for fetching setter climbs with full Climb data.
   Used by the setter profile page for thumbnail rendering.
   """
   input SetterClimbsFullInput {

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -17,7 +17,6 @@ export type Climb = {
   quality_average: string;
   stars: number;
   difficulty_error: string;
-  litUpHoldsMap: LitUpHoldsMap;
   mirrored?: boolean | null; // GraphQL nullable Boolean
   benchmark_difficulty: string | null;
   userAscents?: number | null; // GraphQL nullable Int
@@ -38,7 +37,6 @@ export type ClimbInput = {
   quality_average: string;
   stars: number;
   difficulty_error: string;
-  litUpHoldsMap: LitUpHoldsMap;
   mirrored?: boolean | null;
   benchmark_difficulty?: string | null;
   userAscents?: number | null;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
@@ -4,7 +4,7 @@ import { constructPlayUrlWithSlugs } from '@/app/lib/url-utils';
 import { parseRouteParams } from '@/app/lib/url-utils.server';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getClimb } from '@/app/lib/data/queries';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import PlayViewClient from './play-view-client';
 import { Metadata } from 'next';
 
@@ -91,11 +91,7 @@ export default async function PlayPage(props: {
   try {
     const climb = await getClimb(parsedParams);
     if (climb) {
-      const litUpHoldsMap = convertLitUpHoldsStringToMap(climb.frames, parsedParams.board_name)[0];
-      initialClimb = {
-        ...climb,
-        litUpHoldsMap,
-      };
+      initialClimb = climb;
     }
   } catch {
     // Climb will be loaded from queue context on client

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -171,7 +171,7 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
         </div>
         <SwipeBoardCarousel
           boardDetails={boardDetails}
-          currentClimb={{ litUpHoldsMap: displayClimb.litUpHoldsMap, mirrored: isMirrored }}
+          currentClimb={{ frames: displayClimb.frames, mirrored: isMirrored }}
           nextClimb={nextItem?.climb}
           previousClimb={prevItem?.climb}
           onSwipeNext={handleNext}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -9,7 +9,7 @@ import {
   constructClimbViewUrlWithSlugs,
 } from '@/app/lib/url-utils';
 import { parseRouteParams } from '@/app/lib/url-utils.server';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import { Metadata } from 'next';
 import { fetchClimbDetailData } from '@/app/lib/data/climb-detail-data.server';
 import ClimbDetailPageServer from '@/app/components/climb-detail/climb-detail-page.server';
@@ -116,10 +116,8 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
       notFound();
     }
 
-    const litUpHoldsMap = convertLitUpHoldsStringToMap(currentClimb.frames, parsedParams.board_name)[0];
     const climbWithProcessedData = {
       ...currentClimb,
-      litUpHoldsMap,
       communityGrade: detailData.communityGrade,
     };
 

--- a/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getClimb } from '@/app/lib/data/queries';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import PlayViewClient from '@/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client';
 
 interface BoardSlugPlayPageProps {
@@ -29,11 +29,7 @@ export default async function BoardSlugPlayPage(props: BoardSlugPlayPageProps) {
   try {
     const climb = await getClimb(parsedParams);
     if (climb) {
-      const litUpHoldsMap = convertLitUpHoldsStringToMap(climb.frames, parsedParams.board_name)[0];
-      initialClimb = {
-        ...climb,
-        litUpHoldsMap,
-      };
+      initialClimb = climb;
     }
   } catch {
     // Climb will be loaded from queue context on client

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getClimb } from '@/app/lib/data/queries';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import ClimbDetailPageServer from '@/app/components/climb-detail/climb-detail-page.server';
 import { fetchClimbDetailData } from '@/app/lib/data/climb-detail-data.server';
 
@@ -39,10 +39,8 @@ export default async function BoardSlugViewPage(props: BoardSlugViewPageProps) {
       notFound();
     }
 
-    const litUpHoldsMap = convertLitUpHoldsStringToMap(currentClimb.frames, parsedParams.board_name)[0];
     const climbWithProcessedData = {
       ...currentClimb,
-      litUpHoldsMap,
       communityGrade: detailData.communityGrade,
     };
 

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -100,7 +100,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   );
   const peekLitUpHoldsMap = useMemo(
     () => peekClimb ? convertLitUpHoldsStringToMap(peekClimb.frames, boardDetails.board_name)[0] : undefined,
-    [peekClimb, boardDetails.board_name],
+    [peekClimb?.frames, boardDetails.board_name],
   );
 
   return (

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import BoardRenderer from './board-renderer';
 import {
   useCardSwipeNavigation,
@@ -9,11 +9,11 @@ import {
   ENTER_ANIMATION_DURATION,
 } from '@/app/hooks/use-card-swipe-navigation';
 import type { BoardDetails } from '@/app/lib/types';
-import type { LitUpHoldsMap } from './types';
+import { convertLitUpHoldsStringToMap } from './util';
 import styles from './swipe-board-carousel.module.css';
 
 interface ClimbBoardData {
-  litUpHoldsMap: LitUpHoldsMap;
+  frames: string;
   mirrored?: boolean;
 }
 
@@ -94,6 +94,15 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
 
   const transition = getSwipeTransition();
 
+  const currentLitUpHoldsMap = useMemo(
+    () => convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0],
+    [currentClimb.frames, boardDetails.board_name],
+  );
+  const peekLitUpHoldsMap = useMemo(
+    () => peekClimb ? convertLitUpHoldsStringToMap(peekClimb.frames, boardDetails.board_name)[0] : undefined,
+    [peekClimb, boardDetails.board_name],
+  );
+
   return (
     <div
       className={`${styles.carouselContainer} ${className ?? ''}`}
@@ -109,7 +118,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
       >
         <BoardRenderer
           boardDetails={boardDetails}
-          litUpHoldsMap={currentClimb.litUpHoldsMap}
+          litUpHoldsMap={currentLitUpHoldsMap}
           mirrored={!!currentClimb.mirrored}
           fillHeight
         />
@@ -124,7 +133,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
         >
           <BoardRenderer
             boardDetails={boardDetails}
-            litUpHoldsMap={peekClimb.litUpHoldsMap}
+            litUpHoldsMap={peekLitUpHoldsMap}
             mirrored={!!peekClimb.mirrored}
             fillHeight
           />

--- a/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
@@ -50,7 +50,6 @@ function createTestClimb(overrides?: Partial<Climb>): Climb {
     quality_average: '3.5',
     stars: 3,
     difficulty_error: '0.50',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
@@ -39,7 +39,6 @@ function createTestClimb(overrides?: Partial<Climb>): Climb {
     quality_average: '3.0',
     stars: 0,
     difficulty_error: '0.5',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
@@ -57,7 +57,6 @@ function createTestClimb(overrides?: Partial<Climb>): Climb {
     quality_average: '3.5',
     stars: 3,
     difficulty_error: '0.50',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
@@ -50,7 +50,6 @@ function createTestClimb(overrides?: Partial<Climb>): Climb {
     quality_average: '3.5',
     stars: 3,
     difficulty_error: '0.50',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -105,7 +105,6 @@ function makeClimb(overrides: Partial<Climb> = {}): Climb {
     quality_average: '3.5',
     stars: 0,
     difficulty_error: '0.5',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
@@ -74,7 +74,6 @@ const climb = {
   quality_average: '3',
   stars: 0,
   difficulty_error: '0',
-  litUpHoldsMap: {},
   benchmark_difficulty: null,
 } as Climb;
 

--- a/packages/web/app/components/climb-card/climb-card-cover.tsx
+++ b/packages/web/app/components/climb-card/climb-card-cover.tsx
@@ -16,7 +16,7 @@ const ClimbCardCover = ({ climb, boardDetails, onClick, onDoubleClick }: ClimbCa
   const { ref, onDoubleClick: handleDoubleClick } = useDoubleTap(onDoubleClick);
   const litUpHoldsMap = useMemo(
     () => climb ? convertLitUpHoldsStringToMap(climb.frames, boardDetails.board_name)[0] : undefined,
-    [climb, boardDetails.board_name],
+    [climb?.frames, boardDetails.board_name],
   );
 
   return (

--- a/packages/web/app/components/climb-card/climb-card-cover.tsx
+++ b/packages/web/app/components/climb-card/climb-card-cover.tsx
@@ -1,8 +1,9 @@
 'use client';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 
 type ClimbCardCoverProps = {
   climb?: Climb;
@@ -13,6 +14,10 @@ type ClimbCardCoverProps = {
 
 const ClimbCardCover = ({ climb, boardDetails, onClick, onDoubleClick }: ClimbCardCoverProps) => {
   const { ref, onDoubleClick: handleDoubleClick } = useDoubleTap(onDoubleClick);
+  const litUpHoldsMap = useMemo(
+    () => climb ? convertLitUpHoldsStringToMap(climb.frames, boardDetails.board_name)[0] : undefined,
+    [climb, boardDetails.board_name],
+  );
 
   return (
     <div
@@ -26,7 +31,7 @@ const ClimbCardCover = ({ climb, boardDetails, onClick, onDoubleClick }: ClimbCa
         cursor: onClick || onDoubleClick ? 'pointer' : 'default',
       }}
     >
-      <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={climb?.litUpHoldsMap} mirrored={!!climb?.mirrored} />
+      <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={!!climb?.mirrored} />
     </div>
   );
 };

--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -27,7 +27,7 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
   const pathname = usePathname();
   const litUpHoldsMap = useMemo(
     () => currentClimb ? convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0] : undefined,
-    [currentClimb, boardDetails.board_name],
+    [currentClimb?.frames, boardDetails.board_name],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);

--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { BoardDetails, Climb } from '@/app/lib/types';
 import BoardRenderer from '../board-renderer/board-renderer';
 import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 
 type ClimbThumbnailProps = {
   currentClimb: Climb | null;
@@ -24,6 +25,10 @@ const placeholderStyle = (boardDetails: BoardDetails, maxHeight?: string): React
 
 const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, onNavigate, maxHeight }: ClimbThumbnailProps) => {
   const pathname = usePathname();
+  const litUpHoldsMap = useMemo(
+    () => currentClimb ? convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0] : undefined,
+    [currentClimb, boardDetails.board_name],
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -61,7 +66,7 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
       <div ref={containerRef}>
         <Link href={climbViewUrl} prefetch={false} onClick={() => onNavigate?.()} data-testid="climb-thumbnail-link">
           <BoardRenderer
-            litUpHoldsMap={currentClimb?.litUpHoldsMap}
+            litUpHoldsMap={litUpHoldsMap}
             mirrored={!!currentClimb?.mirrored}
             boardDetails={boardDetails}
             thumbnail
@@ -75,7 +80,7 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
   return (
     <div ref={containerRef}>
       <BoardRenderer
-        litUpHoldsMap={currentClimb?.litUpHoldsMap}
+        litUpHoldsMap={litUpHoldsMap}
         mirrored={!!currentClimb?.mirrored}
         boardDetails={boardDetails}
         thumbnail

--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -99,7 +99,6 @@ function createTestClimbQueueItem(uuid: string): ClimbQueueItem {
       quality_average: '3',
       stars: 3,
       difficulty_error: '',
-      litUpHoldsMap: {},
       mirrored: false,
       benchmark_difficulty: null,
       userAscents: 0,

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -123,7 +123,6 @@ export function toClimbQueueItemInput(item: LocalClimbQueueItem) {
       quality_average: item.climb.quality_average,
       stars: item.climb.stars,
       difficulty_error: item.climb.difficulty_error,
-      litUpHoldsMap: item.climb.litUpHoldsMap,
       mirrored: item.climb.mirrored,
       benchmark_difficulty: item.climb.benchmark_difficulty,
       userAscents: item.climb.userAscents,

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -75,7 +75,6 @@ const mockClimb: Climb = {
   quality_average: '3.5',
   stars: 3,
   difficulty_error: '',
-  litUpHoldsMap: {},
   mirrored: false,
   benchmark_difficulty: null,
   userAscents: 0,

--- a/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
@@ -15,7 +15,6 @@ const mockClimb: Climb = {
   quality_average: '3.5',
   stars: 3,
   difficulty_error: '',
-  litUpHoldsMap: {},
   mirrored: false,
   benchmark_difficulty: null,
   userAscents: 0,

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -97,7 +97,6 @@ function createTestClimb(overrides?: Partial<Climb>): Climb {
     quality_average: '3.5',
     stars: 3,
     difficulty_error: '',
-    litUpHoldsMap: {},
     mirrored: false,
     benchmark_difficulty: null,
     userAscents: 0,

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -136,7 +136,6 @@ function makeClimb(overrides: Partial<Climb> = {}): Climb {
     quality_average: '3.5',
     stars: 0,
     difficulty_error: '0.5',
-    litUpHoldsMap: {},
     benchmark_difficulty: null,
     ...overrides,
   };

--- a/packages/web/app/components/queue-control/__tests__/reducer.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/reducer.test.ts
@@ -15,7 +15,6 @@ const mockClimb: Climb = {
   quality_average: '3.5',
   stars: 3,
   difficulty_error: '',
-  litUpHoldsMap: {},
   mirrored: false,
   benchmark_difficulty: null,
   userAscents: 0,

--- a/packages/web/app/components/queue-control/__tests__/utils.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/utils.test.ts
@@ -20,7 +20,6 @@ const mockClimb: Climb = {
   quality_average: '3.5',
   stars: 3,
   difficulty_error: '',
-  litUpHoldsMap: {},
   mirrored: false,
   benchmark_difficulty: null,
   userAscents: 0,

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -31,7 +31,7 @@ import { VOTE_ON_PROPOSAL, RESOLVE_PROPOSAL, DELETE_PROPOSAL } from '@/app/lib/g
 import type { Proposal } from '@boardsesh/shared-schema';
 import type { Climb, BoardDetails, BoardName } from '@/app/lib/types';
 import ClimbListItem from '@/app/components/climb-card/climb-list-item';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import ProposalVoteBar from './proposal-vote-bar';
@@ -146,10 +146,6 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
       return null;
     }
 
-    const litUpHoldsMap = frames
-      ? convertLitUpHoldsStringToMap(frames, boardName)[0]
-      : {};
-
     const climb: Climb = {
       uuid: climbUuid,
       name: climbName || '',
@@ -162,7 +158,6 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
       quality_average: localProposal.climbQualityAverage || '0',
       stars: 0,
       difficulty_error: localProposal.climbDifficultyError || '0',
-      litUpHoldsMap,
       benchmark_difficulty: localProposal.climbBenchmarkDifficulty || null,
       layoutId,
       boardType,

--- a/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
@@ -24,7 +24,6 @@ function makeClimb(overrides: Partial<Climb> = {}): Climb {
     difficulty: 'V5',
     quality_average: '3',
     setter_username: 'setter1',
-    litUpHoldsMap: {},
     description: '',
     ascensionist_count: 0,
     stars: 3,

--- a/packages/web/app/lib/__tests__/queue-storage-db.test.ts
+++ b/packages/web/app/lib/__tests__/queue-storage-db.test.ts
@@ -44,7 +44,6 @@ function createTestClimb(uuid: string): Climb {
     quality_average: '3',
     stars: 3,
     difficulty_error: '',
-    litUpHoldsMap: {},
     mirrored: false,
     benchmark_difficulty: null,
     userAscents: 0,

--- a/packages/web/app/lib/graphql/operations/climb-search.ts
+++ b/packages/web/app/lib/graphql/operations/climb-search.ts
@@ -14,7 +14,6 @@ const CLIMB_FIELDS = `
   quality_average
   stars
   difficulty_error
-  litUpHoldsMap
   mirrored
   benchmark_difficulty
   userAscents

--- a/packages/web/app/lib/graphql/operations/favorites.ts
+++ b/packages/web/app/lib/graphql/operations/favorites.ts
@@ -89,7 +89,6 @@ export const GET_USER_FAVORITE_CLIMBS = gql`
         quality_average
         stars
         difficulty_error
-        litUpHoldsMap
         benchmark_difficulty
       }
       totalCount
@@ -126,7 +125,6 @@ export interface UserFavoriteClimbsResult {
     quality_average: string;
     stars: number;
     difficulty_error: string;
-    litUpHoldsMap: Record<string, unknown>;
     benchmark_difficulty: string | null;
   }>;
   totalCount: number;

--- a/packages/web/app/lib/graphql/operations/playlists.ts
+++ b/packages/web/app/lib/graphql/operations/playlists.ts
@@ -135,7 +135,6 @@ export const GET_PLAYLIST_CLIMBS = gql`
         quality_average
         stars
         difficulty_error
-        litUpHoldsMap
         benchmark_difficulty
       }
       totalCount
@@ -338,7 +337,6 @@ export interface PlaylistClimbsResult {
     quality_average: string;
     stars: number;
     difficulty_error: string;
-    litUpHoldsMap: Record<string, unknown>;
     benchmark_difficulty: string | null;
   }>;
   totalCount: number;

--- a/packages/web/app/lib/graphql/operations/social.ts
+++ b/packages/web/app/lib/graphql/operations/social.ts
@@ -288,7 +288,7 @@ export const GET_SETTER_PROFILE = gql`
 `;
 
 // ============================================
-// Setter Climbs Full (with litUpHoldsMap for thumbnails)
+// Setter Climbs Full (with full Climb data for thumbnails)
 // ============================================
 
 export const GET_SETTER_CLIMBS_FULL = gql`
@@ -309,7 +309,6 @@ export const GET_SETTER_CLIMBS_FULL = gql`
         stars
         difficulty_error
         benchmark_difficulty
-        litUpHoldsMap
       }
       totalCount
       hasMore

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -15,7 +15,6 @@ export type Climb = {
   quality_average: string;
   stars: number;
   difficulty_error: string;
-  litUpHoldsMap: LitUpHoldsMap;
   mirrored?: boolean;
   benchmark_difficulty: string | null; // Benchmark difficulty, can be null
   userAscents?: number;

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -30,10 +30,10 @@ import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useBoardDetailsMap } from '@/app/hooks/use-board-details-map';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
-import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
+
 import { useSessionDetail } from '@/app/hooks/use-session-detail';
 import { themeTokens } from '@/app/theme/theme-config';
-import type { Climb, BoardName, BoardDetails } from '@/app/lib/types';
+import type { Climb, BoardDetails } from '@/app/lib/types';
 import UserSearchDialog from './user-search-dialog';
 import SessionOverviewPanel from '@/app/components/session-details/session-overview-panel';
 
@@ -104,7 +104,7 @@ function formatAttemptText(tick: SessionDetailTick): string | null {
 
 /**
  * Convert session ticks to deduplicated Climb objects for use with ClimbsList.
- * Keeps the first occurrence of each climbUuid and computes litUpHoldsMap from frames.
+ * Keeps the first occurrence of each climbUuid.
  */
 function convertSessionTicksToClimbs(ticks: SessionDetailTick[]): Climb[] {
   const seen = new Map<string, Climb>();
@@ -115,18 +115,6 @@ function convertSessionTicksToClimbs(ticks: SessionDetailTick[]): Climb[] {
 
     order.push(tick.climbUuid);
 
-    let litUpHoldsMap = {};
-    if (tick.frames && tick.boardType) {
-      try {
-        litUpHoldsMap = convertLitUpHoldsStringToMap(
-          tick.frames,
-          tick.boardType as BoardName,
-        )[0] || {};
-      } catch (err) {
-        console.warn(`Failed to parse litUpHoldsMap for climb ${tick.climbUuid} (boardType: ${tick.boardType}):`, err);
-      }
-    }
-
     seen.set(tick.climbUuid, {
       uuid: tick.climbUuid,
       name: tick.climbName || 'Unknown Climb',
@@ -135,7 +123,6 @@ function convertSessionTicksToClimbs(ticks: SessionDetailTick[]): Climb[] {
       difficulty: tick.difficultyName || '',
       quality_average: tick.quality != null ? String(tick.quality) : '0',
       setter_username: tick.setterUsername || '',
-      litUpHoldsMap,
       description: '',
       ascensionist_count: 0,
       stars: 0,


### PR DESCRIPTION
## Summary
This PR removes the `litUpHoldsMap` field from the `Climb` type and refactors components to compute it on-the-fly from the `frames` string using `convertLitUpHoldsStringToMap()`. This eliminates redundant data storage and computation at the API/database level while maintaining the same functionality at the component level.

## Key Changes

- **Type Definition Updates**
  - Removed `litUpHoldsMap` field from `Climb` and `ClimbInput` types in shared schema and web types
  - Removed `litUpHoldsMap` from GraphQL schema type definitions and query operations

- **Backend Changes**
  - Removed `litUpHoldsMap` computation from all climb query resolvers (search-climbs, get-climb, playlist-climbs, favorite-climbs, setter-follows)
  - Updated controller subscription to derive `litUpHoldsMap` on-the-fly from `frames` string when converting climbs to LED commands
  - Removed `litUpHoldsMap` from test fixtures across integration, queue-sync, redis-pubsub, session-persistence, and websocket-sync tests

- **Frontend Component Updates**
  - **SwipeBoardCarousel**: Added `useMemo` hooks to compute `litUpHoldsMap` from `frames` for current and peek climbs; changed `ClimbBoardData` interface to accept `frames` string instead of pre-computed map
  - **ClimbThumbnail**: Added `useMemo` to compute `litUpHoldsMap` from `frames` and `board_name`
  - **ClimbCardCover**: Added `useMemo` to compute `litUpHoldsMap` from `frames` and `board_name`
  - **PlayViewClient**: Updated to pass `frames` string to SwipeBoardCarousel instead of `litUpHoldsMap`
  - **Session Detail**: Removed `litUpHoldsMap` computation from `convertSessionTicksToClimbs()` function
  - **Proposal Card**: Removed `litUpHoldsMap` computation
  - **Play/View Pages**: Removed `litUpHoldsMap` computation from server-side climb initialization

- **GraphQL Operations**
  - Removed `litUpHoldsMap` field from all GraphQL query fragments (climb-search, playlists, favorites, social operations)
  - Updated query result type interfaces to remove `litUpHoldsMap` property

## Implementation Details

- Components now use `useMemo` with dependencies on `frames` and `board_name` to ensure `litUpHoldsMap` is only recomputed when necessary
- The `convertLitUpHoldsStringToMap()` utility function is now called at the component level (client-side) rather than at the API/database level
- This change reduces payload size for API responses and eliminates redundant computation on the backend
- All test fixtures have been updated to remove the `litUpHoldsMap` property

https://claude.ai/code/session_018dDCjbu7yALL1MD5dY2b7T