### PR TITLE
Add native OAuth transfer flow for Capacitor apps and wire up App plugin

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-geolocation')
     implementation project(':capacitor-community-bluetooth-le')

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')
 

--- a/mobile/ios/App/Podfile
+++ b/mobile/ios/App/Podfile
@@ -11,6 +11,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+  pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'
   pod 'CapacitorCommunityBluetoothLe', :path => '../../node_modules/@capacitor-community/bluetooth-le'

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "@capacitor/android": "^6.0.0",
     "@capacitor/core": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
+    "@capacitor/app": "^6.0.0",
     "@capacitor/browser": "^6.0.0",
     "@capacitor/geolocation": "^6.0.0",
     "@capacitor-community/bluetooth-le": "^6.0.0",

--- a/packages/web/app/api/auth/native/callback/route.ts
+++ b/packages/web/app/api/auth/native/callback/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/lib/auth/auth-options';
+import { issueNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-transfer';
+
+const NATIVE_CALLBACK_SCHEME = 'com.boardsesh.app://auth/callback';
+
+const sanitizeNextPath = (nextPath: string | null): string =>
+  nextPath && nextPath.startsWith('/') ? nextPath : '/';
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.redirect(`${NATIVE_CALLBACK_SCHEME}?error=session_missing`);
+  }
+
+  const nextPath = sanitizeNextPath(request.nextUrl.searchParams.get('next'));
+  let transferToken: string;
+  try {
+    transferToken = issueNativeOAuthTransferToken({
+      userId: session.user.id,
+      nextPath,
+    });
+  } catch {
+    return NextResponse.redirect(`${NATIVE_CALLBACK_SCHEME}?error=token_issue_failed`);
+  }
+
+  const redirectUrl = `${NATIVE_CALLBACK_SCHEME}?transferToken=${encodeURIComponent(transferToken)}&next=${encodeURIComponent(nextPath)}`;
+  return NextResponse.redirect(redirectUrl);
+}

--- a/packages/web/app/api/auth/native/callback/route.ts
+++ b/packages/web/app/api/auth/native/callback/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { issueNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-transfer';
-
-const NATIVE_CALLBACK_SCHEME = 'com.boardsesh.app://auth/callback';
+import { NATIVE_OAUTH_CALLBACK_SCHEME } from '@/app/lib/auth/native-oauth-config';
 
 const sanitizeNextPath = (nextPath: string | null): string =>
   nextPath && nextPath.startsWith('/') ? nextPath : '/';
@@ -11,7 +10,7 @@ const sanitizeNextPath = (nextPath: string | null): string =>
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
-    return NextResponse.redirect(`${NATIVE_CALLBACK_SCHEME}?error=session_missing`);
+    return NextResponse.redirect(`${NATIVE_OAUTH_CALLBACK_SCHEME}?error=session_missing`);
   }
 
   const nextPath = sanitizeNextPath(request.nextUrl.searchParams.get('next'));
@@ -22,9 +21,9 @@ export async function GET(request: NextRequest) {
       nextPath,
     });
   } catch {
-    return NextResponse.redirect(`${NATIVE_CALLBACK_SCHEME}?error=token_issue_failed`);
+    return NextResponse.redirect(`${NATIVE_OAUTH_CALLBACK_SCHEME}?error=token_issue_failed`);
   }
 
-  const redirectUrl = `${NATIVE_CALLBACK_SCHEME}?transferToken=${encodeURIComponent(transferToken)}&next=${encodeURIComponent(nextPath)}`;
+  const redirectUrl = `${NATIVE_OAUTH_CALLBACK_SCHEME}?transferToken=${encodeURIComponent(transferToken)}&next=${encodeURIComponent(nextPath)}`;
   return NextResponse.redirect(redirectUrl);
 }

