### PR TITLE
Constrain onboarding card stack width to match hero

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -290,7 +290,16 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
         )}
 
         {/* Onboarding Cards */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1.5,
+            width: '100%',
+            maxWidth: 420,
+            mx: 'auto',
+          }}
+        >
           <Typography
             variant="body2"
             fontWeight={themeTokens.typography.fontWeight.semibold}


### PR DESCRIPTION
### Motivation
- The onboarding stack (“Make it yours”) was spanning the full content width which visually mismatched the centered, narrower hero CTA (“Start climbing”).
- Constrain the onboarding container so the heading and cards align with the hero block and avoid appearing wider than the section above.

### Description
- Updated the outer wrapper for the Onboarding Cards in `packages/web/app/home-page-content.tsx` to include `width: '100%'`, `maxWidth: 420`, and `mx: 'auto'` so it is centered and constrained to the same approximate width as the hero.
- Left all `OnboardingCard` internals and layout unchanged so cards continue to fill the constrained container.
- Did not add further spacing changes (no change to card internals or layout behavior).

### Testing
- Ran a repository search for relevant text with `rg -n "Make it yours|Start climbing|boards near you|Boards near you|make it yours"`, which succeeded.
- Printed the updated file sections with `sed -n '1,340p' packages/web/app/home-page-content.tsx` and `sed -n '220,360p' packages/web/app/home-page-content.tsx`, which succeeded and show the new wrapper styles.
- Verified the working tree diff with `git diff -- packages/web/app/home-page-content.tsx` and `git status --short`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce33f86df48326b49d3b5d0386f83c)