### PR TITLE
fix: prevent climb list flicker during hydration

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climb-list-utils.test.ts
+++ b/packages/web/app/components/board-page/__tests__/climb-list-utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { classifyClimbListChange, stabilizeClimbArrayRef } from '../climb-list-utils';
+import { Climb } from '@/app/lib/types';
+
+function makeClimb(uuid: string): Climb {
+  return {
+    uuid,
+    setter_username: 'user',
+    name: `Climb ${uuid}`,
+    frames: '',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: 'V3',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  };
+}
+
+describe('classifyClimbListChange', () => {
+  const climbA = makeClimb('a');
+  const climbB = makeClimb('b');
+  const climbC = makeClimb('c');
+  const climbD = makeClimb('d');
+
+  it('returns "same" for identical content with different references', () => {
+    const prev = [climbA, climbB, climbC];
+    const current = [...prev]; // new array, same items
+    expect(classifyClimbListChange(current, prev)).toBe('same');
+  });
+
+  it('returns "same" for two empty arrays', () => {
+    expect(classifyClimbListChange([], [])).toBe('same');
+  });
+
+  it('returns "same" for single-item lists with same UUID', () => {
+    const prev = [climbA];
+    const current = [{ ...climbA }];
+    expect(classifyClimbListChange(current, prev)).toBe('same');
+  });
+
+  it('returns "append" when items are added to the end', () => {
+    const prev = [climbA, climbB];
+    const current = [climbA, climbB, climbC, climbD];
+    expect(classifyClimbListChange(current, prev)).toBe('append');
+  });
+
+  it('returns "replace" for completely different data', () => {
+    const prev = [climbA, climbB];
+    const current = [climbC, climbD];
+    expect(classifyClimbListChange(current, prev)).toBe('replace');
+  });
+
+  it('returns "replace" when same length but different first item', () => {
+    const prev = [climbA, climbB];
+    const current = [climbC, climbD];
+    expect(classifyClimbListChange(current, prev)).toBe('replace');
+  });
+
+  it('returns "replace" when same length and first item but different last item', () => {
+    const prev = [climbA, climbB];
+    const current = [climbA, climbC];
+    expect(classifyClimbListChange(current, prev)).toBe('replace');
+  });
+
+  it('returns "replace" when going from non-empty to empty', () => {
+    const prev = [climbA, climbB];
+    expect(classifyClimbListChange([], prev)).toBe('replace');
+  });
+
+  it('returns "replace" when going from empty to non-empty', () => {
+    const current = [climbA, climbB];
+    expect(classifyClimbListChange(current, [])).toBe('replace');
+  });
+
+  it('returns "append" not "replace" when list grows with same first item', () => {
+    const prev = [climbA];
+    const current = [climbA, climbB];
+    expect(classifyClimbListChange(current, prev)).toBe('append');
+  });
+
+  it('returns "replace" when list grows but first item differs', () => {
+    const prev = [climbA];
+    const current = [climbB, climbC];
+    expect(classifyClimbListChange(current, prev)).toBe('replace');
+  });
+
+  it('returns "replace" when list shrinks with same first item (re-search with fewer results)', () => {
+    const prev = [climbA, climbB, climbC];
+    const current = [climbA, climbB];
+    expect(classifyClimbListChange(current, prev)).toBe('replace');
+  });
+});
+
+describe('stabilizeClimbArrayRef', () => {
+  const climbA = makeClimb('a');
+  const climbB = makeClimb('b');
+  const climbC = makeClimb('c');
+
+  it('returns previous reference when content matches', () => {
+    const prev = [climbA, climbB, climbC];
+    const current = [...prev];
+    const result = stabilizeClimbArrayRef(current, prev);
+    expect(result).toBe(prev); // same reference
+    expect(result).not.toBe(current);
+  });
+
+  it('returns previous reference for empty arrays', () => {
+    const prev: Climb[] = [];
+    const current: Climb[] = [];
+    expect(stabilizeClimbArrayRef(current, prev)).toBe(prev);
+  });
+
+  it('returns current when content differs', () => {
+    const prev = [climbA, climbB];
+    const current = [climbA, climbC];
+    expect(stabilizeClimbArrayRef(current, prev)).toBe(current);
+  });
+
+  it('returns current when lengths differ', () => {
+    const prev = [climbA, climbB];
+    const current = [climbA, climbB, climbC];
+    expect(stabilizeClimbArrayRef(current, prev)).toBe(current);
+  });
+
+  it('returns current for single item that differs', () => {
+    const prev = [climbA];
+    const current = [climbB];
+    expect(stabilizeClimbArrayRef(current, prev)).toBe(current);
+  });
+});

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueContext } from '../graphql-queue';
 import ClimbsList from './climbs-list';
