### PR TITLE
Add user smart card to aurora migration tool and profile OG embeds

### DIFF
--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+import { sql } from '@/app/lib/db/db';
+import { themeTokens } from '@/app/theme/theme-config';
+import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+
+export const runtime = 'edge';
+
+// Maps difficulty ID to font grade name (same as profile-constants.ts)
+const DIFFICULTY_TO_GRADE: Record<number, string> = {
+  10: '4a', 11: '4b', 12: '4c',
+  13: '5a', 14: '5b', 15: '5c',
+  16: '6a', 17: '6a+', 18: '6b', 19: '6b+',
+  20: '6c', 21: '6c+',
+  22: '7a', 23: '7a+', 24: '7b', 25: '7b+', 26: '7c', 27: '7c+',
+  28: '8a', 29: '8a+', 30: '8b', 31: '8b+', 32: '8c', 33: '8c+',
+};
+
+const GRADE_ORDER = Object.values(DIFFICULTY_TO_GRADE);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('user_id');
+
+    if (!userId) {
+      return new Response('Missing user_id parameter', { status: 400 });
+    }
+
+    // Fetch user profile and grade distribution in parallel
+    const [userRows, gradeRows] = await Promise.all([
+      sql`
+        SELECT u.name, u.image, p.display_name, p.avatar_url
+        FROM users u
+        LEFT JOIN user_profiles p ON p.user_id = u.id
+        WHERE u.id = ${userId}
+        LIMIT 1
+      `,
+      sql`
+        SELECT difficulty, COUNT(DISTINCT climb_uuid) as cnt
+        FROM boardsesh_ticks
+        WHERE user_id = ${userId}
+          AND status IN ('flash', 'send')
+          AND difficulty IS NOT NULL
+        GROUP BY difficulty
+        ORDER BY difficulty
+      `,
+    ]);
+
+    if (userRows.length === 0) {
+      return new Response('User not found', { status: 404 });
+    }
+
+    const user = userRows[0];
+    const displayName = user.display_name || user.name || 'Crusher';
+    const avatarUrl = user.avatar_url || user.image;
+
+    // Build grade bars
+    const gradeBars: Array<{ grade: string; count: number; color: string }> = [];
+    let totalClimbs = 0;
+
+    for (const row of gradeRows) {
+      const difficulty = Number(row.difficulty);
+      const count = Number(row.cnt);
+      const grade = DIFFICULTY_TO_GRADE[difficulty];
+      if (!grade) continue;
+
+      totalClimbs += count;
+      const hex = FONT_GRADE_COLORS[grade.toLowerCase()];
+      const color = hex ? getGradeColorWithOpacity(hex, 0.5) : 'rgba(200, 200, 200, 0.5)';
+      gradeBars.push({ grade, count, color });
+    }
+
+    // Sort by grade order
+    gradeBars.sort((a, b) => GRADE_ORDER.indexOf(a.grade) - GRADE_ORDER.indexOf(b.grade));
+
+    const maxCount = Math.max(...gradeBars.map((b) => b.count), 1);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            background: '#FFFFFF',
+            padding: '60px 80px',
+            gap: '40px',
+          }}
+        >
+          {/* Top section: Avatar + Name */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '32px',
+              width: '100%',
+            }}
+          >
+            {avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={avatarUrl}
+                alt=""
+                width={120}
+                height={120}
+                style={{
+                  borderRadius: '60px',
+                  objectFit: 'cover',
+                }}
+              />
+            ) : (
+              <div
+                style={{
+                  width: '120px',
+                  height: '120px',
+                  borderRadius: '60px',
+                  background: themeTokens.neutral[200],
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '48px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {displayName.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '48px',
+                  fontWeight: 'bold',
+                  color: themeTokens.neutral[900],
+                  lineHeight: 1.2,
+                }}
+              >
+                {displayName}
+              </div>
+              <div
+                style={{
+                  fontSize: '24px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {totalClimbs > 0
+                  ? `${totalClimbs} distinct climb${totalClimbs !== 1 ? 's' : ''}`
+                  : 'Boardsesh climber'}
+              </div>
+            </div>
+          </div>
+
+          {/* Grade chart */}
+          {gradeBars.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                gap: '8px',
+              }}
+            >
+              {/* Bars */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  gap: '4px',
+                  height: '160px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      height: `${Math.max((bar.count / maxCount) * 100, 5)}%`,
+                      backgroundColor: bar.color,
+                      borderRadius: '3px 3px 0 0',
+                    }}
+                  />
+                ))}
+              </div>
+              {/* Labels */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '4px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      fontSize: '14px',
+                      textAlign: 'center',
+                      color: themeTokens.neutral[400],
+                    }}
+                  >
+                    {bar.grade}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Branding */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '24px',
+              right: '40px',
+              fontSize: '20px',
+              color: themeTokens.neutral[300],
+              fontWeight: 600,
+            }}
+          >
+            boardsesh.com
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (error) {
+    console.error('Error generating profile OG image:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Error generating image: ${message}`, { status: 500 });
+  }
+}

