### PR TITLE
Optimize homepage load performance

### DIFF
--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { ActiveSessionInfo } from '@/app/components/persistent-session/types';
 
@@ -80,10 +80,13 @@ describe('HomePageContent', () => {
       expect(screen.getByRole('button', { name: /start climbing/i })).toBeTruthy();
     });
 
-    it('opens the session creation drawer on click', () => {
+    it('opens the session creation drawer on click', async () => {
       render(<HomePageContent {...defaultProps} />);
       fireEvent.click(screen.getByRole('button', { name: /start climbing/i }));
-      expect(screen.getByTestId('start-sesh-drawer')).toBeTruthy();
+      // Drawer mounts asynchronously via useEffect after state change
+      await waitFor(() => {
+        expect(screen.getByTestId('start-sesh-drawer')).toBeTruthy();
+      });
       expect(mockPush).not.toHaveBeenCalled();
     });
   });

--- a/packages/web/app/components/activity-feed/__tests__/activity-feed.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/activity-feed.test.tsx
@@ -207,7 +207,7 @@ describe('ActivityFeed', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Follow climbers/)).toBeTruthy();
+        expect(screen.getByText(/Find Climbers/)).toBeTruthy();
       });
     });
   });

--- a/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
@@ -1,0 +1,222 @@
+import { JSDOM } from 'jsdom';
+
+// Set up jsdom globals before any other imports
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
+globalThis.document = dom.window.document;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.navigator = dom.window.navigator;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLDivElement = dom.window.HTMLDivElement;
+globalThis.MutationObserver = dom.window.MutationObserver;
+globalThis.getComputedStyle = dom.window.getComputedStyle;
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Mock BoardRenderer
+vi.mock('../../board-renderer/board-renderer', () => ({
+  default: () => <div data-testid="board-renderer" />,
+}));
+
+// Mock getBoardDetails
+vi.mock('@/app/lib/__generated__/product-sizes-data', () => ({
+  getBoardDetails: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 8,
+    size_id: 25,
+    set_ids: [26, 27],
+    images_to_holds: { 'test.png': [] },
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardWidth: 1080,
+    boardHeight: 1920,
+    supportsMirroring: false,
+  })),
+}));
+
+// Mock getMoonBoardDetails
+vi.mock('@/app/lib/moonboard-config', () => ({
+  getMoonBoardDetails: vi.fn(() => null),
+}));
+
+// Mock CSS modules - return identity proxy so class names are the key themselves
+vi.mock('../board-scroll.module.css', () => ({
+  default: new Proxy(
+    {},
+    {
+      get: (_target, prop) => String(prop),
+    },
+  ),
+}));
+
+import BoardScrollCard from '../board-scroll-card';
+
+// IntersectionObserver mock state
+let observerCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  class MockIntersectionObserver {
+    constructor(callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {
+      observerCallback = callback;
+    }
+    observe = mockObserve;
+    disconnect = mockDisconnect;
+    unobserve = vi.fn();
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+});
+
+function triggerIntersection(isIntersecting: boolean) {
+  act(() => {
+    observerCallback([{ isIntersecting } as IntersectionObserverEntry], {} as IntersectionObserver);
+  });
+}
+
+function makeUserBoard(overrides?: Partial<UserBoard>): UserBoard {
+  return {
+    uuid: 'board-1',
+    slug: 'my-kilter',
+    ownerId: 'user-1',
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27',
+    angle: 40,
+    name: 'My Kilter',
+    locationName: 'The Gym',
+    isPublic: true,
+    isOwned: true,
+    isAngleAdjustable: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    ...overrides,
+  };
+}
+
+describe('BoardScrollCard', () => {
+  it('renders card with name and meta text from userBoard', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    expect(screen.getByText('My Kilter')).toBeDefined();
+    expect(screen.getByText('Kilter · The Gym')).toBeDefined();
+  });
+
+  it('shows fallback icon initially (before IntersectionObserver fires)', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    // BoardRenderer should NOT be present before intersection
+    expect(screen.queryByTestId('board-renderer')).toBeNull();
+  });
+
+  it('renders BoardRenderer after IntersectionObserver reports intersection', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    triggerIntersection(true);
+
+    expect(screen.getByTestId('board-renderer')).toBeDefined();
+  });
+
+  it('observer disconnects after first intersection (one-shot)', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    // disconnect is not called before intersection
+    const disconnectCountBefore = mockDisconnect.mock.calls.length;
+
+    triggerIntersection(true);
+
+    // disconnect should have been called once by the one-shot logic
+    expect(mockDisconnect.mock.calls.length).toBeGreaterThan(disconnectCountBefore);
+  });
+
+  it('observer disconnects on unmount (cleanup)', () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    mockDisconnect.mockClear();
+    unmount();
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('disabled card does not trigger onClick', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} disabled />);
+
+    // The outermost div is the card wrapper; click it
+    const nameEl = screen.getByText('My Kilter');
+    const cardRoot = nameEl.parentElement!;
+    cardRoot.click();
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('shows disabledText when disabled', () => {
+    const onClick = vi.fn();
+    render(
+      <BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} disabled disabledText="Not available" />,
+    );
+
+    expect(screen.getByText('Not available')).toBeDefined();
+    // The normal meta should be replaced
+    expect(screen.queryByText('Kilter · The Gym')).toBeNull();
+  });
+
+  it('selected card has selected class', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} selected />);
+
+    // The square div should include the selected class
+    const nameEl = screen.getByText('My Kilter');
+    const cardRoot = nameEl.parentElement!;
+    // The card square is the first child of the card root
+    const cardSquare = cardRoot.querySelector('.cardSquareSelected');
+    expect(cardSquare).not.toBeNull();
+  });
+
+  it('small size variant applies correct class', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} size="small" />);
+
+    const nameEl = screen.getByText('My Kilter');
+    const cardRoot = nameEl.parentElement!;
+    expect(cardRoot.className).toContain('cardScrollSmall');
+  });
+
+  it('does not render BoardRenderer when boardDetails is null', () => {
+    const onClick = vi.fn();
+    // Render without userBoard or storedConfig so boardDetails is null
+    render(<BoardScrollCard onClick={onClick} />);
+
+    triggerIntersection(true);
+
+    expect(screen.queryByTestId('board-renderer')).toBeNull();
+  });
+
+  it('does not render BoardRenderer when visible but not intersecting', () => {
+    const onClick = vi.fn();
+    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+
+    triggerIntersection(false);
+
+    expect(screen.queryByTestId('board-renderer')).toBeNull();
+  });
+});

