### PR TITLE
Restore wrapper div for canvas thumbnails, keep initial dimensions fix

### DIFF
--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -113,17 +113,20 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   }
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={initialWidth}
-      height={initialHeight}
-      style={{
-        display: 'block',
-        width: '100%',
-        height: 'auto',
-        ...style,
-      }}
-    />
+    <div style={{ position: 'relative', ...style }}>
+      <canvas
+        ref={canvasRef}
+        width={initialWidth}
+        height={initialHeight}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}
+      />
+    </div>
   );
 });
 


### PR DESCRIPTION
The previous commit broke list-view thumbnails: without the wrapper div, maxHeight + aspect-ratio constraints couldn't resolve correctly, making narrow boards render too wide.

Restore the wrapper div with absolute positioning (required for maxHeight-constrained thumbnails) but keep the initial width/height attributes on the canvas element and replace inset:0 with explicit top/left for broader WebKit compatibility.

https://claude.ai/code/session_01NszmcQ1EpM24AY6vBPBYmW