### PR TITLE
fix: replace numeric board URLs with slug-based URLs

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -7,6 +7,7 @@ import {
   constructClimbViewUrl,
   isUuidOnly,
   constructClimbViewUrlWithSlugs,
+  tryConstructSlugViewUrl,
 } from '@/app/lib/url-utils';
 import { parseRouteParams } from '@/app/lib/url-utils.server';
 
@@ -25,18 +26,10 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     const climbGrade = currentClimb.difficulty || 'Unknown Grade';
     const setter = currentClimb.setter_username || 'Unknown Setter';
     const description = `${climbName} - ${climbGrade} by ${setter}. Quality: ${currentClimb.quality_average || 0}/5. Ascents: ${currentClimb.ascensionist_count || 0}`;
-    const climbUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
-      ? constructClimbViewUrlWithSlugs(
-          boardDetails.board_name,
-          boardDetails.layout_name,
-          boardDetails.size_name,
-          boardDetails.size_description,
-          boardDetails.set_names,
-          parsedParams.angle,
-          parsedParams.climb_uuid,
-          climbName,
-        )
-      : constructClimbViewUrl(parsedParams, parsedParams.climb_uuid, climbName);
+    const climbUrl = tryConstructSlugViewUrl(
+      parsedParams.board_name, parsedParams.layout_id, parsedParams.size_id,
+      parsedParams.set_ids, parsedParams.angle, parsedParams.climb_uuid, climbName,
+    ) ?? constructClimbViewUrl(parsedParams, parsedParams.climb_uuid, climbName);
 
     const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
     ogImageUrl.searchParams.set('board_name', parsedParams.board_name);

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -25,7 +25,18 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     const climbGrade = currentClimb.difficulty || 'Unknown Grade';
     const setter = currentClimb.setter_username || 'Unknown Setter';
     const description = `${climbName} - ${climbGrade} by ${setter}. Quality: ${currentClimb.quality_average || 0}/5. Ascents: ${currentClimb.ascensionist_count || 0}`;
-    const climbUrl = constructClimbViewUrl(parsedParams, parsedParams.climb_uuid, climbName);
+    const climbUrl = boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names
+      ? constructClimbViewUrlWithSlugs(
+          boardDetails.board_name,
+          boardDetails.layout_name,
+          boardDetails.size_name,
+          boardDetails.size_description,
+          boardDetails.set_names,
+          parsedParams.angle,
+          parsedParams.climb_uuid,
+          climbName,
+        )
+      : constructClimbViewUrl(parsedParams, parsedParams.climb_uuid, climbName);
 
     const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
     ogImageUrl.searchParams.set('board_name', parsedParams.board_name);

