### PR TITLE
Add password reset flow: API endpoints, email service, and UI

### DIFF
--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -113,4 +113,16 @@ describe('POST /api/auth/forgot-password', () => {
     expect(data.message).toContain('If an account exists');
     expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
   });
+
+  it('returns generic response when mailer fails', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+    mockSendPasswordResetEmail.mockRejectedValue(new Error('SMTP down'));
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toContain('If an account exists');
+  });
 });

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: mockGetClientIp,
+}));
+
+const mockSendPasswordResetEmail = vi.fn();
+vi.mock('@/app/lib/email/email-service', () => ({
+  sendPasswordResetEmail: mockSendPasswordResetEmail,
+}));
+
+const mockUserLimit = vi.fn();
+const mockCredentialsLimit = vi.fn();
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockValues = vi.fn().mockResolvedValue(undefined);
+const mockTxDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+const mockTxInsert = vi.fn(() => ({ values: mockValues }));
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+  await fn({ delete: mockTxDelete, insert: mockTxInsert });
+});
+
+let selectCall = 0;
+const mockSelect = vi.fn(() => {
+  selectCall += 1;
+  return {
+    from: () => ({
+      where: () => ({
+        limit: selectCall === 1 ? mockUserLimit : mockCredentialsLimit,
+      }),
+    }),
+  };
+});
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: mockSelect,
+    transaction: mockTransaction,
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { id: 'users.id', email: 'users.email' },
+  userCredentials: { userId: 'user_credentials.userId' },
+  verificationTokens: { identifier: 'verificationTokens.identifier' },
+}));
+
+import { POST } from '../route';
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/forgot-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/forgot-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCall = 0;
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+  });
+
+  it('returns 429 when rate limited', async () => {
+    mockCheckRateLimit.mockReturnValueOnce({ limited: true, retryAfterSeconds: 30 });
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+    expect(response.status).toBe(429);
+  });
+
+  it('returns 400 for invalid email', async () => {
+    const response = await POST(createRequest({ email: 'bad-email' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns generic response when user is not found', async () => {
+    mockUserLimit.mockResolvedValue([]);
+
+    const response = await POST(createRequest({ email: 'missing@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toContain('If an account exists');
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it('sends reset email for valid credential account', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+
+    expect(response.status).toBe(200);
+    expect(mockTransaction).toHaveBeenCalled();
+    expect(mockSendPasswordResetEmail).toHaveBeenCalled();
+  });
+
+  it('returns generic response and does not send email for OAuth-only account', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'oauth-user' }]);
+    mockCredentialsLimit.mockResolvedValue([]);
+
+    const response = await POST(createRequest({ email: 'oauth@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toContain('If an account exists');
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { sendPasswordResetEmail } from '@/app/lib/email/email-service';
+import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+const MIN_RESPONSE_TIME_MS = 1500;
+const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+
+async function consistentDelay(startTime: number): Promise<void> {
+  const elapsed = Date.now() - startTime;
+  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
+  if (remaining > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remaining));
+  }
+}
+
+function getResetIdentifier(email: string): string {
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}
+
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+  const genericMessage = 'If an account exists for this email, a reset link will be sent.';
+
+  try {
+    const clientIp = getClientIp(request);
+    const rateLimitResult = checkRateLimit(`forgot-password:${clientIp}`, 5, 60_000);
+
+    if (rateLimitResult.limited) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rateLimitResult.retryAfterSeconds),
+          },
+        }
+      );
+    }
+
+    const body = await request.json();
+    const validationResult = forgotPasswordSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { email } = validationResult.data;
+    const db = getDb();
+
+    const user = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1);
+
+    if (user.length === 0) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ message: genericMessage }, { status: 200 });
+    }
+
+    const hasCredentials = await db
+      .select({ userId: schema.userCredentials.userId })
+      .from(schema.userCredentials)
+      .where(eq(schema.userCredentials.userId, user[0].id))
+      .limit(1);
+
+    if (hasCredentials.length === 0) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ message: genericMessage }, { status: 200 });
+    }
+
+    const token = crypto.randomUUID();
+    const expires = new Date(Date.now() + 60 * 60 * 1000);
+    const identifier = getResetIdentifier(email);
+
+    await db.transaction(async (tx) => {
+      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+
+      await tx.insert(schema.verificationTokens).values({
+        identifier,
+        token,
+        expires,
+      });
+    });
+
+    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    await sendPasswordResetEmail(email, token, baseUrl);
+
+    await consistentDelay(startTime);
+    return NextResponse.json({ message: genericMessage }, { status: 200 });
+  } catch (error) {
+    console.error('Forgot password error:', error);
+    await consistentDelay(startTime);
+    return NextResponse.json({ error: 'Failed to process password reset request' }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -97,7 +97,12 @@ export async function POST(request: NextRequest) {
     });
 
     const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
-    await sendPasswordResetEmail(email, token, baseUrl);
+    try {
+      await sendPasswordResetEmail(email, token, baseUrl);
+    } catch (emailError) {
+      // Do not leak whether an account exists during mailer outages.
+      console.error('Failed to send password reset email:', emailError);
+    }
 
     await consistentDelay(startTime);
     return NextResponse.json({ message: genericMessage }, { status: 200 });

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -17,53 +17,54 @@ vi.mock('bcryptjs', () => ({
   },
 }));
 
