### PR TITLE
fix: RustRendererProvider crashes on client-side navigation

### DIFF
--- a/packages/web/app/components/board-renderer/board-renderer-context.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer-context.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { createContext, useContext } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 
 const RustRendererContext = createContext(false);
 
-export const RustRendererProvider = RustRendererContext.Provider;
+export const RustRendererProvider = ({ value, children }: { value: boolean; children: ReactNode }) => (
+  <RustRendererContext value={value}>{children}</RustRendererContext>
+);
+
 export const useRustRenderer = () => useContext(RustRendererContext);


### PR DESCRIPTION
## Summary

- Fixes Sentry error: "Element type is invalid. Received a promise that resolves to: Context. Lazy element type must resolve to a class or function." on the `/list` route
- In React 19, `Context.Provider` is an alias for the Context object itself. When Next.js lazy-loads the `'use client'` module during client-side navigation (e.g. from `/` to the list page), `React.lazy()` resolves to a Context object instead of a function component, which React rejects
- Replaces the bare `RustRendererContext.Provider` re-export with a proper function component wrapper

## Test plan

- [ ] Navigate from home page to a board's list view (client-side navigation) — should no longer crash
- [ ] Verify board renderer feature flag still propagates correctly through the provider
- [ ] Confirm no regressions on direct page load of the list view (SSR path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)