### PR TITLE
refactor: share USER_SPECIFIC_SEARCH_PARAMS + test coverage

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -1,6 +1,6 @@
 import { eq, and, gte, desc } from 'drizzle-orm';
 import type { ClimbSearchInput, ConnectionContext, BoardName } from '@boardsesh/shared-schema';
-import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
+import { SUPPORTED_BOARDS, USER_SPECIFIC_SEARCH_PARAMS } from '@boardsesh/shared-schema';
 import type { ClimbSearchParams, ParsedBoardRouteParameters } from '../../../db/queries/climbs/index';
 import { getClimbByUuid } from '../../../db/queries/climbs/index';
 import { getSizeEdges } from '../../../db/queries/util/product-sizes-data';
@@ -84,13 +84,9 @@ export const climbQueries = {
     }
 
     // Results are cacheable when there are no user-specific filters.
-    // This mirrors the middleware CDN caching logic which also skips cache for these params.
-    const hasUserSpecificFilters = !!(
-      searchParams.hideAttempted ||
-      searchParams.hideCompleted ||
-      searchParams.showOnlyAttempted ||
-      searchParams.showOnlyCompleted ||
-      searchParams.onlyDrafts
+    // Uses the shared constant to stay in sync with CDN/SSR caching layers.
+    const hasUserSpecificFilters = USER_SPECIFIC_SEARCH_PARAMS.some(
+      (param) => !!searchParams[param as keyof typeof searchParams],
     );
 
     // Only resolve userId when user-specific filters are active — otherwise the query

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -74,6 +74,22 @@ export type ClimbSearchInput = {
   onlyDrafts?: boolean;
 };
 
+/**
+ * Search params that require a userId to have any effect on query results.
+ * Used by caching layers (Redis, CDN, SSR) to decide whether results are
+ * user-specific or can be shared across all users.
+ *
+ * Type-checked against ClimbSearchInput so adding/removing a field here
+ * causes a compile error if the type doesn't match.
+ */
+export const USER_SPECIFIC_SEARCH_PARAMS = [
+  'hideAttempted',
+  'hideCompleted',
+  'showOnlyAttempted',
+  'showOnlyCompleted',
+  'onlyDrafts',
+] as const satisfies ReadonlyArray<keyof ClimbSearchInput>;
+
 export type ClimbSearchResult = {
   climbs: Climb[];
   totalCount: number;

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -9,6 +9,7 @@ import {
 import { parseRouteParams } from '@/app/lib/url-utils.server';
 import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-list';
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
+import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
@@ -66,13 +67,7 @@ export default async function DynamicResultsPage(props: {
   searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
   searchParamsObject.page = 0;
 
-  const hasProgressFilters = !!(
-    searchParamsObject.hideAttempted ||
-    searchParamsObject.hideCompleted ||
-    searchParamsObject.showOnlyAttempted ||
-    searchParamsObject.showOnlyCompleted ||
-    searchParamsObject.onlyDrafts
-  );
+  const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);
 
   // Check if this is a default search (no custom filters applied)
   const isDefaultSearch =

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/app/lib/board-data', () => ({
   SUPPORTED_BOARDS: ['kilter', 'tension'],
 }));
 
-const { getListPageCacheTTL } = await import('@/app/lib/list-page-cache');
+const { getListPageCacheTTL, hasUserSpecificFilters } = await import('@/app/lib/list-page-cache');
 
 function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
@@ -15,101 +15,194 @@ const LEGACY_LIST = '/kilter/original/12x12-square/screw_bolt/40/list';
 const SLUG_LIST = '/b/kilter-original-12x12/40/list';
 
 describe('getListPageCacheTTL', () => {
-  // Legacy format: /[board]/[layout]/[size]/[sets]/[angle]/list
-  it('returns TTL for default list page (legacy format)', () => {
-    expect(getListPageCacheTTL(LEGACY_LIST, sp(), false)).toBe(TTL_24H);
+  describe('route matching', () => {
+    // Legacy format: /[board]/[layout]/[size]/[sets]/[angle]/list
+    it('matches legacy format list page', () => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp())).toBe(TTL_24H);
+    });
+
+    it('matches tension board (legacy format)', () => {
+      expect(getListPageCacheTTL('/tension/original/12x12-square/screw_bolt/40/list', sp())).toBe(TTL_24H);
+    });
+
+    it('rejects unsupported board (legacy format)', () => {
+      expect(getListPageCacheTTL('/fakeboard/original/12x12-square/screw_bolt/40/list', sp())).toBeNull();
+    });
+
+    it('rejects legacy path with too few segments', () => {
+      expect(getListPageCacheTTL('/kilter/list', sp())).toBeNull();
+    });
+
+    it('rejects legacy path with 5 segments (needs 6)', () => {
+      expect(getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/list', sp())).toBeNull();
+    });
+
+    // Slug format: /b/[board_slug]/[angle]/list
+    it('matches slug format list page', () => {
+      expect(getListPageCacheTTL(SLUG_LIST, sp())).toBe(TTL_24H);
+    });
+
+    it('matches slug format with different slug', () => {
+      expect(getListPageCacheTTL('/b/tension-two-wall-12x12/30/list', sp())).toBe(TTL_24H);
+    });
+
+    it('rejects slug path with too few segments (/b/list)', () => {
+      expect(getListPageCacheTTL('/b/list', sp())).toBeNull();
+    });
+
+    it('rejects slug path with only 3 segments', () => {
+      expect(getListPageCacheTTL('/b/kilter-original/list', sp())).toBeNull();
+    });
+
+    // Non-list pages
+    it('rejects non-list page (legacy format)', () => {
+      expect(getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp())).toBeNull();
+    });
+
+    it('rejects non-list page (slug format)', () => {
+      expect(getListPageCacheTTL('/b/kilter-original-12x12/40/climb/abc', sp())).toBeNull();
+    });
+
+    it('rejects path not ending in /list', () => {
+      expect(getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/queue', sp())).toBeNull();
+    });
+
+    it('rejects root path', () => {
+      expect(getListPageCacheTTL('/', sp())).toBeNull();
+    });
   });
 
-  it('returns TTL with non-user-specific filters', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', sortBy: 'difficulty' }), false),
-    ).toBe(TTL_24H);
+  describe('non-user-specific filters are always cacheable', () => {
+    it('caches with grade filters', () => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', maxGrade: '20' }))).toBe(TTL_24H);
+    });
+
+    it('caches with sort params', () => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp({ sortBy: 'difficulty', sortOrder: 'asc' }))).toBe(TTL_24H);
+    });
+
+    it('caches with name search', () => {
+      expect(getListPageCacheTTL(SLUG_LIST, sp({ name: 'benchmark' }))).toBe(TTL_24H);
+    });
+
+    it('caches with minAscents', () => {
+      expect(getListPageCacheTTL(SLUG_LIST, sp({ minAscents: '5' }))).toBe(TTL_24H);
+    });
   });
 
