### PR TITLE
Fix Bluetooth blocked in Android Capacitor app

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -5,7 +5,7 @@ import { track } from '@vercel/analytics';
 import { useBoardBluetooth } from './use-board-bluetooth';
 import { useQueueContext } from '../graphql-queue';
 import type { BoardDetails } from '@/app/lib/types';
-import { isCapacitor, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
+import { isCapacitor, isCapacitorWebView, waitForCapacitor, CAPACITOR_BRIDGE_TIMEOUT_MS } from '@/app/lib/ble/capacitor-utils';
 
 interface BluetoothContextValue {
   isConnected: boolean;
@@ -46,7 +46,7 @@ export function BluetoothProvider({
       // UA looks like a native WebView — bridge may not be injected yet.
       // Poll for window.Capacitor; only confirm support once the bridge appears.
       let cancelled = false;
-      waitForCapacitor(2000).then((found) => {
+      waitForCapacitor(CAPACITOR_BRIDGE_TIMEOUT_MS).then((found) => {
         if (!cancelled && found) {
           setIsBluetoothSupported(true);
         }

--- a/packages/web/app/lib/ble/__tests__/capacitor-utils.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-utils.test.ts
@@ -92,7 +92,7 @@ describe('waitForCapacitor', () => {
   afterEach(() => {
     vi.useRealTimers();
     if (originalCapacitor === undefined) {
-      delete (window as Record<string, unknown>).Capacitor;
+      delete (window as unknown as Record<string, unknown>).Capacitor;
     } else {
       window.Capacitor = originalCapacitor;
     }
@@ -110,7 +110,7 @@ describe('waitForCapacitor', () => {
   });
 
   it('resolves true when Capacitor appears during polling', async () => {
-    delete (window as Record<string, unknown>).Capacitor;
+    delete (window as unknown as Record<string, unknown>).Capacitor;
     const { waitForCapacitor } = await loadUtils();
 
     const promise = waitForCapacitor(2000, 100);
@@ -129,7 +129,7 @@ describe('waitForCapacitor', () => {
   });
 
   it('resolves false after timeout if Capacitor never appears', async () => {
-    delete (window as Record<string, unknown>).Capacitor;
+    delete (window as unknown as Record<string, unknown>).Capacitor;
     const { waitForCapacitor } = await loadUtils();
 
     const promise = waitForCapacitor(500, 100);
@@ -145,7 +145,7 @@ describe('isCapacitor', () => {
 
   afterEach(() => {
     if (originalCapacitor === undefined) {
-      delete (window as Record<string, unknown>).Capacitor;
+      delete (window as unknown as Record<string, unknown>).Capacitor;
     } else {
       window.Capacitor = originalCapacitor;
     }
@@ -162,7 +162,7 @@ describe('isCapacitor', () => {
   });
 
   it('returns false when window.Capacitor is undefined', async () => {
-    delete (window as Record<string, unknown>).Capacitor;
+    delete (window as unknown as Record<string, unknown>).Capacitor;
     const { isCapacitor } = await loadUtils();
     expect(isCapacitor()).toBe(false);
   });

--- a/packages/web/app/lib/ble/adapter-factory.ts
+++ b/packages/web/app/lib/ble/adapter-factory.ts
@@ -1,10 +1,10 @@
-import { isCapacitor, isCapacitorWebView, waitForCapacitor } from './capacitor-utils';
+import { isCapacitor, isCapacitorWebView, waitForCapacitor, CAPACITOR_BRIDGE_TIMEOUT_MS } from './capacitor-utils';
 import type { BluetoothAdapter } from './types';
 
 export async function createBluetoothAdapter(): Promise<BluetoothAdapter> {
   // If we detect a WebView but the Capacitor bridge isn't ready yet, wait briefly
   if (!isCapacitor() && isCapacitorWebView()) {
-    await waitForCapacitor(3000);
+    await waitForCapacitor(CAPACITOR_BRIDGE_TIMEOUT_MS);
   }
 
   if (isCapacitor()) {

--- a/packages/web/app/lib/ble/capacitor-utils.ts
+++ b/packages/web/app/lib/ble/capacitor-utils.ts
@@ -19,12 +19,15 @@ export const isCapacitorWebView = (): boolean => {
   return isAndroidWebView || isIOSWebView;
 };
 
+/** Max time (ms) to wait for the Capacitor bridge to appear in a WebView. */
+export const CAPACITOR_BRIDGE_TIMEOUT_MS = 3000;
+
 /**
  * Wait for window.Capacitor to become available, with a timeout.
  * Resolves true if Capacitor appeared, false if timed out.
  */
 export const waitForCapacitor = (
-  timeoutMs = 2000,
+  timeoutMs = CAPACITOR_BRIDGE_TIMEOUT_MS,
   intervalMs = 100,
 ): Promise<boolean> =>
   new Promise((resolve) => {


### PR DESCRIPTION
The Capacitor bridge (window.Capacitor) can load after React hydrates when
using a remote server URL, causing isCapacitor() to miss the WebView context.
Android WebView also lacks navigator.bluetooth, so both detection paths fail
and the UI permanently shows "unsupported browser."

Add user-agent heuristic (isCapacitorWebView) as a synchronous fallback that
detects Android WebView ("wv" marker) and iOS WKWebView (no Safari token).
Also add a polling retry (waitForCapacitor) as a safety net, and harden the
adapter factory to wait for the bridge before falling back to Web Bluetooth.

https://claude.ai/code/session_01QEoZzHs5e4kqAFXd5TGKtu