### PR TITLE
Use theme bottomNavSpacer and Box for consistent bottom spacing in pages

### DIFF
--- a/packages/web/app/feed/feed-page-content.tsx
+++ b/packages/web/app/feed/feed-page-content.tsx
@@ -17,6 +17,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import boardScrollStyles from '@/app/components/board-scroll/board-scroll.module.css';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
+import { themeTokens } from '@/app/theme/theme-config';
 
 type FeedTab = 'sessions' | 'proposals' | 'comments';
 const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
@@ -80,7 +81,7 @@ export default function FeedPageContent({
   }, [updateParam]);
 
   return (
-    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: 'calc(120px + env(safe-area-inset-bottom, 0px))' }}>
+    <Box sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', pb: themeTokens.layout.bottomNavSpacer }}>
       {/* Feed */}
       <Box component="main" sx={{ flex: 1, px: 2, py: 2, pt: 'calc(var(--global-header-height) + 16px)' }}>
         {isAuthenticated && (myBoards.length > 0 || isLoadingBoards) && (

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Box from '@mui/material/Box';
+import { themeTokens } from '@/app/theme/theme-config';
 
 export default function NotificationsLayout({
   children,
@@ -6,8 +8,8 @@ export default function NotificationsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))' }}>
+    <Box sx={{ minHeight: '100dvh', pt: 'var(--global-header-height)', pb: themeTokens.layout.bottomNavSpacer }}>
       {children}
-    </div>
+    </Box>
   );
 }

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -27,6 +27,7 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { usePartyProfile } from '@/app/components/party-manager/party-profile-context';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { themeTokens } from '@/app/theme/theme-config';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
@@ -267,7 +268,7 @@ export default function SettingsPageContent() {
         </Typography>
       </Box>
 
-      <Box component="main" sx={{ padding: '24px', paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))', maxWidth: 600, margin: '0 auto', width: '100%' }}>
+      <Box component="main" sx={{ padding: '24px', paddingBottom: themeTokens.layout.bottomNavSpacer, maxWidth: 600, margin: '0 auto', width: '100%' }}>
         <Card>
           <CardContent>
             <Typography variant="h5">Profile</Typography>


### PR DESCRIPTION
### Motivation
- Centralize the bottom navigation spacer to a theme token so page layouts use a single source of truth for bottom padding.
- Replace raw `div` usage in layouts with Material UI `Box` for consistent styling and theming.

### Description
- Import `themeTokens` and replace hard-coded `paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))'` with `themeTokens.layout.bottomNavSpacer` in `feed-page-content.tsx`, `notifications/layout.tsx`, and `settings-page-content.tsx`.
- Replace the wrapper `div` in `notifications/layout.tsx` with a `Box` and apply `sx` styles using `themeTokens.layout.bottomNavSpacer`.
- Minor layout consistency tweaks to use `Box` `sx` props and maintain `minHeight` values.

### Testing
- Ran TypeScript typecheck (`yarn tsc`) and the project typecheck passed.
- Ran linters (`yarn lint`) and no lint errors were introduced.
- Ran the project's automated test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2c258364832681efe05d1a096320)