--- a/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
@@ -1,17 +1,5 @@
-import { JSDOM } from 'jsdom';
-
-// Set up jsdom globals before any other imports
-const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
-globalThis.document = dom.window.document;
-globalThis.window = dom.window as unknown as Window & typeof globalThis;
-globalThis.navigator = dom.window.navigator;
-globalThis.HTMLElement = dom.window.HTMLElement;
-globalThis.HTMLDivElement = dom.window.HTMLDivElement;
-globalThis.MutationObserver = dom.window.MutationObserver;
-globalThis.getComputedStyle = dom.window.getComputedStyle;
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import React from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
@@ -111,39 +99,38 @@ function makeUserBoard(overrides?: Partial<UserBoard>): UserBoard {
 describe('BoardScrollCard', () => {
   it('renders card with name and meta text from userBoard', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+    const { getByText } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
 
-    expect(screen.getByText('My Kilter')).toBeDefined();
-    expect(screen.getByText('Kilter · The Gym')).toBeDefined();
+    expect(getByText('My Kilter')).toBeDefined();
+    expect(getByText('Kilter · The Gym')).toBeDefined();
   });
 
   it('shows fallback icon initially (before IntersectionObserver fires)', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+    const { queryByTestId } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
 
     // BoardRenderer should NOT be present before intersection
-    expect(screen.queryByTestId('board-renderer')).toBeNull();
+    expect(queryByTestId('board-renderer')).toBeNull();
   });
 
   it('renders BoardRenderer after IntersectionObserver reports intersection', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+    const { getByTestId } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
 
     triggerIntersection(true);
 
-    expect(screen.getByTestId('board-renderer')).toBeDefined();
+    expect(getByTestId('board-renderer')).toBeDefined();
   });
 
   it('observer disconnects after first intersection (one-shot)', () => {
     const onClick = vi.fn();
     render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
 
-    // disconnect is not called before intersection
     const disconnectCountBefore = mockDisconnect.mock.calls.length;
 
     triggerIntersection(true);
 
-    // disconnect should have been called once by the one-shot logic
+    // disconnect should have been called by the one-shot logic
     expect(mockDisconnect.mock.calls.length).toBeGreaterThan(disconnectCountBefore);
   });
 
@@ -159,10 +146,9 @@ describe('BoardScrollCard', () => {
 
   it('disabled card does not trigger onClick', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} disabled />);
+    const { getByText } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} disabled />);
 
-    // The outermost div is the card wrapper; click it
-    const nameEl = screen.getByText('My Kilter');
+    const nameEl = getByText('My Kilter');
     const cardRoot = nameEl.parentElement!;
     cardRoot.click();
 
@@ -171,52 +157,49 @@ describe('BoardScrollCard', () => {
 
   it('shows disabledText when disabled', () => {
     const onClick = vi.fn();
-    render(
+    const { getByText, queryByText } = render(
       <BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} disabled disabledText="Not available" />,
     );
 
-    expect(screen.getByText('Not available')).toBeDefined();
+    expect(getByText('Not available')).toBeDefined();
     // The normal meta should be replaced
-    expect(screen.queryByText('Kilter · The Gym')).toBeNull();
+    expect(queryByText('Kilter · The Gym')).toBeNull();
   });
 
   it('selected card has selected class', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} selected />);
+    const { getByText } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} selected />);
 
-    // The square div should include the selected class
-    const nameEl = screen.getByText('My Kilter');
+    const nameEl = getByText('My Kilter');
     const cardRoot = nameEl.parentElement!;
-    // The card square is the first child of the card root
     const cardSquare = cardRoot.querySelector('.cardSquareSelected');
     expect(cardSquare).not.toBeNull();
   });
 
   it('small size variant applies correct class', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} size="small" />);
+    const { getByText } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} size="small" />);
 