-const mockTokenLimit = vi.fn();
 const mockUserLimit = vi.fn();
 const mockTxCredentialsLimit = vi.fn();
 const mockTxUpdateWhere = vi.fn().mockResolvedValue(undefined);
 const mockTxUserUpdateWhere = vi.fn().mockResolvedValue(undefined);
-const mockTxTokenDeleteWhere = vi.fn().mockResolvedValue(undefined);
 const mockTxInsertValues = vi.fn().mockResolvedValue(undefined);
-const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
-const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
-const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+const mockTxConsumedTokenReturning = vi.fn();
+const mockUsersTable = { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' };
+const mockUserCredentialsTable = { userId: 'userCredentials.userId' };
+const mockVerificationTokensTable = {
+  identifier: 'verificationTokens.identifier',
+  token: 'verificationTokens.token',
+  expires: 'verificationTokens.expires',
+};
+
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
   const tx = {
-    select: () => ({ from: () => ({ where: () => ({ limit: mockTxCredentialsLimit }) }) }),
+    delete: () => ({
+      where: () => ({
+        returning: mockTxConsumedTokenReturning,
+      }),
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: table === mockUsersTable ? mockUserLimit : mockTxCredentialsLimit,
+        }),
+      }),
+    }),
     update: (table: unknown) => ({
       set: () => ({
-        where: table === 'userCredentials' ? mockTxUpdateWhere : mockTxUserUpdateWhere,
+        where: table === mockUserCredentialsTable ? mockTxUpdateWhere : mockTxUserUpdateWhere,
       }),
     }),
     insert: () => ({ values: mockTxInsertValues }),
-    delete: () => ({ where: mockTxTokenDeleteWhere }),
   };
