### PR TITLE
Unify climb info page with play drawer UI

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -132,12 +132,7 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
       <ClimbDetailPageServer
         climb={climbWithProcessedData}
         boardDetails={boardDetails}
-        betaLinks={detailData.betaLinks}
-        climbUuid={parsedParams.climb_uuid}
-        boardType={parsedParams.board_name}
         angle={parsedParams.angle}
-        currentClimbDifficulty={currentClimb.difficulty ?? undefined}
-        boardName={parsedParams.board_name}
       />
     );
   } catch (error) {

--- a/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
@@ -1,62 +1,17 @@
 import React from 'react';
-import ClimbViewActions from '@/app/components/climb-view/climb-view-actions';
-import ClimbDetailInfoShellClient from '@/app/components/climb-detail/climb-detail-info-shell.client';
-import { constructClimbInfoUrl } from '@/app/lib/url-utils';
-import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
-import styles from '@/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/climb-view.module.css';
+import PlayStyleClimbDetailClient from '@/app/components/climb-detail/play-style-climb-detail.client';
 
 interface ClimbDetailPageServerProps {
   climb: Climb;
   boardDetails: BoardDetails;
-  betaLinks: BetaLink[];
-  climbUuid: string;
-  boardType: string;
   angle: number;
-  currentClimbDifficulty?: string;
-  boardName?: string;
 }
 
 export default function ClimbDetailPageServer({
   climb,
   boardDetails,
-  betaLinks,
-  climbUuid,
-  boardType,
   angle,
-  currentClimbDifficulty,
-  boardName,
 }: ClimbDetailPageServerProps) {
-  const auroraAppUrl = constructClimbInfoUrl(
-    boardDetails,
-    climb.uuid,
-  ) ?? undefined;
-
-  return (
-    <div className={styles.pageContainer}>
-      <div className={styles.actionsSection}>
-        <ClimbViewActions
-          climb={climb}
-          boardDetails={boardDetails}
-          auroraAppUrl={auroraAppUrl}
-          angle={angle}
-        />
-      </div>
-
-      <div className={styles.contentWrapper}>
-        <div className={styles.climbSection}>
-          <ClimbDetailInfoShellClient
-            climb={climb}
-            boardDetails={boardDetails}
-            betaLinks={betaLinks}
-            climbUuid={climbUuid}
-            boardType={boardType}
-            angle={angle}
-            currentClimbDifficulty={currentClimbDifficulty}
-            boardName={boardName}
-          />
-        </div>
-      </div>
-    </div>
-  );
+  return <PlayStyleClimbDetailClient climb={climb} boardDetails={boardDetails} angle={angle} />;
 }

--- a/packages/web/app/components/climb-detail/play-style-climb-detail.client.tsx
+++ b/packages/web/app/components/climb-detail/play-style-climb-detail.client.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import BackButton from '@/app/components/back-button';
 import ClimbDetailShellClient from '@/app/components/climb-detail/climb-detail-shell.client';
 import { useBuildClimbDetailSections } from '@/app/components/climb-detail/build-climb-detail-sections';
 import PlayClimbAboveFold from '@/app/components/play-view/play-climb-above-fold';
+import { LogAscentDrawer } from '@/app/components/logbook/log-ascent-drawer';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
@@ -16,6 +17,8 @@ interface PlayStyleClimbDetailClientProps {
 }
 
 export default function PlayStyleClimbDetailClient({ climb, boardDetails, angle }: PlayStyleClimbDetailClientProps) {
+  const [tickOpen, setTickOpen] = useState(false);
+
   const sections = useBuildClimbDetailSections({
     climb,
     climbUuid: climb.uuid,
@@ -36,15 +39,31 @@ export default function PlayStyleClimbDetailClient({ climb, boardDetails, angle 
   }, [boardDetails, angle]);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', pt: 1 }}>
-        <BackButton fallbackUrl={backUrl} />
+    <>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', pt: 1 }}>
+          <BackButton fallbackUrl={backUrl} />
+        </Box>
+        <ClimbDetailShellClient
+          mode="play"
+          aboveFold={(
+            <PlayClimbAboveFold
+              climb={climb}
+              boardDetails={boardDetails}
+              angle={angle}
+              onOpenTick={() => setTickOpen(true)}
+              showPrevNextButtons={false}
+            />
+          )}
+          sections={sections}
+        />
       </Box>
-      <ClimbDetailShellClient
-        mode="play"
-        aboveFold={<PlayClimbAboveFold climb={climb} boardDetails={boardDetails} angle={angle} />}
-        sections={sections}
+      <LogAscentDrawer
+        open={tickOpen}
+        onClose={() => setTickOpen(false)}
+        currentClimb={climb}
+        boardDetails={boardDetails}
       />
-    </Box>
+    </>
   );
 }

--- a/packages/web/app/components/climb-detail/play-style-climb-detail.client.tsx
+++ b/packages/web/app/components/climb-detail/play-style-climb-detail.client.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import BackButton from '@/app/components/back-button';
+import ClimbDetailShellClient from '@/app/components/climb-detail/climb-detail-shell.client';
+import { useBuildClimbDetailSections } from '@/app/components/climb-detail/build-climb-detail-sections';
+import PlayClimbAboveFold from '@/app/components/play-view/play-climb-above-fold';
+import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+interface PlayStyleClimbDetailClientProps {
+  climb: Climb;
+  boardDetails: BoardDetails;
+  angle: number;
+}
+
+export default function PlayStyleClimbDetailClient({ climb, boardDetails, angle }: PlayStyleClimbDetailClientProps) {
+  const sections = useBuildClimbDetailSections({
+    climb,
+    climbUuid: climb.uuid,
+    boardType: boardDetails.board_name,
+    angle,
+    currentClimbDifficulty: climb.difficulty ?? undefined,
+    boardName: boardDetails.board_name,
+  });
+
+  const backUrl = useMemo(() => {
+    const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+
+    if (layout_name && size_name && set_names) {
+      return constructClimbListWithSlugs(board_name, layout_name, size_name, size_description, set_names, angle);
+    }
+
+    return `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
+  }, [boardDetails, angle]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', pt: 1 }}>
+        <BackButton fallbackUrl={backUrl} />
+      </Box>
+      <ClimbDetailShellClient
+        mode="play"
+        aboveFold={<PlayClimbAboveFold climb={climb} boardDetails={boardDetails} angle={angle} />}
+        sections={sections}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/components/play-view/play-climb-above-fold.tsx
+++ b/packages/web/app/components/play-view/play-climb-above-fold.tsx
@@ -13,9 +13,11 @@ import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOu
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import SwipeBoardCarousel from '../board-renderer/swipe-board-carousel';
 import ClimbDetailHeader from '@/app/components/climb-detail/climb-detail-header';
-import { useFavorite } from '../climb-actions';
+import { useFavorite, ClimbActions } from '../climb-actions';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useQueueContext } from '../graphql-queue';
+import { ShareBoardButton } from '../board-page/share-button';
+import { usePathname } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import styles from './play-view-drawer.module.css';
@@ -27,6 +29,7 @@ interface PlayClimbAboveFoldProps {
   onOpenActions?: () => void;
   onOpenQueue?: () => void;
   onOpenTick?: () => void;
+  showPrevNextButtons?: boolean;
 }
 
 export default function PlayClimbAboveFold({
@@ -36,6 +39,7 @@ export default function PlayClimbAboveFold({
   onOpenActions,
   onOpenQueue,
   onOpenTick,
+  showPrevNextButtons = true,
 }: PlayClimbAboveFoldProps) {
   const {
     mirrorClimb,
@@ -46,6 +50,7 @@ export default function PlayClimbAboveFold({
     queue,
     viewOnlyMode,
   } = useQueueContext();
+  const pathname = usePathname();
   const { logbook } = useBoardProvider();
 
   const { isFavorited, toggleFavorite } = useFavorite({
@@ -107,7 +112,6 @@ export default function PlayClimbAboveFold({
           <button
             className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''}`}
             onClick={onOpenTick}
-            disabled={!onOpenTick}
             aria-label="Log ascent"
           >
             <CheckOutlined className={styles.tickFabIcon} />
@@ -119,15 +123,17 @@ export default function PlayClimbAboveFold({
       </div>
 
       <div className={styles.actionBar}>
-        <IconButton
-          disabled={!canSwipePrevious}
-          onClick={() => {
-            const prev = getPreviousClimbQueueItem();
-            if (prev) setCurrentClimbQueueItem(prev);
-          }}
-        >
-          <SkipPreviousOutlined />
-        </IconButton>
+        {showPrevNextButtons && (
+          <IconButton
+            disabled={!canSwipePrevious}
+            onClick={() => {
+              const prev = getPreviousClimbQueueItem();
+              if (prev) setCurrentClimbQueueItem(prev);
+            }}
+          >
+            <SkipPreviousOutlined />
+          </IconButton>
+        )}
 
         {boardDetails.supportsMirroring && (
           <IconButton
@@ -147,25 +153,43 @@ export default function PlayClimbAboveFold({
           {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
         </IconButton>
 
-        <IconButton onClick={onOpenActions} aria-label="Climb actions" disabled={!onOpenActions}>
-          <MoreHorizOutlined />
-        </IconButton>
+        <ClimbActions
+          climb={climb}
+          boardDetails={boardDetails}
+          angle={angle}
+          currentPathname={pathname}
+          viewMode="button"
+          include={['share']}
+          size="default"
+        />
 
-        <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
-          <IconButton onClick={onOpenQueue} aria-label="Open queue" disabled={!onOpenQueue}>
-            <FormatListBulletedOutlined />
+        <ShareBoardButton />
+
+        {onOpenActions && (
+          <IconButton onClick={onOpenActions} aria-label="Climb actions">
+            <MoreHorizOutlined />
           </IconButton>
-        </MuiBadge>
+        )}
 
-        <IconButton
-          disabled={!canSwipeNext}
-          onClick={() => {
-            const next = getNextClimbQueueItem();
-            if (next) setCurrentClimbQueueItem(next);
-          }}
-        >
-          <SkipNextOutlined />
-        </IconButton>
+        {onOpenQueue && (
+          <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
+            <IconButton onClick={onOpenQueue} aria-label="Open queue">
+              <FormatListBulletedOutlined />
+            </IconButton>
+          </MuiBadge>
+        )}
+
+        {showPrevNextButtons && (
+          <IconButton
+            disabled={!canSwipeNext}
+            onClick={() => {
+              const next = getNextClimbQueueItem();
+              if (next) setCurrentClimbQueueItem(next);
+            }}
+          >
+            <SkipNextOutlined />
+          </IconButton>
+        )}
       </div>
     </>
   );

--- a/packages/web/app/components/play-view/play-climb-above-fold.tsx
+++ b/packages/web/app/components/play-view/play-climb-above-fold.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import IconButton from '@mui/material/IconButton';
+import MuiBadge from '@mui/material/Badge';
+import SyncOutlined from '@mui/icons-material/SyncOutlined';
+import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
+import Favorite from '@mui/icons-material/Favorite';
+import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
+import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
+import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
+import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
+import CheckOutlined from '@mui/icons-material/CheckOutlined';
+import SwipeBoardCarousel from '../board-renderer/swipe-board-carousel';
+import ClimbDetailHeader from '@/app/components/climb-detail/climb-detail-header';
+import { useFavorite } from '../climb-actions';
+import { useBoardProvider } from '../board-provider/board-provider-context';
+import { useQueueContext } from '../graphql-queue';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+import styles from './play-view-drawer.module.css';
+
+interface PlayClimbAboveFoldProps {
+  climb: Climb;
+  boardDetails: BoardDetails;
+  angle: number;
+  onOpenActions?: () => void;
+  onOpenQueue?: () => void;
+  onOpenTick?: () => void;
+}
+
+export default function PlayClimbAboveFold({
+  climb,
+  boardDetails,
+  angle,
+  onOpenActions,
+  onOpenQueue,
+  onOpenTick,
+}: PlayClimbAboveFoldProps) {
+  const {
+    mirrorClimb,
+    getNextClimbQueueItem,
+    getPreviousClimbQueueItem,
+    setCurrentClimbQueueItem,
+    currentClimbQueueItem,
+    queue,
+    viewOnlyMode,
+  } = useQueueContext();
+  const { logbook } = useBoardProvider();
+
+  const { isFavorited, toggleFavorite } = useFavorite({
+    climbUuid: climb.uuid,
+  });
+
+  const nextItem = getNextClimbQueueItem();
+  const prevItem = getPreviousClimbQueueItem();
+  const canSwipeNext = !viewOnlyMode && !!nextItem;
+  const canSwipePrevious = !viewOnlyMode && !!prevItem;
+  const isMirrored = !!climb?.mirrored;
+
+  const currentQueueIndex = currentClimbQueueItem
+    ? queue.findIndex(item => item.uuid === currentClimbQueueItem.uuid)
+    : -1;
+  const remainingQueueCount = currentQueueIndex >= 0 ? queue.length - currentQueueIndex : queue.length;
+
+  const filteredLogbook = useMemo(() => {
+    if (!logbook || !climb) return [];
+    return logbook.filter((asc) => asc.climb_uuid === climb.uuid && Number(asc.angle) === angle);
+  }, [logbook, climb, angle]);
+
+  const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
+  const ascentCount = filteredLogbook.length;
+
+  return (
+    <>
+      <div className={styles.headerSection}>
+        <ClimbDetailHeader
+          climb={climb}
+          boardDetails={boardDetails}
+          angle={angle}
+          isAngleAdjustable={true}
+        />
+      </div>
+
+      <div className={styles.boardSectionWrapper}>
+        <SwipeBoardCarousel
+          boardDetails={boardDetails}
+          currentClimb={climb}
+          nextClimb={nextItem?.climb}
+          previousClimb={prevItem?.climb}
+          onSwipeNext={() => {
+            const next = getNextClimbQueueItem();
+            if (next && !viewOnlyMode) setCurrentClimbQueueItem(next);
+          }}
+          onSwipePrevious={() => {
+            const prev = getPreviousClimbQueueItem();
+            if (prev && !viewOnlyMode) setCurrentClimbQueueItem(prev);
+          }}
+          canSwipeNext={canSwipeNext}
+          canSwipePrevious={canSwipePrevious}
+          className={styles.boardSection}
+          boardContainerClassName={styles.swipeCardContainer}
+          fillContainer
+        />
+
+        <div className={styles.tickFabContainer}>
+          <button
+            className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''}`}
+            onClick={onOpenTick}
+            disabled={!onOpenTick}
+            aria-label="Log ascent"
+          >
+            <CheckOutlined className={styles.tickFabIcon} />
+            {ascentCount > 0 && (
+              <span className={styles.tickFabBadge}>{ascentCount}</span>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.actionBar}>
+        <IconButton
+          disabled={!canSwipePrevious}
+          onClick={() => {
+            const prev = getPreviousClimbQueueItem();
+            if (prev) setCurrentClimbQueueItem(prev);
+          }}
+        >
+          <SkipPreviousOutlined />
+        </IconButton>
+
+        {boardDetails.supportsMirroring && (
+          <IconButton
+            color={isMirrored ? 'primary' : 'default'}
+            onClick={() => mirrorClimb()}
+            sx={
+              isMirrored
+                ? { backgroundColor: themeTokens.colors.purple, borderColor: themeTokens.colors.purple, color: 'common.white', '&:hover': { backgroundColor: themeTokens.colors.purple } }
+                : undefined
+            }
+          >
+            <SyncOutlined />
+          </IconButton>
+        )}
+
+        <IconButton onClick={() => toggleFavorite()}>
+          {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
+        </IconButton>
+
+        <IconButton onClick={onOpenActions} aria-label="Climb actions" disabled={!onOpenActions}>
+          <MoreHorizOutlined />
+        </IconButton>
+
+        <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
+          <IconButton onClick={onOpenQueue} aria-label="Open queue" disabled={!onOpenQueue}>
+            <FormatListBulletedOutlined />
+          </IconButton>
+        </MuiBadge>
+
+        <IconButton
+          disabled={!canSwipeNext}
+          onClick={() => {
+            const next = getNextClimbQueueItem();
+            if (next) setCurrentClimbQueueItem(next);
+          }}
+        >
+          <SkipNextOutlined />
+        </IconButton>
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1,35 +1,22 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
-import MuiBadge from '@mui/material/Badge';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import MuiButton from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
-import SyncOutlined from '@mui/icons-material/SyncOutlined';
-import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
-import Favorite from '@mui/icons-material/Favorite';
-import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
-import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
-import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
-import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import HistoryOutlined from '@mui/icons-material/HistoryOutlined';
-import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { useQueueContext } from '../graphql-queue';
-import { useFavorite, ClimbActions } from '../climb-actions';
+import { ClimbActions } from '../climb-actions';
 import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
-import { ShareBoardButton } from '../board-page/share-button';
-import { useBoardProvider } from '../board-provider/board-provider-context';
 import QueueList, { QueueListHandle } from '../queue-control/queue-list';
-import SwipeBoardCarousel from '../board-renderer/swipe-board-carousel';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { themeTokens } from '@/app/theme/theme-config';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
-import ClimbDetailHeader from '@/app/components/climb-detail/climb-detail-header';
 import { LogAscentDrawer } from '../logbook/log-ascent-drawer';
 import type { ActiveDrawer } from '../queue-control/queue-control-bar';
 import type { BoardDetails, Angle, Climb } from '@/app/lib/types';
@@ -39,6 +26,7 @@ import styles from './play-view-drawer.module.css';
 import drawerStyles from '../swipeable-drawer/swipeable-drawer.module.css';
 import ClimbDetailShellClient from '@/app/components/climb-detail/climb-detail-shell.client';
 import { useBuildClimbDetailSections } from '@/app/components/climb-detail/build-climb-detail-sections';
+import PlayClimbAboveFold from './play-climb-above-fold';
 
 
 
@@ -90,34 +78,12 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const queueScrollRef = useRef<HTMLDivElement>(null);
   const [queueScrollEl, setQueueScrollEl] = useState<HTMLDivElement | null>(null);
 
-  // Get logbook data for tick FAB badge
-  const { logbook } = useBoardProvider();
-
   const queueScrollCallbackRef = useCallback((node: HTMLDivElement | null) => {
     queueScrollRef.current = node;
     setQueueScrollEl(node);
   }, []);
 
-  const {
-    currentClimb,
-    currentClimbQueueItem,
-    mirrorClimb,
-    queue,
-    setQueue,
-    getNextClimbQueueItem,
-    getPreviousClimbQueueItem,
-    setCurrentClimbQueueItem,
-    viewOnlyMode,
-  } = useQueueContext();
-
-  const { isFavorited, toggleFavorite } = useFavorite({
-    climbUuid: currentClimb?.uuid ?? '',
-  });
-
-  const currentQueueIndex = currentClimbQueueItem
-    ? queue.findIndex(item => item.uuid === currentClimbQueueItem.uuid)
-    : -1;
-  const remainingQueueCount = currentQueueIndex >= 0 ? queue.length - currentQueueIndex : queue.length;
+  const { currentClimb, queue, setQueue, viewOnlyMode } = useQueueContext();
 
   // Wake lock when drawer is open
   useWakeLock(isOpen);
@@ -219,38 +185,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     }
   }, [setActiveDrawer, isActionsOpen, isQueueOpen, isPlaylistSelectorOpen, isTickDrawerOpen]);
 
-  // Compute ascent info for tick FAB badge
   const currentAngle = typeof angle === 'string' ? parseInt(angle, 10) : angle;
-  const filteredLogbook = useMemo(() => {
-    if (!logbook || !currentClimb) return [];
-    return logbook.filter(
-      (asc) => asc.climb_uuid === currentClimb.uuid && Number(asc.angle) === currentAngle
-    );
-  }, [logbook, currentClimb, currentAngle]);
-
-  const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
-  const ascentCount = filteredLogbook.length;
-
-  // Card-swipe navigation
-  const nextItem = getNextClimbQueueItem();
-  const prevItem = getPreviousClimbQueueItem();
-
-  const handleSwipeNext = useCallback(() => {
-    const next = getNextClimbQueueItem();
-    if (!next || viewOnlyMode) return;
-    setCurrentClimbQueueItem(next);
-  }, [getNextClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode]);
-
-  const handleSwipePrevious = useCallback(() => {
-    const prev = getPreviousClimbQueueItem();
-    if (!prev || viewOnlyMode) return;
-    setCurrentClimbQueueItem(prev);
-  }, [getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode]);
-
-  const canSwipeNext = !viewOnlyMode && !!nextItem;
-  const canSwipePrevious = !viewOnlyMode && !!prevItem;
-
-  const isMirrored = !!currentClimb?.mirrored;
 
 
   return (
@@ -275,123 +210,22 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             boardType={boardDetails.board_name}
             angle={currentAngle}
             aboveFold={
-            <>
-              {/* Header: Grade | Name | Angle Selector */}
-              <div className={styles.headerSection}>
-                <ClimbDetailHeader
-                  climb={currentClimb}
-                  boardDetails={boardDetails}
-                  angle={currentAngle}
-                  isAngleAdjustable={true}
-                />
-              </div>
-
-              {/* Board renderer with card-swipe and floating Tick FAB */}
-              <div className={styles.boardSectionWrapper}>
-                {currentClimb && (
-                  <SwipeBoardCarousel
-                    boardDetails={boardDetails}
-                    currentClimb={currentClimb}
-                    nextClimb={nextItem?.climb}
-                    previousClimb={prevItem?.climb}
-                    onSwipeNext={handleSwipeNext}
-                    onSwipePrevious={handleSwipePrevious}
-                    canSwipeNext={canSwipeNext}
-                    canSwipePrevious={canSwipePrevious}
-                    className={styles.boardSection}
-                    boardContainerClassName={styles.swipeCardContainer}
-                    fillContainer
-                  />
-                )}
-
-                {/* Floating Tick FAB - Spotify style */}
-                <div className={styles.tickFabContainer}>
-                  <button
-                    className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''}`}
-                    onClick={() => setIsTickDrawerOpen(true)}
-                    aria-label="Log ascent"
-                  >
-                    <CheckOutlined className={styles.tickFabIcon} />
-                    {ascentCount > 0 && (
-                      <span className={styles.tickFabBadge}>{ascentCount}</span>
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              <div className={styles.actionBar}>
-            <IconButton
-              disabled={!canSwipePrevious}
-              onClick={() => {
-                const prev = getPreviousClimbQueueItem();
-                if (prev) setCurrentClimbQueueItem(prev);
-              }}
-            >
-              <SkipPreviousOutlined />
-            </IconButton>
-
-            {/* Mirror */}
-            {boardDetails.supportsMirroring && (
-              <IconButton
-                color={isMirrored ? 'primary' : 'default'}
-                onClick={() => mirrorClimb()}
-                sx={
-                  isMirrored
-                    ? { backgroundColor: themeTokens.colors.purple, borderColor: themeTokens.colors.purple, color: 'common.white', '&:hover': { backgroundColor: themeTokens.colors.purple } }
-                    : undefined
-                }
-              >
-                <SyncOutlined />
-              </IconButton>
-            )}
-
-            {/* Favorite */}
-            <IconButton
-              onClick={() => toggleFavorite()}
-            >
-              {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
-            </IconButton>
-
-            {/* Party / LED */}
-            <ShareBoardButton />
-
-            {/* More actions */}
-            <IconButton
-              onClick={() => {
-                setIsQueueOpen(false);
-                setIsPlaylistSelectorOpen(false);
-                setIsActionsOpen(true);
-              }}
-              aria-label="Climb actions"
-            >
-              <MoreHorizOutlined />
-            </IconButton>
-
-            {/* Queue */}
-            <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
-              <IconButton
-                onClick={() => {
+              <PlayClimbAboveFold
+                climb={currentClimb}
+                boardDetails={boardDetails}
+                angle={currentAngle}
+                onOpenTick={() => setIsTickDrawerOpen(true)}
+                onOpenActions={() => {
+                  setIsQueueOpen(false);
+                  setIsPlaylistSelectorOpen(false);
+                  setIsActionsOpen(true);
+                }}
+                onOpenQueue={() => {
                   setIsActionsOpen(false);
                   setIsPlaylistSelectorOpen(false);
                   setIsQueueOpen(true);
                 }}
-                aria-label="Open queue"
-              >
-                <FormatListBulletedOutlined />
-              </IconButton>
-            </MuiBadge>
-
-            <IconButton
-              disabled={!canSwipeNext}
-              onClick={() => {
-                const next = getNextClimbQueueItem();
-                if (next) setCurrentClimbQueueItem(next);
-              }}
-            >
-              <SkipNextOutlined />
-            </IconButton>
-              </div>
-            </>
+              />
             }
           />
         ) : (


### PR DESCRIPTION
## Summary
- extracted a shared `PlayClimbAboveFold` component from `PlayViewDrawer` so the climb header, board renderer, tick FAB, and action row are rendered from one reusable UI component
- updated `PlayViewDrawer` to use the new shared component (no visual regressions to drawer behavior intended)
- replaced the climb info page shell with `PlayStyleClimbDetailClient`, which reuses the same shared play-style UI and adds a top-left back button
- simplified `ClimbDetailPageServer` to delegate directly to the new play-style client component

## Why
This makes the climb info page match the queue control bar's play drawer presentation while reusing the same componentized UI, reducing drift between the two experiences.

## Notes
- on the non-drawer climb info page, drawer-specific actions (more/queue/tick) are rendered but disabled because those drawers are not mounted in that context
- global header continues to be provided by the app-level wrapper; this change adds the requested local top-left back affordance on the info page

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2bc02b108326b55c0adc4279681b)