-  // User-specific params + authenticated session → skip cache
-  it('returns null when authenticated user has hideAttempted=true', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'true' }), true),
-    ).toBeNull();
+  describe('user-specific params skip cache', () => {
+    it.each([
+      ['hideAttempted', 'true'],
+      ['hideAttempted', '1'],
+      ['hideCompleted', 'true'],
+      ['hideCompleted', '1'],
+      ['showOnlyAttempted', 'true'],
+      ['showOnlyAttempted', '1'],
+      ['showOnlyCompleted', 'true'],
+      ['showOnlyCompleted', '1'],
+      ['onlyDrafts', 'true'],
+      ['onlyDrafts', '1'],
+    ])('skips cache for %s=%s (legacy format)', (param, value) => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp({ [param]: value }))).toBeNull();
+    });
+
+    it.each([
+      ['hideAttempted', 'true'],
+      ['hideCompleted', '1'],
+      ['showOnlyAttempted', 'true'],
+      ['showOnlyCompleted', '1'],
+      ['onlyDrafts', 'true'],
+    ])('skips cache for %s=%s (slug format)', (param, value) => {
+      expect(getListPageCacheTTL(SLUG_LIST, sp({ [param]: value }))).toBeNull();
+    });
   });
 
-  it('returns null when authenticated user has onlyDrafts=1', () => {
-    expect(
-      getListPageCacheTTL('/tension/original/12x12-square/screw_bolt/40/list', sp({ onlyDrafts: '1' }), true),
-    ).toBeNull();
+  describe('falsy values for user-specific params are cacheable', () => {
+    it.each([
+      ['hideAttempted', 'false'],
+      ['hideAttempted', '0'],
+      ['hideAttempted', 'undefined'],
+      ['hideAttempted', ''],
+      ['hideCompleted', 'false'],
+      ['hideCompleted', '0'],
+      ['showOnlyAttempted', 'false'],
+      ['showOnlyCompleted', '0'],
+      ['onlyDrafts', 'false'],
+      ['onlyDrafts', '0'],
+    ])('caches for %s=%s', (param, value) => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp({ [param]: value }))).toBe(TTL_24H);
+    });
   });
 
