### PR TITLE
Add Node.js setup to CI workflows and improve test cleanup

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-wake-lock.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-wake-lock.test.ts
@@ -57,13 +57,13 @@ describe('useWakeLock', () => {
   });
 
   it('isSupported is false when navigator.wakeLock is not available', () => {
+    // Remove the property entirely to make 'wakeLock' in navigator return false
     Object.defineProperty(navigator, 'wakeLock', {
       value: undefined,
       writable: true,
       configurable: true,
     });
-    // Delete the property entirely to make 'wakeLock' in navigator return false
-    delete (navigator as unknown as Record<string, unknown>).wakeLock;
+    Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'wakeLock');
 
     const { result } = renderHook(() => useWakeLock(false));
     expect(result.current.isSupported).toBe(false);


### PR DESCRIPTION
## Summary
This PR adds explicit Node.js setup to CI workflows and improves the test cleanup approach in the wake lock test.

## Key Changes
- **CI Workflows**: Added Node.js 22 setup step to both `android-release.yml` and `ios-testflight.yml` workflows before the Bun setup. This ensures Node.js is available in the CI environment, which may be required by Bun or other build dependencies.

- **Test Improvement**: Refactored the `useWakeLock` test to use `Reflect.deleteProperty()` instead of the `delete` operator for removing the `wakeLock` property from the navigator object. This is a more reliable and semantically correct approach for property deletion, with improved code comments explaining the intent.

## Implementation Details
- Node.js version pinned to `22` using the official `actions/setup-node@v4` action
- Test cleanup now uses the Reflect API which is more robust for dynamic property manipulation
- Comment clarified to explain that the property removal is necessary for the `'wakeLock' in navigator` check to return false

https://claude.ai/code/session_01Vf9orubiKaGDMYWwyiehTg