### PR TITLE
fix: remove "Open in App" action for Kilter board

### DIFF
--- a/packages/web/app/components/climb-actions/action-view-renderer.tsx
+++ b/packages/web/app/components/climb-actions/action-view-renderer.tsx
@@ -261,3 +261,16 @@ export function buildActionResult({
     expandedContent,
   };
 }
+
+/**
+ * Builds a ClimbActionResult for an unavailable action.
+ * Use this when an action should not be displayed (e.g., feature not supported for this board).
+ */
+export function buildUnavailableResult(key: ClimbActionType): ClimbActionResult {
+  return {
+    element: null,
+    menuItem: { key },
+    key,
+    available: false,
+  };
+}

--- a/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
@@ -5,7 +5,7 @@ import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
-import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
+import { buildActionResult, buildUnavailableResult, computeActionDisplay } from '../action-view-renderer';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 
 interface OpenInAppActionProps extends ClimbActionProps {
@@ -24,6 +24,11 @@ export function OpenInAppAction({
   auroraAppUrl,
 }: OpenInAppActionProps): ClimbActionResult {
   const url = auroraAppUrl || constructClimbInfoUrl(boardDetails, climb.uuid);
+
+  // Open in App is not available for Kilter (kilterboardapp.com is no longer accessible)
+  if (!url) {
+    return buildUnavailableResult('openInApp');
+  }
   const { iconSize } = computeActionDisplay(viewMode, size, showLabel);
 
   const handleClick = useCallback((e?: React.MouseEvent) => {

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -98,9 +98,11 @@ export function TickAction({
 
     if (!isAuthenticated && alwaysUseApp && loaded) {
       const url = constructClimbInfoUrl(boardDetails, climb.uuid);
-      openExternalUrl(url);
-      onComplete?.();
-      return;
+      if (url) {
+        openExternalUrl(url);
+        onComplete?.();
+        return;
+      }
     }
 
     setDrawerVisible(true);
@@ -112,11 +114,14 @@ export function TickAction({
     setSelectedBoard(null);
   }, []);
 
+  // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
+  const openInAppUrl = useMemo(() => constructClimbInfoUrl(boardDetails, climb.uuid), [boardDetails, climb.uuid]);
+
   const handleOpenInApp = useCallback(() => {
-    const url = constructClimbInfoUrl(boardDetails, climb.uuid);
-    openExternalUrl(url);
+    if (!openInAppUrl) return;
+    openExternalUrl(openInAppUrl);
     closeDrawer();
-  }, [boardDetails, climb.uuid, angle, closeDrawer]);
+  }, [openInAppUrl, closeDrawer]);
 
   const renderSignInPrompt = () => (
     <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
@@ -127,23 +132,27 @@ export function TickAction({
       <MuiButton variant="contained" startIcon={<LoginOutlined />} onClick={() => setShowAuthModal(true)} fullWidth>
         Sign In
       </MuiButton>
-      <Typography variant="body1" component="p" color="text.secondary">
-        Or log your tick in the official app:
-      </Typography>
-      <MuiButton variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-        Open in App
-      </MuiButton>
-      <MuiButton
-        variant="text"
-        size="small"
-        color="secondary"
-        onClick={async () => {
-          await enableAlwaysUseApp();
-          handleOpenInApp();
-        }}
-      >
-        Always open in app
-      </MuiButton>
+      {openInAppUrl && (
+        <>
+          <Typography variant="body1" component="p" color="text.secondary">
+            Or log your tick in the official app:
+          </Typography>
+          <MuiButton variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
+            Open in App
+          </MuiButton>
+          <MuiButton
+            variant="text"
+            size="small"
+            color="secondary"
+            onClick={async () => {
+              await enableAlwaysUseApp();
+              handleOpenInApp();
+            }}
+          >
+            Always open in app
+          </MuiButton>
+        </>
+      )}
     </Stack>
   );
 

--- a/packages/web/app/components/climb-actions/types.ts
+++ b/packages/web/app/components/climb-actions/types.ts
@@ -131,7 +131,7 @@ export interface UseClimbActionsReturn {
   // URLs
   viewDetailsUrl: string;
   forkUrl: string | null;
-  openInAppUrl: string;
+  openInAppUrl: string | null;
 }
 
 /**

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -78,9 +78,9 @@ export function useClimbActions({
   }, [climb, canFork, boardDetails, angle]);
 
   const openInAppUrl = useMemo(() => {
-    if (!climb) return '';
+    if (!climb) return null;
     return auroraAppUrl || constructClimbInfoUrl(boardDetails, climb.uuid);
-  }, [climb, boardDetails, angle, auroraAppUrl]);
+  }, [climb, boardDetails, auroraAppUrl]);
 
   // Action handlers
   const handleViewDetails = useCallback(() => {
@@ -153,7 +153,7 @@ export function useClimbActions({
   }, [onActionComplete]);
 
   const handleOpenInApp = useCallback(() => {
-    if (!climb) return;
+    if (!climb || !openInAppUrl) return;
 
     track('Open in Aurora App', {
       boardName: boardDetails.board_name,

--- a/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
@@ -30,7 +30,7 @@ export default function ClimbDetailPageServer({
   const auroraAppUrl = constructClimbInfoUrl(
     boardDetails,
     climb.uuid,
-  );
+  ) ?? undefined;
 
   return (
     <div className={styles.pageContainer}>

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -11,7 +11,7 @@ import { ClimbActions } from '../climb-actions';
 type ClimbViewActionsProps = {
   climb: Climb;
   boardDetails: BoardDetails;
-  auroraAppUrl: string;
+  auroraAppUrl?: string;
   angle: number;
 };
 

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -32,15 +32,20 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
   const [showAuthModal, setShowAuthModal] = useState(false);
   const { alwaysUseApp, loaded, enableAlwaysUseApp } = useAlwaysTickInApp();
 
+  // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
+  const openInAppUrl = useMemo(
+    () => currentClimb ? constructClimbInfoUrl(boardDetails, currentClimb.uuid) : null,
+    [boardDetails, currentClimb]
+  );
+
   const showDrawer = () => {
     track('Tick Button Clicked', {
       boardLayout: boardDetails.layout_name || '',
       existingAscentCount: badgeCount,
     });
 
-    if (!isAuthenticated && alwaysUseApp && loaded && currentClimb) {
-      const url = constructClimbInfoUrl(boardDetails, currentClimb.uuid);
-      openExternalUrl(url);
+    if (!isAuthenticated && alwaysUseApp && loaded && openInAppUrl) {
+      openExternalUrl(openInAppUrl);
       return;
     }
 
@@ -49,9 +54,8 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
   const closeDrawer = () => setDrawerVisible(false);
 
   const handleOpenInApp = () => {
-    if (!currentClimb) return;
-    const url = constructClimbInfoUrl(boardDetails, currentClimb.uuid);
-    openExternalUrl(url);
+    if (!openInAppUrl) return;
+    openExternalUrl(openInAppUrl);
     closeDrawer();
   };
 
@@ -102,23 +106,27 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
             <Button variant="contained" startIcon={<LoginOutlined />} onClick={() => setShowAuthModal(true)} fullWidth>
               Sign In
             </Button>
-            <Typography variant="body1" component="p" color="text.secondary">
-              Or log your tick in the official app:
-            </Typography>
-            <Button variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-              Open in App
-            </Button>
-            <Button
-              variant="text"
-              size="small"
-              color="secondary"
-              onClick={async () => {
-                await enableAlwaysUseApp();
-                handleOpenInApp();
-              }}
-            >
-              Always open in app
-            </Button>
+            {openInAppUrl && (
+              <>
+                <Typography variant="body1" component="p" color="text.secondary">
+                  Or log your tick in the official app:
+                </Typography>
+                <Button variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
+                  Open in App
+                </Button>
+                <Button
+                  variant="text"
+                  size="small"
+                  color="secondary"
+                  onClick={async () => {
+                    await enableAlwaysUseApp();
+                    handleOpenInApp();
+                  }}
+                >
+                  Always open in app
+                </Button>
+              </>
+            )}
           </Stack>
         </SwipeableDrawer>
       )}

--- a/packages/web/app/components/queue-control/queue-climb-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-climb-list-item.tsx
@@ -81,10 +81,16 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
     router.push(climbViewUrl);
   }, [item.climb, pathname, boardDetails, onClimbNavigate, router]);
 
+  // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
+  const openInAppUrl = useMemo(
+    () => constructClimbInfoUrl(boardDetails, item.climb.uuid),
+    [boardDetails, item.climb.uuid]
+  );
+
   const handleOpenInApp = useCallback(() => {
-    const url = constructClimbInfoUrl(boardDetails, item.climb.uuid);
-    openExternalUrl(url);
-  }, [item.climb, boardDetails]);
+    if (!openInAppUrl) return;
+    openExternalUrl(openInAppUrl);
+  }, [openInAppUrl]);
 
   // Swipe action overrides for ClimbListItem
   const swipeLeftAction: SwipeActionOverride = useMemo(
@@ -267,10 +273,12 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
             <ListItemIcon><CheckOutlined /></ListItemIcon>
             <ListItemText>Tick Climb</ListItemText>
           </MenuItem>
-          <MenuItem onClick={() => { setMenuAnchorEl(null); handleOpenInApp(); }}>
-            <ListItemIcon><AppsOutlined /></ListItemIcon>
-            <ListItemText>Open in App</ListItemText>
-          </MenuItem>
+          {openInAppUrl && (
+            <MenuItem onClick={() => { setMenuAnchorEl(null); handleOpenInApp(); }}>
+              <ListItemIcon><AppsOutlined /></ListItemIcon>
+              <ListItemText>Open in App</ListItemText>
+            </MenuItem>
+          )}
           <MenuItem onClick={() => { setMenuAnchorEl(null); removeFromQueue(item); }} sx={{ color: 'error.main' }}>
             <ListItemIcon><DeleteOutlined color="error" /></ListItemIcon>
             <ListItemText>Remove from Queue</ListItemText>

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -377,10 +377,10 @@ describe('URL construction functions', () => {
   });
 
   describe('constructClimbInfoUrl', () => {
-    it('should construct external info URL for kilter', () => {
+    it('should return null for kilter (app URL no longer accessible)', () => {
       const boardDetails = { board_name: 'kilter' as const };
       const result = constructClimbInfoUrl(boardDetails as unknown as BoardDetails, 'abc123');
-      expect(result).toBe('https://kilterboardapp.com/climbs/abc123');
+      expect(result).toBeNull();
     });
 
     it('should construct external info URL for tension', () => {

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -254,7 +254,13 @@ export const constructClimbViewUrlWithSlugs = (
 export const constructClimbInfoUrl = (
   { board_name }: BoardDetails,
   climb_uuid: ClimbUuid,
-) => `https://${board_name}boardapp${board_name === 'tension' ? '2' : ''}.com/climbs/${climb_uuid}`;
+): string | null => {
+  // Kilter board app URL is no longer accessible
+  if (board_name === 'kilter') {
+    return null;
+  }
+  return `https://${board_name}boardapp${board_name === 'tension' ? '2' : ''}.com/climbs/${climb_uuid}`;
+};
 
 //`/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/info/${climb_uuid}`;
 


### PR DESCRIPTION
The kilterboardapp.com URL is no longer accessible, so we disable the "Open in App" functionality for Kilter boards:

- constructClimbInfoUrl now returns null for Kilter boards
- OpenInAppAction returns unavailable when URL is null
- Hide "Open in App" buttons in tick dialogs for Kilter
- Hide "Open in App" menu item in queue for Kilter
- Update tests to expect null for Kilter

Tension board "Open in App" continues to work as before.