-  // User-specific params + anonymous → still cacheable (params have no effect without userId)
-  it('returns TTL when anonymous user has hideAttempted=true', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'true' }), false),
-    ).toBe(TTL_24H);
+  describe('mixed params', () => {
+    it('skips cache when one user-specific param is true among non-specific ones', () => {
+      expect(
+        getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', hideAttempted: 'true', sortBy: 'difficulty' })),
+      ).toBeNull();
+    });
+
+    it('caches when user-specific params are all falsy', () => {
+      expect(
+        getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', hideAttempted: 'false', onlyDrafts: '0' })),
+      ).toBe(TTL_24H);
+    });
+  });
+});
+
+describe('hasUserSpecificFilters', () => {
+  const baseParams = {
+    gradeAccuracy: 0,
+    maxGrade: 0,
+    minAscents: 0,
+    minGrade: 0,
+    minRating: 0,
+    sortBy: 'ascents' as const,
+    sortOrder: 'desc' as const,
+    name: '',
+    onlyClassics: false,
+    onlyTallClimbs: false,
+    settername: [] as string[],
+    setternameSuggestion: '',
+    holdsFilter: {},
+    hideAttempted: false,
+    hideCompleted: false,
+    showOnlyAttempted: false,
+    showOnlyCompleted: false,
+    onlyDrafts: false,
+    page: 0,
+    pageSize: 20,
+  };
+
+  it('returns false when no user-specific filters are set', () => {
+    expect(hasUserSpecificFilters(baseParams)).toBe(false);
   });
 
-  it('returns TTL when anonymous user has onlyDrafts=1', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ onlyDrafts: '1' }), false),
-    ).toBe(TTL_24H);
+  it.each([
+    'hideAttempted',
+    'hideCompleted',
+    'showOnlyAttempted',
+    'showOnlyCompleted',
+    'onlyDrafts',
+  ] as const)('returns true when %s is true', (param) => {
+    expect(hasUserSpecificFilters({ ...baseParams, [param]: true })).toBe(true);
   });
 
-  // Authenticated user without user-specific params → cacheable
-  it('returns TTL for authenticated user without user-specific params', () => {
-    expect(getListPageCacheTTL(LEGACY_LIST, sp(), true)).toBe(TTL_24H);
+  it('returns false when all user-specific filters are explicitly false', () => {
+    expect(hasUserSpecificFilters({
+      ...baseParams,
+      hideAttempted: false,
+      hideCompleted: false,
+      showOnlyAttempted: false,
+      showOnlyCompleted: false,
+      onlyDrafts: false,
+    })).toBe(false);
   });
 
-  it('treats hideAttempted=false as cacheable even with session', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'false' }), true),
-    ).toBe(TTL_24H);
-  });
-
-  it('treats hideAttempted=0 as cacheable even with session', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: '0' }), true),
-    ).toBe(TTL_24H);
-  });
-
-  it('treats hideAttempted=undefined (string) as cacheable', () => {
-    expect(
-      getListPageCacheTTL(LEGACY_LIST, sp({ hideAttempted: 'undefined' }), false),
-    ).toBe(TTL_24H);
-  });
-
-  // Non-list pages
-  it('returns null for non-list pages', () => {
-    expect(
-      getListPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/climb/abc', sp(), false),
-    ).toBeNull();
-  });
-
-  it('returns null for unsupported board (legacy format)', () => {
-    expect(
-      getListPageCacheTTL('/fakeboard/original/12x12-square/screw_bolt/40/list', sp(), false),
-    ).toBeNull();
-  });
-
-  it('returns null for paths with too few segments', () => {
-    expect(getListPageCacheTTL('/kilter/list', sp(), false)).toBeNull();
-  });
-
-  // Slug format: /b/[board_slug]/[angle]/list
-  it('returns TTL for slug format list page', () => {
-    expect(getListPageCacheTTL(SLUG_LIST, sp(), false)).toBe(TTL_24H);
-  });
-
-  it('returns null for slug format with user-specific params and session', () => {
-    expect(
-      getListPageCacheTTL(SLUG_LIST, sp({ hideCompleted: 'true' }), true),
-    ).toBeNull();
-  });
-
-  it('returns TTL for slug format with user-specific params but no session', () => {
-    expect(
-      getListPageCacheTTL(SLUG_LIST, sp({ hideCompleted: 'true' }), false),
-    ).toBe(TTL_24H);
-  });
-
-  it('returns null for /b/ paths with too few segments', () => {
-    expect(getListPageCacheTTL('/b/list', sp(), false)).toBeNull();
+  it('returns true when multiple user-specific filters are set', () => {
+    expect(hasUserSpecificFilters({
+      ...baseParams,
+      hideAttempted: true,
+      showOnlyCompleted: true,
+    })).toBe(true);
   });
 });

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -5,6 +5,7 @@ import { parsedRouteSearchParamsToSearchParams } from '@/app/lib/url-utils';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-list';
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
+import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
@@ -31,13 +32,7 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
   searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
   searchParamsObject.page = 0;
 
