### PR TITLE
perf: statically prerender home page

### DIFF
--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -125,9 +125,8 @@ export const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoPr
   );
 
   if (linkToHome) {
-    // Use ?select=true to bypass default board redirect and show board selector
     return (
-      <Link href="/?select=true" style={{ textDecoration: 'none', color: 'inherit', display: 'flex' }}>
+      <Link href="/" style={{ textDecoration: 'none', color: 'inherit', display: 'flex' }}>
         {logoContent}
       </Link>
     );

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -165,7 +165,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 if (boardConfigs) {
                   setShowBoardSelector(true);
                 } else {
-                  router.push('/?select=true');
+                  router.push('/');
                 }
               }}
             >

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -38,7 +38,6 @@ const UnifiedSearchDrawer = dynamic(
 
 interface HomePageContentProps {
   boardConfigs: BoardConfigData;
-  isAuthenticatedSSR?: boolean;
   initialPopularConfigs?: PopularBoardConfig[];
 }
 
@@ -101,7 +100,7 @@ function OnboardingCard({ icon, title, description, onClick }: OnboardingCardPro
   );
 }
 
-export default function HomePageContent({ boardConfigs, isAuthenticatedSSR, initialPopularConfigs }: HomePageContentProps) {
+export default function HomePageContent({ boardConfigs, initialPopularConfigs }: HomePageContentProps) {
   const { status } = useSession();
   const router = useRouter();
   const { activeSession } = usePersistentSession();
@@ -118,7 +117,7 @@ export default function HomePageContent({ boardConfigs, isAuthenticatedSSR, init
     if (findClimbersOpen) setFindClimbersMounted(true);
   }, [findClimbersOpen]);
 
-  const isAuthenticated = status === 'authenticated' ? true : (status === 'loading' ? (isAuthenticatedSSR ?? false) : false);
+  const isAuthenticated = status === 'authenticated';
 
   const { boards: discoverBoards, isLoading: isBoardsLoading } = useDiscoverBoards({ limit: 20 });
   const { configs: popularConfigs, isLoading: isConfigsLoading, isLoadingMore, hasMore, loadMore } = usePopularBoardConfigs({ limit: 12, initialData: initialPopularConfigs });

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { getServerAuthToken } from './lib/auth/server-auth';
-import ConsolidatedBoardConfig from './components/setup-wizard/consolidated-board-config';
 import { getAllBoardConfigs } from './lib/server-board-configs';
 import { getPopularBoardConfigs } from './lib/server-popular-configs';
 import HomePageContent from './home-page-content';
+
+export const revalidate = false;
 
 export const metadata: Metadata = {
   title: 'Boardsesh - Train smarter on your climbing board',
@@ -24,30 +24,15 @@ export const metadata: Metadata = {
   },
 };
 
-type HomeProps = {
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-};
-
-export default async function Home({ searchParams }: HomeProps) {
-  const params = await searchParams;
+export default async function Home() {
   const [boardConfigs, popularConfigs] = await Promise.all([
     getAllBoardConfigs(),
     getPopularBoardConfigs(),
   ]);
 
-  // Check if user explicitly wants to see the board selector
-  if (params.select === 'true') {
-    return <ConsolidatedBoardConfig boardConfigs={boardConfigs} />;
-  }
-
-  // Read auth cookie to determine if user is authenticated at SSR time
-  const authToken = await getServerAuthToken();
-  const isAuthenticatedSSR = !!authToken;
-
   return (
     <HomePageContent
       boardConfigs={boardConfigs}
-      isAuthenticatedSSR={isAuthenticatedSSR}
       initialPopularConfigs={popularConfigs}
     />
   );


### PR DESCRIPTION
## Summary
- Remove dynamic APIs (`searchParams`, `cookies()`) from the home page so Next.js can statically generate it at build time
- Add `export const revalidate = false` — page regenerates only on redeploy
- Remove legacy `?select=true` query param from logo and user drawer links
- Drop `isAuthenticatedSSR` prop — client-side `useSession()` already handles auth

Expected TTFB improvement: **~500ms → ~20-50ms** (served from Vercel edge cache instead of hitting origin on every request).

## Test plan
- [ ] Home page renders correctly in dev
- [ ] Logo links to `/` (not `/?select=true`)
- [ ] "Change Board" in user drawer navigates to `/`
- [ ] Auth-dependent "See the feed" section appears after session loads
- [ ] `bun run build:web` shows `/` as static (not dynamic/lambda)
- [ ] After deploy: `x-vercel-cache` header shows `HIT` on subsequent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)