### PR TITLE
Fix friends climbing section hidden behind queue control bar

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -105,7 +105,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
   }, [router]);
 
   return (
-    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: '60px' }}>
+    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: 'calc(120px + env(safe-area-inset-bottom, 0px))' }}>
       <Box
         component="main"
         sx={{


### PR DESCRIPTION
The homepage bottom padding was only 60px, which doesn't account for the queue control bar height when active. Increased to 120px + safe area inset to match the board route layouts.

https://claude.ai/code/session_01CsdeABcHYPunuB66ccxgtq