### PR TITLE
Fix canvas rendering on iOS 18.x Safari

### DIFF
--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -23,6 +23,8 @@ export interface BoardCanvasRendererProps {
  * returning an ImageBitmap that is drawn directly onto the canvas.
  * Falls back to BoardImageLayers if the worker render fails.
  */
+const THUMBNAIL_WIDTH = 300;
+
 const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   boardDetails,
   frames,
@@ -34,6 +36,15 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hasFired = useRef(false);
   const [failed, setFailed] = useState(false);
+
+  // Compute initial canvas dimensions to match worker output, so the element
+  // has a correct intrinsic aspect ratio before the bitmap arrives. Older
+  // iOS Safari (18.x) mis-renders canvases that start at the default 300×150
+  // inside aspect-ratio containers with absolute positioning.
+  const initialWidth = thumbnail ? THUMBNAIL_WIDTH : boardDetails.boardWidth;
+  const initialHeight = thumbnail
+    ? Math.round((THUMBNAIL_WIDTH * boardDetails.boardHeight) / boardDetails.boardWidth)
+    : boardDetails.boardHeight;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -89,6 +100,8 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
     return (
       <canvas
         ref={canvasRef}
+        width={initialWidth}
+        height={initialHeight}
         style={{
           width: '100%',
           height: '100%',
@@ -100,17 +113,17 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   }
 
   return (
-    <div style={{ position: 'relative', ...style }}>
-      <canvas
-        ref={canvasRef}
-        style={{
-          position: 'absolute',
-          inset: 0,
-          width: '100%',
-          height: '100%',
-        }}
-      />
-    </div>
+    <canvas
+      ref={canvasRef}
+      width={initialWidth}
+      height={initialHeight}
+      style={{
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        ...style,
+      }}
+    />
   );
 });
 


### PR DESCRIPTION
Set initial canvas width/height attributes from boardDetails so the
element has correct intrinsic dimensions before the worker bitmap
arrives. Remove absolute positioning wrapper for the non-contain path
and use display:block + height:auto instead, avoiding the
aspect-ratio + position:absolute layout pattern that older WebKit
mis-renders.

https://claude.ai/code/session_01NszmcQ1EpM24AY6vBPBYmW