### PR TITLE
Migrate Rust renderer to Vercel Flags, relax virtualization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,7 @@
         "@types/swagger-ui-react": "^5.18.0",
         "@types/web-bluetooth": "^0.0.21",
         "@vercel/analytics": "^1.6.1",
+        "@vercel/flags": "^3.1.1",
         "@vercel/og": "^0.9.0",
         "@vercel/speed-insights": "^1.3.1",
         "bcryptjs": "^3.0.3",
@@ -451,6 +452,8 @@
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@edge-runtime/cookies": ["@edge-runtime/cookies@5.0.2", "", {}, "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -1167,6 +1170,8 @@
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
+
+    "@vercel/flags": ["@vercel/flags@3.1.1", "", { "dependencies": { "@edge-runtime/cookies": "^5.0.2", "jose": "^5.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0", "@sveltejs/kit": "*", "next": "*", "react": "*", "react-dom": "*" }, "optionalPeers": ["@opentelemetry/api", "@sveltejs/kit", "next", "react", "react-dom"] }, "sha512-JM0xXRCHvN5wiSr9C2u6PSbXMnqN/0IXyNEOob6UYWB70vBWVLUKM96wgSuj6orRzRTowItmja2RTYyRvVhuQg=="],
 
     "@vercel/og": ["@vercel/og@0.9.0", "", { "dependencies": { "@resvg/resvg-wasm": "2.4.0", "satori": "0.19.2" } }, "sha512-0BErl/dln19LMVEk2OF3BRQ44yYlKexILnZ5OuVS5Tmxe4xCl3Lpuv2VD2vyfRK4QwJDVJNOSRBIF2nw6OjHwg=="],
 
