### PR TITLE
Fix e2e CI: install unzip for Bun setup and bump Playwright image

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.0-noble
 
     services:
       postgres:
@@ -59,6 +59,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
+
+    - name: Install unzip (required by setup-bun)
+      run: apt-get update && apt-get install -y unzip
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
The Playwright v1.57.0-noble container is missing unzip, which causes
oven-sh/setup-bun to fail before any tests run. Added an apt-get step
to install unzip. Also bumped the container image to v1.58.0 to match
the installed @playwright/test version.

https://claude.ai/code/session_013RtzXrdALd8mMEH8q3juMF