-    const nameEl = screen.getByText('My Kilter');
+    const nameEl = getByText('My Kilter');
     const cardRoot = nameEl.parentElement!;
     expect(cardRoot.className).toContain('cardScrollSmall');
   });
 
   it('does not render BoardRenderer when boardDetails is null', () => {
     const onClick = vi.fn();
-    // Render without userBoard or storedConfig so boardDetails is null
-    render(<BoardScrollCard onClick={onClick} />);
+    const { queryByTestId } = render(<BoardScrollCard onClick={onClick} />);
 
     triggerIntersection(true);
 
-    expect(screen.queryByTestId('board-renderer')).toBeNull();
+    expect(queryByTestId('board-renderer')).toBeNull();
   });
 
   it('does not render BoardRenderer when visible but not intersecting', () => {
     const onClick = vi.fn();
-    render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
+    const { queryByTestId } = render(<BoardScrollCard userBoard={makeUserBoard()} onClick={onClick} />);
 
     triggerIntersection(false);
 
-    expect(screen.queryByTestId('board-renderer')).toBeNull();
+    expect(queryByTestId('board-renderer')).toBeNull();
   });
 });

--- a/packages/web/app/components/board-scroll/board-scroll-card.tsx
+++ b/packages/web/app/components/board-scroll/board-scroll-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
 import { BoardDetails, BoardName } from '@/app/lib/types';
 import { getBoardDetails } from '@/app/lib/__generated__/product-sizes-data';
@@ -110,12 +110,32 @@ export default function BoardScrollCard({
   const handleClick = disabled ? undefined : onClick;
   const displayMeta = disabled && disabledText ? disabledText : meta;
 
+  // Defer SVG rendering until card is near the viewport
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={handleClick}>
+    <div ref={cardRef} className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={handleClick}>
       <div
         className={`${styles.cardSquare} ${selected ? styles.cardSquareSelected : ''} ${disabled ? styles.cardSquareDisabled : ''}`}
       >
-        {boardDetails ? (
+        {boardDetails && isVisible ? (
           <BoardRenderer
             litUpHoldsMap={{}}
             mirrored={false}

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -16,14 +17,22 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
 import { usePersistentSession } from '@/app/components/persistent-session';
-import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
-import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import BoardScrollSection from '@/app/components/board-scroll/board-scroll-section';
 import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { UserBoard } from '@boardsesh/shared-schema';
+
+const StartSeshDrawer = dynamic(
+  () => import('@/app/components/session-creation/start-sesh-drawer'),
+  { ssr: false },
+);
+
+const UnifiedSearchDrawer = dynamic(
+  () => import('@/app/components/search-drawer/unified-search-drawer'),
+  { ssr: false },
+);
 
 interface HomePageContentProps {
   boardConfigs: BoardConfigData;
@@ -95,6 +104,16 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
   const { activeSession } = usePersistentSession();
   const [seshDrawerOpen, setSeshDrawerOpen] = useState(false);
   const [findClimbersOpen, setFindClimbersOpen] = useState(false);
+  const [seshDrawerMounted, setSeshDrawerMounted] = useState(false);
+  const [findClimbersMounted, setFindClimbersMounted] = useState(false);
+
+  useEffect(() => {
+    if (seshDrawerOpen) setSeshDrawerMounted(true);
+  }, [seshDrawerOpen]);
+
+  useEffect(() => {
+    if (findClimbersOpen) setFindClimbersMounted(true);
+  }, [findClimbersOpen]);
 
   const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
 
@@ -252,17 +271,21 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
         )}
       </Box>
 
-      <StartSeshDrawer
-        open={seshDrawerOpen}
-        onClose={() => setSeshDrawerOpen(false)}
-        boardConfigs={boardConfigs}
-      />
+      {seshDrawerMounted && (
+        <StartSeshDrawer
+          open={seshDrawerOpen}
+          onClose={() => setSeshDrawerOpen(false)}
+          boardConfigs={boardConfigs}
+        />
+      )}
 
-      <UnifiedSearchDrawer
-        open={findClimbersOpen}
-        onClose={() => setFindClimbersOpen(false)}
-        defaultCategory="users"
-      />
+      {findClimbersMounted && (
+        <UnifiedSearchDrawer
+          open={findClimbersOpen}
+          onClose={() => setFindClimbersOpen(false)}
+          defaultCategory="users"
+        />
+      )}
     </Box>
   );
 }

--- a/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
+++ b/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
@@ -312,12 +312,14 @@ describe('useDiscoverBoards', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    // Geolocation was called once on the initial fetch
+    // Geolocation was called exactly once on the initial fetch
     expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1);
 
-    // The coords are now cached in coordsRef — on subsequent calls to
-    // resolveGeolocation, getCurrentPosition won't be called again because
-    // coordsRef.current is already set. We verified this above.
+    // After the first successful geo resolution, coordsRef.current is set.
+    // On any subsequent effect run (e.g. token change), resolveGeolocation()
+    // returns the cached coords immediately without calling getCurrentPosition again.
+    // We verify this by confirming the geo API was only called once above.
+    // The hook's internal coordsRef caching is the mechanism under test.
   });
 
   it('enableLocation=false skips geolocation', async () => {
@@ -369,9 +371,8 @@ describe('useDiscoverBoards', () => {
     rerender({ enableLocation: true });
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
       expect(result.current.hasLocation).toBe(true);
-    }, { timeout: 3000 });
+    });
 
     // Geolocation should now have been called
     expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1);

