### PR TITLE
fix: use Vercel-CDN-Cache-Control for list page CDN caching

### DIFF
--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -4,86 +4,102 @@ vi.mock('@/app/lib/board-data', () => ({
   SUPPORTED_BOARDS: ['kilter', 'tension'],
 }));
 
-const { getListPageCacheControl } = await import('@/app/lib/list-page-cache');
+const { getListPageCacheTTL } = await import('@/app/lib/list-page-cache');
 
 function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
 }
 
-describe('getListPageCacheControl', () => {
-  it('returns public cache header for default list page', () => {
-    expect(getListPageCacheControl('/kilter/original/12x12-square/screw_bolt/40/list', sp())).toBe(
-      'public, s-maxage=86400, stale-while-revalidate=604800',
-    );
+const TTL_24H = 86400;
+
+describe('getListPageCacheTTL', () => {
+  // Legacy format: /[board]/[layout]/[size]/[sets]/[angle]/list
+  it('returns TTL for default list page (legacy format)', () => {
+    expect(getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/list', sp())).toBe(TTL_24H);
   });
 
-  it('returns public cache header with non-user-specific filters', () => {
+  it('returns TTL with non-user-specific filters', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/kilter/original/12x12-square/screw_bolt/40/list',
         sp({ minGrade: '10', sortBy: 'difficulty' }),
       ),
-    ).toBe('public, s-maxage=86400, stale-while-revalidate=604800');
+    ).toBe(TTL_24H);
   });
 
-  it('returns private when hideAttempted=true', () => {
+  it('returns null when hideAttempted=true', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/kilter/original/12x12-square/screw_bolt/40/list',
         sp({ hideAttempted: 'true' }),
       ),
-    ).toBe('private, no-store');
+    ).toBeNull();
   });
 
-  it('returns private when onlyDrafts=1', () => {
+  it('returns null when onlyDrafts=1', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/tension/original/12x12-square/screw_bolt/40/list',
         sp({ onlyDrafts: '1' }),
       ),
-    ).toBe('private, no-store');
+    ).toBeNull();
   });
 
   it('treats hideAttempted=false as cacheable', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/kilter/original/12x12-square/screw_bolt/40/list',
         sp({ hideAttempted: 'false' }),
       ),
-    ).toBe('public, s-maxage=86400, stale-while-revalidate=604800');
+    ).toBe(TTL_24H);
   });
 
   it('treats hideAttempted=0 as cacheable', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/kilter/original/12x12-square/screw_bolt/40/list',
         sp({ hideAttempted: '0' }),
       ),
-    ).toBe('public, s-maxage=86400, stale-while-revalidate=604800');
+    ).toBe(TTL_24H);
   });
 
   it('treats hideAttempted=undefined (string) as cacheable', () => {
     expect(
-      getListPageCacheControl(
+      getListPageCacheTTL(
         '/kilter/original/12x12-square/screw_bolt/40/list',
         sp({ hideAttempted: 'undefined' }),
       ),
-    ).toBe('public, s-maxage=86400, stale-while-revalidate=604800');
+    ).toBe(TTL_24H);
   });
 
   it('returns null for non-list pages', () => {
     expect(
-      getListPageCacheControl('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp()),
+      getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp()),
     ).toBeNull();
   });
 
-  it('returns null for unsupported board', () => {
+  it('returns null for unsupported board (legacy format)', () => {
     expect(
-      getListPageCacheControl('/fakeboard/original/12x12-square/screw_bolt/40/list', sp()),
+      getListPageCacheTTL('/fakeboard/original/12x12-square/screw_bolt/40/list', sp()),
     ).toBeNull();
   });
 
   it('returns null for paths with too few segments', () => {
-    expect(getListPageCacheControl('/kilter/list', sp())).toBeNull();
+    expect(getListPageCacheTTL('/kilter/list', sp())).toBeNull();
+  });
+
+  // Slug format: /b/[board_slug]/[angle]/list
+  it('returns TTL for slug format list page', () => {
+    expect(getListPageCacheTTL('/b/kilter-original-12x12/40/list', sp())).toBe(TTL_24H);
+  });
+
+  it('returns null for slug format with user-specific params', () => {
+    expect(
+      getListPageCacheTTL('/b/kilter-original-12x12/40/list', sp({ hideCompleted: 'true' })),
+    ).toBeNull();
+  });
+
+  it('returns null for /b/ paths with too few segments', () => {
+    expect(getListPageCacheTTL('/b/list', sp())).toBeNull();
   });
 });

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -11,95 +11,105 @@ function sp(params: Record<string, string> = {}): URLSearchParams {
 }
 
 const TTL_24H = 86400;
