### PR TITLE
Change climb card cover to single click for selecting active climb

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -279,7 +279,7 @@ export default function LikedClimbsList({
                 climb={climb}
                 boardDetails={boardDetails}
                 selected={selectedClimbUuid === climb.uuid}
-                onCoverDoubleClick={climbHandlersMap.get(climb.uuid)}
+                onCoverClick={climbHandlersMap.get(climb.uuid)}
               />
             </Box>
           ))}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -375,7 +375,7 @@ const ClimbsList = ({
                   climb={climb}
                   boardDetails={resolveBoardDetails(climb)}
                   selected={selectedClimbUuid === climb.uuid}
-                  onCoverDoubleClick={climbHandlersMap.get(climb.uuid)}
+                  onCoverClick={climbHandlersMap.get(climb.uuid)}
                   unsupported={unsupportedClimbs?.has(climb.uuid)}
                 />
               </div>


### PR DESCRIPTION
The grid/card view required double-click/double-tap to select a climb, which was inconsistent with the list view's single-click behavior. Switched both the main climbs list and liked climbs list from onCoverDoubleClick to onCoverClick.

https://claude.ai/code/session_01Djo7j3NMFUEBC2wnfSsNKx