### PR TITLE
Fix bottom padding on mobile to account for safe area inset

### DIFF
--- a/packages/web/app/feed/feed-page-content.tsx
+++ b/packages/web/app/feed/feed-page-content.tsx
@@ -80,7 +80,7 @@ export default function FeedPageContent({
   }, [updateParam]);
 
   return (
-    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: '60px' }}>
+    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: 'calc(120px + env(safe-area-inset-bottom, 0px))' }}>
       {/* Feed */}
       <Box component="main" sx={{ flex: 1, px: 2, py: 2, pt: 'calc(var(--global-header-height) + 16px)' }}>
         {isAuthenticated && (myBoards.length > 0 || isLoadingBoards) && (

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -6,7 +6,7 @@ export default function NotificationsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))' }}>
       {children}
     </div>
   );

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -267,7 +267,7 @@ export default function SettingsPageContent() {
         </Typography>
       </Box>
 
-      <Box component="main" sx={{ padding: '24px', maxWidth: 600, margin: '0 auto', width: '100%' }}>
+      <Box component="main" sx={{ padding: '24px', paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))', maxWidth: 600, margin: '0 auto', width: '100%' }}>
         <Card>
           <CardContent>
             <Typography variant="h5">Profile</Typography>


### PR DESCRIPTION
## Summary
Updated bottom padding/margin calculations across multiple pages to properly account for mobile safe area insets (notches, home indicators, etc.) and ensure content isn't hidden behind fixed UI elements.

## Key Changes
- **Feed page**: Changed `pb: '60px'` to `pb: 'calc(120px + env(safe-area-inset-bottom, 0px))'` to add dynamic safe area spacing
- **Notifications layout**: Updated `paddingBottom` from `'env(safe-area-inset-bottom)'` to `'calc(120px + env(safe-area-inset-bottom, 0px))'` with fallback value
- **Settings page**: Added `paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))'` to main content area

## Implementation Details
- Uses CSS `env(safe-area-inset-bottom)` to detect device safe areas (notches, home indicators)
- Includes fallback value of `0px` for browsers that don't support safe area insets
- Combines fixed 120px padding with dynamic safe area inset for consistent spacing across all devices
- Ensures scrollable content has adequate bottom spacing and isn't obscured by fixed navigation or system UI

https://claude.ai/code/session_014qaYkwF2UxNK8w9AxmENUU