### PR TITLE
Refactor account deletion with GraphQL and published climb handling

### DIFF
--- a/packages/backend/src/graphql/resolvers/users/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/users/mutations.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import type { ConnectionContext, UserProfile, AuroraCredentialStatus } from '@boardsesh/shared-schema';
+import type { ConnectionContext, UserProfile, AuroraCredentialStatus, DeleteAccountInput } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
@@ -148,6 +148,57 @@ export const userMutations = {
           eq(dbSchema.auroraCredentials.boardType, boardType)
         )
       );
+
+    return true;
+  },
+
+  /**
+   * Delete the current user's account.
+   * 1. Deletes draft climbs
+   * 2. Optionally removes setter name from published climbs
+   * 3. Deletes the user row (cascading all related data)
+   */
+  deleteAccount: async (
+    _: unknown,
+    { input }: { input: DeleteAccountInput },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+
+    const userId = ctx.userId!;
+
+    await db.transaction(async (tx) => {
+      // Delete draft climbs created by this user
+      await tx
+        .delete(dbSchema.boardClimbs)
+        .where(
+          and(
+            eq(dbSchema.boardClimbs.userId, userId),
+            eq(dbSchema.boardClimbs.isDraft, true)
+          )
+        );
+
+      // Optionally remove setter name from published climbs
+      if (input.removeSetterName) {
+        await tx
+          .update(dbSchema.boardClimbs)
+          .set({ setterUsername: null })
+          .where(
+            and(
+              eq(dbSchema.boardClimbs.userId, userId),
+              eq(dbSchema.boardClimbs.isDraft, false)
+            )
+          );
+      }
+
+      // Delete the user row — all related tables with onDelete: cascade
+      // will be cleaned up automatically by the database.
+      // boardClimbs.userId has onDelete: 'set null', so published climbs
+      // will have their userId set to null (preserved).
+      await tx
+        .delete(dbSchema.users)
+        .where(eq(dbSchema.users.id, userId));
+    });
 
     return true;
   },

--- a/packages/backend/src/graphql/resolvers/users/queries.ts
+++ b/packages/backend/src/graphql/resolvers/users/queries.ts
@@ -1,8 +1,8 @@
-import { eq, and } from 'drizzle-orm';
-import type { ConnectionContext, UserProfile, AuroraCredentialStatus } from '@boardsesh/shared-schema';
+import { eq, and, count } from 'drizzle-orm';
+import type { ConnectionContext, UserProfile, AuroraCredentialStatus, DeleteAccountInfo } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { validateInput } from '../shared/helpers';
+import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { BoardNameSchema } from '../../../validation/schemas';
 
 export const userQueries = {
@@ -98,6 +98,31 @@ export const userQueries = {
       syncedAt: c.lastSyncAt?.toISOString() || undefined,
       // Note: We don't expose the actual token for security
       token: c.auroraToken ? '[ENCRYPTED]' : undefined,
+    };
+  },
+
+  /**
+   * Get info needed before account deletion (published climb count)
+   */
+  deleteAccountInfo: async (
+    _: unknown,
+    __: unknown,
+    ctx: ConnectionContext
+  ): Promise<DeleteAccountInfo> => {
+    requireAuthenticated(ctx);
+
+    const result = await db
+      .select({ count: count() })
+      .from(dbSchema.boardClimbs)
+      .where(
+        and(
+          eq(dbSchema.boardClimbs.userId, ctx.userId!),
+          eq(dbSchema.boardClimbs.isDraft, false)
+        )
+      );
+
+    return {
+      publishedClimbCount: result[0]?.count ?? 0,
     };
   },
 };

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -77,6 +77,14 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     updateProfile(input: UpdateProfileInput!): UserProfile!
 
