### PR TITLE
Fix queue bar disappearing when using "Continue climbing" button

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -150,13 +150,16 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR }: Ho
             startIcon={<PlayArrowRounded />}
             onClick={() => {
               if (activeSession) {
+                let url: string;
                 if (activeSession.boardPath.startsWith('/b/')) {
                   const segments = activeSession.boardPath.split('/');
-                  router.push(constructBoardSlugListUrl(segments[2], activeSession.parsedParams.angle));
+                  url = constructBoardSlugListUrl(segments[2], activeSession.parsedParams.angle);
                 } else {
                   // Legacy/custom path — navigate directly
-                  router.push(activeSession.boardPath);
+                  url = activeSession.boardPath;
                 }
+                const separator = url.includes('?') ? '&' : '?';
+                router.push(`${url}${separator}session=${activeSession.sessionId}`);
               } else {
                 setSeshDrawerOpen(true);
               }


### PR DESCRIPTION
The home page "Continue climbing" button navigated to the board page
without the ?session= query parameter, causing the session bridge to
not detect the active session and the queue bar to disappear. Now
appends the session ID to the URL, matching the bottom tab bar behavior.

https://claude.ai/code/session_014Mo7uQqUFbHMJBreHz3nzD