### PR TITLE
Fix ellipsis button not hiding on iOS Safari in climb list

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.module.css
+++ b/packages/web/app/components/climb-card/climb-list-item.module.css
@@ -4,12 +4,12 @@
   gap: 4px;
 }
 
-.menuButton {
+.menuButton.menuButton {
   display: none;
 }
 
 @media (min-width: 768px) {
-  .menuButton {
+  .menuButton.menuButton {
     display: inline-flex;
   }
 }


### PR DESCRIPTION
MUI's IconButton injects its own `display: inline-flex` style that has
higher specificity than the CSS module's `display: none`. Double the
class selector (.menuButton.menuButton) to boost specificity and
ensure the button stays hidden on mobile viewports.

https://claude.ai/code/session_019vZE6Y2vVjTXxV4S9D8aoN