-  await fn(tx);
-});
-
-let selectCall = 0;
-const mockSelect = vi.fn(() => {
-  selectCall += 1;
-  return {
-    from: () => ({
-      where: () => ({
-        limit: selectCall === 1 ? mockTokenLimit : mockUserLimit,
-      }),
-    }),
-  };
+  return await fn(tx);
 });
 
 vi.mock('@/app/lib/db/db', () => ({
   getDb: () => ({
-    select: mockSelect,
-    delete: mockDelete,
     transaction: mockTransaction,
   }),
 }));
 
 vi.mock('@/app/lib/db/schema', () => ({
-  verificationTokens: { identifier: 'verificationTokens.identifier', token: 'verificationTokens.token', expires: 'verificationTokens.expires' },
-  users: { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' },
-  userCredentials: 'userCredentials',
+  verificationTokens: mockVerificationTokensTable,
+  users: mockUsersTable,
+  userCredentials: mockUserCredentialsTable,
 }));
 
 import { POST } from '../route';
@@ -79,10 +80,11 @@ function createRequest(body: Record<string, unknown>): NextRequest {
 describe('POST /api/auth/reset-password', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    selectCall = 0;
     mockGetClientIp.mockReturnValue('127.0.0.1');
     mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
     mockHash.mockResolvedValue('hashed-password');
+    mockTxConsumedTokenReturning.mockResolvedValue([{ identifier: 'password-reset:test@example.com' }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
     mockTxCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
   });
 
@@ -91,8 +93,8 @@ describe('POST /api/auth/reset-password', () => {
     expect(response.status).toBe(400);
   });
 
-  it('returns 400 when reset token does not exist', async () => {
-    mockTokenLimit.mockResolvedValue([]);
+  it('returns 400 when token is not consumed (invalid or expired)', async () => {
+    mockTxConsumedTokenReturning.mockResolvedValue([]);
 
     const response = await POST(
       createRequest({
@@ -107,9 +109,6 @@ describe('POST /api/auth/reset-password', () => {
   });
 
   it('resets password successfully', async () => {
-    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
-    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
-
     const response = await POST(
       createRequest({
         email: 'test@example.com',
@@ -125,26 +124,7 @@ describe('POST /api/auth/reset-password', () => {
     expect(mockTxUpdateWhere).toHaveBeenCalled();
   });
 
-  it('returns 400 when token is expired', async () => {
-    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() - 60_000) }]);
-    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
-
-    const response = await POST(
-      createRequest({
-        email: 'test@example.com',
-        token: crypto.randomUUID(),
-        password: 'validpassword',
-        confirmPassword: 'validpassword',
-      })
-    );
-
-    expect(response.status).toBe(400);
-    expect(mockDelete).toHaveBeenCalled();
-  });
-
   it('inserts credentials when user does not already have password credentials', async () => {
-    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
-    mockUserLimit.mockResolvedValue([{ id: 'oauth-user' }]);
     mockTxCredentialsLimit.mockResolvedValue([]);
 
     const response = await POST(

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: mockGetClientIp,
+}));
+
+const mockHash = vi.fn();
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: mockHash,
+  },
+}));
+
+const mockTokenLimit = vi.fn();
+const mockUserLimit = vi.fn();
+const mockTxCredentialsLimit = vi.fn();
+const mockTxUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxUserUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxTokenDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxInsertValues = vi.fn().mockResolvedValue(undefined);
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+  const tx = {
+    select: () => ({ from: () => ({ where: () => ({ limit: mockTxCredentialsLimit }) }) }),
+    update: (table: unknown) => ({
+      set: () => ({
+        where: table === 'userCredentials' ? mockTxUpdateWhere : mockTxUserUpdateWhere,
+      }),
+    }),
+    insert: () => ({ values: mockTxInsertValues }),
+    delete: () => ({ where: mockTxTokenDeleteWhere }),
+  };
+  await fn(tx);
+});
+
+let selectCall = 0;
+const mockSelect = vi.fn(() => {
+  selectCall += 1;
+  return {
+    from: () => ({
+      where: () => ({
+        limit: selectCall === 1 ? mockTokenLimit : mockUserLimit,
+      }),
+    }),
+  };
+});
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: mockSelect,
+    delete: mockDelete,
+    transaction: mockTransaction,
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  verificationTokens: { identifier: 'verificationTokens.identifier', token: 'verificationTokens.token', expires: 'verificationTokens.expires' },
+  users: { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' },
+  userCredentials: 'userCredentials',
+}));
+
+import { POST } from '../route';
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/reset-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCall = 0;
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+    mockHash.mockResolvedValue('hashed-password');
+    mockTxCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+  });
+
+  it('returns 400 for invalid request body', async () => {
+    const response = await POST(createRequest({ email: 'bad', token: 'x', password: '123', confirmPassword: '123' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when reset token does not exist', async () => {
+    mockTokenLimit.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('resets password successfully', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHash).toHaveBeenCalledWith('validpassword', 12);
+    expect(mockTransaction).toHaveBeenCalled();
+    expect(mockTxUpdateWhere).toHaveBeenCalled();
+  });
+
+  it('returns 400 when token is expired', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() - 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it('inserts credentials when user does not already have password credentials', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'oauth-user' }]);
+    mockTxCredentialsLimit.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        email: 'oauth@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockTxInsertValues).toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
@@ -64,33 +64,33 @@ export async function POST(request: NextRequest) {
     const db = getDb();
     const identifier = getResetIdentifier(email);
 
-    const resetToken = await db
-      .select()
-      .from(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, token)))
-      .limit(1);
+    const transactionResult = await db.transaction(async (tx) => {
+      const consumedToken = await tx
+        .delete(schema.verificationTokens)
+        .where(
+          and(
+            eq(schema.verificationTokens.identifier, identifier),
+            eq(schema.verificationTokens.token, token),
+            gt(schema.verificationTokens.expires, new Date()),
+          ),
+        )
+        .returning({ identifier: schema.verificationTokens.identifier });
 
-    if (resetToken.length === 0) {
-      await consistentDelay(startTime);
-      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
-    }
+      if (consumedToken.length === 0) {
+        return { ok: false as const };
+      }
 
-    if (new Date() > resetToken[0].expires) {
-      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
-      await consistentDelay(startTime);
-      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
-    }
+      const user = await tx
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, email))
+        .limit(1);
 
-    const user = await db.select().from(schema.users).where(eq(schema.users.email, email)).limit(1);
-    if (user.length === 0) {
-      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
-      await consistentDelay(startTime);
-      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
-    }
+      if (user.length === 0) {
+        return { ok: false as const };
+      }
 
-    const passwordHash = await bcrypt.hash(password, 12);
-
-    await db.transaction(async (tx) => {
+      const passwordHash = await bcrypt.hash(password, 12);
       const existingCredentials = await tx
         .select()
         .from(schema.userCredentials)
@@ -114,8 +114,13 @@ export async function POST(request: NextRequest) {
         .set({ emailVerified: new Date(), updatedAt: new Date() })
         .where(and(eq(schema.users.id, user[0].id), isNull(schema.users.emailVerified)));
 
-      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      return { ok: true as const };
     });
+
+    if (!transactionResult.ok) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
 
     await consistentDelay(startTime);
     return NextResponse.json({

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq, isNull } from 'drizzle-orm';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+
+const resetPasswordSchema = z
+  .object({
+    email: z.string().email('Invalid email address'),
+    token: z.string().uuid('Invalid reset token'),
+    password: z.string().min(8, 'Password must be at least 8 characters').max(128, 'Password must be less than 128 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+const MIN_RESPONSE_TIME_MS = 1500;
+
+function getResetIdentifier(email: string): string {
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}
+
+async function consistentDelay(startTime: number): Promise<void> {
+  const elapsed = Date.now() - startTime;
+  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
+  if (remaining > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remaining));
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+  try {
+    const clientIp = getClientIp(request);
+    const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 10, 60_000);
+
+    if (rateLimitResult.limited) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rateLimitResult.retryAfterSeconds),
+          },
+        }
+      );
+    }
+
+    const body = await request.json();
+    const validationResult = resetPasswordSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
+    }
+
+    const { email, token, password } = validationResult.data;
+    const db = getDb();
+    const identifier = getResetIdentifier(email);
+
+    const resetToken = await db
+      .select()
+      .from(schema.verificationTokens)
+      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, token)))
+      .limit(1);
+
+    if (resetToken.length === 0) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    if (new Date() > resetToken[0].expires) {
+      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    const user = await db.select().from(schema.users).where(eq(schema.users.email, email)).limit(1);
+    if (user.length === 0) {
+      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+
+    await db.transaction(async (tx) => {
+      const existingCredentials = await tx
+        .select()
+        .from(schema.userCredentials)
+        .where(eq(schema.userCredentials.userId, user[0].id))
+        .limit(1);
+
+      if (existingCredentials.length > 0) {
+        await tx
+          .update(schema.userCredentials)
+          .set({ passwordHash, updatedAt: new Date() })
+          .where(eq(schema.userCredentials.userId, user[0].id));
+      } else {
+        await tx.insert(schema.userCredentials).values({
+          userId: user[0].id,
+          passwordHash,
+        });
+      }
+
+      await tx
+        .update(schema.users)
+        .set({ emailVerified: new Date(), updatedAt: new Date() })
+        .where(and(eq(schema.users.id, user[0].id), isNull(schema.users.emailVerified)));
+
+      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+    });
+
+    await consistentDelay(startTime);
+    return NextResponse.json({
+      message: 'Password reset successful. You can now sign in with your new password.',
+    });
+  } catch (error) {
+    console.error('Reset password error:', error);
+    await consistentDelay(startTime);
+    return NextResponse.json({ error: 'Failed to reset password' }, { status: 500 });
+  }
+}

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import MailOutlined from '@mui/icons-material/MailOutlined';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Logo from '@/app/components/brand/logo';
+import BackButton from '@/app/components/back-button';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export default function ForgotPasswordContent() {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const { showMessage } = useSnackbar();
+
+  const handleSubmit = async () => {
+    if (!email) {
+      setEmailError('Please enter your email');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        showMessage(data.error || 'Failed to request password reset', 'error');
+        return;
+      }
+
+      showMessage(data.message || 'If an account exists, a reset link has been sent.', 'success');
+    } catch (error) {
+      console.error('Forgot password error:', error);
+      showMessage('Failed to request password reset', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+      <Box
+        component="header"
+        sx={{
+          background: 'var(--semantic-surface)',
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          boxShadow: themeTokens.shadows.xs,
+          height: 64,
+        }}
+      >
+        <BackButton />
+        <Logo size="sm" showText={false} />
+        <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
+          Reset Password
+        </Typography>
+      </Box>
+
+      <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
+        <Card sx={{ width: '100%', maxWidth: 400 }}>
+          <CardContent>
+            <Stack spacing={2}>
+              <Typography variant="body1" component="p" color="text.secondary">
+                Enter your account email and we&apos;ll send you a link to reset your password.
+              </Typography>
+
+              <TextField
+                label="Email"
+                type="email"
+                placeholder="your@email.com"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  if (emailError) setEmailError(null);
+                }}
+                error={!!emailError}
+                helperText={emailError}
+                required
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <MailOutlined />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={loading}
+                startIcon={loading ? <CircularProgress size={16} /> : undefined}
+              >
+                Send Reset Link
+              </Button>
+
+              <Button variant="text" href="/auth/login">
+                Back to Login
+              </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/auth/forgot-password/page.tsx
+++ b/packages/web/app/auth/forgot-password/page.tsx
@@ -1,0 +1,12 @@
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import ForgotPasswordContent from './forgot-password-content';
+
+export const metadata = createNoIndexMetadata({
+  title: 'Forgot Password',
+  description: 'Request a password reset link for your Boardsesh account',
+  path: '/auth/forgot-password',
+});
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordContent />;
+}

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -315,6 +315,10 @@ export default function AuthPageContent() {
                 >
                   Login
                 </Button>
+
+                <Button variant="text" href="/auth/forgot-password">
+                  Forgot password?
+                </Button>
               </Box>
             </TabPanel>
 

--- a/packages/web/app/auth/reset-password/page.tsx
+++ b/packages/web/app/auth/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import ResetPasswordContent from './reset-password-content';
+
+export const metadata = createNoIndexMetadata({
+  title: 'Create New Password',
+  description: 'Set a new password for your Boardsesh account',
+  path: '/auth/reset-password',
+});
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import LockOutlined from '@mui/icons-material/LockOutlined';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Logo from '@/app/components/brand/logo';
+import BackButton from '@/app/components/back-button';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export default function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { showMessage } = useSnackbar();
+
+  const token = searchParams.get('token') || '';
+  const email = searchParams.get('email') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const isLinkInvalid = !token || !email;
+
+  const handleSubmit = async () => {
+    if (!password) {
+      setPasswordError('Please enter a new password');
+      return;
+    }
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters');
+      return;
+    }
+    if (!confirmPassword) {
+      setConfirmPasswordError('Please confirm your new password');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setConfirmPasswordError('Passwords do not match');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, token, password, confirmPassword }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        showMessage(data.error || 'Failed to reset password', 'error');
+        return;
+      }
+
+      showMessage('Password updated successfully. Please sign in.', 'success');
+      router.push('/auth/login');
+    } catch (error) {
+      console.error('Reset password error:', error);
+      showMessage('Failed to reset password', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+      <Box
+        component="header"
+        sx={{
+          background: 'var(--semantic-surface)',
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          boxShadow: themeTokens.shadows.xs,
+          height: 64,
+        }}
+      >
+        <BackButton />
+        <Logo size="sm" showText={false} />
+        <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
+          Create New Password
+        </Typography>
+      </Box>
+
+      <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
+        <Card sx={{ width: '100%', maxWidth: 400 }}>
+          <CardContent>
+            <Stack spacing={2}>
+              {isLinkInvalid ? (
+                <Typography variant="body1" color="error">
+                  This reset link is invalid. Please request a new password reset email.
+                </Typography>
+              ) : (
+                <>
+                  <Typography variant="body1" component="p" color="text.secondary">
+                    Enter a new password for <strong>{email}</strong>.
+                  </Typography>
+
+                  <TextField
+                    label="New Password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (passwordError) setPasswordError(null);
+                    }}
+                    error={!!passwordError}
+                    helperText={passwordError}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <LockOutlined />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+
+                  <TextField
+                    label="Confirm New Password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value);
+                      if (confirmPasswordError) setConfirmPasswordError(null);
+                    }}
+                    error={!!confirmPasswordError}
+                    helperText={confirmPasswordError}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <LockOutlined />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+
+                  <Button
+                    variant="contained"
+                    onClick={handleSubmit}
+                    disabled={loading}
+                    startIcon={loading ? <CircularProgress size={16} /> : undefined}
+                  >
+                    Update Password
+                  </Button>
+                </>
+              )}
+
+              <Button variant="text" href="/auth/login">
+                Back to Login
+              </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/lib/email/email-service.ts
+++ b/packages/web/app/lib/email/email-service.ts
@@ -96,3 +96,50 @@ export async function sendVerificationEmail(
     text: `Welcome to Boardsesh!\n\nPlease verify your email address by clicking this link:\n\n${verifyUrl}\n\nThis link expires in 24 hours.\n\nIf you didn't create a Boardsesh account, you can safely ignore this email.`,
   });
 }
