### PR TITLE
Make email verification non-blocking

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -69,7 +69,7 @@ Boardsesh uses NextAuth.js v4 for authentication with the following components:
 ### Key Features
 
 - **Conditional Providers**: OAuth buttons only appear when provider credentials are configured
-- **Email Verification**: New email/password accounts require email verification
+- **Email Verification**: Non-blocking — verification emails are sent when SMTP is configured, but users can log in immediately
 - **Account Linking**: Accounts are automatically linked by email — signing in with OAuth using an email that already has a password account links both methods to the same user
 - **JWT Sessions**: Stateless authentication with 5-minute refresh interval
 - **Rate Limiting**: In-memory rate limiting on auth endpoints (best-effort in serverless)
@@ -296,7 +296,7 @@ ngrok http 3000
 
 ## Email Verification Setup
 
-Email verification is required for email/password accounts. OAuth accounts are pre-verified by the provider.
+Email verification is non-blocking. When SMTP credentials (`SMTP_USER` and `SMTP_PASSWORD`) are configured, verification emails are sent on registration, but users can log in and use the app immediately. OAuth accounts are pre-verified by the provider. SMTP credential presence auto-enables verification emails. To disable verification entirely (even with SMTP configured), set `EMAIL_VERIFICATION_ENABLED=false` as an emergency kill switch.
 
 ### Fastmail Setup (Recommended)
 
@@ -340,10 +340,9 @@ open http://localhost:3000/auth/login
 
 1. Click **Create Account** tab
 2. Enter email, password, and name
-3. Submit the form
-4. Check inbox for verification email
-5. Click verification link
-6. Login with credentials
+3. Submit the form — user is auto-logged in immediately
+4. Check inbox for verification email (if SMTP configured)
+5. Click verification link — redirects to app with `?verified=true`
 
 ### 2. Test OAuth Providers
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -69,7 +69,7 @@ Boardsesh uses NextAuth.js v4 for authentication with the following components:
 ### Key Features
 
 - **Conditional Providers**: OAuth buttons only appear when provider credentials are configured
-- **Email Verification**: New email/password accounts require email verification
+- **Email Verification**: Non-blocking — verification emails are sent when SMTP is configured, but users can log in immediately
 - **Account Linking**: OAuth users can add passwords; password users cannot add OAuth (security)
 - **JWT Sessions**: Stateless authentication with 5-minute refresh interval
 - **Rate Limiting**: In-memory rate limiting on auth endpoints (best-effort in serverless)
@@ -295,7 +295,7 @@ ngrok http 3000
 
 ## Email Verification Setup
 
-Email verification is required for email/password accounts. OAuth accounts are pre-verified by the provider.
+Email verification is non-blocking. When SMTP credentials (`SMTP_USER` and `SMTP_PASSWORD`) are configured, verification emails are sent on registration, but users can log in and use the app immediately. OAuth accounts are pre-verified by the provider. No `EMAIL_VERIFICATION_ENABLED` env var is needed — SMTP credential presence auto-enables verification emails.
 
 ### Fastmail Setup (Recommended)
 
@@ -339,10 +339,9 @@ open http://localhost:3000/auth/login
 
 1. Click **Create Account** tab
 2. Enter email, password, and name
-3. Submit the form
-4. Check inbox for verification email
-5. Click verification link
-6. Login with credentials
+3. Submit the form — user is auto-logged in immediately
+4. Check inbox for verification email (if SMTP configured)
+5. Click verification link — redirects to app with `?verified=true`
 
 ### 2. Test OAuth Providers
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -295,7 +295,7 @@ ngrok http 3000
 
 ## Email Verification Setup
 
-Email verification is non-blocking. When SMTP credentials (`SMTP_USER` and `SMTP_PASSWORD`) are configured, verification emails are sent on registration, but users can log in and use the app immediately. OAuth accounts are pre-verified by the provider. No `EMAIL_VERIFICATION_ENABLED` env var is needed — SMTP credential presence auto-enables verification emails.
+Email verification is non-blocking. When SMTP credentials (`SMTP_USER` and `SMTP_PASSWORD`) are configured, verification emails are sent on registration, but users can log in and use the app immediately. OAuth accounts are pre-verified by the provider. SMTP credential presence auto-enables verification emails. To disable verification entirely (even with SMTP configured), set `EMAIL_VERIFICATION_ENABLED=false` as an emergency kill switch.
 
 ### Fastmail Setup (Recommended)
 

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -46,8 +46,8 @@
       "verified": "Email verified! You can now log in.",
       "registrationFailed": "Registration failed",
       "registrationFailedRetry": "Registration failed. Please try again.",
