### PR TITLE
Optimize climb search queries and remove user tick tracking

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -146,22 +146,16 @@ describe('Climb Query Functions', () => {
       expect(result.hasMore).toBe(false);
     });
 
-    it('should include user-specific data when userId provided', async () => {
+    it('should accept userId for personal progress filters without error', async () => {
       const searchParams: ClimbSearchParams = {
         page: 0,
         pageSize: 10,
       };
-      const userId = 123;
 
-      const result = await searchClimbs(testParams, searchParams, userId);
+      const result = await searchClimbs(testParams, searchParams, 'some-user-id');
 
       expect(result).toBeDefined();
-      // When userId is provided, user-specific fields should be present
-      // (userAscents, userAttempts if the user has data)
-      result.climbs.forEach((climb) => {
-        expect(climb).toHaveProperty('userAscents');
-        expect(climb).toHaveProperty('userAttempts');
-      });
+      expect(result.climbs).toBeInstanceOf(Array);
     });
 
     it('should handle pagination correctly', async () => {
@@ -261,73 +255,6 @@ describe('Climb Query Functions', () => {
       // Both should execute without errors (may return null if no data)
       expect(kilterResult === null || typeof kilterResult === 'object').toBe(true);
       expect(tensionResult === null || typeof tensionResult === 'object').toBe(true);
-    });
-  });
-
-  describe('User tick LEFT JOIN (userAscents/userAttempts)', () => {
-    it('should return 0 for userAscents and userAttempts when user has no ticks', async () => {
-      const searchParams: ClimbSearchParams = {
-        page: 0,
-        pageSize: 5,
-      };
-      // Use a non-existent user ID to guarantee no ticks
-      const userId = 'nonexistent-user-id-no-ticks';
-
-      const result = await searchClimbs(testParams, searchParams, userId);
-
-      // Skip assertions if no test data available for these params
-      if (result.climbs.length === 0) return;
-
-      result.climbs.forEach((climb) => {
-        expect(climb.userAscents).toBe(0);
-        expect(climb.userAttempts).toBe(0);
-      });
-    });
-
-    it('should not reduce result count when userId is provided', async () => {
-      const searchParams: ClimbSearchParams = {
-        page: 0,
-        pageSize: 10,
-      };
-
-      const withoutUser = await searchClimbs(testParams, searchParams);
-      const withUser = await searchClimbs(testParams, searchParams, 'some-user-id');
-
-      // LEFT JOIN should not filter out any climbs
-      expect(withUser.climbs.length).toBe(withoutUser.climbs.length);
-    });
-
-    it('should return same climb UUIDs with and without userId', async () => {
-      const searchParams: ClimbSearchParams = {
-        page: 0,
-        pageSize: 10,
-        sortBy: 'ascents',
-        sortOrder: 'desc',
-      };
-
-      const withoutUser = await searchClimbs(testParams, searchParams);
-      const withUser = await searchClimbs(testParams, searchParams, 'some-user-id');
-
-      const withoutUuids = withoutUser.climbs.map((c) => c.uuid);
-      const withUuids = withUser.climbs.map((c) => c.uuid);
-
-      expect(withUuids).toEqual(withoutUuids);
-    });
-
-    it('should return numeric values for userAscents and userAttempts', async () => {
-      const searchParams: ClimbSearchParams = {
-        page: 0,
-        pageSize: 5,
-      };
-
-      const result = await searchClimbs(testParams, searchParams, 'any-user');
-
-      result.climbs.forEach((climb) => {
-        expect(typeof climb.userAscents).toBe('number');
-        expect(typeof climb.userAttempts).toBe('number');
-        expect(climb.userAscents).toBeGreaterThanOrEqual(0);
-        expect(climb.userAttempts).toBeGreaterThanOrEqual(0);
-      });
     });
   });
 

--- a/packages/backend/src/db/queries/climbs/count-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/count-climbs.ts
@@ -22,10 +22,13 @@ export const countClimbs = async (
 ): Promise<number> => {
   const filters = createClimbFilters(params, searchParams, sizeEdges, userId);
 
+  const isDraftsQuery = !!searchParams.onlyDrafts;
+
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
     ...filters.getSizeConditions(),
-    ...filters.getClimbStatsConditions(),
+    // Draft climbs never have stats rows — skip stats filters to avoid rejecting all drafts
+    ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),
   ];
 
   try {

--- a/packages/backend/src/db/queries/climbs/get-climb.ts
+++ b/packages/backend/src/db/queries/climbs/get-climb.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { db } from '../../client';
 import { getBoardTables, type BoardName } from '../util/table-select';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import type { Climb } from '@boardsesh/shared-schema';
 
 interface GetClimbParams {
@@ -24,7 +25,7 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
         frames: tables.climbs.frames,
         angle: sql<number>`COALESCE(${tables.climbStats.angle}, ${params.angle})`,
         ascensionist_count: sql<number>`COALESCE(${tables.climbStats.ascensionistCount}, 0)`,
-        difficulty: tables.difficultyGrades.boulderName,
+        difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
         quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
         difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
         benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -35,11 +36,6 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
         sql`${tables.climbStats.climbUuid} = ${tables.climbs.uuid}
         AND ${tables.climbStats.boardType} = ${params.board_name}
         AND ${tables.climbStats.angle} = ${params.angle}`
-      )
-      .leftJoin(
-        tables.difficultyGrades,
-        sql`${tables.difficultyGrades.difficulty} = ROUND(${tables.climbStats.displayDifficulty}::numeric)
-        AND ${tables.difficultyGrades.boardType} = ${params.board_name}`
       )
       .where(
         sql`${tables.climbs.boardType} = ${params.board_name}
@@ -55,7 +51,6 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
 
     const row = result[0];
 
-    // Transform the result into the complete Climb type
     const climb: Climb = {
       uuid: row.uuid,
       setter_username: row.setter_username || '',
@@ -64,7 +59,7 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
       frames: row.frames || '',
       angle: Number(params.angle),
       ascensionist_count: Number(row.ascensionist_count || 0),
-      difficulty: row.difficulty || '',
+      difficulty: getGradeLabel(row.difficulty_id),
       quality_average: row.quality_average?.toString() || '0',
       stars: Math.round((Number(row.quality_average) || 0) * 5),
       difficulty_error: row.difficulty_error?.toString() || '0',

--- a/packages/backend/src/db/queries/climbs/search-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/search-climbs.ts
@@ -23,8 +23,6 @@ export const searchClimbs = async (
     const climbs: Climb[] = result.climbs.map((row) => ({
       ...row,
       mirrored: null,
-      userAscents: null,
-      userAttempts: null,
     }));
 
     return {

--- a/packages/backend/src/db/queries/climbs/search-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/search-climbs.ts
@@ -23,6 +23,8 @@ export const searchClimbs = async (
     const climbs: Climb[] = result.climbs.map((row) => ({
       ...row,
       mirrored: null,
+      userAscents: null,
+      userAttempts: null,
     }));
 
     return {

--- a/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
@@ -3,6 +3,7 @@ import type { ConnectionContext, Climb, BoardName } from '@boardsesh/shared-sche
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { GetUserFavoriteClimbsInputSchema } from '../../../validation/schemas';
 import { getBoardTables, isValidBoardName } from '../../../db/queries/util/table-select';
@@ -68,7 +69,7 @@ export const favoriteClimbsQuery = {
         frames: tables.climbs.frames,
         // Stats data
         ascensionist_count: tables.climbStats.ascensionistCount,
-        difficulty: tables.difficultyGrades.boulderName,
+        difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
         quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
         difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
         benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -87,13 +88,6 @@ export const favoriteClimbsQuery = {
           eq(tables.climbStats.climbUuid, dbSchema.userFavorites.climbUuid),
           eq(tables.climbStats.boardType, boardName),
           eq(tables.climbStats.angle, input.angle)
-        )
-      )
-      .leftJoin(
-        tables.difficultyGrades,
-        and(
-          eq(tables.difficultyGrades.difficulty, sql`ROUND(${tables.climbStats.displayDifficulty}::numeric)`),
-          eq(tables.difficultyGrades.boardType, boardName)
         )
       )
       .where(
@@ -118,7 +112,7 @@ export const favoriteClimbsQuery = {
       frames: result.frames || '',
       angle: input.angle,
       ascensionist_count: Number(result.ascensionist_count || 0),
-      difficulty: result.difficulty || '',
+      difficulty: getGradeLabel(result.difficulty_id),
       quality_average: result.quality_average?.toString() || '0',
       stars: Math.round((Number(result.quality_average) || 0) * 5),
       difficulty_error: result.difficulty_error?.toString() || '0',

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -3,6 +3,7 @@ import type { ConnectionContext, Climb, BoardName } from '@boardsesh/shared-sche
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import { validateInput } from '../../shared/helpers';
 import { GetPlaylistClimbsInputSchema } from '../../../../validation/schemas';
 import { getBoardTables, isValidBoardName } from '../../../../db/queries/util/table-select';
@@ -77,7 +78,7 @@ async function fetchSpecificBoardClimbs(
       description: tables.climbs.description,
       frames: tables.climbs.frames,
       ascensionist_count: tables.climbStats.ascensionistCount,
-      difficulty: tables.difficultyGrades.boulderName,
+      difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
       quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
       difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
       benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -90,13 +91,6 @@ async function fetchSpecificBoardClimbs(
         eq(tables.climbStats.climbUuid, dbSchema.playlistClimbs.climbUuid),
         eq(tables.climbStats.boardType, boardName),
         eq(tables.climbStats.angle, inputAngle),
-      ),
-    )
-    .leftJoin(
-      tables.difficultyGrades,
-      and(
-        eq(tables.difficultyGrades.difficulty, sql`ROUND(${tables.climbStats.displayDifficulty}::numeric)`),
-        eq(tables.difficultyGrades.boardType, boardName),
       ),
     )
     .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
@@ -115,7 +109,7 @@ async function fetchSpecificBoardClimbs(
     frames: result.frames || '',
     angle: inputAngle,
     ascensionist_count: Number(result.ascensionist_count || 0),
-    difficulty: result.difficulty || '',
+    difficulty: getGradeLabel(result.difficulty_id),
     quality_average: result.quality_average?.toString() || '0',
     stars: Math.round((Number(result.quality_average) || 0) * 5),
     difficulty_error: result.difficulty_error?.toString() || '0',
@@ -151,7 +145,7 @@ async function fetchAllBoardsClimbs(
       frames: tables.climbs.frames,
       statsAngle: tables.climbStats.angle,
       ascensionist_count: tables.climbStats.ascensionistCount,
-      difficulty: tables.difficultyGrades.boulderName,
+      difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
       quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
       difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
       benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -175,13 +169,6 @@ async function fetchAllBoardsClimbs(
         )`),
       ),
     )
