### PR TITLE
Add Discord invite card to home screen onboarding section

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -321,7 +321,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
             icon={<DiscordIcon />}
             title="Join the crew on Discord"
             description="Share beta, report bugs, and help shape what's next"
-            onClick={() => window.open('https://discord.gg/boardsesh', '_blank', 'noopener,noreferrer')}
+            onClick={() => window.open('https://discord.gg/YXA8GsXfQK', '_blank', 'noopener,noreferrer')}
           />
         </Box>
 

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -13,6 +13,7 @@ import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
+import SvgIcon from '@mui/material/SvgIcon';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -65,6 +66,14 @@ interface OnboardingCardProps {
   title: string;
   description: string;
   onClick: () => void;
+}
+
+function DiscordIcon() {
+  return (
+    <SvgIcon viewBox="0 -28.5 256 256">
+      <path d="M216.856 16.597A208.502 208.502 0 0 0 164.042 0c-2.275 4.113-4.933 9.645-6.766 14.046-19.692-2.961-39.203-2.961-58.533 0-1.832-4.4-4.55-9.933-6.846-14.046a207.809 207.809 0 0 0-52.855 16.638C5.618 67.147-3.443 116.4 1.087 164.956c22.169 16.555 43.653 26.612 64.775 33.193a161.094 161.094 0 0 0 13.882-22.584 136.428 136.428 0 0 1-21.846-10.632 108.636 108.636 0 0 0 5.356-4.237c42.122 19.702 87.89 19.702 129.51 0a131.66 131.66 0 0 0 5.355 4.237 136.07 136.07 0 0 1-21.886 10.653c4.006 8.02 8.638 15.67 13.862 22.564 21.142-6.58 42.646-16.637 64.815-33.213 5.316-56.288-9.08-105.09-38.056-148.36ZM85.474 135.095c-12.645 0-23.015-11.805-23.015-26.18s10.149-26.2 23.015-26.2c12.867 0 23.236 11.804 23.015 26.2.02 14.375-10.148 26.18-23.015 26.18Zm85.051 0c-12.645 0-23.014-11.805-23.014-26.18s10.148-26.2 23.014-26.2c12.867 0 23.236 11.804 23.015 26.2 0 14.375-10.148 26.18-23.015 26.18Z" />
+    </SvgIcon>
+  );
 }
 
 function OnboardingCard({ icon, title, description, onClick }: OnboardingCardProps) {
@@ -306,6 +315,13 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
             title="Connect your board"
             description="Pair via Bluetooth and light up your next climb"
             onClick={() => setSeshDrawerOpen(true)}
+          />
+
+          <OnboardingCard
+            icon={<DiscordIcon />}
+            title="Join the crew on Discord"
+            description="Share beta, report bugs, and help shape what's next"
+            onClick={() => window.open('https://discord.gg/boardsesh', '_blank', 'noopener,noreferrer')}
           />
         </Box>
 


### PR DESCRIPTION
Adds a fifth onboarding card with Discord icon that links to the
Boardsesh Discord server, matching the existing card style.

https://claude.ai/code/session_01PP2SWGGYtUw2F9RvsfiqAU