### PR TITLE
Fix grouped bar chart not rendering, fix date picker overflow on mobile

### DIFF
--- a/packages/web/app/components/charts/css-bar-chart.module.css
+++ b/packages/web/app/components/charts/css-bar-chart.module.css
@@ -91,6 +91,7 @@
   flex: 1;
   min-width: 8px;
   max-width: 48px;
+  height: 100%;
   display: flex;
   gap: 1px;
   align-items: flex-end;

--- a/packages/web/app/crusher/[user_id]/components/board-stats-section.tsx
+++ b/packages/web/app/crusher/[user_id]/components/board-stats-section.tsx
@@ -127,25 +127,23 @@ export default function BoardStatsSection({
           {/* Weekly Attempts */}
           {weeklyBars && (
             <div className={styles.boardChartSection}>
-              <div className={styles.boardChartHeader}>
-                <Typography variant="body2" component="span" fontWeight={600} className={styles.boardChartTitle}>
-                  Weekly Attempts
-                </Typography>
-                <Stack direction="row" spacing={1} alignItems="center" className={styles.weeklyDateRange}>
-                  <MuiDatePicker
-                    value={weeklyFromDate ? dayjs(weeklyFromDate) : null}
-                    onChange={(val) => onWeeklyFromDateChange(val ? val.format('YYYY-MM-DD') : '')}
-                    slotProps={{ textField: { size: 'small', placeholder: 'From' } }}
-                    label="From"
-                  />
-                  <MuiDatePicker
-                    value={weeklyToDate ? dayjs(weeklyToDate) : null}
-                    onChange={(val) => onWeeklyToDateChange(val ? val.format('YYYY-MM-DD') : '')}
-                    slotProps={{ textField: { size: 'small', placeholder: 'To' } }}
-                    label="To"
-                  />
-                </Stack>
-              </div>
+              <Typography variant="body2" component="span" fontWeight={600} className={styles.boardChartTitle}>
+                Weekly Attempts
+              </Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} className={styles.weeklyDateRange}>
+                <MuiDatePicker
+                  value={weeklyFromDate ? dayjs(weeklyFromDate) : null}
+                  onChange={(val) => onWeeklyFromDateChange(val ? val.format('YYYY-MM-DD') : '')}
+                  slotProps={{ textField: { size: 'small' } }}
+                  label="From"
+                />
+                <MuiDatePicker
+                  value={weeklyToDate ? dayjs(weeklyToDate) : null}
+                  onChange={(val) => onWeeklyToDateChange(val ? val.format('YYYY-MM-DD') : '')}
+                  slotProps={{ textField: { size: 'small' } }}
+                  label="To"
+                />
+              </Stack>
               <CssBarChart bars={weeklyBars} height={180} mobileHeight={120} gap={3} ariaLabel="Weekly attempts by difficulty" />
             </div>
           )}

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -243,22 +243,15 @@
   margin-bottom: 0;
 }
 
-.boardChartHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px; /* spacing.2 */
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
 .boardChartTitle {
+  display: block;
   font-size: 13px;
   color: var(--neutral-600);
+  margin-bottom: 8px; /* spacing.2 */
 }
 
 .weeklyDateRange {
-  flex-shrink: 0;
+  margin-bottom: 12px; /* spacing.3 */
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
- Add height: 100% to groupedBarColumn so percentage-based child heights resolve correctly (bars were collapsing to 0px without explicit height)
- Move weekly date pickers below the title instead of inline, and use responsive Stack direction (column on mobile, row on desktop) to prevent overflow on narrow screens

https://claude.ai/code/session_01ENwN3qAPqtNmmQtGfMNCXZ