### PR TITLE
Fix tension link UX to show 12-hour sync messaging

### DIFF
--- a/packages/web/app/api/internal/aurora-credentials/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/route.ts
@@ -143,8 +143,8 @@ export async function POST(request: NextRequest) {
           encryptedPassword,
           auroraUserId: loginResponse.user_id,
           auroraToken: encryptedToken,
-          lastSyncAt: now,
-          syncStatus: "active",
+          lastSyncAt: null,
+          syncStatus: "pending",
           syncError: null,
           updatedAt: now,
         })
@@ -163,8 +163,8 @@ export async function POST(request: NextRequest) {
         encryptedPassword,
         auroraUserId: loginResponse.user_id,
         auroraToken: encryptedToken,
-        lastSyncAt: now,
-        syncStatus: "active",
+        lastSyncAt: null,
+        syncStatus: "pending",
         syncError: null,
       });
     }
@@ -210,8 +210,8 @@ export async function POST(request: NextRequest) {
         boardType,
         auroraUsername: username,
         auroraUserId: loginResponse.user_id,
-        lastSyncAt: now.toISOString(),
-        syncStatus: "active",
+        lastSyncAt: null,
+        syncStatus: "pending",
         syncError: null,
         createdAt: now.toISOString(),
       },

--- a/packages/web/app/api/internal/aurora-credentials/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/route.ts
@@ -8,7 +8,6 @@ import { authOptions } from "@/app/lib/auth/auth-options";
 import { encrypt, decrypt } from "@boardsesh/crypto";
 import AuroraClimbingClient from "@/app/lib/api-wrappers/aurora-rest-client/aurora-rest-client";
 import { AuroraBoardName } from "@/app/lib/api-wrappers/aurora/types";
-import { syncUserData } from "@/app/lib/data-sync/aurora/user-sync";
 
 const saveCredentialsSchema = z.object({
   boardType: z.enum(["kilter", "tension"]),
@@ -205,34 +204,6 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Trigger sync in background
-    let finalSyncStatus = "active";
-    let finalSyncError: string | null = null;
-
-    try {
-      // Sync user data from Aurora to boardsesh_ticks
-      await syncUserData(boardType as AuroraBoardName, loginResponse.token, loginResponse.user_id);
-    } catch (syncError) {
-      console.error("Sync error (non-blocking):", syncError);
-      finalSyncStatus = "error";
-      finalSyncError = syncError instanceof Error ? syncError.message : "Sync failed";
-
-      // Update sync status to reflect error
-      await db
-        .update(schema.auroraCredentials)
-        .set({
-          syncStatus: "error",
-          syncError: finalSyncError,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.auroraCredentials.userId, session.user.id),
-            eq(schema.auroraCredentials.boardType, boardType)
-          )
-        );
-    }
-
     return NextResponse.json({
       success: true,
       credential: {
@@ -240,8 +211,8 @@ export async function POST(request: NextRequest) {
         auroraUsername: username,
         auroraUserId: loginResponse.user_id,
         lastSyncAt: now.toISOString(),
-        syncStatus: finalSyncStatus,
-        syncError: finalSyncError,
+        syncStatus: "active",
+        syncError: null,
         createdAt: now.toISOString(),
       },
     });

--- a/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
+++ b/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
@@ -142,7 +142,7 @@ describe('BoardImportPrompt', () => {
       });
 
       await waitFor(() => {
-        expect(mockShowMessage).toHaveBeenCalledWith('Tension account linked successfully', 'success');
+        expect(mockShowMessage).toHaveBeenCalledWith('Tension account linked. Your data will show up within 12 hours.', 'success');
       });
     });
 

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -353,7 +353,11 @@ export default function AuroraCredentialsSection() {
         throw new Error(error.error || 'Failed to save credentials');
       }
 
-      showMessage(`${selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} account linked successfully`, 'success');
+      if (selectedBoard === 'tension') {
+        showMessage('Tension account linked. Your data will show up within 12 hours.', 'success');
+      } else {
+        showMessage(`${selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} account linked successfully`, 'success');
+      }
       setIsModalOpen(false);
       setFormValues({ username: '', password: '' });
       await fetchCredentials();
@@ -546,7 +550,7 @@ export default function AuroraCredentialsSection() {
           <Typography variant="h5">Board Accounts</Typography>
           <Typography variant="body2" component="span" color="text.secondary" className={styles.sectionDescription}>
             Link your board accounts to import your Aurora data to Boardsesh, or import from a JSON export file.
-            We'll automatically sync your logbook, ascents, and climbs FROM Aurora every 6 hours.
+            We'll automatically sync your logbook, ascents, and climbs FROM Aurora every 12 hours.
             Data created in Boardsesh stays local and does not sync back to Aurora.
           </Typography>
 
@@ -597,7 +601,7 @@ export default function AuroraCredentialsSection() {
         <Typography variant="body2" component="span" color="text.secondary" className={styles.modalDescription}>
           Enter your {selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1)} Board
           username and password to import your Aurora data.
-          Your credentials are encrypted and securely stored. Data syncs every 6 hours.
+          Your credentials are encrypted and securely stored. Data syncs every 12 hours.
         </Typography>
         <Box
           component="form"

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -107,7 +107,11 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         throw new Error(error.error || 'Failed to save credentials');
       }
 
-      showMessage(`${boardName} account linked successfully`, 'success');
+      if (boardType === 'tension') {
+        showMessage('Tension account linked. Your data will show up within 12 hours.', 'success');
+      } else {
+        showMessage(`${boardName} account linked successfully`, 'success');
+      }
       setIsModalOpen(false);
       setFormValues({ username: '', password: '' });
       await fetchCredential();
@@ -300,7 +304,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         <DialogContent>
           <Typography variant="body2" component="span" color="text.secondary" className={styles.modalDescription}>
             Enter your {boardName} Board username and password to import your Aurora data.
-            Your credentials are encrypted and securely stored. Data syncs every 6 hours.
+            Your credentials are encrypted and securely stored. Data syncs every 12 hours.
           </Typography>
           <Box
             component="form"


### PR DESCRIPTION
### Motivation
- Users linking a Tension account were seeing an immediate error because the server attempted an immediate sync after linking even though Tension data is ingested on a 12-hour cadence. 
- The UI and tests needed to reflect the real sync cadence so post-link messaging doesn't mislead users.

### Description
- Stop attempting an immediate post-link sync by removing the `syncUserData` call from the `POST /api/internal/aurora-credentials` handler and always return `syncStatus: "active"`/`syncError: null` after saving credentials. 
- Update the Tension-specific success snackbar text to `"Tension account linked. Your data will show up within 12 hours."` in `BoardImportPrompt` and `AuroraCredentialsSection`. 
- Change explanatory copy in the account-link modal and settings from "every 6 hours" to "every 12 hours" so UI text matches the actual sync schedule. 
- Adjust the existing unit test in `packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx` to expect the new Tension success message.

### Testing
- Updated unit test expectation for `BoardImportPrompt` and attempted to run the single test with `bun run --filter=@boardsesh/web test:run packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx`, but the run failed because `vitest` was not available in the execution environment (`vitest: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5ec4039883268d28e47ece6aa485)