### PR TITLE
fix: stack overflow on /aurora-migration on iOS

### DIFF
--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -54,7 +54,7 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
   const [importError, setImportError] = useState<string | null>(null);
   const receivedCompleteRef = useRef(false);
 
-  const fetchCredential = useCallback(async () => {
+  const fetchCredential = async () => {
     try {
       const response = await fetch('/api/internal/aurora-credentials');
       if (response.ok) {
@@ -69,11 +69,12 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
     } finally {
       setLoadingCredential(false);
     }
-  }, [boardType]);
+  };
 
   useEffect(() => {
     fetchCredential();
-  }, [fetchCredential]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardType]);
 
   // --- Link Account handlers ---
 


### PR DESCRIPTION
## Summary

- Fixes Sentry error: "Maximum call stack size exceeded" (RangeError) on `/aurora-migration`, affecting iOS Chrome users
- Commit `3a583165` refactored `fetchCredential` to use `useCallback` + `useEffect([fetchCredential])`. This creates an infinite render loop when React 19 canary doesn't perfectly memoize the callback — each render creates a new ref, the effect fires, `setCredential()` triggers another render, repeat. iOS crashes first due to its ~8K frame stack limit vs ~25K on desktop
- Reverts to the original pattern: plain async function with `useEffect([boardType])`, matching the working pattern in `aurora-credentials-section.tsx`

## Test plan

- [ ] Open `/aurora-migration` on iOS Chrome/Safari — should no longer crash
- [ ] Link/unlink credentials — verify `fetchCredential()` still refreshes after save/remove
- [ ] Verify page renders correctly for both authenticated and unauthenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)