-  const hasProgressFilters = !!(
-    searchParamsObject.hideAttempted ||
-    searchParamsObject.hideCompleted ||
-    searchParamsObject.showOnlyAttempted ||
-    searchParamsObject.showOnlyCompleted ||
-    searchParamsObject.onlyDrafts
-  );
+  const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);
 
   const isDefaultSearch =
     !searchParamsObject.gradeAccuracy &&

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -1,33 +1,30 @@
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
+import { USER_SPECIFIC_SEARCH_PARAMS } from '@boardsesh/shared-schema';
+import type { SearchRequestPagination } from '@/app/lib/types';
 
-/** Search params that indicate user-specific queries — must not be CDN-cached. */
-const USER_SPECIFIC_PARAMS = ['hideAttempted', 'hideCompleted', 'showOnlyAttempted', 'showOnlyCompleted', 'onlyDrafts'];
+/**
+ * Checks whether search params contain any user-specific filters.
+ * Used by SSR pages to decide whether to resolve a user session.
+ */
+export function hasUserSpecificFilters(searchParams: SearchRequestPagination): boolean {
+  return USER_SPECIFIC_SEARCH_PARAMS.some((param) => !!searchParams[param]);
+}
 
 /**
  * Checks whether a request is a cacheable list page and returns the CDN cache
  * duration in seconds, or null if the request should not be CDN-cached.
  *
- * User-specific params (hideAttempted, etc.) only prevent caching when the
- * request has an authenticated session — matching the GraphQL resolver logic
- * where userId is only resolved when user-specific filters are active.
- * Without a session these params have no effect on query results.
- *
  * Matches both URL formats:
  *   - /[board]/[layout]/[size]/[sets]/[angle]/list  (legacy numeric)
  *   - /b/[board_slug]/[angle]/list                  (new slug format)
  */
-export function getListPageCacheTTL(pathname: string, searchParams: URLSearchParams, hasSession: boolean): number | null {
+export function getListPageCacheTTL(pathname: string, searchParams: URLSearchParams): number | null {
   // Fast-path: skip parsing for routes that clearly aren't list pages
   if (!pathname.endsWith('/list')) {
     return null;
   }
 
   const pathParts = pathname.split('/').filter(Boolean);
-  const lastPart = pathParts[pathParts.length - 1];
-
-  if (lastPart !== 'list') {
-    return null;
-  }
 
   const isLegacyFormat =
     pathParts.length >= 6 &&
@@ -41,18 +38,13 @@ export function getListPageCacheTTL(pathname: string, searchParams: URLSearchPar
     return null;
   }
 
-  // User-specific params only matter when there's an authenticated session.
-  // Without a session, these params have no effect on query results (the DB
-  // query ignores them without a userId), so the response is still cacheable.
-  if (hasSession) {
-    const hasUserSpecificParams = USER_SPECIFIC_PARAMS.some((param) => {
-      const value = searchParams.get(param);
-      return value === 'true' || value === '1';
-    });
+  const hasUserParams = USER_SPECIFIC_SEARCH_PARAMS.some((param) => {
+    const value = searchParams.get(param);
+    return value === 'true' || value === '1';
+  });
 
-    if (hasUserSpecificParams) {
-      return null;
-    }
+  if (hasUserParams) {
+    return null;
   }
 
   return 86400; // 24 hours

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -43,9 +43,7 @@ export function middleware(request: NextRequest) {
   // for dynamic pages (pages that use searchParams) with "private, no-store".
   // Vercel-CDN-Cache-Control is the highest-priority header for Vercel's CDN
   // and is not touched by Next.js rendering.
-  const hasSession = request.cookies.has('__Secure-next-auth.session-token') ||
-    request.cookies.has('next-auth.session-token');
-  const cacheTTL = getListPageCacheTTL(pathname, request.nextUrl.searchParams, hasSession);
+  const cacheTTL = getListPageCacheTTL(pathname, request.nextUrl.searchParams);
   if (cacheTTL !== null) {
     const cdnCacheValue = `s-maxage=${cacheTTL}, stale-while-revalidate=${cacheTTL * 7}`;
     const response = NextResponse.next();


### PR DESCRIPTION
## Summary

Follow-up to #1068. The list of user-specific search params was duplicated in 4 places — if one drifted, caching would silently break.

- **Shared constant**: `USER_SPECIFIC_SEARCH_PARAMS` in `@boardsesh/shared-schema`, type-checked with `satisfies ReadonlyArray<keyof ClimbSearchInput>` so adding/removing a field causes a compile error
- **4 consumers updated**: middleware CDN caching, GraphQL Redis caching, both SSR list pages
- **Removed session cookie check** from CDN caching — user-specific params should always skip CDN cache regardless of auth state
- **52 tests** covering all param combinations, both URL formats, route matching edge cases, and the `hasUserSpecificFilters` helper

## Test plan

- [x] `bun run typecheck` passes (shared, backend, web)
- [x] 52/52 middleware tests pass
- [ ] Deploy and verify CDN caching still works for list pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)