-    .leftJoin(
-      tables.difficultyGrades,
-      and(
-        eq(tables.difficultyGrades.boardType, tables.climbs.boardType),
-        eq(tables.difficultyGrades.difficulty, sql`CAST(${tables.climbStats.displayDifficulty} AS INTEGER)`),
-      ),
-    )
     .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
     .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
     .limit(pageSize + 1)
@@ -200,7 +187,7 @@ async function fetchAllBoardsClimbs(
       frames: result.frames || '',
       angle: result.playlistAngle ?? result.statsAngle ?? DEFAULT_ANGLE,
       ascensionist_count: Number(result.ascensionist_count || 0),
-      difficulty: result.difficulty || '',
+      difficulty: getGradeLabel(result.difficulty_id),
       quality_average: result.quality_average?.toString() || '0',
       stars: Math.round((Number(result.quality_average) || 0) * 5),
       difficulty_error: result.difficulty_error?.toString() || '0',

--- a/packages/backend/src/graphql/resolvers/social/proposals/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/mutations.ts
@@ -2,6 +2,7 @@ import { eq, and, sql, isNull } from 'drizzle-orm';
 import type { ConnectionContext, ProposalStatus } from '@boardsesh/shared-schema';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../../shared/helpers';
 import {
   CreateProposalInputSchema,
@@ -65,21 +66,17 @@ export const socialProposalMutations = {
         currentValue = communityStatus.communityGrade;
       } else {
         try {
-          // Use unified board_climb_stats table with board_type filter
-          // Join board_difficulty_grades for accurate grade name
+          // Look up display_difficulty from stats, then resolve grade name in-memory
           const result = await db.execute(sql`
-            SELECT dg.boulder_name as grade_name
+            SELECT ROUND(cs.display_difficulty::numeric, 0) as difficulty_id
             FROM board_climb_stats cs
-            LEFT JOIN board_difficulty_grades dg
-              ON dg.difficulty = ROUND(cs.display_difficulty::numeric)
-              AND dg.board_type = cs.board_type
             WHERE cs.climb_uuid = ${climbUuid}
               AND cs.angle = ${angle}
               AND cs.board_type = ${boardType}
             LIMIT 1
           `);
-          const rows = (result as unknown as { rows: Array<{ grade_name: string | null }> }).rows;
-          currentValue = rows[0]?.grade_name || 'Unknown';
+          const rows = (result as unknown as { rows: Array<{ difficulty_id: number | null }> }).rows;
+          currentValue = getGradeLabel(rows[0]?.difficulty_id ?? null) || 'Unknown';
         } catch {
           currentValue = 'Unknown';
         }

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -1,6 +1,7 @@
 import { eq, and, desc, sql, count as drizzleCount, isNull, inArray } from 'drizzle-orm';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import { validateInput } from '../shared/helpers';
 import { ActivityFeedInputSchema } from '../../../validation/schemas';
 import { encodeOffsetCursor, decodeOffsetCursor } from '../../../utils/feed-cursor';
@@ -631,8 +632,7 @@ async function fetchGradeDistributionBatch(
   const result = await db.execute(sql`
     SELECT
       COALESCE(t.session_id, t.inferred_session_id) AS effective_session_id,
-      dg.boulder_name AS grade,
-      dg.difficulty AS diff_num,
+      t.difficulty AS diff_num,
       COUNT(*) FILTER (WHERE t.status = 'flash')::int AS flash,
       COUNT(*) FILTER (WHERE t.status = 'send')::int AS send,
       (
@@ -640,17 +640,14 @@ async function fetchGradeDistributionBatch(
         + COALESCE(SUM(t.attempt_count) FILTER (WHERE t.status = 'attempt'), 0)
       )::int AS attempt
     FROM boardsesh_ticks t
-    LEFT JOIN board_difficulty_grades dg
-      ON dg.difficulty = t.difficulty AND dg.board_type = t.board_type
     WHERE COALESCE(t.session_id, t.inferred_session_id) IN ${sql`(${sql.join(sessionIds.map(id => sql`${id}`), sql`, `)})`}
       AND t.difficulty IS NOT NULL
-    GROUP BY effective_session_id, dg.boulder_name, dg.difficulty
-    ORDER BY dg.difficulty DESC
+    GROUP BY effective_session_id, t.difficulty
+    ORDER BY t.difficulty DESC
   `);
 
   const rows = (result as unknown as { rows: Array<{
     effective_session_id: string;
-    grade: string | null;
     diff_num: number;
     flash: number;
     send: number;
@@ -659,9 +656,10 @@ async function fetchGradeDistributionBatch(
 
   const map = new Map<string, SessionGradeDistributionItem[]>();
   for (const r of rows) {
-    if (r.grade == null) continue;
+    const grade = getGradeLabel(r.diff_num);
+    if (!grade) continue;
     const distribution = map.get(r.effective_session_id) ?? [];
-    distribution.push({ grade: r.grade, flash: r.flash, send: r.send, attempt: r.attempt });
+    distribution.push({ grade, flash: r.flash, send: r.send, attempt: r.attempt });
     map.set(r.effective_session_id, distribution);
   }
   return map;

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -3,6 +3,7 @@ import type { ConnectionContext, Climb, BoardName } from '@boardsesh/shared-sche
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { getGradeLabel } from '@boardsesh/db/queries';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import {
   FollowSetterInputSchema,
@@ -138,7 +139,7 @@ export const setterFollowQueries = {
         statsAngle: dbSchema.boardClimbStats.angle,
         qualityAverage: dbSchema.boardClimbStats.qualityAverage,
         ascensionistCount: dbSchema.boardClimbStats.ascensionistCount,
-        difficultyName: dbSchema.boardDifficultyGrades.boulderName,
+        difficultyId: sql<number | null>`ROUND(${dbSchema.boardClimbStats.displayDifficulty}::numeric, 0)`,
       })
       .from(dbSchema.boardClimbs)
       .leftJoin(
@@ -153,13 +154,6 @@ export const setterFollowQueries = {
             ORDER BY s.ascensionist_count DESC NULLS LAST
             LIMIT 1
           )`),
-        )
-      )
-      .leftJoin(
-        dbSchema.boardDifficultyGrades,
-        and(
-          eq(dbSchema.boardDifficultyGrades.boardType, dbSchema.boardClimbs.boardType),
-          eq(dbSchema.boardDifficultyGrades.difficulty, sql`CAST(${dbSchema.boardClimbStats.displayDifficulty} AS INTEGER)`),
         )
       )
       .where(and(...conditions))
@@ -178,7 +172,7 @@ export const setterFollowQueries = {
         boardType: c.boardType,
         layoutId: c.layoutId,
         angle: c.statsAngle ?? null,
-        difficultyName: c.difficultyName ?? null,
+        difficultyName: getGradeLabel(c.difficultyId),
         qualityAverage: c.qualityAverage ?? null,
         ascensionistCount: c.ascensionistCount ?? null,
         createdAt: c.createdAt ?? null,
@@ -263,7 +257,7 @@ export const setterFollowQueries = {
           description: tables.climbs.description,
           frames: tables.climbs.frames,
           ascensionist_count: tables.climbStats.ascensionistCount,
-          difficulty: tables.difficultyGrades.boulderName,
+          difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
           quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
           difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
           benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -275,13 +269,6 @@ export const setterFollowQueries = {
             eq(tables.climbStats.climbUuid, tables.climbs.uuid),
             eq(tables.climbStats.boardType, boardName),
             eq(tables.climbStats.angle, angle)
-          )
-        )
-        .leftJoin(
-          tables.difficultyGrades,
-          and(
-            eq(tables.difficultyGrades.difficulty, sql`ROUND(${tables.climbStats.displayDifficulty}::numeric)`),
-            eq(tables.difficultyGrades.boardType, boardName)
           )
         )
         .where(and(...filterConditions))
@@ -305,7 +292,7 @@ export const setterFollowQueries = {
         frames: result.frames || '',
         angle,
         ascensionist_count: Number(result.ascensionist_count || 0),
-        difficulty: result.difficulty || '',
+        difficulty: getGradeLabel(result.difficulty_id),
         quality_average: result.quality_average?.toString() || '0',
         stars: Math.round((Number(result.quality_average) || 0) * 5),
         difficulty_error: result.difficulty_error?.toString() || '0',
@@ -354,7 +341,7 @@ export const setterFollowQueries = {
           frames: tables.climbs.frames,
           statsAngle: tables.climbStats.angle,
           ascensionist_count: tables.climbStats.ascensionistCount,
-          difficulty: tables.difficultyGrades.boulderName,
+          difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
           quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
           difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
           benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
@@ -372,13 +359,6 @@ export const setterFollowQueries = {
               ORDER BY s.ascensionist_count DESC NULLS LAST
               LIMIT 1
             )`),
-          )
-        )
-        .leftJoin(
-          tables.difficultyGrades,
-          and(
-            eq(tables.difficultyGrades.boardType, tables.climbs.boardType),
-            eq(tables.difficultyGrades.difficulty, sql`CAST(${tables.climbStats.displayDifficulty} AS INTEGER)`),
           )
         )
         .where(eq(tables.climbs.setterUsername, username))
@@ -404,7 +384,7 @@ export const setterFollowQueries = {
           frames: result.frames || '',
           angle: result.statsAngle ?? DEFAULT_ANGLE,
           ascensionist_count: Number(result.ascensionist_count || 0),
-          difficulty: result.difficulty || '',
+          difficulty: getGradeLabel(result.difficulty_id),
           quality_average: result.quality_average?.toString() || '0',
           stars: Math.round((Number(result.quality_average) || 0) * 5),
           difficulty_error: result.difficulty_error?.toString() || '0',

--- a/packages/db/src/client/neon.ts
+++ b/packages/db/src/client/neon.ts
@@ -2,11 +2,25 @@ import { neon, neonConfig, Pool } from '@neondatabase/serverless';
 import { drizzle as drizzleHttp } from 'drizzle-orm/neon-http';
 import { drizzle as drizzleServerless } from 'drizzle-orm/neon-serverless';
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js';
+import type { Logger } from 'drizzle-orm';
 import postgres from 'postgres';
 import ws from 'ws';
 import { getConnectionConfig, configureNeonForEnvironment, isTestEnvironment } from './config';
 import * as schema from '../schema/index';
 import * as relations from '../relations/index';
+
+// Query logger enabled via DEBUG_SQL=true — logs all queries with execution time
+class QueryLogger implements Logger {
+  logQuery(query: string, params: unknown[]): void {
+    const timestamp = new Date().toISOString();
+    console.log(`[SQL ${timestamp}] ${query}`);
+    if (params.length > 0) {
+      console.log(`[SQL params] ${JSON.stringify(params)}`);
+    }
+  }
+}
+
+const sqlLogger = process.env.DEBUG_SQL === 'true' ? new QueryLogger() : undefined;
 
 // Configure WebSocket constructor
 neonConfig.webSocketConstructor = ws;
@@ -40,11 +54,11 @@ export function createDb() {
     if (isTest) {
       // Use postgres-js directly for tests (no Neon proxy needed)
       postgresClient = postgres(connectionString);
-      db = drizzlePostgres(postgresClient, { schema: fullSchema });
+      db = drizzlePostgres(postgresClient, { schema: fullSchema, logger: sqlLogger });
     } else {
       // Use Neon serverless for production/development
       const poolInstance = createPool();
-      db = drizzleServerless(poolInstance, { schema: fullSchema });
+      db = drizzleServerless(poolInstance, { schema: fullSchema, logger: sqlLogger });
     }
   }
   return db;
@@ -54,7 +68,7 @@ export function createNeonHttp() {
   configureNeonForEnvironment();
   const { connectionString } = getConnectionConfig();
   const sql = neon(connectionString);
-  return drizzleHttp({ client: sql, schema: fullSchema });
+  return drizzleHttp({ client: sql, schema: fullSchema, logger: sqlLogger });
 }
 
 export type DbInstance = ReturnType<typeof createDb>;

--- a/packages/db/src/queries/climbs/grade-lookup.ts
+++ b/packages/db/src/queries/climbs/grade-lookup.ts
@@ -1,0 +1,42 @@
+/**
+ * Static grade lookup map for converting difficulty IDs to boulder grade names.
+ * Replaces the board_difficulty_grades JOIN in search queries.
+ *
+ * The difficulty_id values match the `difficulty` column in board_difficulty_grades.
+ * This data is stable and identical across all board types.
+ */
+const GRADE_MAP: Record<number, string> = {
+  10: '4a/V0',
+  11: '4b/V0',
+  12: '4c/V0',
+  13: '5a/V1',
+  14: '5b/V1',
+  15: '5c/V2',
+  16: '6a/V3',
+  17: '6a+/V3',
+  18: '6b/V4',
+  19: '6b+/V4',
+  20: '6c/V5',
+  21: '6c+/V5',
+  22: '7a/V6',
+  23: '7a+/V7',
+  24: '7b/V8',
+  25: '7b+/V8',
+  26: '7c/V9',
+  27: '7c+/V10',
+  28: '8a/V11',
+  29: '8a+/V12',
+  30: '8b/V13',
+  31: '8b+/V14',
+  32: '8c/V15',
+  33: '8c+/V16',
+};
+
+/**
+ * Look up the boulder grade name for a rounded difficulty ID.
+ * Returns empty string if the ID is not found (e.g., null display_difficulty).
+ */
+export function getGradeLabel(difficultyId: number | null): string {
+  if (difficultyId === null || difficultyId === undefined) return '';
+  return GRADE_MAP[difficultyId] ?? '';
+}

--- a/packages/db/src/queries/climbs/grade-lookup.ts
+++ b/packages/db/src/queries/climbs/grade-lookup.ts
@@ -32,11 +32,19 @@ const GRADE_MAP: Record<number, string> = {
   33: '8c+/V16',
 };
 
+// Track warned IDs to avoid log spam
+const warnedIds = new Set<number>();
+
 /**
  * Look up the boulder grade name for a rounded difficulty ID.
  * Returns empty string if the ID is not found (e.g., null display_difficulty).
  */
 export function getGradeLabel(difficultyId: number | null): string {
   if (difficultyId === null || difficultyId === undefined) return '';
-  return GRADE_MAP[difficultyId] ?? '';
+  const label = GRADE_MAP[difficultyId];
+  if (label === undefined && !warnedIds.has(difficultyId)) {
+    warnedIds.add(difficultyId);
+    console.warn(`[grade-lookup] Unknown difficulty ID: ${difficultyId} — not in grade map (range 10-33)`);
+  }
+  return label ?? '';
 }

--- a/packages/db/src/queries/climbs/index.ts
+++ b/packages/db/src/queries/climbs/index.ts
@@ -1,5 +1,6 @@
 export { searchClimbs } from './search-climbs';
 export { createClimbFilters } from './create-climb-filters';
+export { getGradeLabel } from './grade-lookup';
 export type {
   BoardRouteParams,
   ClimbSearchParams,

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -30,7 +30,10 @@ export const searchClimbs = async (
 
   const filters = createClimbFilters(params, searchParams, sizeEdges, userId);
 
-  const sortBy = searchParams.sortBy || (searchParams.onlyDrafts ? 'creation' : 'ascents');
+  // Drafts never have stats, so force creation sort (stats-based sorts would be meaningless)
+  const sortBy = searchParams.onlyDrafts
+    ? 'creation'
+    : (searchParams.sortBy || 'ascents');
   const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
 
   // For the popular sort, pre-aggregate total ascents across all angles via a joined subquery
@@ -74,10 +77,14 @@ export const searchClimbs = async (
 
   const sortColumn = allowedSortColumns[sortBy] || sql`${boardClimbStats.ascensionistCount}`;
 
+  const isDraftsQuery = !!searchParams.onlyDrafts;
+
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
     ...filters.getSizeConditions(),
-    ...filters.getClimbStatsConditions(),
+    // Draft climbs never have board_climb_stats rows, so stats-based filters
+    // (grade range, min ascents, quality, accuracy) would reject every draft.
+    ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),
   ];
 
   const selectFields = {
@@ -98,10 +105,9 @@ export const searchClimbs = async (
     ? sql`${sortColumn} ASC NULLS FIRST`
     : sql`${sortColumn} DESC NULLS LAST`;
 
-  // Always use board_climbs as the driving table with LEFT JOIN to board_climb_stats.
-  // This ensures climbs without stats rows are not silently dropped from results.
-  // The board_climb_stats_ascents_covering_idx helps the JOIN, and the planner
-  // can use it for the ORDER BY when sorting by ascents.
+  // LEFT JOIN board_climb_stats for grade/sort data.
+  // Draft climbs never have stats rows so the JOIN returns NULLs — that's fine,
+  // stats conditions are already skipped above and sort is forced to creation.
   const coreQuery = db
     .select(selectFields)
     .from(boardClimbs)

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -35,6 +35,8 @@ export const searchClimbs = async (
 
   // For the popular sort, pre-aggregate total ascents across all angles via a joined subquery
   // instead of a correlated subquery that runs per candidate row.
+  // Scoped with an EXISTS to only aggregate stats for climbs matching the search filters,
+  // avoiding a full scan of board_climb_stats for the entire board_type.
   const popularCountsSubquery = sortBy === 'popular'
     ? db
         .select({
@@ -42,7 +44,18 @@ export const searchClimbs = async (
           totalAscensionistCount: sql<number>`COALESCE(SUM(${boardClimbStats.ascensionistCount}), 0)`.as('total_ascensionist_count'),
         })
         .from(boardClimbStats)
-        .where(eq(boardClimbStats.boardType, params.board_name))
+        .where(and(
+          eq(boardClimbStats.boardType, params.board_name),
+          sql`EXISTS (
+            SELECT 1 FROM ${boardClimbs}
+            WHERE ${boardClimbs.uuid} = ${boardClimbStats.climbUuid}
+            AND ${boardClimbs.boardType} = ${params.board_name}
+            AND ${boardClimbs.layoutId} = ${params.layout_id}
+            AND ${boardClimbs.isListed} = true
+            AND ${boardClimbs.isDraft} = false
+            AND ${boardClimbs.framesCount} = 1
+          )`,
+        ))
         .groupBy(boardClimbStats.climbUuid)
         .as('popular_counts')
     : null;

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -144,9 +144,18 @@ async function statsDrivenSearch(
 
   // Stats-driven query didn't fill the page — supplement with no-stats climbs.
   // These have 0 ascents and sort after all stats-having climbs.
-  const statsCount = page * pageSize + results.length;
+  // We need the total stats count to calculate how many no-stats climbs were
+  // already shown on previous pages (for correct OFFSET).
   const remaining = pageSize + 1 - results.length;
-  const noStatsOffset = Math.max(0, page * pageSize - statsCount);
+
+  const [statsCountResult] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(boardClimbStats)
+    .innerJoin(boardClimbs, and(...climbJoinConditions))
+    .where(and(...statsWhereConditions));
+
+  const totalStatsCount = Number(statsCountResult?.count ?? 0);
+  const noStatsOffset = Math.max(0, page * pageSize - totalStatsCount);
 
   const noStatsResults = remaining > 0 ? await db
     .select({

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -3,10 +3,9 @@ import type { DbInstance } from '../../client/neon';
 import {
   boardClimbs,
   boardClimbStats,
-  boardDifficultyGrades,
-  boardseshTicks,
 } from '../../schema/index';
 import { createClimbFilters } from './create-climb-filters';
+import { getGradeLabel } from './grade-lookup';
 import type { BoardRouteParams, ClimbSearchParams, ClimbRow, ClimbSearchResult, SizeEdges } from './types';
 
 /**
@@ -31,22 +30,36 @@ export const searchClimbs = async (
 
   const filters = createClimbFilters(params, searchParams, sizeEdges, userId);
 
+  const sortBy = searchParams.sortBy || (searchParams.onlyDrafts ? 'creation' : 'ascents');
+  const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
+
+  // For the popular sort, pre-aggregate total ascents across all angles via a joined subquery
+  // instead of a correlated subquery that runs per candidate row.
+  const popularCountsSubquery = sortBy === 'popular'
+    ? db
+        .select({
+          climbUuid: boardClimbStats.climbUuid,
+          totalAscensionistCount: sql<number>`COALESCE(SUM(${boardClimbStats.ascensionistCount}), 0)`.as('total_ascensionist_count'),
+        })
+        .from(boardClimbStats)
+        .where(eq(boardClimbStats.boardType, params.board_name))
+        .groupBy(boardClimbStats.climbUuid)
+        .as('popular_counts')
+    : null;
+
   // Define sort columns
-  const defaultSort = searchParams.onlyDrafts ? 'creation' : 'ascents';
   const allowedSortColumns: Record<string, ReturnType<typeof sql>> = {
     ascents: sql`${boardClimbStats.ascensionistCount}`,
     difficulty: sql`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
     name: sql`${boardClimbs.name}`,
     quality: sql`${boardClimbStats.qualityAverage}`,
     creation: sql`${boardClimbs.createdAt}`,
-    popular: sql`(
-      SELECT COALESCE(SUM(cs.ascensionist_count), 0)
-      FROM ${boardClimbStats} cs
-      WHERE cs.board_type = ${params.board_name} AND cs.climb_uuid = ${boardClimbs.uuid}
-    )`,
+    ...(popularCountsSubquery
+      ? { popular: sql`${popularCountsSubquery.totalAscensionistCount}` }
+      : {}),
   };
 
-  const sortColumn = allowedSortColumns[searchParams.sortBy || defaultSort] || sql`${boardClimbStats.ascensionistCount}`;
+  const sortColumn = allowedSortColumns[sortBy] || sql`${boardClimbStats.ascensionistCount}`;
 
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
@@ -54,73 +67,88 @@ export const searchClimbs = async (
     ...filters.getClimbStatsConditions(),
   ];
 
-  const baseSelectFields = {
+  const selectFields = {
     uuid: boardClimbs.uuid,
     setter_username: boardClimbs.setterUsername,
     name: boardClimbs.name,
-    description: boardClimbs.description,
     frames: boardClimbs.frames,
     is_draft: boardClimbs.isDraft,
     angle: boardClimbStats.angle,
     ascensionist_count: boardClimbStats.ascensionistCount,
-    difficulty: boardDifficultyGrades.boulderName,
+    difficulty_id: sql<number>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
     quality_average: sql<number>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
     difficulty_error: sql<number>`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
     benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
   };
 
-  const userTicksSubquery = userId
-    ? db
-        .select({
-          climbUuid: boardseshTicks.climbUuid,
-          userAscents: sql<number>`COUNT(*) FILTER (WHERE ${boardseshTicks.status} IN ('flash', 'send'))`.as('user_ascents'),
-          userAttempts: sql<number>`COUNT(*) FILTER (WHERE ${boardseshTicks.status} = 'attempt')`.as('user_attempts'),
-        })
-        .from(boardseshTicks)
-        .where(and(
-          eq(boardseshTicks.userId, userId),
-          eq(boardseshTicks.boardType, params.board_name),
-          eq(boardseshTicks.angle, params.angle),
-        ))
-        .groupBy(boardseshTicks.climbUuid)
-        .as('user_ticks')
-    : null;
-
-  const selectFields = userId && userTicksSubquery
-    ? {
-        ...baseSelectFields,
-        userAscents: sql<number>`COALESCE(${userTicksSubquery.userAscents}, 0)`,
-        userAttempts: sql<number>`COALESCE(${userTicksSubquery.userAttempts}, 0)`,
-      }
-    : baseSelectFields;
-
-  const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
-
-  const difficultyGradesJoinCondition = and(
-    eq(boardDifficultyGrades.difficulty, sql`ROUND(${boardClimbStats.displayDifficulty}::numeric)`),
-    eq(boardDifficultyGrades.boardType, params.board_name),
-  );
-
   const orderByClause = sortOrder === 'asc'
     ? sql`${sortColumn} ASC NULLS FIRST`
     : sql`${sortColumn} DESC NULLS LAST`;
 
-  const coreQuery = db
-    .select(selectFields)
-    .from(boardClimbs)
-    .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()))
-    .leftJoin(boardDifficultyGrades, difficultyGradesJoinCondition);
+  // For the default ascents sort, drive from board_climb_stats to leverage the
+  // covering index (board_type, angle, ascensionist_count DESC NULLS LAST).
+  // PostgreSQL reads the index in sorted order and stops after 21 qualifying rows,
+  // avoiding a full sort of all matching climbs.
+  const useStatsDriven = sortBy === 'ascents' && sortOrder === 'desc';
 
-  const baseQuery = (userId && userTicksSubquery
-    ? coreQuery.leftJoin(userTicksSubquery, eq(userTicksSubquery.climbUuid, boardClimbs.uuid))
-    : coreQuery
-  )
-    .where(and(...whereConditions))
-    .orderBy(orderByClause, desc(boardClimbs.uuid))
-    .limit(pageSize + 1)
-    .offset(page * pageSize);
+  type SelectResult = {
+    uuid: string;
+    setter_username: string | null;
+    name: string | null;
+    frames: string | null;
+    is_draft: boolean | null;
+    angle: number | null;
+    ascensionist_count: string | null;
+    difficulty_id: number;
+    quality_average: number;
+    difficulty_error: number;
+    benchmark_difficulty: number | null;
+  };
 
-  const results = await baseQuery;
+  let results: SelectResult[];
+
+  if (useStatsDriven) {
+    // Stats-driven: FROM board_climb_stats INNER JOIN board_climbs
+    // The climb filter conditions move to the JOIN predicate so the index scan
+    // on board_climb_stats drives the query in sorted order.
+    const climbJoinConditions = [
+      eq(boardClimbs.uuid, boardClimbStats.climbUuid),
+      ...filters.getClimbWhereConditions(),
+      ...filters.getSizeConditions(),
+    ];
+
+    const statsWhereConditions = [
+      eq(boardClimbStats.boardType, params.board_name),
+      eq(boardClimbStats.angle, params.angle),
+      ...filters.getClimbStatsConditions(),
+    ];
+
+    results = await db
+      .select(selectFields)
+      .from(boardClimbStats)
+      .innerJoin(boardClimbs, and(...climbJoinConditions))
+      .where(and(...statsWhereConditions))
+      .orderBy(sql`${boardClimbStats.ascensionistCount} DESC NULLS LAST`, desc(boardClimbs.uuid))
+      .limit(pageSize + 1)
+      .offset(page * pageSize);
+  } else {
+    // Standard path: FROM board_climbs LEFT JOIN board_climb_stats
+    const coreQuery = db
+      .select(selectFields)
+      .from(boardClimbs)
+      .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()));
+
+    // Only add popular counts join when sorting by popular
+    const queryWithJoins = popularCountsSubquery
+      ? coreQuery.leftJoin(popularCountsSubquery, eq(popularCountsSubquery.climbUuid, boardClimbs.uuid))
+      : coreQuery;
+
+    results = await queryWithJoins
+      .where(and(...whereConditions))
+      .orderBy(orderByClause, desc(boardClimbs.uuid))
+      .limit(pageSize + 1)
+      .offset(page * pageSize);
+  }
 
   const hasMore = results.length > pageSize;
   const trimmedResults = hasMore ? results.slice(0, pageSize) : results;
@@ -129,18 +157,16 @@ export const searchClimbs = async (
     uuid: result.uuid,
     setter_username: result.setter_username || '',
     name: result.name || '',
-    description: result.description || '',
+    description: '',
     frames: result.frames || '',
     angle: Number(params.angle),
     ascensionist_count: Number(result.ascensionist_count || 0),
-    difficulty: result.difficulty || '',
+    difficulty: getGradeLabel(result.difficulty_id),
     quality_average: result.quality_average?.toString() || '0',
     stars: Math.round((Number(result.quality_average) || 0) * 5),
     difficulty_error: result.difficulty_error?.toString() || '0',
     benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
     is_draft: result.is_draft ?? false,
-    userAscents: userId ? Number((result as Record<string, unknown>)?.userAscents || 0) : undefined,
-    userAttempts: userId ? Number((result as Record<string, unknown>)?.userAttempts || 0) : undefined,
   }));
 
   return { climbs, hasMore };

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -8,6 +8,37 @@ import { createClimbFilters } from './create-climb-filters';
 import { getGradeLabel } from './grade-lookup';
 import type { BoardRouteParams, ClimbSearchParams, ClimbRow, ClimbSearchResult, SizeEdges } from './types';
 
+type RawSelectResult = {
+  uuid: string;
+  setter_username: string | null;
+  name: string | null;
+  frames: string | null;
+  is_draft: boolean | null;
+  angle: number | null;
+  ascensionist_count: string | null;
+  difficulty_id: number | null;
+  quality_average: number | null;
+  difficulty_error: number | null;
+  benchmark_difficulty: number | null;
+};
+
+function mapResultToClimbRow(result: RawSelectResult, angle: number): ClimbRow {
+  return {
+    uuid: result.uuid,
+    setter_username: result.setter_username || '',
+    name: result.name || '',
+    frames: result.frames || '',
+    angle,
+    ascensionist_count: Number(result.ascensionist_count || 0),
+    difficulty: getGradeLabel(result.difficulty_id),
+    quality_average: result.quality_average?.toString() || '0',
+    stars: Math.round((Number(result.quality_average) || 0) * 5),
+    difficulty_error: result.difficulty_error?.toString() || '0',
+    benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
+    is_draft: result.is_draft ?? false,
+  };
+}
+
 /**
  * Search for climbs with various filters.
  * Shared between the GraphQL backend resolver and Next.js SSR.
@@ -35,11 +66,146 @@ export const searchClimbs = async (
     ? 'creation'
     : (searchParams.sortBy || 'ascents');
   const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
+  const isDraftsQuery = !!searchParams.onlyDrafts;
 
+  // For the default hot path (ascents DESC), use a stats-driven query that reads
+  // the covering index in sorted order and stops after pageSize+1 qualifying rows.
+  // This avoids scanning all 15K+ matching climbs just to sort and take 21.
+  //
+  // Climbs without stats (0 ascents) sort last in DESC order so they never appear
+  // on early pages. When the stats-driven query returns fewer rows than needed,
+  // a supplementary query fetches no-stats climbs to fill remaining slots.
+  const useStatsDriven = sortBy === 'ascents' && sortOrder === 'desc' && !isDraftsQuery;
+
+  if (useStatsDriven) {
+    return statsDrivenSearch(db, params, searchParams, filters, sizeEdges, page, pageSize, userId);
+  }
+
+  return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize);
+};
+
+/**
+ * Stats-driven search: FROM board_climb_stats with covering index.
+ * PostgreSQL reads the index in ascensionist_count DESC order and stops early.
+ * Supplementary query fetches no-stats climbs when we run out of stats-having climbs.
+ */
+async function statsDrivenSearch(
+  db: DbInstance,
+  params: BoardRouteParams,
+  searchParams: ClimbSearchParams,
+  filters: ReturnType<typeof createClimbFilters>,
+  sizeEdges: SizeEdges,
+  page: number,
+  pageSize: number,
+  userId?: string,
+): Promise<ClimbSearchResult> {
+  const selectFields = {
+    uuid: boardClimbs.uuid,
+    setter_username: boardClimbs.setterUsername,
+    name: boardClimbs.name,
+    frames: boardClimbs.frames,
+    is_draft: boardClimbs.isDraft,
+    angle: boardClimbStats.angle,
+    ascensionist_count: boardClimbStats.ascensionistCount,
+    difficulty_id: sql<number | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
+    quality_average: sql<number | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
+    difficulty_error: sql<number | null>`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
+    benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
+  };
+
+  // Move climb filters to the JOIN predicate so the covering index scan on
+  // board_climb_stats drives the query in sorted order.
+  const climbJoinConditions = [
+    eq(boardClimbs.uuid, boardClimbStats.climbUuid),
+    ...filters.getClimbWhereConditions(),
+    ...filters.getSizeConditions(),
+  ];
+
+  const statsWhereConditions = [
+    eq(boardClimbStats.boardType, params.board_name),
+    eq(boardClimbStats.angle, params.angle),
+    ...filters.getClimbStatsConditions(),
+  ];
+
+  const results: RawSelectResult[] = await db
+    .select(selectFields)
+    .from(boardClimbStats)
+    .innerJoin(boardClimbs, and(...climbJoinConditions))
+    .where(and(...statsWhereConditions))
+    .orderBy(sql`${boardClimbStats.ascensionistCount} DESC NULLS LAST`, desc(boardClimbs.uuid))
+    .limit(pageSize + 1)
+    .offset(page * pageSize) as unknown as RawSelectResult[];
+
+  // If the stats-driven query filled the page, no-stats climbs aren't needed yet
+  if (results.length > pageSize) {
+    const climbs = results.slice(0, pageSize).map((r) => mapResultToClimbRow(r, params.angle));
+    return { climbs, hasMore: true };
+  }
+
+  // Stats-driven query didn't fill the page — supplement with no-stats climbs.
+  // These have 0 ascents and sort after all stats-having climbs.
+  const statsCount = page * pageSize + results.length;
+  const remaining = pageSize + 1 - results.length;
+  const noStatsOffset = Math.max(0, page * pageSize - statsCount);
+
+  const noStatsResults = remaining > 0 ? await db
+    .select({
+      uuid: boardClimbs.uuid,
+      setter_username: boardClimbs.setterUsername,
+      name: boardClimbs.name,
+      frames: boardClimbs.frames,
+      is_draft: boardClimbs.isDraft,
+      angle: sql<null>`NULL`.as('angle'),
+      ascensionist_count: sql<null>`NULL`.as('ascensionist_count'),
+      difficulty_id: sql<null>`NULL`.as('difficulty_id'),
+      quality_average: sql<null>`NULL`.as('quality_average'),
+      difficulty_error: sql<null>`NULL`.as('difficulty_error'),
+      benchmark_difficulty: sql<null>`NULL`.as('benchmark_difficulty'),
+    })
+    .from(boardClimbs)
+    .where(and(
+      ...filters.getClimbWhereConditions(),
+      ...filters.getSizeConditions(),
+      sql`NOT EXISTS (
+        SELECT 1 FROM ${boardClimbStats}
+        WHERE ${boardClimbStats.boardType} = ${params.board_name}
+        AND ${boardClimbStats.climbUuid} = ${boardClimbs.uuid}
+        AND ${boardClimbStats.angle} = ${params.angle}
+      )`,
+    ))
+    .orderBy(desc(boardClimbs.uuid))
+    .limit(remaining)
+    .offset(noStatsOffset) as unknown as RawSelectResult[] : [];
+
+  const combined: RawSelectResult[] = [...results, ...noStatsResults];
+  const hasMore = combined.length > pageSize;
+  const trimmed = hasMore ? combined.slice(0, pageSize) : combined;
+
+  // description is intentionally excluded — it's unbounded text that inflates I/O.
+  // Features needing it should fetch separately via the climb detail query.
+  const climbs = trimmed.map((r) => mapResultToClimbRow(r, params.angle));
+  return { climbs, hasMore };
+}
+
+/**
+ * Standard search: FROM board_climbs LEFT JOIN board_climb_stats.
+ * Used for non-default sorts (difficulty, name, quality, creation, popular)
+ * and for draft queries.
+ */
+async function standardSearch(
+  db: DbInstance,
+  params: BoardRouteParams,
+  searchParams: ClimbSearchParams,
+  filters: ReturnType<typeof createClimbFilters>,
+  sortBy: string,
+  sortOrder: string,
+  isDraftsQuery: boolean,
+  page: number,
+  pageSize: number,
+): Promise<ClimbSearchResult> {
   // For the popular sort, pre-aggregate total ascents across all angles via a joined subquery
   // instead of a correlated subquery that runs per candidate row.
-  // Scoped with an EXISTS to only aggregate stats for climbs matching the search filters,
-  // avoiding a full scan of board_climb_stats for the entire board_type.
+  // Scoped with an EXISTS to only aggregate stats for climbs matching the search filters.
   const popularCountsSubquery = sortBy === 'popular'
     ? db
         .select({
@@ -63,7 +229,6 @@ export const searchClimbs = async (
         .as('popular_counts')
     : null;
 
-  // Define sort columns
   const allowedSortColumns: Record<string, ReturnType<typeof sql>> = {
     ascents: sql`${boardClimbStats.ascensionistCount}`,
     difficulty: sql`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
@@ -75,9 +240,7 @@ export const searchClimbs = async (
       : {}),
   };
 
-  const sortColumn = allowedSortColumns[sortBy] || sql`${boardClimbStats.ascensionistCount}`;
-
-  const isDraftsQuery = !!searchParams.onlyDrafts;
+  const sortColumn = allowedSortColumns[sortBy] || sql`${boardClimbs.createdAt}`;
 
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
@@ -96,8 +259,8 @@ export const searchClimbs = async (
     angle: boardClimbStats.angle,
     ascensionist_count: boardClimbStats.ascensionistCount,
     difficulty_id: sql<number | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
-    quality_average: sql<number>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
-    difficulty_error: sql<number>`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
+    quality_average: sql<number | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
+    difficulty_error: sql<number | null>`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
     benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
   };
 
@@ -105,45 +268,27 @@ export const searchClimbs = async (
     ? sql`${sortColumn} ASC NULLS FIRST`
     : sql`${sortColumn} DESC NULLS LAST`;
 
-  // LEFT JOIN board_climb_stats for grade/sort data.
-  // Draft climbs never have stats rows so the JOIN returns NULLs — that's fine,
-  // stats conditions are already skipped above and sort is forced to creation.
+  // LEFT JOIN preserves climbs without stats (they get NULL stats columns).
   const coreQuery = db
     .select(selectFields)
     .from(boardClimbs)
     .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()));
 
-  // Only add popular counts join when sorting by popular
   const queryWithJoins = popularCountsSubquery
     ? coreQuery.leftJoin(popularCountsSubquery, eq(popularCountsSubquery.climbUuid, boardClimbs.uuid))
     : coreQuery;
 
-  const results = await queryWithJoins
+  const results: RawSelectResult[] = await queryWithJoins
     .where(and(...whereConditions))
     .orderBy(orderByClause, desc(boardClimbs.uuid))
     .limit(pageSize + 1)
-    .offset(page * pageSize);
+    .offset(page * pageSize) as unknown as RawSelectResult[];
 
   const hasMore = results.length > pageSize;
-  const trimmedResults = hasMore ? results.slice(0, pageSize) : results;
+  const trimmed = hasMore ? results.slice(0, pageSize) : results;
 
-  // description is intentionally excluded from search results — it's unbounded text
-  // that inflates I/O and transfer. Any feature needing it should fetch it separately
-  // via the single-climb detail query (getClimbByUuid).
-  const climbs: ClimbRow[] = trimmedResults.map((result) => ({
-    uuid: result.uuid,
-    setter_username: result.setter_username || '',
-    name: result.name || '',
-    frames: result.frames || '',
-    angle: Number(params.angle),
-    ascensionist_count: Number(result.ascensionist_count || 0),
-    difficulty: getGradeLabel(result.difficulty_id),
-    quality_average: result.quality_average?.toString() || '0',
-    stars: Math.round((Number(result.quality_average) || 0) * 5),
-    difficulty_error: result.difficulty_error?.toString() || '0',
-    benchmark_difficulty: result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-    is_draft: result.is_draft ?? false,
-  }));
-
+  // description is intentionally excluded — it's unbounded text that inflates I/O.
+  // Features needing it should fetch separately via the climb detail query.
+  const climbs = trimmed.map((r) => mapResultToClimbRow(r, params.angle));
   return { climbs, hasMore };
-};
+}

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -75,7 +75,7 @@ export const searchClimbs = async (
     is_draft: boardClimbs.isDraft,
     angle: boardClimbStats.angle,
     ascensionist_count: boardClimbStats.ascensionistCount,
-    difficulty_id: sql<number>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
+    difficulty_id: sql<number | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
     quality_average: sql<number>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
     difficulty_error: sql<number>`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
     benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
@@ -85,79 +85,36 @@ export const searchClimbs = async (
     ? sql`${sortColumn} ASC NULLS FIRST`
     : sql`${sortColumn} DESC NULLS LAST`;
 
-  // For the default ascents sort, drive from board_climb_stats to leverage the
-  // covering index (board_type, angle, ascensionist_count DESC NULLS LAST).
-  // PostgreSQL reads the index in sorted order and stops after 21 qualifying rows,
-  // avoiding a full sort of all matching climbs.
-  const useStatsDriven = sortBy === 'ascents' && sortOrder === 'desc';
+  // Always use board_climbs as the driving table with LEFT JOIN to board_climb_stats.
+  // This ensures climbs without stats rows are not silently dropped from results.
+  // The board_climb_stats_ascents_covering_idx helps the JOIN, and the planner
+  // can use it for the ORDER BY when sorting by ascents.
+  const coreQuery = db
+    .select(selectFields)
+    .from(boardClimbs)
+    .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()));
 
-  type SelectResult = {
-    uuid: string;
-    setter_username: string | null;
-    name: string | null;
-    frames: string | null;
-    is_draft: boolean | null;
-    angle: number | null;
-    ascensionist_count: string | null;
-    difficulty_id: number;
-    quality_average: number;
-    difficulty_error: number;
-    benchmark_difficulty: number | null;
-  };
+  // Only add popular counts join when sorting by popular
+  const queryWithJoins = popularCountsSubquery
+    ? coreQuery.leftJoin(popularCountsSubquery, eq(popularCountsSubquery.climbUuid, boardClimbs.uuid))
+    : coreQuery;
 
-  let results: SelectResult[];
-
-  if (useStatsDriven) {
-    // Stats-driven: FROM board_climb_stats INNER JOIN board_climbs
-    // The climb filter conditions move to the JOIN predicate so the index scan
-    // on board_climb_stats drives the query in sorted order.
-    const climbJoinConditions = [
-      eq(boardClimbs.uuid, boardClimbStats.climbUuid),
-      ...filters.getClimbWhereConditions(),
-      ...filters.getSizeConditions(),
-    ];
-
-    const statsWhereConditions = [
-      eq(boardClimbStats.boardType, params.board_name),
-      eq(boardClimbStats.angle, params.angle),
-      ...filters.getClimbStatsConditions(),
-    ];
-
-    results = await db
-      .select(selectFields)
-      .from(boardClimbStats)
-      .innerJoin(boardClimbs, and(...climbJoinConditions))
-      .where(and(...statsWhereConditions))
-      .orderBy(sql`${boardClimbStats.ascensionistCount} DESC NULLS LAST`, desc(boardClimbs.uuid))
-      .limit(pageSize + 1)
-      .offset(page * pageSize);
-  } else {
-    // Standard path: FROM board_climbs LEFT JOIN board_climb_stats
-    const coreQuery = db
-      .select(selectFields)
-      .from(boardClimbs)
-      .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()));
-
-    // Only add popular counts join when sorting by popular
-    const queryWithJoins = popularCountsSubquery
-      ? coreQuery.leftJoin(popularCountsSubquery, eq(popularCountsSubquery.climbUuid, boardClimbs.uuid))
-      : coreQuery;
-
-    results = await queryWithJoins
-      .where(and(...whereConditions))
-      .orderBy(orderByClause, desc(boardClimbs.uuid))
-      .limit(pageSize + 1)
-      .offset(page * pageSize);
-  }
+  const results = await queryWithJoins
+    .where(and(...whereConditions))
+    .orderBy(orderByClause, desc(boardClimbs.uuid))
+    .limit(pageSize + 1)
+    .offset(page * pageSize);
 
   const hasMore = results.length > pageSize;
   const trimmedResults = hasMore ? results.slice(0, pageSize) : results;
 
+  // description is intentionally excluded from search results — it's unbounded text
+  // that inflates I/O and transfer. Any feature needing it should fetch it separately
+  // via the single-climb detail query (getClimbByUuid).
   const climbs: ClimbRow[] = trimmedResults.map((result) => ({
     uuid: result.uuid,
     setter_username: result.setter_username || '',
     name: result.name || '',
-    description: '',
     frames: result.frames || '',
     angle: Number(params.angle),
     ascensionist_count: Number(result.ascensionist_count || 0),

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -143,7 +143,18 @@ async function statsDrivenSearch(
   }
 
   // Stats-driven query didn't fill the page — supplement with no-stats climbs.
-  // These have 0 ascents and sort after all stats-having climbs.
+  // Skip supplementary query when stats filters are active (minAscents, grade range,
+  // quality, accuracy) — climbs without stats can't satisfy those filters by definition,
+  // so including them would leak unfiltered results.
+  const hasStatsFilters = filters.getClimbStatsConditions().length > 0;
+
+  if (hasStatsFilters) {
+    const climbs = results.map((r) => mapResultToClimbRow(r, params.angle));
+    return { climbs, hasMore: false };
+  }
+
+  // No stats filters active — safe to include no-stats climbs (they have 0 ascents
+  // and sort after all stats-having climbs in DESC order).
   // We need the total stats count to calculate how many no-stats climbs were
   // already shown on previous pages (for correct OFFSET).
   const remaining = pageSize + 1 - results.length;
@@ -190,8 +201,6 @@ async function statsDrivenSearch(
   const hasMore = combined.length > pageSize;
   const trimmed = hasMore ? combined.slice(0, pageSize) : combined;
 
-  // description is intentionally excluded — it's unbounded text that inflates I/O.
-  // Features needing it should fetch separately via the climb detail query.
   const climbs = trimmed.map((r) => mapResultToClimbRow(r, params.angle));
   return { climbs, hasMore };
 }

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -78,6 +78,4 @@ export interface ClimbRow {
   difficulty_error: string;
   benchmark_difficulty: string | null;
   is_draft: boolean;
-  userAscents?: number;
-  userAttempts?: number;
 }

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -62,13 +62,13 @@ export interface ClimbSearchResult {
 
 /**
  * A single row from the climb search query.
- * Lightweight - no litUpHoldsMap or other derived fields.
+ * Lightweight - no description (unbounded text), no litUpHoldsMap or other derived fields.
+ * Features that need description should fetch it separately via the climb detail query.
  */
 export interface ClimbRow {
   uuid: string;
   setter_username: string;
   name: string;
-  description: string;
   frames: string;
   angle: number;
   ascensionist_count: number;

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -15,8 +15,6 @@ const CLIMB_FIELDS = `
   difficulty_error
   mirrored
   benchmark_difficulty
-  userAscents
-  userAttempts
 `;
 
 const QUEUE_ITEM_USER_FIELDS = `

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -6,7 +6,6 @@ const CLIMB_FIELDS = `
   uuid
   setter_username
   name
-  description
   frames
   angle
   ascensionist_count

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -49,7 +49,7 @@ export const climbTypeDefs = /* GraphQL */ `
     uuid: ID!
     setter_username: String!
     name: String!
-    description: String!
+    description: String
     frames: String!
     angle: Int!
     ascensionist_count: Int!

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -12,8 +12,8 @@ export const climbTypeDefs = /* GraphQL */ `
     setter_username: String!
     "Name/title of the climb"
     name: String!
-    "Description or notes about the climb"
-    description: String!
+    "Description or notes about the climb (nullable - omitted from search results, fetch separately via climb detail query)"
+    description: String
     "Encoded hold positions and colors for lighting up the board"
     frames: String!
     "Board angle in degrees when this climb was set"

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -29,7 +29,7 @@ export type ClimbInput = {
   uuid: string;
   setter_username: string;
   name: string;
-  description: string;
+  description?: string | null;
   frames: string;
   angle: number;
   ascensionist_count: number;

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -9,7 +9,7 @@ export type Climb = {
   layoutId?: number | null; // GraphQL nullable Int - layout the climb belongs to
   setter_username: string;
   name: string;
-  description: string;
+  description?: string | null;
   frames: string;
   angle: number;
   ascensionist_count: number;

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -7,6 +7,7 @@
 import 'server-only';
 import { cache } from 'react';
 import { sql } from '@/app/lib/db/db';
+import { getGradeLabel } from '@boardsesh/db/queries';
 
 import { Climb, ParsedBoardRouteParametersWithUuid, BoardName, LayoutId, Size } from '../types';
 import {
@@ -26,7 +27,7 @@ export const getClimb = cache(async (params: ParsedBoardRouteParametersWithUuid)
   const result = await sql`
         SELECT climbs.uuid, climbs.setter_username, climbs.name, climbs.description,
         climbs.frames, COALESCE(climb_stats.angle, ${params.angle}) as angle, COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
-        dg.boulder_name as difficulty,
+        ROUND(climb_stats.display_difficulty::numeric, 0) as difficulty_id,
         ROUND(climb_stats.quality_average::numeric, 2) as quality_average,
         ROUND(climb_stats.difficulty_average::numeric - climb_stats.display_difficulty::numeric, 2) AS difficulty_error,
         CASE WHEN climb_stats.benchmark_difficulty > 0 THEN climb_stats.benchmark_difficulty::text ELSE NULL END as benchmark_difficulty
@@ -35,16 +36,14 @@ export const getClimb = cache(async (params: ParsedBoardRouteParametersWithUuid)
           ON climb_stats.climb_uuid = climbs.uuid
           AND climb_stats.angle = ${params.angle}
           AND climb_stats.board_type = ${params.board_name}
-        LEFT JOIN board_difficulty_grades dg
-          ON dg.difficulty = ROUND(climb_stats.display_difficulty::numeric)
-          AND dg.board_type = ${params.board_name}
         WHERE climbs.board_type = ${params.board_name}
         AND climbs.layout_id = ${params.layout_id}
         AND climbs.uuid = ${params.climb_uuid}
         AND climbs.frames_count = 1
         limit 1
       `;
-  return result[0] as Climb;
+  const row = result[0] as Climb & { difficulty_id: number | null };
+  return { ...row, difficulty: getGradeLabel(row.difficulty_id) } as Climb;
 });
 
 export interface ClimbStatsForAngle {
@@ -70,16 +69,16 @@ export const getClimbStatsForAllAngles = async (
       climb_stats.display_difficulty,
       climb_stats.fa_username,
       climb_stats.fa_at,
-      dg.boulder_name as difficulty
+      ROUND(climb_stats.display_difficulty::numeric, 0) as difficulty_id
     FROM board_climb_stats climb_stats
-    LEFT JOIN board_difficulty_grades dg
-      ON dg.difficulty = ROUND(climb_stats.display_difficulty::numeric)
-      AND dg.board_type = ${params.board_name}
     WHERE climb_stats.board_type = ${params.board_name}
     AND climb_stats.climb_uuid = ${params.climb_uuid}
     ORDER BY climb_stats.angle ASC
   `;
-  return result as ClimbStatsForAngle[];
+  return (result as Array<ClimbStatsForAngle & { difficulty_id: number | null }>).map((row) => ({
+    ...row,
+    difficulty: getGradeLabel(row.difficulty_id),
+  })) as ClimbStatsForAngle[];
 };
 
 export type LayoutRow = {

--- a/packages/web/app/lib/graphql/operations/climb-search.ts
+++ b/packages/web/app/lib/graphql/operations/climb-search.ts
@@ -15,8 +15,6 @@ const CLIMB_SEARCH_FIELDS = `
   difficulty_error
   benchmark_difficulty
   is_draft
-  userAscents
-  userAttempts
 `;
 
 // Full fragment for single-climb views that need all fields


### PR DESCRIPTION
## Summary
This PR refactors the climb search query to improve performance and simplifies the data model by removing user-specific tick tracking from search results.

## Key Changes

- **Query Optimization**: Implemented a stats-driven query path for the default ascents sort that leverages a covering index on `board_climb_stats(board_type, angle, ascensionist_count DESC NULLS LAST)`. This allows PostgreSQL to read results in sorted order and stop early, avoiding full table scans.

- **Popular Sort Improvement**: Replaced correlated subqueries with a pre-aggregated joined subquery for the popular sort, reducing per-row computation.

- **Grade Lookup Refactor**: Replaced the `board_difficulty_grades` JOIN with a static `GRADE_MAP` lookup table in a new `grade-lookup.ts` module. Since grade data is stable and identical across all board types, this eliminates an unnecessary JOIN and simplifies the query.

- **Removed User Tick Tracking**: Removed `userAscents` and `userAttempts` fields from climb search results. These fields were previously populated via a user-specific subquery but are no longer needed in the search response.

- **Simplified Select Fields**: Removed `description` field from search results (now hardcoded to empty string) and changed `difficulty` to be computed from `difficulty_id` using the grade lookup function.

## Implementation Details

- The stats-driven query path is only used for the default ascents sort in descending order, where the covering index provides the most benefit.
- For other sort orders and types, the standard climb-driven query path is used with appropriate JOINs.
- The `GRADE_MAP` is a static record mapping difficulty IDs (10-33) to boulder grade names (4a/V0 through 8c+/V16).
- Backend and web packages updated to handle the removal of user tick fields from the response.

https://claude.ai/code/session_01RPqXq9Br1u7YCVPJeDGtgP