### PR TITLE
feat: disable list virtualization when Rust renderer is enabled

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -13,6 +13,7 @@ import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton'
 import { themeTokens } from '@/app/theme/theme-config';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
 
 type ViewMode = 'grid' | 'list';
 
@@ -68,6 +69,8 @@ const ClimbsList = ({
   renderItemExtra,
   showBottomSpacer,
 }: ClimbsListProps) => {
+  const isRustRendererEnabled = useFeatureFlag('rust-svg-rendering');
+
   // Progressive rendering for grid mode only (list mode uses the virtualizer).
   // Show first batch immediately, rest after a frame. Only batch when the list
   // is replaced (new search), not when items are appended (infinite scroll)
@@ -106,6 +109,7 @@ const ClimbsList = ({
   );
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const useVirtualization = viewMode === 'list' && !isRustRendererEnabled;
 
   const onClimbSelectRef = useRef(onClimbSelect);
   onClimbSelectRef.current = onClimbSelect;
@@ -165,11 +169,9 @@ const ClimbsList = ({
     [boardDetails, boardDetailsMap],
   );
 
-  // --- Window virtualizer for list mode ---
-  // Items are cheap <img> tags (Rust renderer), so we use a large overscan
-  // buffer to prevent blank flashes during fast scrolling.
+  // --- Window virtualizer for list mode (disabled when Rust renderer is active) ---
   const virtualizer = useWindowVirtualizer({
-    count: climbs.length,
+    count: useVirtualization ? climbs.length : 0,
     estimateSize: () => ESTIMATED_LIST_ITEM_HEIGHT,
     overscan: 15,
     getItemKey: (index) => climbs[index].uuid,
@@ -278,8 +280,8 @@ const ClimbsList = ({
             <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} viewMode="grid" />
           ) : null}
         </Box>
-      ) : (
-        /* List (compact) mode — virtualized with window scroll */
+      ) : useVirtualization ? (
+        /* List mode — virtualized with window scroll */
         <div
           style={{
             height: virtualizer.getTotalSize(),
@@ -320,6 +322,30 @@ const ClimbsList = ({
                 </div>
               );
             })
+          )}
+        </div>
+      ) : (
+        /* List mode — non-virtualized (Rust renderer: items are cheap <img> tags) */
+        <div>
+          {isFetching && climbs.length === 0 ? (
+            <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} viewMode="list" />
+          ) : (
+            visibleClimbs.map((climb, index) => (
+              <div key={climb.uuid}>
+                <div {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}>
+                  <ClimbListItem
+                    climb={climb}
+                    boardDetails={resolveBoardDetails(climb)}
+                    selected={selectedClimbUuid === climb.uuid}
+                    onSelect={climbHandlersMap.get(climb.uuid)}
+                    onThumbnailClick={climbHandlersMap.get(climb.uuid)}
+                    disableThumbnailNavigation
+                    unsupported={unsupportedClimbs?.has(climb.uuid)}
+                  />
+                </div>
+                {renderItemExtra?.(climb)}
+              </div>
+            ))
           )}
         </div>
       )}

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -14,7 +14,6 @@ async function identify() {
 
 export const rustSvgRendering = flag({
   key: 'rust-svg-rendering',
-  adapter,
   defaultValue: false,
   description: 'Use Rust WASM renderer for board overlays instead of SVG',
   identify,
@@ -22,9 +21,11 @@ export const rustSvgRendering = flag({
     { value: true, label: 'Enabled' },
     { value: false, label: 'Disabled' },
   ],
-  decide() {
-    return false;
-  },
+  // When the adapter is available, let it be the sole decision maker.
+  // When no adapter (local dev), use decide() which falls back to defaultValue.
+  ...(adapter
+    ? { adapter }
+    : { decide: () => false as boolean }),
 });
 
 // Add new flags above this line, then add them to allFlags below.

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -44,7 +44,7 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     '/api/v1/:path*',
-    // Match all page routes but skip static files and Next.js internals
-    '/((?!_next/static|_next/image|favicon.ico|monitoring|.*\\..*).*)',
+    // Match all page routes but skip static files, Next.js internals, and Vercel Flags Explorer
+    '/((?!_next/static|_next/image|favicon.ico|monitoring|\\.well-known/vercel/flags|.*\\..*).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- When the `rust-svg-rendering` feature flag is true, the climb list skips window virtualization and renders items directly with progressive batching
- Rust renderer thumbnails are cheap `<img>` tags, so virtualization adds complexity without benefit
- Infinite scroll continues to work via the existing sentinel/IntersectionObserver

## Test plan
- [ ] Enable `rust-svg-rendering` flag and verify list mode renders without virtualization (no absolute positioning, no fixed-height container)
- [ ] Verify infinite scroll still triggers in non-virtualized list mode
- [ ] Verify switching between grid/list view modes works
- [ ] Disable the flag and confirm virtualized list mode still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)