### PR TITLE
fix: remove decide() from feature flags to fix adapter conflict

### DIFF
--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -4,7 +4,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 
 // Only use the Vercel adapter when the FLAGS env var is available (set automatically
-// on Vercel). Locally, flags fall through to their decide() functions.
+// on Vercel). Locally, flags fall through to their defaultValue.
 const adapter = process.env.FLAGS ? vercelAdapter() : undefined;
 
 async function identify() {
@@ -22,11 +22,6 @@ export const rustSvgRendering = flag({
     { value: true, label: 'Enabled' },
     { value: false, label: 'Disabled' },
   ],
-  decide() {
-    // HOTFIX: always return false — adapter is returning true incorrectly.
-    // TODO: investigate and restore adapter-based evaluation.
-    return false;
-  },
 });
 
 // Add new flags above this line, then add them to allFlags below.


### PR DESCRIPTION
## Summary

- Removes the `decide()` function from feature flag definitions that was conflicting with the Vercel adapter
- Per the [flags SDK docs](https://flags-sdk.dev/en/docs/api-reference/frameworks/next), the adapter "implements the `decide` and `origin` functions" — providing both caused the adapter's evaluation to be bypassed, resulting in all flags returning `true` regardless of dashboard config
- With `decide()` removed, the adapter handles evaluation in production and `defaultValue: false` covers local dev

Follows up on the hotfix in 4ae87ff0 which hardcoded `decide()` to return `false`.

## Test plan

- [ ] Verify flags resolve to `false` locally (no `FLAGS` env var → `defaultValue` used)
- [ ] Verify flags respect Vercel dashboard targeting rules in preview/production deployments
- [ ] Confirm `rust-svg-rendering` is disabled in the Vercel Flags dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)