### PR TITLE
fix: restore ascent count to climb list byline

### DIFF
--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -204,9 +204,14 @@ describe('ClimbTitle', () => {
       expect(screen.getByText('project')).toBeTruthy();
     });
 
-    it('renders "0 ascents" when ascensionist_count is 0', () => {
+    it('renders "project" when ascensionist_count is 0 and no grade', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '0', ascensionist_count: 0 })} gradePosition="right" />);
-      expect(screen.getByText('0 ascents')).toBeTruthy();
+      expect(screen.getByText('project')).toBeTruthy();
+    });
+
+    it('renders singular "ascent" when ascensionist_count is 1', () => {
+      render(<ClimbTitle climb={makeClimb({ ascensionist_count: 1 })} gradePosition="right" />);
+      expect(screen.getByText(/1 ascent(?!s)/)).toBeTruthy();
     });
 
     it('renders benchmark icon after climb name', () => {

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -204,6 +204,11 @@ describe('ClimbTitle', () => {
       expect(screen.getByText('project')).toBeTruthy();
     });
 
+    it('renders "0 ascents" when ascensionist_count is 0', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '0', ascensionist_count: 0 })} gradePosition="right" />);
+      expect(screen.getByText('0 ascents')).toBeTruthy();
+    });
+
     it('renders benchmark icon after climb name', () => {
       render(<ClimbTitle climb={makeClimb({ benchmark_difficulty: '10' })} gradePosition="right" />);
       expect(screen.getByTestId('CopyrightOutlinedIcon')).toBeTruthy();

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -184,9 +184,9 @@ describe('ClimbTitle', () => {
       expect(screen.queryByText(/@ 40°/)).toBeNull();
     });
 
-    it('does not render ascent count', () => {
+    it('renders ascent count', () => {
       render(<ClimbTitle climb={makeClimb({ ascensionist_count: 72 })} gradePosition="right" showSetterInfo />);
-      expect(screen.queryByText(/72 ascents/)).toBeNull();
+      expect(screen.getByText(/72 ascents/)).toBeTruthy();
     });
 
     it('renders "project" when no grade quality', () => {

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -154,7 +154,7 @@ describe('ClimbTitle', () => {
 
     it('renders quality stars in subtitle', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '4.2' })} gradePosition="right" />);
-      expect(screen.getByText('4.2★')).toBeTruthy();
+      expect(screen.getByText(/4\.2★/)).toBeTruthy();
     });
 
     it('renders setter name in subtitle when showSetterInfo is true', () => {
@@ -163,20 +163,20 @@ describe('ClimbTitle', () => {
       expect(screen.getByText(/DanielBolts/)).toBeTruthy();
     });
 
-    it('renders subtitle as "stars · setter_name" format', () => {
+    it('renders subtitle as "ascents · stars · setter_name" format', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '3.5', setter_username: 'alice' })} gradePosition="right" showSetterInfo />);
-      expect(screen.getByText('3.5★ · alice')).toBeTruthy();
+      expect(screen.getByText('10 ascents · 3.5★ · alice')).toBeTruthy();
     });
 
-    it('renders only stars when showSetterInfo is false', () => {
+    it('renders only ascents and stars when showSetterInfo is false', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '3.5' })} gradePosition="right" />);
-      expect(screen.getByText('3.5★')).toBeTruthy();
+      expect(screen.getByText('10 ascents · 3.5★')).toBeTruthy();
       expect(screen.queryByText(/setter_joe/)).toBeNull();
     });
 
-    it('renders only stars when setter_username is missing', () => {
+    it('renders only ascents and stars when setter_username is missing', () => {
       render(<ClimbTitle climb={makeClimb({ setter_username: undefined })} gradePosition="right" showSetterInfo />);
-      expect(screen.getByText('3.5★')).toBeTruthy();
+      expect(screen.getByText('10 ascents · 3.5★')).toBeTruthy();
     });
 
     it('does not render angle even when showAngle is true', () => {
@@ -189,13 +189,18 @@ describe('ClimbTitle', () => {
       expect(screen.getByText(/72 ascents/)).toBeTruthy();
     });
 
-    it('renders "project" when no grade quality', () => {
+    it('renders only ascent count when no grade quality', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '0' })} gradePosition="right" />);
-      expect(screen.getByText('project')).toBeTruthy();
+      expect(screen.getByText('10 ascents')).toBeTruthy();
     });
 
-    it('renders "project" when difficulty is null', () => {
+    it('renders only ascent count when difficulty is null', () => {
       render(<ClimbTitle climb={makeClimb({ difficulty: null, quality_average: null })} gradePosition="right" />);
+      expect(screen.getByText('10 ascents')).toBeTruthy();
+    });
+
+    it('renders "project" when no grade and no ascents', () => {
+      render(<ClimbTitle climb={makeClimb({ quality_average: '0', ascensionist_count: undefined })} gradePosition="right" />);
       expect(screen.getByText('project')).toBeTruthy();
     });
 

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -167,7 +167,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
 
   const setterText = climb.is_draft
     ? `Draft by ${climb.setter_username}`
-    : `By ${climb.setter_username} - ${climb.ascensionist_count ?? 0} ascents`;
+    : `By ${climb.setter_username}${climb.ascensionist_count ? ` - ${climb.ascensionist_count} ascent${climb.ascensionist_count === 1 ? '' : 's'}` : ''}`;
 
   const setterElement = showSetterInfo && climb.setter_username && (
     <Typography
@@ -190,8 +190,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     if (climb.is_draft) {
       subtitleParts.push('Draft');
     }
-    if (!climb.is_draft && climb.ascensionist_count !== undefined) {
-      subtitleParts.push(`${climb.ascensionist_count} ascents`);
+    if (!climb.is_draft && climb.ascensionist_count) {
+      subtitleParts.push(`${climb.ascensionist_count} ascent${climb.ascensionist_count === 1 ? '' : 's'}`);
     }
     if (hasGrade) {
       subtitleParts.push(`${climb.quality_average}\u2605`);
@@ -261,8 +261,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     if (showSetterInfo && climb.setter_username) {
       secondLineContent.push(`${climb.setter_username}`);
     }
-    if (!climb.is_draft && climb.ascensionist_count !== undefined) {
-      secondLineContent.push(`${climb.ascensionist_count} ascents`);
+    if (!climb.is_draft && climb.ascensionist_count) {
+      secondLineContent.push(`${climb.ascensionist_count} ascent${climb.ascensionist_count === 1 ? '' : 's'}`);
     }
 
     return (

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -190,6 +190,9 @@ const ClimbTitle: React.FC<ClimbTitleProps> = ({
     if (climb.is_draft) {
       subtitleParts.push('Draft');
     }
+    if (!climb.is_draft && climb.ascensionist_count !== undefined) {
+      subtitleParts.push(`${climb.ascensionist_count} ascents`);
+    }
     if (hasGrade) {
       subtitleParts.push(`${climb.quality_average}\u2605`);
     }


### PR DESCRIPTION
The ascent count was accidentally removed from the gradePosition="right" layout (used by climb list items). Re-adds it with the correct order: ascents, quality, setter.

https://claude.ai/code/session_016xqngzosWkpugM4W2Rr1Ym