### PR TITLE
Filter DuckDuckGo browser-internal "pageContext" error from Sentry

### DIFF
--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -48,6 +48,15 @@ Sentry.init({
       return null;
     }
 
+    // Ignore DuckDuckGo browser-internal feature detection errors
+    // (e.g., "feature named `pageContext` was not found")
+    if (
+      errorMessage.includes("feature named") &&
+      errorMessage.includes("was not found")
+    ) {
+      return null;
+    }
+
     return event;
   },
 });


### PR DESCRIPTION
DuckDuckGo Mobile on iOS throws "feature named `pageContext` was not found" from its internal feature detection system. This is not an app error — add it to the beforeSend filter alongside existing browser extension and Safari navigation error filters.

https://claude.ai/code/session_01StNZ6He42vECjuMJnezAHw