### PR TITLE
Fix code duplication, non-null assertions, and missing tests from PR #1045

### DIFF
--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -3,10 +3,9 @@
 import React from 'react';
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
-import { useParams, usePathname, useSearchParams } from 'next/navigation';
-import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
-import { BoardRouteParametersWithUuid, BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { BoardDetails } from '@/app/lib/types';
+import { useResolvedBoardDetails } from '@/app/hooks/use-resolved-board-details';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
 import { track } from '@vercel/analytics';
 import IconButton from '@mui/material/IconButton';
@@ -23,29 +22,10 @@ const NextButton = (props: IconButtonProps) => (
 
 export default function NextClimbButton({ navigate = false, boardDetails }: NextClimbButtonProps) {
   const { setCurrentClimbQueueItem, getNextClimbQueueItem, viewOnlyMode } = useQueueContext();
-  const rawParams = useParams<BoardRouteParametersWithUuid>();
-  const { board_name, layout_id, size_id, set_ids, angle } =
-    parseBoardRouteParams(rawParams);
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isPlayPage = pathname.includes('/play/');
+  const { rawParams, angle, pathname, searchParams, isPlayPage, resolvedDetails } =
+    useResolvedBoardDetails(boardDetails);
 
   const nextClimb = getNextClimbQueueItem();
-
-  // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
-  let resolvedDetails: BoardRouteIdentity;
-  if (boardDetails) {
-    resolvedDetails = boardDetails;
-  } else if (isNumericId(rawParams.layout_id)) {
-    try {
-      resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    } catch (error) {
-      console.warn('[NextClimbButton] Failed to resolve board details from static data:', error);
-      resolvedDetails = { board_name, layout_id, size_id, set_ids };
-    }
-  } else {
-    resolvedDetails = { board_name, layout_id, size_id, set_ids };
-  }
 
   const buildClimbUrl = () => {
     if (!nextClimb) return '';

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -4,11 +4,9 @@ import React from 'react';
 
 import Link from 'next/link';
 import { useQueueContext } from '../graphql-queue';
-import { useParams } from 'next/navigation';
-import { parseBoardRouteParams, constructPlayUrlWithSlugs, getContextAwareClimbViewUrl, isNumericId } from '@/app/lib/url-utils';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { BoardRouteParametersWithUuid, BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { BoardDetails } from '@/app/lib/types';
+import { useResolvedBoardDetails } from '@/app/hooks/use-resolved-board-details';
 import { track } from '@vercel/analytics';
 import FastRewindOutlined from '@mui/icons-material/FastRewindOutlined';
 import IconButton from '@mui/material/IconButton';
@@ -25,29 +23,10 @@ const PreviousButton = (props: IconButtonProps) => (
 
 export default function PreviousClimbButton({ navigate = false, boardDetails }: PreviousClimbButtonProps) {
   const { getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode } = useQueueContext();
-  const rawParams = useParams<BoardRouteParametersWithUuid>();
-  const { board_name, layout_id, size_id, set_ids, angle } =
-    parseBoardRouteParams(rawParams);
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isPlayPage = pathname.includes('/play/');
+  const { rawParams, angle, pathname, searchParams, isPlayPage, resolvedDetails } =
+    useResolvedBoardDetails(boardDetails);
 
   const previousClimb = getPreviousClimbQueueItem();
-
-  // Prefer the passed boardDetails; only resolve from static data if params are numeric (not slugs)
-  let resolvedDetails: BoardRouteIdentity;
-  if (boardDetails) {
-    resolvedDetails = boardDetails;
-  } else if (isNumericId(rawParams.layout_id)) {
-    try {
-      resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
-    } catch (error) {
-      console.warn('[PreviousClimbButton] Failed to resolve board details from static data:', error);
-      resolvedDetails = { board_name, layout_id, size_id, set_ids };
-    }
-  } else {
-    resolvedDetails = { board_name, layout_id, size_id, set_ids };
-  }
 
   const buildClimbUrl = () => {
     if (!previousClimb) return '';

--- a/packages/web/app/hooks/use-resolved-board-details.ts
+++ b/packages/web/app/hooks/use-resolved-board-details.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useParams, usePathname, useSearchParams } from 'next/navigation';
+import { parseBoardRouteParams, isNumericId } from '@/app/lib/url-utils';
+import { BoardRouteParametersWithUuid, BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+
+/**
+ * Resolves board details for URL construction in queue navigation buttons.
+ *
+ * Prefers passed `boardDetails`; falls back to static data lookup when
+ * route params are numeric IDs (not slugs). Returns the raw route identity
+ * when neither source is available.
+ */
+export function useResolvedBoardDetails(boardDetails?: BoardDetails) {
+  const rawParams = useParams<BoardRouteParametersWithUuid>();
+  const { board_name, layout_id, size_id, set_ids, angle } =
+    parseBoardRouteParams(rawParams);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isPlayPage = pathname.includes('/play/');
+
+  let resolvedDetails: BoardRouteIdentity;
+  if (boardDetails) {
+    resolvedDetails = boardDetails;
+  } else if (isNumericId(rawParams.layout_id)) {
+    try {
+      resolvedDetails = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
+    } catch (error) {
+      console.warn('[useResolvedBoardDetails] Failed to resolve board details from static data:', error);
+      resolvedDetails = { board_name, layout_id, size_id, set_ids };
+    }
+  } else {
+    resolvedDetails = { board_name, layout_id, size_id, set_ids };
+  }
+
+  return {
+    rawParams,
+    board_name,
+    layout_id,
+    size_id,
+    set_ids,
+    angle,
+    pathname,
+    searchParams,
+    isPlayPage,
+    resolvedDetails,
+  };
+}

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -23,6 +23,9 @@ import {
   getContextAwareClimbViewUrl,
   constructBoardSlugViewUrl,
   constructBoardSlugPlaylistsUrl,
+  tryConstructSlugPlayUrl,
+  tryConstructSlugViewUrl,
+  tryConstructSlugListUrl,
   DEFAULT_SEARCH_PARAMS
 } from '../url-utils';
 import type { SearchRequestPagination, BoardDetails } from '../types';
@@ -1229,5 +1232,62 @@ describe('getContextAwareClimbViewUrl - static data fallback', () => {
     );
     // Should fall back to numeric constructClimbViewUrl
     expect(result).toBe('/kilter/9999/9999/9999/40/view/test-climb-abc123');
+  });
+});
+
+describe('tryConstructSlugPlayUrl', () => {
+  it('should return a slug-based play URL when static data resolves', () => {
+    const result = tryConstructSlugPlayUrl('kilter', 1, 7, [1, 20], 40, 'abc123', 'Test Climb');
+    expect(result).not.toBeNull();
+    expect(result).toContain('/kilter/');
+    expect(result).toContain('/play/test-climb-abc123');
+    expect(result).not.toMatch(/\/\d+\/\d+\//); // No numeric segments
+  });
+
+  it('should return a slug-based play URL without climb name', () => {
+    const result = tryConstructSlugPlayUrl('kilter', 1, 7, [1, 20], 40, 'abc123');
+    expect(result).not.toBeNull();
+    expect(result).toContain('/play/abc123');
+  });
+
+  it('should return null when static data lookup fails', () => {
+    const result = tryConstructSlugPlayUrl('kilter', 9999, 9999, [9999], 40, 'abc123', 'Test');
+    expect(result).toBeNull();
+  });
+});
+
+describe('tryConstructSlugViewUrl', () => {
+  it('should return a slug-based view URL when static data resolves', () => {
+    const result = tryConstructSlugViewUrl('kilter', 1, 7, [1, 20], 40, 'abc123', 'Test Climb');
+    expect(result).not.toBeNull();
+    expect(result).toContain('/kilter/');
+    expect(result).toContain('/view/test-climb-abc123');
+    expect(result).not.toMatch(/\/\d+\/\d+\//);
+  });
+
+  it('should return a slug-based view URL without climb name', () => {
+    const result = tryConstructSlugViewUrl('kilter', 1, 7, [1, 20], 40, 'abc123');
+    expect(result).not.toBeNull();
+    expect(result).toContain('/view/abc123');
+  });
+
+  it('should return null when static data lookup fails', () => {
+    const result = tryConstructSlugViewUrl('kilter', 9999, 9999, [9999], 40, 'abc123', 'Test');
+    expect(result).toBeNull();
+  });
+});
+
+describe('tryConstructSlugListUrl', () => {
+  it('should return a slug-based list URL when static data resolves', () => {
+    const result = tryConstructSlugListUrl('kilter', 1, 7, [1, 20], 40);
+    expect(result).not.toBeNull();
+    expect(result).toContain('/kilter/');
+    expect(result).toContain('/list');
+    expect(result).not.toMatch(/\/\d+\/\d+\//);
+  });
+
+  it('should return null when static data lookup fails', () => {
+    const result = tryConstructSlugListUrl('kilter', 9999, 9999, [9999], 40);
+    expect(result).toBeNull();
   });
 });

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -478,6 +478,9 @@ export const constructCreateClimbUrl = (
   return baseUrl;
 };
 
+/** BoardDetails with slug fields guaranteed to be present. */
+type ResolvedBoardSlugs = BoardDetails & Required<Pick<BoardDetails, 'layout_name' | 'size_name' | 'set_names'>>;
+
 /**
  * Resolve slug-ready board details from static data.
  * Returns null if the lookup fails or the result lacks slug fields.
@@ -487,11 +490,11 @@ const tryResolveBoardSlugs = (
   layout_id: number,
   size_id: number,
   set_ids: number[],
-): BoardDetails | null => {
+): ResolvedBoardSlugs | null => {
   try {
     const details = getBoardDetailsForBoard({ board_name, layout_id, size_id, set_ids });
     if (details.layout_name && details.size_name && details.set_names) {
-      return details;
+      return details as ResolvedBoardSlugs;
     }
   } catch {
     // Static data lookup failed for this board config
@@ -506,7 +509,7 @@ export const tryConstructSlugPlayUrl = (
 ): string | null => {
   const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
   return d ? constructPlayUrlWithSlugs(
-    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle, climb_uuid, climbName,
+    d.board_name, d.layout_name, d.size_name, d.size_description, d.set_names, angle, climb_uuid, climbName,
   ) : null;
 };
 
@@ -517,7 +520,7 @@ export const tryConstructSlugViewUrl = (
 ): string | null => {
   const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
   return d ? constructClimbViewUrlWithSlugs(
-    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle, climb_uuid, climbName,
+    d.board_name, d.layout_name, d.size_name, d.size_description, d.set_names, angle, climb_uuid, climbName,
   ) : null;
 };
 
@@ -528,7 +531,7 @@ export const tryConstructSlugListUrl = (
 ): string | null => {
   const d = tryResolveBoardSlugs(board_name, layout_id, size_id, set_ids);
   return d ? constructClimbListWithSlugs(
-    d.board_name, d.layout_name!, d.size_name!, d.size_description, d.set_names!, angle,
+    d.board_name, d.layout_name, d.size_name, d.size_description, d.set_names, angle,
   ) : null;
 };
 


### PR DESCRIPTION
- Extract useResolvedBoardDetails hook to eliminate duplicated board
  details resolution logic in next-climb-button and previous-climb-button
- Add ResolvedBoardSlugs narrowed type to remove non-null assertions (!)
  on layout_name, size_name, and set_names in tryConstructSlug* functions
- Add direct unit tests for tryConstructSlugPlayUrl, tryConstructSlugViewUrl,
  and tryConstructSlugListUrl

https://claude.ai/code/session_0137cTCUx2hRXvDYAkWEMsXR