### PR TITLE
Hide global header on home page, update hero copy

### DIFF
--- a/packages/web/app/components/global-header/__tests__/global-header.test.tsx
+++ b/packages/web/app/components/global-header/__tests__/global-header.test.tsx
@@ -60,7 +60,7 @@ describe('GlobalHeader', () => {
     vi.clearAllMocks();
     mockActiveSession = null;
     mockIsOnBoardRoute = false;
-    mockPathname = '/';
+    mockPathname = '/some-page';
     mockBridgeState = {
       openClimbSearchDrawer: null,
       searchPillSummary: null,

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -23,6 +23,9 @@ const TITLE_HEADER_PAGES: Record<string, string> = {
   '/aurora-migration': 'Aurora Migration',
 };
 
+/** Pages where the global header is completely hidden */
+const HIDDEN_HEADER_PAGES = ['/'];
+
 interface GlobalHeaderProps {
   boardConfigs: BoardConfigData;
 }
@@ -37,6 +40,11 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const pathname = usePathname();
 
   const hasActiveSession = !!activeSession;
+
+  // Hide header completely on certain pages
+  if (HIDDEN_HEADER_PAGES.includes(pathname)) {
+    return null;
+  }
 
   // Check if current page wants a simple title header
   const titleHeaderPage = Object.entries(TITLE_HEADER_PAGES).find(([prefix]) => pathname.startsWith(prefix));

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -112,7 +112,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
           flex: 1,
           px: 2,
           py: 2,
-          pt: 'calc(var(--global-header-height) + 16px)',
+          pt: 2,
           display: 'flex',
           flexDirection: 'column',
           gap: 3,

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -140,7 +140,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
             variant="body1"
             sx={{ color: 'var(--neutral-500)', maxWidth: 320 }}
           >
-            Start a session to track your climbing, control LEDs, and invite friends.
+            Start a session to track your climbing, control your board, measure your performance, and invite friends.
           </Typography>
           <Button
             variant="contained"


### PR DESCRIPTION
## Summary
- Hide the global header (search bar + sesh button) on the home page since it has its own hero/onboarding layout
- Update home page hero subtitle: "control LEDs" → "control your board, measure your performance"

## Test plan
- [ ] Visit home page — no global header visible, content starts at top
- [ ] Navigate to a board page — global header appears normally
- [ ] Visit /aurora-migration — title header with back button shown
- [ ] Run `bun run typecheck` — no errors
- [ ] Run tests — global-header and aurora-migration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)