### PR TITLE
fix: WebSocket error events leaking as unhandled rejections

### DIFF
--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -72,7 +72,9 @@ export function createGraphQLClient(
   class SafeWebSocket extends WebSocket {
     constructor(url: string | URL, protocols?: string | string[]) {
       super(url, protocols);
-      this.addEventListener('error', () => {});
+      this.addEventListener('error', (event) => {
+        if (DEBUG) console.log(`[GraphQL] Client #${clientId} WebSocket native error suppressed`, event);
+      });
     }
   }
 

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -536,8 +536,9 @@ export function useSessionLifecycle({
             await execute(clientToCleanup, { query: LEAVE_SESSION }).catch(() => {});
           }
           clientToCleanup.dispose();
-        }).catch(() => {
+        }).catch((err) => {
           // Swallow errors during cleanup — the WebSocket is being torn down
+          if (DEBUG) console.log('[PersistentSession] Cleanup error suppressed:', err);
         });
       }
 


### PR DESCRIPTION
## Summary

- Fixes Sentry error: "Event `Event` (type=error) captured as promise rejection" with `target: [object WebSocket]` on the list route during party sessions
- graphql-ws uses Promises internally for connection management. During retries or disposal, native WebSocket `error` events can escape through the Promise chain as unhandled rejections — especially on flaky mobile connections
- **Fix 1:** Wrap WebSocket with a pre-attached noop error listener via `webSocketImpl`, ensuring the error event is always "handled" at the native level before graphql-ws processes it
- **Fix 2:** Add `.catch()` to the cleanup Promise chain in `use-session-lifecycle` and `await` the LEAVE_SESSION mutation before `dispose()`, preventing WebSocket termination mid-mutation

## Test plan

- [ ] Join a party session, then navigate away — no unhandled rejection in console
- [ ] Kill the backend while in a session — reconnection still works, no unhandled rejection
- [ ] Verify WebSocket connection/reconnection behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)