+
+export async function sendPasswordResetEmail(
+  email: string,
+  token: string,
+  baseUrl: string
+): Promise<void> {
+  const validatedEmail = emailSchema.parse(email);
+
+  const resetUrl = `${baseUrl}/auth/reset-password?token=${token}&email=${encodeURIComponent(validatedEmail)}`;
+  const safeResetUrl = escapeHtml(resetUrl);
+
+  await getTransporter().sendMail({
+    from: process.env.EMAIL_FROM || process.env.SMTP_USER,
+    to: validatedEmail,
+    subject: 'Reset your Boardsesh password',
+    html: `
+      <div style="font-family: ${themeTokens.typography.fontFamily}; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h1 style="color: ${emailColors.primary}; margin-bottom: 24px;">Password reset request</h1>
+        <p style="color: ${emailColors.textPrimary}; font-size: 16px; line-height: 1.5;">
+          We received a request to reset your Boardsesh password.
+        </p>
+        <a href="${safeResetUrl}" style="
+          display: inline-block;
+          background-color: ${emailColors.primary};
+          color: white;
+          padding: 14px 28px;
+          text-decoration: none;
+          border-radius: ${themeTokens.borderRadius.md}px;
+          margin: 24px 0;
+          font-weight: ${themeTokens.typography.fontWeight.semibold};
+          font-size: 16px;
+        ">Reset Password</a>
+        <p style="color: ${emailColors.textSecondary}; font-size: 14px; margin-top: 24px;">
+          Or copy and paste this link into your browser:
+        </p>
+        <p style="color: ${emailColors.primary}; font-size: 14px; word-break: break-all;">
+          ${safeResetUrl}
+        </p>
+        <hr style="border: none; border-top: 1px solid ${emailColors.border}; margin: 32px 0;" />
+        <p style="color: ${emailColors.textMuted}; font-size: 12px;">
+          This link expires in 1 hour. If you did not request a password reset, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+    text: `Reset your Boardsesh password\n\nUse this link to reset your password:\n\n${resetUrl}\n\nThis link expires in 1 hour.\n\nIf you did not request this, you can safely ignore this email.`,
+  });
+}


### PR DESCRIPTION
### Motivation
- Implement a complete password reset flow (request + reset) to allow users to request a reset link and set a new password.
- Provide consistent, non-revealing responses and rate limiting to protect against abuse and user enumeration.
- Add frontend pages and UI to let users request a reset and set a new password from emailed links.

### Description
- Added `POST /api/auth/forgot-password` in `packages/web/app/api/auth/forgot-password/route.ts` with input validation via `zod`, rate limiting via `checkRateLimit`, a consistent response delay (`consistentDelay`), DB lookups via `getDb`, token creation and transactional writes to `verificationTokens`, and invocation of `sendPasswordResetEmail`.
- Added `POST /api/auth/reset-password` in `packages/web/app/api/auth/reset-password/route.ts` with validation, token verification/expiration handling, password hashing via `bcrypt.hash`, DB transaction to update or insert `userCredentials`, set `emailVerified` conditionally, and deletion of the verification token.
- Implemented `sendPasswordResetEmail` in `packages/web/app/lib/email/email-service.ts` to build a safe reset URL and send email content (HTML and text) with a 1-hour expiry notice.
- Added client UI and pages: `forgot-password-content.tsx` and `page.tsx`, `reset-password-content.tsx` and `page.tsx`, and wired a "Forgot password?" link into the login UI (`auth-page-content.tsx`).
- Added unit tests for both endpoints at `__tests__/route.test.ts` which mock DB, rate limiter, email service, and bcrypt to validate behaviors for rate limits, invalid input, non-existent users, OAuth-only accounts, token expiry, and successful flows.

### Testing
- New Vitest unit tests were added at `packages/web/app/api/auth/forgot-password/__tests__/route.test.ts` and `packages/web/app/api/auth/reset-password/__tests__/route.test.ts` and executed as part of the test suite.
- All added route tests passed when running the test suite (`pnpm test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb2d833d483268bd124f90816d635)