### PR TITLE
Make profile card full width on aurora migration page

### DIFF
--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -215,15 +215,17 @@ export default function AuroraMigrationContent() {
                     <Typography variant="h6" sx={{ mb: 1 }}>
                       Your Boardsesh profile
                     </Typography>
-                    {isAuthenticated && session?.user?.id ? (
-                      <UserSmartCard userId={session.user.id} refreshKey={importRefreshKey} />
-                    ) : (
+                    {!isAuthenticated && (
                       <Typography variant="body2" color="text.secondary">
                         Sign in first to see your profile.
                       </Typography>
                     )}
                   </div>
                 </div>
+
+                {isAuthenticated && session?.user?.id && (
+                  <UserSmartCard userId={session.user.id} refreshKey={importRefreshKey} />
+                )}
               </Stack>
             </CardContent>
           </MuiCard>


### PR DESCRIPTION
Move UserSmartCard out of the stepRow container so it spans the full width of the parent card, matching the BoardImportPrompt cards above it.

https://claude.ai/code/session_01Li2BqnWC8cw9ojA4wjSb25