### PR TITLE
Show avatar on home page in header position without full header

### DIFF
--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -69,6 +69,28 @@
   flex-shrink: 0;
 }
 
+.headerTransparent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: var(--global-header-height);
+  padding: 0 16px;
+  padding-top: env(safe-area-inset-top, 0px);
+  background: transparent;
+  border-bottom: none;
+  pointer-events: none;
+  touch-action: manipulation;
+}
+
+.headerTransparent > * {
+  pointer-events: auto;
+}
+
 :global(html[data-theme="dark"]) .header {
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.4));
   -webkit-backdrop-filter: blur(20px);

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -43,9 +43,13 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
 
   const hasActiveSession = !!activeSession;
 
-  // Hide header completely on certain pages
+  // On hidden-header pages, show only the avatar in a transparent bar
   if (HIDDEN_HEADER_PAGES.includes(pathname)) {
-    return null;
+    return (
+      <header className={styles.headerTransparent}>
+        <UserDrawer boardConfigs={boardConfigs} />
+      </header>
+    );
   }
 
   // Check if current page wants a simple title header

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -187,7 +187,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
           flex: 1,
           px: 2,
           py: 2,
-          pt: 2,
+          pt: 'var(--global-header-height)',
           display: 'flex',
           flexDirection: 'column',
           gap: 3,


### PR DESCRIPTION
Instead of hiding the global header entirely on the home page, render a transparent header bar with just the UserDrawer avatar. Uses pointer-events: none on the container so clicks pass through to the page content beneath.

https://claude.ai/code/session_01GDZthriY1JwVXaaiJegHm6