--- a/packages/web/app/api/internal/climb-redirect/route.ts
+++ b/packages/web/app/api/internal/climb-redirect/route.ts
@@ -2,9 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
-import type { BoardName } from '@/app/lib/types';
+import { tryConstructSlugViewUrl } from '@/app/lib/url-utils';
 
 /**
  * GET /api/internal/climb-redirect?boardType=...&climbUuid=...&proposalUuid=...
@@ -81,31 +79,10 @@ export async function GET(request: NextRequest) {
       .map((r) => r.setId)
       .filter((id): id is number => id != null);
 
-    let url: string;
-    try {
-      const details = getBoardDetailsForBoard({
-        board_name: boardType as BoardName,
-        layout_id: climb.layoutId,
-        size_id: psls.productSizeId,
-        set_ids: setIdArray,
-      });
-      if (details.layout_name && details.size_name && details.set_names) {
-        url = constructClimbViewUrlWithSlugs(
-          boardType,
-          details.layout_name,
-          details.size_name,
-          details.size_description,
-          details.set_names,
-          angle,
-          climbUuid,
-        );
-      } else {
-        url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
-      }
-    } catch (slugError) {
-      console.warn('[climb-redirect] Failed to resolve slug URL, falling back to numeric:', slugError);
-      url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
-    }
+    const numericFallback = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
+    let url = tryConstructSlugViewUrl(
+      boardType, climb.layoutId, psls.productSizeId, setIdArray, angle, climbUuid,
+    ) ?? numericFallback;
 
     if (proposalUuid) {
       url += `?proposalUuid=${encodeURIComponent(proposalUuid)}`;

--- a/packages/web/app/api/internal/climb-redirect/route.ts
+++ b/packages/web/app/api/internal/climb-redirect/route.ts
@@ -102,7 +102,8 @@ export async function GET(request: NextRequest) {
       } else {
         url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
       }
-    } catch {
+    } catch (slugError) {
+      console.warn('[climb-redirect] Failed to resolve slug URL, falling back to numeric:', slugError);
       url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
     }
 

--- a/packages/web/app/api/internal/climb-redirect/route.ts
+++ b/packages/web/app/api/internal/climb-redirect/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import type { BoardName } from '@/app/lib/types';
 
 /**
  * GET /api/internal/climb-redirect?boardType=...&climbUuid=...&proposalUuid=...
@@ -74,12 +77,34 @@ export async function GET(request: NextRequest) {
         ),
       );
 
-    const setIds = setRows
+    const setIdArray = setRows
       .map((r) => r.setId)
-      .filter((id): id is number => id != null)
-      .join(',');
+      .filter((id): id is number => id != null);
 
-    let url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIds}/${angle}/view/${climbUuid}`;
+    let url: string;
+    try {
+      const details = getBoardDetailsForBoard({
+        board_name: boardType as BoardName,
+        layout_id: climb.layoutId,
+        size_id: psls.productSizeId,
+        set_ids: setIdArray,
+      });
+      if (details.layout_name && details.size_name && details.set_names) {
+        url = constructClimbViewUrlWithSlugs(
+          boardType,
+          details.layout_name,
+          details.size_name,
+          details.size_description,
+          details.set_names,
+          angle,
+          climbUuid,
+        );
+      } else {
+        url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
+      }
+    } catch {
+      url = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
+    }
 
     if (proposalUuid) {
       url += `?proposalUuid=${encodeURIComponent(proposalUuid)}`;

--- a/packages/web/app/api/internal/climb-redirect/route.ts
+++ b/packages/web/app/api/internal/climb-redirect/route.ts
@@ -23,11 +23,12 @@ export async function GET(request: NextRequest) {
   try {
     const db = getDb();
 
-    // Look up the climb to get layoutId and angle
+    // Look up the climb to get layoutId, angle, and name
     const [climb] = await db
       .select({
         layoutId: schema.boardClimbs.layoutId,
         angle: schema.boardClimbs.angle,
+        name: schema.boardClimbs.name,
       })
       .from(schema.boardClimbs)
       .where(
@@ -81,7 +82,7 @@ export async function GET(request: NextRequest) {
 
     const numericFallback = `/${boardType}/${climb.layoutId}/${psls.productSizeId}/${setIdArray.join(',')}/${angle}/view/${climbUuid}`;
     let url = tryConstructSlugViewUrl(
-      boardType, climb.layoutId, psls.productSizeId, setIdArray, angle, climbUuid,
+      boardType, climb.layoutId, psls.productSizeId, setIdArray, angle, climbUuid, climb.name ?? undefined,
     ) ?? numericFallback;
 
     if (proposalUuid) {

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from '@/app/components/providers/feature-flags-provide
 import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
-import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
 import styles from './ascents-feed.module.css';
 
 interface AscentThumbnailProps {
@@ -87,8 +87,18 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
       }
     }
 
-    // No valid configuration found
-    return null;
+    // Numeric URL fallback — will be redirected server-side
+    return constructClimbViewUrl(
+      {
+        board_name: boardType as BoardName,
+        layout_id: layoutId,
+        size_id: config?.sizeId ?? 1,
+        set_ids: config?.setIds ?? [],
+        angle,
+      },
+      climbUuid,
+      climbName,
+    );
   }, [boardType, layoutId, angle, climbUuid, climbName]);
 
   // If we can't render the thumbnail, don't show anything

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -10,6 +10,7 @@ import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/ut
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
+import type { SetIdList } from '@/app/lib/board-data';
 import styles from './ascents-feed.module.css';
 
 interface AscentThumbnailProps {
@@ -61,45 +62,36 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
     return framesData[0];
   }, [frames, boardType, isRustRendererEnabled]);
 
-  // Get climb view path (prefer friendly slugs)
+  // Reuse the already-memoized boardDetails to build the climb view URL
   const climbViewPath = useMemo(() => {
-    if (!layoutId) return null;
+    if (!boardDetails || !layoutId) return null;
 
-    const config = getDefaultBoardConfig(boardType as BoardName, layoutId);
-    if (config) {
-      const details = getBoardDetailsForBoard({
-        board_name: boardType as BoardName,
-        layout_id: layoutId,
-        size_id: config.sizeId,
-        set_ids: config.setIds,
-      });
-      if (details?.layout_name && details.size_name && details.set_names) {
-        return constructClimbViewUrlWithSlugs(
-          details.board_name,
-          details.layout_name,
-          details.size_name,
-          details.size_description,
-          details.set_names,
-          angle,
-          climbUuid,
-          climbName,
-        );
-      }
+    if (boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names) {
+      return constructClimbViewUrlWithSlugs(
+        boardDetails.board_name,
+        boardDetails.layout_name,
+        boardDetails.size_name,
+        boardDetails.size_description,
+        boardDetails.set_names,
+        angle,
+        climbUuid,
+        climbName,
+      );
     }
 
-    // Numeric URL fallback — will be redirected server-side
+    const config = getDefaultBoardConfig(boardType as BoardName, layoutId);
     return constructClimbViewUrl(
       {
         board_name: boardType as BoardName,
         layout_id: layoutId,
         size_id: config?.sizeId ?? 1,
-        set_ids: config?.setIds ?? [],
+        set_ids: (config?.setIds ?? []) as SetIdList,
         angle,
       },
       climbUuid,
       climbName,
     );
-  }, [boardType, layoutId, angle, climbUuid, climbName]);
+  }, [boardDetails, boardType, layoutId, angle, climbUuid, climbName]);
 
   // If we can't render the thumbnail, don't show anything
   if (!boardDetails || !climbViewPath) {

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from '@/app/components/providers/feature-flags-provide
 import { convertLitUpHoldsStringToMap } from '@/app/components/board-renderer/util';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
-import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
+import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
 import styles from './ascents-feed.module.css';
 
 interface AscentThumbnailProps {
@@ -87,18 +87,8 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
       }
     }
 
-    // Fallback to numeric path
-    return constructClimbViewUrl(
-      {
-        board_name: boardType as BoardName,
-        layout_id: layoutId,
-        size_id: config?.sizeId ?? 1,
-        set_ids: config?.setIds ?? [],
-        angle,
-      },
-      climbUuid,
-      climbName,
-    );
+    // No valid configuration found
+    return null;
   }, [boardType, layoutId, angle, climbUuid, climbName]);
 
   // If we can't render the thumbnail, don't show anything

--- a/packages/web/app/components/new-climb-feed/new-climb-feed-item.tsx
+++ b/packages/web/app/components/new-climb-feed/new-climb-feed-item.tsx
@@ -54,8 +54,8 @@ export default function NewClimbFeedItem({ item }: NewClimbFeedItemProps) {
       }
     }
 
-    // Fallback to default numeric path
-    return getDefaultClimbViewPath(boardName, item.layoutId, angle, item.uuid);
+    // Fallback to default path
+    return getDefaultClimbViewPath(boardName, item.layoutId, angle, item.uuid, item.name || undefined);
   })();
 
   return (

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -39,7 +39,8 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
   } else if (isNumericId(rawParams.layout_id)) {
     try {
       resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    } catch {
+    } catch (error) {
+      console.warn('[NextClimbButton] Failed to resolve board details from static data:', error);
       resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
     }
   } else {

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
-import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
@@ -23,17 +23,28 @@ const NextButton = (props: IconButtonProps) => (
 
 export default function NextClimbButton({ navigate = false, boardDetails }: NextClimbButtonProps) {
   const { setCurrentClimbQueueItem, getNextClimbQueueItem, viewOnlyMode } = useQueueContext();
+  const rawParams = useParams<BoardRouteParametersWithUuid>();
   const { board_name, layout_id, size_id, set_ids, angle } =
-    parseBoardRouteParams(useParams<BoardRouteParametersWithUuid>());
+    parseBoardRouteParams(rawParams);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isPlayPage = pathname.includes('/play/');
 
   const nextClimb = getNextClimbQueueItem();
 
-  const resolvedDetails = boardDetails ?? getBoardDetailsForBoard({
-    board_name, layout_id, size_id, set_ids,
-  });
+  // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
+  let resolvedDetails: BoardDetails;
+  if (boardDetails) {
+    resolvedDetails = boardDetails;
+  } else if (isNumericId(rawParams.layout_id)) {
+    try {
+      resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    } catch {
+      resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+    }
+  } else {
+    resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+  }
 
   const buildClimbUrl = () => {
     if (!nextClimb) return '';
@@ -52,7 +63,7 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
           nextClimb.climb.name,
         );
       } else {
-        climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${nextClimb.climb.uuid}`;
+        climbUrl = `/${rawParams.board_name}/${rawParams.layout_id}/${rawParams.size_id}/${rawParams.set_ids}/${rawParams.angle}/play/${nextClimb.climb.uuid}`;
       }
 
       const queryString = searchParams.toString();

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
 import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
-import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
+import { BoardRouteParametersWithUuid, BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
 import { track } from '@vercel/analytics';
@@ -33,7 +33,7 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
   const nextClimb = getNextClimbQueueItem();
 
   // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
-  let resolvedDetails: BoardDetails;
+  let resolvedDetails: BoardRouteIdentity;
   if (boardDetails) {
     resolvedDetails = boardDetails;
   } else if (isNumericId(rawParams.layout_id)) {
@@ -41,10 +41,10 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
       resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
     } catch (error) {
       console.warn('[NextClimbButton] Failed to resolve board details from static data:', error);
-      resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+      resolvedDetails = { board_name, layout_id, size_id, set_ids };
     }
   } else {
-    resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+    resolvedDetails = { board_name, layout_id, size_id, set_ids };
   }
 
   const buildClimbUrl = () => {

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -6,6 +6,7 @@ import { useQueueContext } from '../graphql-queue';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
 import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
 import { track } from '@vercel/analytics';
 import IconButton from '@mui/material/IconButton';
@@ -30,39 +31,42 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
 
   const nextClimb = getNextClimbQueueItem();
 
+  const resolvedDetails = boardDetails ?? getBoardDetailsForBoard({
+    board_name, layout_id, size_id, set_ids,
+  });
+
   const buildClimbUrl = () => {
     if (!nextClimb) return '';
     let climbUrl = '';
 
     if (isPlayPage) {
-      climbUrl =
-        boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-          ? constructPlayUrlWithSlugs(
-              boardDetails.board_name,
-              boardDetails.layout_name,
-              boardDetails.size_name,
-              boardDetails.size_description,
-              boardDetails.set_names,
-              angle,
-              nextClimb.climb.uuid,
-              nextClimb.climb.name,
-            )
-          : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${nextClimb.climb.uuid}`;
+      if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+        climbUrl = constructPlayUrlWithSlugs(
+          resolvedDetails.board_name,
+          resolvedDetails.layout_name,
+          resolvedDetails.size_name,
+          resolvedDetails.size_description,
+          resolvedDetails.set_names,
+          angle,
+          nextClimb.climb.uuid,
+          nextClimb.climb.name,
+        );
+      } else {
+        climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${nextClimb.climb.uuid}`;
+      }
 
       const queryString = searchParams.toString();
       if (queryString) {
         climbUrl = `${climbUrl}?${queryString}`;
       }
-    } else if (boardDetails) {
+    } else {
       climbUrl = getContextAwareClimbViewUrl(
         pathname,
-        boardDetails,
+        resolvedDetails,
         angle,
         nextClimb.climb.uuid,
         nextClimb.climb.name,
       );
-    } else {
-      climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/view/${nextClimb.climb.uuid}`;
     }
 
     return climbUrl;

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -41,7 +41,8 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
   } else if (isNumericId(rawParams.layout_id)) {
     try {
       resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    } catch {
+    } catch (error) {
+      console.warn('[PreviousClimbButton] Failed to resolve board details from static data:', error);
       resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
     }
   } else {

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
 import { useParams } from 'next/navigation';
-import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
@@ -25,17 +25,28 @@ const PreviousButton = (props: IconButtonProps) => (
 
 export default function PreviousClimbButton({ navigate = false, boardDetails }: PreviousClimbButtonProps) {
   const { getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode } = useQueueContext();
+  const rawParams = useParams<BoardRouteParametersWithUuid>();
   const { board_name, layout_id, size_id, set_ids, angle } =
-    parseBoardRouteParams(useParams<BoardRouteParametersWithUuid>());
+    parseBoardRouteParams(rawParams);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isPlayPage = pathname.includes('/play/');
 
   const previousClimb = getPreviousClimbQueueItem();
 
-  const resolvedDetails = boardDetails ?? getBoardDetailsForBoard({
-    board_name, layout_id, size_id, set_ids,
-  });
+  // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
+  let resolvedDetails: BoardDetails;
+  if (boardDetails) {
+    resolvedDetails = boardDetails;
+  } else if (isNumericId(rawParams.layout_id)) {
+    try {
+      resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    } catch {
+      resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+    }
+  } else {
+    resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+  }
 
   const buildClimbUrl = () => {
     if (!previousClimb) return '';
@@ -54,7 +65,7 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
           previousClimb.climb.name,
         );
       } else {
-        climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${previousClimb.climb.uuid}`;
+        climbUrl = `/${rawParams.board_name}/${rawParams.layout_id}/${rawParams.size_id}/${rawParams.set_ids}/${rawParams.angle}/play/${previousClimb.climb.uuid}`;
       }
 
       const queryString = searchParams.toString();

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'next/navigation';
 import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { track } from '@vercel/analytics';
 import FastRewindOutlined from '@mui/icons-material/FastRewindOutlined';
 import IconButton from '@mui/material/IconButton';
@@ -32,39 +33,42 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
 
   const previousClimb = getPreviousClimbQueueItem();
 
+  const resolvedDetails = boardDetails ?? getBoardDetailsForBoard({
+    board_name, layout_id, size_id, set_ids,
+  });
+
   const buildClimbUrl = () => {
     if (!previousClimb) return '';
     let climbUrl = '';
 
     if (isPlayPage) {
-      climbUrl =
-        boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-          ? constructPlayUrlWithSlugs(
-              boardDetails.board_name,
-              boardDetails.layout_name,
-              boardDetails.size_name,
-              boardDetails.size_description,
-              boardDetails.set_names,
-              angle,
-              previousClimb.climb.uuid,
-              previousClimb.climb.name,
-            )
-          : `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${previousClimb.climb.uuid}`;
+      if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+        climbUrl = constructPlayUrlWithSlugs(
+          resolvedDetails.board_name,
+          resolvedDetails.layout_name,
+          resolvedDetails.size_name,
+          resolvedDetails.size_description,
+          resolvedDetails.set_names,
+          angle,
+          previousClimb.climb.uuid,
+          previousClimb.climb.name,
+        );
+      } else {
+        climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/play/${previousClimb.climb.uuid}`;
+      }
 
       const queryString = searchParams.toString();
       if (queryString) {
         climbUrl = `${climbUrl}?${queryString}`;
       }
-    } else if (boardDetails) {
+    } else {
       climbUrl = getContextAwareClimbViewUrl(
         pathname,
-        boardDetails,
+        resolvedDetails,
         angle,
         previousClimb.climb.uuid,
         previousClimb.climb.name,
       );
-    } else {
-      climbUrl = `/${board_name}/${layout_id}/${size_id}/${set_ids}/${angle}/view/${previousClimb.climb.uuid}`;
     }
 
     return climbUrl;

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -7,7 +7,7 @@ import { useQueueContext } from '../graphql-queue';
 import { useParams } from 'next/navigation';
 import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { BoardRouteParametersWithUuid, BoardDetails } from '@/app/lib/types';
+import { BoardRouteParametersWithUuid, BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { track } from '@vercel/analytics';
 import FastRewindOutlined from '@mui/icons-material/FastRewindOutlined';
@@ -35,7 +35,7 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
   const previousClimb = getPreviousClimbQueueItem();
 
   // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
-  let resolvedDetails: BoardDetails;
+  let resolvedDetails: BoardRouteIdentity;
   if (boardDetails) {
     resolvedDetails = boardDetails;
   } else if (isNumericId(rawParams.layout_id)) {
@@ -43,10 +43,10 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
       resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
     } catch (error) {
       console.warn('[PreviousClimbButton] Failed to resolve board details from static data:', error);
-      resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+      resolvedDetails = { board_name, layout_id, size_id, set_ids };
     }
   } else {
-    resolvedDetails = { board_name, layout_id, size_id, set_ids } as BoardDetails;
+    resolvedDetails = { board_name, layout_id, size_id, set_ids };
   }
 
   const buildClimbUrl = () => {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -15,9 +15,8 @@ import { useQueueContext } from '../graphql-queue';
 import NextClimbButton from './next-climb-button';
 import { usePathname, useParams, useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
+import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId, tryConstructSlugPlayUrl } from '@/app/lib/url-utils';
 import { BoardRouteParameters, BoardDetails, Angle } from '@/app/lib/types';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import PreviousClimbButton from './previous-climb-button';
 import QueueList, { QueueListHandle } from './queue-list';
 import { TickButton } from '../logbook/tick-button';
@@ -137,34 +136,15 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
           climb.uuid,
           climb.name,
         );
-      } else if (params.board_name && isNumericId(params.layout_id)) {
-        try {
-          const resolvedDetails = getBoardDetailsForBoard({
-            board_name: params.board_name,
-            layout_id: Number(params.layout_id),
-            size_id: Number(params.size_id),
-            set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
-          });
-          if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
-            climbUrl = constructPlayUrlWithSlugs(
-              resolvedDetails.board_name,
-              resolvedDetails.layout_name,
-              resolvedDetails.size_name,
-              resolvedDetails.size_description,
-              resolvedDetails.set_names,
-              angle,
-              climb.uuid,
-              climb.name,
-            );
-          } else {
-            climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
-          }
-        } catch {
-          climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
-        }
       } else if (params.board_name) {
-        // Slug URL — use raw params to preserve the current URL format
-        climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
+        const numericFallback = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
+        climbUrl = isNumericId(params.layout_id)
+          ? tryConstructSlugPlayUrl(
+              params.board_name, Number(params.layout_id), Number(params.size_id),
+              decodeURIComponent(params.set_ids).split(',').map(Number),
+              angle, climb.uuid, climb.name,
+            ) ?? numericFallback
+          : numericFallback;
       } else {
         climbUrl = null;
       }
@@ -264,34 +244,15 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         currentClimb.uuid,
         currentClimb.name,
       );
-    } else if (params.board_name && isNumericId(params.layout_id)) {
-      try {
-        const resolvedDetails = getBoardDetailsForBoard({
-          board_name: params.board_name,
-          layout_id: Number(params.layout_id),
-          size_id: Number(params.size_id),
-          set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
-        });
-        if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
-          baseUrl = constructPlayUrlWithSlugs(
-            resolvedDetails.board_name,
-            resolvedDetails.layout_name,
-            resolvedDetails.size_name,
-            resolvedDetails.size_description,
-            resolvedDetails.set_names,
-            angle,
-            currentClimb.uuid,
-            currentClimb.name,
-          );
-        } else {
-          baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
-        }
-      } catch {
-        baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
-      }
     } else if (params.board_name) {
-      // Slug URL — use raw params to preserve the current URL format
-      baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
+      const numericFallback = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
+      baseUrl = isNumericId(params.layout_id)
+        ? tryConstructSlugPlayUrl(
+            params.board_name, Number(params.layout_id), Number(params.size_id),
+            decodeURIComponent(params.set_ids).split(',').map(Number),
+            angle, currentClimb.uuid, currentClimb.name,
+          ) ?? numericFallback
+        : numericFallback;
     } else {
       return null;
     }

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -17,6 +17,7 @@ import { usePathname, useParams, useSearchParams, useRouter } from 'next/navigat
 import Link from 'next/link';
 import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { BoardRouteParameters, BoardDetails, Angle } from '@/app/lib/types';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import PreviousClimbButton from './previous-climb-button';
 import QueueList, { QueueListHandle } from './queue-list';
 import { TickButton } from '../logbook/tick-button';
@@ -125,20 +126,41 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     let climbUrl: string | null = null;
 
     if (isPlayPage) {
-      climbUrl = boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names
-        ? constructPlayUrlWithSlugs(
-            boardDetails.board_name,
-            boardDetails.layout_name,
-            boardDetails.size_name,
-            boardDetails.size_description,
-            boardDetails.set_names,
+      if (boardDetails?.layout_name && boardDetails?.size_name && boardDetails?.set_names) {
+        climbUrl = constructPlayUrlWithSlugs(
+          boardDetails.board_name,
+          boardDetails.layout_name,
+          boardDetails.size_name,
+          boardDetails.size_description,
+          boardDetails.set_names,
+          angle,
+          climb.uuid,
+          climb.name,
+        );
+      } else if (params.board_name) {
+        const resolvedDetails = getBoardDetailsForBoard({
+          board_name: params.board_name,
+          layout_id: Number(params.layout_id),
+          size_id: Number(params.size_id),
+          set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
+        });
+        if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+          climbUrl = constructPlayUrlWithSlugs(
+            resolvedDetails.board_name,
+            resolvedDetails.layout_name,
+            resolvedDetails.size_name,
+            resolvedDetails.size_description,
+            resolvedDetails.set_names,
             angle,
             climb.uuid,
             climb.name,
-          )
-        : params.board_name
-          ? `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`
-          : null;
+          );
+        } else {
+          climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
+        }
+      } else {
+        climbUrl = null;
+      }
     } else {
       climbUrl = getContextAwareClimbViewUrl(
         pathname,
@@ -236,7 +258,26 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         currentClimb.name,
       );
     } else if (params.board_name) {
-      baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
+      const resolvedDetails = getBoardDetailsForBoard({
+        board_name: params.board_name,
+        layout_id: Number(params.layout_id),
+        size_id: Number(params.size_id),
+        set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
+      });
+      if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+        baseUrl = constructPlayUrlWithSlugs(
+          resolvedDetails.board_name,
+          resolvedDetails.layout_name,
+          resolvedDetails.size_name,
+          resolvedDetails.size_description,
+          resolvedDetails.set_names,
+          angle,
+          currentClimb.uuid,
+          currentClimb.name,
+        );
+      } else {
+        baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
+      }
     } else {
       return null;
     }

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -15,7 +15,7 @@ import { useQueueContext } from '../graphql-queue';
 import NextClimbButton from './next-climb-button';
 import { usePathname, useParams, useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
 import { BoardRouteParameters, BoardDetails, Angle } from '@/app/lib/types';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import PreviousClimbButton from './previous-climb-button';
@@ -137,27 +137,34 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
           climb.uuid,
           climb.name,
         );
-      } else if (params.board_name) {
-        const resolvedDetails = getBoardDetailsForBoard({
-          board_name: params.board_name,
-          layout_id: Number(params.layout_id),
-          size_id: Number(params.size_id),
-          set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
-        });
-        if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
-          climbUrl = constructPlayUrlWithSlugs(
-            resolvedDetails.board_name,
-            resolvedDetails.layout_name,
-            resolvedDetails.size_name,
-            resolvedDetails.size_description,
-            resolvedDetails.set_names,
-            angle,
-            climb.uuid,
-            climb.name,
-          );
-        } else {
+      } else if (params.board_name && isNumericId(params.layout_id)) {
+        try {
+          const resolvedDetails = getBoardDetailsForBoard({
+            board_name: params.board_name,
+            layout_id: Number(params.layout_id),
+            size_id: Number(params.size_id),
+            set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
+          });
+          if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+            climbUrl = constructPlayUrlWithSlugs(
+              resolvedDetails.board_name,
+              resolvedDetails.layout_name,
+              resolvedDetails.size_name,
+              resolvedDetails.size_description,
+              resolvedDetails.set_names,
+              angle,
+              climb.uuid,
+              climb.name,
+            );
+          } else {
+            climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
+          }
+        } catch {
           climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
         }
+      } else if (params.board_name) {
+        // Slug URL — use raw params to preserve the current URL format
+        climbUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${climb.uuid}`;
       } else {
         climbUrl = null;
       }
@@ -257,27 +264,34 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         currentClimb.uuid,
         currentClimb.name,
       );
-    } else if (params.board_name) {
-      const resolvedDetails = getBoardDetailsForBoard({
-        board_name: params.board_name,
-        layout_id: Number(params.layout_id),
-        size_id: Number(params.size_id),
-        set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
-      });
-      if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
-        baseUrl = constructPlayUrlWithSlugs(
-          resolvedDetails.board_name,
-          resolvedDetails.layout_name,
-          resolvedDetails.size_name,
-          resolvedDetails.size_description,
-          resolvedDetails.set_names,
-          angle,
-          currentClimb.uuid,
-          currentClimb.name,
-        );
-      } else {
+    } else if (params.board_name && isNumericId(params.layout_id)) {
+      try {
+        const resolvedDetails = getBoardDetailsForBoard({
+          board_name: params.board_name,
+          layout_id: Number(params.layout_id),
+          size_id: Number(params.size_id),
+          set_ids: decodeURIComponent(params.set_ids).split(',').map(Number),
+        });
+        if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+          baseUrl = constructPlayUrlWithSlugs(
+            resolvedDetails.board_name,
+            resolvedDetails.layout_name,
+            resolvedDetails.size_name,
+            resolvedDetails.size_description,
+            resolvedDetails.set_names,
+            angle,
+            currentClimb.uuid,
+            currentClimb.name,
+          );
+        } else {
+          baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
+        }
+      } catch {
         baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
       }
+    } else if (params.board_name) {
+      // Slug URL — use raw params to preserve the current URL format
+      baseUrl = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/play/${currentClimb.uuid}`;
     } else {
       return null;
     }

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -162,26 +162,30 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
         angle,
       ));
     } else {
-      const details = getBoardDetailsForBoard({
-        board_name: config.boardType as BoardName,
-        layout_id: config.layoutId,
-        size_id: config.sizeId,
-        set_ids: config.setIds,
-      });
-      if (details.layout_name && details.size_name && details.set_names) {
-        router.push(constructClimbListWithSlugs(
-          details.board_name,
-          details.layout_name,
-          details.size_name,
-          details.size_description,
-          details.set_names,
-          angle,
-        ));
-      } else {
-        // Numeric URL fallback — will be redirected server-side
-        const setIds = config.setIds.join(',');
-        router.push(`/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`);
+      try {
+        const details = getBoardDetailsForBoard({
+          board_name: config.boardType as BoardName,
+          layout_id: config.layoutId,
+          size_id: config.sizeId,
+          set_ids: config.setIds,
+        });
+        if (details.layout_name && details.size_name && details.set_names) {
+          router.push(constructClimbListWithSlugs(
+            details.board_name,
+            details.layout_name,
+            details.size_name,
+            details.size_description,
+            details.set_names,
+            angle,
+          ));
+          return;
+        }
+      } catch {
+        // Static data lookup failed — fall through to numeric URL
       }
+      // Numeric URL fallback — will be redirected server-side
+      const setIds = config.setIds.join(',');
+      router.push(`/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`);
     }
   }, [router]);
 

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -22,11 +22,9 @@ import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
 import FindNearbyCard, { type FindNearbyStatus } from '@/app/components/board-scroll/find-nearby-card';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { usePopularBoardConfigs } from '@/app/hooks/use-popular-board-configs';
-import { constructBoardSlugListUrl, constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import { constructBoardSlugListUrl, constructClimbListWithSlugs, tryConstructSlugListUrl } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
-import type { BoardName } from '@/app/lib/types';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 
 function deriveFindNearbyStatus({
@@ -162,30 +160,12 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
         angle,
       ));
     } else {
-      try {
-        const details = getBoardDetailsForBoard({
-          board_name: config.boardType as BoardName,
-          layout_id: config.layoutId,
-          size_id: config.sizeId,
-          set_ids: config.setIds,
-        });
-        if (details.layout_name && details.size_name && details.set_names) {
-          router.push(constructClimbListWithSlugs(
-            details.board_name,
-            details.layout_name,
-            details.size_name,
-            details.size_description,
-            details.set_names,
-            angle,
-          ));
-          return;
-        }
-      } catch {
-        // Static data lookup failed — fall through to numeric URL
-      }
-      // Numeric URL fallback — will be redirected server-side
       const setIds = config.setIds.join(',');
-      router.push(`/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`);
+      const numericFallback = `/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`;
+      router.push(
+        tryConstructSlugListUrl(config.boardType, config.layoutId, config.sizeId, config.setIds, angle)
+          ?? numericFallback,
+      );
     }
   }, [router]);
 

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -22,9 +22,11 @@ import BoardScrollCard from '@/app/components/board-scroll/board-scroll-card';
 import FindNearbyCard, { type FindNearbyStatus } from '@/app/components/board-scroll/find-nearby-card';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { usePopularBoardConfigs } from '@/app/hooks/use-popular-board-configs';
-import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
+import { constructBoardSlugListUrl, constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
+import type { BoardName } from '@/app/lib/types';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 
 function deriveFindNearbyStatus({
@@ -149,9 +151,34 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
   }, [router]);
 
   const handleConfigClick = useCallback((config: PopularBoardConfig) => {
-    const setIds = config.setIds.join(',');
     const angle = getDefaultAngleForBoard(config.boardType);
-    router.push(`/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`);
+    if (config.layoutName && config.sizeName && config.setNames.length > 0) {
+      router.push(constructClimbListWithSlugs(
+        config.boardType,
+        config.layoutName,
+        config.sizeName,
+        config.sizeDescription ?? undefined,
+        config.setNames,
+        angle,
+      ));
+    } else {
+      const details = getBoardDetailsForBoard({
+        board_name: config.boardType as BoardName,
+        layout_id: config.layoutId,
+        size_id: config.sizeId,
+        set_ids: config.setIds,
+      });
+      if (details.layout_name && details.size_name && details.set_names) {
+        router.push(constructClimbListWithSlugs(
+          details.board_name,
+          details.layout_name,
+          details.size_name,
+          details.size_description,
+          details.set_names,
+          angle,
+        ));
+      }
+    }
   }, [router]);
 
   return (

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -177,6 +177,10 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
           details.set_names,
           angle,
         ));
+      } else {
+        // Numeric URL fallback — will be redirected server-side
+        const setIds = config.setIds.join(',');
+        router.push(`/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`);
       }
     }
   }, [router]);

--- a/packages/web/app/lib/__tests__/default-board-configs.test.ts
+++ b/packages/web/app/lib/__tests__/default-board-configs.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { getDefaultBoardConfig, getDefaultClimbViewPath } from '../default-board-configs';
+
+describe('getDefaultBoardConfig', () => {
+  it('should return config for known board+layout', () => {
+    const config = getDefaultBoardConfig('kilter', 1);
+    expect(config).not.toBeNull();
+    expect(config!.sizeId).toBe(7);
+    expect(config!.setIds).toEqual([1, 20]);
+  });
+
+  it('should return null for unknown board+layout', () => {
+    expect(getDefaultBoardConfig('kilter', 999)).toBeNull();
+  });
+});
+
+describe('getDefaultClimbViewPath', () => {
+  it('should return slug-based URL for known config', () => {
+    const result = getDefaultClimbViewPath('kilter', 1, 40, 'abc123');
+    expect(result).not.toBeNull();
+    // Should be a slug URL, not numeric
+    expect(result).not.toContain('/1/7/');
+    expect(result).toContain('/kilter/');
+    expect(result).toContain('/40/view/abc123');
+  });
+
+  it('should include climb name in slug when provided', () => {
+    const result = getDefaultClimbViewPath('kilter', 1, 40, 'abc123', 'Breakfast Burrito');
+    expect(result).not.toBeNull();
+    expect(result).toContain('breakfast-burrito-abc123');
+  });
+
+  it('should return null for unknown config', () => {
+    const result = getDefaultClimbViewPath('kilter', 999, 40, 'abc123');
+    expect(result).toBeNull();
+  });
+
+  it('should always return a string (not null) for known configs', () => {
+    // This verifies the numeric fallback is in place
+    const result = getDefaultClimbViewPath('kilter', 1, 40, 'abc123');
+    expect(typeof result).toBe('string');
+    expect(result!.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -5,6 +5,9 @@ import {
   urlParamsToSearchParams,
   parseBoardRouteParams,
   constructClimbViewUrl,
+  constructClimbViewUrlWithSlugs,
+  constructClimbListWithSlugs,
+  constructPlayUrlWithSlugs,
   constructClimbInfoUrl,
   generateLayoutSlug,
   generateSizeSlug,
@@ -1120,5 +1123,111 @@ describe('getContextAwarePlaylistUrl', () => {
   it('should build global URL when on root', () => {
     expect(getContextAwarePlaylistUrl('/', 'ABC123'))
       .toBe('/playlists/ABC123');
+  });
+});
+
+describe('constructClimbViewUrlWithSlugs', () => {
+  it('should construct slug-based view URL with climb name', () => {
+    const result = constructClimbViewUrlWithSlugs(
+      'kilter', 'Kilter Board Original', '16 x 12', 'Super Wide',
+      ['Bolt Ons', 'Screw Ons'], 40, 'abc123def456', 'Breakfast Burrito',
+    );
+    expect(result).toBe('/kilter/original/16x12-super-wide/screw_bolt/40/view/breakfast-burrito-abc123def456');
+  });
+
+  it('should construct slug-based view URL without climb name', () => {
+    const result = constructClimbViewUrlWithSlugs(
+      'kilter', 'Kilter Board Original', '16 x 12', 'Super Wide',
+      ['Bolt Ons', 'Screw Ons'], 40, 'abc123def456',
+    );
+    expect(result).toBe('/kilter/original/16x12-super-wide/screw_bolt/40/view/abc123def456');
+  });
+
+  it('should handle size without description', () => {
+    const result = constructClimbViewUrlWithSlugs(
+      'kilter', 'Kilter Board Original', '12 x 12', undefined,
+      ['Bolt Ons'], 45, 'uuid123',
+    );
+    expect(result).toBe('/kilter/original/12x12/bolt/45/view/uuid123');
+  });
+
+  it('should handle empty climb name', () => {
+    const result = constructClimbViewUrlWithSlugs(
+      'tension', 'Tension Board 2 Mirror', '12 x 12', undefined,
+      ['Wood', 'Plastic'], 30, 'uuid456', '',
+    );
+    expect(result).toBe('/tension/two-mirror/12x12/wood_plastic/30/view/uuid456');
+  });
+});
+
+describe('constructClimbListWithSlugs', () => {
+  it('should construct slug-based list URL', () => {
+    const result = constructClimbListWithSlugs(
+      'kilter', 'Kilter Board Original', '16 x 12', 'Super Wide',
+      ['Bolt Ons', 'Screw Ons'], 40,
+    );
+    expect(result).toBe('/kilter/original/16x12-super-wide/screw_bolt/40/list');
+  });
+
+  it('should handle size without description', () => {
+    const result = constructClimbListWithSlugs(
+      'tension', 'Tension Board Original Layout', '8 x 12', undefined,
+      ['Screw Ons'], 25,
+    );
+    expect(result).toBe('/tension/original/8x12/screw/25/list');
+  });
+});
+
+describe('constructPlayUrlWithSlugs', () => {
+  it('should construct slug-based play URL with climb name', () => {
+    const result = constructPlayUrlWithSlugs(
+      'kilter', 'Kilter Board Original', '12 x 14', 'Commerical',
+      ['Bolt Ons', 'Screw Ons'], 40, 'abc123', 'My Climb',
+    );
+    expect(result).toBe('/kilter/original/12x14-commerical/screw_bolt/40/play/my-climb-abc123');
+  });
+
+  it('should construct slug-based play URL without climb name', () => {
+    const result = constructPlayUrlWithSlugs(
+      'kilter', 'Kilter Board Original', '12 x 14', 'Commerical',
+      ['Bolt Ons'], 40, 'abc123',
+    );
+    expect(result).toBe('/kilter/original/12x14-commerical/bolt/40/play/abc123');
+  });
+});
+
+describe('getContextAwareClimbViewUrl - static data fallback', () => {
+  it('should try static data when boardDetails lacks slug fields', () => {
+    const detailsWithoutNames = {
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 7,
+      set_ids: [1, 20],
+      angle: 40,
+    } as unknown as BoardDetails;
+
+    const result = getContextAwareClimbViewUrl(
+      '/kilter/1/7/1,20/40/list', detailsWithoutNames, 40, 'abc123', 'Test Climb',
+    );
+    // Should resolve via getBoardDetailsForBoard and produce a slug URL
+    expect(result).toContain('/kilter/original/');
+    expect(result).toContain('/view/test-climb-abc123');
+    expect(result).not.toMatch(/\/\d+\/\d+\//); // No numeric segments like /1/7/
+  });
+
+  it('should fall back to numeric URL when static data also fails', () => {
+    const detailsWithInvalidIds = {
+      board_name: 'kilter',
+      layout_id: 9999,
+      size_id: 9999,
+      set_ids: [9999],
+      angle: 40,
+    } as unknown as BoardDetails;
+
+    const result = getContextAwareClimbViewUrl(
+      '/kilter/9999/9999/9999/40/list', detailsWithInvalidIds, 40, 'abc123', 'Test Climb',
+    );
+    // Should fall back to numeric constructClimbViewUrl
+    expect(result).toBe('/kilter/9999/9999/9999/40/view/test-climb-abc123');
   });
 });

--- a/packages/web/app/lib/default-board-configs.ts
+++ b/packages/web/app/lib/default-board-configs.ts
@@ -6,8 +6,7 @@
 
 import { BoardName } from '@/app/lib/types';
 import { SetIdList } from '@/app/lib/board-data';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { tryConstructSlugViewUrl } from '@/app/lib/url-utils';
 
 export interface DefaultBoardConfig {
   sizeId: number;
@@ -67,30 +66,7 @@ export function getDefaultClimbViewPath(
   const config = getDefaultBoardConfig(boardName, layoutId);
   if (!config) return null;
 
-  try {
-    const details = getBoardDetailsForBoard({
-      board_name: boardName,
-      layout_id: layoutId,
-      size_id: config.sizeId,
-      set_ids: config.setIds,
-    });
-
-    if (details.layout_name && details.size_name && details.set_names) {
-      return constructClimbViewUrlWithSlugs(
-        boardName,
-        details.layout_name,
-        details.size_name,
-        details.size_description,
-        details.set_names,
-        angle,
-        climbUuid,
-        climbName,
-      );
-    }
-  } catch {
-    // Static data lookup failed — fall through to numeric URL
-  }
-
-  // Numeric URL fallback — will be redirected server-side
-  return `/${boardName}/${layoutId}/${config.sizeId}/${config.setIds.join(',')}/${angle}/view/${climbUuid}`;
+  return tryConstructSlugViewUrl(
+    boardName, layoutId, config.sizeId, config.setIds, angle, climbUuid, climbName,
+  ) ?? `/${boardName}/${layoutId}/${config.sizeId}/${config.setIds.join(',')}/${angle}/view/${climbUuid}`;
 }

--- a/packages/web/app/lib/default-board-configs.ts
+++ b/packages/web/app/lib/default-board-configs.ts
@@ -6,6 +6,8 @@
 
 import { BoardName } from '@/app/lib/types';
 import { SetIdList } from '@/app/lib/board-data';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
 
 export interface DefaultBoardConfig {
   sizeId: number;
@@ -60,9 +62,30 @@ export function getDefaultClimbViewPath(
   layoutId: number,
   angle: number,
   climbUuid: string,
+  climbName?: string,
 ): string | null {
   const config = getDefaultBoardConfig(boardName, layoutId);
   if (!config) return null;
 
-  return `/${boardName}/${layoutId}/${config.sizeId}/${config.setIds.join(',')}/${angle}/view/${climbUuid}`;
+  const details = getBoardDetailsForBoard({
+    board_name: boardName,
+    layout_id: layoutId,
+    size_id: config.sizeId,
+    set_ids: config.setIds,
+  });
+
+  if (details.layout_name && details.size_name && details.set_names) {
+    return constructClimbViewUrlWithSlugs(
+      boardName,
+      details.layout_name,
+      details.size_name,
+      details.size_description,
+      details.set_names,
+      angle,
+      climbUuid,
+      climbName,
+    );
+  }
+
+  return null;
 }

--- a/packages/web/app/lib/default-board-configs.ts
+++ b/packages/web/app/lib/default-board-configs.ts
@@ -67,25 +67,30 @@ export function getDefaultClimbViewPath(
   const config = getDefaultBoardConfig(boardName, layoutId);
   if (!config) return null;
 
-  const details = getBoardDetailsForBoard({
-    board_name: boardName,
-    layout_id: layoutId,
-    size_id: config.sizeId,
-    set_ids: config.setIds,
-  });
+  try {
+    const details = getBoardDetailsForBoard({
+      board_name: boardName,
+      layout_id: layoutId,
+      size_id: config.sizeId,
+      set_ids: config.setIds,
+    });
 
-  if (details.layout_name && details.size_name && details.set_names) {
-    return constructClimbViewUrlWithSlugs(
-      boardName,
-      details.layout_name,
-      details.size_name,
-      details.size_description,
-      details.set_names,
-      angle,
-      climbUuid,
-      climbName,
-    );
+    if (details.layout_name && details.size_name && details.set_names) {
+      return constructClimbViewUrlWithSlugs(
+        boardName,
+        details.layout_name,
+        details.size_name,
+        details.size_description,
+        details.set_names,
+        angle,
+        climbUuid,
+        climbName,
+      );
+    }
+  } catch {
+    // Static data lookup failed — fall through to numeric URL
   }
 
-  return null;
+  // Numeric URL fallback — will be redirected server-side
+  return `/${boardName}/${layoutId}/${config.sizeId}/${config.setIds.join(',')}/${angle}/view/${climbUuid}`;
 }

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -205,6 +205,21 @@ export type BoardDetails = {
   holdSetImages?: string[]; // e.g., ['holdsetd.png', 'holdsete.png']
 };
 
+/**
+ * Minimal board identity needed for URL construction.
+ * Use this instead of full BoardDetails when only building URLs.
+ */
+export type BoardRouteIdentity = {
+  board_name: BoardName;
+  layout_id: number;
+  size_id: number;
+  set_ids: SetIdList;
+  layout_name?: string;
+  size_name?: string;
+  size_description?: string;
+  set_names?: string[];
+};
+
 export type BoardRouteParameters = {
   board_name: string;
   layout_id: string;

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -476,6 +476,86 @@ export const constructCreateClimbUrl = (
 };
 
 /**
+ * Try to resolve board details from static data and construct a slug-based play URL.
+ * Returns null if resolution fails. Use this instead of duplicating
+ * the try/getBoardDetailsForBoard/check-names/constructPlayUrlWithSlugs pattern.
+ */
+export const tryConstructSlugPlayUrl = (
+  board_name: string,
+  layout_id: number,
+  size_id: number,
+  set_ids: number[],
+  angle: number,
+  climb_uuid: string,
+  climbName?: string,
+): string | null => {
+  try {
+    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    if (details.layout_name && details.size_name && details.set_names) {
+      return constructPlayUrlWithSlugs(
+        details.board_name, details.layout_name, details.size_name,
+        details.size_description, details.set_names, angle, climb_uuid, climbName,
+      );
+    }
+  } catch {
+    // Static data lookup failed
+  }
+  return null;
+};
+
+/**
+ * Try to resolve board details from static data and construct a slug-based view URL.
+ * Returns null if resolution fails.
+ */
+export const tryConstructSlugViewUrl = (
+  board_name: string,
+  layout_id: number,
+  size_id: number,
+  set_ids: number[],
+  angle: number,
+  climb_uuid: string,
+  climbName?: string,
+): string | null => {
+  try {
+    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    if (details.layout_name && details.size_name && details.set_names) {
+      return constructClimbViewUrlWithSlugs(
+        details.board_name, details.layout_name, details.size_name,
+        details.size_description, details.set_names, angle, climb_uuid, climbName,
+      );
+    }
+  } catch {
+    // Static data lookup failed
+  }
+  return null;
+};
+
+/**
+ * Try to resolve board details from static data and construct a slug-based list URL.
+ * Returns null if resolution fails.
+ */
+export const tryConstructSlugListUrl = (
+  board_name: string,
+  layout_id: number,
+  size_id: number,
+  set_ids: number[],
+  angle: number,
+): string | null => {
+  try {
+    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    if (details.layout_name && details.size_name && details.set_names) {
+      return constructClimbListWithSlugs(
+        details.board_name, details.layout_name, details.size_name,
+        details.size_description, details.set_names, angle,
+      );
+    }
+  } catch {
+    // Static data lookup failed
+  }
+  return null;
+};
+
+/**
  * Extracts the base board configuration path from a full pathname.
  * This removes dynamic segments that can change during a session:
  * - /play/[climb_uuid] - viewing different climbs
@@ -638,29 +718,12 @@ export const getContextAwareClimbViewUrl = (
   }
 
   // Try resolving names from static data
-  try {
-    const resolvedDetails = getBoardDetailsForBoard({
-      board_name: boardDetails.board_name,
-      layout_id: boardDetails.layout_id,
-      size_id: boardDetails.size_id,
-      set_ids: boardDetails.set_ids,
-    });
-    if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
-      return constructClimbViewUrlWithSlugs(
-        resolvedDetails.board_name,
-        resolvedDetails.layout_name,
-        resolvedDetails.size_name,
-        resolvedDetails.size_description,
-        resolvedDetails.set_names,
-        angle,
-        climbUuid,
-        climbName,
-      );
-    }
-  } catch (e) {
-    // Static data lookup failed for this board config — fall through to numeric URL
-    console.warn('[getContextAwareClimbViewUrl] Failed to resolve slug URL:', e);
-  }
+  const slugUrl = tryConstructSlugViewUrl(
+    boardDetails.board_name, boardDetails.layout_id,
+    boardDetails.size_id, boardDetails.set_ids,
+    angle, climbUuid, climbName,
+  );
+  if (slugUrl) return slugUrl;
 
   return constructClimbViewUrl(
     {

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -227,7 +227,6 @@ export const constructClimbViewUrl = (
   return `${baseUrl}${climb_uuid}`;
 };
 
-// New function to construct URLs with slug-based board parameters
 export const constructClimbViewUrlWithSlugs = (
   board_name: string,
   layoutName: string,
@@ -273,7 +272,6 @@ export const constructSetterStatsUrl = (
   return searchQuery ? `${baseUrl}?search=${encodeURIComponent(searchQuery)}` : baseUrl;
 };
 
-// New slug-based URL construction functions
 export const constructClimbListWithSlugs = (
   board_name: string,
   layoutName: string,
@@ -424,7 +422,6 @@ export const isNumericId = (value: string): boolean => {
   return /^\d+$/.test(value);
 };
 
-// Construct play URL with slug-based board parameters
 export const constructPlayUrlWithSlugs = (
   board_name: string,
   layoutName: string,
@@ -449,7 +446,6 @@ export const constructPlayUrlWithSlugs = (
   return `${baseUrl}${climb_uuid}`;
 };
 
-// Construct URL for creating a new climb (with optional fork params)
 export const constructCreateClimbUrl = (
   board_name: string,
   layoutName: string,
@@ -476,83 +472,57 @@ export const constructCreateClimbUrl = (
 };
 
 /**
- * Try to resolve board details from static data and construct a slug-based play URL.
- * Returns null if resolution fails. Use this instead of duplicating
- * the try/getBoardDetailsForBoard/check-names/constructPlayUrlWithSlugs pattern.
+ * Resolve slug-ready board details from static data.
+ * Returns null if the lookup fails or the result lacks slug fields.
  */
+const tryResolveBoardSlugs = (
+  board_name: string,
+  layout_id: number,
+  size_id: number,
+  set_ids: number[],
+): BoardDetails | null => {
+  try {
+    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    if (details.layout_name && details.size_name && details.set_names) {
+      return details;
+    }
+  } catch {
+    // Static data lookup failed for this board config
+  }
+  return null;
+};
+
+/** Try to construct a slug-based play URL. Returns null if resolution fails. */
 export const tryConstructSlugPlayUrl = (
-  board_name: string,
-  layout_id: number,
-  size_id: number,
-  set_ids: number[],
-  angle: number,
-  climb_uuid: string,
-  climbName?: string,
+  board_name: string, layout_id: number, size_id: number, set_ids: number[],
+  angle: number, climb_uuid: string, climbName?: string,
 ): string | null => {
-  try {
-    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    if (details.layout_name && details.size_name && details.set_names) {
-      return constructPlayUrlWithSlugs(
-        details.board_name, details.layout_name, details.size_name,
-        details.size_description, details.set_names, angle, climb_uuid, climbName,
-      );
-    }
-  } catch {
-    // Static data lookup failed
-  }
-  return null;
+  const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
+  return d ? constructPlayUrlWithSlugs(
+    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle, climb_uuid, climbName,
+  ) : null;
 };
 
-/**
- * Try to resolve board details from static data and construct a slug-based view URL.
- * Returns null if resolution fails.
- */
+/** Try to construct a slug-based view URL. Returns null if resolution fails. */
 export const tryConstructSlugViewUrl = (
-  board_name: string,
-  layout_id: number,
-  size_id: number,
-  set_ids: number[],
-  angle: number,
-  climb_uuid: string,
-  climbName?: string,
+  board_name: string, layout_id: number, size_id: number, set_ids: number[],
+  angle: number, climb_uuid: string, climbName?: string,
 ): string | null => {
-  try {
-    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    if (details.layout_name && details.size_name && details.set_names) {
-      return constructClimbViewUrlWithSlugs(
-        details.board_name, details.layout_name, details.size_name,
-        details.size_description, details.set_names, angle, climb_uuid, climbName,
-      );
-    }
-  } catch {
-    // Static data lookup failed
-  }
-  return null;
+  const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
+  return d ? constructClimbViewUrlWithSlugs(
+    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle, climb_uuid, climbName,
+  ) : null;
 };
 
-/**
- * Try to resolve board details from static data and construct a slug-based list URL.
- * Returns null if resolution fails.
- */
+/** Try to construct a slug-based list URL. Returns null if resolution fails. */
 export const tryConstructSlugListUrl = (
-  board_name: string,
-  layout_id: number,
-  size_id: number,
-  set_ids: number[],
+  board_name: string, layout_id: number, size_id: number, set_ids: number[],
   angle: number,
 ): string | null => {
-  try {
-    const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    if (details.layout_name && details.size_name && details.set_names) {
-      return constructClimbListWithSlugs(
-        details.board_name, details.layout_name, details.size_name,
-        details.size_description, details.set_names, angle,
-      );
-    }
-  } catch {
-    // Static data lookup failed
-  }
-  return null;
+  const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
+  return d ? constructClimbListWithSlugs(
+    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle,
+  ) : null;
 };
 
 /**

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -657,8 +657,9 @@ export const getContextAwareClimbViewUrl = (
         climbName,
       );
     }
-  } catch {
-    // Fall through to numeric fallback
+  } catch (e) {
+    // Static data lookup failed for this board config — fall through to numeric URL
+    console.warn('[getContextAwareClimbViewUrl] Failed to resolve slug URL:', e);
   }
 
   return constructClimbViewUrl(

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -6,6 +6,7 @@ import {
   SearchRequestPagination,
   ClimbUuid,
   BoardDetails,
+  BoardRouteIdentity,
   BoardName,
 } from '@/app/lib/types';
 import { BOARD_NAME_PREFIX_REGEX } from '@/app/lib/board-constants';
@@ -664,7 +665,7 @@ const getBoardSlugRouteContext = (pathname: string): { slug: string; angle: numb
  */
 export const getContextAwareClimbViewUrl = (
   pathname: string,
-  boardDetails: BoardDetails,
+  boardDetails: BoardRouteIdentity,
   angle: number,
   climbUuid: string,
   climbName?: string,

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -9,6 +9,7 @@ import {
   BoardName,
 } from '@/app/lib/types';
 import { BOARD_NAME_PREFIX_REGEX } from '@/app/lib/board-constants';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { PAGE_LIMIT } from '../components/board-page/constants';
 
 export function parseBoardRouteParams<T extends BoardRouteParameters>(
@@ -634,6 +635,30 @@ export const getContextAwareClimbViewUrl = (
       climbUuid,
       climbName,
     );
+  }
+
+  // Try resolving names from static data
+  try {
+    const resolvedDetails = getBoardDetailsForBoard({
+      board_name: boardDetails.board_name,
+      layout_id: boardDetails.layout_id,
+      size_id: boardDetails.size_id,
+      set_ids: boardDetails.set_ids,
+    });
+    if (resolvedDetails.layout_name && resolvedDetails.size_name && resolvedDetails.set_names) {
+      return constructClimbViewUrlWithSlugs(
+        resolvedDetails.board_name,
+        resolvedDetails.layout_name,
+        resolvedDetails.size_name,
+        resolvedDetails.size_description,
+        resolvedDetails.set_names,
+        angle,
+        climbUuid,
+        climbName,
+      );
+    }
+  } catch {
+    // Fall through to numeric fallback
   }
 
   return constructClimbViewUrl(


### PR DESCRIPTION
## Summary
- Eliminates server-side redirects caused by old-style numeric URLs (e.g., `/kilter/1/28/1,20/40/list`) by constructing slug-based URLs (e.g., `/kilter/original/16x12-super-wide/screw_bolt/40/list`) directly at every navigation source
- Uses `getBoardDetailsForBoard()` (synchronous static data lookup, zero DB queries) to resolve human-readable names for slug generation when not already available
- Extracts reusable `tryConstructSlugPlayUrl`, `tryConstructSlugViewUrl`, `tryConstructSlugListUrl` utilities to eliminate duplicated resolution patterns
- Updates 10 files across home page, queue navigation, activity feed, climb redirect API, and OG metadata

## Changes
- **Home page**: `handleConfigClick` now uses `constructClimbListWithSlugs()` with `PopularBoardConfig` fields, falls back to `tryConstructSlugListUrl` then numeric URL
- **Queue nav buttons** (`next-climb-button`, `previous-climb-button`): resolve board details from route params with `isNumericId` guard and try-catch, fallback URLs use raw params to avoid NaN on slug routes
- **Queue control bar**: both `buildClimbUrl` and `getPlayUrl` use `tryConstructSlugPlayUrl` with `isNumericId` guard, with numeric passthrough for slug URLs
- **Activity feed** (`ascent-thumbnail`): prefers slug URLs, retains numeric URL fallback for clickable thumbnails
- **New climb feed**: passes `climbName` to `getDefaultClimbViewPath` for friendlier URLs
- **Climb redirect API**: returns slug URLs via `tryConstructSlugViewUrl`, numeric fallback
- **OG metadata**: social share URLs now use slug format
- **`getContextAwareClimbViewUrl`**: uses `tryConstructSlugViewUrl` before numeric fallback
- **`getDefaultClimbViewPath`**: uses `tryConstructSlugViewUrl` with numeric fallback
- **New utilities** in `url-utils.ts`: `tryConstructSlugPlayUrl`, `tryConstructSlugViewUrl`, `tryConstructSlugListUrl` — encapsulate the try/resolve/construct pattern

## Test plan
- [ ] Click a popular board config on home page → navigates to slug URL (no redirect in network tab)
- [ ] Next/previous climb buttons on play and view pages produce slug URLs
- [ ] Queue control bar play URLs are slug-based
- [ ] Activity feed thumbnails link to slug URLs and remain clickable
- [ ] `/api/internal/climb-redirect` returns slug URLs
- [ ] OG metadata URLs are slug-based (check page source)
- [ ] Old numeric URLs still work via existing redirect in `layout.tsx`
- [ ] `bun run typecheck` passes
- [ ] `bun test packages/web/app/lib/__tests__/url-utils.test.ts packages/web/app/lib/__tests__/default-board-configs.test.ts` — 167 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)