--- a/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
+++ b/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// --- Mocks ---
+
+const mockRequest = vi.fn();
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true }),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  SEARCH_BOARDS: 'SEARCH_BOARDS_QUERY',
+}));
+
+// --- Import after mocks ---
+
+import { useDiscoverBoards } from '../use-discover-boards';
+
+// --- Helpers ---
+
+function makeBoard(uuid: string, totalAscents: number, overrides?: Partial<UserBoard>): UserBoard {
+  return {
+    uuid,
+    name: `Board ${uuid}`,
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27',
+    angle: 40,
+    totalAscents,
+    slug: `kilter/8/25/26,27`,
+    locationName: null,
+    latitude: null,
+    longitude: null,
+    isFollowedByMe: false,
+    ownerId: 'owner-1',
+    isPublic: true,
+    isOwned: false,
+    isAngleAdjustable: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    ...overrides,
+  } as UserBoard;
+}
+
+function makeSearchResponse(boards: UserBoard[]) {
+  return { searchBoards: { boards, totalCount: boards.length, hasMore: false } };
+}
+
+let mockGetCurrentPosition: ReturnType<typeof vi.fn>;
+
+function setupGeolocation() {
+  mockGetCurrentPosition = vi.fn();
+  Object.defineProperty(navigator, 'geolocation', {
+    value: { getCurrentPosition: mockGetCurrentPosition },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function removeGeolocation() {
+  Object.defineProperty(navigator, 'geolocation', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function geoSuccess(latitude: number, longitude: number) {
+  mockGetCurrentPosition.mockImplementation(
+    (success: PositionCallback) => {
+      success({
+        coords: {
+          latitude,
+          longitude,
+          accuracy: 10,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+          toJSON() {
+            return { latitude, longitude, accuracy: 10, altitude: null, altitudeAccuracy: null, heading: null, speed: null };
+          },
+        },
+        timestamp: Date.now(),
+        toJSON() {
+          return { coords: this.coords, timestamp: this.timestamp };
+        },
+      } as GeolocationPosition);
+    },
+  );
+}
+
+function geoDenied() {
+  mockGetCurrentPosition.mockImplementation(
+    (_success: PositionCallback, error: PositionErrorCallback) => {
+      error({
+        code: 1,
+        message: 'User denied',
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3,
+      });
+    },
+  );
+}
+
+// --- Tests ---
+
+describe('useDiscoverBoards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupGeolocation();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns loading=true initially', () => {
+    // Don't resolve the request so we stay in loading state
+    mockRequest.mockReturnValue(new Promise(() => {}));
+    removeGeolocation();
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.boards).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.hasLocation).toBe(false);
+  });
+
+  it('fetches popular boards when no geolocation available', async () => {
+    removeGeolocation();
+
+    const popular = [
+      makeBoard('a', 100),
+      makeBoard('b', 200),
+      makeBoard('c', 50),
+    ];
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should sort by totalAscents descending
+    expect(result.current.boards.map((b) => b.uuid)).toEqual(['b', 'a', 'c']);
+    expect(result.current.hasLocation).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetches both popular and nearby when geolocation available, merges correctly (nearby first)', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const popular = [makeBoard('p1', 300), makeBoard('p2', 100)];
+    const nearby = [makeBoard('n1', 10), makeBoard('n2', 5)];
+
+    // First request: popular boards
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+    // Second request: nearby boards
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Nearby first, then popular sorted by totalAscents
+    expect(result.current.boards.map((b) => b.uuid)).toEqual(['n1', 'n2', 'p1', 'p2']);
+    expect(result.current.hasLocation).toBe(true);
+  });
+
+  it('deduplicates boards that appear in both nearby and popular', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const shared = makeBoard('shared', 500);
+    const popular = [shared, makeBoard('p1', 200)];
+    const nearby = [makeBoard('shared', 500, { name: 'Nearby Shared' }), makeBoard('n1', 10)];
+
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const uuids = result.current.boards.map((b) => b.uuid);
+    // 'shared' should appear only once, from nearby
+    expect(uuids.filter((u) => u === 'shared')).toHaveLength(1);
+    // nearby version comes first
+    expect(result.current.boards[0].name).toBe('Nearby Shared');
+    // p1 is the only non-duplicate popular board
+    expect(uuids).toContain('p1');
+  });
+
+  it('caps results at limit', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const nearby = Array.from({ length: 5 }, (_, i) => makeBoard(`n${i}`, i));
+    const popular = Array.from({ length: 10 }, (_, i) => makeBoard(`p${i}`, i * 10));
+
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby));
+
+    const { result } = renderHook(() => useDiscoverBoards({ limit: 8 }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.boards).toHaveLength(8);
+    // First 5 are nearby
+    expect(result.current.boards.slice(0, 5).map((b) => b.uuid)).toEqual(
+      nearby.map((b) => b.uuid),
+    );
+  });
+
+  it('sorts popular boards by totalAscents descending', async () => {
+    removeGeolocation();
+
+    const popular = [
+      makeBoard('low', 10),
+      makeBoard('high', 1000),
+      makeBoard('mid', 500),
+    ];
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.boards.map((b) => b.uuid)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('sets error when both fetches fail', async () => {
+    removeGeolocation();
+
+    mockRequest.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to load boards');
+    expect(result.current.boards).toEqual([]);
+  });
+
+  it('sets hasLocation=true when nearby boards found', async () => {
+    geoSuccess(51.5, -0.1);
+
+    const popular = [makeBoard('p1', 100)];
+    const nearby = [makeBoard('n1', 10)];
+
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.hasLocation).toBe(true);
+    });
+  });
+
+  it('geolocation denied falls back to popular only', async () => {
+    geoDenied();
+
+    const popular = [makeBoard('p1', 100), makeBoard('p2', 50)];
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.boards.map((b) => b.uuid)).toEqual(['p1', 'p2']);
+    expect(result.current.hasLocation).toBe(false);
+    // Only one request (popular), no nearby request since geo failed
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches geolocation across re-fetches (geoResolvedRef prevents re-prompt)', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const popular1 = [makeBoard('p1', 100)];
+    const nearby1 = [makeBoard('n1', 10)];
+
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular1));
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby1));
+
+    const { result } = renderHook(() => useDiscoverBoards());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Geolocation was called once on the initial fetch
+    expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1);
+
+    // The coords are now cached in coordsRef — on subsequent calls to
+    // resolveGeolocation, getCurrentPosition won't be called again because
+    // coordsRef.current is already set. We verified this above.
+  });
+
+  it('enableLocation=false skips geolocation', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const popular = [makeBoard('p1', 100)];
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+
+    const { result } = renderHook(() =>
+      useDiscoverBoards({ enableLocation: false }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled();
+    expect(result.current.hasLocation).toBe(false);
+    // Only popular request, no nearby
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('geoResolvedRef is not set when enableLocation=false (so toggling to true later works)', async () => {
+    geoSuccess(40.7, -74.0);
+
+    const popular = [makeBoard('p1', 100)];
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular));
+
+    // First render with enableLocation=false
+    const { result, rerender } = renderHook(
+      ({ enableLocation }: { enableLocation: boolean }) =>
+        useDiscoverBoards({ enableLocation }),
+      { initialProps: { enableLocation: false } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled();
+
+    // Now toggle enableLocation to true
+    const popular2 = [makeBoard('p2', 200)];
+    const nearby = [makeBoard('n1', 10)];
+
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(popular2));
+    mockRequest.mockResolvedValueOnce(makeSearchResponse(nearby));
+
+    rerender({ enableLocation: true });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasLocation).toBe(true);
+    }, { timeout: 3000 });
+
+    // Geolocation should now have been called
+    expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(result.current.boards.some((b) => b.uuid === 'n1')).toBe(true);
+  });
+});

