### PR TITLE
fix: eliminate unnecessary board-render API requests after WASM worke…

### DIFF
--- a/docs/wasm-worker-rendering.md
+++ b/docs/wasm-worker-rendering.md
@@ -114,7 +114,9 @@ React hydrates `BoardImageLayers`. The DOM matches the server-rendered HTML, so 
 
 ### 3. Worker Takeover
 
-After mount, `useCanvasRendererReady` resolves to `true` once the worker pool is initialized and the WASM modules are loaded. `BoardCanvasRenderer` replaces `BoardImageLayers` in the visible layout:
+After mount, `useCanvasRendererReady` resolves to `true` once the browser supports `OffscreenCanvas` and the feature flag is enabled. `BoardCanvasRenderer` replaces `BoardImageLayers` in the visible layout.
+
+A module-level `globalCanvasReady` flag ensures that only the first batch of component instances goes through the `false`→`true` transition. Subsequent instances (e.g. from infinite scroll) initialise with `true` immediately, avoiding a one-frame flash of `BoardImageLayers` and the API request it would trigger.
 
 1. `BoardCanvasRenderer` sends a render request to the `WorkerManager`.
 2. The `WorkerManager` checks the LRU cache. On a cache hit, it returns the cached `ImageBitmap` immediately.

--- a/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
@@ -104,6 +104,24 @@ describe('BoardImageLayers', () => {
     });
   });
 
+  it('sets loading="lazy" on the overlay image but not background images', () => {
+    const { container } = render(
+      <BoardImageLayers
+        boardDetails={mockBoardDetails}
+        frames="p1r42p2r43"
+        mirrored={false}
+      />,
+    );
+
+    const images = container.querySelectorAll('img');
+    // Last image is the overlay
+    expect(images[images.length - 1].getAttribute('loading')).toBe('lazy');
+    // Background images should NOT have loading="lazy"
+    for (let i = 0; i < images.length - 1; i++) {
+      expect(images[i].getAttribute('loading')).toBeNull();
+    }
+  });
+
   it('renders multiple background images when board has multiple sets', () => {
     const multiSetBoard: BoardDetails = {
       ...mockBoardDetails,

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -76,7 +76,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
         <img key={url} src={url} alt="" style={imgStyle} />
       ))}
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={overlayUrl} alt="" style={imgStyle} onLoad={handleOverlayLoad} onError={handleOverlayError} />
+      <img src={overlayUrl} alt="" loading="lazy" style={imgStyle} onLoad={handleOverlayLoad} onError={handleOverlayError} />
     </div>
   );
 });

--- a/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
+++ b/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
@@ -321,6 +321,26 @@ describe('useCanvasRendererReady', () => {
     const { result } = renderHook(() => useCanvasRendererReady(true));
     expect(result.current).toBe(false);
   });
+
+  it('subsequent hook instances start with true immediately after first mount', async () => {
+    stubGlobals();
+    const { useCanvasRendererReady } = await import('../worker-manager');
+
+    // First instance — triggers the useEffect that sets globalCanvasReady
+    const { result: first } = renderHook(() => useCanvasRendererReady(true));
+    expect(first.current).toBe(true);
+
+    // Second instance — should initialise with true immediately (no false→true flash)
+    let initialValue: boolean | undefined;
+    renderHook(() => {
+      const ready = useCanvasRendererReady(true);
+      if (initialValue === undefined) {
+        initialValue = ready;
+      }
+      return ready;
+    });
+    expect(initialValue).toBe(true);
+  });
 });
 
 // ==========================================================================

--- a/packages/web/app/lib/board-render-worker/worker-manager.ts
+++ b/packages/web/app/lib/board-render-worker/worker-manager.ts
@@ -184,14 +184,28 @@ export function isWorkerRenderingSupported(): boolean {
 }
 
 /**
+ * Module-level flag so that once any component instance has confirmed the
+ * canvas renderer is ready, subsequent instances (e.g. from infinite scroll)
+ * can initialise with `true` immediately — avoiding a one-frame flash of
+ * BoardImageLayers and the API request it triggers.
+ */
+let globalCanvasReady = false;
+
+/**
  * Hook that returns true once the Web Worker canvas renderer is ready (client-side only).
  * Returns false during SSR and initial hydration so the server-rendered BoardImageLayers
  * HTML matches the client. After mount, flips to true and the canvas renderer takes over.
+ *
+ * After the first mount, `globalCanvasReady` is set so that new component instances
+ * (from infinite scroll, navigation, etc.) skip the false→true transition entirely.
  */
 export function useCanvasRendererReady(featureFlagEnabled: boolean): boolean {
-  const [ready, setReady] = React.useState(false);
+  const [ready, setReady] = React.useState(
+    () => globalCanvasReady && featureFlagEnabled && isWorkerRenderingSupported(),
+  );
   React.useEffect(() => {
     if (featureFlagEnabled && isWorkerRenderingSupported()) {
+      globalCanvasReady = true;
       setReady(true);
     }
   }, [featureFlagEnabled]);


### PR DESCRIPTION
…r takeover

useCanvasRendererReady started every new component instance with canvasReady=false, causing a one-frame flash of BoardImageLayers (and its /api/internal/board-render <img> request) before the useEffect flipped it to true. This happened for every infinite-scroll item.

Add a module-level globalCanvasReady flag so that after the first mount confirms the renderer is ready, subsequent instances initialise with true immediately — no BoardImageLayers rendered, no API request.

Also add loading="lazy" to the overlay <img> in BoardImageLayers so that off-screen items from SSR don't trigger eager fetches during the hydration window.