### PR TITLE
Fix AbortError unhandled rejection on board list page (iOS Safari)

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -144,11 +144,13 @@ const ClimbsList = ({
   onClimbSelectRef.current = onClimbSelect;
 
   useEffect(() => {
-    getPreference<ViewMode>(VIEW_MODE_PREFERENCE_KEY).then((stored) => {
-      if (stored === 'grid' || stored === 'list') {
-        setViewMode(stored);
-      }
-    });
+    getPreference<ViewMode>(VIEW_MODE_PREFERENCE_KEY)
+      .then((stored) => {
+        if (stored === 'grid' || stored === 'list') {
+          setViewMode(stored);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   const handleViewModeChange = useCallback((mode: ViewMode) => {

--- a/packages/web/app/components/search-drawer/recent-searches-storage.ts
+++ b/packages/web/app/components/search-drawer/recent-searches-storage.ts
@@ -29,6 +29,10 @@ const initDB = async (): Promise<IDBPDatabase | null> => {
           db.createObjectStore(STORE_NAME);
         }
       },
+    }).catch((error) => {
+      // Reset so subsequent calls can retry instead of being permanently broken
+      dbPromise = null;
+      throw error;
     });
   }
   return dbPromise;

--- a/packages/web/app/lib/idb-helper.ts
+++ b/packages/web/app/lib/idb-helper.ts
@@ -27,6 +27,10 @@ export function createIndexedDBStore(
             db.createObjectStore(storeName);
           }
         },
+      }).catch((error) => {
+        // Reset so subsequent calls can retry instead of being permanently broken
+        dbPromise = null;
+        throw error;
       });
     }
     return dbPromise;

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -11,13 +11,28 @@ const LEGACY_LOCALSTORAGE_KEYS: Record<string, string> = {
 const getDB = createIndexedDBStore('boardsesh-user-preferences', STORE_NAME);
 
 /**
+ * Check if an error is a DOMException AbortError (code 20).
+ * These are benign on iOS Safari when the page navigates or backgrounds,
+ * causing in-flight IndexedDB transactions to abort.
+ */
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+/**
  * Get a preference value from IndexedDB.
  */
 export const getPreference = async <T>(key: string): Promise<T | null> => {
   try {
     const db = await getDB();
     if (!db) return null;
-    const value = await db.get(STORE_NAME, key);
+
+    // Use explicit transaction so we await tx.done, preventing unhandled
+    // rejections from the idb library's internal transaction promise.
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const value = await tx.store.get(key);
+    await tx.done;
+
     if (value !== undefined) return value as T;
 
     // Attempt one-time migration from localStorage
@@ -26,7 +41,9 @@ export const getPreference = async <T>(key: string): Promise<T | null> => {
       let migrated = false;
       let migratedValue: T | null = null;
       await migrateFromLocalStorage<T>(legacyKey, async (val) => {
-        await db.put(STORE_NAME, val, key);
+        const writeTx = db.transaction(STORE_NAME, 'readwrite');
+        writeTx.store.put(val, key);
+        await writeTx.done;
         migratedValue = val;
         migrated = true;
       });
@@ -35,7 +52,9 @@ export const getPreference = async <T>(key: string): Promise<T | null> => {
 
     return null;
   } catch (error) {
-    console.error('Failed to get preference:', error);
+    if (!isAbortError(error)) {
+      console.error('Failed to get preference:', error);
+    }
     return null;
   }
 };
@@ -47,9 +66,13 @@ export const setPreference = async <T>(key: string, value: T): Promise<void> => 
   try {
     const db = await getDB();
     if (!db) return;
-    await db.put(STORE_NAME, value, key);
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.store.put(value, key);
+    await tx.done;
   } catch (error) {
-    console.error('Failed to save preference:', error);
+    if (!isAbortError(error)) {
+      console.error('Failed to save preference:', error);
+    }
   }
 };
 
@@ -60,9 +83,13 @@ export const removePreference = async (key: string): Promise<void> => {
   try {
     const db = await getDB();
     if (!db) return;
-    await db.delete(STORE_NAME, key);
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.store.delete(key);
+    await tx.done;
   } catch (error) {
-    console.error('Failed to remove preference:', error);
+    if (!isAbortError(error)) {
+      console.error('Failed to remove preference:', error);
+    }
   }
 };
 


### PR DESCRIPTION
IndexedDB transactions abort during page navigation on iOS Safari, causing unhandled promise rejections from the idb library's internal transaction promises. Three fixes:

1. Use explicit transactions (db.transaction + await tx.done) in user-preferences-db so transaction abort rejections are caught by the try/catch instead of floating unhandled.

2. Reset cached dbPromise on failure in idb-helper and recent-searches-storage so a transient error doesn't permanently break all IDB operations for the page session.

3. Suppress console.error for AbortError (benign navigation artifact) and add missing .catch() in climbs-list preference loading.

https://claude.ai/code/session_01KeUXkjSf897TuAhKAoxxYU