--- a/packages/web/app/components/auth/__tests__/social-login-buttons.test.ts
+++ b/packages/web/app/components/auth/__tests__/social-login-buttons.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildNativeOAuthSignInUrl } from '../social-login-buttons';
+import { buildNativeOAuthSignInUrl } from '@/app/lib/auth/native-oauth-url';
 
 describe('buildNativeOAuthSignInUrl', () => {
   it('builds a provider sign-in URL with native callback route', () => {
@@ -24,4 +24,3 @@ describe('buildNativeOAuthSignInUrl', () => {
     expect(url).toContain('next%3D%252F');
   });
 });
-

--- a/packages/web/app/components/auth/__tests__/social-login-buttons.test.ts
+++ b/packages/web/app/components/auth/__tests__/social-login-buttons.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildNativeOAuthSignInUrl } from '../social-login-buttons';
+
+describe('buildNativeOAuthSignInUrl', () => {
+  it('builds a provider sign-in URL with native callback route', () => {
+    const url = buildNativeOAuthSignInUrl({
+      origin: 'https://boardsesh.com',
+      provider: 'google',
+      callbackPath: '/settings',
+    });
+
+    expect(url).toBe(
+      'https://boardsesh.com/api/auth/signin/google?callbackUrl=https%3A%2F%2Fboardsesh.com%2Fapi%2Fauth%2Fnative%2Fcallback%3Fnext%3D%252Fsettings',
+    );
+  });
+
+  it('normalizes non-relative callback path values', () => {
+    const url = buildNativeOAuthSignInUrl({
+      origin: 'https://boardsesh.com',
+      provider: 'apple',
+      callbackPath: 'https://example.com/evil',
+    });
+
+    expect(url).toContain('next%3D%252F');
+  });
+});
+

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -8,6 +8,7 @@ import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import { signIn } from 'next-auth/react';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { buildNativeOAuthSignInUrl } from '@/app/lib/auth/native-oauth-url';
 
 // Note: OAuth provider icons and button colors use brand-specific colors
 // per Google/Apple/Facebook brand guidelines, not design system tokens
@@ -54,24 +55,6 @@ type ProvidersConfig = {
 type SocialLoginButtonsProps = {
   callbackUrl?: string;
   disabled?: boolean;
-};
-
-const sanitizeRelativePath = (path: string): string => (path.startsWith('/') ? path : '/');
-
-export const buildNativeOAuthSignInUrl = ({
-  origin,
-  provider,
-  callbackPath,
-}: {
-  origin: string;
-  provider: string;
-  callbackPath: string;
-}): string => {
-  const nextPath = sanitizeRelativePath(callbackPath);
-  const nativeCallbackUrl = `${origin}/api/auth/native/callback?next=${encodeURIComponent(nextPath)}`;
-  const signInUrl = new URL(`/api/auth/signin/${provider}`, origin);
-  signInUrl.searchParams.set('callbackUrl', nativeCallbackUrl);
-  return signInUrl.toString();
 };
 
 export default function SocialLoginButtons({

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -5,9 +5,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
-import Collapse from '@mui/material/Collapse';
 import Typography from '@mui/material/Typography';
-import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { signIn } from 'next-auth/react';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
@@ -66,7 +64,6 @@ export default function SocialLoginButtons({
   const [loading, setLoading] = useState(true);
   const [isBluefy, setIsBluefy] = useState(false);
   const [isCapacitorApp, setIsCapacitorApp] = useState(false);
-  const [showOAuthInfo, setShowOAuthInfo] = useState(false);
 
   useEffect(() => {
     if (typeof navigator !== 'undefined') {
@@ -89,7 +86,28 @@ export default function SocialLoginButtons({
       });
   }, []);
 
-  const handleSocialSignIn = (provider: string) => {
+  const handleSocialSignIn = async (provider: string) => {
+    if (isCapacitorApp) {
+      const browser = window.Capacitor?.Plugins?.Browser;
+      if (!browser) {
+        return;
+      }
+
+      const nextPath = callbackUrl.startsWith('/') ? callbackUrl : '/';
+      const nativeCallbackUrl =
+        `${window.location.origin}/api/auth/native/callback?next=${encodeURIComponent(nextPath)}`;
+
+      const result = await signIn(provider, {
+        callbackUrl: nativeCallbackUrl,
+        redirect: false,
+      });
+
+      if (result?.url) {
+        await browser.open({ url: result.url });
+      }
+      return;
+    }
+
     signIn(provider, { callbackUrl });
   };
 
@@ -106,33 +124,19 @@ export default function SocialLoginButtons({
     return null;
   }
 
-  if (isBluefy || isCapacitorApp) {
-    const appName = isCapacitorApp ? 'the Boardsesh app' : 'Bluefy';
+  if (isBluefy) {
     return (
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        <Button
-          fullWidth
-          size="large"
-          variant="outlined"
-          startIcon={<InfoOutlined />}
-          onClick={() => setShowOAuthInfo((prev) => !prev)}
-        >
-          Sign-in options unavailable in {appName}
-        </Button>
-        <Collapse in={showOAuthInfo}>
-          <Alert severity="info" sx={{ mt: 1 }}>
-            <Typography variant="body2" component="div">
-              Google, Apple, and Facebook sign-in are not supported in {appName}.
-            </Typography>
-            <Typography variant="body2" component="div" sx={{ mt: 1 }}>
-              To sign in, open <strong>boardsesh.com</strong> in
-              Safari, sign in with your preferred provider, then go
-              to <strong>Settings</strong> and set a password. You can then use
-              that email and password to log in here.
-            </Typography>
-          </Alert>
-        </Collapse>
-      </Box>
+      <Alert severity="info" sx={{ mt: 1 }}>
+        <Typography variant="body2" component="div">
+          Google, Apple, and Facebook sign-in are not supported in Bluefy.
+        </Typography>
+        <Typography variant="body2" component="div" sx={{ mt: 1 }}>
+          To sign in, open <strong>boardsesh.com</strong> in
+          Safari, sign in with your preferred provider, then go
+          to <strong>Settings</strong> and set a password. You can then use
+          that email and password to log in here.
+        </Typography>
+      </Alert>
     );
   }
 

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -56,6 +56,24 @@ type SocialLoginButtonsProps = {
   disabled?: boolean;
 };
 
+const sanitizeRelativePath = (path: string): string => (path.startsWith('/') ? path : '/');
+
+export const buildNativeOAuthSignInUrl = ({
+  origin,
+  provider,
+  callbackPath,
+}: {
+  origin: string;
+  provider: string;
+  callbackPath: string;
+}): string => {
+  const nextPath = sanitizeRelativePath(callbackPath);
+  const nativeCallbackUrl = `${origin}/api/auth/native/callback?next=${encodeURIComponent(nextPath)}`;
+  const signInUrl = new URL(`/api/auth/signin/${provider}`, origin);
+  signInUrl.searchParams.set('callbackUrl', nativeCallbackUrl);
+  return signInUrl.toString();
+};
+
 export default function SocialLoginButtons({
   callbackUrl = '/',
   disabled = false,
@@ -93,18 +111,13 @@ export default function SocialLoginButtons({
         return;
       }
 
-      const nextPath = callbackUrl.startsWith('/') ? callbackUrl : '/';
-      const nativeCallbackUrl =
-        `${window.location.origin}/api/auth/native/callback?next=${encodeURIComponent(nextPath)}`;
-
-      const result = await signIn(provider, {
-        callbackUrl: nativeCallbackUrl,
-        redirect: false,
+      const url = buildNativeOAuthSignInUrl({
+        origin: window.location.origin,
+        provider,
+        callbackPath: callbackUrl,
       });
 
-      if (result?.url) {
-        await browser.open({ url: result.url });
-      }
+      await browser.open({ url });
       return;
     }
 

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -1,14 +1,65 @@
 'use client';
 
-import React from 'react';
-import { SessionProvider } from 'next-auth/react';
+import React, { useEffect } from 'react';
+import { SessionProvider, signIn } from 'next-auth/react';
 import { ReactNode } from 'react';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
 interface SessionProviderWrapperProps {
   children: ReactNode;
 }
 
 export default function SessionProviderWrapper({ children }: SessionProviderWrapperProps) {
+  useEffect(() => {
+    if (!isNativeApp()) {
+      return;
+    }
+
+    const appPlugin = window.Capacitor?.Plugins?.App;
+    if (!appPlugin) {
+      return;
+    }
+
+    let listenerHandle: { remove: () => Promise<void> } | null = null;
+
+    appPlugin.addListener('appUrlOpen', async ({ url }) => {
+      if (!url.startsWith('com.boardsesh.app://auth/callback')) {
+        return;
+      }
+
+      const parsed = new URL(url);
+      const transferToken = parsed.searchParams.get('transferToken');
+      const nextPath = parsed.searchParams.get('next') ?? '/';
+
+      await window.Capacitor?.Plugins?.Browser?.close?.();
+
+      if (!transferToken) {
+        return;
+      }
+
+      const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
+      const result = await signIn('native-oauth', {
+        transferToken,
+        callbackUrl: safeCallbackUrl,
+        redirect: false,
+      });
+
+      if (result?.url) {
+        window.location.assign(result.url);
+      } else {
+        window.location.assign(safeCallbackUrl);
+      }
+    }).then((handle) => {
+      listenerHandle = handle;
+    }).catch((error) => {
+      console.error('[Native OAuth] Failed to register appUrlOpen listener:', error);
+    });
+
+    return () => {
+      void listenerHandle?.remove();
+    };
+  }, []);
+
   return (
     <SessionProvider
       refetchOnWindowFocus={false}

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -28,29 +28,38 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
         return;
       }
 
-      const parsed = new URL(url);
-      const callbackError = parsed.searchParams.get('error');
-      const transferToken = parsed.searchParams.get('transferToken');
-      const nextPath = parsed.searchParams.get('next') ?? '/';
+      try {
+        const parsed = new URL(url);
+        const callbackError = parsed.searchParams.get('error');
+        const transferToken = parsed.searchParams.get('transferToken');
+        const nextPath = parsed.searchParams.get('next') ?? '/';
+        const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
 
-      await window.Capacitor?.Plugins?.Browser?.close?.();
+        if (callbackError || !transferToken) {
+          window.location.assign('/auth/login?error=OAuthCallback');
+          return;
+        }
 
-      if (callbackError || !transferToken) {
+        const result = await signIn('native-oauth', {
+          transferToken,
+          callbackUrl: safeCallbackUrl,
+          redirect: false,
+        });
+
+        if (result?.error) {
+          window.location.assign('/auth/login?error=OAuthCallback');
+          return;
+        }
+
+        if (result?.url) {
+          window.location.assign(result.url);
+        } else {
+          window.location.assign(safeCallbackUrl);
+        }
+      } catch {
         window.location.assign('/auth/login?error=OAuthCallback');
-        return;
-      }
-
-      const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
-      const result = await signIn('native-oauth', {
-        transferToken,
-        callbackUrl: safeCallbackUrl,
-        redirect: false,
-      });
-
-      if (result?.url) {
-        window.location.assign(result.url);
-      } else {
-        window.location.assign(safeCallbackUrl);
+      } finally {
+        await window.Capacitor?.Plugins?.Browser?.close?.();
       }
     }).then((handle) => {
       listenerHandle = handle;
@@ -59,7 +68,12 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
     });
 
     return () => {
-      void listenerHandle?.remove();
+      if (!listenerHandle) {
+        return;
+      }
+      void listenerHandle.remove().catch((error) => {
+        console.error('[Native OAuth] Failed to remove appUrlOpen listener:', error);
+      });
     };
   }, []);
 

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 import { SessionProvider, signIn } from 'next-auth/react';
 import { ReactNode } from 'react';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { NATIVE_OAUTH_CALLBACK_SCHEME } from '@/app/lib/auth/native-oauth-config';
 
 interface SessionProviderWrapperProps {
   children: ReactNode;
@@ -23,17 +24,19 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
     let listenerHandle: { remove: () => Promise<void> } | null = null;
 
     appPlugin.addListener('appUrlOpen', async ({ url }) => {
-      if (!url.startsWith('com.boardsesh.app://auth/callback')) {
+      if (!url.startsWith(NATIVE_OAUTH_CALLBACK_SCHEME)) {
         return;
       }
 
       const parsed = new URL(url);
+      const callbackError = parsed.searchParams.get('error');
       const transferToken = parsed.searchParams.get('transferToken');
       const nextPath = parsed.searchParams.get('next') ?? '/';
 
       await window.Capacitor?.Plugins?.Browser?.close?.();
 
-      if (!transferToken) {
+      if (callbackError || !transferToken) {
+        window.location.assign('/auth/login?error=OAuthCallback');
         return;
       }
 

--- a/packages/web/app/lib/auth/__tests__/native-oauth-transfer.test.ts
+++ b/packages/web/app/lib/auth/__tests__/native-oauth-transfer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { issueNativeOAuthTransferToken, verifyNativeOAuthTransferToken } from '../native-oauth-transfer';
+
+describe('native OAuth transfer token', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'));
+    vi.stubEnv('NEXTAUTH_SECRET', 'test-nextauth-secret');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('issues and verifies a valid token', () => {
+    const token = issueNativeOAuthTransferToken({
+      userId: 'user_123',
+      nextPath: '/settings',
+    });
+
+    expect(verifyNativeOAuthTransferToken(token)).toEqual({
+      userId: 'user_123',
+      nextPath: '/settings',
+    });
+  });
+
+  it('normalizes unsafe paths to root', () => {
+    const token = issueNativeOAuthTransferToken({
+      userId: 'user_123',
+      nextPath: 'https://evil.example',
+    });
+
+    expect(verifyNativeOAuthTransferToken(token)).toEqual({
+      userId: 'user_123',
+      nextPath: '/',
+    });
+  });
+
+  it('rejects expired tokens', () => {
+    const token = issueNativeOAuthTransferToken({
+      userId: 'user_123',
+      nextPath: '/feed',
+    });
+
+    vi.setSystemTime(new Date('2026-04-03T12:03:01Z'));
+
+    expect(verifyNativeOAuthTransferToken(token)).toBeNull();
+  });
+
+  it('rejects tampered tokens', () => {
+    const token = issueNativeOAuthTransferToken({
+      userId: 'user_123',
+      nextPath: '/feed',
+    });
+
+    const [payload, signature] = token.split('.');
+    const tamperedPayload = `${payload}x`;
+    const tamperedToken = `${tamperedPayload}.${signature}`;
+
+    expect(verifyNativeOAuthTransferToken(tamperedToken)).toBeNull();
+  });
+
+  it('returns null when NEXTAUTH_SECRET is missing during verification', () => {
+    const token = issueNativeOAuthTransferToken({
+      userId: 'user_123',
+      nextPath: '/feed',
+    });
+
+    vi.unstubAllEnvs();
+
+    expect(verifyNativeOAuthTransferToken(token)).toBeNull();
+  });
+});

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -8,6 +8,7 @@ import { getDb } from "@/app/lib/db/db";
 import * as schema from "@/app/lib/db/schema";
 import { eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
+import { verifyNativeOAuthTransferToken } from "@/app/lib/auth/native-oauth-transfer";
 
 // Build providers array conditionally based on available env vars
 const providers: NextAuthOptions['providers'] = [];
@@ -41,6 +42,46 @@ if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
     })
   );
 }
+
+// Always add credentials provider
+providers.push(
+  CredentialsProvider({
+    id: "native-oauth",
+    name: "Native OAuth",
+    credentials: {
+      transferToken: { label: "Transfer Token", type: "text" },
+    },
+    async authorize(credentials) {
+      if (!credentials?.transferToken) {
+        return null;
+      }
+
+      const decoded = verifyNativeOAuthTransferToken(credentials.transferToken);
+      if (!decoded) {
+        return null;
+      }
+
+      const db = getDb();
+      const users = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, decoded.userId))
+        .limit(1);
+
+      if (users.length === 0) {
+        return null;
+      }
+
+      const user = users[0];
+      return {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        image: user.image,
+      };
+    },
+  }),
+);
 
 // Always add credentials provider
 providers.push(

--- a/packages/web/app/lib/auth/native-oauth-config.ts
+++ b/packages/web/app/lib/auth/native-oauth-config.ts
@@ -1,0 +1,2 @@
+export const NATIVE_OAUTH_CALLBACK_SCHEME = 'com.boardsesh.app://auth/callback';
+

--- a/packages/web/app/lib/auth/native-oauth-transfer.ts
+++ b/packages/web/app/lib/auth/native-oauth-transfer.ts
@@ -1,0 +1,97 @@
+import crypto from 'crypto';
+
+const NATIVE_OAUTH_TRANSFER_TTL_SECONDS = 120;
+
+type NativeOAuthTransferPayload = {
+  userId: string;
+  nextPath: string;
+  iat: number;
+  exp: number;
+};
+
+const base64UrlEncode = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');
+
+const base64UrlDecode = (value: string): string =>
+  Buffer.from(value, 'base64url').toString('utf8');
+
+const getNativeOAuthSecret = (): string => {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is required for native OAuth transfer flow');
+  }
+  return secret;
+};
+
+const sanitizeNextPath = (nextPath: string): string =>
+  nextPath.startsWith('/') ? nextPath : '/';
+
+export const issueNativeOAuthTransferToken = ({
+  userId,
+  nextPath,
+}: {
+  userId: string;
+  nextPath: string;
+}): string => {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: NativeOAuthTransferPayload = {
+    userId,
+    nextPath: sanitizeNextPath(nextPath),
+    iat: now,
+    exp: now + NATIVE_OAUTH_TRANSFER_TTL_SECONDS,
+  };
+
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = crypto
+    .createHmac('sha256', getNativeOAuthSecret())
+    .update(encodedPayload)
+    .digest('base64url');
+
+  return `${encodedPayload}.${signature}`;
+};
+
+export const verifyNativeOAuthTransferToken = (
+  token: string,
+): { userId: string; nextPath: string } | null => {
+  let secret: string;
+  try {
+    secret = getNativeOAuthSecret();
+  } catch {
+    return null;
+  }
+
+  const [encodedPayload, signature] = token.split('.');
+  if (!encodedPayload || !signature) {
+    return null;
+  }
+
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(encodedPayload)
+    .digest('base64url');
+
+  if (signature.length !== expectedSignature.length) {
+    return null;
+  }
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    return null;
+  }
+
+  let payload: NativeOAuthTransferPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as NativeOAuthTransferPayload;
+  } catch {
+    return null;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (!payload?.userId || !payload?.nextPath || !payload?.exp || payload.exp < now) {
+    return null;
+  }
+
+  return {
+    userId: payload.userId,
+    nextPath: sanitizeNextPath(payload.nextPath),
+  };
+};

--- a/packages/web/app/lib/auth/native-oauth-url.ts
+++ b/packages/web/app/lib/auth/native-oauth-url.ts
@@ -1,0 +1,18 @@
+const sanitizeRelativePath = (path: string): string => (path.startsWith('/') ? path : '/');
+
+export const buildNativeOAuthSignInUrl = ({
+  origin,
+  provider,
+  callbackPath,
+}: {
+  origin: string;
+  provider: string;
+  callbackPath: string;
+}): string => {
+  const nextPath = sanitizeRelativePath(callbackPath);
+  const nativeCallbackUrl = `${origin}/api/auth/native/callback?next=${encodeURIComponent(nextPath)}`;
+  const signInUrl = new URL(`/api/auth/signin/${provider}`, origin);
+  signInUrl.searchParams.set('callbackUrl', nativeCallbackUrl);
+  return signInUrl.toString();
+};
+

--- a/packages/web/app/lib/ble/capacitor-types.d.ts
+++ b/packages/web/app/lib/ble/capacitor-types.d.ts
@@ -31,6 +31,13 @@ interface CapacitorBrowserPlugin {
   close(): Promise<void>;
 }
 
+interface CapacitorAppPlugin {
+  addListener(
+    eventName: 'appUrlOpen',
+    listenerFunc: (event: { url: string }) => void,
+  ): Promise<{ remove: () => Promise<void> }>;
+}
+
 interface CapacitorGlobal {
   isNativePlatform(): boolean;
   getPlatform(): string;
@@ -39,6 +46,7 @@ interface CapacitorGlobal {
     Geolocation?: CapacitorGeolocationPlugin;
     KeepAwake?: CapacitorKeepAwakePlugin;
     Browser?: CapacitorBrowserPlugin;
+    App?: CapacitorAppPlugin;
     [key: string]: unknown;
   };
 }


### PR DESCRIPTION
### Motivation

- Enable OAuth sign-in from the native Capacitor app by opening the system browser for provider auth and securely transferring the authenticated user back to the app. 
- Provide a short-lived, signed transfer token to avoid exposing credentials across app/open redirects. 
- Register the Capacitor `App` plugin in native project configs so the web app can listen for `appUrlOpen` callbacks.

### Description

- Implemented a signed transfer token flow with `issueNativeOAuthTransferToken` and `verifyNativeOAuthTransferToken` in `packages/web/app/lib/auth/native-oauth-transfer.ts`. 
- Added a `native-oauth` `CredentialsProvider` to `packages/web/app/lib/auth/auth-options.ts` that verifies transfer tokens and resolves the corresponding user. 
- Added server callback route `packages/web/app/api/auth/native/callback/route.ts` to issue transfer tokens after a successful web session. 
- Updated client logic in `packages/web/app/components/auth/social-login-buttons.tsx` to open provider auth in the Capacitor `Browser` and point the provider callback to the native callback endpoint when running inside the Capacitor app. 
- Made `SessionProvider` (`packages/web/app/components/providers/session-provider.tsx`) listen for `appUrlOpen` events via the Capacitor `App` plugin and complete sign-in by calling `signIn('native-oauth', { transferToken })`. 
- Added TypeScript types for the Capacitor `App` plugin in `packages/web/app/lib/ble/capacitor-types.d.ts`. 
- Added unit tests for the transfer token logic in `packages/web/app/lib/auth/__tests__/native-oauth-transfer.test.ts`. 
- Added `@capacitor/app` to `mobile/package.json` and wired the plugin into Android (`mobile/android/capacitor.settings.gradle`, `mobile/android/app/capacitor.build.gradle`) and iOS (`mobile/ios/App/Podfile`).

### Testing

- Ran the new unit tests `packages/web/app/lib/auth/__tests__/native-oauth-transfer.test.ts` with `vitest`, and they passed. 
- Verified the token encode/verify behavior, expiration handling, tamper detection, and path sanitization via the automated tests. 
- No automated test failures were observed in the modified test scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d034a384b88326a8edc2ae1738a042)