### PR TITLE
Fix iOS universal links not opening on cold start

### DIFF
--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -7,6 +7,26 @@ class BoardseshViewController: CAPBridgeViewController {
 
         // Disable rubber-band bounce so the page cannot overscroll
         webView?.scrollView.bounces = false
+
+        // If a universal link triggered a cold start, navigate to it now
+        // that the bridge and WebView are ready.
+        if let sceneDelegate = view.window?.windowScene?.delegate as? SceneDelegate,
+           let pendingURL = sceneDelegate.pendingUniversalLinkURL {
+            sceneDelegate.pendingUniversalLinkURL = nil
+            webView?.load(URLRequest(url: pendingURL))
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Fallback: the window may not be set during viewDidLoad on first launch.
+        // Check again once the view is fully in the hierarchy.
+        if let sceneDelegate = view.window?.windowScene?.delegate as? SceneDelegate,
+           let pendingURL = sceneDelegate.pendingUniversalLinkURL {
+            sceneDelegate.pendingUniversalLinkURL = nil
+            webView?.load(URLRequest(url: pendingURL))
+        }
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/mobile/ios/App/App/SceneDelegate.swift
+++ b/mobile/ios/App/App/SceneDelegate.swift
@@ -4,9 +4,20 @@ import Capacitor
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    /// Universal link URL received during cold start, before the Capacitor bridge is ready.
+    var pendingUniversalLinkURL: URL?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        // Save any universal link that triggered this cold start.
+        // The bridge isn't ready yet, so we store it and let
+        // BoardseshViewController pick it up after viewDidLoad.
+        if let userActivity = connectionOptions.userActivities.first(where: {
+            $0.activityType == NSUserActivityTypeBrowsingWeb
+        }), let url = userActivity.webpageURL {
+            pendingUniversalLinkURL = url
+        }
 
         let window = UIWindow(windowScene: windowScene)
         let storyboard = UIStoryboard(name: "Main", bundle: nil)


### PR DESCRIPTION
When a universal link triggers a cold start, the Capacitor bridge isn't ready yet so the link is silently dropped. Store the pending URL in SceneDelegate and let BoardseshViewController pick it up once the WebView is loaded (viewDidLoad + viewDidAppear fallback).