### PR TITLE
Center and constrain onboarding cards container on home page

### DIFF
--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -290,7 +290,16 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
         )}
 
         {/* Onboarding Cards */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1.5,
+            width: '100%',
+            maxWidth: 420,
+            mx: 'auto',
+          }}
+        >
           <Typography
             variant="body2"
             fontWeight={themeTokens.typography.fontWeight.semibold}


### PR DESCRIPTION
### Motivation
- Limit the width and center the onboarding cards column to improve layout on wide screens and keep content visually consistent.

### Description
- Updated the `Box` wrapper in `packages/web/app/home-page-content.tsx` to include `width: '100%'`, `maxWidth: 420`, and `mx: 'auto'` in its `sx` props so onboarding cards are centered and constrained.

### Testing
- Ran the web app dev build and unit test suite (`yarn build` and `yarn test`) and verified no regressions; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2c79820c8326aef7b1c0445ac41d)