### PR TITLE
Use www.boardsesh.com for Capacitor app server URL

### DIFF
--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -20,7 +20,7 @@ import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
 
 public class MainActivity extends BridgeActivity {
-    private static final String DEFAULT_RETRY_URL = "https://boardsesh.com";
+    private static final String DEFAULT_RETRY_URL = "https://www.boardsesh.com";
     private final OfflineFallbackStateMachine fallbackState = new OfflineFallbackStateMachine();
 
     @Override

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -4,7 +4,7 @@ const config: CapacitorConfig = {
   appId: 'com.boardsesh.app',
   appName: 'Boardsesh',
   server: {
-    url: process.env.CAPACITOR_DEV_URL ?? 'https://boardsesh.com',
+    url: process.env.CAPACITOR_DEV_URL ?? 'https://www.boardsesh.com',
     allowNavigation: ['boardsesh.com', '*.boardsesh.com'],
   },
   ios: {

--- a/mobile/ios/App/App/OfflineFallbackSupport.swift
+++ b/mobile/ios/App/App/OfflineFallbackSupport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum OfflineFallbackSupport {
-    static let defaultURL = URL(string: "https://boardsesh.com")!
+    static let defaultURL = URL(string: "https://www.boardsesh.com")!
 
     static func sanitizedRetryURL(_ candidate: URL?) -> URL {
         guard let candidate, let scheme = candidate.scheme?.lowercased() else {


### PR DESCRIPTION
The apex domain (boardsesh.com) requires an A record which was removed.
The www subdomain resolves via CNAME to Vercel, so the app needs to
point there instead.

https://claude.ai/code/session_01XAjARAC6tXCKU4r9B9khVE