### PR TITLE
fix: restore feature flag controls for WASM renderer

### DIFF
--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { BoardDetails, Climb } from '@/app/lib/types';
+import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import BoardImageLayers from '../board-renderer/board-image-layers';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 
 type ClimbThumbnailProps = {
@@ -16,8 +19,13 @@ type ClimbThumbnailProps = {
 
 const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, onNavigate, maxHeight }: ClimbThumbnailProps) => {
   const pathname = usePathname();
+  const isRustRendererEnabled = useFeatureFlag('rust-svg-rendering');
+  const litUpHoldsMap = useMemo(
+    () => currentClimb && !isRustRendererEnabled ? convertLitUpHoldsStringToMap(currentClimb.frames, boardDetails.board_name)[0] : undefined,
+    [currentClimb?.frames, boardDetails.board_name, isRustRendererEnabled],
+  );
 
-  const renderContent = currentClimb ? (
+  const renderContent = isRustRendererEnabled && currentClimb ? (
     <BoardImageLayers
       boardDetails={boardDetails}
       frames={currentClimb.frames}
@@ -30,6 +38,8 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
         height: '100%',
       }}
     />
+  ) : currentClimb ? (
+    <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={!!currentClimb.mirrored} />
   ) : null;
 
   if (enableNavigation && currentClimb) {

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -23,9 +23,9 @@ export const rustSvgRendering = flag({
     { value: false, label: 'Disabled' },
   ],
   decide() {
-    // HOTFIX: always return false — adapter is returning true incorrectly.
-    // TODO: investigate and restore adapter-based evaluation.
-    return false;
+    // Return undefined to defer to the Vercel adapter's dashboard rules.
+    // Falls through to defaultValue (false) when no adapter is active.
+    return undefined as unknown as boolean;
   },
 });
 

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -22,11 +22,6 @@ export const rustSvgRendering = flag({
     { value: true, label: 'Enabled' },
     { value: false, label: 'Disabled' },
   ],
-  decide() {
-    // Return undefined to defer to the Vercel adapter's dashboard rules.
-    // Falls through to defaultValue (false) when no adapter is active.
-    return undefined as unknown as boolean;
-  },
 });
 
 // Add new flags above this line, then add them to allFlags below.


### PR DESCRIPTION
## Summary
- **Restore feature flag gate in ClimbThumbnail** — was unconditionally rendering `BoardImageLayers` after the rebase, bypassing the `rust-svg-rendering` flag. Now properly falls back to SVG `BoardRenderer` when the flag is off.
- **Revert flags hotfix** (`4ae87ff`) — removes the hardcoded `decide() { return false }` so flags defer to the Vercel adapter again for dashboard control.

## Test plan
- [ ] Verify flag defaults to `false` — climb list should render SVG thumbnails
- [ ] Enable `rust-svg-rendering` via Vercel Flags dashboard — thumbnails should switch to WASM-rendered WebP overlays
- [ ] Disable the flag again — thumbnails revert to SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)