### PR TITLE
Add guided tour from home page + rename Session Overview

### DIFF
--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -160,7 +160,7 @@ A new landing/home screen accessible via the first tab. This is a placeholder fo
 **Feature flag**: `NEXT_PUBLIC_ENABLE_HOME_SCREEN`
 - When `'true'`: Home tab navigates to the `/home` route
 - When falsy (default): Home tab navigates to `/list` instead (acts as the Climb tab)
-- This matches the existing feature flag pattern (e.g., `NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR` in `onboarding-tour.tsx`)
+- This matches the existing feature flag pattern
 - Add to `.env.local`: `NEXT_PUBLIC_ENABLE_HOME_SCREEN=false`
 
 ### Files to modify
@@ -755,7 +755,7 @@ Minor refinements to the queue list to match the new design language.
 - Queue drawer now opens from the dedicated Queue button on the bar (not from tapping climb info)
 - Placement stays bottom, height stays 70%
 - Add a count badge on the Queue button showing queue length
-- **Keep**: The existing `TOUR_DRAWER_EVENT` listener that opens/closes the drawer for the onboarding tour. The tour may need to target the new Queue button instead of the old click area.
+- **Keep**: The existing `TOUR_PLAY_VIEW_EVENT` listener that opens/closes the play view for the guided tour.
 - **Keep**: The `handleDrawerOpenChange` callback that scrolls to the current climb when the drawer opens
 
 ---

--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -20,8 +20,6 @@ NEXTAUTH_URL=http://localhost:3000
 # For production, set this via your deployment platform's environment variables (e.g., Vercel)
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
 
-# Feature flags
-NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR=false
 
 # S3 Storage Configuration (optional, for production)
 # When these are set, avatar uploads go to S3 instead of local disk

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Button from '@mui/material/Button';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
@@ -10,6 +10,7 @@ import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-dra
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
 import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
+import { TOUR_SESH_OVERVIEW_EVENT } from '@/app/components/onboarding/onboarding-tour';
 import { usePersistentSession, useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -31,10 +32,27 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [startSeshOpen, setStartSeshOpen] = useState(false);
   const [seshSettingsOpen, setSeshSettingsOpen] = useState(false);
+  const [seshOverviewTourMode, setSeshOverviewTourMode] = useState(false);
   const { activeSession } = usePersistentSession();
   const isOnBoardRoute = useIsOnBoardRoute();
   const { openClimbSearchDrawer, searchPillSummary, hasActiveFilters: filtersActive } = useSearchDrawerBridge();
   const pathname = usePathname();
+
+  // Listen for tour events to open/close the session overview drawer
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { open } = (e as CustomEvent<{ open: boolean }>).detail;
+      if (open) {
+        setSeshOverviewTourMode(true);
+        setSeshSettingsOpen(true);
+      } else {
+        setSeshSettingsOpen(false);
+        setSeshOverviewTourMode(false);
+      }
+    };
+    window.addEventListener(TOUR_SESH_OVERVIEW_EVENT, handler);
+    return () => window.removeEventListener(TOUR_SESH_OVERVIEW_EVENT, handler);
+  }, []);
 
   const hasActiveSession = !!activeSession;
 
@@ -118,7 +136,11 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
 
       <SeshSettingsDrawer
         open={seshSettingsOpen}
-        onClose={() => setSeshSettingsOpen(false)}
+        onClose={() => {
+          setSeshSettingsOpen(false);
+          setSeshOverviewTourMode(false);
+        }}
+        tourMode={seshOverviewTourMode}
       />
     </>
   );

--- a/packages/web/app/components/onboarding/onboarding-tour.module.css
+++ b/packages/web/app/components/onboarding/onboarding-tour.module.css
@@ -13,9 +13,13 @@
   text-align: right;
 }
 
