### PR TITLE
[codex] Add missing iOS location privacy string

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -38,8 +38,10 @@
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Boardsesh uses Bluetooth to connect to your climbing training board and illuminate routes.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Boardsesh uses your location to make your session discoverable to nearby climbers and support nearby session features.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Boardsesh uses your location to make your session discoverable to nearby climbers.</string>
+	<string>Boardsesh uses your location to make your session discoverable to nearby climbers and support nearby session features.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary
- add `NSLocationAlwaysAndWhenInUseUsageDescription` to the iOS app Info.plist
- tighten the existing `NSLocationWhenInUseUsageDescription` wording so the location use case is explicit and consistent

## Root Cause
App Store Connect accepted build 16 but sent warning `ITMS-90683: Missing purpose string in Info.plist`, specifically requiring `NSLocationAlwaysAndWhenInUseUsageDescription` for the `App.app` bundle.

The app already had `NSLocationWhenInUseUsageDescription`, but after the Capacitor 8 upgrade the shipped iOS bundle references location-related APIs strongly enough that App Store validation now also expects the always-and-when-in-use key to be present.

## Impact
- resolves the App Store Connect privacy warning for the next iOS upload
- keeps the location permission copy aligned with the app's nearby session discovery use case

## Validation
- ran `plutil -lint mobile/ios/App/App/Info.plist`
- verified both location usage keys are present in the plist output
- ran `git diff --check`

## Follow-up
A new iOS build must be uploaded to App Store Connect for the warning to clear on a subsequent delivery.