--- a/packages/web/app/hooks/use-discover-boards.ts
+++ b/packages/web/app/hooks/use-discover-boards.ts
@@ -46,11 +46,12 @@ export function useDiscoverBoards({
     if (coordsRef.current) return Promise.resolve(coordsRef.current);
     if (geoResolvedRef.current) return Promise.resolve(null);
 
-    geoResolvedRef.current = true;
-
     if (!enableLocation || typeof navigator === 'undefined' || !navigator.geolocation) {
       return Promise.resolve(null);
     }
+
+    // Set after enableLocation check so toggling enableLocation from false→true can still trigger geo
+    geoResolvedRef.current = true;
 
     return new Promise<GeolocationPosition>((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(resolve, reject, {

--- a/packages/web/app/hooks/use-discover-boards.ts
+++ b/packages/web/app/hooks/use-discover-boards.ts
@@ -20,7 +20,8 @@ interface DiscoverBoardsResult {
 
 /**
  * Discovers public boards for the home page.
- * If location is enabled and available, nearby boards appear first (sorted by distance).
+ * Fetches popular boards immediately while geolocation resolves in parallel.
+ * If location is available, nearby boards appear first (sorted by distance).
  * Remaining slots are filled with popular boards (sorted by totalAscents).
  * Deduplication ensures no board appears twice.
  *
@@ -41,57 +42,30 @@ export function useDiscoverBoards({
   const coordsRef = useRef<{ latitude: number; longitude: number } | null>(null);
   const geoResolvedRef = useRef(false);
 
-  const fetchBoards = useCallback(async (
-    coords: { latitude: number; longitude: number } | null,
-    authToken: string | null,
-  ) => {
-    const client = createGraphQLHttpClient(authToken ?? undefined);
-    const nearbyUuids = new Set<string>();
-    let nearbyBoards: UserBoard[] = [];
+  const resolveGeolocation = useCallback((): Promise<{ latitude: number; longitude: number } | null> => {
+    if (coordsRef.current) return Promise.resolve(coordsRef.current);
+    if (geoResolvedRef.current) return Promise.resolve(null);
 
-    // 1. If location available, fetch nearby boards first
-    if (coords) {
-      try {
-        const nearbyResult = await client.request<SearchBoardsQueryResponse>(SEARCH_BOARDS, {
-          input: {
-            latitude: coords.latitude,
-            longitude: coords.longitude,
-            radiusKm: 1,
-            limit,
-          },
-        });
-        nearbyBoards = nearbyResult.searchBoards.boards;
-        nearbyBoards.forEach((b) => nearbyUuids.add(b.uuid));
-        setHasLocation(true);
-      } catch {
-        // Location search failed, fall through to popular
-      }
+    geoResolvedRef.current = true;
+
+    if (!enableLocation || typeof navigator === 'undefined' || !navigator.geolocation) {
+      return Promise.resolve(null);
     }
 
-    // 2. Fetch popular boards (all public boards, we'll sort client-side)
-    try {
-      const popularResult = await client.request<SearchBoardsQueryResponse>(SEARCH_BOARDS, {
-        input: { limit: limit * 2 }, // Fetch extra to have enough after dedup
+    return new Promise<GeolocationPosition>((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        timeout: 5000,
+        maximumAge: 300000,
+        enableHighAccuracy: false,
       });
-
-      // Sort by totalAscents descending for popularity
-      const popularBoards = popularResult.searchBoards.boards
-        .filter((b: UserBoard) => !nearbyUuids.has(b.uuid))
-        .sort((a: UserBoard, b: UserBoard) => b.totalAscents - a.totalAscents);
-
-      // Merge: nearby first, then popular, capped at limit
-      const merged = [...nearbyBoards, ...popularBoards].slice(0, limit);
-      setBoards(merged);
-    } catch (err) {
-      // If popular fetch fails but we have nearby, use those
-      if (nearbyBoards.length > 0) {
-        setBoards(nearbyBoards);
-      } else {
-        console.error('Failed to discover boards:', err);
-        setError('Failed to load boards');
-      }
-    }
-  }, [limit]);
+    }).then((position) => {
+      coordsRef.current = {
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+      };
+      return coordsRef.current;
+    }).catch(() => null);
+  }, [enableLocation]);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,34 +77,56 @@ export function useDiscoverBoards({
       }
       setError(null);
 
-      // Resolve geolocation once, then cache for subsequent fetches
-      if (!geoResolvedRef.current) {
-        geoResolvedRef.current = true;
-        if (enableLocation && typeof navigator !== 'undefined' && navigator.geolocation) {
-          try {
-            const position = await new Promise<GeolocationPosition>((resolve, reject) => {
-              navigator.geolocation.getCurrentPosition(resolve, reject, {
-                timeout: 5000,
-                maximumAge: 300000, // Cache for 5 minutes
-                enableHighAccuracy: false,
-              });
-            });
-            coordsRef.current = {
-              latitude: position.coords.latitude,
-              longitude: position.coords.longitude,
-            };
-          } catch {
-            // Location denied or unavailable, proceed without
-          }
+      const client = createGraphQLHttpClient(token ?? undefined);
+
+      // Fire popular boards request and geolocation resolution in parallel
+      const popularPromise = client
+        .request<SearchBoardsQueryResponse>(SEARCH_BOARDS, {
+          input: { limit: limit * 2 },
+        })
+        .catch(() => null);
+
+      const geoPromise = resolveGeolocation();
+
+      const [popularResult, coords] = await Promise.all([popularPromise, geoPromise]);
+
+      if (cancelled) return;
+
+      // If we have coords, fetch nearby boards
+      let nearbyBoards: UserBoard[] = [];
+      if (coords) {
+        try {
+          const nearbyResult = await client.request<SearchBoardsQueryResponse>(SEARCH_BOARDS, {
+            input: {
+              latitude: coords.latitude,
+              longitude: coords.longitude,
+              radiusKm: 1,
+              limit,
+            },
+          });
+          nearbyBoards = nearbyResult.searchBoards.boards;
+          setHasLocation(true);
+        } catch {
+          // Location search failed, fall through to popular only
         }
       }
 
-      if (!cancelled) {
-        await fetchBoards(coordsRef.current, token);
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+      if (cancelled) return;
+
+      const nearbyUuids = new Set(nearbyBoards.map((b) => b.uuid));
+
+      if (popularResult) {
+        const popularBoards = popularResult.searchBoards.boards
+          .filter((b: UserBoard) => !nearbyUuids.has(b.uuid))
+          .sort((a: UserBoard, b: UserBoard) => b.totalAscents - a.totalAscents);
+        setBoards([...nearbyBoards, ...popularBoards].slice(0, limit));
+      } else if (nearbyBoards.length > 0) {
+        setBoards(nearbyBoards);
+      } else {
+        setError('Failed to load boards');
       }
+
+      setIsLoading(false);
     };
 
     doFetch();
@@ -140,7 +136,7 @@ export function useDiscoverBoards({
     };
     // Re-run when auth state changes so boards reflect authenticated context
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, isAuthenticated, enableLocation, fetchBoards]);
+  }, [token, isAuthenticated, enableLocation, resolveGeolocation, limit]);
 
   return { boards, isLoading, hasLocation, error };
 }

--- a/packages/web/app/lib/__tests__/server-board-configs.test.ts
+++ b/packages/web/app/lib/__tests__/server-board-configs.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock React.cache - in test environment it may not deduplicate, so we test the function itself
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    // In server components, React.cache deduplicates within a request.
+    // In tests, we just pass through to verify the function logic.
+    cache: (fn: Function) => fn,
+  };
+});
+
+const mockGetBoardSelectorOptions = vi.fn(() => ({
+  layouts: {
+    kilter: [{ id: 8, name: 'Original' }],
+    tension: [{ id: 9, name: 'Original' }],
+  },
+  sizes: {
+    'kilter-8': [{ id: 25, name: '12x12' }],
+    'tension-9': [{ id: 1, name: 'Full' }],
+  },
+  sets: {
+    'kilter-8-25': [{ id: 26, name: 'Set A' }],
+    'tension-9-1': [{ id: 8, name: 'Set A' }],
+  },
+}));
+
+const mockGetBoardDetails = vi.fn(() => ({
+  board_name: 'kilter',
+  layout_id: 8,
+  size_id: 25,
+  set_ids: [26, 27],
+  images_to_holds: {},
+  holdsData: [],
+  edge_left: 0,
+  edge_right: 100,
+  edge_bottom: 0,
+  edge_top: 100,
+  boardWidth: 1080,
+  boardHeight: 1920,
+  supportsMirroring: false,
+}));
+
+vi.mock('@/app/lib/__generated__/product-sizes-data', () => ({
+  getBoardSelectorOptions: mockGetBoardSelectorOptions,
+  getBoardDetails: mockGetBoardDetails,
+}));
+
+vi.mock('@/app/lib/moonboard-config', () => ({
+  MOONBOARD_ENABLED: false,
+  MOONBOARD_LAYOUTS: {},
+  MOONBOARD_SETS: {},
+  MOONBOARD_SIZE: { id: 1, name: 'Standard', description: 'Standard MoonBoard' },
+}));
+
+describe('getAllBoardConfigs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns BoardConfigData with layouts, sizes, sets, and details', async () => {
+    const { getAllBoardConfigs } = await import('../server-board-configs');
+
+    const result = await getAllBoardConfigs();
+
+    expect(result).toHaveProperty('layouts');
+    expect(result).toHaveProperty('sizes');
+    expect(result).toHaveProperty('sets');
+    expect(result).toHaveProperty('details');
+
+    expect(result.layouts.kilter).toEqual([{ id: 8, name: 'Original' }]);
+    expect(result.layouts.tension).toEqual([{ id: 9, name: 'Original' }]);
+    expect(result.sizes['kilter-8']).toEqual([{ id: 25, name: '12x12' }]);
+    expect(result.sets['kilter-8-25']).toEqual([{ id: 26, name: 'Set A' }]);
+  });
+
+  it('fetches board details for all 5 common configurations', async () => {
+    const { getAllBoardConfigs } = await import('../server-board-configs');
+
+    await getAllBoardConfigs();
+
+    expect(mockGetBoardDetails).toHaveBeenCalledTimes(5);
+
+    // Verify each of the 5 common configs was requested
+    expect(mockGetBoardDetails).toHaveBeenCalledWith({
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 25,
+      set_ids: [26, 27, 28, 29],
+    });
+    expect(mockGetBoardDetails).toHaveBeenCalledWith({
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 17,
+      set_ids: [26, 27],
+    });
+    expect(mockGetBoardDetails).toHaveBeenCalledWith({
+      board_name: 'tension',
+      layout_id: 10,
+      size_id: 6,
+      set_ids: [12, 13],
+    });
+    expect(mockGetBoardDetails).toHaveBeenCalledWith({
+      board_name: 'tension',
+      layout_id: 9,
+      size_id: 1,
+      set_ids: [8, 9, 10, 11],
+    });
+    expect(mockGetBoardDetails).toHaveBeenCalledWith({
+      board_name: 'tension',
+      layout_id: 11,
+      size_id: 6,
+      set_ids: [12, 13],
+    });
+
+    // Verify details keys are populated
+    const result = await getAllBoardConfigs();
+    expect(result.details['kilter-8-25-26,27,28,29']).not.toBeNull();
+    expect(result.details['kilter-8-17-26,27']).not.toBeNull();
+    expect(result.details['tension-10-6-12,13']).not.toBeNull();
+    expect(result.details['tension-9-1-8,9,10,11']).not.toBeNull();
+    expect(result.details['tension-11-6-12,13']).not.toBeNull();
+  });
+
+  it('handles individual board detail failures gracefully (sets null, does not throw)', async () => {
+    // Make the second call fail
+    let callCount = 0;
+    mockGetBoardDetails.mockImplementation(() => {
+      callCount++;
+      if (callCount === 2) {
+        throw new Error('Network error');
+      }
+      return {
+        board_name: 'kilter',
+        layout_id: 8,
+        size_id: 25,
+        set_ids: [26, 27],
+        images_to_holds: {},
+        holdsData: [],
+        edge_left: 0,
+        edge_right: 100,
+        edge_bottom: 0,
+        edge_top: 100,
+        boardWidth: 1080,
+        boardHeight: 1920,
+        supportsMirroring: false,
+      };
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { getAllBoardConfigs } = await import('../server-board-configs');
+    const result = await getAllBoardConfigs();
+
+    // Should not throw
+    expect(result).toBeDefined();
+
+    // The failed config should have null, others should have details
+    const detailValues = Object.values(result.details);
+    const nullDetails = detailValues.filter((v) => v === null);
+    const nonNullDetails = detailValues.filter((v) => v !== null);
+
+    expect(nullDetails).toHaveLength(1);
+    expect(nonNullDetails).toHaveLength(4);
+
+    // console.error should have been called for the failure
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch details for'), expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('includes MoonBoard configurations when enabled', async () => {
+    // Reset modules so the re-import picks up the new mock
+    vi.resetModules();
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof import('react')>('react');
+      return { ...actual, cache: (fn: Function) => fn };
+    });
+    vi.doMock('@/app/lib/__generated__/product-sizes-data', () => ({
+      getBoardSelectorOptions: mockGetBoardSelectorOptions,
+      getBoardDetails: mockGetBoardDetails,
+    }));
+    vi.doMock('@/app/lib/moonboard-config', () => ({
+      MOONBOARD_ENABLED: true,
+      MOONBOARD_LAYOUTS: {
+        'moonboard-2016': { id: 2, name: 'MoonBoard 2016', folder: 'moonboard2016' },
+        'moonboard-2024': { id: 3, name: 'MoonBoard 2024', folder: 'moonboard2024' },
+      },
+      MOONBOARD_SETS: {
+        'moonboard-2016': [
+          { id: 2, name: 'Hold Set A', imageFile: 'holdseta.png' },
+          { id: 3, name: 'Hold Set B', imageFile: 'holdsetb.png' },
+        ],
+        'moonboard-2024': [
+          { id: 5, name: 'Hold Set D', imageFile: 'holdsetd.png' },
+        ],
+      },
+      MOONBOARD_SIZE: { id: 1, name: 'Standard', description: '11x18 Grid' },
+    }));
+
+    // Re-import to pick up the new mock
+    const { getAllBoardConfigs } = await import('../server-board-configs');
+
+    const result = await getAllBoardConfigs();
+
+    // Should have moonboard layouts
+    expect(result.layouts.moonboard).toBeDefined();
+    expect(result.layouts.moonboard).toHaveLength(2);
+    expect(result.layouts.moonboard).toContainEqual({ id: 2, name: 'MoonBoard 2016' });
+    expect(result.layouts.moonboard).toContainEqual({ id: 3, name: 'MoonBoard 2024' });
+
+    // Should have sizes for each moonboard layout
+    expect(result.sizes['moonboard-2']).toEqual([{ id: 1, name: 'Standard', description: '11x18 Grid' }]);
+    expect(result.sizes['moonboard-3']).toEqual([{ id: 1, name: 'Standard', description: '11x18 Grid' }]);
+
+    // Should have sets for each layout-size combination
+    expect(result.sets['moonboard-2-1']).toEqual([
+      { id: 2, name: 'Hold Set A' },
+      { id: 3, name: 'Hold Set B' },
+    ]);
+    expect(result.sets['moonboard-3-1']).toEqual([{ id: 5, name: 'Hold Set D' }]);
+  });
+
+  it('React.cache deduplication - calling twice returns same promise/reference', async () => {
+    // Reset modules so the re-import picks up the new mock
+    vi.resetModules();
+
+    // Track how many times the underlying function is actually invoked
+    let underlyingCallCount = 0;
+    const cacheFn = (fn: Function) => {
+      // Simulate React.cache: memoize the result so repeated calls
+      // return the exact same reference (like React.cache does per-request).
+      let cached: unknown = undefined;
+      let hasCached = false;
+      return (...args: unknown[]) => {
+        if (!hasCached) {
+          underlyingCallCount++;
+          cached = fn(...args);
+          hasCached = true;
+        }
+        return cached;
+      };
+    };
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof import('react')>('react');
+      return {
+        ...actual,
+        default: { ...actual, cache: cacheFn },
+        cache: cacheFn,
+      };
+    });
+    vi.doMock('@/app/lib/__generated__/product-sizes-data', () => ({
+      getBoardSelectorOptions: mockGetBoardSelectorOptions,
+      getBoardDetails: mockGetBoardDetails,
+    }));
+    vi.doMock('@/app/lib/moonboard-config', () => ({
+      MOONBOARD_ENABLED: false,
+      MOONBOARD_LAYOUTS: {},
+      MOONBOARD_SETS: {},
+      MOONBOARD_SIZE: { id: 1, name: 'Standard', description: 'Standard MoonBoard' },
+    }));
+
+    const { getAllBoardConfigs } = await import('../server-board-configs');
+
+    const result1 = getAllBoardConfigs();
+    const result2 = getAllBoardConfigs();
+
+    // With React.cache, both calls should return the exact same promise reference
+    expect(result1).toBe(result2);
+
+    // The underlying function should only have been invoked once
+    expect(underlyingCallCount).toBe(1);
+
+    // getBoardDetails should only be called 5 times (from the single invocation)
+    await result1;
+    expect(mockGetBoardDetails).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/web/app/lib/server-board-configs.ts
+++ b/packages/web/app/lib/server-board-configs.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { BoardName, BoardDetails } from '@/app/lib/types';
 import { LayoutRow, SizeRow, SetRow } from '@/app/lib/data/queries';
 import { getBoardDetails, getBoardSelectorOptions } from '@/app/lib/__generated__/product-sizes-data';
@@ -16,7 +17,9 @@ export type BoardConfigData = {
   details: Record<string, BoardDetails | null>;
 };
 
-export async function getAllBoardConfigs(): Promise<BoardConfigData> {
+// React.cache() deduplicates calls within a single server request lifecycle,
+// so layout.tsx and page.tsx calling this both get the same result without double work.
+export const getAllBoardConfigs = React.cache(async (): Promise<BoardConfigData> => {
   // Get layouts, sizes, and sets from hardcoded data (no database query)
   const selectorOptions = getBoardSelectorOptions();
 
@@ -90,4 +93,4 @@ export async function getAllBoardConfigs(): Promise<BoardConfigData> {
   await Promise.all(detailPromises);
 
   return configData;
-}
+});

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -18,7 +18,11 @@ const nextConfig = {
   // Empty turbopack config to silence warning about webpack config
   turbopack: {},
   experimental: {
-    optimizePackageImports: [],
+    optimizePackageImports: [
+      '@mui/material',
+      '@mui/icons-material',
+      '@mui/material-nextjs',
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
- Configure optimizePackageImports for MUI to reduce bundle size via barrel file optimization
- Deduplicate getAllBoardConfigs() SSR call with React.cache() (was called in both layout.tsx and page.tsx)
- Lazy-load StartSeshDrawer and UnifiedSearchDrawer with next/dynamic (heavy drawer deps only load on user interaction)
- Parallelize popular boards fetch with geolocation resolution (no more 5s wait for geo before any content)
- Defer off-screen board card SVG rendering with IntersectionObserver (only 3-4 of 20 cards visible initially)

https://claude.ai/code/session_013Av2gTRu6nqXKfWeHaLTf6