### PR TITLE
Skip branch deploy for mobile-only changes

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -3,6 +3,8 @@ name: Branch Deploy
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'mobile/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Add paths-ignore for mobile/** so PRs that only touch the mobile
directory don't trigger the Branch Deploy workflow.

https://claude.ai/code/session_01AH4waHnWVEy5aAqx8sQsR6