### PR TITLE
Improve homepage copy: lead with outcomes, not features

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -134,13 +134,13 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
             fontWeight={themeTokens.typography.fontWeight.bold}
             sx={{ color: 'var(--neutral-900)' }}
           >
-            Ready to climb?
+            Get on the wall
           </Typography>
           <Typography
             variant="body1"
             sx={{ color: 'var(--neutral-500)', maxWidth: 320 }}
           >
-            Start a session to track your climbing, control your board, and invite your friends.
+            Track your sends, light up holds, and climb with friends — all in one session.
           </Typography>
           <Button
             variant="contained"
@@ -188,34 +188,34 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
               px: 0.5,
             }}
           >
-            Get started
+            Make it yours
           </Typography>
 
           <OnboardingCard
             icon={<WarningAmberOutlined />}
-            title="Old Kilter app users"
-            description="Migrate your data to Boardsesh before it's lost"
+            title="Coming from Kilter?"
+            description="Bring your logbook and history over in one step"
             onClick={() => router.push('/aurora-migration')}
           />
 
           <OnboardingCard
             icon={<PeopleOutlined />}
-            title="Find climbers"
-            description="Follow friends and see their sessions in your feed"
+            title="Find your crew"
+            description="Follow friends and see what they're climbing"
             onClick={() => setFindClimbersOpen(true)}
           />
 
           <OnboardingCard
             icon={<LocalOfferOutlined />}
-            title="Create playlists"
-            description="Organize climbs into collections for your sessions"
+            title="Build a playlist"
+            description="Line up your climbs before you get to the gym"
             onClick={() => router.push('/playlists')}
           />
 
           <OnboardingCard
             icon={<BluetoothOutlined />}
             title="Connect your board"
-            description="Light up holds on your board via Bluetooth"
+            description="Pair via Bluetooth and light up your next climb"
             onClick={() => setSeshDrawerOpen(true)}
           />
         </Box>
@@ -224,7 +224,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
         {isAuthenticated && (
           <Box sx={{ textAlign: 'center', py: 2 }}>
             <Typography variant="body2" sx={{ color: 'var(--neutral-400)', mb: 1 }}>
-              Looking for your activity feed?
+              Your friends are climbing.
             </Typography>
             <Button
               variant="text"
@@ -232,7 +232,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
               onClick={() => router.push('/feed')}
               sx={{ textTransform: 'none' }}
             >
-              Go to Feed
+              See the feed
             </Button>
           </Box>
         )}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -17,11 +17,11 @@ import type { Viewport, Metadata } from 'next';
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.boardsesh.com'),
   title: {
-    default: 'Boardsesh - LED Climbing Board Training',
+    default: 'Boardsesh - Train smarter on your climbing board',
     template: '%s | Boardsesh',
   },
   description:
-    'Track your climbing sessions, control LED boards via Bluetooth, and train with friends on Kilter, Tension, and MoonBoard.',
+    'Track sessions, control LEDs, and climb with friends on Kilter, Tension, and MoonBoard. One app for every board.',
   openGraph: {
     type: 'website',
     siteName: 'Boardsesh',

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -6,20 +6,20 @@ import { getAllBoardConfigs } from './lib/server-board-configs';
 import HomePageContent from './home-page-content';
 
 export const metadata: Metadata = {
-  title: 'Boardsesh - LED Climbing Board Training Hub',
+  title: 'Boardsesh - Train smarter on your climbing board',
   description:
-    'Your all-in-one hub for LED climbing board training. Track sessions, control Kilter, Tension, and MoonBoard LEDs via Bluetooth, create playlists, and climb with friends.',
+    'Track sessions, control LEDs, and climb with friends on Kilter, Tension, and MoonBoard. One app for every board.',
   openGraph: {
-    title: 'Boardsesh - LED Climbing Board Training Hub',
+    title: 'Boardsesh - Train smarter on your climbing board',
     description:
-      'Track your climbing, control LED boards, and train with friends.',
+      'One app for Kilter, Tension, and MoonBoard. Track sessions, control LEDs, climb together.',
     url: 'https://www.boardsesh.com',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Boardsesh - LED Climbing Board Training Hub',
+    title: 'Boardsesh - Train smarter on your climbing board',
     description:
-      'Track your climbing, control LED boards, and train with friends.',
+      'One app for Kilter, Tension, and MoonBoard. Track sessions, control LEDs, climb together.',
   },
 };
 


### PR DESCRIPTION
Rewrites hero, onboarding cards, auth nudge, and SEO metadata
to speak to climbers instead of listing capabilities.

https://claude.ai/code/session_019UcAqNbzcqdXF6nNJU6FgY