+const LEGACY_LIST = '/kilter/original/12x12-square/screw_bolt/40/list';
+const SLUG_LIST = '/b/kilter-original-12x12/40/list';
 
 describe('getListPageCacheTTL', () => {
   // Legacy format: /[board]/[layout]/[size]/[sets]/[angle]/list
   it('returns TTL for default list page (legacy format)', () => {
-    expect(getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/list', sp())).toBe(TTL_24H);
+    expect(getListPageCacheTTL(LEGACY_LIST, sp(), false)).toBe(TTL_24H);
   });
 
   it('returns TTL with non-user-specific filters', () => {
     expect(
-      getListPageCacheTTL(
-        '/kilter/original/12x12-square/screw_bolt/40/list',
-        sp({ minGrade: '10', sortBy: 'difficulty' }),
-      ),
+      getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', sortBy: 'difficulty' }), false),
     ).toBe(TTL_24H);
   });
 
-  it('returns null when hideAttempted=true', () => {
+  // User-specific params + authenticated session → skip cache
+  it('returns null when authenticated user has hideAttempted=true', () => {
     expect(
-      getListPageCacheTTL(
-        '/kilter/original/12x12-square/screw_bolt/40/list',
-        sp({ hideAttempted: 'true' }),
-      ),
+      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'true' }), true),
     ).toBeNull();
   });
 
-  it('returns null when onlyDrafts=1', () => {
+  it('returns null when authenticated user has onlyDrafts=1', () => {
     expect(
-      getListPageCacheTTL(
-        '/tension/original/12x12-square/screw_bolt/40/list',
-        sp({ onlyDrafts: '1' }),
-      ),
+      getListPageCacheTTL('/tension/original/12x12-square/screw_bolt/40/list', sp({ onlyDrafts: '1' }), true),
     ).toBeNull();
   });
 
-  it('treats hideAttempted=false as cacheable', () => {
+  // User-specific params + anonymous → still cacheable (params have no effect without userId)
+  it('returns TTL when anonymous user has hideAttempted=true', () => {
     expect(
-      getListPageCacheTTL(
-        '/kilter/original/12x12-square/screw_bolt/40/list',
-        sp({ hideAttempted: 'false' }),
-      ),
+      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'true' }), false),
     ).toBe(TTL_24H);
   });
 
-  it('treats hideAttempted=0 as cacheable', () => {
+  it('returns TTL when anonymous user has onlyDrafts=1', () => {
     expect(
-      getListPageCacheTTL(
-        '/kilter/original/12x12-square/screw_bolt/40/list',
-        sp({ hideAttempted: '0' }),
-      ),
+      getListPageCacheTTL(LEGACY_LIST, sp({ onlyDrafts: '1' }), false),
+    ).toBe(TTL_24H);
+  });
+
+  // Authenticated user without user-specific params → cacheable
+  it('returns TTL for authenticated user without user-specific params', () => {
+    expect(getListPageCacheTTL(LEGACY_LIST, sp(), true)).toBe(TTL_24H);
+  });
+
+  it('treats hideAttempted=false as cacheable even with session', () => {
+    expect(
+      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'false' }), true),
+    ).toBe(TTL_24H);
+  });
+
+  it('treats hideAttempted=0 as cacheable even with session', () => {
+    expect(
+      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: '0' }), true),
     ).toBe(TTL_24H);
   });
 
   it('treats hideAttempted=undefined (string) as cacheable', () => {
     expect(
-      getListPageCacheTTL(
-        '/kilter/original/12x12-square/screw_bolt/40/list',
-        sp({ hideAttempted: 'undefined' }),
-      ),
+      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'undefined' }), false),
     ).toBe(TTL_24H);
   });
 
