### PR TITLE
iOS: Drop Release entitlements to avoid Associated Domains provisioning mismatch

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -377,7 +377,6 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
### Motivation
- The Release archive was failing because the distribution provisioning profile does not include the Associated Domains capability but the Release build configuration requested the `com.apple.developer.associated-domains` entitlement.

### Description
- Remove `CODE_SIGN_ENTITLEMENTS = App/App.entitlements` from the Release build configuration in `mobile/ios/App/App.xcodeproj/project.pbxproj` so Release archives no longer request the associated-domains entitlement while leaving Debug entitlements unchanged.

### Testing
- Confirmed the change via `git diff -- mobile/ios/App/App.xcodeproj/project.pbxproj` and located the `CODE_SIGN_ENTITLEMENTS` lines with `rg -n "CODE_SIGN_ENTITLEMENTS" mobile/ios/App/App.xcodeproj/project.pbxproj` (both succeeded); attempted `xcodebuild -version` in this environment which failed with `command not found`, so a full `xcodebuild archive` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d03e362ce083269f2e142b34bfc8d7)