### PR TITLE
Fix iOS build: add OfflineFallbackSupport.swift to Xcode project and fix WKNavigationDelegate methods

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
 		B1A2C3D4E5F60718 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A2C3D4E5F60717 /* SceneDelegate.swift */; };
 		C1A2B3D4E5F60720 /* BoardseshViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3D4E5F60719 /* BoardseshViewController.swift */; };
+		D1A2B3C4E5F60722 /* OfflineFallbackSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60721 /* OfflineFallbackSupport.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -26,6 +27,7 @@
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B1A2C3D4E5F60717 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C1A2B3D4E5F60719 /* BoardseshViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardseshViewController.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60721 /* OfflineFallbackSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineFallbackSupport.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				B1A2C3D4E5F60717 /* SceneDelegate.swift */,
 				C1A2B3D4E5F60719 /* BoardseshViewController.swift */,
+				D1A2B3C4E5F60721 /* OfflineFallbackSupport.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -218,6 +221,7 @@
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
 				B1A2C3D4E5F60718 /* SceneDelegate.swift in Sources */,
 				C1A2B3D4E5F60720 /* BoardseshViewController.swift in Sources */,
+				D1A2B3C4E5F60722 /* OfflineFallbackSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -25,7 +25,7 @@ final class NetworkStatus {
     }
 }
 
-class BoardseshViewController: CAPBridgeViewController {
+class BoardseshViewController: CAPBridgeViewController, WKNavigationDelegate {
     private let fallbackState = IOSOfflineFallbackStateMachine()
 
     override func viewDidLoad() {
@@ -33,6 +33,9 @@ class BoardseshViewController: CAPBridgeViewController {
 
         // Disable rubber-band bounce so the page cannot overscroll
         webView?.scrollView.bounces = false
+
+        // Become the navigation delegate so we can intercept load failures.
+        webView?.navigationDelegate = self
 
         // Start monitor eagerly so offline decisions have recent connectivity state.
         _ = NetworkStatus.shared
@@ -59,32 +62,26 @@ class BoardseshViewController: CAPBridgeViewController {
         webView?.load(URLRequest(url: pendingURL))
     }
 
-    override func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         fallbackState.onPageStarted()
-        super.webView(webView, didStartProvisionalNavigation: navigation)
     }
 
-    override func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         fallbackState.onPageFinished()
-        super.webView(webView, didFinish: navigation)
     }
 
-    override func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         fallbackState.onMainFrameError(webView.url)
         if shouldTriggerOfflineFallback(error: error) {
             tryCacheThenFallback(webView)
         }
-
-        super.webView(webView, didFail: navigation, withError: error)
     }
 
-    override func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         fallbackState.onMainFrameError(webView.url)
         if shouldTriggerOfflineFallback(error: error) {
             tryCacheThenFallback(webView)
         }
-
-        super.webView(webView, didFailProvisionalNavigation: navigation, withError: error)
     }
 
     private func shouldTriggerOfflineFallback(error: Error) -> Bool {


### PR DESCRIPTION
OfflineFallbackSupport.swift existed on disk but was missing from the Xcode
project file, causing 'cannot find IOSOfflineFallbackStateMachine in scope'.
The WKNavigationDelegate methods used override/super on methods not declared
in CAPBridgeViewController — switched to direct WKNavigationDelegate conformance.

https://claude.ai/code/session_016g5Xwb3YRWTkmwHRJTvbH3