### PR TITLE
fix: enable Redis cache for logged-in users

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -83,9 +83,7 @@ export const climbQueries = {
       };
     }
 
-    const userId = ctx.isAuthenticated ? ctx.userId : undefined;
-
-    // Results are cacheable when there's no userId AND no user-specific filters.
+    // Results are cacheable when there are no user-specific filters.
     // This mirrors the middleware CDN caching logic which also skips cache for these params.
     const hasUserSpecificFilters = !!(
       searchParams.hideAttempted ||
@@ -95,6 +93,10 @@ export const climbQueries = {
       searchParams.onlyDrafts
     );
 
+    // Only resolve userId when user-specific filters are active — otherwise the query
+    // results are identical to anonymous and can be served from Redis cache.
+    const userId = (ctx.isAuthenticated && hasUserSpecificFilters) ? ctx.userId : undefined;
+
     // Return context for field resolvers - queries are executed lazily per field
     // Personal progress filters now use boardsesh_ticks table with NextAuth user ID
     return {
@@ -102,7 +104,7 @@ export const climbQueries = {
       searchParams,
       sizeEdges,
       userId,
-      _isCacheable: !userId && !hasUserSpecificFilters,
+      _isCacheable: !hasUserSpecificFilters,
     };
   },
 


### PR DESCRIPTION
## Summary

Two bugs in PR #1060's caching implementation that made it ineffective in production:

### 1. Redis cache bypassed for all logged-in users
- `_isCacheable` in the searchClimbs GraphQL resolver checked `!userId`, which is always false for authenticated users
- Query results are identical for anonymous and logged-in users when no user-specific filters are active
- **Fix:** Only resolve `userId` when user-specific filters (`hideAttempted`, `hideCompleted`, etc.) are present, matching how the SSR layer already works

### 2. CDN Cache-Control headers overwritten by Next.js
- Next.js overwrites `Cache-Control` set in middleware with `private, no-store` for dynamic pages (pages using `searchParams`)
- **Fix:** Use `Vercel-CDN-Cache-Control` and `CDN-Cache-Control` headers instead, which Vercel's CDN respects as highest priority and Next.js doesn't touch
- Also fixed route matching to support the new `/b/[slug]/[angle]/list` URL format

## Test plan

- [x] `bun run typecheck:backend` passes
- [x] Middleware tests pass (13/13)
- [ ] Deploy to preview and verify:
  - [ ] Logged-in users see fast search queries (Redis cache hits after first request)
  - [ ] `curl -I` on list page shows `Vercel-CDN-Cache-Control` header
  - [ ] User-specific filters still work correctly for logged-in users
  - [ ] Anonymous users still get cached results

🤖 Generated with [Claude Code](https://claude.com/claude-code)