### PR TITLE
Add climbing.com article link and date to aurora migration page

### DIFF
--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -68,6 +68,10 @@ export default function AuroraMigrationContent() {
                     component="img"
                     src="https://cdn.climbing.com/wp-content/uploads/2026/03/Untitled-design-1-2.jpg"
                     alt="The Kilter Board App Just Disappeared Without Warning"
+                    loading="lazy"
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                      e.currentTarget.style.display = 'none';
+                    }}
                     className={styles.articleImage}
                   />
                   <Box className={styles.articleBody}>

--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -49,20 +49,30 @@ export default function AuroraMigrationContent() {
                 </Typography>
 
                 <Typography variant="body1" component="p">
-                  On March 25, the{' '}
-                  <MuiLink
-                    href="https://www.climbing.com/news/why-the-kilter-board-app-suddenly-disappeared/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Kilter board app suddenly disappeared
-                  </MuiLink>
-                  , as Aurora randomly shut down its Kilter backend. In response Kilter
-                  rushed out their own app which was still in beta, but the outcome of
-                  these two entities fighting is that the customer gets left holding the
-                  bag, and everyone likely has lost their data (including playlists,
-                  logbooks and draft climbs).
+                  On March 25, the Kilter board app suddenly disappeared, as Aurora
+                  randomly shut down its Kilter backend. In response Kilter rushed out
+                  their own app which was still in beta, but the outcome of these two
+                  entities fighting is that the customer gets left holding the bag, and
+                  everyone likely has lost their data (including playlists, logbooks and
+                  draft climbs).
                 </Typography>
+
+                <MuiLink
+                  href="https://www.climbing.com/news/why-the-kilter-board-app-suddenly-disappeared/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="none"
+                  className={styles.articleCard}
+                >
+                  <Box className={styles.articleBody}>
+                    <Typography variant="subtitle2" color="text.primary">
+                      Why the Kilter Board App Suddenly Disappeared
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      climbing.com
+                    </Typography>
+                  </Box>
+                </MuiLink>
 
                 <Typography variant="body1" component="p">
                   This single-vendor risk first became obvious 2 years ago, when you

--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -49,12 +49,19 @@ export default function AuroraMigrationContent() {
                 </Typography>
 
                 <Typography variant="body1" component="p">
-                  Today the Kilter board app suddenly disappeared, as Aurora randomly
-                  shut down its Kilter backend. In response Kilter rushed out their own
-                  app which was still in beta, but the outcome of these two entities
-                  fighting is that the customer gets left holding the bag, and everyone
-                  likely has lost their data (including playlists, logbooks and draft
-                  climbs).
+                  On March 25, the{' '}
+                  <MuiLink
+                    href="https://www.climbing.com/news/why-the-kilter-board-app-suddenly-disappeared/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Kilter board app suddenly disappeared
+                  </MuiLink>
+                  , as Aurora randomly shut down its Kilter backend. In response Kilter
+                  rushed out their own app which was still in beta, but the outcome of
+                  these two entities fighting is that the customer gets left holding the
+                  bag, and everyone likely has lost their data (including playlists,
+                  logbooks and draft climbs).
                 </Typography>
 
                 <Typography variant="body1" component="p">

--- a/packages/web/app/aurora-migration/aurora-migration-content.tsx
+++ b/packages/web/app/aurora-migration/aurora-migration-content.tsx
@@ -54,7 +54,7 @@ export default function AuroraMigrationContent() {
                   their own app which was still in beta, but the outcome of these two
                   entities fighting is that the customer gets left holding the bag, and
                   everyone likely has lost their data (including playlists, logbooks and
-                  draft climbs).
+                  draft climbs). For more info read:
                 </Typography>
 
                 <MuiLink
@@ -64,11 +64,20 @@ export default function AuroraMigrationContent() {
                   underline="none"
                   className={styles.articleCard}
                 >
+                  <Box
+                    component="img"
+                    src="https://cdn.climbing.com/wp-content/uploads/2026/03/Untitled-design-1-2.jpg"
+                    alt="The Kilter Board App Just Disappeared Without Warning"
+                    className={styles.articleImage}
+                  />
                   <Box className={styles.articleBody}>
-                    <Typography variant="subtitle2" color="text.primary">
-                      Why the Kilter Board App Suddenly Disappeared
+                    <Typography variant="subtitle2" color="text.primary" className={styles.articleTitle}>
+                      The Kilter Board App Just Disappeared Without Warning. Here&apos;s What Really Happened.
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="body2" color="text.secondary" className={styles.articleDescription}>
+                      For years, climbing&apos;s most successful training board has been at war with its app developer. Now, climbers are paying the price.
+                    </Typography>
+                    <Typography variant="caption" color="text.disabled">
                       climbing.com
                     </Typography>
                   </Box>

--- a/packages/web/app/aurora-migration/aurora-migration.module.css
+++ b/packages/web/app/aurora-migration/aurora-migration.module.css
@@ -86,6 +86,7 @@
   width: 100%;
   height: 200px;
   object-fit: cover;
+  background: var(--neutral-100);
 }
 
 .articleBody {

--- a/packages/web/app/aurora-migration/aurora-migration.module.css
+++ b/packages/web/app/aurora-migration/aurora-migration.module.css
@@ -70,20 +70,41 @@
 
 .articleCard {
   display: flex;
+  flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--neutral-200);
   border-radius: 12px;
   transition: border-color 0.15s;
+  background: var(--semantic-surface);
 }
 
 .articleCard:hover {
   border-color: var(--color-primary);
 }
 
+.articleImage {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
 .articleBody {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  gap: 4px;
   padding: 12px 16px;
-  min-width: 0;
+}
+
+.articleTitle {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.articleDescription {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/packages/web/app/aurora-migration/aurora-migration.module.css
+++ b/packages/web/app/aurora-migration/aurora-migration.module.css
@@ -67,3 +67,23 @@
 .cardContent {
   width: 100%;
 }
+
+.articleCard {
+  display: flex;
+  overflow: hidden;
+  border: 1px solid var(--neutral-200);
+  border-radius: 12px;
+  transition: border-color 0.15s;
+}
+
+.articleCard:hover {
+  border-color: var(--color-primary);
+}
+
+.articleBody {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 12px 16px;
+  min-width: 0;
+}


### PR DESCRIPTION
Replace "Today" with "On March 25" and link "Kilter board app suddenly
disappeared" to the climbing.com article covering the incident.

https://claude.ai/code/session_017gTGG487er2hqKHmNYYhxr