### PR TITLE
Fix WASM file tracing for Vercel standalone output

### DIFF
--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -14,19 +14,22 @@ let renderOverlay: ((configJson: string) => Uint8Array) | null = null;
 let wasmInitPromise: Promise<void> | null = null;
 
 function findWasmPath(): string {
-  const wasmFile = 'node_modules/@boardsesh/board-renderer-wasm/pkg/board_renderer_wasm_bg.wasm';
+  const wasmFilename = 'board_renderer_wasm_bg.wasm';
   const candidates = [
-    // Vercel standalone: cwd is /var/task, node_modules at /var/task/node_modules
-    join(process.cwd(), wasmFile),
     // Monorepo dev: cwd is packages/web, workspace deps hoisted to root
-    join(process.cwd(), '..', '..', wasmFile),
-    // Vercel standalone alt: nested under packages/web
-    join(process.cwd(), 'packages', 'web', wasmFile),
+    join(process.cwd(), '..', '..', 'node_modules/@boardsesh/board-renderer-wasm/pkg', wasmFilename),
+    // Vercel standalone: cwd is /var/task, node_modules at root
+    join(process.cwd(), 'node_modules/@boardsesh/board-renderer-wasm/pkg', wasmFilename),
+    // Vercel standalone: nested under packages/web
+    join(process.cwd(), 'packages/web/node_modules/@boardsesh/board-renderer-wasm/pkg', wasmFilename),
+    // Relative to __dirname (works if file tracing copies it alongside the route)
+    join(process.cwd(), '.next/server', wasmFilename),
   ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) return candidate;
   }
-  // Return first candidate so readFile gives a clear error with the attempted path
+  // Log all searched paths to help debug Vercel deployment issues
+  console.error(`WASM file not found. cwd=${process.cwd()}, searched:`, candidates);
   return candidates[0];
 }
 

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -24,9 +24,13 @@ const nextConfig = {
       '@mui/material-nextjs',
     ],
   },
-  // Include WASM binary in standalone output for serverless functions
+  // Include WASM binary in standalone output for serverless functions.
+  // Both paths needed: monorepo root (hoisted deps) and local node_modules (symlink).
   outputFileTracingIncludes: {
-    '/api/internal/board-render': ['./node_modules/@boardsesh/board-renderer-wasm/pkg/*.wasm'],
+    '/api/internal/board-render': [
+      './node_modules/@boardsesh/board-renderer-wasm/pkg/*.wasm',
+      '../../node_modules/@boardsesh/board-renderer-wasm/pkg/*.wasm',
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary
- Fix WASM file not found on Vercel (`ENOENT` at `/var/task/packages/web/node_modules/...`)
- Add monorepo root path to `outputFileTracingIncludes` so Next.js includes the `.wasm` binary in the standalone serverless bundle
- Expand `findWasmPath()` search to cover Vercel's standalone directory layout
- Add diagnostic logging (searched paths + cwd) when WASM file can't be found

## Test plan
- [ ] Deploy to Vercel and verify `/api/internal/board-render?board_name=kilter&layout_id=1&size_id=7&set_ids=1,20&frames=p1073r42p1090r43p1157r44` returns a PNG (not ENOENT)
- [ ] If still failing, check Vercel function logs for the diagnostic output showing searched paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)