### PR TITLE
Add ITSAppUsesNonExemptEncryption=false to Info.plist

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -36,6 +36,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Boardsesh uses Bluetooth to connect to your climbing training board and illuminate routes.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>


### PR DESCRIPTION
Declares that the app does not use non-exempt encryption, skipping
App Store export compliance documentation requirement.

https://claude.ai/code/session_01Jz4CSbXyfydiXTUthrZGMH