### PR TITLE
feat: add grade display format setting (V-Grade vs Font)

### DIFF
--- a/packages/web/app/components/activity-feed/__tests__/session-feed-card.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/session-feed-card.test.tsx
@@ -53,7 +53,16 @@ vi.mock('@/app/theme/theme-config', () => ({
 vi.mock('@/app/lib/grade-colors', () => ({
   getGradeColor: () => '#F44336',
   getGradeTextColor: () => '#FFFFFF',
-  formatVGrade: (g: string | null | undefined) => g ?? null,
+}));
+
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (g: string | null | undefined) => g ?? null,
+    getGradeColor: vi.fn(),
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 import SessionFeedCard from '../session-feed-card';

--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -21,7 +21,8 @@ import OutcomeDoughnut from '@/app/components/charts/outcome-doughnut';
 import VoteButton from '@/app/components/social/vote-button';
 import FeedCommentButton from '@/app/components/social/feed-comment-button';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeColor, getGradeTextColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor, getGradeTextColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionFeedCardProps {
   session: SessionFeedItem;
@@ -63,6 +64,8 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export default function SessionFeedCard({ session }: SessionFeedCardProps) {
+  const { formatGrade } = useGradeFormat();
+
   const {
     sessionId,
     sessionName,
@@ -224,7 +227,7 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
             )}
             {hardestGrade && (
               <Chip
-                label={formatVGrade(hardestGrade) ?? hardestGrade}
+                label={formatGrade(hardestGrade) ?? hardestGrade}
                 size="small"
                 sx={{
                   borderRadius: themeTokens.borderRadius.full,

--- a/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
@@ -14,7 +14,8 @@ import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import GroupsOutlined from '@mui/icons-material/GroupsOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { ActivityFeedItem } from '@boardsesh/shared-schema';
-import { getGradeColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryMetadata {
   totalSends?: number;
@@ -30,6 +31,8 @@ interface SessionSummaryFeedItemProps {
 }
 
 export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemProps) {
+  const { formatGrade } = useGradeFormat();
+
   let metadata: SessionSummaryMetadata = {};
   try {
     if (typeof item.metadata === 'string') {
@@ -97,7 +100,7 @@ export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemP
             {gradeDistribution.slice(0, 6).map((g) => (
               <Box key={g.grade} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                 <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24 }}>
-                  {formatVGrade(g.grade) ?? g.grade}
+                  {formatGrade(g.grade) ?? g.grade}
                 </Typography>
                 <LinearProgress
                   variant="determinate"

--- a/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
+++ b/packages/web/app/components/charts/__tests__/grade-distribution-bar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -11,45 +11,28 @@ vi.mock('react-chartjs-2', () => ({
 
 vi.mock('../chart-registry', () => ({}));
 
-import GradeDistributionBar, { formatGradeLabels } from '../grade-distribution-bar';
+// Mock the useGradeFormat hook
+const mockFormatGrade = vi.fn((grade: string | null | undefined) => {
+  if (!grade) return null;
+  // Extract V-grade by default (mimicking v-grade format)
+  const vGradeMatch = grade.match(/V\d+/i);
+  return vGradeMatch ? vGradeMatch[0].toUpperCase() : grade;
+});
 
-describe('formatGradeLabels', () => {
-  it('extracts V-grade from combined Font/V-grade strings', () => {
-    expect(formatGradeLabels(['6a/V3', '6b/V4'])).toEqual(['V3', 'V4']);
-  });
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: mockFormatGrade,
+    getGradeColor: vi.fn(),
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
+}));
 
-  it('passes through bare V-grade strings', () => {
-    expect(formatGradeLabels(['V3', 'V5'])).toEqual(['V3', 'V5']);
-  });
+import GradeDistributionBar from '../grade-distribution-bar';
 
-  it('adds "+" when Font grade has "+" suffix (e.g., 6c+ → V5+)', () => {
-    expect(formatGradeLabels(['6c/V5', '6c+/V5'])).toEqual(['V5', 'V5+']);
-  });
-
-  it('handles mix of single and dual Font grades per V-grade', () => {
-    expect(formatGradeLabels(['5c/V2', '6a/V3', '6a+/V3', '6b/V4'])).toEqual([
-      'V2', 'V3', 'V3+', 'V4',
-    ]);
-  });
-
-  it('falls back to original string when no V-grade is found', () => {
-    expect(formatGradeLabels(['6A', '7A+'])).toEqual(['6A', '7A+']);
-  });
-
-  it('only adds "+" when V-grade has multiple Font grades', () => {
-    // 7a+/V7: V7 has only one Font grade (7a+), so no "+" needed
-    expect(formatGradeLabels(['7a/V6', '7a+/V7'])).toEqual(['V6', 'V7']);
-    // 6b+/V4: V4 has two Font grades (6b, 6b+), so "+" is added
-    expect(formatGradeLabels(['6b/V4', '6b+/V4'])).toEqual(['V4', 'V4+']);
-  });
-
-  it('handles empty array', () => {
-    expect(formatGradeLabels([])).toEqual([]);
-  });
-
-  it('handles numeric-only grades that lack V prefix', () => {
-    expect(formatGradeLabels(['0', '1', '2'])).toEqual(['0', '1', '2']);
-  });
+beforeEach(() => {
+  mockFormatGrade.mockClear();
 });
 
 describe('GradeDistributionBar', () => {
@@ -96,7 +79,7 @@ describe('GradeDistributionBar', () => {
     expect(data.datasets).toHaveLength(2); // Flash, Send only
   });
 
-  it('renders V-grade labels on x-axis from combined Font/V-grade strings', () => {
+  it('renders grade labels on x-axis using formatGrade hook', () => {
     const gradeDistribution = [
       { grade: '6a+/V3', flash: 1, send: 1, attempt: 0 },
       { grade: '6a/V3', flash: 2, send: 3, attempt: 1 },
@@ -105,11 +88,15 @@ describe('GradeDistributionBar', () => {
     render(<GradeDistributionBar gradeDistribution={gradeDistribution} />);
     const chartEl = screen.getByTestId('chart-bar');
     const data = JSON.parse(chartEl.getAttribute('data-data') || '{}');
-    // Data is reversed (hardest-first → easiest-first), so 6a/V3 comes before 6a+/V3
-    expect(data.labels).toEqual(['V3', 'V3+']);
+    // Data is reversed (hardest-first → easiest-first)
+    // Mock returns V-grade extracted from the string
+    expect(data.labels).toEqual(['V3', 'V3']);
+    // Verify formatGrade was called for each grade
+    expect(mockFormatGrade).toHaveBeenCalledWith('6a/V3');
+    expect(mockFormatGrade).toHaveBeenCalledWith('6a+/V3');
   });
 
-  it('does not add "+" when V-grade has only one Font grade mapping', () => {
+  it('uses formatGrade hook for grade formatting', () => {
     const gradeDistribution = [
       { grade: '7a+/V7', flash: 0, send: 1, attempt: 0 },
       { grade: '7a/V6', flash: 1, send: 0, attempt: 0 },
@@ -118,7 +105,6 @@ describe('GradeDistributionBar', () => {
     render(<GradeDistributionBar gradeDistribution={gradeDistribution} />);
     const chartEl = screen.getByTestId('chart-bar');
     const data = JSON.parse(chartEl.getAttribute('data-data') || '{}');
-    // V7 has only one Font grade (7a+), so no "+" is added
     expect(data.labels).toEqual(['V6', 'V7']);
   });
 });

--- a/packages/web/app/components/charts/grade-distribution-bar.tsx
+++ b/packages/web/app/components/charts/grade-distribution-bar.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Bar } from 'react-chartjs-2';
 import './chart-registry'; // Ensure Chart.js components are registered
-import { formatVGrade } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 export interface GradeDistributionItem {
   grade: string;
@@ -24,15 +24,6 @@ interface GradeDistributionBarProps {
   stacked?: boolean;
 }
 
-/**
- * Format grade strings to V-grade labels for chart display.
- * Uses formatVGrade which appends "+" when the Font grade has a "+"
- * (e.g., "6c+/V5" → "V5+").
- */
-export function formatGradeLabels(grades: string[]): string[] {
-  return grades.map((g) => formatVGrade(g) ?? g);
-}
-
 // Match profile page "Ascents by Difficulty" colors
 const FLASH_COLOR = 'rgba(75,192,192,0.5)';
 const SEND_COLOR = 'rgba(192,75,75,0.5)';
@@ -45,12 +36,14 @@ export default function GradeDistributionBar({
   showAttempts = true,
   stacked = true,
 }: GradeDistributionBarProps) {
+  const { formatGrade } = useGradeFormat();
+
   if (gradeDistribution.length === 0) return null;
 
   // Data comes sorted hardest-first from backend; reverse to show lowest→highest on x-axis
   const sorted = [...gradeDistribution].reverse();
 
-  const labels = formatGradeLabels(sorted.map((g) => g.grade));
+  const labels = sorted.map((g) => formatGrade(g.grade) ?? g.grade);
 
   // In compact mode, use near-full width bars for a dense chart
   const barPct = compact ? 0.95 : 0.8;

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -8,13 +8,22 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-vi.mock('@/app/lib/grade-colors', () => ({
-  getSoftVGradeColor: (vGrade: string) => `#color-${vGrade}`,
-  formatVGrade: (d: string | null | undefined) => {
-    if (!d) return null;
-    const match = d.match(/V\d+\+?/i);
-    return match ? match[0].toUpperCase() : null;
-  },
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (d: string | null | undefined) => {
+      if (!d) return null;
+      const match = d.match(/V\d+\+?/i);
+      return match ? match[0].toUpperCase() : null;
+    },
+    getGradeColor: (d: string | null | undefined) => {
+      if (!d) return undefined;
+      const match = d.match(/V\d+\+?/i);
+      return match ? `#color-${match[0].toUpperCase()}` : undefined;
+    },
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -5,8 +5,8 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import CopyrightOutlined from '@mui/icons-material/CopyrightOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getSoftVGradeColor, formatVGrade } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 export type ClimbTitleData = {
   name?: string;
@@ -62,6 +62,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   gradePosition = 'inline',
 }) => {
   const isDark = useIsDarkMode();
+  const { formatGrade, getGradeColor } = useGradeFormat();
 
   if (!climb) {
     return (
@@ -88,7 +89,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
   const benchmarkValue = climb.benchmark_difficulty != null ? Number(climb.benchmark_difficulty) : null;
   const isBenchmark = benchmarkValue !== null && benchmarkValue > 0 && !Number.isNaN(benchmarkValue);
 
-  const vGrade = formatVGrade(displayDifficulty);
+  const formattedGrade = formatGrade(displayDifficulty);
 
   const textOverflowStyles = ellipsis
     ? {
@@ -147,9 +148,9 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     </Typography>
   );
 
-  const gradeColor = vGrade ? getSoftVGradeColor(vGrade, isDark) : undefined;
+  const gradeColor = formattedGrade ? getGradeColor(displayDifficulty, isDark) : undefined;
 
-  const largeGradeElement = vGrade && (
+  const largeGradeElement = formattedGrade && (
     <Typography
       variant="body2"
       component="span"
@@ -160,7 +161,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         color: gradeColor ?? 'text.secondary',
       }}
     >
-      {vGrade}
+      {formattedGrade}
     </Typography>
   );
 
@@ -219,7 +220,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: `${themeTokens.spacing[2]}px`, flexShrink: 0 }}>
           {rightAddon}
           {largeGradeElement}
-          {!vGrade && displayDifficulty && (
+          {!formattedGrade && displayDifficulty && (
             <Typography
               variant="body2"
               component="span"

--- a/packages/web/app/components/session-details/__tests__/session-overview-panel.test.tsx
+++ b/packages/web/app/components/session-details/__tests__/session-overview-panel.test.tsx
@@ -7,8 +7,14 @@ vi.mock('@/app/components/charts/grade-distribution-bar', () => ({
   default: () => <div data-testid="grade-distribution-bar" />,
 }));
 
-vi.mock('@/app/lib/grade-colors', () => ({
-  formatVGrade: (g: string | null | undefined) => g ?? null,
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (g: string | null | undefined) => g ?? null,
+    getGradeColor: vi.fn(),
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 import SessionOverviewPanel from '../session-overview-panel';

--- a/packages/web/app/components/session-details/session-overview-panel.tsx
+++ b/packages/web/app/components/session-details/session-overview-panel.tsx
@@ -21,7 +21,7 @@ import RemoveCircleOutlineOutlined from '@mui/icons-material/RemoveCircleOutline
 import type { SessionFeedParticipant, SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 import { deduplicateBy } from '@/app/utils/deduplicate';
 import GradeDistributionBar from '@/app/components/charts/grade-distribution-bar';
-import { formatVGrade } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionOverviewPanelProps {
   participants: SessionFeedParticipant[];
@@ -88,6 +88,8 @@ export default function SessionOverviewPanel({
   removingUserId = null,
   getParticipantHref,
 }: SessionOverviewPanelProps) {
+  const { formatGrade } = useGradeFormat();
+
   // Defensive dedup: during WebSocket reconnection race conditions the server
   // may briefly report the same participant twice. Deduplicating by userId
   // keeps the UI stable until the next authoritative state sync arrives.
@@ -214,7 +216,7 @@ export default function SessionOverviewPanel({
         )}
         <Chip label={`${tickCount} climb${tickCount !== 1 ? 's' : ''}`} variant="outlined" />
         {hardestGrade && (
-          <Chip label={`Hardest: ${formatVGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
+          <Chip label={`Hardest: ${formatGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
         )}
       </Box>
 

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -18,13 +18,15 @@ import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { SessionSummary } from '@boardsesh/shared-schema';
-import { getGradeColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryViewProps {
   summary: SessionSummary;
 }
 
 export default function SessionSummaryView({ summary }: SessionSummaryViewProps) {
+  const { formatGrade } = useGradeFormat();
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((g) => g.count), 1);
 
   const formatDuration = (minutes: number | null | undefined) => {
@@ -106,7 +108,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                 {summary.hardestClimb.climbName}
               </Typography>
               <Chip
-                label={formatVGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
+                label={formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
                 size="small"
                 sx={{
                   bgcolor: getGradeColor(summary.hardestClimb.grade),
@@ -133,7 +135,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                     variant="body2"
                     sx={{ minWidth: 40, fontWeight: 600, textAlign: 'right' }}
                   >
-                    {formatVGrade(g.grade) ?? g.grade}
+                    {formatGrade(g.grade) ?? g.grade}
                   </Typography>
                   <LinearProgress
                     variant="determinate"

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -12,6 +12,7 @@ import {
   type GetUserProfileStatsQueryResponse,
 } from '@/app/lib/graphql/operations';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import {
   type UserProfile,
   type LogbookEntry,
@@ -29,6 +30,7 @@ import {
 export function useProfileData(userId: string) {
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
+  const { gradeFormat } = useGradeFormat();
 
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
@@ -158,18 +160,18 @@ export function useProfileData(userId: string) {
   );
 
   const chartDataAggregated = useMemo(
-    () => buildAggregatedChartData(allBoardsTicks, aggregatedTimeframe),
-    [allBoardsTicks, aggregatedTimeframe],
+    () => buildAggregatedChartData(allBoardsTicks, aggregatedTimeframe, gradeFormat),
+    [allBoardsTicks, aggregatedTimeframe, gradeFormat],
   );
 
   const boardChartData = useMemo(
-    () => buildBoardChartData(filteredLogbook),
-    [filteredLogbook],
+    () => buildBoardChartData(filteredLogbook, gradeFormat),
+    [filteredLogbook, gradeFormat],
   );
 
   const statisticsSummary = useMemo(
-    () => buildStatisticsSummary(profileStats),
-    [profileStats],
+    () => buildStatisticsSummary(profileStats, gradeFormat),
+    [profileStats, gradeFormat],
   );
 
   return {

--- a/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
@@ -4,11 +4,13 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import type { ChartData } from '../profile-stats-charts';
 import type { GetUserProfileStatsQueryResponse } from '@/app/lib/graphql/operations';
+import { type GradeDisplayFormat } from '@/app/lib/grade-colors';
 import {
   type LogbookEntry,
   type TimeframeType,
   type AggregatedTimeframeType,
-  difficultyMapping,
+  getDifficultyMapping,
+  sortGrades,
   angleColors,
   getGradeChartColor,
   getLayoutKey,
@@ -49,8 +51,10 @@ export function filterLogbookByTimeframe(
 export function buildAggregatedChartData(
   allBoardsTicks: Record<string, LogbookEntry[]>,
   aggregatedTimeframe: AggregatedTimeframeType,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): ChartData | null {
   const now = dayjs();
+  const difficultyMapping = getDifficultyMapping(gradeFormat);
 
   const filterByTimeframe = (entry: LogbookEntry) => {
     const climbedAt = dayjs(entry.climbed_at);
@@ -99,7 +103,7 @@ export function buildAggregatedChartData(
     return null;
   }
 
-  const sortedGrades = Object.values(difficultyMapping).filter((g) => allGrades.has(g));
+  const sortedGrades = sortGrades(Array.from(allGrades), gradeFormat);
 
   const layoutOrder = [
     'kilter-1', 'kilter-8', 'tension-9', 'tension-10', 'tension-11',
@@ -127,7 +131,10 @@ export function buildAggregatedChartData(
   return { labels: sortedGrades, datasets };
 }
 
-export function buildBoardChartData(filteredLogbook: LogbookEntry[]): {
+export function buildBoardChartData(
+  filteredLogbook: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): {
   chartDataBar: ChartData | null;
   chartDataPie: ChartData | null;
   chartDataWeeklyBar: ChartData | null;
@@ -135,6 +142,8 @@ export function buildBoardChartData(filteredLogbook: LogbookEntry[]): {
   if (filteredLogbook.length === 0) {
     return { chartDataBar: null, chartDataPie: null, chartDataWeeklyBar: null };
   }
+
+  const difficultyMapping = getDifficultyMapping(gradeFormat);
 
   // Bar chart - Flash vs Redpoint
   const greaterThanOne: Record<string, number> = {};
@@ -150,7 +159,7 @@ export function buildBoardChartData(filteredLogbook: LogbookEntry[]): {
       }
     }
   });
-  const barLabels = Object.keys({ ...greaterThanOne, ...equalToOne }).sort();
+  const barLabels = sortGrades(Object.keys({ ...greaterThanOne, ...equalToOne }), gradeFormat);
   const chartDataBar: ChartData = {
     labels: barLabels,
     datasets: [
@@ -199,13 +208,18 @@ export function buildBoardChartData(filteredLogbook: LogbookEntry[]): {
       weeklyData[week] = { ...(weeklyData[week] || {}), [difficulty]: (weeklyData[week]?.[difficulty] || 0) + 1 };
     }
   });
-  const datasets = Object.values(difficultyMapping)
-    .map((difficulty) => ({
-      label: difficulty,
-      data: weeks.map((week) => weeklyData[week]?.[difficulty] || 0),
-      backgroundColor: getGradeChartColor(difficulty),
-    }))
-    .filter((dataset) => dataset.data.some((value) => value > 0));
+  // Get unique grades that appear in the data, sorted properly
+  const usedGrades = new Set<string>();
+  Object.values(weeklyData).forEach((weekGrades) => {
+    Object.keys(weekGrades).forEach((grade) => usedGrades.add(grade));
+  });
+  const sortedUsedGrades = sortGrades(Array.from(usedGrades), gradeFormat);
+
+  const datasets = sortedUsedGrades.map((difficulty) => ({
+    label: difficulty,
+    data: weeks.map((week) => weeklyData[week]?.[difficulty] || 0),
+    backgroundColor: getGradeChartColor(difficulty),
+  }));
   const chartDataWeeklyBar: ChartData = { labels: weeks, datasets };
 
   return { chartDataBar, chartDataPie, chartDataWeeklyBar };
@@ -224,11 +238,13 @@ export interface LayoutPercentage {
 
 export function buildStatisticsSummary(
   profileStats: GetUserProfileStatsQueryResponse['userProfileStats'] | null,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): { totalAscents: number; layoutPercentages: LayoutPercentage[] } {
   if (!profileStats) {
     return { totalAscents: 0, layoutPercentages: [] };
   }
 
+  const difficultyMapping = getDifficultyMapping(gradeFormat);
   const totalAscents = profileStats.totalDistinctClimbs;
 
   const layoutsWithExactPercentages = profileStats.layoutStats

--- a/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
+++ b/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
@@ -1,4 +1,9 @@
-import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import {
+  FONT_GRADE_COLORS,
+  V_GRADE_COLORS,
+  getGradeColorWithOpacity,
+  type GradeDisplayFormat,
+} from '@/app/lib/grade-colors';
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 
 export interface UserProfile {
@@ -36,31 +41,94 @@ export type AggregatedTimeframeType = 'today' | 'lastWeek' | 'lastMonth' | 'last
 
 export const BOARD_TYPES = SUPPORTED_BOARDS;
 
-export const difficultyMapping: Record<number, string> = {
-  10: '4a',
-  11: '4b',
-  12: '4c',
-  13: '5a',
-  14: '5b',
-  15: '5c',
-  16: '6a',
-  17: '6a+',
-  18: '6b',
-  19: '6b+',
-  20: '6c',
-  21: '6c+',
-  22: '7a',
-  23: '7a+',
-  24: '7b',
-  25: '7b+',
-  26: '7c',
-  27: '7c+',
-  28: '8a',
-  29: '8a+',
-  30: '8b',
-  31: '8b+',
-  32: '8c',
-  33: '8c+',
+// Font grade mapping (uppercase for display)
+const fontGradeMapping: Record<number, string> = {
+  10: '4A',
+  11: '4B',
+  12: '4C',
+  13: '5A',
+  14: '5B',
+  15: '5C',
+  16: '6A',
+  17: '6A+',
+  18: '6B',
+  19: '6B+',
+  20: '6C',
+  21: '6C+',
+  22: '7A',
+  23: '7A+',
+  24: '7B',
+  25: '7B+',
+  26: '7C',
+  27: '7C+',
+  28: '8A',
+  29: '8A+',
+  30: '8B',
+  31: '8B+',
+  32: '8C',
+  33: '8C+',
+};
+
+// V-grade mapping
+const vGradeMapping: Record<number, string> = {
+  10: 'V0',
+  11: 'V0',
+  12: 'V0',
+  13: 'V1',
+  14: 'V1',
+  15: 'V2',
+  16: 'V3',
+  17: 'V3+',
+  18: 'V4',
+  19: 'V4+',
+  20: 'V5',
+  21: 'V5+',
+  22: 'V6',
+  23: 'V7',
+  24: 'V8',
+  25: 'V8+',
+  26: 'V9',
+  27: 'V10',
+  28: 'V11',
+  29: 'V12',
+  30: 'V13',
+  31: 'V14',
+  32: 'V15',
+  33: 'V16',
+};
+
+// Default mapping (for backwards compatibility - uses Font grades)
+export const difficultyMapping: Record<number, string> = fontGradeMapping;
+
+// Get difficulty mapping based on format preference
+export const getDifficultyMapping = (format: GradeDisplayFormat): Record<number, string> => {
+  return format === 'v-grade' ? vGradeMapping : fontGradeMapping;
+};
+
+// Build reverse mapping from grade string to numeric difficulty for sorting
+const buildGradeOrder = (mapping: Record<number, string>): Map<string, number> => {
+  const order = new Map<string, number>();
+  for (const [numStr, grade] of Object.entries(mapping)) {
+    const num = parseInt(numStr, 10);
+    // For grades that map to the same string (e.g., V0 from 10, 11, 12), keep the lowest number
+    if (!order.has(grade) || num < (order.get(grade) ?? Infinity)) {
+      order.set(grade, num);
+    }
+  }
+  return order;
+};
+
+const fontGradeOrder = buildGradeOrder(fontGradeMapping);
+const vGradeOrder = buildGradeOrder(vGradeMapping);
+
+// Sort grades by their numeric difficulty value
+export const sortGrades = (grades: string[], format: GradeDisplayFormat): string[] => {
+  const gradeOrder = format === 'v-grade' ? vGradeOrder : fontGradeOrder;
+  return [...grades].sort((a, b) => {
+    const orderA = gradeOrder.get(a) ?? 999;
+    const orderB = gradeOrder.get(b) ?? 999;
+    return orderA - orderB;
+  });
 };
 
 export const angleColors = [
@@ -125,6 +193,12 @@ export const getLayoutColor = (boardType: string, layoutId: number | null | unde
 };
 
 export const getGradeChartColor = (grade: string): string => {
+  // Check V-grade first (e.g., "V3", "V5+")
+  const normalizedVGrade = grade.toUpperCase().replace(/\+$/, '');
+  if (V_GRADE_COLORS[normalizedVGrade]) {
+    return getGradeColorWithOpacity(V_GRADE_COLORS[normalizedVGrade], 0.8);
+  }
+  // Then check Font grade (e.g., "6A", "7C+")
   const hexColor = FONT_GRADE_COLORS[grade.toLowerCase()];
   return hexColor ? getGradeColorWithOpacity(hexColor, 0.8) : 'rgba(200, 200, 200, 0.7)';
 };

--- a/packages/web/app/hooks/use-grade-format.ts
+++ b/packages/web/app/hooks/use-grade-format.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  getGradeDisplayFormat,
+  setGradeDisplayFormat,
+  type GradeDisplayFormat,
+} from '@/app/lib/user-preferences-db';
+import { formatGrade, getSoftGradeColorByFormat } from '@/app/lib/grade-colors';
+
+export function useGradeFormat() {
+  const [gradeFormat, setGradeFormatState] = useState<GradeDisplayFormat>('v-grade');
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    getGradeDisplayFormat().then((value) => {
+      setGradeFormatState(value);
+      setLoaded(true);
+    });
+  }, []);
+
+  const setGradeFormat = useCallback(async (format: GradeDisplayFormat) => {
+    await setGradeDisplayFormat(format);
+    setGradeFormatState(format);
+  }, []);
+
+  const formatGradeWithPreference = useCallback(
+    (difficulty: string | null | undefined): string | null => {
+      return formatGrade(difficulty, gradeFormat);
+    },
+    [gradeFormat],
+  );
+
+  const getGradeColor = useCallback(
+    (difficulty: string | null | undefined, darkMode?: boolean): string | undefined => {
+      return getSoftGradeColorByFormat(difficulty, gradeFormat, darkMode);
+    },
+    [gradeFormat],
+  );
+
+  return useMemo(
+    () => ({
+      gradeFormat,
+      setGradeFormat,
+      loaded,
+      formatGrade: formatGradeWithPreference,
+      getGradeColor,
+    }),
+    [gradeFormat, setGradeFormat, loaded, formatGradeWithPreference, getGradeColor],
+  );
+}

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -162,6 +162,67 @@ export function formatVGrade(difficulty: string | null | undefined): string | nu
 }
 
 /**
+ * Extract Font grade from a difficulty string (e.g., "6a/V3" -> "6A")
+ * @param difficulty - Difficulty string that may contain Font grade
+ * @returns Uppercase Font grade string for display (e.g., "6A", "7B+") or null if not found
+ */
+function extractFontGrade(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  // Try to extract from "6a/V3" format first
+  const slashIndex = difficulty.indexOf('/');
+  if (slashIndex > 0) {
+    return difficulty.substring(0, slashIndex).toUpperCase();
+  }
+  // Fall back to regex match for standalone Font grade
+  const fontGradeMatch = difficulty.match(/\d[abc]\+?/i);
+  return fontGradeMatch ? fontGradeMatch[0].toUpperCase() : null;
+}
+
+/**
+ * Format a difficulty string to a Font grade display label.
+ * @param difficulty - Difficulty string (e.g., "6a/V3", "7b+/V8")
+ * @returns Font grade string (e.g., "6a", "7b+") or null if not found
+ */
+export function formatFontGrade(difficulty: string | null | undefined): string | null {
+  return extractFontGrade(difficulty);
+}
+
+export type GradeDisplayFormat = 'v-grade' | 'font';
+
+/**
+ * Format a difficulty string based on the specified format preference.
+ * @param difficulty - Difficulty string (e.g., "6a/V3")
+ * @param format - Display format: 'v-grade' or 'font'
+ * @returns Formatted grade string based on the format, or null if not found
+ */
+export function formatGrade(difficulty: string | null | undefined, format: GradeDisplayFormat): string | null {
+  if (format === 'font') {
+    return formatFontGrade(difficulty);
+  }
+  return formatVGrade(difficulty);
+}
+
+/**
+ * Get a softened grade color based on the display format.
+ * @param difficulty - Difficulty string (e.g., "6a/V3")
+ * @param format - Display format: 'v-grade' or 'font'
+ * @param darkMode - Whether dark mode is active
+ * @returns Softened color string suitable for text display
+ */
+export function getSoftGradeColorByFormat(
+  difficulty: string | null | undefined,
+  format: GradeDisplayFormat,
+  darkMode?: boolean
+): string | undefined {
+  if (format === 'font') {
+    const fontGrade = extractFontGrade(difficulty);
+    return getSoftFontGradeColor(fontGrade, darkMode);
+  }
+  const vGrade = extractVGrade(difficulty);
+  return getSoftVGradeColor(vGrade, darkMode);
+}
+
+/**
  * Get a semi-transparent version of a grade color for backgrounds
  * @param color - Hex color string
  * @param opacity - Opacity value between 0 and 1

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -80,3 +80,21 @@ export const getAlwaysTickInApp = async (): Promise<boolean> => {
 export const setAlwaysTickInApp = async (enabled: boolean): Promise<void> => {
   await setPreference('alwaysTickInApp', enabled);
 };
+
+export type GradeDisplayFormat = 'v-grade' | 'font';
+
+/**
+ * Get the grade display format preference.
+ * Defaults to 'v-grade' if not set.
+ */
+export const getGradeDisplayFormat = async (): Promise<GradeDisplayFormat> => {
+  const value = await getPreference<GradeDisplayFormat>('gradeDisplayFormat');
+  return value === 'font' ? 'font' : 'v-grade';
+};
+
+/**
+ * Set the grade display format preference.
+ */
+export const setGradeDisplayFormat = async (format: GradeDisplayFormat): Promise<void> => {
+  await setPreference('gradeDisplayFormat', format);
+};

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -26,6 +26,9 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { usePartyProfile } from '@/app/components/party-manager/party-profile-context';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
@@ -58,6 +61,7 @@ export default function SettingsPageContent() {
   const { refreshProfile: refreshPartyProfile } = usePartyProfile();
   const { showMessage } = useSnackbar();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { gradeFormat, setGradeFormat, loaded: gradeFormatLoaded } = useGradeFormat();
 
   // Redirect unauthenticated users to login with a return URL
   useEffect(() => {
@@ -392,6 +396,40 @@ export default function SettingsPageContent() {
                   Save Changes
                 </Button>
               </Box>
+            </Box>
+          </CardContent>
+        </Card>
+
+        <MuiDivider sx={{ my: 2 }} />
+
+        <Card>
+          <CardContent>
+            <Typography variant="h5">Display Preferences</Typography>
+            <Typography variant="body2" component="span" color="text.secondary" sx={{ display: 'block', marginBottom: 3 }}>
+              Customize how grades and other data are displayed
+            </Typography>
+
+            <Box>
+              <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>Grade Display Format</Typography>
+              <ToggleButtonGroup
+                value={gradeFormat}
+                exclusive
+                onChange={(_e, newFormat) => {
+                  if (newFormat !== null) {
+                    setGradeFormat(newFormat);
+                  }
+                }}
+                disabled={!gradeFormatLoaded}
+                size="small"
+                fullWidth
+              >
+                <ToggleButton value="v-grade">
+                  V-Grade (V3, V6, ...)
+                </ToggleButton>
+                <ToggleButton value="font">
+                  Font (6A, 7C+, ...)
+                </ToggleButton>
+              </ToggleButtonGroup>
             </Box>
           </CardContent>
         </Card>


### PR DESCRIPTION
Add a user preference to switch between V-Grade (V3, V6, ...) and Font grade (6A, 7C+, ...) display formats across the app.

Changes:
- Add grade format preference to IndexedDB (user-preferences-db.ts)
- Create useGradeFormat hook for accessing the preference
- Add formatFontGrade(), formatGrade(), getSoftGradeColorByFormat() to grade-colors.ts
- Add settings UI toggle in Display Preferences section
- Update ClimbTitle, GradeDistributionBar, SessionSummaryView, SessionOverviewPanel, and activity feed components to use the hook
- Update profile stats charts to respect grade format preference
- Fix grade sorting to use numeric order instead of alphabetical
- Update tests with useGradeFormat mocks