-      "checkEmail": "Please check your email to verify your account",
       "accountCreated": "Account created! Logging you in...",
+      "accountCreatedCheckEmail": "Account created! Check your email to verify.",
       "loginAfterCreate": "Please log in with your account"
     }
   },

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -46,8 +46,8 @@
       "verified": "¡Correo verificado! Ya puedes iniciar sesión.",
       "registrationFailed": "No se pudo crear la cuenta",
       "registrationFailedRetry": "No se pudo crear la cuenta. Inténtalo otra vez.",
-      "checkEmail": "Revisa tu correo para verificar tu cuenta",
       "accountCreated": "¡Cuenta creada! Iniciando sesión...",
+      "accountCreatedCheckEmail": "¡Cuenta creada! Revisa tu correo para verificarla.",
       "loginAfterCreate": "Inicia sesión con tu cuenta"
     }
   },

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -46,8 +46,8 @@
       "verified": "E-mail vérifié ! Vous pouvez maintenant vous connecter.",
       "registrationFailed": "Impossible de créer le compte",
       "registrationFailedRetry": "Impossible de créer le compte. Réessayez.",
-      "checkEmail": "Consultez votre boîte mail pour vérifier votre compte",
       "accountCreated": "Compte créé ! Connexion en cours...",
+      "accountCreatedCheckEmail": "Compte créé ! Consultez votre boîte mail pour le vérifier.",
       "loginAfterCreate": "Connectez-vous avec votre compte"
     }
   },

--- a/packages/web/app/api/auth/register/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/register/__tests__/route.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock bcrypt — the route imports the named `hash` export
+const mockBcryptHash = vi.fn();
+vi.mock('bcryptjs', () => ({
+  hash: (...args: unknown[]) => mockBcryptHash(...args),
+  default: {
+    hash: (...args: unknown[]) => mockBcryptHash(...args),
+  },
+}));
+
+// Mock rate limiter
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+// Mock email service
+const mockSendVerificationEmail = vi.fn();
+vi.mock('@/app/lib/email/email-service', () => ({
+  sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+}));
+
+// Mock database
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { email: 'users.email' },
+  userCredentials: { userId: 'userCredentials.userId' },
+  userProfiles: { userId: 'userProfiles.userId' },
+  verificationTokens: { identifier: 'verificationTokens.identifier' },
+}));
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  email: 'test@example.com',
+  password: 'password123',
+  name: 'Test User',
+};
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+    mockBcryptHash.mockResolvedValue('$2a$12$hashedpassword');
+
+    // Default: no existing user
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockResolvedValue([]);
+
+    // Default: transaction succeeds
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+      };
+      await fn(tx);
+    });
+  });
+
+  describe('without SMTP configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', '');
+      vi.stubEnv('SMTP_PASSWORD', '');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+    });
+
+    it('registers user with emailVerified set and requiresVerification false', async () => {
+      // Re-import to pick up env changes
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(false);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not create verification token in transaction', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      let insertCallCount = 0;
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          insert: () => {
+            insertCallCount++;
+            return { values: vi.fn().mockResolvedValue(undefined) };
+          },
+        };
+        await fn(tx);
+      });
+
+      await POST(createRequest(validBody));
+      // 3 inserts: user, credentials, profile (no verification token)
+      expect(insertCallCount).toBe(3);
+    });
+  });
+
+  describe('with SMTP configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+      vi.stubEnv('NEXTAUTH_URL', 'http://localhost:3000');
+    });
+
+    it('sends verification email and returns emailSent true', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockSendVerificationEmail.mockResolvedValue(undefined);
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(true);
+      expect(mockSendVerificationEmail).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.any(String),
+        'http://localhost:3000',
+      );
+    });
+
+    it('still returns 201 when verification email fails to send', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockSendVerificationEmail.mockRejectedValue(new Error('SMTP error'));
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(false);
+    });
+
+    it('creates verification token in transaction', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      let insertCallCount = 0;
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          insert: () => {
+            insertCallCount++;
+            return { values: vi.fn().mockResolvedValue(undefined) };
+          },
+        };
+        await fn(tx);
+      });
+
+      mockSendVerificationEmail.mockResolvedValue(undefined);
+
+      await POST(createRequest(validBody));
+      // 4 inserts: user, credentials, profile, verification token
+      expect(insertCallCount).toBe(4);
+    });
+  });
+
+  describe('with EMAIL_VERIFICATION_ENABLED=false kill switch', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', 'false');
+    });
+
+    it('skips verification even when SMTP is configured', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.emailSent).toBe(false);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation and error handling', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', '');
+      vi.stubEnv('SMTP_PASSWORD', '');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+    });
+
+    it('returns 400 for invalid email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ ...validBody, email: 'not-an-email' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 for short password', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ ...validBody, password: 'short' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 409 when user already exists', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([{ id: 'existing-user', email: 'test@example.com' }]);
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(409);
+    });
+
+    it('returns 429 when rate limited', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockCheckRateLimit.mockReturnValue({ limited: true, retryAfterSeconds: 30 });
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('30');
+    });
+
+    it('returns 409 on race condition (unique constraint)', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockTransaction.mockRejectedValue({ code: '23505' });
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(409);
+    });
+  });
+});