@@ -2157,6 +2162,8 @@
     "@tree-sitter-grammars/tree-sitter-yaml/node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
 
     "@tree-sitter-grammars/tree-sitter-yaml/tree-sitter": ["tree-sitter@0.22.4", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg=="],
+
+    "@vercel/flags/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 

--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -22,7 +22,7 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
 
 # Feature flags
 NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR=false
-NEXT_PUBLIC_RUST_BOARD_RENDERER_ENABLED=false
+
 
 # S3 Storage Configuration (optional, for production)
 # When these are set, avatar uploads go to S3 instead of local disk

--- a/packages/web/app/.well-known/vercel/flags/route.ts
+++ b/packages/web/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { verifyAccess, type ApiData } from '@vercel/flags';
+import { getProviderData } from '@vercel/flags/next';
+import * as flags from '../../../flags';
+
+export async function GET(request: Request) {
+  const access = await verifyAccess(request.headers.get('Authorization'));
+  if (!access) return NextResponse.json(null, { status: 401 });
+  return NextResponse.json<ApiData>(getProviderData(flags));
+}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -18,6 +18,8 @@ import { UISearchParamsProvider } from '@/app/components/queue-control/ui-search
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
 import LastUsedBoardTracker from '@/app/components/board-page/last-used-board-tracker';
 import { themeTokens } from '@/app/theme/theme-config';
+import { RustRendererProvider } from '@/app/components/board-renderer/board-renderer-context';
+import { rustSvgRendering } from '@/app/flags';
 
 export async function generateMetadata(props: { params: Promise<BoardRouteParameters> }): Promise<Metadata> {
   const params = await props.params;
@@ -70,6 +72,9 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   const { angle } = parsedParams;
 
+  // Evaluate feature flag server-side (Vercel Flags runtime control)
+  const useRustRenderer = await rustSvgRendering();
+
   // Fetch the board details server-side
   const boardDetails = getBoardDetailsForBoard(parsedParams);
 
@@ -86,6 +91,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
     : `/${boardDetails.board_name}`;
 
   return (
+    <RustRendererProvider value={useRustRenderer}>
     <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', padding: 0, background: 'var(--semantic-surface)' }}>
       <LastUsedBoardTracker
         url={listUrl}
@@ -128,5 +134,6 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
         </ConnectionSettingsProvider>
       </BoardSessionBridge>
     </div>
+    </RustRendererProvider>
   );
 }

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link';
 import { BoardDetails, BoardName } from '@/app/lib/types';
 import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import BoardImageLayers from '@/app/components/board-renderer/board-image-layers';
-import { convertLitUpHoldsStringToMap, isRustRendererEnabled } from '@/app/components/board-renderer/util';
+import { useRustRenderer } from '@/app/components/board-renderer/board-renderer-context';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
@@ -30,6 +31,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   frames,
   isMirror,
 }) => {
+  const isRustRendererEnabled = useRustRenderer();
   // Memoize board details to avoid recomputing on every render
   const boardDetails = useMemo<BoardDetails | null>(() => {
     if (!layoutId) return null;
@@ -57,7 +59,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
     if (!frames || !boardType) return undefined;
     const framesData = convertLitUpHoldsStringToMap(frames, boardType as BoardName);
     return framesData[0];
-  }, [frames, boardType]);
+  }, [frames, boardType, isRustRendererEnabled]);
 
   // Get climb view path (prefer friendly slugs)
   const climbViewPath = useMemo(() => {

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -13,6 +13,7 @@ import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton'
 import { themeTokens } from '@/app/theme/theme-config';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+import { useRustRenderer } from '@/app/components/board-renderer/board-renderer-context';
 
 type ViewMode = 'grid' | 'list';
 
@@ -165,10 +166,13 @@ const ClimbsList = ({
   );
 
   // --- Window virtualizer for list mode ---
+  // Rust renderer uses cheap <img> tags instead of SVG, so we can afford
+  // more items in the DOM for smoother scrolling (less blank flashes).
+  const isRustRenderer = useRustRenderer();
   const virtualizer = useWindowVirtualizer({
     count: climbs.length,
     estimateSize: () => ESTIMATED_LIST_ITEM_HEIGHT,
-    overscan: 5,
+    overscan: isRustRenderer ? 20 : 5,
     getItemKey: (index) => climbs[index].uuid,
   });
 

--- a/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
@@ -10,7 +10,6 @@ vi.mock('../util', () => ({
     (_bd: BoardDetails, frames: string, thumbnail?: boolean) =>
       `/api/internal/board-render?frames=${frames}${thumbnail ? '&thumbnail=1' : ''}`,
   ),
-  isRustRendererEnabled: true,
 }));
 
 import BoardImageLayers from '../board-image-layers';

--- a/packages/web/app/components/board-renderer/board-renderer-context.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer-context.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+const RustRendererContext = createContext(false);
+
+export const RustRendererProvider = RustRendererContext.Provider;
+export const useRustRenderer = () => useContext(RustRendererContext);

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -10,7 +10,8 @@ import {
   ENTER_ANIMATION_DURATION,
 } from '@/app/hooks/use-card-swipe-navigation';
 import type { BoardDetails } from '@/app/lib/types';
-import { convertLitUpHoldsStringToMap, isRustRendererEnabled } from './util';
+import { useRustRenderer } from './board-renderer-context';
+import { convertLitUpHoldsStringToMap } from './util';
 import styles from './swipe-board-carousel.module.css';
 
 interface ClimbBoardData {
@@ -94,14 +95,15 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   };
 
   const transition = getSwipeTransition();
+  const isRustRendererEnabled = useRustRenderer();
 
   const currentLitUpHoldsMap = useMemo(
     () => isRustRendererEnabled ? undefined : convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0],
-    [currentClimb.frames, boardDetails.board_name],
+    [currentClimb.frames, boardDetails.board_name, isRustRendererEnabled],
   );
   const peekLitUpHoldsMap = useMemo(
     () => isRustRendererEnabled || !peekClimb ? undefined : convertLitUpHoldsStringToMap(peekClimb.frames, boardDetails.board_name)[0],
-    [peekClimb, boardDetails.board_name],
+    [peekClimb, boardDetails.board_name, isRustRendererEnabled],
   );
 
   const renderBoard = (climb: ClimbBoardData, litUpHoldsMap: ReturnType<typeof convertLitUpHoldsStringToMap>[0] | undefined) => {

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -2,8 +2,6 @@ import { BoardDetails, BoardName } from '@/app/lib/types';
 import { BOARD_IMAGE_DIMENSIONS } from '../../lib/board-data';
 import { LitUpHoldsMap, HOLD_STATE_MAP } from './types';
 
-export const isRustRendererEnabled = process.env.NEXT_PUBLIC_RUST_BOARD_RENDERER_ENABLED === 'true';
-
 /**
  * Build the URL for the WASM-rendered overlay image.
  * Mirroring is handled via CSS (scaleX(-1)), not a separate render — halves cache variants.

--- a/packages/web/app/components/climb-card/climb-card-cover.tsx
+++ b/packages/web/app/components/climb-card/climb-card-cover.tsx
@@ -4,7 +4,8 @@ import type { Climb, BoardDetails } from '@/app/lib/types';
 import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import BoardImageLayers from '@/app/components/board-renderer/board-image-layers';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
-import { convertLitUpHoldsStringToMap, isRustRendererEnabled } from '@/app/components/board-renderer/util';
+import { useRustRenderer } from '@/app/components/board-renderer/board-renderer-context';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 
 type ClimbCardCoverProps = {
   climb?: Climb;
@@ -15,9 +16,10 @@ type ClimbCardCoverProps = {
 
 const ClimbCardCover = ({ climb, boardDetails, onClick, onDoubleClick }: ClimbCardCoverProps) => {
   const { ref, onDoubleClick: handleDoubleClick } = useDoubleTap(onDoubleClick);
+  const isRustRendererEnabled = useRustRenderer();
   const litUpHoldsMap = useMemo(
     () => climb && !isRustRendererEnabled ? convertLitUpHoldsStringToMap(climb.frames, boardDetails.board_name)[0] : undefined,
-    [climb?.frames, boardDetails.board_name],
+    [climb?.frames, boardDetails.board_name, isRustRendererEnabled],
   );
 
   const renderContent = isRustRendererEnabled && climb ? (

--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -5,8 +5,9 @@ import { usePathname } from 'next/navigation';
 import { BoardDetails, Climb } from '@/app/lib/types';
 import BoardRenderer from '../board-renderer/board-renderer';
 import BoardImageLayers from '../board-renderer/board-image-layers';
+import { useRustRenderer } from '../board-renderer/board-renderer-context';
 import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
-import { convertLitUpHoldsStringToMap, isRustRendererEnabled } from '@/app/components/board-renderer/util';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 
 type ClimbThumbnailProps = {
   currentClimb: Climb | null;
@@ -26,9 +27,10 @@ const placeholderStyle = (boardDetails: BoardDetails, maxHeight?: string): React
 
 const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, onNavigate, maxHeight }: ClimbThumbnailProps) => {
   const pathname = usePathname();
+  const isRustRendererEnabled = useRustRenderer();
   const litUpHoldsMap = useMemo(
     () => currentClimb && !isRustRendererEnabled ? convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0] : undefined,
-    [currentClimb?.frames, boardDetails.board_name],
+    [currentClimb?.frames, boardDetails.board_name, isRustRendererEnabled],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -54,7 +56,7 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  }, [isRustRendererEnabled]);
 
   if (!isVisible) {
     return <div ref={containerRef} style={placeholderStyle(boardDetails, maxHeight)} />;

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -1,0 +1,7 @@
+import { flag } from '@vercel/flags/next';
+
+export const rustSvgRendering = flag<boolean>({
+  key: 'rust-svg-rendering',
+  decide: () => false,
+  description: 'Use Rust WASM renderer for board overlays instead of SVG',
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,6 +47,7 @@
     "@types/swagger-ui-react": "^5.18.0",
     "@types/web-bluetooth": "^0.0.21",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/flags": "^3.1.1",
     "@vercel/og": "^0.9.0",
     "@vercel/speed-insights": "^1.3.1",
     "bcryptjs": "^3.0.3",


### PR DESCRIPTION
## Summary
- Migrate the Rust WASM renderer feature flag from build-time env var (`NEXT_PUBLIC_RUST_BOARD_RENDERER_ENABLED`) to **Vercel Flags** (`rust-svg-rendering`) for runtime control without redeploys
- Add `@vercel/flags` SDK with a boolean flag definition and `.well-known/vercel/flags` API route for the Vercel toolbar
- Create `RustRendererProvider` context — flag is evaluated server-side in the board layout, passed to all client components via React context
- Increase climb list virtualizer overscan from **5 to 20** when Rust renderer is active — `<img>` tags are far cheaper than SVG, so more DOM items means smoother scrolling with no blank flashes
- Activity feed thumbnails gracefully degrade to SVG renderer when outside the board layout (context defaults to `false`)

## Test plan
- [ ] `bun run typecheck:web` passes
- [ ] 16 existing tests pass (`bun test:run`)
- [ ] Deploy to Vercel preview — flag defaults to `false`, legacy SVG renderer active
- [ ] Toggle `rust-svg-rendering` flag to `true` via Vercel Flags dashboard — Rust renderer activates
- [ ] Verify climb list scrolling is smoother with increased overscan (20 items buffered vs 5)
- [ ] Verify activity feed thumbnails still render (fallback to SVG since outside board layout provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)