### PR TITLE
Add Kilter board sync using new OAuth2 API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,23 @@
         "next-auth",
       ],
     },
+    "packages/kilter-sync": {
+      "name": "@boardsesh/kilter-sync",
+      "version": "1.0.0",
+      "dependencies": {
+        "@boardsesh/crypto": "*",
+        "@boardsesh/db": "*",
+        "@neondatabase/serverless": "1.0.2",
+        "drizzle-orm": "^0.45.1",
+        "ws": "^8.19.0",
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
+        "@types/ws": "^8.18.1",
+        "oxlint": "^1.50.0",
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/moonboard-ocr": {
       "name": "@boardsesh/moonboard-ocr",
       "version": "0.2.0",
@@ -153,6 +170,7 @@
         "@aws-sdk/client-s3": "^3.1000.0",
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
+        "@boardsesh/kilter-sync": "*",
         "@boardsesh/shared-schema": "*",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
@@ -420,6 +438,8 @@
     "@boardsesh/crypto": ["@boardsesh/crypto@workspace:packages/crypto"],
 
     "@boardsesh/db": ["@boardsesh/db@workspace:packages/db"],
+
+    "@boardsesh/kilter-sync": ["@boardsesh/kilter-sync@workspace:packages/kilter-sync"],
 
     "@boardsesh/moonboard-ocr": ["@boardsesh/moonboard-ocr@workspace:packages/moonboard-ocr"],
 

--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -214,9 +214,15 @@ Failed to decrypt credentials
 - Verify user has `syncStatus: active` or `error` (not `disabled`)
 - Check Aurora API is accessible from the environment
 
+## Kilter Sync (New API)
+
+The original Kilter backend (`kilterboardapp.com`) was shut down in early 2026 and replaced by a new platform at `portal.kiltergrips.com` with OAuth2/Keycloak authentication. Kilter sync is now handled by the separate `@boardsesh/kilter-sync` package — see [docs/kilter-sync.md](./kilter-sync.md) for details.
+
+The `@boardsesh/aurora-sync` package only syncs **Tension** users. Kilter credentials are excluded from its runner via `ne(auroraCredentials.boardType, 'kilter')`.
+
 ## JSON Export Import (Alternative to API Sync)
 
-Since the Kilter backend has been shut down, API-based sync is no longer available for Kilter users. As an alternative, users can import their data from Aurora's JSON export file.
+Users can also import their data from Aurora's JSON export file as a fallback.
 
 ### How It Works
 

--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -1,0 +1,165 @@
+# Kilter Sync
+
+This document describes how user data is synced from the new Kilter API (portal.kiltergrips.com) to the Boardsesh database using the `@boardsesh/kilter-sync` package.
+
+## Background
+
+In early 2026, the original Kilter backend (`kilterboardapp.com`) was shut down and replaced by a new platform at `portal.kiltergrips.com`. The new backend uses:
+
+- **OAuth2/Keycloak** authentication instead of the old `/sessions` cookie-based auth
+- A new REST API at `portal.kiltergrips.com/api`
+- A sync stream endpoint at `sync1.kiltergrips.com/sync/stream`
+
+The `@boardsesh/kilter-sync` package implements Boardsesh's integration with this new API, separate from the `@boardsesh/aurora-sync` package which handles Tension (and previously Kilter).
+
+Our approach is based on the analysis of the new Kilter API documented in [ruairica/kilter-app-migration](https://github.com/ruairica/kilter-app-migration), a community migration tool that helped map out the new OAuth2 endpoints and data formats.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌───────────────────────────────┐
+│  External Cron  │────▶│  Vercel / Railway              │
+│  (cron-job.org) │     │  GET /api/internal/             │
+└─────────────────┘     │      kilter-sync-cron          │
+                        └──────────────┬────────────────┘
+                                       │
+                    ┌──────────────────┤
+                    ▼                  ▼
+          ┌─────────────────┐  ┌─────────────────┐
+          │  Kilter IDP     │  │  Kilter Sync    │
+          │  (Keycloak)     │  │  Stream         │
+          │  idp.kilter     │  │  sync1.kilter   │
+          │  grips.com      │  │  grips.com      │
+          └─────────────────┘  └─────────────────┘
+                                       │
+                                       ▼
+                              ┌─────────────────┐
+                              │  Neon Database   │
+                              └─────────────────┘
+```
+
+## How It Differs from Aurora Sync
+
+| Aspect | Aurora Sync (Tension) | Kilter Sync |
+|--------|----------------------|-------------|
+| Auth | Cookie token via `/sessions` | OAuth2 JWT via Keycloak IDP |
+| User ID | Numeric (from login response) | UUID in JWT `sub` claim; numeric ID discovered from sync |
+| Sync URL | `tensionboardapp2.com/sync` | `sync1.kiltergrips.com/sync/stream` |
+| Auth header | `Cookie: token=...` | `Authorization: Bearer ...` |
+| REST API | `api.kilterboardapp.com/v1` | `portal.kiltergrips.com/api` |
+| Package | `@boardsesh/aurora-sync` | `@boardsesh/kilter-sync` |
+
+## Authentication Flow
+
+1. **POST** credentials to Keycloak IDP:
+   ```
+   POST https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token
+   Content-Type: application/x-www-form-urlencoded
+
+   grant_type=password&client_id=kilter-app&username=...&password=...
+   ```
+
+2. **Receive** a JWT `access_token` in the response.
+
+3. **Decode** the JWT payload to extract the user's UUID from the `sub` claim. The signature is not verified since the token was received directly from the IDP over HTTPS.
+
+4. **Use** the token as a Bearer token for all API calls:
+   ```
+   Authorization: Bearer <access_token>
+   ```
+
+## Numeric User ID Discovery
+
+The OAuth2 JWT provides a UUID, but the sync stream data still uses numeric Aurora user IDs internally (for `user_syncs`, walls, tags, circuits). On the first sync:
+
+1. We pass `user_id: 0` in the sync request timestamps
+2. The sync response's `user_syncs` array contains the real numeric `user_id`
+3. We extract it and back-populate `auroraCredentials.auroraUserId`
+4. Subsequent syncs use the correct numeric ID
+
+## Incremental Sync
+
+The sync stream works identically to the old Aurora `/sync` endpoint:
+
+1. Send table timestamps as URL-encoded form data (Bearer auth instead of Cookie)
+2. Server returns only data changed since last sync
+3. Response uses `_complete` flag for pagination
+4. Batched upserts (100 rows per INSERT) into the unified board tables
+
+### Tables Synced
+
+| Sync Table | Database Target | Dual Write |
+|------------|----------------|------------|
+| users | board_users | - |
+| walls | board_walls | - |
+| draft_climbs | board_climbs | - |
+| ascents | boardsesh_ticks | - |
+| bids | boardsesh_ticks | - |
+| tags | board_tags | - |
+| circuits | board_circuits | playlists, playlist_climbs |
+
+## Package Structure
+
+```
+packages/kilter-sync/
+├── src/
+│   ├── api/
+│   │   ├── kilter-client.ts      # OAuth2 client, JWT decode, API methods
+│   │   ├── kilter-sync-api.ts    # Sync stream wrapper
+│   │   ├── types.ts              # TypeScript types
+│   │   └── index.ts
+│   ├── sync/
+│   │   ├── user-sync.ts          # User data sync (upserts, batching)
+│   │   ├── convert-quality.ts    # Quality scale conversion (1-3 → 1-5)
+│   │   └── index.ts
+│   ├── runner/
+│   │   ├── sync-runner.ts        # KilterSyncRunner (credential management)
+│   │   ├── types.ts
+│   │   └── index.ts
+│   ├── db/
+│   │   └── table-select.ts       # Unified table references
+│   └── index.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Integration Points
+
+### Credential Storage
+
+Kilter credentials are stored in the same `aurora_credentials` table as Tension, with `board_type = 'kilter'`. The encrypted username and password are used to obtain fresh OAuth2 tokens on each sync.
+
+### Cron Endpoint
+
+```
+GET /api/internal/kilter-sync-cron
+Authorization: Bearer <CRON_SECRET>
+```
+
+Syncs one Kilter user per invocation (oldest `lastSyncAt` first). This is separate from the Aurora sync cron which handles Tension.
+
+### Account Linking UI
+
+The Settings page "Link" button for Kilter uses the same dialog as Tension but routes through the `KilterClient.signIn()` OAuth2 flow in the credentials API route.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | Neon PostgreSQL connection string |
+| `AURORA_CREDENTIALS_SECRET` | Encryption key for stored credentials |
+| `CRON_SECRET` | Bearer token for authenticating cron requests |
+
+## Troubleshooting
+
+### "Invalid username or password" on link
+
+The Keycloak IDP returns 400/401 for bad credentials. Verify the user can log in at portal.kiltergrips.com directly.
+
+### auroraUserId shows as 0
+
+This is expected on the first link. The numeric ID is populated after the first successful sync. If it stays at 0 after sync, check the sync logs for errors from `sync1.kiltergrips.com`.
+
+### Sync stream returns empty data
+
+The Bearer token may have expired. The cron job obtains a fresh token on each run. If running manually, ensure the token is recent.

--- a/packages/kilter-sync/oxlint.json
+++ b/packages/kilter-sync/oxlint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-explicit-any": "deny"
+  }
+}

--- a/packages/kilter-sync/package.json
+++ b/packages/kilter-sync/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@boardsesh/kilter-sync",
+  "version": "1.0.0",
+  "description": "Kilter board sync using the new portal.kiltergrips.com API",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./runner": {
+      "types": "./src/runner/index.ts",
+      "import": "./src/runner/index.ts",
+      "default": "./src/runner/index.ts"
+    },
+    "./api": {
+      "types": "./src/api/index.ts",
+      "import": "./src/api/index.ts",
+      "default": "./src/api/index.ts"
+    },
+    "./sync": {
+      "types": "./src/sync/index.ts",
+      "import": "./src/sync/index.ts",
+      "default": "./src/sync/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "oxlint .",
+    "lint-fix": "oxlint --fix .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@boardsesh/crypto": "*",
+    "@boardsesh/db": "*",
+    "@neondatabase/serverless": "1.0.2",
+    "drizzle-orm": "^0.45.1",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "@types/ws": "^8.18.1",
+    "oxlint": "^1.50.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/kilter-sync/src/api/index.ts
+++ b/packages/kilter-sync/src/api/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export { KilterClient, getUserUuidFromToken } from './kilter-client';
+export { kilterUserSync, kilterSharedSync } from './kilter-sync-api';

--- a/packages/kilter-sync/src/api/kilter-client.ts
+++ b/packages/kilter-sync/src/api/kilter-client.ts
@@ -30,7 +30,11 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
   // Base64url → Base64
   const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
   const json = Buffer.from(base64, 'base64').toString('utf-8');
-  return JSON.parse(json);
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new Error('Failed to parse JWT payload — token may be malformed');
+  }
 }
 
 /**

--- a/packages/kilter-sync/src/api/kilter-client.ts
+++ b/packages/kilter-sync/src/api/kilter-client.ts
@@ -1,0 +1,203 @@
+/**
+ * Kilter API client using OAuth2/Keycloak authentication.
+ *
+ * Auth flow:
+ *   1. POST credentials to Keycloak IDP → receive JWT access_token
+ *   2. Decode JWT to extract user UUID from `sub` claim
+ *   3. Use Bearer token for all subsequent API calls
+ *
+ * Endpoints:
+ *   - IDP:  https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token
+ *   - API:  https://portal.kiltergrips.com/api
+ *   - Sync: https://sync1.kiltergrips.com/sync/stream
+ */
+
+import type { KilterTokenResponse, KilterLoginResult, KilterSyncData } from './types';
+
+const KILTER_IDP_URL = 'https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token';
+const KILTER_API_BASE = 'https://portal.kiltergrips.com/api';
+const KILTER_SYNC_URL = 'https://sync1.kiltergrips.com/sync/stream';
+
+/**
+ * Decode a JWT and return the payload. Does NOT verify the signature —
+ * the token was received directly from the IDP over HTTPS so
+ * signature verification is unnecessary for extracting claims.
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid JWT format');
+  }
+  // Base64url → Base64
+  const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const json = Buffer.from(base64, 'base64').toString('utf-8');
+  return JSON.parse(json);
+}
+
+/**
+ * Extract the user UUID from a Kilter JWT access token.
+ */
+export function getUserUuidFromToken(accessToken: string): string {
+  const payload = decodeJwtPayload(accessToken);
+  const sub = payload.sub;
+  if (typeof sub !== 'string' || sub.length === 0) {
+    throw new Error('JWT does not contain a valid `sub` claim');
+  }
+  return sub;
+}
+
+export class KilterClient {
+  private accessToken: string | null = null;
+  private userUuid: string | null = null;
+
+  /** Set an existing token (e.g. from encrypted storage) */
+  setToken(accessToken: string): void {
+    this.accessToken = accessToken;
+    this.userUuid = getUserUuidFromToken(accessToken);
+  }
+
+  getAccessToken(): string | null {
+    return this.accessToken;
+  }
+
+  getUserUuid(): string | null {
+    return this.userUuid;
+  }
+
+  /**
+   * Authenticate with Kilter via Keycloak Resource Owner Password Credentials grant.
+   */
+  async signIn(username: string, password: string): Promise<KilterLoginResult> {
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      client_id: 'kilter-app', // public client, no secret
+      username,
+      password,
+    });
+
+    const response = await fetch(KILTER_IDP_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 400) {
+        // Keycloak returns 401 for bad credentials
+        let detail = '';
+        try {
+          const errJson = (await response.json()) as Record<string, unknown>;
+          detail = (errJson.error_description as string) || (errJson.error as string) || '';
+        } catch {
+          // ignore parse errors
+        }
+        throw new Error(detail || 'Invalid username or password');
+      }
+      if (response.status === 429) {
+        throw new Error('Too many login attempts. Please try again later.');
+      }
+      throw new Error(`Kilter IDP error: ${response.status} ${response.statusText}`);
+    }
+
+    const tokenResponse = (await response.json()) as KilterTokenResponse;
+
+    if (!tokenResponse.access_token) {
+      throw new Error('Login succeeded but no access_token returned');
+    }
+
+    this.accessToken = tokenResponse.access_token;
+    this.userUuid = getUserUuidFromToken(tokenResponse.access_token);
+
+    return {
+      accessToken: tokenResponse.access_token,
+      userUuid: this.userUuid,
+      username,
+    };
+  }
+
+  /**
+   * Make an authenticated GET request to the Kilter API.
+   */
+  async apiGet<T>(endpoint: string): Promise<T> {
+    if (!this.accessToken) {
+      throw new Error('Not authenticated — call signIn() first');
+    }
+
+    const url = `${KILTER_API_BASE}${endpoint}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Kilter API GET ${endpoint} failed: ${response.status} ${text}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  /**
+   * Make an authenticated POST request to the Kilter API.
+   */
+  async apiPost<T>(endpoint: string, body: unknown): Promise<T> {
+    if (!this.accessToken) {
+      throw new Error('Not authenticated — call signIn() first');
+    }
+
+    const url = `${KILTER_API_BASE}${endpoint}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Kilter API POST ${endpoint} failed: ${response.status} ${text}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  /**
+   * Call the Kilter sync stream endpoint.
+   * Accepts URL-encoded form data (same format as old Aurora /sync)
+   * but uses Bearer auth instead of Cookie auth.
+   */
+  async syncStream(formBody: string): Promise<KilterSyncData> {
+    if (!this.accessToken) {
+      throw new Error('Not authenticated — call signIn() first');
+    }
+
+    const response = await fetch(KILTER_SYNC_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: formBody,
+      signal: AbortSignal.timeout(60000), // Sync can be slow
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Kilter sync stream failed: ${response.status} ${text}`);
+    }
+
+    return response.json() as Promise<KilterSyncData>;
+  }
+}
+
+export default KilterClient;

--- a/packages/kilter-sync/src/api/kilter-client.ts
+++ b/packages/kilter-sync/src/api/kilter-client.ts
@@ -12,11 +12,10 @@
  *   - Sync: https://sync1.kiltergrips.com/sync/stream
  */
 
-import type { KilterTokenResponse, KilterLoginResult, KilterSyncData } from './types';
+import type { KilterTokenResponse, KilterLoginResult } from './types';
 
 const KILTER_IDP_URL = 'https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token';
 const KILTER_API_BASE = 'https://portal.kiltergrips.com/api';
-const KILTER_SYNC_URL = 'https://sync1.kiltergrips.com/sync/stream';
 
 /**
  * Decode a JWT and return the payload. Does NOT verify the signature —
@@ -170,34 +169,6 @@ export class KilterClient {
     return response.json() as Promise<T>;
   }
 
-  /**
-   * Call the Kilter sync stream endpoint.
-   * Accepts URL-encoded form data (same format as old Aurora /sync)
-   * but uses Bearer auth instead of Cookie auth.
-   */
-  async syncStream(formBody: string): Promise<KilterSyncData> {
-    if (!this.accessToken) {
-      throw new Error('Not authenticated — call signIn() first');
-    }
-
-    const response = await fetch(KILTER_SYNC_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        Accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: formBody,
-      signal: AbortSignal.timeout(60000), // Sync can be slow
-    });
-
-    if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      throw new Error(`Kilter sync stream failed: ${response.status} ${text}`);
-    }
-
-    return response.json() as Promise<KilterSyncData>;
-  }
 }
 
 export default KilterClient;

--- a/packages/kilter-sync/src/api/kilter-sync-api.ts
+++ b/packages/kilter-sync/src/api/kilter-sync-api.ts
@@ -1,0 +1,65 @@
+/**
+ * Kilter sync stream API wrapper.
+ *
+ * The new Kilter backend exposes a sync endpoint at sync1.kiltergrips.com/sync/stream
+ * that accepts the same table-timestamp form data as the old Aurora /sync endpoint,
+ * but uses Bearer token auth instead of Cookie auth.
+ */
+
+import type { KilterSyncData, KilterSyncOptions } from './types';
+
+const KILTER_SYNC_URL = 'https://sync1.kiltergrips.com/sync/stream';
+
+/**
+ * Call the Kilter user sync stream.
+ * Mirrors the interface of the old Aurora userSync function.
+ */
+export async function kilterUserSync(
+  accessToken: string,
+  options: KilterSyncOptions = {},
+): Promise<KilterSyncData> {
+  const { sharedSyncs = [], userSyncs = [] } = options;
+
+  const searchParams = new URLSearchParams();
+
+  // Add shared sync timestamps
+  for (const sync of sharedSyncs) {
+    searchParams.append(sync.table_name, sync.last_synchronized_at);
+  }
+
+  // Add user sync timestamps
+  for (const sync of userSyncs) {
+    searchParams.append(sync.table_name, sync.last_synchronized_at);
+  }
+
+  const requestBody = searchParams.toString();
+
+  const response = await fetch(KILTER_SYNC_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: requestBody,
+    signal: AbortSignal.timeout(60000),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Kilter sync stream failed: ${response.status} ${errorText}`);
+  }
+
+  return response.json() as Promise<KilterSyncData>;
+}
+
+/**
+ * Call the Kilter shared sync stream (for global data like climbs, products, etc.)
+ */
+export async function kilterSharedSync(
+  accessToken: string,
+  options: KilterSyncOptions = {},
+): Promise<KilterSyncData> {
+  // Shared sync uses the same endpoint but only with sharedSyncs timestamps
+  return kilterUserSync(accessToken, options);
+}

