### PR TITLE
Set Twitter image runtime to edge instead of importing

### DIFF
--- a/packages/web/app/twitter-image.tsx
+++ b/packages/web/app/twitter-image.tsx
@@ -1,1 +1,3 @@
-export { default, alt, size, contentType, runtime } from './opengraph-image';
+export { default, alt, size, contentType } from './opengraph-image';
+
+export const runtime = 'edge';


### PR DESCRIPTION
## Summary
Changed the `twitter-image.tsx` file to explicitly define the `runtime` export as `'edge'` instead of re-exporting it from `opengraph-image.tsx`.

## Key Changes
- Removed `runtime` from the re-export statement of `opengraph-image`
- Added explicit `export const runtime = 'edge'` declaration in `twitter-image.tsx`

## Implementation Details
This change ensures that the Twitter image route has its own explicit runtime configuration set to `'edge'`, rather than relying on the runtime value from the OpenGraph image module. This provides better clarity and allows for independent runtime configuration between the two image generation endpoints.

https://claude.ai/code/session_01FfUCDtivgh8EZGJey4YENA