### PR TITLE
Skip rendering transparent/hidden SVG circles across board renderers

### DIFF
--- a/packages/web/app/components/board-renderer/board-heatmap.tsx
+++ b/packages/web/app/components/board-renderer/board-heatmap.tsx
@@ -394,8 +394,8 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
             </>
           )}
 
-          {/* Interaction layer */}
-          {holdsData.map((hold) => (
+          {/* Interaction layer - only render when click handler exists */}
+          {onHoldClick && holdsData.map((hold) => (
             <circle
               key={`click-${hold.id}`}
               cx={hold.cx}
@@ -403,17 +403,13 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
               r={hold.r}
               fill="transparent"
               className="cursor-pointer"
-              onClick={
-                onHoldClick
-                  ? () => {
-                      onHoldClick(hold.id);
-                      track('Heatmap Hold Clicked', {
-                        hold_id: hold.id,
-                        boardLayout: `${boardDetails.layout_name}`,
-                      });
-                    }
-                  : undefined
-              }
+              onClick={() => {
+                onHoldClick(hold.id);
+                track('Heatmap Hold Clicked', {
+                  hold_id: hold.id,
+                  boardLayout: `${boardDetails.layout_name}`,
+                });
+              }}
             />
           ))}
 

--- a/packages/web/app/components/board-renderer/board-litup-holds.tsx
+++ b/packages/web/app/components/board-renderer/board-litup-holds.tsx
@@ -32,9 +32,11 @@ const BoardLitupHolds = React.memo(
   ({ holdsData, litUpHoldsMap, mirrored, thumbnail, onHoldClick }: BoardLitupHoldsProps) => {
     if (!holdsData) return null;
 
-    // In thumbnail mode, only render holds that are actually lit up (typically 5-15)
-    // instead of iterating all holds on the board (hundreds) with transparent circles.
-    const holdsToRender = thumbnail
+    // Skip transparent circles when they serve no purpose:
+    // - Thumbnail mode: only render lit-up holds (typically 5-15 vs hundreds)
+    // - No click handler: transparent circles are invisible and non-interactive
+    const skipTransparent = thumbnail || !onHoldClick;
+    const holdsToRender = skipTransparent
       ? holdsData.filter((hold) => {
           const entry = litUpHoldsMap[hold.id];
           return entry?.state && entry.state !== 'OFF';

--- a/packages/web/app/components/moonboard-renderer/moonboard-renderer.tsx
+++ b/packages/web/app/components/moonboard-renderer/moonboard-renderer.tsx
@@ -93,10 +93,13 @@ const MoonBoardRenderer: React.FC<MoonBoardRendererProps> = ({
         />
       ))}
 
-      {/* Render clickable grid holds */}
+      {/* Render hold circles - skip transparent ones when they serve no purpose */}
       {gridHolds.map((hold) => {
         const color = getHoldColor(hold.id);
         const isLitUp = color !== 'transparent';
+
+        // Skip transparent circles in thumbnail mode or when there's no click handler
+        if (!isLitUp && (thumbnail || !onHoldClick)) return null;
 
         return (
           <circle


### PR DESCRIPTION
Transparent circles with no click handler are invisible and non-interactive,
wasting DOM nodes. This affects three components:

- BoardLitupHolds: filter out non-lit holds when no onHoldClick (not just thumbnail)
- MoonBoardRenderer: skip transparent circles in thumbnail mode and when non-interactive
- BoardHeatmap: only render interaction layer when onHoldClick is provided

https://claude.ai/code/session_01Q4deXCGFnq1HisCkiefQem