--- a/packages/kilter-sync/src/api/types.ts
+++ b/packages/kilter-sync/src/api/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Types for the new Kilter API at portal.kiltergrips.com
+ * Uses OAuth2/Keycloak authentication instead of the old Aurora /sessions endpoint.
+ */
+
+/** Kilter OAuth2 token response from Keycloak IDP */
+export interface KilterTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+  refresh_token?: string;
+  token_type: string;
+  scope?: string;
+}
+
+/** Result of a successful Kilter login */
+export interface KilterLoginResult {
+  /** JWT access token for API calls */
+  accessToken: string;
+  /** User UUID extracted from the JWT `sub` claim */
+  userUuid: string;
+  /** Username passed at login (Keycloak doesn't return it in the token response) */
+  username: string;
+}
+
+/** A log entry (ascent or attempt) from the Kilter API */
+export interface KilterLogEntry {
+  uuid?: string;
+  climbUuid: string;
+  angle?: number;
+  topped: boolean;
+  flashed: boolean;
+  bidCount: number;
+  createdAt?: string;
+  date?: string;
+}
+
+/** A climb from the Kilter API */
+export interface KilterClimb {
+  climbUuid: string;
+  name: string;
+  productLayoutUuid: string;
+  [key: string]: unknown;
+}
+
+/** Grade entry from /grades */
+export interface KilterGradeEntry {
+  difficultyGradeId: number;
+  fontScale: string;
+}
+
+/** A circuit/playlist from the Kilter API */
+export interface KilterCircuit {
+  circuitUuid: string;
+  name: string;
+  description: string;
+  color: string;
+  isPrivate: boolean;
+  userUuid: string;
+  creatorName: string;
+  productLayoutUuid: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Sync stream request tables and timestamps — same format as old Aurora /sync */
+export interface KilterSyncOptions {
+  tables?: string[];
+  sharedSyncs?: Array<{ table_name: string; last_synchronized_at: string }>;
+  userSyncs?: Array<{ table_name: string; last_synchronized_at: string; user_id: number }>;
+}
+
+/**
+ * Sync stream response — the new Kilter sync endpoint returns the same
+ * table-keyed JSON structure as the old Aurora /sync, just at a different URL
+ * and with Bearer auth instead of Cookie auth.
+ */
+export interface KilterSyncData {
+  [tableName: string]: unknown;
+  _complete?: boolean;
+  user_syncs?: Array<{
+    table_name: string;
+    last_synchronized_at: string;
+    user_id: number;
+  }>;
+}
+
+/** User tables available through the sync stream */
+export const KILTER_USER_TABLES = [
+  'users',
+  'walls',
+  'wall_expungements',
+  'draft_climbs',
+  'ascents',
+  'bids',
+  'tags',
+  'circuits',
+];
+
+/** Shared (global) tables available through the sync stream */
+export const KILTER_SHARED_SYNC_TABLES = [
+  'products',
+  'product_sizes',
+  'holes',
+  'leds',
+  'products_angles',
+  'layouts',
+  'product_sizes_layouts_sets',
+  'placements',
+  'sets',
+  'placement_roles',
+  'climbs',
+  'climb_stats',
+  'beta_links',
+  'attempts',
+  'kits',
+];

--- a/packages/kilter-sync/src/db/table-select.ts
+++ b/packages/kilter-sync/src/db/table-select.ts
@@ -1,0 +1,39 @@
+import {
+  boardClimbs,
+  boardClimbStats,
+  boardDifficultyGrades,
+  boardProductSizes,
+  boardLayouts,
+  boardUsers,
+  boardCircuits,
+  boardClimbStatsHistory,
+  boardAttempts,
+  boardProducts,
+  boardSharedSyncs,
+  boardUserSyncs,
+  boardClimbHolds,
+  boardBetaLinks,
+  boardWalls,
+  boardTags,
+} from '@boardsesh/db/schema/boards';
+
+export const UNIFIED_TABLES = {
+  climbs: boardClimbs,
+  climbStats: boardClimbStats,
+  difficultyGrades: boardDifficultyGrades,
+  productSizes: boardProductSizes,
+  layouts: boardLayouts,
+  users: boardUsers,
+  circuits: boardCircuits,
+  climbStatsHistory: boardClimbStatsHistory,
+  attempts: boardAttempts,
+  products: boardProducts,
+  userSyncs: boardUserSyncs,
+  sharedSyncs: boardSharedSyncs,
+  climbHolds: boardClimbHolds,
+  betaLinks: boardBetaLinks,
+  walls: boardWalls,
+  tags: boardTags,
+} as const;
+
+export type UnifiedTableSet = typeof UNIFIED_TABLES;

--- a/packages/kilter-sync/src/index.ts
+++ b/packages/kilter-sync/src/index.ts
@@ -1,0 +1,14 @@
+// Main exports for @boardsesh/kilter-sync package
+
+// API exports
+export * from './api/index';
+
+// Sync exports
+export * from './sync/index';
+
+// Runner exports
+export * from './runner/index';
+
+// DB utilities
+export { UNIFIED_TABLES } from './db/table-select';
+export type { UnifiedTableSet } from './db/table-select';

--- a/packages/kilter-sync/src/runner/index.ts
+++ b/packages/kilter-sync/src/runner/index.ts
@@ -1,0 +1,2 @@
+export { KilterSyncRunner } from './sync-runner';
+export type { KilterSyncRunnerConfig, KilterSyncSummary, KilterSyncError, KilterCredentialRecord } from './types';

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -1,0 +1,226 @@
+/**
+ * Kilter sync runner — authenticates via OAuth2 and syncs user data
+ * from the new Kilter API (portal.kiltergrips.com).
+ *
+ * Only processes credentials where boardType = 'kilter'.
+ */
+
+import { neon, neonConfig, Pool } from '@neondatabase/serverless';
+import { drizzle as drizzleHttp } from 'drizzle-orm/neon-http';
+import { eq, and, or, isNotNull, sql } from 'drizzle-orm';
+import ws from 'ws';
+
+import { auroraCredentials } from '@boardsesh/db/schema/auth';
+import { syncKilterUserData } from '../sync/user-sync';
+import { KilterClient } from '../api/kilter-client';
+import { decrypt, encrypt } from '@boardsesh/crypto';
+import type { KilterSyncRunnerConfig, KilterSyncSummary, KilterCredentialRecord } from './types';
+
+neonConfig.webSocketConstructor = ws;
+
+function createFreshPool(): Pool {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is required');
+  }
+  return new Pool({
+    connectionString,
+    connectionTimeoutMillis: 30000,
+    idleTimeoutMillis: 30000,
+    max: 5,
+  });
+}
+
+function createHttpDb() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is required');
+  }
+  const sqlClient = neon(connectionString);
+  return drizzleHttp({ client: sqlClient });
+}
+
+export class KilterSyncRunner {
+  private config: KilterSyncRunnerConfig;
+
+  constructor(config: KilterSyncRunnerConfig = {}) {
+    this.config = config;
+  }
+
+  private log(message: string): void {
+    if (this.config.onLog) {
+      this.config.onLog(message);
+    } else {
+      console.log(message);
+    }
+  }
+
+  private handleError(error: Error, context: { userId?: string }): void {
+    if (this.config.onError) {
+      this.config.onError(error, context);
+    } else {
+      console.error(`[KilterSyncRunner] Error:`, error, context);
+    }
+  }
+
+  /**
+   * Sync the next Kilter user that needs syncing (oldest lastSyncAt first).
+   */
+  async syncNextUser(): Promise<KilterSyncSummary> {
+    const results: KilterSyncSummary = {
+      total: 1,
+      successful: 0,
+      failed: 0,
+      errors: [],
+    };
+
+    const cred = await this.getNextCredentialToSync();
+
+    if (!cred) {
+      this.log(`[KilterSyncRunner] No Kilter users to sync`);
+      results.total = 0;
+      return results;
+    }
+
+    this.log(`[KilterSyncRunner] Syncing user: ${cred.userId}`);
+
+    try {
+      await this.syncSingleCredential(cred);
+      results.successful++;
+      this.log(`[KilterSyncRunner] Successfully synced user ${cred.userId}`);
+    } catch (error) {
+      results.failed++;
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      results.errors.push({ userId: cred.userId, error: errorMsg });
+      this.handleError(error instanceof Error ? error : new Error(errorMsg), { userId: cred.userId });
+      this.log(`[KilterSyncRunner] Failed to sync user ${cred.userId}: ${errorMsg}`);
+    }
+
+    return results;
+  }
+
+  /**
+   * Sync a specific user by NextAuth userId.
+   */
+  async syncUser(userId: string): Promise<void> {
+    const db = createHttpDb();
+    const credentials = await db
+      .select()
+      .from(auroraCredentials)
+      .where(and(eq(auroraCredentials.userId, userId), eq(auroraCredentials.boardType, 'kilter')))
+      .limit(1);
+
+    if (credentials.length === 0) {
+      throw new Error(`No Kilter credentials found for user ${userId}`);
+    }
+
+    await this.syncSingleCredential(credentials[0] as KilterCredentialRecord);
+  }
+
+  private async getNextCredentialToSync(): Promise<KilterCredentialRecord | null> {
+    const db = createHttpDb();
+    const credentials = await db
+      .select()
+      .from(auroraCredentials)
+      .where(
+        and(
+          eq(auroraCredentials.boardType, 'kilter'),
+          or(eq(auroraCredentials.syncStatus, 'active'), eq(auroraCredentials.syncStatus, 'error')),
+          isNotNull(auroraCredentials.encryptedUsername),
+          isNotNull(auroraCredentials.encryptedPassword),
+          isNotNull(auroraCredentials.auroraUserId),
+        ),
+      )
+      .orderBy(sql`${auroraCredentials.lastSyncAt} ASC NULLS FIRST`)
+      .limit(1);
+
+    return credentials.length > 0 ? (credentials[0] as KilterCredentialRecord) : null;
+  }
+
+  private async syncSingleCredential(cred: KilterCredentialRecord): Promise<void> {
+    if (!cred.encryptedUsername || !cred.encryptedPassword || !cred.auroraUserId) {
+      throw new Error('Missing credentials or user ID');
+    }
+
+    let username: string;
+    let password: string;
+    try {
+      username = decrypt(cred.encryptedUsername);
+      password = decrypt(cred.encryptedPassword);
+    } catch (decryptError) {
+      await this.updateCredentialStatus(cred.userId, 'error', `Decryption failed: ${decryptError}`);
+      throw new Error(`Failed to decrypt credentials: ${decryptError}`);
+    }
+
+    // Authenticate with new Kilter OAuth2
+    this.log(`[KilterSyncRunner] Authenticating user ${cred.userId} via Kilter OAuth2...`);
+    const kilterClient = new KilterClient();
+    let accessToken: string;
+
+    try {
+      const loginResult = await kilterClient.signIn(username, password);
+      accessToken = loginResult.accessToken;
+    } catch (loginError) {
+      await this.updateCredentialStatus(cred.userId, 'error', `Login failed: ${loginError}`);
+      throw new Error(`Kilter OAuth2 login failed: ${loginError}`);
+    }
+
+    // Store the new token
+    await this.updateStoredToken(cred.userId, accessToken);
+
+    // Sync user data
+    const pool = createFreshPool();
+    try {
+      this.log(`[KilterSyncRunner] Syncing data for user ${cred.userId}...`);
+      await syncKilterUserData(
+        pool,
+        accessToken,
+        cred.auroraUserId,
+        cred.userId,
+        undefined,
+        this.log.bind(this),
+      );
+
+      await this.updateCredentialStatus(cred.userId, 'active', null, new Date());
+    } finally {
+      await pool.end();
+    }
+  }
+
+  private async updateCredentialStatus(
+    userId: string,
+    status: string,
+    error: string | null,
+    lastSyncAt?: Date,
+  ): Promise<void> {
+    const db = createHttpDb();
+    const updateData: Record<string, unknown> = {
+      syncStatus: status,
+      syncError: error,
+      updatedAt: new Date(),
+    };
+    if (lastSyncAt) {
+      updateData.lastSyncAt = lastSyncAt;
+    }
+
+    await db
+      .update(auroraCredentials)
+      .set(updateData)
+      .where(and(eq(auroraCredentials.userId, userId), eq(auroraCredentials.boardType, 'kilter')));
+  }
+
+  private async updateStoredToken(userId: string, token: string): Promise<void> {
+    const encryptedToken = encrypt(token);
+    const db = createHttpDb();
+    await db
+      .update(auroraCredentials)
+      .set({ auroraToken: encryptedToken, updatedAt: new Date() })
+      .where(and(eq(auroraCredentials.userId, userId), eq(auroraCredentials.boardType, 'kilter')));
+  }
+
+  async close(): Promise<void> {
+    // No-op — pools are created and closed per operation
+  }
+}
+
+export default KilterSyncRunner;

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -138,8 +138,8 @@ export class KilterSyncRunner {
   }
 
   private async syncSingleCredential(cred: KilterCredentialRecord): Promise<void> {
-    if (!cred.encryptedUsername || !cred.encryptedPassword || !cred.auroraUserId) {
-      throw new Error('Missing credentials or user ID');
+    if (!cred.encryptedUsername || !cred.encryptedPassword) {
+      throw new Error('Missing credentials');
     }
 
     let username: string;
@@ -171,15 +171,22 @@ export class KilterSyncRunner {
     // Sync user data
     const pool = createFreshPool();
     try {
-      this.log(`[KilterSyncRunner] Syncing data for user ${cred.userId}...`);
-      await syncKilterUserData(
+      const auroraUserId = cred.auroraUserId || 0;
+      this.log(`[KilterSyncRunner] Syncing data for user ${cred.userId} (aurora ID: ${auroraUserId})...`);
+      const syncResult = await syncKilterUserData(
         pool,
         accessToken,
-        cred.auroraUserId,
+        auroraUserId,
         cred.userId,
         undefined,
         this.log.bind(this),
       );
+
+      // Back-populate the numeric user ID if we discovered it
+      if (syncResult.discoveredAuroraUserId && syncResult.discoveredAuroraUserId !== auroraUserId) {
+        this.log(`[KilterSyncRunner] Back-populating auroraUserId: ${syncResult.discoveredAuroraUserId}`);
+        await this.updateAuroraUserId(cred.userId, syncResult.discoveredAuroraUserId);
+      }
 
       await this.updateCredentialStatus(cred.userId, 'active', null, new Date());
     } finally {
@@ -206,6 +213,14 @@ export class KilterSyncRunner {
     await db
       .update(auroraCredentials)
       .set(updateData)
+      .where(and(eq(auroraCredentials.userId, userId), eq(auroraCredentials.boardType, 'kilter')));
+  }
+
+  private async updateAuroraUserId(userId: string, auroraUserId: number): Promise<void> {
+    const db = createHttpDb();
+    await db
+      .update(auroraCredentials)
+      .set({ auroraUserId, updatedAt: new Date() })
       .where(and(eq(auroraCredentials.userId, userId), eq(auroraCredentials.boardType, 'kilter')));
   }
 

--- a/packages/kilter-sync/src/runner/types.ts
+++ b/packages/kilter-sync/src/runner/types.ts
@@ -1,0 +1,28 @@
+export interface KilterSyncRunnerConfig {
+  onLog?: (message: string) => void;
+  onError?: (error: Error, context: { userId?: string }) => void;
+}
+
+export interface KilterSyncSummary {
+  total: number;
+  successful: number;
+  failed: number;
+  errors: KilterSyncError[];
+}
+
+export interface KilterSyncError {
+  userId: string;
+  error: string;
+}
+
+export interface KilterCredentialRecord {
+  userId: string;
+  boardType: string;
+  encryptedUsername: string | null;
+  encryptedPassword: string | null;
+  auroraUserId: number | null;
+  auroraToken: string | null;
+  syncStatus: string | null;
+  syncError: string | null;
+  lastSyncAt: Date | null;
+}

--- a/packages/kilter-sync/src/sync/convert-quality.ts
+++ b/packages/kilter-sync/src/sync/convert-quality.ts
@@ -1,0 +1,7 @@
+/**
+ * Convert Aurora/Kilter quality (1-3) to Boardsesh quality (1-5)
+ */
+export function convertQuality(quality: number | null | undefined): number | null {
+  if (quality == null) return null;
+  return Math.round((quality / 3.0) * 5);
+}

--- a/packages/kilter-sync/src/sync/index.ts
+++ b/packages/kilter-sync/src/sync/index.ts
@@ -1,0 +1,3 @@
+export { syncKilterUserData, getLastSyncTimes } from './user-sync';
+export type { KilterSyncUserDataResult, SyncTableResult } from './user-sync';
+export { convertQuality } from './convert-quality';

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -265,30 +265,20 @@ async function upsertTableData(
     case 'tags': {
       const tagsSchema = UNIFIED_TABLES.tags;
       await processBatches(data, BATCH_SIZE, async (batch) => {
-        for (const item of batch) {
-          const result = await db
-            .update(tagsSchema)
-            .set({ isListed: Boolean(item.is_listed) })
-            .where(
-              and(
-                eq(tagsSchema.boardType, BOARD_TYPE),
-                eq(tagsSchema.entityUuid, item.entity_uuid),
-                eq(tagsSchema.userId, Number(auroraUserId)),
-                eq(tagsSchema.name, item.name),
-              ),
-            )
-            .returning();
-
-          if (result.length === 0) {
-            await db.insert(tagsSchema).values({
-              boardType: BOARD_TYPE,
-              entityUuid: item.entity_uuid,
-              userId: Number(auroraUserId),
-              name: item.name,
-              isListed: Boolean(item.is_listed),
-            });
-          }
-        }
+        const values = batch.map((item) => ({
+          boardType: BOARD_TYPE,
+          entityUuid: item.entity_uuid,
+          userId: Number(auroraUserId),
+          name: item.name,
+          isListed: Boolean(item.is_listed),
+        }));
+        await db
+          .insert(tagsSchema)
+          .values(values)
+          .onConflictDoUpdate({
+            target: [tagsSchema.boardType, tagsSchema.entityUuid, tagsSchema.userId, tagsSchema.name],
+            set: { isListed: sql`excluded.is_listed` },
+          });
       });
       break;
     }
@@ -365,20 +355,29 @@ async function upsertTableData(
           if (item.climbs && Array.isArray(item.climbs)) {
             await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
 
+            const climbValues: Array<{
+              playlistId: bigint;
+              climbUuid: string;
+              angle: number | null;
+              position: number;
+            }> = [];
             for (let i = 0; i < item.climbs.length; i++) {
-              const climb = item.climbs[i];
+              const climb = item.climbs[i] as Record<string, unknown>;
               const climbUuid = climb.climb_uuid || climb.uuid || climb;
-              const climbAngle = climb.angle ?? null;
-              const climbPosition = climb.position ?? i;
-
               if (typeof climbUuid === 'string') {
-                await db.insert(playlistClimbs).values({
+                climbValues.push({
                   playlistId: playlist.id,
                   climbUuid,
-                  angle: climbAngle,
-                  position: climbPosition,
+                  angle: (climb.angle as number) ?? null,
+                  position: (climb.position as number) ?? i,
                 });
               }
+            }
+
+            if (climbValues.length > 0) {
+              await processBatches(climbValues, BATCH_SIZE, async (batch) => {
+                await db.insert(playlistClimbs).values(batch);
+              });
             }
           }
         }

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -444,15 +444,23 @@ export interface SyncTableResult {
 }
 
 export interface KilterSyncUserDataResult {
-  [tableName: string]: SyncTableResult;
+  tables: Record<string, SyncTableResult>;
+  /** The numeric Aurora user ID discovered from the sync response. Null if not found. */
+  discoveredAuroraUserId: number | null;
 }
 
 /**
  * Sync user data from the new Kilter API into the Boardsesh database.
  *
+ * The new Kilter OAuth2 flow gives us a UUID (from JWT), but the sync stream
+ * still uses numeric Aurora user IDs internally. On the first sync, pass
+ * `auroraUserId = 0` — this function will discover the real numeric ID from
+ * the sync response's `user_syncs` array and return it in the result so the
+ * caller can back-populate `auroraCredentials.auroraUserId`.
+ *
  * @param pool      - Neon connection pool
  * @param accessToken - Kilter OAuth2 access token (Bearer)
- * @param auroraUserId - The user's numeric Aurora user ID (still used in sync stream data)
+ * @param auroraUserId - The user's numeric Aurora user ID (0 if unknown)
  * @param nextAuthUserId - The Boardsesh NextAuth user ID
  * @param tables    - Which tables to sync (defaults to all user tables)
  * @param log       - Logger function
@@ -480,17 +488,37 @@ export async function syncKilterUserData(
 
   log(`[KilterSync] Syncing ${tables.length} tables for user ${auroraUserId}`);
 
-  const totalResults: KilterSyncUserDataResult = {};
+  const totalResults: Record<string, SyncTableResult> = {};
   let currentOptions = syncOptions;
   let isComplete = false;
   let attempts = 0;
   const maxAttempts = 50;
 
+  // Track the real numeric user ID discovered from the sync response
+  let resolvedUserId = auroraUserId;
+  let discoveredAuroraUserId: number | null = null;
+
   while (!isComplete && attempts < maxAttempts) {
     attempts++;
-    log(`[KilterSync] Sync batch ${attempts} for user ${auroraUserId}`);
+    log(`[KilterSync] Sync batch ${attempts} for user ${resolvedUserId}`);
 
     const syncResults = await kilterUserSync(accessToken, currentOptions) as KilterSyncData;
+
+    // Discover the numeric user ID from user_syncs on the first batch
+    if (discoveredAuroraUserId === null && syncResults['user_syncs'] && Array.isArray(syncResults['user_syncs'])) {
+      const userSyncsData = syncResults['user_syncs'] as Array<{
+        table_name: string;
+        last_synchronized_at: string;
+        user_id: number;
+      }>;
+      if (userSyncsData.length > 0 && userSyncsData[0].user_id > 0) {
+        discoveredAuroraUserId = userSyncsData[0].user_id;
+        if (resolvedUserId === 0) {
+          resolvedUserId = discoveredAuroraUserId;
+          log(`[KilterSync] Discovered numeric user ID: ${resolvedUserId}`);
+        }
+      }
+    }
 
     // Process batch in a transaction
     const client = await pool.connect();
@@ -503,7 +531,7 @@ export async function syncKilterUserData(
         if (syncResults[tableName] && Array.isArray(syncResults[tableName])) {
           const data = syncResults[tableName] as SyncRow[];
 
-          const upsertResult = await upsertTableData(tx, tableName, auroraUserId, nextAuthUserId, data, log);
+          const upsertResult = await upsertTableData(tx, tableName, resolvedUserId, nextAuthUserId, data, log);
 
           if (!totalResults[tableName]) {
             totalResults[tableName] = { synced: 0 };
@@ -532,7 +560,7 @@ export async function syncKilterUserData(
           userSyncs: userSyncsData.map((s) => ({
             table_name: s.table_name,
             last_synchronized_at: s.last_synchronized_at,
-            user_id: Number(auroraUserId),
+            user_id: Number(resolvedUserId),
           })),
         };
       }
@@ -565,5 +593,5 @@ export async function syncKilterUserData(
     log(`[KilterSync] Reached max attempts (${maxAttempts})`);
   }
 
-  return totalResults;
+  return { tables: totalResults, discoveredAuroraUserId };
 }

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -1,0 +1,570 @@
+/**
+ * Kilter user data sync.
+ *
+ * Uses the new sync stream at sync1.kiltergrips.com with Bearer token auth.
+ * The response format is the same table-keyed JSON as the old Aurora /sync,
+ * so we reuse the same upsert logic from aurora-sync.
+ */
+
+import { kilterUserSync } from '../api/kilter-sync-api';
+import type { KilterSyncOptions, KilterSyncData } from '../api/types';
+import { KILTER_USER_TABLES } from '../api/types';
+import { eq, and, inArray, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/neon-serverless';
+import type { NeonDatabase } from 'drizzle-orm/neon-serverless';
+import type { Pool } from '@neondatabase/serverless';
+import { UNIFIED_TABLES } from '../db/table-select';
+import { boardseshTicks, playlists, playlistClimbs, playlistOwnership } from '@boardsesh/db/schema/app';
+import { randomUUID } from 'crypto';
+import { convertQuality } from './convert-quality';
+
+const BOARD_TYPE = 'kilter' as const;
+const BATCH_SIZE = 100;
+
+async function processBatches<T>(
+  data: T[],
+  batchSize: number,
+  processor: (batch: T[]) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < data.length; i += batchSize) {
+    const batch = data.slice(i, i + batchSize);
+    await processor(batch);
+  }
+}
+
+interface UpsertResult {
+  synced: number;
+  skipped: number;
+  skippedReason?: string;
+}
+
+type SyncRow = Record<string, string>;
+
+async function upsertTableData(
+  db: NeonDatabase<Record<string, never>>,
+  tableName: string,
+  auroraUserId: number,
+  nextAuthUserId: string,
+  data: SyncRow[],
+  log: (message: string) => void = console.log,
+): Promise<UpsertResult> {
+  if (data.length === 0) return { synced: 0, skipped: 0 };
+
+  log(`  Upserting ${data.length} rows for ${tableName} in batches of ${BATCH_SIZE}`);
+
+  switch (tableName) {
+    case 'users': {
+      const usersSchema = UNIFIED_TABLES.users;
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const values = batch.map((item) => ({
+          boardType: BOARD_TYPE,
+          id: Number(item.id),
+          username: item.username,
+          createdAt: item.created_at,
+        }));
+        await db
+          .insert(usersSchema)
+          .values(values)
+          .onConflictDoUpdate({
+            target: [usersSchema.boardType, usersSchema.id],
+            set: { username: sql`excluded.username` },
+          });
+      });
+      break;
+    }
+
+    case 'walls': {
+      const wallsSchema = UNIFIED_TABLES.walls;
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const values = batch.map((item) => ({
+          boardType: BOARD_TYPE,
+          uuid: item.uuid,
+          userId: Number(auroraUserId),
+          name: item.name,
+          productId: Number(item.product_id),
+          isAdjustable: Boolean(item.is_adjustable),
+          angle: Number(item.angle),
+          layoutId: Number(item.layout_id),
+          productSizeId: Number(item.product_size_id),
+          hsm: Number(item.hsm),
+          serialNumber: item.serial_number,
+          createdAt: item.created_at,
+        }));
+        await db
+          .insert(wallsSchema)
+          .values(values)
+          .onConflictDoUpdate({
+            target: [wallsSchema.boardType, wallsSchema.uuid],
+            set: {
+              name: sql`excluded.name`,
+              isAdjustable: sql`excluded.is_adjustable`,
+              angle: sql`excluded.angle`,
+              layoutId: sql`excluded.layout_id`,
+              productSizeId: sql`excluded.product_size_id`,
+              hsm: sql`excluded.hsm`,
+              serialNumber: sql`excluded.serial_number`,
+            },
+          });
+      });
+      break;
+    }
+
+    case 'draft_climbs': {
+      const climbsSchema = UNIFIED_TABLES.climbs;
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const values = batch.map((item) => ({
+          boardType: BOARD_TYPE,
+          uuid: item.uuid,
+          layoutId: Number(item.layout_id),
+          setterId: Number(auroraUserId),
+          setterUsername: item.setter_username || '',
+          name: item.name || 'Untitled Draft',
+          description: item.description || '',
+          hsm: Number(item.hsm),
+          edgeLeft: Number(item.edge_left),
+          edgeRight: Number(item.edge_right),
+          edgeBottom: Number(item.edge_bottom),
+          edgeTop: Number(item.edge_top),
+          angle: item.angle != null && !isNaN(Number(item.angle)) ? Number(item.angle) : null,
+          framesCount: Number(item.frames_count || 1),
+          framesPace: Number(item.frames_pace || 0),
+          frames: item.frames || '',
+          isDraft: true,
+          isListed: false,
+          createdAt: item.created_at || new Date().toISOString(),
+          synced: true,
+          syncError: null,
+          userId: null,
+        }));
+        await db
+          .insert(climbsSchema)
+          .values(values)
+          .onConflictDoUpdate({
+            target: climbsSchema.uuid,
+            set: {
+              layoutId: sql`excluded.layout_id`,
+              setterId: sql`excluded.setter_id`,
+              setterUsername: sql`excluded.setter_username`,
+              name: sql`excluded.name`,
+              description: sql`excluded.description`,
+              hsm: sql`excluded.hsm`,
+              edgeLeft: sql`excluded.edge_left`,
+              edgeRight: sql`excluded.edge_right`,
+              edgeBottom: sql`excluded.edge_bottom`,
+              edgeTop: sql`excluded.edge_top`,
+              angle: sql`excluded.angle`,
+              framesCount: sql`excluded.frames_count`,
+              framesPace: sql`excluded.frames_pace`,
+              frames: sql`excluded.frames`,
+              isDraft: sql`excluded.is_draft`,
+              isListed: sql`excluded.is_listed`,
+            },
+          });
+      });
+      break;
+    }
+
+    case 'ascents': {
+      if (!nextAuthUserId) {
+        log(`  Skipping ascents sync: no NextAuth user ID`);
+        return { synced: 0, skipped: data.length, skippedReason: 'No NextAuth user ID' };
+      }
+      const now = new Date().toISOString();
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const tickValues = batch.map((item) => ({
+          uuid: randomUUID(),
+          userId: nextAuthUserId,
+          boardType: BOARD_TYPE,
+          climbUuid: item.climb_uuid,
+          angle: Number(item.angle),
+          isMirror: Boolean(item.is_mirror),
+          status: (Number(item.attempt_id) === 1 ? 'flash' : 'send') as 'flash' | 'send' | 'attempt',
+          attemptCount: Number(item.bid_count || 1),
+          quality: convertQuality(item.quality ? Number(item.quality) : null),
+          difficulty: item.difficulty ? Number(item.difficulty) : null,
+          isBenchmark: Boolean(item.is_benchmark || 0),
+          comment: item.comment || '',
+          climbedAt: new Date(item.climbed_at).toISOString(),
+          createdAt: item.created_at ? new Date(item.created_at).toISOString() : now,
+          updatedAt: now,
+          auroraType: 'ascents' as const,
+          auroraId: item.uuid,
+          auroraSyncedAt: now,
+        }));
+        await db
+          .insert(boardseshTicks)
+          .values(tickValues)
+          .onConflictDoUpdate({
+            target: boardseshTicks.auroraId,
+            set: {
+              climbUuid: sql`excluded.climb_uuid`,
+              angle: sql`excluded.angle`,
+              isMirror: sql`excluded.is_mirror`,
+              status: sql`excluded.status`,
+              attemptCount: sql`excluded.attempt_count`,
+              quality: sql`excluded.quality`,
+              difficulty: sql`excluded.difficulty`,
+              isBenchmark: sql`excluded.is_benchmark`,
+              comment: sql`excluded.comment`,
+              climbedAt: sql`excluded.climbed_at`,
+              updatedAt: sql`excluded.updated_at`,
+              auroraSyncedAt: sql`excluded.aurora_synced_at`,
+            },
+          });
+      });
+      break;
+    }
+
+    case 'bids': {
+      if (!nextAuthUserId) {
+        log(`  Skipping bids sync: no NextAuth user ID`);
+        return { synced: 0, skipped: data.length, skippedReason: 'No NextAuth user ID' };
+      }
+      const now = new Date().toISOString();
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const tickValues = batch.map((item) => ({
+          uuid: randomUUID(),
+          userId: nextAuthUserId,
+          boardType: BOARD_TYPE,
+          climbUuid: item.climb_uuid,
+          angle: Number(item.angle),
+          isMirror: Boolean(item.is_mirror),
+          status: 'attempt' as const,
+          attemptCount: Number(item.bid_count || 1),
+          quality: null,
+          difficulty: null,
+          isBenchmark: false,
+          comment: item.comment || '',
+          climbedAt: new Date(item.climbed_at).toISOString(),
+          createdAt: new Date(item.created_at).toISOString(),
+          updatedAt: now,
+          auroraType: 'bids' as const,
+          auroraId: item.uuid,
+          auroraSyncedAt: now,
+        }));
+        await db
+          .insert(boardseshTicks)
+          .values(tickValues)
+          .onConflictDoUpdate({
+            target: boardseshTicks.auroraId,
+            set: {
+              climbUuid: sql`excluded.climb_uuid`,
+              angle: sql`excluded.angle`,
+              isMirror: sql`excluded.is_mirror`,
+              attemptCount: sql`excluded.attempt_count`,
+              comment: sql`excluded.comment`,
+              climbedAt: sql`excluded.climbed_at`,
+              updatedAt: sql`excluded.updated_at`,
+              auroraSyncedAt: sql`excluded.aurora_synced_at`,
+            },
+          });
+      });
+      break;
+    }
+
+    case 'tags': {
+      const tagsSchema = UNIFIED_TABLES.tags;
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        for (const item of batch) {
+          const result = await db
+            .update(tagsSchema)
+            .set({ isListed: Boolean(item.is_listed) })
+            .where(
+              and(
+                eq(tagsSchema.boardType, BOARD_TYPE),
+                eq(tagsSchema.entityUuid, item.entity_uuid),
+                eq(tagsSchema.userId, Number(auroraUserId)),
+                eq(tagsSchema.name, item.name),
+              ),
+            )
+            .returning();
+
+          if (result.length === 0) {
+            await db.insert(tagsSchema).values({
+              boardType: BOARD_TYPE,
+              entityUuid: item.entity_uuid,
+              userId: Number(auroraUserId),
+              name: item.name,
+              isListed: Boolean(item.is_listed),
+            });
+          }
+        }
+      });
+      break;
+    }
+
+    case 'circuits': {
+      const circuitsSchema = UNIFIED_TABLES.circuits;
+
+      await processBatches(data, BATCH_SIZE, async (batch) => {
+        const values = batch.map((item) => ({
+          boardType: BOARD_TYPE,
+          uuid: item.uuid,
+          name: item.name,
+          description: item.description,
+          color: item.color,
+          userId: Number(auroraUserId),
+          isPublic: Boolean(item.is_public),
+          createdAt: item.created_at,
+          updatedAt: item.updated_at,
+        }));
+        await db
+          .insert(circuitsSchema)
+          .values(values)
+          .onConflictDoUpdate({
+            target: [circuitsSchema.boardType, circuitsSchema.uuid],
+            set: {
+              name: sql`excluded.name`,
+              description: sql`excluded.description`,
+              color: sql`excluded.color`,
+              isPublic: sql`excluded.is_public`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+      });
+
+      // Dual-write to playlists
+      if (nextAuthUserId) {
+        for (const item of data) {
+          const formattedColor = item.color ? `#${item.color}` : null;
+
+          const [playlist] = await db
+            .insert(playlists)
+            .values({
+              uuid: item.uuid,
+              boardType: BOARD_TYPE,
+              layoutId: null,
+              name: item.name || 'Untitled Circuit',
+              description: item.description || null,
+              isPublic: Boolean(item.is_public),
+              color: formattedColor,
+              auroraType: 'circuits',
+              auroraId: item.uuid,
+              auroraSyncedAt: new Date(),
+              createdAt: item.created_at ? new Date(item.created_at) : new Date(),
+              updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+            })
+            .onConflictDoUpdate({
+              target: playlists.auroraId,
+              set: {
+                name: item.name || 'Untitled Circuit',
+                description: item.description || null,
+                isPublic: Boolean(item.is_public),
+                color: formattedColor,
+                updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+                auroraSyncedAt: new Date(),
+              },
+            })
+            .returning({ id: playlists.id });
+
+          await db
+            .insert(playlistOwnership)
+            .values({ playlistId: playlist.id, userId: nextAuthUserId, role: 'owner' })
+            .onConflictDoNothing();
+
+          if (item.climbs && Array.isArray(item.climbs)) {
+            await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
+
+            for (let i = 0; i < item.climbs.length; i++) {
+              const climb = item.climbs[i];
+              const climbUuid = climb.climb_uuid || climb.uuid || climb;
+              const climbAngle = climb.angle ?? null;
+              const climbPosition = climb.position ?? i;
+
+              if (typeof climbUuid === 'string') {
+                await db.insert(playlistClimbs).values({
+                  playlistId: playlist.id,
+                  climbUuid,
+                  angle: climbAngle,
+                  position: climbPosition,
+                });
+              }
+            }
+          }
+        }
+        log(`  Synced ${data.length} circuits to playlists table`);
+      }
+      break;
+    }
+
+    default:
+      log(`  No upsert logic for table: ${tableName}`);
+      return { synced: 0, skipped: data.length, skippedReason: `No upsert logic for table: ${tableName}` };
+  }
+
+  return { synced: data.length, skipped: 0 };
+}
+
+async function updateUserSyncs(
+  tx: NeonDatabase<Record<string, never>>,
+  userSyncs: Array<{ table_name: string; last_synchronized_at: string; user_id: number }>,
+) {
+  const userSyncsSchema = UNIFIED_TABLES.userSyncs;
+
+  for (const sync of userSyncs) {
+    await tx
+      .insert(userSyncsSchema)
+      .values({
+        boardType: BOARD_TYPE,
+        userId: Number(sync.user_id),
+        tableName: sync.table_name,
+        lastSynchronizedAt: sync.last_synchronized_at,
+      })
+      .onConflictDoUpdate({
+        target: [userSyncsSchema.boardType, userSyncsSchema.userId, userSyncsSchema.tableName],
+        set: { lastSynchronizedAt: sync.last_synchronized_at },
+      });
+  }
+}
+
+export async function getLastSyncTimes(pool: Pool, userId: number, tableNames: string[]) {
+  const userSyncsSchema = UNIFIED_TABLES.userSyncs;
+  const client = await pool.connect();
+
+  try {
+    const db = drizzle(client);
+    return await db
+      .select()
+      .from(userSyncsSchema)
+      .where(
+        and(
+          eq(userSyncsSchema.boardType, BOARD_TYPE),
+          eq(userSyncsSchema.userId, Number(userId)),
+          inArray(userSyncsSchema.tableName, tableNames),
+        ),
+      );
+  } finally {
+    client.release();
+  }
+}
+
+export interface SyncTableResult {
+  synced: number;
+  skipped?: number;
+  skippedReason?: string;
+}
+
+export interface KilterSyncUserDataResult {
+  [tableName: string]: SyncTableResult;
+}
+
+/**
+ * Sync user data from the new Kilter API into the Boardsesh database.
+ *
+ * @param pool      - Neon connection pool
+ * @param accessToken - Kilter OAuth2 access token (Bearer)
+ * @param auroraUserId - The user's numeric Aurora user ID (still used in sync stream data)
+ * @param nextAuthUserId - The Boardsesh NextAuth user ID
+ * @param tables    - Which tables to sync (defaults to all user tables)
+ * @param log       - Logger function
+ */
+export async function syncKilterUserData(
+  pool: Pool,
+  accessToken: string,
+  auroraUserId: number,
+  nextAuthUserId: string,
+  tables: string[] = KILTER_USER_TABLES,
+  log: (message: string) => void = console.log,
+): Promise<KilterSyncUserDataResult> {
+  const syncOptions: KilterSyncOptions = { tables };
+
+  // Get existing sync timestamps
+  const allSyncTimes = await getLastSyncTimes(pool, auroraUserId, tables);
+  const userSyncMap = new Map(allSyncTimes.map((s) => [s.tableName, s.lastSynchronizedAt]));
+  const defaultTimestamp = '1970-01-01 00:00:00.000000';
+
+  syncOptions.userSyncs = tables.map((tableName) => ({
+    table_name: tableName,
+    last_synchronized_at: userSyncMap.get(tableName) || defaultTimestamp,
+    user_id: Number(auroraUserId),
+  }));
+
+  log(`[KilterSync] Syncing ${tables.length} tables for user ${auroraUserId}`);
+
+  const totalResults: KilterSyncUserDataResult = {};
+  let currentOptions = syncOptions;
+  let isComplete = false;
+  let attempts = 0;
+  const maxAttempts = 50;
+
+  while (!isComplete && attempts < maxAttempts) {
+    attempts++;
+    log(`[KilterSync] Sync batch ${attempts} for user ${auroraUserId}`);
+
+    const syncResults = await kilterUserSync(accessToken, currentOptions) as KilterSyncData;
+
+    // Process batch in a transaction
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const tx = drizzle(client);
+
+      for (const tableName of tables) {
+        log(`[KilterSync] Processing ${tableName} (batch ${attempts})`);
+        if (syncResults[tableName] && Array.isArray(syncResults[tableName])) {
+          const data = syncResults[tableName] as SyncRow[];
+
+          const upsertResult = await upsertTableData(tx, tableName, auroraUserId, nextAuthUserId, data, log);
+
+          if (!totalResults[tableName]) {
+            totalResults[tableName] = { synced: 0 };
+          }
+          totalResults[tableName].synced += upsertResult.synced;
+          if (upsertResult.skipped > 0) {
+            totalResults[tableName].skipped = (totalResults[tableName].skipped || 0) + upsertResult.skipped;
+            totalResults[tableName].skippedReason = upsertResult.skippedReason;
+          }
+        } else if (!totalResults[tableName]) {
+          totalResults[tableName] = { synced: 0 };
+        }
+      }
+
+      // Update sync timestamps
+      if (syncResults['user_syncs'] && Array.isArray(syncResults['user_syncs'])) {
+        const userSyncsData = syncResults['user_syncs'] as Array<{
+          table_name: string;
+          last_synchronized_at: string;
+          user_id: number;
+        }>;
+        await updateUserSyncs(tx, userSyncsData);
+
+        currentOptions = {
+          ...currentOptions,
+          userSyncs: userSyncsData.map((s) => ({
+            table_name: s.table_name,
+            last_synchronized_at: s.last_synchronized_at,
+            user_id: Number(auroraUserId),
+          })),
+        };
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      const errorMessage =
+        error instanceof Error
+          ? error.message.includes('violates foreign key constraint')
+            ? `FK constraint violation: ${error.message.split('violates foreign key constraint')[1]?.split('"')[1] || 'unknown'}`
+            : error.message.slice(0, 2000)
+          : String(error).slice(0, 2000);
+      log(`[KilterSync] Database error: ${errorMessage}`);
+      throw new Error(`Database error: ${errorMessage}`);
+    } finally {
+      client.release();
+    }
+
+    isComplete = syncResults._complete !== false;
+
+    if (!isComplete) {
+      log(`[KilterSync] Sync not complete, continuing...`);
+    } else {
+      log(`[KilterSync] Sync complete after ${attempts} batches`);
+    }
+  }
+
+  if (attempts >= maxAttempts) {
+    log(`[KilterSync] Reached max attempts (${maxAttempts})`);
+  }
+
+  return totalResults;
+}

--- a/packages/kilter-sync/tsconfig.json
+++ b/packages/kilter-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/web/app/api/internal/aurora-credentials/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/route.ts
@@ -9,6 +9,7 @@ import { encrypt, decrypt } from "@boardsesh/crypto";
 import AuroraClimbingClient from "@/app/lib/api-wrappers/aurora-rest-client/aurora-rest-client";
 import { AuroraBoardName } from "@/app/lib/api-wrappers/aurora/types";
 import { syncUserData } from "@/app/lib/data-sync/aurora/user-sync";
+import { KilterClient } from "@boardsesh/kilter-sync/api";
 
 const saveCredentialsSchema = z.object({
   boardType: z.enum(["kilter", "tension"]),
@@ -99,20 +100,43 @@ export async function POST(request: NextRequest) {
 
     const { boardType, username, password } = validationResult.data;
 
-    // First, verify credentials by attempting login
-    const auroraClient = new AuroraClimbingClient({ boardName: boardType as AuroraBoardName });
-    let loginResponse;
-    try {
-      loginResponse = await auroraClient.signIn(username, password);
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("401")) {
-        return NextResponse.json({ error: "Invalid Aurora credentials" }, { status: 401 });
-      }
-      throw error;
-    }
+    // Authenticate — Kilter uses OAuth2/Keycloak, Tension uses old Aurora /sessions
+    let loginToken: string;
+    let loginUserId: number;
 
-    if (!loginResponse.token || !loginResponse.user_id) {
-      return NextResponse.json({ error: "Invalid login response from Aurora" }, { status: 400 });
+    if (boardType === "kilter") {
+      const kilterClient = new KilterClient();
+      let kilterLogin;
+      try {
+        kilterLogin = await kilterClient.signIn(username, password);
+      } catch (error) {
+        if (error instanceof Error && (error.message.includes("Invalid") || error.message.includes("401"))) {
+          return NextResponse.json({ error: "Invalid Kilter credentials" }, { status: 401 });
+        }
+        throw error;
+      }
+      loginToken = kilterLogin.accessToken;
+      // The new Kilter API returns a UUID, but our DB schema uses numeric IDs.
+      // We need to resolve the numeric user ID from the sync stream data.
+      // For now, store 0 and let the first sync populate it.
+      loginUserId = 0;
+    } else {
+      const auroraClient = new AuroraClimbingClient({ boardName: boardType as AuroraBoardName });
+      let loginResponse;
+      try {
+        loginResponse = await auroraClient.signIn(username, password);
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("401")) {
+          return NextResponse.json({ error: "Invalid Aurora credentials" }, { status: 401 });
+        }
+        throw error;
+      }
+
+      if (!loginResponse.token || !loginResponse.user_id) {
+        return NextResponse.json({ error: "Invalid login response from Aurora" }, { status: 400 });
+      }
+      loginToken = loginResponse.token;
+      loginUserId = loginResponse.user_id;
     }
 
     const db = getDb();
@@ -121,7 +145,7 @@ export async function POST(request: NextRequest) {
     // Encrypt credentials
     const encryptedUsername = encrypt(username);
     const encryptedPassword = encrypt(password);
-    const encryptedToken = encrypt(loginResponse.token);
+    const encryptedToken = encrypt(loginToken);
 
     // Check if credentials already exist
     const existing = await db
@@ -142,7 +166,7 @@ export async function POST(request: NextRequest) {
         .set({
           encryptedUsername,
           encryptedPassword,
-          auroraUserId: loginResponse.user_id,
+          auroraUserId: loginUserId,
           auroraToken: encryptedToken,
           lastSyncAt: now,
           syncStatus: "active",
@@ -162,7 +186,7 @@ export async function POST(request: NextRequest) {
         boardType,
         encryptedUsername,
         encryptedPassword,
-        auroraUserId: loginResponse.user_id,
+        auroraUserId: loginUserId,
         auroraToken: encryptedToken,
         lastSyncAt: now,
         syncStatus: "active",
@@ -186,7 +210,7 @@ export async function POST(request: NextRequest) {
       await db
         .update(schema.userBoardMappings)
         .set({
-          boardUserId: loginResponse.user_id,
+          boardUserId: loginUserId,
           boardUsername: username,
           linkedAt: now,
         })
@@ -200,24 +224,30 @@ export async function POST(request: NextRequest) {
       await db.insert(schema.userBoardMappings).values({
         userId: session.user.id,
         boardType,
-        boardUserId: loginResponse.user_id,
+        boardUserId: loginUserId,
         boardUsername: username,
       });
     }
 
-    // Trigger sync in background
+    // Trigger initial sync — Kilter uses the new sync package, Tension uses Aurora sync
     let finalSyncStatus = "active";
     let finalSyncError: string | null = null;
 
     try {
-      // Sync user data from Aurora to boardsesh_ticks
-      await syncUserData(boardType as AuroraBoardName, loginResponse.token, loginResponse.user_id);
+      if (boardType === "kilter") {
+        // Kilter sync will happen via the cron job (KilterSyncRunner).
+        // The first sync is deferred because we may not have the numeric
+        // user ID yet (the OAuth2 token contains a UUID, not a number).
+        // Mark as active — the cron will pick it up.
+        console.log("[aurora-credentials] Kilter credentials saved. Sync will run via cron.");
+      } else {
+        await syncUserData(boardType as AuroraBoardName, loginToken, loginUserId);
+      }
     } catch (syncError) {
       console.error("Sync error (non-blocking):", syncError);
       finalSyncStatus = "error";
       finalSyncError = syncError instanceof Error ? syncError.message : "Sync failed";
 
-      // Update sync status to reflect error
       await db
         .update(schema.auroraCredentials)
         .set({
@@ -238,7 +268,7 @@ export async function POST(request: NextRequest) {
       credential: {
         boardType,
         auroraUsername: username,
-        auroraUserId: loginResponse.user_id,
+        auroraUserId: loginUserId,
         lastSyncAt: now.toISOString(),
         syncStatus: finalSyncStatus,
         syncError: finalSyncError,

--- a/packages/web/app/api/internal/kilter-sync-cron/route.ts
+++ b/packages/web/app/api/internal/kilter-sync-cron/route.ts
@@ -104,27 +104,34 @@ export async function GET(request: Request) {
           ),
         );
 
-      // If we don't have a numeric user ID yet, we need the sync to discover it.
-      // The sync stream will return user data that includes the numeric ID.
+      // auroraUserId may be 0 on the first sync (new Kilter OAuth2 doesn't
+      // return numeric IDs). The sync function discovers it from the response.
       const auroraUserId = cred.auroraUserId || 0;
 
       console.log(`[Kilter Sync Cron] Syncing data for user ${cred.userId} (aurora ID: ${auroraUserId})...`);
 
-      await syncKilterUserData(pool, loginResult.accessToken, auroraUserId, cred.userId);
+      const syncResult = await syncKilterUserData(pool, loginResult.accessToken, auroraUserId, cred.userId);
 
-      // Update last sync time on success
+      // Update last sync time and back-populate the numeric user ID if discovered
       {
         const updateClient = await pool.connect();
         try {
           const updateDb = drizzle(updateClient);
+          const updateFields: Record<string, unknown> = {
+            lastSyncAt: new Date(),
+            syncStatus: 'active',
+            syncError: null,
+            updatedAt: new Date(),
+          };
+
+          if (syncResult.discoveredAuroraUserId && syncResult.discoveredAuroraUserId !== auroraUserId) {
+            updateFields.auroraUserId = syncResult.discoveredAuroraUserId;
+            console.log(`[Kilter Sync Cron] Back-populated auroraUserId: ${syncResult.discoveredAuroraUserId}`);
+          }
+
           await updateDb
             .update(schema.auroraCredentials)
-            .set({
-              lastSyncAt: new Date(),
-              syncStatus: 'active',
-              syncError: null,
-              updatedAt: new Date(),
-            })
+            .set(updateFields)
             .where(
               and(
                 eq(schema.auroraCredentials.userId, cred.userId),

--- a/packages/web/app/api/internal/kilter-sync-cron/route.ts
+++ b/packages/web/app/api/internal/kilter-sync-cron/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
-import { eq, and, or, isNotNull, asc } from 'drizzle-orm';
+import { eq, and, or, isNotNull, sql } from 'drizzle-orm';
 import { decrypt, encrypt } from '@boardsesh/crypto';
 import * as schema from '@/app/lib/db/schema';
 import { KilterClient, syncKilterUserData } from '@boardsesh/kilter-sync';
@@ -52,7 +52,7 @@ export async function GET(request: Request) {
               isNotNull(schema.auroraCredentials.encryptedPassword),
             ),
           )
-          .orderBy(asc(schema.auroraCredentials.lastSyncAt))
+          .orderBy(sql`${schema.auroraCredentials.lastSyncAt} ASC NULLS FIRST`)
           .limit(1);
       } finally {
         client.release();

--- a/packages/web/app/api/internal/kilter-sync-cron/route.ts
+++ b/packages/web/app/api/internal/kilter-sync-cron/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/app/lib/db/db';
+import { eq, and, or, isNotNull, asc } from 'drizzle-orm';
+import { decrypt, encrypt } from '@boardsesh/crypto';
+import * as schema from '@/app/lib/db/schema';
+import { KilterClient, syncKilterUserData } from '@boardsesh/kilter-sync';
+import { getPool } from '@/app/lib/db/db';
+import { drizzle } from 'drizzle-orm/neon-serverless';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+interface SyncResult {
+  userId: string;
+  error?: string;
+}
+
+/**
+ * GET /api/internal/kilter-sync-cron
+ *
+ * Syncs ONE Kilter user per invocation using the new Kilter OAuth2 API.
+ * Picks the credential with the oldest lastSyncAt.
+ */
+export async function GET(request: Request) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (process.env.VERCEL_ENV !== 'development' && authHeader !== `Bearer ${CRON_SECRET}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const pool = getPool();
+
+    // Get ONE Kilter credential to sync
+    let credentials;
+    {
+      const client = await pool.connect();
+      try {
+        const db = drizzle(client);
+        credentials = await db
+          .select()
+          .from(schema.auroraCredentials)
+          .where(
+            and(
+              eq(schema.auroraCredentials.boardType, 'kilter'),
+              or(
+                eq(schema.auroraCredentials.syncStatus, 'active'),
+                eq(schema.auroraCredentials.syncStatus, 'error'),
+              ),
+              isNotNull(schema.auroraCredentials.encryptedUsername),
+              isNotNull(schema.auroraCredentials.encryptedPassword),
+            ),
+          )
+          .orderBy(asc(schema.auroraCredentials.lastSyncAt))
+          .limit(1);
+      } finally {
+        client.release();
+      }
+    }
+
+    if (credentials.length === 0) {
+      console.log('[Kilter Sync Cron] No Kilter users to sync');
+      return NextResponse.json({
+        success: true,
+        results: { total: 0, successful: 0, failed: 0, errors: [] },
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    const cred = credentials[0];
+    console.log(`[Kilter Sync Cron] Syncing user ${cred.userId}`);
+
+    const results = {
+      total: 1,
+      successful: 0,
+      failed: 0,
+      errors: [] as SyncResult[],
+    };
+
+    try {
+      if (!cred.encryptedUsername || !cred.encryptedPassword) {
+        throw new Error('Missing encrypted credentials');
+      }
+
+      const username = decrypt(cred.encryptedUsername);
+      const password = decrypt(cred.encryptedPassword);
+
+      // Authenticate with new Kilter OAuth2
+      console.log(`[Kilter Sync Cron] Authenticating via Kilter OAuth2...`);
+      const kilterClient = new KilterClient();
+      const loginResult = await kilterClient.signIn(username, password);
+
+      // Store the fresh token
+      const encryptedToken = encrypt(loginResult.accessToken);
+      const db = getDb();
+      await db
+        .update(schema.auroraCredentials)
+        .set({ auroraToken: encryptedToken, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.auroraCredentials.userId, cred.userId),
+            eq(schema.auroraCredentials.boardType, 'kilter'),
+          ),
+        );
+
+      // If we don't have a numeric user ID yet, we need the sync to discover it.
+      // The sync stream will return user data that includes the numeric ID.
+      const auroraUserId = cred.auroraUserId || 0;
+
+      console.log(`[Kilter Sync Cron] Syncing data for user ${cred.userId} (aurora ID: ${auroraUserId})...`);
+
+      await syncKilterUserData(pool, loginResult.accessToken, auroraUserId, cred.userId);
+
+      // Update last sync time on success
+      {
+        const updateClient = await pool.connect();
+        try {
+          const updateDb = drizzle(updateClient);
+          await updateDb
+            .update(schema.auroraCredentials)
+            .set({
+              lastSyncAt: new Date(),
+              syncStatus: 'active',
+              syncError: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(schema.auroraCredentials.userId, cred.userId),
+                eq(schema.auroraCredentials.boardType, 'kilter'),
+              ),
+            );
+        } finally {
+          updateClient.release();
+        }
+      }
+
+      results.successful++;
+      console.log(`[Kilter Sync Cron] Successfully synced user ${cred.userId}`);
+    } catch (error) {
+      results.failed++;
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      results.errors.push({ userId: cred.userId, error: errorMsg });
+
+      // Update sync status to error
+      const updateClient = await pool.connect();
+      try {
+        const updateDb = drizzle(updateClient);
+        await updateDb
+          .update(schema.auroraCredentials)
+          .set({
+            syncStatus: 'error',
+            syncError: errorMsg,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.auroraCredentials.userId, cred.userId),
+              eq(schema.auroraCredentials.boardType, 'kilter'),
+            ),
+          );
+      } catch (updateError) {
+        console.error(`[Kilter Sync Cron] Failed to update error status:`, updateError);
+      } finally {
+        updateClient.release();
+      }
+
+      console.error(`[Kilter Sync Cron] Failed to sync user ${cred.userId}:`, errorMsg);
+    }
+
+    return NextResponse.json({
+      success: true,
+      results,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[Kilter Sync Cron] Cron job failed:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -89,7 +89,6 @@ export function BoardCredentialCard({
 }: BoardCredentialCardProps) {
   const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
   const totalUnsynced = unsyncedCounts.ascents + unsyncedCounts.climbs;
-  const isKilter = boardType === 'kilter';
 
   const getSyncStatusTag = () => {
     if (!credential) return null;
@@ -129,23 +128,15 @@ export function BoardCredentialCard({
               {boardName} Board
             </Typography>
           </div>
-          {isKilter ? (
-            <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
-              The Kilter backend has been shut down. You can import your data using an Aurora JSON export file.
-            </Typography>
-          ) : (
-            <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
-              Not connected. Link your {boardName} account to import your Aurora data, or import from a JSON export file.
-            </Typography>
-          )}
+          <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
+            Not connected. Link your {boardName} account to import your data, or import from a JSON export file.
+          </Typography>
           <div className={styles.buttonRow}>
-            {!isKilter && (
-              <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
-                Link
-              </Button>
-            )}
+            <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
+              Link
+            </Button>
             <Button
-              variant={isKilter ? 'contained' : 'outlined'}
+              variant="outlined"
               startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
               onClick={onImportJson}
               disabled={isImporting}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
     "@auth/drizzle-adapter": "^1.11.1",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@boardsesh/crypto": "*",
+    "@boardsesh/kilter-sync": "*",
     "@boardsesh/db": "*",
     "@boardsesh/shared-schema": "*",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
## Summary
Implements user data synchronization for Kilter climbing boards using the new portal.kiltergrips.com API with OAuth2/Keycloak authentication, replacing the legacy Aurora-based sync approach.

## Key Changes

### New Package: `@boardsesh/kilter-sync`
- **KilterClient** (`kilter-client.ts`): OAuth2 authentication via Keycloak IDP with JWT token handling
  - `signIn()` method for username/password authentication
  - JWT payload decoding to extract user UUID from `sub` claim
  - Authenticated API methods (`apiGet`, `apiPost`)
  
- **Sync API** (`kilter-sync-api.ts`): Wrapper for the new sync stream endpoint at `sync1.kiltergrips.com/sync/stream`
  - Accepts same table-timestamp format as old Aurora `/sync` endpoint
  - Uses Bearer token authentication instead of cookies
  
- **User Data Sync** (`user-sync.ts`): Core sync logic with table-specific upsert handlers
  - Processes 8 user tables: users, walls, draft_climbs, ascents, bids, tags, circuits
  - Batch processing (100 rows per batch) for performance
  - Dual-write circuits to playlists table with ownership tracking
  - Converts Aurora quality scale (1-3) to Boardsesh scale (1-5)
  - Tracks sync timestamps per table to enable incremental syncs
  
- **Sync Runner** (`sync-runner.ts`): Orchestrates credential management and sync execution
  - Selects next user to sync (oldest `lastSyncAt` first)
  - Handles credential decryption and token refresh
  - Updates sync status and error tracking
  - Supports both one-off user sync and next-user-in-queue patterns

### Integration Points
- **Cron endpoint** (`kilter-sync-cron/route.ts`): Scheduled sync runner that processes one Kilter user per invocation
- **Credentials API** (`aurora-credentials/route.ts`): Updated to support Kilter OAuth2 login flow alongside existing Tension/Aurora support
- **Web package**: Added `@boardsesh/kilter-sync` dependency

## Notable Implementation Details
- Reuses existing upsert logic from Aurora sync by maintaining compatible response format
- Numeric user IDs stored in database; UUID from JWT `sub` claim used for API calls
- Circuits synced to both `boardCircuits` and `playlists` tables for compatibility
- Batch processing prevents memory issues with large datasets
- Incremental sync via timestamp tracking reduces bandwidth and processing time
- Error handling with status tracking (active/error) for credential management

https://claude.ai/code/session_01JovD5dhQgoa1WktjHX5kCF