### PR TITLE
fix: remove remaining ?session= URL construction and simplify session…

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -242,12 +242,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       // Ignore errors loading recent searches
     }
 
-    // Preserve active session param so BoardSessionBridge can re-activate the session
-    if (activeSession?.sessionId && url) {
-      const separator = url.includes('?') ? '&' : '?';
-      url = `${url}${separator}session=${activeSession.sessionId}`;
-    }
-
     const currentUrl = pathname + (typeof window !== 'undefined' ? window.location.search : '');
     if (url !== currentUrl) {
       router.push(url);

--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -35,14 +35,9 @@ export function useSessionIdManagement({
   const { token: wsAuthToken } = useWsAuthToken();
   const persistentSession = usePersistentSession();
 
-  // Session ID source differs by mode:
-  // - Board mode: read from cookie (previously URL ?session= param)
-  // - Off-board mode: read from persistent IndexedDB storage
+  // Session ID always comes from the cookie (global, path=/)
   const sessionIdFromCookie = getClimbSessionCookie();
-  const persistentSessionId = persistentSession.activeSession?.sessionId ?? null;
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(
-    isOffBoardMode ? persistentSessionId : sessionIdFromCookie,
-  );
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(sessionIdFromCookie);
 
   // Backward compat: migrate ?session= URL param to cookie and strip from URL
   useEffect(() => {
@@ -57,12 +52,6 @@ export function useSessionIdManagement({
       router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
     }
   }, [searchParams, isOffBoardMode, pathname, router]);
-
-  // Sync activeSessionId from persistent session (off-board mode only)
-  useEffect(() => {
-    if (!isOffBoardMode) return;
-    setActiveSessionId(persistentSessionId);
-  }, [isOffBoardMode, persistentSessionId]);
 
   const sessionId = activeSessionId;
 


### PR DESCRIPTION
… ID source

- Remove ?session= URL append in bottom-tab-bar.tsx (cookie persists across navigations, no URL manipulation needed)
- Simplify use-session-id-management to always read session ID from cookie instead of dual-sourcing from cookie + IndexedDB