+  // Non-list pages
   it('returns null for non-list pages', () => {
     expect(
-      getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp()),
+      getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp(), false),
     ).toBeNull();
   });
 
   it('returns null for unsupported board (legacy format)', () => {
     expect(
-      getListPageCacheTTL('/fakeboard/original/12x12-square/screw_bolt/40/list', sp()),
+      getListPageCacheTTL('/fakeboard/original/12x12-square/screw_bolt/40/list', sp(), false),
     ).toBeNull();
   });
 
   it('returns null for paths with too few segments', () => {
-    expect(getListPageCacheTTL('/kilter/list', sp())).toBeNull();
+    expect(getListPageCacheTTL('/kilter/list', sp(), false)).toBeNull();
   });
 
   // Slug format: /b/[board_slug]/[angle]/list
   it('returns TTL for slug format list page', () => {
-    expect(getListPageCacheTTL('/b/kilter-original-12x12/40/list', sp())).toBe(TTL_24H);
+    expect(getListPageCacheTTL(SLUG_LIST, sp(), false)).toBe(TTL_24H);
   });
 
-  it('returns null for slug format with user-specific params', () => {
+  it('returns null for slug format with user-specific params and session', () => {
     expect(
-      getListPageCacheTTL('/b/kilter-original-12x12/40/list', sp({ hideCompleted: 'true' })),
+      getListPageCacheTTL(SLUG_LIST, sp({ hideCompleted: 'true' }), true),
     ).toBeNull();
   });
 
+  it('returns TTL for slug format with user-specific params but no session', () => {
+    expect(
+      getListPageCacheTTL(SLUG_LIST, sp({ hideCompleted: 'true' }), false),
+    ).toBe(TTL_24H);
+  });
+
   it('returns null for /b/ paths with too few segments', () => {
-    expect(getListPageCacheTTL('/b/list', sp())).toBeNull();
+    expect(getListPageCacheTTL('/b/list', sp(), false)).toBeNull();
   });
 });

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -4,24 +4,35 @@ import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 const USER_SPECIFIC_PARAMS = ['hideAttempted', 'hideCompleted', 'showOnlyAttempted', 'showOnlyCompleted', 'onlyDrafts'];
 
 /**
- * Returns the appropriate Cache-Control header value for a list page request,
- * or null if the request is not a list page.
+ * Checks whether a request is a cacheable list page and returns the CDN cache
+ * duration in seconds, or null if the request should not be CDN-cached.
+ *
+ * Matches both URL formats:
+ *   - /[board]/[layout]/[size]/[sets]/[angle]/list  (legacy numeric)
+ *   - /b/[board_slug]/[angle]/list                  (new slug format)
  */
