### PR TITLE
fix: queue control bar thumbnail + A/B test metrics for Rust renderer

### DIFF
--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -34,8 +34,6 @@ const ClimbThumbnail = ({ boardDetails, currentClimb, enableNavigation = false, 
       style={{
         aspectRatio: `${boardDetails.boardWidth} / ${boardDetails.boardHeight}`,
         maxHeight: maxHeight ?? '10vh',
-        width: 'auto',
-        height: '100%',
       }}
     />
   ) : currentClimb ? (

--- a/packages/web/app/components/climb-card/drawer-climb-header.tsx
+++ b/packages/web/app/components/climb-card/drawer-climb-header.tsx
@@ -13,7 +13,7 @@ type DrawerClimbHeaderProps = {
 export default function DrawerClimbHeader({ climb, boardDetails }: DrawerClimbHeaderProps) {
   return (
     <div className={styles.drawerHeader}>
-      <div style={{ flexShrink: 0, maxWidth: 56 }}>
+      <div style={{ flexShrink: 0, width: 56 }}>
         <ClimbThumbnail boardDetails={boardDetails} currentClimb={climb} maxHeight="80px" />
       </div>
       <ClimbTitle climb={climb} gradePosition="right" titleFontSize={themeTokens.typography.fontSize.xl} showSetterInfo />

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -96,11 +96,7 @@
 
 .boardPreviewContainer {
   width: 36px;
-  height: auto;
   flex-shrink: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

- **Thumbnail fix**: `.boardPreviewContainer` used `display: flex; justify-content: center`, which sizes flex items to content width. `BoardImageLayers` has all children `position: absolute` (zero content width), collapsing the thumbnail to 0×0. Switched to block layout so children fill the 36px container width.
- **Same fix in DrawerClimbHeader**: `maxWidth: 56` → `width: 56` for the same reason.
- **A/B test metrics**: Added `FlagValues` from `flags/react` to root layout, which renders `<script data-flag-values>` in the DOM. Vercel Analytics/Speed Insights automatically correlate Web Vitals and events with flag variants.
- **Custom render timing**: `BoardImageLayers` tracks overlay image load time, `BoardRenderer` tracks SVG paint time, board-render API exposes `Server-Timing` header with WASM/Sharp durations.

## Test plan

- [ ] Enable `rust-svg-rendering` flag, add climb to queue — verify thumbnail renders in control bar
- [ ] Swipe left/right on queue bar — confirm crossfade animation works
- [ ] Disable flag — verify SVG renderer thumbnail still works
- [ ] Open play view drawer — verify DrawerClimbHeader thumbnail renders with Rust renderer
- [ ] Inspect DOM for `<script data-flag-values>` with correct values
- [ ] Check Speed Insights dashboard — "Flags" filter should appear with `rust-svg-rendering`
- [ ] Check Web Analytics — `Board Render Complete` events should appear with `renderer` property
- [ ] Check Network panel — `/api/internal/board-render` responses have `Server-Timing` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)