### PR TITLE
Disable lazy loading for thumbnail overlay images in climb list

### DIFF
--- a/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
@@ -122,6 +122,20 @@ describe('BoardImageLayers', () => {
     }
   });
 
+  it('does not set loading="lazy" on thumbnail overlay images', () => {
+    const { container } = render(
+      <BoardImageLayers
+        boardDetails={mockBoardDetails}
+        frames="p1r42p2r43"
+        mirrored={false}
+        thumbnail
+      />,
+    );
+
+    const images = container.querySelectorAll('img');
+    expect(images[images.length - 1].getAttribute('loading')).toBeNull();
+  });
+
   it('renders multiple background images when board has multiple sets', () => {
     const multiSetBoard: BoardDetails = {
       ...mockBoardDetails,

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -83,7 +83,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
         <img
           src={overlayUrl}
           alt=""
-          loading="lazy"
+          loading={thumbnail ? undefined : 'lazy'}
           style={imgStyle}
           onLoad={handleOverlayLoad}
           onError={handleOverlayError}


### PR DESCRIPTION
### Motivation
- Ensure climb list thumbnails render their overlay immediately by removing `loading="lazy"` when images are rendered as thumbnails, avoiding blank/placeholder behavior in list rows.

### Description
- Update `BoardImageLayers` to set `loading={thumbnail ? undefined : 'lazy'}` on the overlay `<img>` so thumbnail overlays do not receive a `loading` attribute.
- Add a unit test in `packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx` to assert that thumbnail overlay images do not have `loading="lazy"`.
- Preserve existing behavior so non-thumbnail overlays still use `loading="lazy"` and background images remain without a `loading` attribute.

### Testing
- Ran `bun run --filter=@boardsesh/web test:run packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx`, which failed because `vitest` was not found in the execution environment.
- Ran `bunx vitest run packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx`, which failed due to npm registry access (`403`) in this environment.
- The new test was added; it should pass in CI or a developer environment with test dependencies available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5b0bedb48326850e49f973481489)