### PR TITLE
Move flash vs redpoint chart under grade distribution

### DIFF
--- a/packages/web/app/crusher/[user_id]/components/__tests__/board-stats-section.test.tsx
+++ b/packages/web/app/crusher/[user_id]/components/__tests__/board-stats-section.test.tsx
@@ -42,7 +42,6 @@ const defaultProps = {
   loadingStats: false,
   filteredLogbook: [],
   weeklyBars: null,
-  flashRedpointBars: null,
   isOwnProfile: false,
   weeklyFromDate: '',
   onWeeklyFromDateChange: vi.fn(),

--- a/packages/web/app/crusher/[user_id]/components/board-stats-section.tsx
+++ b/packages/web/app/crusher/[user_id]/components/board-stats-section.tsx
@@ -12,8 +12,8 @@ import { DatePicker as MuiDatePicker } from '@mui/x-date-pickers/DatePicker';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import BoardImportPrompt from '@/app/components/settings/board-import-prompt';
 import dayjs from 'dayjs';
-import { CssBarChart, GroupedBarChart } from '@/app/components/charts/css-bar-chart';
-import type { CssBarChartBar, GroupedBar } from '@/app/components/charts/css-bar-chart';
+import { CssBarChart } from '@/app/components/charts/css-bar-chart';
+import type { CssBarChartBar } from '@/app/components/charts/css-bar-chart';
 import {
   type TimeframeType,
   type LogbookEntry,
@@ -34,7 +34,6 @@ interface BoardStatsSectionProps {
   loadingStats: boolean;
   filteredLogbook: LogbookEntry[];
   weeklyBars: CssBarChartBar[] | null;
-  flashRedpointBars: GroupedBar[] | null;
   isOwnProfile: boolean;
   weeklyFromDate: string;
   onWeeklyFromDateChange: (date: string) => void;
@@ -54,7 +53,6 @@ export default function BoardStatsSection({
   loadingStats,
   filteredLogbook,
   weeklyBars,
-  flashRedpointBars,
   isOwnProfile,
   weeklyFromDate,
   onWeeklyFromDateChange,
@@ -148,15 +146,6 @@ export default function BoardStatsSection({
             </div>
           )}
 
-          {/* Flash vs Redpoint */}
-          {flashRedpointBars && (
-            <div className={styles.boardChartSection}>
-              <Typography variant="body2" component="span" fontWeight={600} className={styles.boardChartTitle}>
-                Flash vs Redpoint
-              </Typography>
-              <GroupedBarChart bars={flashRedpointBars} height={140} mobileHeight={100} gap={2} ariaLabel="Flash vs redpoint by grade" />
-            </div>
-          )}
         </div>
       )}
     </CardContent></MuiCard>

--- a/packages/web/app/crusher/[user_id]/components/profile-header.tsx
+++ b/packages/web/app/crusher/[user_id]/components/profile-header.tsx
@@ -14,8 +14,8 @@ import { PersonOutlined, Instagram } from '@mui/icons-material';
 import FollowButton from '@/app/components/ui/follow-button';
 import FollowerCount from '@/app/components/social/follower-count';
 import { FOLLOW_USER, UNFOLLOW_USER } from '@/app/lib/graphql/operations';
-import { CssBarChart } from '@/app/components/charts/css-bar-chart';
-import type { CssBarChartBar, BarSegment } from '@/app/components/charts/css-bar-chart';
+import { CssBarChart, GroupedBarChart } from '@/app/components/charts/css-bar-chart';
+import type { CssBarChartBar, BarSegment, GroupedBar } from '@/app/components/charts/css-bar-chart';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import type { UserProfile } from '../utils/profile-constants';
 import { type AggregatedTimeframeType, aggregatedTimeframeOptions } from '../utils/profile-constants';
@@ -36,6 +36,7 @@ interface ProfileHeaderProps {
   onAggregatedTimeframeChange: (value: AggregatedTimeframeType) => void;
   loadingAggregated: boolean;
   aggregatedStackedBars: { bars: CssBarChartBar[]; legendEntries: LayoutLegendEntry[] } | null;
+  aggregatedFlashRedpointBars: GroupedBar[] | null;
 }
 
 export default function ProfileHeader({
@@ -49,6 +50,7 @@ export default function ProfileHeader({
   onAggregatedTimeframeChange,
   loadingAggregated,
   aggregatedStackedBars,
+  aggregatedFlashRedpointBars,
 }: ProfileHeaderProps) {
   const displayName = profile.profile?.displayName || profile.name || 'Crusher';
   const avatarUrl = profile.profile?.avatarUrl || profile.image;
@@ -251,6 +253,22 @@ export default function ProfileHeader({
               <EmptyState description="No ascent data for this period" />
             )}
           </div>
+
+          {/* Flash vs Redpoint */}
+          {aggregatedFlashRedpointBars && !loadingAggregated && (
+            <div className={styles.flashRedpointSection}>
+              <Typography variant="body2" component="span" fontWeight={600} className={styles.gradeDistributionTitle}>
+                Flash vs Redpoint
+              </Typography>
+              <GroupedBarChart
+                bars={aggregatedFlashRedpointBars}
+                height={140}
+                mobileHeight={100}
+                gap={2}
+                ariaLabel="Flash vs redpoint by grade"
+              />
+            </div>
+          )}
         </CardContent></MuiCard>
       )}
     </>

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -23,7 +23,7 @@ import {
   filterLogbookByTimeframe,
   buildAggregatedStackedBars,
   buildWeeklyBars,
-  buildFlashRedpointBars,
+  buildAggregatedFlashRedpointBars,
   buildStatisticsSummary,
 } from '../utils/chart-data-builders';
 
@@ -170,9 +170,9 @@ export function useProfileData(userId: string) {
     [filteredLogbook, weeklyFromDate, weeklyToDate],
   );
 
-  const flashRedpointBars = useMemo(
-    () => buildFlashRedpointBars(filteredLogbook),
-    [filteredLogbook],
+  const aggregatedFlashRedpointBars = useMemo(
+    () => buildAggregatedFlashRedpointBars(allBoardsTicks, aggregatedTimeframe),
+    [allBoardsTicks, aggregatedTimeframe],
   );
 
   const statisticsSummary = useMemo(
@@ -204,7 +204,6 @@ export function useProfileData(userId: string) {
     toDate,
     setToDate,
     weeklyBars,
-    flashRedpointBars,
     weeklyFromDate,
     setWeeklyFromDate,
     weeklyToDate,
@@ -215,6 +214,7 @@ export function useProfileData(userId: string) {
     setAggregatedTimeframe,
     loadingAggregated,
     aggregatedStackedBars,
+    aggregatedFlashRedpointBars,
 
     // Profile stats summary
     loadingProfileStats,

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -38,7 +38,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
     toDate,
     setToDate,
     weeklyBars,
-    flashRedpointBars,
+    aggregatedFlashRedpointBars,
     weeklyFromDate,
     setWeeklyFromDate,
     weeklyToDate,
@@ -103,6 +103,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
             onAggregatedTimeframeChange={setAggregatedTimeframe}
             loadingAggregated={loadingAggregated}
             aggregatedStackedBars={aggregatedStackedBars}
+            aggregatedFlashRedpointBars={aggregatedFlashRedpointBars}
           />
         )}
 
@@ -118,7 +119,6 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
           loadingStats={loadingStats}
           filteredLogbook={filteredLogbook}
           weeklyBars={weeklyBars}
-          flashRedpointBars={flashRedpointBars}
           isOwnProfile={isOwnProfile}
           weeklyFromDate={weeklyFromDate}
           onWeeklyFromDateChange={setWeeklyFromDate}

--- a/packages/web/app/crusher/[user_id]/profile-page.module.css
+++ b/packages/web/app/crusher/[user_id]/profile-page.module.css
@@ -206,6 +206,12 @@
   flex-shrink: 0;
 }
 
+.flashRedpointSection {
+  border-top: 1px solid var(--neutral-200);
+  padding-top: 16px; /* spacing.4 */
+  margin-top: 16px; /* spacing.4 */
+}
+
 .stackedChartLegend {
   display: flex;
   flex-wrap: wrap;

--- a/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
@@ -257,6 +257,38 @@ export function buildFlashRedpointBars(filteredLogbook: LogbookEntry[]): Grouped
   }));
 }
 
+// ── Aggregated flash vs redpoint (all boards) ─────────────────────────
+
+export function buildAggregatedFlashRedpointBars(
+  allBoardsTicks: Record<string, LogbookEntry[]>,
+  aggregatedTimeframe: AggregatedTimeframeType,
+): GroupedBar[] | null {
+  const now = dayjs();
+
+  const filterByTimeframe = (entry: LogbookEntry) => {
+    const climbedAt = dayjs(entry.climbed_at);
+    switch (aggregatedTimeframe) {
+      case 'today':
+        return climbedAt.isSame(now, 'day');
+      case 'lastWeek':
+        return climbedAt.isAfter(now.subtract(1, 'week'));
+      case 'lastMonth':
+        return climbedAt.isAfter(now.subtract(1, 'month'));
+      case 'lastYear':
+        return climbedAt.isAfter(now.subtract(1, 'year'));
+      case 'all':
+      default:
+        return true;
+    }
+  };
+
+  const allEntries = BOARD_TYPES.flatMap((boardType) =>
+    (allBoardsTicks[boardType] || []).filter(filterByTimeframe),
+  );
+
+  return buildFlashRedpointBars(allEntries);
+}
+
 // ── Statistics summary (layout percentages) ─────────────────────────
 
 export interface LayoutPercentage {


### PR DESCRIPTION
Flash/redpoint is a variant of grade distribution, so it now lives in the stats summary card alongside it. Both charts share the same aggregated timeframe toggle and combine data from all boards.

- Add buildAggregatedFlashRedpointBars that filters all boards' ticks by the aggregated timeframe then delegates to buildFlashRedpointBars
- Remove flash/redpoint from BoardStatsSection
- Add flash/redpoint to ProfileHeader below grade distribution, separated by a subtle border
- Clean up unused per-board flashRedpointBars from hook and page content

https://claude.ai/code/session_01ENwN3qAPqtNmmQtGfMNCXZ