+    """
+    Delete the current user's account.
+    Deletes draft climbs, optionally removes setter name from published climbs,
+    then deletes the user row (cascading all related data).
+    Requires authentication.
+    """
+    deleteAccount(input: DeleteAccountInput!): Boolean!
+
     # ============================================
     # Aurora Credentials Mutations (require auth)
     # ============================================

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -86,6 +86,12 @@ export const queriesTypeDefs = /* GraphQL */ `
     profile: UserProfile
 
     """
+    Get info needed before account deletion (published climb count).
+    Requires authentication.
+    """
+    deleteAccountInfo: DeleteAccountInfo!
+
+    """
     Get status of all stored Aurora credentials.
     Requires authentication.
     """

--- a/packages/shared-schema/src/schema/user.ts
+++ b/packages/shared-schema/src/schema/user.ts
@@ -70,4 +70,20 @@ export const userTypeDefs = /* GraphQL */ `
     "Aurora account password"
     password: String!
   }
+
+  """
+  Information needed before account deletion.
+  """
+  type DeleteAccountInfo {
+    "Number of published (non-draft) climbs the user has created"
+    publishedClimbCount: Int!
+  }
+
+  """
+  Input for the deleteAccount mutation.
+  """
+  input DeleteAccountInput {
+    "Whether to remove the setter name from published climbs"
+    removeSetterName: Boolean!
+  }
 `;

--- a/packages/shared-schema/src/types/user.ts
+++ b/packages/shared-schema/src/types/user.ts
@@ -35,3 +35,11 @@ export type SaveAuroraCredentialInput = {
   username: string;
   password: string;
 };
+
+export type DeleteAccountInfo = {
+  publishedClimbCount: number;
+};
+
+export type DeleteAccountInput = {
+  removeSetterName: boolean;
+};

--- a/packages/web/app/components/settings/delete-account-section.tsx
+++ b/packages/web/app/components/settings/delete-account-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
@@ -11,44 +11,88 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
 import { signOut } from 'next-auth/react';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  GET_DELETE_ACCOUNT_INFO,
+  DELETE_ACCOUNT,
+  type GetDeleteAccountInfoResponse,
+  type DeleteAccountResponse,
+} from '@/app/lib/graphql/operations/account';
 
 export default function DeleteAccountSection() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
   const [deleting, setDeleting] = useState(false);
+  const [removeSetterName, setRemoveSetterName] = useState(false);
+  const [publishedClimbCount, setPublishedClimbCount] = useState<number | null>(null);
+  const [loadingInfo, setLoadingInfo] = useState(false);
   const { showMessage } = useSnackbar();
+  const { token } = useWsAuthToken();
 
   const isConfirmed = confirmText === 'DELETE';
+
+  useEffect(() => {
+    if (!dialogOpen || !token) return;
+
+    let cancelled = false;
+    setLoadingInfo(true);
+
+    const client = createGraphQLHttpClient(token);
+    client
+      .request<GetDeleteAccountInfoResponse>(GET_DELETE_ACCOUNT_INFO)
+      .then((data) => {
+        if (!cancelled) {
+          setPublishedClimbCount(data.deleteAccountInfo.publishedClimbCount);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPublishedClimbCount(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingInfo(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dialogOpen, token]);
 
   const handleOpen = () => {
     setDialogOpen(true);
     setConfirmText('');
+    setRemoveSetterName(false);
+    setPublishedClimbCount(null);
   };
 
   const handleClose = () => {
     if (deleting) return;
     setDialogOpen(false);
     setConfirmText('');
+    setRemoveSetterName(false);
+    setPublishedClimbCount(null);
   };
 
   const handleDelete = async () => {
-    if (!isConfirmed) return;
+    if (!isConfirmed || !token) return;
 
     try {
       setDeleting(true);
-      const response = await fetch('/api/internal/delete-account', {
-        method: 'DELETE',
+
+      const client = createGraphQLHttpClient(token);
+      await client.request<DeleteAccountResponse>(DELETE_ACCOUNT, {
+        input: { removeSetterName },
       });
 
-      if (!response.ok) {
-        const data: { error?: string } = await response.json();
-        showMessage(data.error || 'Failed to delete account', 'error');
-        return;
-      }
-
-      // Account deleted - sign out and redirect to home
+      // Account deleted — sign out and redirect to home
       await signOut({ callbackUrl: '/' });
     } catch (error) {
       console.error('Delete account error:', error);
@@ -57,6 +101,8 @@ export default function DeleteAccountSection() {
       setDeleting(false);
     }
   };
+
+  const hasPublishedClimbs = publishedClimbCount !== null && publishedClimbCount > 0;
 
   return (
     <>
@@ -79,9 +125,37 @@ export default function DeleteAccountSection() {
         <DialogTitle>Delete your account?</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            This is permanent. Your profile, saved climbs, logbook entries, and
+            This is permanent. Your profile, draft climbs, logbook entries, and
             all other data will be deleted and cannot be recovered.
           </Typography>
+
+          {loadingInfo && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Checking your climbs...
+            </Typography>
+          )}
+
+          {hasPublishedClimbs && (
+            <>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                You have <strong>{publishedClimbCount}</strong> published{' '}
+                {publishedClimbCount === 1 ? 'climb' : 'climbs'} that will be
+                preserved after deletion.
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={removeSetterName}
+                    onChange={(e) => setRemoveSetterName(e.target.checked)}
+                    disabled={deleting}
+                  />
+                }
+                label="Remove my setter name from published climbs"
+                sx={{ mb: 2, display: 'flex' }}
+              />
+            </>
+          )}
+
           <Typography variant="body2" sx={{ mb: 2 }}>
             Type <strong>DELETE</strong> to confirm.
           </Typography>

--- a/packages/web/app/lib/graphql/operations/account.ts
+++ b/packages/web/app/lib/graphql/operations/account.ts
@@ -1,0 +1,24 @@
+import { gql } from 'graphql-request';
+import type { DeleteAccountInfo } from '@boardsesh/shared-schema';
+
+export const GET_DELETE_ACCOUNT_INFO = gql`
+  query GetDeleteAccountInfo {
+    deleteAccountInfo {
+      publishedClimbCount
+    }
+  }
+`;
+
+export interface GetDeleteAccountInfoResponse {
+  deleteAccountInfo: DeleteAccountInfo;
+}
+
+export const DELETE_ACCOUNT = gql`
+  mutation DeleteAccount($input: DeleteAccountInput!) {
+    deleteAccount(input: $input)
+  }
+`;
+
+export interface DeleteAccountResponse {
+  deleteAccount: boolean;
+}


### PR DESCRIPTION
## Summary
Refactored the account deletion flow to use GraphQL instead of a custom API endpoint, and added support for preserving published climbs while optionally removing the setter name from them.

## Key Changes

**Frontend (Web)**
- Replaced REST API call (`/api/internal/delete-account`) with GraphQL mutations
- Added `useEffect` hook to fetch account deletion info (published climb count) when the delete dialog opens
- Added checkbox UI to allow users to optionally remove their setter name from published climbs
- Updated confirmation dialog to display published climb count and removal option
- Changed wording from "saved climbs" to "draft climbs" in the deletion warning

**Backend (GraphQL)**
- Added `deleteAccountInfo` query to retrieve the count of published climbs for the current user
- Added `deleteAccount` mutation that:
  - Deletes all draft climbs created by the user
  - Optionally removes setter name from published climbs (if requested)
  - Deletes the user row, cascading related data while preserving published climbs via `onDelete: 'set null'` on the userId foreign key
- Implemented transaction-based deletion to ensure data consistency

**Schema**
- Added `DeleteAccountInfo` type with `publishedClimbCount` field
- Added `DeleteAccountInput` type with `removeSetterName` boolean flag
- Added GraphQL operation definitions for the new query and mutation

## Notable Implementation Details

- The deletion uses a database transaction to ensure atomicity across multiple operations
- Published climbs are preserved by leveraging the existing `onDelete: 'set null'` constraint on the `boardClimbs.userId` foreign key
- The frontend fetches deletion info on-demand when the dialog opens, with proper cleanup via the useEffect return function
- The UI conditionally displays the setter name removal option only when the user has published climbs

https://claude.ai/code/session_01HCPuTmaY5FBTEfPcMTBZTH