### PR TITLE
Fix WASM-rendered images distorted on narrow boards

### DIFF
--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -85,16 +85,32 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
     );
   }
 
+  if (contain) {
+    return (
+      <canvas
+        ref={canvasRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain',
+          ...style,
+        }}
+      />
+    );
+  }
+
   return (
-    <canvas
-      ref={canvasRef}
-      style={{
-        width: '100%',
-        height: contain ? '100%' : 'auto',
-        objectFit: contain ? 'contain' : undefined,
-        ...style,
-      }}
-    />
+    <div style={{ position: 'relative', ...style }}>
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+        }}
+      />
+    </div>
   );
 });
 


### PR DESCRIPTION
Wrap the canvas element in a container div with position: relative
(matching the BoardImageLayers pattern) so that aspectRatio + maxHeight
CSS properties work together correctly. Previously, width: 100% on the
canvas prevented it from shrinking when maxHeight constrained the height
on narrow (tall) boards.

https://claude.ai/code/session_01NCxaBvd9jdt2GbvpYN9tNL