### PR TITLE
perf: increase bitmap cache from 50 to 150 for 100+ thumbnail lists

### DIFF
--- a/packages/web/app/lib/board-render-worker/worker-manager.ts
+++ b/packages/web/app/lib/board-render-worker/worker-manager.ts
@@ -18,7 +18,7 @@ import { isCapacitor } from '@/app/lib/ble/capacitor-utils';
 const THUMBNAIL_WIDTH = 300;
 
 // LRU cache for rendered bitmaps
-const CACHE_MAX = 50;
+const CACHE_MAX = 150;
 const bitmapCache = new Map<string, ImageBitmap>();
 
 function cacheKey(boardDetails: BoardDetails, frames: string, mirrored: boolean, thumbnail: boolean): string {


### PR DESCRIPTION
Prevents eviction churn when rendering large climb lists without virtualization. ~81MB worst case at 300px thumbnail width.

https://claude.ai/code/session_012bKJBToYezwwepDb5toU4g