### PR TITLE
Fix Vercel Flags decide function to respect overrides

### DIFF
--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -2,6 +2,13 @@ import { flag } from '@vercel/flags/next';
 
 export const rustSvgRendering = flag<boolean>({
   key: 'rust-svg-rendering',
-  decide: () => false,
+  defaultValue: false,
   description: 'Use Rust WASM renderer for board overlays instead of SVG',
+  options: [
+    { value: true, label: 'Enabled' },
+    { value: false, label: 'Disabled' },
+  ],
+  decide() {
+    return this.defaultValue as boolean;
+  },
 });


### PR DESCRIPTION
## Summary
- Fix `rustSvgRendering` flag's `decide` function which was hardcoded to `() => false`, ignoring Vercel Flags dashboard overrides
- Add `defaultValue`, `options` array, and a `decide` that returns `defaultValue` — Vercel Flags middleware applies overrides before `decide` runs

## Test plan
- [ ] Deploy to Vercel, set `rust-svg-rendering` to `true` in Flags dashboard
- [ ] Verify climb list renders with Rust WASM overlay images instead of SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)