### PR TITLE
Fix WASM canvas renderer ignoring aspect-ratio due to height: 100%

### DIFF
--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -90,7 +90,7 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
       ref={canvasRef}
       style={{
         width: '100%',
-        height: '100%',
+        height: contain ? '100%' : 'auto',
         objectFit: contain ? 'contain' : undefined,
         ...style,
       }}


### PR DESCRIPTION
The canvas element had height: 100% as a default style, which prevented
CSS aspect-ratio from computing the correct height (aspect-ratio only
works when the dimension is auto). This caused misaligned renders on the
climb info page and queue suggestion thumbnails.

https://claude.ai/code/session_01SPMtmKHWaTMYuCZdUcHB6n