--- a/packages/web/app/api/auth/register/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/register/__tests__/route.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock bcrypt
+const mockBcryptHash = vi.fn();
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: (...args: unknown[]) => mockBcryptHash(...args),
+  },
+}));
+
+// Mock rate limiter
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+// Mock email service
+const mockSendVerificationEmail = vi.fn();
+vi.mock('@/app/lib/email/email-service', () => ({
+  sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+}));
+
+// Mock database
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { email: 'users.email' },
+  userCredentials: { userId: 'userCredentials.userId' },
+  userProfiles: { userId: 'userProfiles.userId' },
+  verificationTokens: { identifier: 'verificationTokens.identifier' },
+}));
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  email: 'test@example.com',
+  password: 'password123',
+  name: 'Test User',
+};
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+    mockBcryptHash.mockResolvedValue('$2a$12$hashedpassword');
+
+    // Default: no existing user
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockResolvedValue([]);
+
+    // Default: transaction succeeds
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+      };
+      await fn(tx);
+    });
+  });
+
+  describe('without SMTP configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', '');
+      vi.stubEnv('SMTP_PASSWORD', '');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+    });
+
+    it('registers user with emailVerified set and requiresVerification false', async () => {
+      // Re-import to pick up env changes
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(false);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not create verification token in transaction', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      let insertCallCount = 0;
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          insert: () => {
+            insertCallCount++;
+            return { values: vi.fn().mockResolvedValue(undefined) };
+          },
+        };
+        await fn(tx);
+      });
+
+      await POST(createRequest(validBody));
+      // 3 inserts: user, credentials, profile (no verification token)
+      expect(insertCallCount).toBe(3);
+    });
+  });
+
+  describe('with SMTP configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+      vi.stubEnv('NEXTAUTH_URL', 'http://localhost:3000');
+    });
+
+    it('sends verification email and returns emailSent true', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockSendVerificationEmail.mockResolvedValue(undefined);
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(true);
+      expect(mockSendVerificationEmail).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.any(String),
+        'http://localhost:3000',
+      );
+    });
+
+    it('still returns 201 when verification email fails to send', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockSendVerificationEmail.mockRejectedValue(new Error('SMTP error'));
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.requiresVerification).toBe(false);
+      expect(data.emailSent).toBe(false);
+    });
+
+    it('creates verification token in transaction', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      let insertCallCount = 0;
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          insert: () => {
+            insertCallCount++;
+            return { values: vi.fn().mockResolvedValue(undefined) };
+          },
+        };
+        await fn(tx);
+      });
+
+      mockSendVerificationEmail.mockResolvedValue(undefined);
+
+      await POST(createRequest(validBody));
+      // 4 inserts: user, credentials, profile, verification token
+      expect(insertCallCount).toBe(4);
+    });
+  });
+
+  describe('with EMAIL_VERIFICATION_ENABLED=false kill switch', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', 'false');
+    });
+
+    it('skips verification even when SMTP is configured', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.emailSent).toBe(false);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation and error handling', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', '');
+      vi.stubEnv('SMTP_PASSWORD', '');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+    });
+
+    it('returns 400 for invalid email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ ...validBody, email: 'not-an-email' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 for short password', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ ...validBody, password: 'short' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 409 when user already exists', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([{ id: 'existing-user', email: 'test@example.com' }]);
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(409);
+    });
+
+    it('returns 429 when rate limited', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockCheckRateLimit.mockReturnValue({ limited: true, retryAfterSeconds: 30 });
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('30');
+    });
+
+    it('returns 409 on race condition (unique constraint)', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockTransaction.mockRejectedValue({ code: '23505' });
+
+      const response = await POST(createRequest(validBody));
+      expect(response.status).toBe(409);
+    });
+  });
+});

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -7,7 +7,9 @@ import { z } from 'zod';
 import { sendVerificationEmail } from '@/app/lib/email/email-service';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
 
