### PR TITLE
Add disable-svg-virtualisation feature flag

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -71,6 +71,7 @@ const ClimbsList = ({
   showBottomSpacer,
 }: ClimbsListProps) => {
   const isRustRendererEnabled = useFeatureFlag('rust-svg-rendering');
+  const disableSvgVirtualisation = useFeatureFlag('disable-svg-virtualisation');
 
   // Progressive rendering for grid mode only (list mode uses the virtualizer).
   // Show first batch immediately, rest after a frame. Only batch when the list
@@ -122,7 +123,7 @@ const ClimbsList = ({
   );
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
-  const useVirtualization = viewMode === 'list' && !isRustRendererEnabled;
+  const useVirtualization = viewMode === 'list' && !isRustRendererEnabled && !disableSvgVirtualisation;
 
   // Track batch render timing after DOM commit
   useEffect(() => {

--- a/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-thumbnail.test.tsx
@@ -18,7 +18,7 @@ vi.mock('next/link', () => ({
 import ClimbThumbnail from '../climb-thumbnail';
 import { FeatureFlagsProvider } from '../../providers/feature-flags-provider';
 
-const defaultFlags = { 'rust-svg-rendering': false as const };
+const defaultFlags = { 'rust-svg-rendering': false as const, 'disable-svg-virtualisation': false as const };
 
 function renderWithFlags(ui: React.ReactElement) {
   return render(

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -34,8 +34,8 @@ export const disableSvgVirtualisation = flag({
   description: 'Disable list virtualisation when using SVG rendering (keeps SVG, skips windowing)',
   identify,
   options: [
-    { value: true, label: 'Enabled' },
-    { value: false, label: 'Disabled' },
+    { value: true, label: 'Virtualisation Off' },
+    { value: false, label: 'Virtualisation On' },
   ],
   ...(adapter
     ? { adapter }

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -28,8 +28,22 @@ export const rustSvgRendering = flag({
     : { decide: () => false as boolean }),
 });
 
+export const disableSvgVirtualisation = flag({
+  key: 'disable-svg-virtualisation',
+  defaultValue: false,
+  description: 'Disable list virtualisation when using SVG rendering (keeps SVG, skips windowing)',
+  identify,
+  options: [
+    { value: true, label: 'Enabled' },
+    { value: false, label: 'Disabled' },
+  ],
+  ...(adapter
+    ? { adapter }
+    : { decide: () => false as boolean }),
+});
+
 // Add new flags above this line, then add them to allFlags below.
-export const allFlags = [rustSvgRendering] as const;
+export const allFlags = [rustSvgRendering, disableSvgVirtualisation] as const;
 
 type FlagTuple = typeof allFlags;
 export type FeatureFlags = {


### PR DESCRIPTION
Adds a new feature flag that disables list virtualisation while keeping
the SVG rendering path (unlike rust-svg-rendering which switches renderer).

https://claude.ai/code/session_011TZyBeyw9FhpdFsTMBSaDy