--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import Box from '@mui/material/Box';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -17,13 +17,19 @@ import {
 import { useSession } from 'next-auth/react';
 import AuthModal from '@/app/components/auth/auth-modal';
 import BoardImportPrompt from '@/app/components/settings/board-import-prompt';
+import UserSmartCard from '@/app/components/social/user-smart-card';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './aurora-migration.module.css';
 
 export default function AuroraMigrationContent() {
   const { data: session, status } = useSession();
   const [authModalOpen, setAuthModalOpen] = useState(false);
+  const [importRefreshKey, setImportRefreshKey] = useState(0);
   const isAuthenticated = status === 'authenticated';
+
+  const handleImportComplete = useCallback(() => {
+    setImportRefreshKey((prev: number) => prev + 1);
+  }, []);
 
   return (
     <Box className={styles.pageLayout}>
@@ -186,10 +192,38 @@ export default function AuroraMigrationContent() {
                       Kilter. For Tension, linking your account will automatically sync
                       your data every 12 hours so you always have a backup.
                     </Typography>
-                    <BoardImportPrompt boardType="kilter" />
-                    <BoardImportPrompt boardType="tension" />
+                    <BoardImportPrompt boardType="kilter" onImportComplete={handleImportComplete} />
+                    <BoardImportPrompt boardType="tension" onImportComplete={handleImportComplete} />
                   </Stack>
                 )}
+
+                {/* Step 4: Your profile */}
+                <div className={styles.stepRow}>
+                  <MuiAvatar
+                    className={styles.stepNumber}
+                    sx={{
+                      width: 32,
+                      height: 32,
+                      fontSize: 14,
+                      fontWeight: 600,
+                      bgcolor: themeTokens.colors.primary,
+                    }}
+                  >
+                    4
+                  </MuiAvatar>
+                  <div className={styles.stepContent}>
+                    <Typography variant="h6" sx={{ mb: 1 }}>
+                      Your Boardsesh profile
+                    </Typography>
+                    {isAuthenticated && session?.user?.id ? (
+                      <UserSmartCard userId={session.user.id} refreshKey={importRefreshKey} />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        Sign in first to see your profile.
+                      </Typography>
+                    )}
+                  </div>
+                </div>
               </Stack>
             </CardContent>
           </MuiCard>

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -30,9 +30,10 @@ import styles from './aurora-credentials-section.module.css';
 
 interface BoardImportPromptProps {
   boardType: 'kilter' | 'tension';
+  onImportComplete?: () => void;
 }
 
-export default function BoardImportPrompt({ boardType }: BoardImportPromptProps) {
+export default function BoardImportPrompt({ boardType, onImportComplete }: BoardImportPromptProps) {
   const { showMessage } = useSnackbar();
   const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
 
@@ -215,6 +216,7 @@ export default function BoardImportPrompt({ boardType }: BoardImportPromptProps)
             receivedCompleteRef.current = true;
             setImportResult(event.results);
             setImportPhase('complete');
+            onImportComplete?.();
             {
               const totalImported =
                 event.results.ascents.imported +

--- a/packages/web/app/components/social/user-smart-card.module.css
+++ b/packages/web/app/components/social/user-smart-card.module.css
@@ -1,0 +1,103 @@
+.card {
+  overflow: hidden;
+}
+
+.cardInner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.infoSection {
+  flex: 1;
+  min-width: 0;
+}
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.chartSection {
+  margin-top: 12px;
+}
+
+.chartLabel {
+  margin-bottom: 6px;
+}
+
+.gradeBarContainer {
+  display: flex;
+  gap: 2px;
+  align-items: flex-end;
+  height: 32px;
+}
+
+.gradeBar {
+  flex: 1;
+  min-width: 4px;
+  max-width: 24px;
+  border-radius: 2px 2px 0 0;
+  transition: opacity 0.15s ease;
+}
+
+.gradeLegend {
+  display: flex;
+  gap: 2px;
+  margin-top: 2px;
+}
+
+.gradeLegendLabel {
+  flex: 1;
+  min-width: 4px;
+  max-width: 24px;
+  text-align: center;
+  font-size: 8px;
+  color: var(--neutral-400);
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.arrowIcon {
+  flex-shrink: 0;
+  color: var(--neutral-400);
+}
+
+/* Loading skeleton */
+.skeletonRow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.skeletonInfo {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (max-width: 576px) {
+  .cardInner {
+    gap: 12px;
+  }
+
+  .gradeBarContainer {
+    height: 24px;
+  }
+
+  .gradeLegendLabel {
+    font-size: 7px;
+  }
+}

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import MuiCard from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import MuiAvatar from '@mui/material/Avatar';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Box from '@mui/material/Box';
+import { PersonOutlined, ArrowForwardIos } from '@mui/icons-material';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  GET_USER_PROFILE_STATS,
+  type GetUserProfileStatsQueryVariables,
+  type GetUserProfileStatsQueryResponse,
+} from '@/app/lib/graphql/operations';
+import { difficultyMapping } from '@/app/crusher/[user_id]/utils/profile-constants';
+import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import styles from './user-smart-card.module.css';
+
+interface UserSmartCardProps {
+  userId: string;
+  refreshKey?: number;
+}
+
+interface ProfileData {
+  id: string;
+  name: string | null;
+  image: string | null;
+  profile: {
+    displayName: string | null;
+    avatarUrl: string | null;
+  } | null;
+  credentials?: Array<{
+    boardType: string;
+    auroraUsername: string;
+  }>;
+  followerCount: number;
+  followingCount: number;
+}
+
+interface GradeBar {
+  grade: string;
+  count: number;
+  color: string;
+}
+
+const GRADE_ORDER = Object.values(difficultyMapping);
+const CHIP_SX = { height: 20, fontSize: '0.7rem' } as const;
+
+export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardProps) {
+  const router = useRouter();
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [totalClimbs, setTotalClimbs] = useState(0);
+  const [gradeBars, setGradeBars] = useState<GradeBar[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [profileRes, statsData] = await Promise.all([
+        fetch(`/api/internal/profile/${userId}`).then((r) => (r.ok ? r.json() : null)),
+        (async () => {
+          try {
+            const client = createGraphQLHttpClient(null);
+            const res = await client.request<GetUserProfileStatsQueryResponse, GetUserProfileStatsQueryVariables>(
+              GET_USER_PROFILE_STATS,
+              { userId },
+            );
+            return res.userProfileStats;
+          } catch {
+            return null;
+          }
+        })(),
+      ]);
+
+      if (profileRes) {
+        setProfile(profileRes);
+      }
+
+      if (statsData) {
+        setTotalClimbs(statsData.totalDistinctClimbs);
+
+        // Aggregate grade counts across all layouts
+        const gradeAgg: Record<number, number> = {};
+        for (const layout of statsData.layoutStats) {
+          for (const gc of layout.gradeCounts) {
+            const num = parseInt(gc.grade, 10);
+            if (!isNaN(num)) {
+              gradeAgg[num] = (gradeAgg[num] || 0) + gc.count;
+            }
+          }
+        }
+
+        // Convert to sorted bars
+        const bars: GradeBar[] = Object.entries(gradeAgg)
+          .map(([numStr, count]) => {
+            const num = parseInt(numStr, 10);
+            const grade = difficultyMapping[num] || numStr;
+            const hex = FONT_GRADE_COLORS[grade.toLowerCase()];
+            const color = hex ? getGradeColorWithOpacity(hex, 0.4) : 'rgba(200, 200, 200, 0.4)';
+            return { grade, count, color };
+          })
+          .sort((a: GradeBar, b: GradeBar) => GRADE_ORDER.indexOf(a.grade) - GRADE_ORDER.indexOf(b.grade));
+
+        setGradeBars(bars);
+      }
+    } catch {
+      // Silently fail — card is a nice-to-have
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const maxCount = useMemo(() => Math.max(...gradeBars.map((b: GradeBar) => b.count), 1), [gradeBars]);
+
+  const displayName = profile?.profile?.displayName || profile?.name || 'Crusher';
+  const avatarUrl = profile?.profile?.avatarUrl || profile?.image;
+
+  if (loading) {
+    return (
+      <MuiCard variant="outlined" className={styles.card}>
+        <CardContent>
+          <div className={styles.skeletonRow}>
+            <Skeleton variant="circular" width={48} height={48} />
+            <div className={styles.skeletonInfo}>
+              <Skeleton variant="text" width="60%" height={24} />
+              <Skeleton variant="text" width="40%" height={16} />
+              <Skeleton variant="rectangular" width="100%" height={32} sx={{ borderRadius: 0.5, mt: 1 }} />
+            </div>
+          </div>
+        </CardContent>
+      </MuiCard>
+    );
+  }
+
+  if (!profile) return null;
+
+  return (
+    <MuiCard variant="outlined" className={styles.card}>
+      <CardActionArea onClick={() => router.push(`/crusher/${userId}`)}>
+        <CardContent>
+          <div className={styles.cardInner}>
+            <MuiAvatar src={avatarUrl ?? undefined} sx={{ width: 48, height: 48 }}>
+              {!avatarUrl && <PersonOutlined />}
+            </MuiAvatar>
+
+            <div className={styles.infoSection}>
+              <div className={styles.nameRow}>
+                <Typography variant="subtitle1" component="span" fontWeight={600} noWrap>
+                  {displayName}
+                </Typography>
+              </div>
+
+              <Typography variant="caption" component="span" color="text.secondary">
+                {profile.followerCount} follower{profile.followerCount !== 1 ? 's' : ''}
+                {' · '}
+                {profile.followingCount} following
+              </Typography>
+
+              {profile.credentials && profile.credentials.length > 0 && (
+                <div className={styles.chips}>
+                  {profile.credentials.map((cred: { boardType: string; auroraUsername: string }) => (
+                    <Chip
+                      key={cred.boardType}
+                      label={cred.boardType.charAt(0).toUpperCase() + cred.boardType.slice(1)}
+                      size="small"
+                      variant="outlined"
+                      sx={CHIP_SX}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <ArrowForwardIos className={styles.arrowIcon} fontSize="small" />
+          </div>
+
+          {gradeBars.length > 0 && (
+            <div className={styles.chartSection}>
+              <Typography variant="caption" component="span" color="text.secondary" className={styles.chartLabel}>
+                {totalClimbs} distinct climb{totalClimbs !== 1 ? 's' : ''}
+              </Typography>
+
+              <div className={styles.gradeBarContainer}>
+                {gradeBars.map((bar: GradeBar) => (
+                  <Box
+                    key={bar.grade}
+                    className={styles.gradeBar}
+                    sx={{
+                      height: `${Math.max((bar.count / maxCount) * 100, 8)}%`,
+                      backgroundColor: bar.color,
+                    }}
+                    title={`${bar.grade}: ${bar.count}`}
+                  />
+                ))}
+              </div>
+              <div className={styles.gradeLegend}>
+                {gradeBars.map((bar: GradeBar) => (
+                  <span key={bar.grade} className={styles.gradeLegendLabel}>
+                    {bar.grade}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </MuiCard>
+  );
+}

--- a/packages/web/app/crusher/[user_id]/page.tsx
+++ b/packages/web/app/crusher/[user_id]/page.tsx
@@ -1,15 +1,69 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { sql } from '@/app/lib/db/db';
 import ProfilePageContent from './profile-page-content';
-
-export const metadata: Metadata = {
-  title: 'Profile | Boardsesh',
-  description: 'View climbing profile and stats',
-};
 
 type PageProps = {
   params: Promise<{ user_id: string }>;
 };
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { user_id } = await params;
+
+  try {
+    const rows = await sql`
+      SELECT u.name, p.display_name, p.avatar_url
+      FROM users u
+      LEFT JOIN user_profiles p ON p.user_id = u.id
+      WHERE u.id = ${user_id}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return {
+        title: 'Profile | Boardsesh',
+        description: 'View climbing profile and stats',
+      };
+    }
+
+    const row = rows[0];
+    const displayName = (row.display_name as string) || (row.name as string) || 'Crusher';
+    const description = `${displayName}'s climbing profile on Boardsesh`;
+
+    const ogImageUrl = new URL('/api/og/profile', 'https://boardsesh.com');
+    ogImageUrl.searchParams.set('user_id', user_id);
+
+    return {
+      title: `${displayName} | Boardsesh`,
+      description,
+      openGraph: {
+        title: `${displayName} | Boardsesh`,
+        description,
+        type: 'profile',
+        url: `/crusher/${user_id}`,
+        images: [
+          {
+            url: ogImageUrl.toString(),
+            width: 1200,
+            height: 630,
+            alt: `${displayName}'s climbing profile`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${displayName} | Boardsesh`,
+        description,
+        images: [ogImageUrl.toString()],
+      },
+    };
+  } catch {
+    return {
+      title: 'Profile | Boardsesh',
+      description: 'View climbing profile and stats',
+    };
+  }
+}
 
 export default async function ProfilePage({ params }: PageProps) {
   const { user_id } = await params;


### PR DESCRIPTION
- Add UserSmartCard shared component (packages/web/app/components/social/) with compact profile preview and subtle grade distribution chart
- Add step 4 to aurora migration page showing the card after sign-in, refreshing after data import, clickable to navigate to profile page
- Add onImportComplete callback to BoardImportPrompt for refresh wiring
- Add dynamic generateMetadata to /crusher/[user_id] profile page with user-specific title, description, and OG image
- Add /api/og/profile edge endpoint generating 1200x630 OG images with avatar, display name, and grade distribution bars

https://claude.ai/code/session_01WHnnyXkuHu7LQczXnispRx