-const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === 'true';
+// Email verification is active when SMTP is configured and not explicitly disabled
+const smtpConfigured = !!(process.env.SMTP_USER && process.env.SMTP_PASSWORD);
+const emailVerificationActive = smtpConfigured && process.env.EMAIL_VERIFICATION_ENABLED !== 'false';
 
 const registerSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -65,19 +67,21 @@ export async function POST(request: NextRequest) {
     // Create new user
     const userId = crypto.randomUUID();
     const passwordHash = await hash(password, 12);
-    const verificationToken = emailVerificationEnabled ? crypto.randomUUID() : null;
-    const tokenExpires = emailVerificationEnabled ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
+    const verificationToken = emailVerificationActive ? crypto.randomUUID() : null;
+    const tokenExpires = emailVerificationActive ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
 
     // Use transaction to ensure user, credentials, profile, and token are created atomically
     // If any insert fails, all changes are rolled back
     try {
       await db.transaction(async (tx) => {
-        // Insert user (emailVerified is null if verification enabled, otherwise auto-verified)
+        // Insert user. When verification is active, emailVerified stays null until the user
+        // clicks the link (non-blocking — they can still log in). With no SMTP / verification
+        // off, mark verified immediately so no-SMTP deployments keep auto-verified behavior.
         await tx.insert(schema.users).values({
           id: userId,
           email,
           name: name || email.split('@')[0],
-          emailVerified: emailVerificationEnabled ? null : new Date(),
+          emailVerified: emailVerificationActive ? null : new Date(),
         });
 
         // Insert credentials
@@ -91,8 +95,8 @@ export async function POST(request: NextRequest) {
           userId,
         });
 
-        // Insert verification token if email verification is enabled
-        if (emailVerificationEnabled && verificationToken && tokenExpires) {
+        // Insert verification token if email verification is active
+        if (emailVerificationActive && verificationToken && tokenExpires) {
           await tx.insert(schema.verificationTokens).values({
             identifier: email,
             token: verificationToken,
@@ -109,35 +113,24 @@ export async function POST(request: NextRequest) {
       throw insertError;
     }
 
-    // Send verification email if enabled
-    if (emailVerificationEnabled && verificationToken) {
+    // Send the verification email when SMTP is configured. The user is already usable either way,
+    // so a send failure does not block registration.
+    let emailSent = false;
+    if (emailVerificationActive && verificationToken) {
       const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
-      let emailSent = false;
       try {
         await sendVerificationEmail(email, verificationToken, baseUrl);
         emailSent = true;
       } catch (emailError) {
         console.error('Failed to send verification email:', emailError);
-        // User is created, they can use resend functionality
       }
-
-      return NextResponse.json(
-        {
-          message: emailSent
-            ? 'Account created. Please check your email to verify your account.'
-            : 'Account created. Please request a new verification email.',
-          requiresVerification: true,
-          emailSent,
-        },
-        { status: 201 },
-      );
     }
 
-    // Email verification disabled - user can log in immediately
     return NextResponse.json(
       {
-        message: 'Account created. You can now log in.',
+        message: 'Account created successfully.',
         requiresVerification: false,
+        emailSent,
       },
       { status: 201 },
     );

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -7,7 +7,9 @@ import { z } from "zod";
 import { sendVerificationEmail } from "@/app/lib/email/email-service";
 import { checkRateLimit, getClientIp } from "@/app/lib/auth/rate-limiter";
 
+// Email verification is active when SMTP is configured and not explicitly disabled
 const smtpConfigured = !!(process.env.SMTP_USER && process.env.SMTP_PASSWORD);
+const emailVerificationActive = smtpConfigured && process.env.EMAIL_VERIFICATION_ENABLED !== "false";
 
 const registerSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -70,8 +72,8 @@ export async function POST(request: NextRequest) {
     // Create new user
     const userId = crypto.randomUUID();
     const passwordHash = await bcrypt.hash(password, 12);
-    const verificationToken = smtpConfigured ? crypto.randomUUID() : null;
-    const tokenExpires = smtpConfigured ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
+    const verificationToken = emailVerificationActive ? crypto.randomUUID() : null;
+    const tokenExpires = emailVerificationActive ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
 
     // Use transaction to ensure user, credentials, profile, and token are created atomically
     // If any insert fails, all changes are rolled back
@@ -82,7 +84,7 @@ export async function POST(request: NextRequest) {
           id: userId,
           email,
           name: name || email.split("@")[0],
-          emailVerified: null,
+          emailVerified: emailVerificationActive ? null : new Date(),
         });
 
         // Insert credentials
@@ -97,7 +99,7 @@ export async function POST(request: NextRequest) {
         });
 
         // Insert verification token if email verification is enabled
-        if (smtpConfigured && verificationToken && tokenExpires) {
+        if (emailVerificationActive && verificationToken && tokenExpires) {
           await tx.insert(schema.verificationTokens).values({
             identifier: email,
             token: verificationToken,
@@ -119,7 +121,7 @@ export async function POST(request: NextRequest) {
 
     // Send verification email in the background if SMTP is configured
     let emailSent = false;
-    if (smtpConfigured && verificationToken) {
+    if (emailVerificationActive && verificationToken) {
       const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
       try {
         await sendVerificationEmail(email, verificationToken, baseUrl);

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { sendVerificationEmail } from "@/app/lib/email/email-service";
 import { checkRateLimit, getClientIp } from "@/app/lib/auth/rate-limiter";
 
-const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === "true";
+const smtpConfigured = !!(process.env.SMTP_USER && process.env.SMTP_PASSWORD);
 
 const registerSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -70,8 +70,8 @@ export async function POST(request: NextRequest) {
     // Create new user
     const userId = crypto.randomUUID();
     const passwordHash = await bcrypt.hash(password, 12);
-    const verificationToken = emailVerificationEnabled ? crypto.randomUUID() : null;
-    const tokenExpires = emailVerificationEnabled ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
+    const verificationToken = smtpConfigured ? crypto.randomUUID() : null;
+    const tokenExpires = smtpConfigured ? new Date(Date.now() + 24 * 60 * 60 * 1000) : null; // 24 hours
 
     // Use transaction to ensure user, credentials, profile, and token are created atomically
     // If any insert fails, all changes are rolled back
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
           id: userId,
           email,
           name: name || email.split("@")[0],
-          emailVerified: emailVerificationEnabled ? null : new Date(),
+          emailVerified: null,
         });
 
         // Insert credentials
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
         });
 
         // Insert verification token if email verification is enabled
-        if (emailVerificationEnabled && verificationToken && tokenExpires) {
+        if (smtpConfigured && verificationToken && tokenExpires) {
           await tx.insert(schema.verificationTokens).values({
             identifier: email,
             token: verificationToken,
@@ -117,35 +117,23 @@ export async function POST(request: NextRequest) {
       throw insertError;
     }
 
-    // Send verification email if enabled
-    if (emailVerificationEnabled && verificationToken) {
+    // Send verification email in the background if SMTP is configured
+    let emailSent = false;
+    if (smtpConfigured && verificationToken) {
       const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
-      let emailSent = false;
       try {
         await sendVerificationEmail(email, verificationToken, baseUrl);
         emailSent = true;
       } catch (emailError) {
         console.error("Failed to send verification email:", emailError);
-        // User is created, they can use resend functionality
       }
-
-      return NextResponse.json(
-        {
-          message: emailSent
-            ? "Account created. Please check your email to verify your account."
-            : "Account created. Please request a new verification email.",
-          requiresVerification: true,
-          emailSent,
-        },
-        { status: 201 }
-      );
     }
 
-    // Email verification disabled - user can log in immediately
     return NextResponse.json(
       {
-        message: "Account created. You can now log in.",
+        message: "Account created successfully.",
         requiresVerification: false,
+        emailSent,
       },
       { status: 201 }
     );

--- a/packages/web/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock rate limiter
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+// Mock email service
+const mockSendVerificationEmail = vi.fn();
+vi.mock('@/app/lib/email/email-service', () => ({
+  sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+}));
+
+// Mock database
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
+const mockDelete = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { email: 'users.email', emailVerified: 'users.emailVerified' },
+  verificationTokens: { identifier: 'verificationTokens.identifier' },
+}));
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/resend-verification', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/resend-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+
+    // Default DB chain
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+
+    // Default transaction
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        delete: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+      };
+      await fn(tx);
+    });
+  });
+
+  describe('without SMTP configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', '');
+      vi.stubEnv('SMTP_PASSWORD', '');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+    });
+
+    it('returns generic 200 without querying DB or sending email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.message).toBeTruthy();
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with EMAIL_VERIFICATION_ENABLED=false', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', 'false');
+    });
+
+    it('returns generic 200 even when SMTP is configured', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(200);
+
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with SMTP configured and verification active', () => {
+    beforeEach(() => {
+      vi.stubEnv('SMTP_USER', 'user@fastmail.com');
+      vi.stubEnv('SMTP_PASSWORD', 'app-password');
+      vi.stubEnv('EMAIL_VERIFICATION_ENABLED', '');
+      vi.stubEnv('NEXTAUTH_URL', 'http://localhost:3000');
+    });
+
+    it('sends verification email for unverified user', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([{ email: 'test@example.com', emailVerified: null }]);
+      mockSendVerificationEmail.mockResolvedValue(undefined);
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(200);
+      expect(mockSendVerificationEmail).toHaveBeenCalled();
+      expect(mockTransaction).toHaveBeenCalled();
+    });
+
+    it('returns generic message for already-verified user without sending email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([{ email: 'test@example.com', emailVerified: new Date() }]);
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(200);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns generic message for non-existent user without sending email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([]);
+
+      const response = await POST(createRequest({ email: 'nonexistent@example.com' }));
+      expect(response.status).toBe(200);
+      expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid email', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      const response = await POST(createRequest({ email: 'not-an-email' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 429 when rate limited', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockCheckRateLimit.mockReturnValue({ limited: true, retryAfterSeconds: 30 });
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(429);
+    });
+
+    it('returns 500 when email send fails', async () => {
+      vi.resetModules();
+      const { POST } = await import('../route');
+
+      mockLimit.mockResolvedValue([{ email: 'test@example.com', emailVerified: null }]);
+      mockSendVerificationEmail.mockRejectedValue(new Error('SMTP error'));
+
+      const response = await POST(createRequest({ email: 'test@example.com' }));
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/packages/web/app/api/auth/resend-verification/route.ts
+++ b/packages/web/app/api/auth/resend-verification/route.ts
@@ -24,11 +24,22 @@ async function consistentDelay(startTime: number): Promise<void> {
   }
 }
 
+const smtpConfigured = !!(process.env.SMTP_USER && process.env.SMTP_PASSWORD);
+const emailVerificationActive = smtpConfigured && process.env.EMAIL_VERIFICATION_ENABLED !== "false";
+
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   const genericMessage = 'If an account exists and needs verification, a verification email will be sent';
 
   try {
+    // If email verification is disabled or SMTP is not configured, return generic message
+    if (!emailVerificationActive) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { message: genericMessage },
+        { status: 200 }
+      );
+    }
     // Rate limiting - 5 requests per minute per IP
     const clientIp = getClientIp(request);
     const rateLimitResult = checkRateLimit(`resend-verification:${clientIp}`, 5, 60_000);

--- a/packages/web/app/api/auth/resend-verification/route.ts
+++ b/packages/web/app/api/auth/resend-verification/route.ts
@@ -24,11 +24,22 @@ async function consistentDelay(startTime: number): Promise<void> {
   }
 }
 
+const smtpConfigured = !!(process.env.SMTP_USER && process.env.SMTP_PASSWORD);
+const emailVerificationActive = smtpConfigured && process.env.EMAIL_VERIFICATION_ENABLED !== "false";
+
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   const genericMessage = "If an account exists and needs verification, a verification email will be sent";
 
   try {
+    // If email verification is disabled or SMTP is not configured, return generic message
+    if (!emailVerificationActive) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { message: genericMessage },
+        { status: 200 }
+      );
+    }
     // Rate limiting - 5 requests per minute per IP
     const clientIp = getClientIp(request);
     const rateLimitResult = checkRateLimit(`resend-verification:${clientIp}`, 5, 60_000);

--- a/packages/web/app/api/auth/verify-email/route.ts
+++ b/packages/web/app/api/auth/verify-email/route.ts
@@ -68,6 +68,6 @@ export async function GET(request: NextRequest) {
       .where(and(eq(schema.verificationTokens.identifier, email), eq(schema.verificationTokens.token, token)));
   });
 
-  // Redirect to login with success message
-  return NextResponse.redirect(new URL('/auth/login?verified=true', request.url));
+  // Redirect to the app — the user is likely already logged in
+  return NextResponse.redirect(new URL('/?verified=true', request.url));
 }

