### PR TITLE
Fix WKNavigationDelegate selector mismatch in decidePolicyFor methods

### DIFF
--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -55,7 +55,7 @@ final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        if let orig = original, orig.responds(to: #selector(WKNavigationDelegate.webView(_:decidePolicyFor:decisionHandler:) as ((WKNavigationDelegate) -> (WKWebView, WKNavigationAction, @escaping (WKNavigationActionPolicy) -> Void) -> Void)?)) {
+        if let orig = original {
             orig.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
         } else {
             decisionHandler(.allow)
@@ -63,7 +63,7 @@ final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
-        if let orig = original, orig.responds(to: #selector(WKNavigationDelegate.webView(_:decidePolicyFor:decisionHandler:) as ((WKNavigationDelegate) -> (WKWebView, WKNavigationResponse, @escaping (WKNavigationResponsePolicy) -> Void) -> Void)?)) {
+        if let orig = original {
             orig.webView?(webView, decidePolicyFor: navigationResponse, decisionHandler: decisionHandler)
         } else {
             decisionHandler(.allow)


### PR DESCRIPTION
The #selector cast for the overloaded webView(_:decidePolicyFor:decisionHandler:)
methods failed to compile because the closure signature changed in newer
Swift/WebKit to include @MainActor @Sendable. Removed the responds(to:) check
entirely — optional chaining on the delegate call already handles the case
where the original delegate doesn't implement the method.

https://claude.ai/code/session_01NYkAXRtk9pruoCxerivKjF