-.skipLink a {
+.skipLink button {
   font-size: 13px;
   color: var(--neutral-400);
   cursor: pointer;
   text-decoration: underline;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
 }

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -9,19 +9,13 @@ import MuiTypography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
 import {
-  FormatListBulletedOutlined,
   ViewWeekOutlined,
-  CancelOutlined,
-  SearchOutlined,
-  GridOnOutlined,
-  DragIndicatorOutlined,
   SwipeOutlined,
   PlayCircleOutlineOutlined,
   AssessmentOutlined,
 } from '@mui/icons-material';
 import { useSession } from 'next-auth/react';
 import {
-  shouldShowOnboarding,
   saveOnboardingStatus,
   isGuidedTourPending,
   clearGuidedTourPending,
@@ -34,7 +28,6 @@ const TOUR_START_DELAY = 800;
 const DRAWER_ANIMATION_DELAY = 450;
 
 // Custom event names for controlling drawers from the tour
-export const TOUR_DRAWER_EVENT = 'onboarding-tour:set-queue-drawer';
 export const TOUR_PLAY_VIEW_EVENT = 'onboarding-tour:set-play-view';
 export const TOUR_SESH_OVERVIEW_EVENT = 'onboarding-tour:set-sesh-overview';
 
@@ -44,10 +37,6 @@ const getTarget = (selector: string): (() => HTMLElement) | null => {
 };
 
 // Dispatch custom events to open/close drawers
-const setTourDrawer = (open: boolean) => {
-  window.dispatchEvent(new CustomEvent(TOUR_DRAWER_EVENT, { detail: { open } }));
-};
-
 const setTourPlayView = (open: boolean) => {
   window.dispatchEvent(new CustomEvent(TOUR_PLAY_VIEW_EVENT, { detail: { open } }));
 };
@@ -158,17 +147,12 @@ export function CustomTour({
   );
 }
 
-const isOnboardingTourEnabled = process.env.NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR === 'true';
-
 const OnboardingTour: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState(0);
-  const [isGuidedMode, setIsGuidedMode] = useState(false);
   const { data: session } = useSession();
-  const drawerOpenedByTour = useRef(false);
   const playViewOpenedByTour = useRef(false);
   const seshOverviewOpenedByTour = useRef(false);
-  const isMobileRef = useRef(false);
 
   // Check for guided tour pending flag (set from home page "Take the tour")
   useEffect(() => {
@@ -176,7 +160,6 @@ const OnboardingTour: React.FC = () => {
       const pending = await isGuidedTourPending();
       if (pending) {
         await clearGuidedTourPending();
-        setIsGuidedMode(true);
         // Wait for the page to settle
         setTimeout(() => {
           setOpen(true);
@@ -187,40 +170,8 @@ const OnboardingTour: React.FC = () => {
     checkGuidedTour();
   }, []);
 
-  // Existing auto-onboarding (env var + mobile only)
-  useEffect(() => {
-    if (!isOnboardingTourEnabled) return;
-    if (isGuidedMode) return; // Don't double-trigger if guided tour is active
-
-    const checkMobile = () => {
-      isMobileRef.current = window.matchMedia('(max-width: 768px)').matches;
-    };
-    checkMobile();
-
-    if (!isMobileRef.current) return;
-
-    const checkOnboarding = async () => {
-      const userId = session?.user?.id;
-      const shouldShow = await shouldShowOnboarding(userId);
-      if (shouldShow) {
-        setTimeout(() => {
-          const climbCard = document.getElementById('onboarding-climb-card');
-          if (climbCard) {
-            setOpen(true);
-          }
-        }, TOUR_START_DELAY);
-      }
-    };
-
-    checkOnboarding();
-  }, [session?.user?.id, isGuidedMode]);
-
   const handleClose = useCallback(async () => {
     // Close any drawers opened by the tour
-    if (drawerOpenedByTour.current) {
-      setTourDrawer(false);
-      drawerOpenedByTour.current = false;
-    }
     if (playViewOpenedByTour.current) {
       setTourPlayView(false);
       playViewOpenedByTour.current = false;
@@ -232,54 +183,15 @@ const OnboardingTour: React.FC = () => {
 
     setOpen(false);
     setCurrent(0);
-    setIsGuidedMode(false);
 
     // Save completion status
     const userId = session?.user?.id;
     await saveOnboardingStatus(userId);
   }, [session?.user?.id]);
 
-  const handleStepChange = useCallback((step: number) => {
-    if (isGuidedMode) {
-      handleGuidedStepChange(step);
-    } else {
-      handleOriginalStepChange(step);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isGuidedMode]);
-
-  // Original onboarding step change logic
-  const handleOriginalStepChange = useCallback((step: number) => {
-    const QUEUE_DRAWER_OPEN_STEP = 3;
-    const QUEUE_DRAWER_CLOSE_STEP = 6;
-
-    if (step === QUEUE_DRAWER_OPEN_STEP && !drawerOpenedByTour.current) {
-      setTourDrawer(true);
-      drawerOpenedByTour.current = true;
-      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
-      return;
-    }
-
-    if (step === QUEUE_DRAWER_CLOSE_STEP && drawerOpenedByTour.current) {
-      setTourDrawer(false);
-      drawerOpenedByTour.current = false;
-      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
-      return;
-    }
-
-    if (step === QUEUE_DRAWER_OPEN_STEP - 1 && drawerOpenedByTour.current) {
-      setTourDrawer(false);
-      drawerOpenedByTour.current = false;
-      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
-      return;
-    }
-
-    setCurrent(step);
-  }, []);
-
   // Guided tour step change logic
-  // Steps: 0=swipe actions, 1=queue bar, 2=climb drawer (open play view), 3=session overview (open drawer), 4=done
-  const handleGuidedStepChange = useCallback((step: number) => {
+  // Steps: 0=swipe actions, 1=queue bar, 2=climb drawer (open play view), 3=session overview (open drawer)
+  const handleStepChange = useCallback((step: number) => {
     const PLAY_VIEW_STEP = 2;
     const SESH_OVERVIEW_STEP = 3;
 
@@ -344,97 +256,7 @@ const OnboardingTour: React.FC = () => {
     </>
   );
 
-  const originalTourSteps: TourStep[] = [
-    {
-      title: 'Select a Climb',
-      description: withSkip('Double-tap any climb card to make it the active climb and add it to your queue.'),
-      target: getTarget('#onboarding-climb-card'),
-      placement: 'bottom',
-    },
-    {
-      title: 'Navigate Your Queue',
-      description: withSkip('Swipe left or right on this bar to go to the next or previous climb in your queue.'),
-      target: getTarget('#onboarding-queue-bar'),
-      cover: (
-        <div className={styles.stepIcon}>
-          <ViewWeekOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'View Your Queue',
-      description: withSkip('Tap here to open the queue drawer and see all your climbs, history, and suggestions.'),
-      target: getTarget('#onboarding-queue-toggle'),
-      cover: (
-        <div className={styles.stepIcon}>
-          <FormatListBulletedOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'Queue Item Actions',
-      description: withSkip(
-        'Swipe queue items left to remove them from the queue, or swipe right to log an ascent.',
-      ),
-      target: getTarget('[data-testid="queue-item"]'),
-      mask: false,
-      cover: (
-        <div className={styles.stepIcon}>
-          <ViewWeekOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'Reorder Your Queue',
-      description: withSkip(
-        'Press and hold a queue item, then drag it up or down to reorder your queue.',
-      ),
-      target: getTarget('[data-testid="queue-item"]'),
-      mask: false,
-      cover: (
-        <div className={styles.stepIcon}>
-          <DragIndicatorOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'Close the Queue',
-      description: withSkip('Tap outside the drawer to close it and return to the climb list.'),
-      target: null,
-      mask: false,
-      cover: (
-        <div className={styles.stepIcon}>
-          <CancelOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'Search by Hold',
-      description: withSkip(
-        'Open the search panel and use the "Search by Hold" tab to find climbs that use specific holds on the board.',
-      ),
-      target: getTarget('#onboarding-search-button'),
-      cover: (
-        <div className={styles.stepIcon}>
-          <SearchOutlined />
-        </div>
-      ),
-    },
-    {
-      title: 'Heatmap',
-      description: withSkip(
-        'The heatmap shows how frequently each hold is used across matching climbs. It uses your current search filters (grades, ascents, etc.), so adjust those first to see relevant hold usage.',
-      ),
-      target: getTarget('#onboarding-search-button'),
-      cover: (
-        <div className={styles.stepIcon}>
-          <GridOnOutlined />
-        </div>
-      ),
-    },
-  ];
-
-  const guidedTourSteps: TourStep[] = [
+  const tourSteps: TourStep[] = [
     {
       title: 'Swipe Actions',
       description: withSkip(
@@ -488,10 +310,7 @@ const OnboardingTour: React.FC = () => {
     },
   ];
 
-  const tourSteps = isGuidedMode ? guidedTourSteps : originalTourSteps;
-
   if (!open) return null;
-  if (!isGuidedMode && !isOnboardingTourEnabled) return null;
 
   return (
     <CustomTour

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -32,8 +32,8 @@ export const TOUR_PLAY_VIEW_EVENT = 'onboarding-tour:set-play-view';
 export const TOUR_SESH_OVERVIEW_EVENT = 'onboarding-tour:set-sesh-overview';
 
 // Helper to create a target function that resolves a CSS selector to an element
-const getTarget = (selector: string): (() => HTMLElement) | null => {
-  return (() => document.querySelector<HTMLElement>(selector)!) as (() => HTMLElement) | null;
+const getTarget = (selector: string): () => HTMLElement | null => {
+  return () => document.querySelector<HTMLElement>(selector);
 };
 
 // Dispatch custom events to open/close drawers
@@ -48,7 +48,7 @@ const setTourSeshOverview = (open: boolean) => {
 export interface TourStep {
   title: string;
   description: React.ReactNode;
-  target: (() => HTMLElement) | null;
+  target: (() => HTMLElement | null) | null;
   placement?: 'top' | 'bottom' | 'left' | 'right';
   mask?: boolean;
   cover?: React.ReactNode;
@@ -251,7 +251,7 @@ const OnboardingTour: React.FC = () => {
     <>
       {description}
       <div className={styles.skipLink}>
-        <a onClick={handleClose}>Skip tour</a>
+        <button type="button" onClick={handleClose}>Skip tour</button>
       </div>
     </>
   );

--- a/packages/web/app/components/onboarding/onboarding-tour.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour.tsx
@@ -15,9 +15,17 @@ import {
   SearchOutlined,
   GridOnOutlined,
   DragIndicatorOutlined,
+  SwipeOutlined,
+  PlayCircleOutlineOutlined,
+  AssessmentOutlined,
 } from '@mui/icons-material';
 import { useSession } from 'next-auth/react';
-import { shouldShowOnboarding, saveOnboardingStatus } from '@/app/lib/onboarding-db';
+import {
+  shouldShowOnboarding,
+  saveOnboardingStatus,
+  isGuidedTourPending,
+  clearGuidedTourPending,
+} from '@/app/lib/onboarding-db';
 import styles from './onboarding-tour.module.css';
 
 // Delay in ms before the tour starts after the page loads
@@ -25,20 +33,30 @@ const TOUR_START_DELAY = 800;
 // Delay in ms for drawer open/close animation
 const DRAWER_ANIMATION_DELAY = 450;
 
-// Custom event name for controlling the queue drawer from the tour
+// Custom event names for controlling drawers from the tour
 export const TOUR_DRAWER_EVENT = 'onboarding-tour:set-queue-drawer';
+export const TOUR_PLAY_VIEW_EVENT = 'onboarding-tour:set-play-view';
+export const TOUR_SESH_OVERVIEW_EVENT = 'onboarding-tour:set-sesh-overview';
 
 // Helper to create a target function that resolves a CSS selector to an element
 const getTarget = (selector: string): (() => HTMLElement) | null => {
   return (() => document.querySelector<HTMLElement>(selector)!) as (() => HTMLElement) | null;
 };
 
-// Dispatch a custom event to open/close the queue drawer
+// Dispatch custom events to open/close drawers
 const setTourDrawer = (open: boolean) => {
   window.dispatchEvent(new CustomEvent(TOUR_DRAWER_EVENT, { detail: { open } }));
 };
 
-interface TourStep {
+const setTourPlayView = (open: boolean) => {
+  window.dispatchEvent(new CustomEvent(TOUR_PLAY_VIEW_EVENT, { detail: { open } }));
+};
+
+const setTourSeshOverview = (open: boolean) => {
+  window.dispatchEvent(new CustomEvent(TOUR_SESH_OVERVIEW_EVENT, { detail: { open } }));
+};
+
+export interface TourStep {
   title: string;
   description: React.ReactNode;
   target: (() => HTMLElement) | null;
@@ -47,7 +65,7 @@ interface TourStep {
   cover?: React.ReactNode;
 }
 
-function CustomTour({
+export function CustomTour({
   open,
   current,
   steps,
@@ -145,14 +163,35 @@ const isOnboardingTourEnabled = process.env.NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR =
 const OnboardingTour: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState(0);
+  const [isGuidedMode, setIsGuidedMode] = useState(false);
   const { data: session } = useSession();
   const drawerOpenedByTour = useRef(false);
+  const playViewOpenedByTour = useRef(false);
+  const seshOverviewOpenedByTour = useRef(false);
   const isMobileRef = useRef(false);
 
+  // Check for guided tour pending flag (set from home page "Take the tour")
+  useEffect(() => {
+    const checkGuidedTour = async () => {
+      const pending = await isGuidedTourPending();
+      if (pending) {
+        await clearGuidedTourPending();
+        setIsGuidedMode(true);
+        // Wait for the page to settle
+        setTimeout(() => {
+          setOpen(true);
+        }, TOUR_START_DELAY);
+      }
+    };
+
+    checkGuidedTour();
+  }, []);
+
+  // Existing auto-onboarding (env var + mobile only)
   useEffect(() => {
     if (!isOnboardingTourEnabled) return;
+    if (isGuidedMode) return; // Don't double-trigger if guided tour is active
 
-    // Only show on mobile
     const checkMobile = () => {
       isMobileRef.current = window.matchMedia('(max-width: 768px)').matches;
     };
@@ -164,9 +203,7 @@ const OnboardingTour: React.FC = () => {
       const userId = session?.user?.id;
       const shouldShow = await shouldShowOnboarding(userId);
       if (shouldShow) {
-        // Wait for the page to settle before showing the tour
         setTimeout(() => {
-          // Double-check that the climb card exists (page has loaded)
           const climbCard = document.getElementById('onboarding-climb-card');
           if (climbCard) {
             setOpen(true);
@@ -176,17 +213,26 @@ const OnboardingTour: React.FC = () => {
     };
 
     checkOnboarding();
-  }, [session?.user?.id]);
+  }, [session?.user?.id, isGuidedMode]);
 
   const handleClose = useCallback(async () => {
-    // Close the drawer if it was opened by the tour
+    // Close any drawers opened by the tour
     if (drawerOpenedByTour.current) {
       setTourDrawer(false);
       drawerOpenedByTour.current = false;
     }
+    if (playViewOpenedByTour.current) {
+      setTourPlayView(false);
+      playViewOpenedByTour.current = false;
+    }
+    if (seshOverviewOpenedByTour.current) {
+      setTourSeshOverview(false);
+      seshOverviewOpenedByTour.current = false;
+    }
 
     setOpen(false);
     setCurrent(0);
+    setIsGuidedMode(false);
 
     // Save completion status
     const userId = session?.user?.id;
@@ -194,20 +240,26 @@ const OnboardingTour: React.FC = () => {
   }, [session?.user?.id]);
 
   const handleStepChange = useCallback((step: number) => {
-    // Steps 3-5 are inside the queue drawer (swipe actions, drag & drop, close drawer)
+    if (isGuidedMode) {
+      handleGuidedStepChange(step);
+    } else {
+      handleOriginalStepChange(step);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isGuidedMode]);
+
+  // Original onboarding step change logic
+  const handleOriginalStepChange = useCallback((step: number) => {
     const QUEUE_DRAWER_OPEN_STEP = 3;
     const QUEUE_DRAWER_CLOSE_STEP = 6;
 
-    // Opening the queue drawer before step 5 (index 4)
     if (step === QUEUE_DRAWER_OPEN_STEP && !drawerOpenedByTour.current) {
       setTourDrawer(true);
       drawerOpenedByTour.current = true;
-      // Delay step transition to let drawer animate in
       setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
       return;
     }
 
-    // Close the queue drawer when moving to the step after drawer section
     if (step === QUEUE_DRAWER_CLOSE_STEP && drawerOpenedByTour.current) {
       setTourDrawer(false);
       drawerOpenedByTour.current = false;
@@ -215,10 +267,66 @@ const OnboardingTour: React.FC = () => {
       return;
     }
 
-    // Going backwards out of the drawer section - close drawer
     if (step === QUEUE_DRAWER_OPEN_STEP - 1 && drawerOpenedByTour.current) {
       setTourDrawer(false);
       drawerOpenedByTour.current = false;
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    setCurrent(step);
+  }, []);
+
+  // Guided tour step change logic
+  // Steps: 0=swipe actions, 1=queue bar, 2=climb drawer (open play view), 3=session overview (open drawer), 4=done
+  const handleGuidedStepChange = useCallback((step: number) => {
+    const PLAY_VIEW_STEP = 2;
+    const SESH_OVERVIEW_STEP = 3;
+
+    // Opening play view
+    if (step === PLAY_VIEW_STEP && !playViewOpenedByTour.current) {
+      setTourPlayView(true);
+      playViewOpenedByTour.current = true;
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Closing play view, opening session overview
+    if (step === SESH_OVERVIEW_STEP && playViewOpenedByTour.current) {
+      setTourPlayView(false);
+      playViewOpenedByTour.current = false;
+      setTimeout(() => {
+        setTourSeshOverview(true);
+        seshOverviewOpenedByTour.current = true;
+        setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      }, DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Opening session overview directly (if play view wasn't open)
+    if (step === SESH_OVERVIEW_STEP && !seshOverviewOpenedByTour.current) {
+      setTourSeshOverview(true);
+      seshOverviewOpenedByTour.current = true;
+      setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Going back from session overview
+    if (step === SESH_OVERVIEW_STEP - 1 && seshOverviewOpenedByTour.current) {
+      setTourSeshOverview(false);
+      seshOverviewOpenedByTour.current = false;
+      setTimeout(() => {
+        setTourPlayView(true);
+        playViewOpenedByTour.current = true;
+        setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
+      }, DRAWER_ANIMATION_DELAY);
+      return;
+    }
+
+    // Going back from play view
+    if (step === PLAY_VIEW_STEP - 1 && playViewOpenedByTour.current) {
+      setTourPlayView(false);
+      playViewOpenedByTour.current = false;
       setTimeout(() => setCurrent(step), DRAWER_ANIMATION_DELAY);
       return;
     }
@@ -236,7 +344,7 @@ const OnboardingTour: React.FC = () => {
     </>
   );
 
-  const tourSteps: TourStep[] = [
+  const originalTourSteps: TourStep[] = [
     {
       title: 'Select a Climb',
       description: withSkip('Double-tap any climb card to make it the active climb and add it to your queue.'),
@@ -326,7 +434,64 @@ const OnboardingTour: React.FC = () => {
     },
   ];
 
-  if (!isOnboardingTourEnabled || !open) return null;
+  const guidedTourSteps: TourStep[] = [
+    {
+      title: 'Swipe Actions',
+      description: withSkip(
+        'Swipe any climb card left to add it to your queue, or swipe right to favorite it. Try a long swipe right to add it to a playlist.',
+      ),
+      target: getTarget('#onboarding-climb-card'),
+      placement: 'bottom',
+      cover: (
+        <div className={styles.stepIcon}>
+          <SwipeOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Queue Control Bar',
+      description: withSkip(
+        'This bar shows your current climb. Swipe left or right to navigate between queued climbs. Double-tap a climb card above to add it here.',
+      ),
+      target: getTarget('#onboarding-queue-bar'),
+      cover: (
+        <div className={styles.stepIcon}>
+          <ViewWeekOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Climb Detail View',
+      description: withSkip(
+        'Tap the queue bar to open the full climb view. Here you can see the board with lit holds, log ascents, and browse your queue.',
+      ),
+      target: null,
+      mask: false,
+      cover: (
+        <div className={styles.stepIcon}>
+          <PlayCircleOutlineOutlined />
+        </div>
+      ),
+    },
+    {
+      title: 'Session Overview',
+      description: withSkip(
+        'Track your session progress here. See your sends, grade pyramid, and session stats. Tap the Sesh button in the header to open this anytime.',
+      ),
+      target: null,
+      mask: false,
+      cover: (
+        <div className={styles.stepIcon}>
+          <AssessmentOutlined />
+        </div>
+      ),
+    },
+  ];
+
+  const tourSteps = isGuidedMode ? guidedTourSteps : originalTourSteps;
+
+  if (!open) return null;
+  if (!isGuidedMode && !isOnboardingTourEnabled) return null;
 
   return (
     <CustomTour

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -23,7 +23,7 @@ import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { themeTokens } from '@/app/theme/theme-config';
-import { TOUR_DRAWER_EVENT } from '../onboarding/onboarding-tour';
+import { TOUR_DRAWER_EVENT, TOUR_PLAY_VIEW_EVENT } from '../onboarding/onboarding-tour';
 import { ShareBoardButton } from '../board-page/share-button';
 import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMATION_DURATION } from '@/app/hooks/use-card-swipe-navigation';
 import PlayViewDrawer from '../play-view/play-view-drawer';
@@ -78,6 +78,16 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     };
     window.addEventListener(TOUR_DRAWER_EVENT, handler);
     return () => window.removeEventListener(TOUR_DRAWER_EVENT, handler);
+  }, []);
+
+  // Listen for tour events to open/close the play view drawer
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { open } = (e as CustomEvent<{ open: boolean }>).detail;
+      setActiveDrawer(open ? 'play' : 'none');
+    };
+    window.addEventListener(TOUR_PLAY_VIEW_EVENT, handler);
+    return () => window.removeEventListener(TOUR_PLAY_VIEW_EVENT, handler);
   }, []);
 
   // Scroll to current climb when drawer finishes opening

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -23,7 +23,7 @@ import { TickButton } from '../logbook/tick-button';
 import ClimbThumbnail from '../climb-card/climb-thumbnail';
 import ClimbTitle from '../climb-card/climb-title';
 import { themeTokens } from '@/app/theme/theme-config';
-import { TOUR_DRAWER_EVENT, TOUR_PLAY_VIEW_EVENT } from '../onboarding/onboarding-tour';
+import { TOUR_PLAY_VIEW_EVENT } from '../onboarding/onboarding-tour';
 import { ShareBoardButton } from '../board-page/share-button';
 import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMATION_DURATION } from '@/app/hooks/use-card-swipe-navigation';
 import PlayViewDrawer from '../play-view/play-view-drawer';
@@ -68,16 +68,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         clearTimeout(enterFallbackRef.current);
       }
     };
-  }, []);
-
-  // Listen for tour events to open/close the queue drawer
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const { open } = (e as CustomEvent<{ open: boolean }>).detail;
-      setActiveDrawer(open ? 'queue' : 'none');
-    };
-    window.addEventListener(TOUR_DRAWER_EVENT, handler);
-    return () => window.removeEventListener(TOUR_DRAWER_EVENT, handler);
   }, []);
 
   // Listen for tour events to open/close the play view drawer

--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -170,7 +170,7 @@ describe('SeshSettingsDrawer', () => {
 
   it('renders drawer title', () => {
     render(<SeshSettingsDrawer open={true} onClose={vi.fn()} />);
-    expect(screen.getByTestId('swipeable-drawer').getAttribute('data-title')).toBe('Sesh Settings');
+    expect(screen.getByTestId('swipeable-drawer').getAttribute('data-title')).toBe('Session Overview');
   });
 
   it('renders session detail content', () => {

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -27,9 +27,119 @@ import SessionDetailContent from '@/app/session/[sessionId]/session-detail-conte
 interface SeshSettingsDrawerProps {
   open: boolean;
   onClose: () => void;
+  tourMode?: boolean;
 }
 
-export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawerProps) {
+// Mock data for the guided tour - a busy Saturday session with a grade pyramid
+function buildTourMockSession(): SessionDetail {
+  const sessionStart = new Date();
+  sessionStart.setMinutes(sessionStart.getMinutes() - 95);
+
+  // Grade pyramid: V5(6), V6(5), V7(4), V8(3), V9(2), V10(1), V11(1), V12(1) = 23 sends
+  const gradeDistribution = [
+    { grade: 'V5', flash: 2, send: 4, attempt: 6 },
+    { grade: 'V6', flash: 1, send: 4, attempt: 5 },
+    { grade: 'V7', flash: 1, send: 3, attempt: 5 },
+    { grade: 'V8', flash: 1, send: 2, attempt: 4 },
+    { grade: 'V9', flash: 0, send: 2, attempt: 3 },
+    { grade: 'V10', flash: 0, send: 1, attempt: 2 },
+    { grade: 'V11', flash: 0, send: 1, attempt: 2 },
+    { grade: 'V12', flash: 0, send: 1, attempt: 3 },
+  ];
+
+  // Build mock ticks spread across the session
+  const climbNames = [
+    'The Scoop', 'Galaxy Brain', 'Crimpy McFace', 'Sloper City',
+    'Dynomite', 'Pinch Me', 'Compression Test', 'Moonwalk',
+    'Undercling King', 'Toe Hook Special', 'Heel Hook Hero', 'The Roof Rider',
+    'Power Endurance', 'Deadpoint Deluxe', 'The Mantle', 'Campus Master',
+    'Volume Rider', 'Arete Affair', 'Slab Wizard', 'The Overhang',
+    'Gaston Groove', 'Bicycle Crunch', 'Rose Move',
+  ];
+
+  const grades = [
+    'V5', 'V5', 'V5', 'V5', 'V5', 'V5',
+    'V6', 'V6', 'V6', 'V6', 'V6',
+    'V7', 'V7', 'V7', 'V7',
+    'V8', 'V8', 'V8',
+    'V9', 'V9',
+    'V10',
+    'V11',
+    'V12',
+  ];
+
+  const difficultyMap: Record<string, number> = {
+    'V5': 17, 'V6': 18, 'V7': 19, 'V8': 20,
+    'V9': 21, 'V10': 22, 'V11': 23, 'V12': 24,
+  };
+
+  const flashIndices = new Set([0, 2, 6, 11, 15]); // 5 flashes
+  const mirrorIndices = new Set([3, 8, 14, 19]);
+  const benchmarkIndices = new Set([1, 7, 12, 20]);
+  const setters = ['alex_m', 'sarah_k', 'mike_t', 'jenny_l', 'pro_setter'];
+
+  const ticks = grades.map((grade, i) => {
+    const tickTime = new Date(sessionStart);
+    tickTime.setMinutes(tickTime.getMinutes() + Math.floor((i / grades.length) * 95));
+
+    const isFlash = flashIndices.has(i);
+    return {
+      uuid: `tour-tick-${i}`,
+      userId: i % 3 === 0 ? 'tour-user-2' : i % 3 === 1 ? 'tour-user-3' : 'tour-user-1',
+      climbUuid: `tour-climb-${i}`,
+      climbName: climbNames[i],
+      boardType: 'kilter',
+      layoutId: 1,
+      angle: 40,
+      status: isFlash ? 'flash' : 'send',
+      attemptCount: isFlash ? 1 : Math.ceil(Math.random() * 4) + 1,
+      difficulty: difficultyMap[grade],
+      difficultyName: grade,
+      quality: Math.floor(Math.random() * 3) + 1,
+      isMirror: mirrorIndices.has(i),
+      isBenchmark: benchmarkIndices.has(i),
+      comment: null,
+      frames: null,
+      setterUsername: setters[i % setters.length],
+      climbedAt: tickTime.toISOString(),
+      upvotes: 0,
+      totalAttempts: null,
+    };
+  });
+
+  // Reverse so most recent first
+  ticks.reverse();
+
+  return {
+    sessionId: 'tour-mock-session',
+    sessionType: 'party',
+    sessionName: 'Saturday Proj Session',
+    ownerUserId: 'tour-user-1',
+    participants: [
+      { userId: 'tour-user-1', displayName: 'You', avatarUrl: null, sends: 10, flashes: 2, attempts: 18 },
+      { userId: 'tour-user-2', displayName: 'Alex', avatarUrl: null, sends: 8, flashes: 2, attempts: 16 },
+      { userId: 'tour-user-3', displayName: 'Sarah', avatarUrl: null, sends: 5, flashes: 1, attempts: 14 },
+    ],
+    totalSends: 23,
+    totalFlashes: 5,
+    totalAttempts: 48,
+    tickCount: 23,
+    gradeDistribution,
+    boardTypes: ['kilter'],
+    hardestGrade: 'V12',
+    firstTickAt: sessionStart.toISOString(),
+    lastTickAt: new Date().toISOString(),
+    durationMinutes: 95,
+    goal: 'Send a V12',
+    ticks,
+    upvotes: 0,
+    downvotes: 0,
+    voteScore: 0,
+    commentCount: 0,
+  };
+}
+
+export default function SeshSettingsDrawer({ open, onClose, tourMode }: SeshSettingsDrawerProps) {
   const { activeSession, session, users, endSessionWithSummary, liveSessionStats } = usePersistentSession();
   const { boardDetails, angle } = useQueueBridgeBoardInfo();
   const { token: authToken } = useWsAuthToken();
@@ -62,7 +172,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
       const client = createGraphQLHttpClient(authToken);
       return client.request<GetSessionDetailQueryResponse>(GET_SESSION_DETAIL, { sessionId });
     },
-    enabled: open && !!sessionId && !!authToken,
+    enabled: open && !tourMode && !!sessionId && !!authToken,
     staleTime: 5000,
     refetchOnWindowFocus: false,
   });
@@ -86,6 +196,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
   // Build a placeholder SessionDetail from live context when the real
   // sessionDetail hasn't loaded yet (or isn't available at all).
   const fallbackSession = useMemo<SessionDetail | null>(() => {
+    if (tourMode) return null;
     if (!activeSession || !sessionId) return null;
     if (sessionDetail) return null; // not needed when we have real data
 
@@ -125,9 +236,17 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
       voteScore: 0,
       commentCount: 0,
     };
-  }, [activeSession, sessionId, sessionDetail, session?.startedAt, session?.name, session?.goal, users, boardDetails?.board_name]);
+  }, [tourMode, activeSession, sessionId, sessionDetail, session?.startedAt, session?.name, session?.goal, users, boardDetails?.board_name]);
+
+  // Tour mode mock data
+  const tourMockSession = useMemo<SessionDetail | null>(() => {
+    if (!tourMode) return null;
+    return buildTourMockSession();
+  }, [tourMode]);
 
   const sessionForView = useMemo<SessionDetail | null>(() => {
+    if (tourMode) return tourMockSession;
+
     const base = sessionDetail ?? fallbackSession;
     if (!base) return null;
 
@@ -157,13 +276,14 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
       lastTickAt,
       ticks: mergedTicks,
     };
-  }, [sessionDetail, fallbackSession, mergedStats]);
+  }, [tourMode, tourMockSession, sessionDetail, fallbackSession, mergedStats]);
 
-  if (!activeSession) return null;
+  // In tour mode, always render even without an active session
+  if (!tourMode && !activeSession) return null;
 
   return (
     <SwipeableDrawer
-      title="Sesh Settings"
+      title="Session Overview"
       placement="top"
       open={open}
       onClose={onClose}
@@ -172,7 +292,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
         wrapper: { height: '100dvh' },
         body: { padding: 0, paddingBottom: 0 },
       }}
-      footer={(
+      footer={!tourMode ? (
         <Button
           variant="outlined"
           color="error"
@@ -190,16 +310,16 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
         >
           Stop Session
         </Button>
-      )}
+      ) : undefined}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pb: 2 }}>
-        {isLoading && !sessionForView && (
+        {!tourMode && isLoading && !sessionForView && (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress size={28} />
           </Box>
         )}
 
-        {isError && (
+        {!tourMode && isError && (
           <Alert severity="warning" sx={{ mx: 1 }}>
             Couldn&apos;t load full session details. Live stats will continue when available.
           </Alert>
@@ -214,21 +334,25 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
           />
         )}
 
-        <Divider />
+        {!tourMode && (
+          <>
+            <Divider />
 
-        {boardDetails && angle !== undefined && (
-          <Box sx={{ px: 1 }}>
-            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-              Angle
-            </Typography>
-            <AngleSelector
-              boardName={boardDetails.board_name}
-              boardDetails={boardDetails}
-              currentAngle={angle}
-              currentClimb={null}
-              onAngleChange={handleAngleChange}
-            />
-          </Box>
+            {boardDetails && angle !== undefined && (
+              <Box sx={{ px: 1 }}>
+                <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+                  Angle
+                </Typography>
+                <AngleSelector
+                  boardName={boardDetails.board_name}
+                  boardDetails={boardDetails}
+                  currentAngle={angle}
+                  currentClimb={null}
+                  onAngleChange={handleAngleChange}
+                />
+              </Box>
+            )}
+          </>
         )}
       </Box>
     </SwipeableDrawer>

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -7,11 +7,14 @@ import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActionArea from '@mui/material/CardActionArea';
+import Backdrop from '@mui/material/Backdrop';
+import Paper from '@mui/material/Paper';
 import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
+import ExploreOutlined from '@mui/icons-material/ExploreOutlined';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -19,6 +22,7 @@ import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import BoardScrollSection from '@/app/components/board-scroll/board-scroll-section';
 import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
+import { setGuidedTourPending } from '@/app/lib/onboarding-db';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
@@ -93,10 +97,21 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
   const router = useRouter();
   const [seshDrawerOpen, setSeshDrawerOpen] = useState(false);
   const [findClimbersOpen, setFindClimbersOpen] = useState(false);
+  const [tourIntroOpen, setTourIntroOpen] = useState(false);
 
   const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
 
   const { boards: discoverBoards, isLoading: isBoardsLoading } = useDiscoverBoards({ limit: 20 });
+
+  const handleTakeTour = useCallback(() => {
+    setTourIntroOpen(true);
+  }, []);
+
+  const handleTourIntroGotIt = useCallback(async () => {
+    setTourIntroOpen(false);
+    await setGuidedTourPending();
+    setSeshDrawerOpen(true);
+  }, []);
 
   const handleBoardClick = useCallback((board: UserBoard) => {
     if (board.slug) {
@@ -192,6 +207,13 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
           </Typography>
 
           <OnboardingCard
+            icon={<ExploreOutlined />}
+            title="Take the tour"
+            description="Learn how to use Boardsesh step by step"
+            onClick={handleTakeTour}
+          />
+
+          <OnboardingCard
             icon={<WarningAmberOutlined />}
             title="Old Kilter app users"
             description="Migrate your data to Boardsesh before it's lost"
@@ -249,6 +271,45 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
         onClose={() => setFindClimbersOpen(false)}
         defaultCategory="users"
       />
+
+      {/* Tour intro overlay */}
+      {tourIntroOpen && (
+        <>
+          <Backdrop
+            open
+            sx={{ zIndex: 1100, backgroundColor: 'rgba(0,0,0,0.5)' }}
+            onClick={() => setTourIntroOpen(false)}
+          />
+          <Paper
+            sx={{
+              position: 'fixed',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              zIndex: 1101,
+              p: 3,
+              maxWidth: 320,
+              borderRadius: 2,
+              textAlign: 'center',
+            }}
+          >
+            <ExploreOutlined sx={{ fontSize: 40, color: themeTokens.colors.primary, mb: 1 }} />
+            <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+              Welcome to the tour!
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
+              Let&apos;s walk through how Boardsesh works. First, create your climbing session by selecting a board and tapping Sesh.
+            </Typography>
+            <Button
+              variant="contained"
+              onClick={handleTourIntroGotIt}
+              sx={{ textTransform: 'none', borderRadius: `${themeTokens.borderRadius.full}px` }}
+            >
+              Let&apos;s go!
+            </Button>
+          </Paper>
+        </>
+      )}
     </Box>
   );
 }

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -22,7 +22,7 @@ import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import BoardScrollSection from '@/app/components/board-scroll/board-scroll-section';
 import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
-import { setGuidedTourPending } from '@/app/lib/onboarding-db';
+import { setGuidedTourPending, clearGuidedTourPending } from '@/app/lib/onboarding-db';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
@@ -98,6 +98,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
   const [seshDrawerOpen, setSeshDrawerOpen] = useState(false);
   const [findClimbersOpen, setFindClimbersOpen] = useState(false);
   const [tourIntroOpen, setTourIntroOpen] = useState(false);
+  const tourTriggeredSeshDrawer = useRef(false);
 
   const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
 
@@ -110,6 +111,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
   const handleTourIntroGotIt = useCallback(async () => {
     setTourIntroOpen(false);
     await setGuidedTourPending();
+    tourTriggeredSeshDrawer.current = true;
     setSeshDrawerOpen(true);
   }, []);
 
@@ -262,7 +264,15 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
 
       <StartSeshDrawer
         open={seshDrawerOpen}
-        onClose={() => setSeshDrawerOpen(false)}
+        onClose={() => {
+          setSeshDrawerOpen(false);
+          // If the tour triggered this drawer and user closed without creating a session,
+          // clear the pending flag so the tour doesn't unexpectedly start on a board page
+          if (tourTriggeredSeshDrawer.current) {
+            tourTriggeredSeshDrawer.current = false;
+            clearGuidedTourPending();
+          }
+        }}
         boardConfigs={boardConfigs}
       />
 

--- a/packages/web/app/lib/onboarding-db.ts
+++ b/packages/web/app/lib/onboarding-db.ts
@@ -57,15 +57,30 @@ export const setGuidedTourPending = async (): Promise<void> => {
   }
 };
 
+// Pending flag expires after 5 minutes to avoid stale triggers
+const GUIDED_TOUR_EXPIRY_MS = 5 * 60 * 1000;
+
 /**
  * Check if the guided tour is pending (called on board page mount).
+ * Returns false if the flag is older than 5 minutes.
  */
 export const isGuidedTourPending = async (): Promise<boolean> => {
   try {
     const db = await getDB();
     if (!db) return false;
     const data = await db.get(STORE_NAME, GUIDED_TOUR_KEY);
-    return !!data?.pending;
+    if (!data?.pending) return false;
+
+    // Check expiry
+    if (data.setAt) {
+      const elapsed = Date.now() - new Date(data.setAt as string).getTime();
+      if (elapsed > GUIDED_TOUR_EXPIRY_MS) {
+        await db.delete(STORE_NAME, GUIDED_TOUR_KEY);
+        return false;
+      }
+    }
+
+    return true;
   } catch {
     return false;
   }

--- a/packages/web/app/lib/onboarding-db.ts
+++ b/packages/web/app/lib/onboarding-db.ts
@@ -23,21 +23,6 @@ const getStorageKey = (userId?: string | number | null): string => {
 };
 
 /**
- * Get the onboarding status from IndexedDB
- */
-export const getOnboardingStatus = async (userId?: string | number | null): Promise<OnboardingStatus | null> => {
-  try {
-    const db = await getDB();
-    if (!db) return null;
-    const key = getStorageKey(userId);
-    return await db.get(STORE_NAME, key);
-  } catch (error) {
-    console.error('Failed to get onboarding status:', error);
-    return null;
-  }
-};
-
-/**
  * Save the onboarding status to IndexedDB
  */
 export const saveOnboardingStatus = async (userId?: string | number | null): Promise<void> => {
@@ -52,20 +37,6 @@ export const saveOnboardingStatus = async (userId?: string | number | null): Pro
     await db.put(STORE_NAME, status, key);
   } catch (error) {
     console.error('Failed to save onboarding status:', error);
-  }
-};
-
-/**
- * Check if onboarding should be shown.
- * Returns true if onboarding hasn't been completed or a newer version is available.
- */
-export const shouldShowOnboarding = async (userId?: string | number | null): Promise<boolean> => {
-  try {
-    const status = await getOnboardingStatus(userId);
-    if (!status) return true;
-    return status.completedVersion < ONBOARDING_VERSION;
-  } catch {
-    return true;
   }
 };
 

--- a/packages/web/app/lib/onboarding-db.ts
+++ b/packages/web/app/lib/onboarding-db.ts
@@ -68,3 +68,47 @@ export const shouldShowOnboarding = async (userId?: string | number | null): Pro
     return true;
   }
 };
+
+// --- Guided Tour (cross-page "Take the tour" flow) ---
+
+const GUIDED_TOUR_KEY = 'guided-tour-pending';
+
+/**
+ * Mark the guided tour as pending (set before navigating away from home page).
+ */
+export const setGuidedTourPending = async (): Promise<void> => {
+  try {
+    const db = await getDB();
+    if (!db) return;
+    await db.put(STORE_NAME, { pending: true, setAt: new Date().toISOString() }, GUIDED_TOUR_KEY);
+  } catch (error) {
+    console.error('Failed to set guided tour pending:', error);
+  }
+};
+
+/**
+ * Check if the guided tour is pending (called on board page mount).
+ */
+export const isGuidedTourPending = async (): Promise<boolean> => {
+  try {
+    const db = await getDB();
+    if (!db) return false;
+    const data = await db.get(STORE_NAME, GUIDED_TOUR_KEY);
+    return !!data?.pending;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Clear the guided tour pending flag (called when tour starts on board page).
+ */
+export const clearGuidedTourPending = async (): Promise<void> => {
+  try {
+    const db = await getDB();
+    if (!db) return;
+    await db.delete(STORE_NAME, GUIDED_TOUR_KEY);
+  } catch (error) {
+    console.error('Failed to clear guided tour pending:', error);
+  }
+};


### PR DESCRIPTION
- Add "Take the tour" card under "Get started" on home page with intro overlay
- Tour flow: intro → StartSeshDrawer → board page guided tour (swipe actions,
  queue bar, climb drawer, session overview with mock data)
- Guided tour state persists across page navigation via IndexedDB
- Rename "Sesh Settings" drawer to "Session Overview" permanently
- Mock session data shows busy V5-V12 grade pyramid with 23 sends, 3 participants
- Add TOUR_PLAY_VIEW_EVENT and TOUR_SESH_OVERVIEW_EVENT for drawer control
- Export CustomTour and TourStep for reuse

https://claude.ai/code/session_016UF7nZYT5MSD2cYY6n2jZD