### PR TITLE
Consolidate climb action drawers to parent components

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -33,6 +33,19 @@ import styles from '@/app/components/library/playlist-view.module.css';
 
 type ViewMode = 'grid' | 'list';
 
+// Static drawer style objects (hoisted to avoid per-render allocation)
+const sharedDrawerStyles = {
+  wrapper: { height: 'auto', width: '100%' },
+  body: { padding: `${themeTokens.spacing[2]}px 0` },
+  header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
+} as const;
+
+const sharedPlaylistDrawerStyles = {
+  wrapper: { height: 'auto', maxHeight: '70vh', width: '100%' },
+  body: { padding: 0 },
+  header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
+} as const;
+
 type LikedClimbsListProps = {
   boardDetails: BoardDetails;
   angle: number;
@@ -196,6 +209,10 @@ export default function LikedClimbsList({
     setDrawerMode(null);
   }, []);
 
+  const handleSwitchToPlaylist = useCallback(() => {
+    setDrawerMode('playlist');
+  }, []);
+
   const handleDrawerTransitionEnd = useCallback((open: boolean) => {
     if (!open) setActiveDrawerClimb(null);
   }, []);
@@ -309,11 +326,7 @@ export default function LikedClimbsList({
         open={drawerMode === 'actions'}
         onClose={handleCloseDrawer}
         onTransitionEnd={handleDrawerTransitionEnd}
-        styles={{
-          wrapper: { height: 'auto', width: '100%' },
-          body: { padding: `${themeTokens.spacing[2]}px 0` },
-          header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
-        }}
+        styles={sharedDrawerStyles}
         keepMounted={false}
       >
         {activeDrawerClimb && (
@@ -324,9 +337,7 @@ export default function LikedClimbsList({
             currentPathname={pathname}
             viewMode="list"
             exclude={excludeActions}
-            onOpenPlaylistSelector={() => {
-              setDrawerMode('playlist');
-            }}
+            onOpenPlaylistSelector={handleSwitchToPlaylist}
             onActionComplete={handleCloseDrawer}
           />
         )}
@@ -338,11 +349,7 @@ export default function LikedClimbsList({
         open={drawerMode === 'playlist'}
         onClose={handleCloseDrawer}
         onTransitionEnd={handleDrawerTransitionEnd}
-        styles={{
-          wrapper: { height: 'auto', maxHeight: '70vh', width: '100%' },
-          body: { padding: 0 },
-          header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
-        }}
+        styles={sharedPlaylistDrawerStyles}
         keepMounted={false}
       >
         {activeDrawerClimb && (

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -239,6 +239,10 @@ const ClimbsList = ({
     setDrawerMode(null);
   }, []);
 
+  const handleSwitchToPlaylist = useCallback(() => {
+    setDrawerMode('playlist');
+  }, []);
+
   const handleDrawerTransitionEnd = useCallback((open: boolean) => {
     if (!open) setActiveDrawerClimb(null);
   }, []);
@@ -496,9 +500,7 @@ const ClimbsList = ({
             currentPathname={pathname}
             viewMode="list"
             exclude={excludeActions}
-            onOpenPlaylistSelector={() => {
-              setDrawerMode('playlist');
-            }}
+            onOpenPlaylistSelector={handleSwitchToPlaylist}
             onActionComplete={handleCloseDrawer}
           />
         )}

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -135,8 +135,9 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(({
 }) => {
   const pathname = usePathname();
   const isDark = useIsDarkMode();
-  // When parent provides drawer callbacks, skip local drawer state entirely
-  const hasParentDrawers = Boolean(onOpenActions || onOpenPlaylistSelector);
+  // When parent provides both drawer callbacks, skip local drawers entirely.
+  // Both must be present to ensure the parent handles all drawer interactions.
+  const hasParentDrawers = Boolean(onOpenActions && onOpenPlaylistSelector);
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [isPlaylistSelectorOpen, setIsPlaylistSelectorOpen] = useState(false);
   const [rightSwipeOffset, setRightSwipeOffset] = useState(0);


### PR DESCRIPTION
## Summary
Refactored climb list components to use shared drawer state at the parent level instead of individual drawers in each list item. This reduces DOM complexity and improves performance by rendering a single pair of drawers (actions + playlist selector) for all list items.

## Key Changes
- **ClimbsList & LikedClimbsList**: Added shared drawer state management with `activeDrawerClimb` and `drawerMode` to coordinate a single pair of bottom drawers for all list items
- **ClimbListItem**: Added optional `onOpenActions` and `onOpenPlaylistSelector` callbacks that allow parent components to handle drawer opening, with fallback to local state when callbacks aren't provided
- **Drawer Consolidation**: Moved drawer rendering from individual list items to parent components, reducing the number of drawer instances from N (one per item) to 2 (one pair shared by all items)
- **Style Optimization**: Hoisted static drawer style objects in ClimbsList to avoid per-render allocations
- **Callback Integration**: Updated swipe handlers and action buttons to delegate to parent callbacks when available

## Implementation Details
- The refactoring maintains backward compatibility by keeping local drawer state in ClimbListItem when parent callbacks aren't provided
- Drawer state properly cleans up `activeDrawerClimb` on transition end to prevent stale references
- Board details resolution is memoized to handle cases where the active climb belongs to a different board
- Excluded climb actions are computed based on board name and view mode ('list')

https://claude.ai/code/session_01TAEWqxR8wLKT6xjvQpoRLf