+import { stabilizeClimbArrayRef } from './climb-list-utils';
 import BoardCreationBanner from '../board-entity/board-creation-banner';
 import RecentSearchPills from '../search-drawer/recent-search-pills';
 import AngleSelector from './angle-selector';
@@ -56,15 +57,8 @@ const BoardPageClimbsList = ({
 
     // Return the previous reference when content hasn't changed to avoid
     // triggering downstream progressive rendering during SSR→client handoff.
-    const prev = prevClimbsRef.current;
-    if (
-      deduped.length === prev.length &&
-      deduped.length > 0 &&
-      deduped[0]?.uuid === prev[0]?.uuid &&
-      deduped[deduped.length - 1]?.uuid === prev[prev.length - 1]?.uuid
-    ) {
-      return prev;
-    }
+    const stable = stabilizeClimbArrayRef(deduped, prevClimbsRef.current);
+    if (stable !== deduped) return stable;
 
     prevClimbsRef.current = deduped;
     return deduped;

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueContext } from '../graphql-queue';
@@ -47,11 +47,27 @@ const BoardPageClimbsList = ({
   // fill on the server side in the page component. This way the user never sees a loading state for
   // the climb list.
   // Deduplicate climbs by uuid to prevent React key warnings during hydration/re-renders
+  const prevClimbsRef = useRef<Climb[]>([]);
   const climbs = useMemo(() => {
     const rawClimbs = !hasDoneFirstFetch ? initialClimbs : climbSearchResults || [];
-    return rawClimbs.filter((climb, index, self) =>
+    const deduped = rawClimbs.filter((climb, index, self) =>
       index === self.findIndex((c) => c.uuid === climb.uuid)
     );
+
+    // Return the previous reference when content hasn't changed to avoid
+    // triggering downstream progressive rendering during SSR→client handoff.
+    const prev = prevClimbsRef.current;
+    if (
+      deduped.length === prev.length &&
+      deduped.length > 0 &&
+      deduped[0]?.uuid === prev[0]?.uuid &&
+      deduped[deduped.length - 1]?.uuid === prev[prev.length - 1]?.uuid
+    ) {
+      return prev;
+    }
+
+    prevClimbsRef.current = deduped;
+    return deduped;
   }, [hasDoneFirstFetch, initialClimbs, climbSearchResults]);
 
   const header = useMemo(() => (

--- a/packages/web/app/components/board-page/climb-list-utils.ts
+++ b/packages/web/app/components/board-page/climb-list-utils.ts
@@ -1,0 +1,49 @@
+import { Climb } from '@/app/lib/types';
+
+/**
+ * Classifies a climb list change to determine how to render it.
+ *
+ * - 'append': new items added to the end (infinite scroll) — show all immediately
+ * - 'same': same data with a new reference (e.g. SSR→client handoff) — show all immediately
+ * - 'replace': genuinely new data (new search) — batch render for performance
+ */
+export function classifyClimbListChange(
+  current: Climb[],
+  previous: Climb[],
+): 'append' | 'same' | 'replace' {
+  // Detect append (infinite scroll): new list is longer and starts with the same first item
+  const isAppend = current.length > previous.length &&
+    previous.length > 0 &&
+    current[0]?.uuid === previous[0]?.uuid;
+
+  if (isAppend) return 'append';
+
+  // Detect same data with a new reference (e.g. SSR→client handoff, useMemo recomputation)
+  const isSameData = current.length === previous.length &&
+    (current.length === 0 ||
+      (current[0]?.uuid === previous[0]?.uuid &&
+       current[current.length - 1]?.uuid === previous[previous.length - 1]?.uuid));
+
+  if (isSameData) return 'same';
+
+  return 'replace';
+}
+
+/**
+ * Returns the previous array reference if the content hasn't changed,
+ * preventing unnecessary downstream re-renders.
+ */
+export function stabilizeClimbArrayRef(
+  current: Climb[],
+  previous: Climb[],
+): Climb[] {
+  if (
+    current.length === previous.length &&
+    (current.length === 0 ||
+      (current[0]?.uuid === previous[0]?.uuid &&
+       current[current.length - 1]?.uuid === previous[previous.length - 1]?.uuid))
+  ) {
+    return previous;
+  }
+  return current;
+}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -101,13 +101,19 @@ const ClimbsList = ({
       prevClimbs.length > 0 &&
       climbs[0]?.uuid === prevClimbs[0]?.uuid;
 
+    // Detect same data with new reference (e.g. SSR → client handoff)
+    const isSameData = climbs.length === prevClimbs.length &&
+      climbs.length > 0 &&
+      climbs[0]?.uuid === prevClimbs[0]?.uuid &&
+      climbs[climbs.length - 1]?.uuid === prevClimbs[prevClimbs.length - 1]?.uuid;
+
     // Record batch start for any data change that adds items
     if (climbs.length > prevClimbs.length) {
       batchStartRef.current = { time: performance.now(), prevLength: prevClimbs.length, isInitial: prevClimbs.length === 0 };
     }
 
-    if (isAppend) {
-      // Show all items immediately — no batching for appended pages
+    if (isAppend || isSameData) {
+      // Show all items immediately — no batching for appended pages or unchanged data
       setVisibleCount(climbs.length);
     } else if (climbs.length > INITIAL_BATCH) {
       setVisibleCount(INITIAL_BATCH);

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -15,6 +15,7 @@ import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
 import { trackListBatchRender } from '@/app/lib/rendering-metrics';
+import { classifyClimbListChange } from './climb-list-utils';
 
 type ViewMode = 'grid' | 'list';
 
@@ -96,23 +97,14 @@ const ClimbsList = ({
     const prevClimbs = prevClimbsRef.current;
     prevClimbsRef.current = climbs;
 
-    // Detect append (infinite scroll): new list starts with all previous items
-    const isAppend = climbs.length > prevClimbs.length &&
-      prevClimbs.length > 0 &&
-      climbs[0]?.uuid === prevClimbs[0]?.uuid;
-
-    // Detect same data with new reference (e.g. SSR → client handoff)
-    const isSameData = climbs.length === prevClimbs.length &&
-      climbs.length > 0 &&
-      climbs[0]?.uuid === prevClimbs[0]?.uuid &&
-      climbs[climbs.length - 1]?.uuid === prevClimbs[prevClimbs.length - 1]?.uuid;
+    const changeType = classifyClimbListChange(climbs, prevClimbs);
 
     // Record batch start for any data change that adds items
     if (climbs.length > prevClimbs.length) {
       batchStartRef.current = { time: performance.now(), prevLength: prevClimbs.length, isInitial: prevClimbs.length === 0 };
     }
 
-    if (isAppend || isSameData) {
+    if (changeType === 'append' || changeType === 'same') {
       // Show all items immediately — no batching for appended pages or unchanged data
       setVisibleCount(climbs.length);
     } else if (climbs.length > INITIAL_BATCH) {


### PR DESCRIPTION
## Summary

- Fixes a visual flicker where climb list items beyond the 6th briefly disappear and reappear during SSR→client hydration handoff
- Root cause: the progressive rendering logic (`INITIAL_BATCH=6`) was triggering when `hasDoneFirstFetch` flipped, creating a new array reference for identical data
- Two-layer fix: stabilize the `climbs` array reference upstream when content is unchanged, and add a defensive `isSameData` guard in the progressive rendering logic
- Works across all rendering paths: grid mode, virtualized list, and non-virtualized list (rust/wasm renderer)

## Test plan

- [ ] Load a climb list page with >6 results — no flicker on initial load
- [ ] Change search filters to get different results — progressive rendering still batches (6 items first, then rest)
- [ ] Scroll down to trigger infinite scroll — append still works smoothly
- [ ] Test in both grid and list view modes
- [ ] Test with `wasm-rendering` / `rust-svg-rendering` feature flags enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)