### PR TITLE
Add App Links and Universal Links verification files

### DIFF
--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -80,6 +80,6 @@ export const config = {
   matcher: [
     '/api/v1/:path*',
     // Match all page routes but skip static files, Next.js internals, and Vercel Flags Explorer
-    '/((?!_next/static|_next/image|favicon.ico|monitoring|\\.well-known/vercel/flags|.*\\..*).*)',
+    '/((?!_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
   ],
 };

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -38,6 +38,12 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/.well-known/apple-app-site-association',
+        headers: [
+          { key: 'Content-Type', value: 'application/json' },
+        ],
+      },
+      {
         source: '/:path*',
         headers: [
           { key: 'X-Frame-Options', value: 'SAMEORIGIN' },

--- a/packages/web/public/.well-known/apple-app-site-association
+++ b/packages/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "9L3HKPZBH3.com.boardsesh.app",
+        "paths": ["/join/*"]
+      }
+    ]
+  }
+}

--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.boardsesh.app",
+      "sha256_cert_fingerprints": [
+        "TODO:REPLACE_WITH_YOUR_SHA256_FINGERPRINT"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
iOS Universal Links need apple-app-site-association and Android App Links need assetlinks.json served from /.well-known/. Without these, deep links into the app never worked.

Also excludes all .well-known paths from middleware and sets the correct Content-Type header for the AASA file.

Note: assetlinks.json needs the SHA-256 signing cert fingerprint filled in before Android App Links will verify.

https://claude.ai/code/session_01XAjARAC6tXCKU4r9B9khVE