--- a/packages/web/app/api/auth/verify-email/route.ts
+++ b/packages/web/app/api/auth/verify-email/route.ts
@@ -105,8 +105,8 @@ export async function GET(request: NextRequest) {
       );
   });
 
-  // Redirect to login with success message
+  // Redirect to app — user is likely already logged in
   return NextResponse.redirect(
-    new URL("/auth/login?verified=true", request.url)
+    new URL("/?verified=true", request.url)
   );
 }

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -159,34 +159,23 @@ export default function AuthPageContent() {
 
       track('Signup Completed', {
         auth_method: 'credentials',
-        requires_verification: Boolean(data.requiresVerification),
+        verification_email_sent: Boolean(data.emailSent),
       });
       // First-touch attribution — written once and never overwritten.
       // PostHog merges these onto the authenticated user once alias() runs
-      // in party-profile-context after the auto-signin below.
-      //
-      // Caveat: if requires_verification is true, we hit the early return below
-      // and the auto-signin never runs, so alias() may not fire in this session.
-      // signup_at / signup_auth_method then live on the anonymous distinct_id
-      // until the user comes back to verify and log in — at which point PostHog
-      // merges them onto the authenticated user. Until that merge they're
-      // visible in Live Events under the anon profile, which can briefly skew
-      // person-property dashboards.
+      // in party-profile-context after the auto-signin below. Verification is
+      // non-blocking, so the auto-signin always runs and alias() fires this session.
       setPersonProperties(undefined, {
         signup_at: new Date().toISOString(),
         signup_auth_method: 'credentials',
       });
 
-      // Check if email verification is required
-      if (data.requiresVerification) {
-        showMessage(t('login.toasts.checkEmail'), 'info');
-        setActiveTab('login');
-        setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
-        return;
-      }
-
-      // Email verification disabled - auto-login after successful registration
-      showMessage(t('login.toasts.accountCreated'), 'success');
+      // Verification is non-blocking: always auto-login. When a verification email went
+      // out, nudge the user to check their inbox; otherwise just confirm and sign in.
+      showMessage(
+        data.emailSent ? t('login.toasts.accountCreatedCheckEmail') : t('login.toasts.accountCreated'),
+        'success',
+      );
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -167,16 +167,12 @@ export default function AuthPageContent() {
         return;
       }
 
-      // Check if email verification is required
-      if (data.requiresVerification) {
-        showMessage('Please check your email to verify your account', 'info');
-        setActiveTab('login');
-        setLoginValues(prev => ({ ...prev, email: registerValues.email }));
-        return;
-      }
-
-      // Email verification disabled - auto-login after successful registration
-      showMessage('Account created! Logging you in...', 'success');
+      showMessage(
+        data.emailSent
+          ? 'Account created! Check your email to verify.'
+          : 'Account created! Logging you in...',
+        'success'
+      );
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -23,7 +23,9 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-const KNOWN_VERIFY_ERROR_CODES = new Set(['EmailNotVerified', 'InvalidToken', 'TokenExpired', 'TooManyAttempts']);
+// EmailNotVerified is intentionally absent: verification is non-blocking, so the
+// sign-in callback never redirects here with that code.
+const KNOWN_VERIFY_ERROR_CODES = new Set(['InvalidToken', 'TokenExpired', 'TooManyAttempts']);
 
 type EmailErrors = { email?: string };
 

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -43,8 +43,6 @@ export default function VerifyRequestContent() {
 
   const getErrorMessage = () => {
     switch (error) {
-      case 'EmailNotVerified':
-        return 'Please verify your email before signing in.';
       case 'InvalidToken':
         return 'The verification link is invalid. Please request a new one.';
       case 'TokenExpired':

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -120,18 +120,12 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
         return;
       }
 
-      // Check if email verification is required
-      if (data.requiresVerification) {
-        showMessage(t('login.toasts.checkEmail'), 'info');
-        setActiveTab('login');
-        setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
-        setRegisterValues(initialRegisterValues);
-        setRegisterErrors({});
-        return;
-      }
-
-      // Email verification disabled - auto-login after successful registration
-      showMessage(t('login.toasts.accountCreated'), 'success');
+      // Verification is non-blocking: always auto-login. When a verification email went
+      // out, nudge the user to check their inbox; otherwise just confirm and sign in.
+      showMessage(
+        data.emailSent ? t('login.toasts.accountCreatedCheckEmail') : t('login.toasts.accountCreated'),
+        'success',
+      );
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -148,18 +148,12 @@ export default function AuthModal({
         return;
       }
 
-      // Check if email verification is required
-      if (data.requiresVerification) {
-        showMessage('Please check your email to verify your account', 'info');
-        setActiveTab('login');
-        setLoginValues(prev => ({ ...prev, email: registerValues.email }));
-        setRegisterValues(initialRegisterValues);
-        setRegisterErrors({});
-        return;
-      }
-
-      // Email verification disabled - auto-login after successful registration
-      showMessage('Account created! Logging you in...', 'success');
+      showMessage(
+        data.emailSent
+          ? 'Account created! Check your email to verify.'
+          : 'Account created! Logging you in...',
+        'success'
+      );
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -222,21 +222,13 @@ export const authOptions: NextAuthOptions = {
         return true;
       }
 
-      // For credentials, check if email is verified
+      // For credentials, just verify we have an email
       if (!user.email) {
         return false;
       }
 
-      const db = getDb();
-      const existingUser = await db.select().from(schema.users).where(eq(schema.users.email, user.email)).limit(1);
-
-      // Check if email verification is enabled (disabled by default until Fastmail auth is set up)
-      const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === 'true';
-      if (emailVerificationEnabled && existingUser.length > 0 && !existingUser[0].emailVerified) {
-        // Redirect to verification page with error
-        return '/auth/verify-request?error=EmailNotVerified';
-      }
-
+      // Email verification is non-blocking — credentials users sign in regardless of
+      // verified status. Verification emails (when SMTP is configured) are informational.
       return true;
     },
     async session({ session, token }) {

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -125,23 +125,9 @@ export const authOptions: NextAuthOptions = {
         return true;
       }
 
-      // For credentials, check if email is verified
+      // For credentials, just verify we have an email
       if (!user.email) {
         return false;
-      }
-
-      const db = getDb();
-      const existingUser = await db
-        .select()
-        .from(schema.users)
-        .where(eq(schema.users.email, user.email))
-        .limit(1);
-
-      // Check if email verification is enabled (disabled by default until Fastmail auth is set up)
-      const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === "true";
-      if (emailVerificationEnabled && existingUser.length > 0 && !existingUser[0].emailVerified) {
-        // Redirect to verification page with error
-        return "/auth/verify-request?error=EmailNotVerified";
       }
 
       return true;


### PR DESCRIPTION
## Summary
- Removes login blocking for unverified email users — users can register and use the app immediately
- Replaces `EMAIL_VERIFICATION_ENABLED` env var with automatic SMTP detection (`SMTP_USER` + `SMTP_PASSWORD`)
- Verification emails still sent in background when SMTP is configured
- Verify-email redirect goes to `/` instead of `/auth/login` since users are already logged in

## Test plan
- [ ] Register a new account — should auto-login immediately
- [ ] Check inbox for verification email (when SMTP configured)
- [ ] Click verification link — should redirect to app root
- [ ] Login with existing unverified user — should succeed without redirect
- [ ] Register without SMTP configured — should work with no email sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)