### PR TITLE
Rank popular boards by ascents-per-problem ratio instead of raw climb count

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -227,6 +227,7 @@ export interface CachedPopularConfig {
   setIds: number[];
   setNames: string[];
   climbCount: number;
+  totalAscents: number;
   displayName: string;
 }
 
@@ -316,7 +317,8 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
       bps.description AS size_description,
       configs.set_ids,
       configs.set_names,
-      COALESCE(cc.climb_count, 0) AS climb_count
+      COALESCE(cc.climb_count, 0) AS climb_count,
+      COALESCE(cc.total_ascents, 0) AS total_ascents
     FROM (
       SELECT
         psls.board_type,
@@ -332,8 +334,12 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
     JOIN board_layouts bl ON bl.board_type = configs.board_type AND bl.id = configs.layout_id
     JOIN board_product_sizes bps ON bps.board_type = configs.board_type AND bps.id = configs.size_id
     LEFT JOIN LATERAL (
-      SELECT COUNT(*)::int AS climb_count
+      SELECT
+        COUNT(DISTINCT bc.uuid)::int AS climb_count,
+        COALESCE(SUM(bcs.ascensionist_count), 0)::int AS total_ascents
       FROM board_climbs bc
+      LEFT JOIN board_climb_stats bcs
+        ON bcs.board_type = bc.board_type AND bcs.climb_uuid = bc.uuid
       WHERE bc.board_type = configs.board_type
         AND bc.layout_id = configs.layout_id
         AND bc.is_listed = true
@@ -357,7 +363,7 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
     ) cc ON true
     WHERE bl.is_listed = true
       AND bps.is_listed = true
-    ORDER BY climb_count DESC, configs.board_type, bl.name
+    ORDER BY (total_ascents::float / NULLIF(climb_count, 0)) DESC NULLS LAST, total_ascents DESC, configs.board_type, bl.name
   `);
 
   // db.execute() returns QueryResult with .rows for neon-serverless, or an array directly for postgres-js
@@ -380,6 +386,7 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
       setIds: (row.set_ids as number[]).map(Number),
       setNames,
       climbCount: Number(row.climb_count),
+      totalAscents: Number(row.total_ascents),
       displayName: formatDisplayName(boardType, layoutName, sizeName, setNames),
     };
   });

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -264,6 +264,8 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     setNames: [String!]!
     "Number of listed climbs for this layout"
     climbCount: Int!
+    "Total sends across all climbs and angles"
+    totalAscents: Int!
     "Pre-formatted display name for UI (e.g. 'OG 12x12 Full Ride')"
     displayName: String!
   }

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -127,6 +127,7 @@ export type PopularBoardConfig = {
   setIds: number[];
   setNames: string[];
   climbCount: number;
+  totalAscents: number;
   displayName: string;
 };
 

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -214,6 +214,7 @@ describe('HomePageContent', () => {
           setIds: [26, 27],
           setNames: ['Set A', 'Set B'],
           climbCount: 500,
+          totalAscents: 5000,
           displayName: 'OG 12x12',
         },
       ];

--- a/packages/web/app/components/board-scroll/board-scroll-card.tsx
+++ b/packages/web/app/components/board-scroll/board-scroll-card.tsx
@@ -101,7 +101,7 @@ export default function BoardScrollCard({
       } else if (popularConfig) {
         const boardName = popularConfig.boardType as BoardName;
         cardName = popularConfig.displayName;
-        cardMeta = `${BOARD_TYPE_LABELS[boardName] || boardName} \u00B7 ${popularConfig.climbCount.toLocaleString()} routes`;
+        cardMeta = `${BOARD_TYPE_LABELS[boardName] || boardName} \u00B7 ${popularConfig.totalAscents.toLocaleString()} sends`;
 
         if (boardName === 'moonboard') {
           details = getMoonBoardDetails({

--- a/packages/web/app/hooks/__tests__/use-popular-board-configs.test.ts
+++ b/packages/web/app/hooks/__tests__/use-popular-board-configs.test.ts
@@ -35,6 +35,7 @@ function makeConfig(
     setIds: [1, 2],
     setNames: ['Set A', 'Set B'],
     climbCount,
+    totalAscents: climbCount * 10,
     displayName: `Layout ${boardType} Size 10`,
     ...overrides,
   };

--- a/packages/web/app/lib/graphql/operations/boards.ts
+++ b/packages/web/app/lib/graphql/operations/boards.ts
@@ -134,6 +134,7 @@ export const GET_POPULAR_BOARD_CONFIGS = gql`
         setIds
         setNames
         climbCount
+        totalAscents
         displayName
       }
       totalCount


### PR DESCRIPTION
Boards with more sends relative to their total problems now rank higher,
so popularity reflects actual usage rather than catalog size. The LATERAL
subquery joins board_climb_stats to sum ascensionist_count, and the
frontend displays total sends instead of route count.

https://claude.ai/code/session_01EUGDj3HybixtPwkaWXbRHR