### PR TITLE
Allow queue next/previous navigation from any page (fix home navigation)

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -118,7 +118,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   const nextClimb = getNextClimbQueueItem();
   const previousClimb = getPreviousClimbQueueItem();
-  const shouldNavigate = isViewPage || isPlayPage;
+  // Queue navigation should move to the selected climb from anywhere in the app.
+  // On play pages we preserve in-place URL behavior; elsewhere we route to view pages.
+  const shouldNavigate = true;
 
   // Build URL for a climb item (for navigation on view/play pages)
   const buildClimbUrl = useCallback((climb: { uuid: string; name: string }) => {
@@ -519,8 +521,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   {/* Navigation buttons - desktop only */}
                   <span className={styles.navButtons}>
                     <Stack direction="row" spacing={1}>
-                      <PreviousClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
-                      <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
+                      <PreviousClimbButton navigate={true} boardDetails={boardDetails} />
+                      <NextClimbButton navigate={true} boardDetails={boardDetails} />
                     </Stack>
                   </span>
                   {/* Party button */}


### PR DESCRIPTION
### Motivation
- Queue navigation in the bottom control bar was limited to board view/play routes, which prevented moving the queue forward/backward from non-board pages such as the home page.

### Description
- Set `shouldNavigate = true` in `packages/web/app/components/queue-control/queue-control-bar.tsx` so queue navigation attempts routing regardless of the current route.
- Updated desktop controls to pass `navigate={true}` to `PreviousClimbButton` and `NextClimbButton` so click navigation works from non-board pages.
- Preserved existing play-mode in-place URL behavior because the button components still build and handle `isPlayPage` routes when needed.

### Testing
- Ran `pnpm --filter @boardsesh/web typecheck`, which could not complete successfully in this environment because `node_modules` are missing and TypeScript/third-party types cannot be resolved.
- No unit or e2e tests were executed here, and the change was validated by code inspection and local behavior reasoning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce497035b48326affa45978eb0c4b1)