### PR TITLE
Upgrade Node.js from 20 to 22 LTS across CI workflows and dev-db Dockerfile

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/backend-typecheck.yml
+++ b/.github/workflows/backend-typecheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Install unzip (required by setup-bun)
       run: apt-get update && apt-get install -y unzip

--- a/.github/workflows/moonboard-ocr-tests.yml
+++ b/.github/workflows/moonboard-ocr-tests.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -59,7 +59,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -36,8 +36,8 @@ RUN apt-get update && \
       unzip \
       jq \
       gnupg && \
-    # Install Node.js 20 for TypeScript import/seed scripts
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    # Install Node.js 22 LTS for TypeScript import/seed scripts
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Node 20 reaches end-of-life April 2026. Upgrade all references to Node 22,
the current active LTS.

https://claude.ai/code/session_01X86r4iQFp95p9rdeqn3btC