-export function getListPageCacheControl(pathname: string, searchParams: URLSearchParams): string | null {
+export function getListPageCacheTTL(pathname: string, searchParams: URLSearchParams): number | null {
   // Fast-path: skip parsing for routes that clearly aren't list pages
   if (!pathname.endsWith('/list')) {
     return null;
   }
 
   const pathParts = pathname.split('/').filter(Boolean);
+  const lastPart = pathParts[pathParts.length - 1];
 
-  // Must end with /list and have at least 6 segments: board/layout/size/sets/angle/list
-  if (pathParts.length < 6 || pathParts[pathParts.length - 1] !== 'list') {
+  if (lastPart !== 'list') {
     return null;
   }
 
-  // First segment must be a supported board
-  if (!(SUPPORTED_BOARDS as readonly string[]).includes(pathParts[0].toLowerCase())) {
+  const isLegacyFormat =
+    pathParts.length >= 6 &&
+    (SUPPORTED_BOARDS as readonly string[]).includes(pathParts[0].toLowerCase());
+
+  const isSlugFormat =
+    pathParts.length >= 4 &&
+    pathParts[0] === 'b';
+
+  if (!isLegacyFormat && !isSlugFormat) {
     return null;
   }
 
@@ -31,8 +42,8 @@ export function getListPageCacheControl(pathname: string, searchParams: URLSearc
   });
 
   if (hasUserSpecificParams) {
-    return 'private, no-store';
+    return null;
   }
 
-  return 'public, s-maxage=86400, stale-while-revalidate=604800';
+  return 86400; // 24 hours
 }

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -7,11 +7,16 @@ const USER_SPECIFIC_PARAMS = ['hideAttempted', 'hideCompleted', 'showOnlyAttempt
  * Checks whether a request is a cacheable list page and returns the CDN cache
  * duration in seconds, or null if the request should not be CDN-cached.
  *
+ * User-specific params (hideAttempted, etc.) only prevent caching when the
+ * request has an authenticated session — matching the GraphQL resolver logic
+ * where userId is only resolved when user-specific filters are active.
+ * Without a session these params have no effect on query results.
+ *
  * Matches both URL formats:
  *   - /[board]/[layout]/[size]/[sets]/[angle]/list  (legacy numeric)
  *   - /b/[board_slug]/[angle]/list                  (new slug format)
  */
-export function getListPageCacheTTL(pathname: string, searchParams: URLSearchParams): number | null {
+export function getListPageCacheTTL(pathname: string, searchParams: URLSearchParams, hasSession: boolean): number | null {
   // Fast-path: skip parsing for routes that clearly aren't list pages
   if (!pathname.endsWith('/list')) {
     return null;
@@ -36,13 +41,18 @@ export function getListPageCacheTTL(pathname: string, searchParams: URLSearchPar
     return null;
   }
 
-  const hasUserSpecificParams = USER_SPECIFIC_PARAMS.some((param) => {
-    const value = searchParams.get(param);
-    return value === 'true' || value === '1';
-  });
+  // User-specific params only matter when there's an authenticated session.
+  // Without a session, these params have no effect on query results (the DB
+  // query ignores them without a userId), so the response is still cacheable.
+  if (hasSession) {
+    const hasUserSpecificParams = USER_SPECIFIC_PARAMS.some((param) => {
+      const value = searchParams.get(param);
+      return value === 'true' || value === '1';
+    });
 
-  if (hasUserSpecificParams) {
-    return null;
+    if (hasUserSpecificParams) {
+      return null;
+    }
   }
 
   return 86400; // 24 hours

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
-import { getListPageCacheControl } from './app/lib/list-page-cache';
+import { getListPageCacheTTL } from './app/lib/list-page-cache';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
 
@@ -39,10 +39,16 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  const cacheControl = getListPageCacheControl(pathname, request.nextUrl.searchParams);
-  if (cacheControl !== null) {
+  // Use Vercel-CDN-Cache-Control because Next.js overwrites Cache-Control
+  // for dynamic pages (pages that use searchParams) with "private, no-store".
+  // Vercel-CDN-Cache-Control is the highest-priority header for Vercel's CDN
+  // and is not touched by Next.js rendering.
+  const cacheTTL = getListPageCacheTTL(pathname, request.nextUrl.searchParams);
+  if (cacheTTL !== null) {
+    const cdnCacheValue = `s-maxage=${cacheTTL}, stale-while-revalidate=${cacheTTL * 7}`;
     const response = NextResponse.next();
-    response.headers.set('Cache-Control', cacheControl);
+    response.headers.set('Vercel-CDN-Cache-Control', cdnCacheValue);
+    response.headers.set('CDN-Cache-Control', cdnCacheValue);
     return response;
   }
 

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -43,7 +43,9 @@ export function middleware(request: NextRequest) {
   // for dynamic pages (pages that use searchParams) with "private, no-store".
   // Vercel-CDN-Cache-Control is the highest-priority header for Vercel's CDN
   // and is not touched by Next.js rendering.
-  const cacheTTL = getListPageCacheTTL(pathname, request.nextUrl.searchParams);
+  const hasSession = request.cookies.has('__Secure-next-auth.session-token') ||
+    request.cookies.has('next-auth.session-token');
+  const cacheTTL = getListPageCacheTTL(pathname, request.nextUrl.searchParams, hasSession);
   if (cacheTTL !== null) {
     const cdnCacheValue = `s-maxage=${cacheTTL}, stale-while-revalidate=${cacheTTL * 7}`;
     const response = NextResponse.next();


### PR DESCRIPTION
Next.js overwrites Cache-Control headers set in middleware for dynamic pages (pages using searchParams) with "private, no-store". Switch to Vercel-CDN-Cache-Control which is the highest-priority CDN header and is not touched by Next.js rendering.

Also fixes route matching to support the new /b/[slug]/[angle]/list URL format alongside the legacy numeric format.