### PR TITLE
test: add BLE payload tests for Kilter Original 12x12 and 8x12 boards

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/app/lib/moonboard-config', () => ({
 }));
 
 import { getBluetoothPacket } from '../bluetooth';
+import { getLedPlacements } from '../../../lib/__generated__/led-placements-data';
 
 // ---- Packet decoder ----
 
@@ -110,5 +111,80 @@ describe('getBluetoothPacket — Aurora payload verification', () => {
     expect(CORRECT_8x12_POSITIONS[4665]).toBe(1);  // leftmost y=-4
     expect(CORRECT_8x12_POSITIONS[4655]).toBe(19); // rightmost y=-4
     expect(CORRECT_8x12_POSITIONS[4669]).toBe(20); // rightmost y=-8
+  });
+});
+
+// ---- Kilter Original (Layout 1) validated payloads ----
+// These payloads were validated by a 3rd party tool for the four corner holds
+// (top-left, top-right, bottom-left, bottom-right) on each board size.
+
+const VALIDATED_12x12_HEX = '010dbb02544400e3dc01e30000f42100f403';
+const VALIDATED_8x12_ORIGINAL_HEX = '010d7802543800e33701e30000f41500f403';
+
+// Frames: top-left finish, top-right finish, bottom-left foot, bottom-right foot
+const CORNERS_12x12_FRAMES = 'p1379r44p1395r44p1447r45p1464r45';
+const CORNERS_8x12_ORIGINAL_FRAMES = 'p1382r44p1392r44p1450r45p1461r45';
+
+const CORRECT_12x12_POSITIONS: Record<number, number> = {
+  1379: 68,   // top-left
+  1395: 476,  // top-right
+  1447: 0,    // bottom-left (kickboard)
+  1464: 33,   // bottom-right (kickboard)
+};
+
+const CORRECT_8x12_ORIGINAL_POSITIONS: Record<number, number> = {
+  1382: 56,   // top-left
+  1392: 311,  // top-right
+  1450: 0,    // bottom-left (kickboard)
+  1461: 21,   // bottom-right (kickboard)
+};
+
+function toHex(packet: Uint8Array): string {
+  return Array.from(packet)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('getBluetoothPacket — Kilter Original (Layout 1) payload verification', () => {
+  it('generates correct full packet for Kilter 12x12 Original (size 10)', () => {
+    const packet = getBluetoothPacket(CORNERS_12x12_FRAMES, CORRECT_12x12_POSITIONS, 'kilter');
+    expect(toHex(packet)).toBe(VALIDATED_12x12_HEX);
+  });
+
+  it('generates correct full packet for Kilter 8x12 Original (size 8)', () => {
+    const packet = getBluetoothPacket(CORNERS_8x12_ORIGINAL_FRAMES, CORRECT_8x12_ORIGINAL_POSITIONS, 'kilter');
+    expect(toHex(packet)).toBe(VALIDATED_8x12_ORIGINAL_HEX);
+  });
+
+  it('12x12 LED data from getLedPlacements matches validated positions', () => {
+    const ledMap = getLedPlacements('kilter', 1, 10);
+    expect(ledMap[1379]).toBe(68);   // top-left
+    expect(ledMap[1395]).toBe(476);  // top-right
+    expect(ledMap[1447]).toBe(0);    // bottom-left
+    expect(ledMap[1464]).toBe(33);   // bottom-right
+  });
+
+  it('8x12 Original LED data from getLedPlacements matches validated positions', () => {
+    const ledMap = getLedPlacements('kilter', 1, 8);
+    expect(ledMap[1382]).toBe(56);   // top-left
+    expect(ledMap[1392]).toBe(311);  // top-right
+    expect(ledMap[1450]).toBe(0);    // bottom-left
+    expect(ledMap[1461]).toBe(21);   // bottom-right
+  });
+
+  it('12x12 full packet matches when using real LED data', () => {
+    const ledMap = getLedPlacements('kilter', 1, 10);
+    const packet = getBluetoothPacket(CORNERS_12x12_FRAMES, ledMap, 'kilter');
+    const ourPositions = decodeLedPositions(packet).map((l) => l.position);
+    const validatedPositions = decodeLedPositions(VALIDATED_12x12_HEX).map((l) => l.position);
+    expect(ourPositions).toEqual(validatedPositions);
+  });
+
+  it('8x12 Original full packet matches when using real LED data', () => {
+    const ledMap = getLedPlacements('kilter', 1, 8);
+    const packet = getBluetoothPacket(CORNERS_8x12_ORIGINAL_FRAMES, ledMap, 'kilter');
+    const ourPositions = decodeLedPositions(packet).map((l) => l.position);
+    const validatedPositions = decodeLedPositions(VALIDATED_8x12_ORIGINAL_HEX).map((l) => l.position);
+    expect(ourPositions).toEqual(validatedPositions);
   });
 });


### PR DESCRIPTION
Verified that the 8x12 Full Ride fix (dde0905) did not break 12x12 rendering. Added 6 tests using validated 3rd-party reference payloads for Layout 1 Original boards (12x12 size 10, 8x12 size 8) covering corner holds with full packet byte verification and real LED data lookups via getLedPlacements.

https://claude.ai/code/session_013k6aTy6mFTcfrD2gfiiCyN