### PR TITLE
Fix iOS export signing for widget extension

### DIFF
--- a/mobile/ios/ExportOptions.plist
+++ b/mobile/ios/ExportOptions.plist
@@ -7,12 +7,7 @@
     <key>teamID</key>
     <string>9L3HKPZBH3</string>
     <key>signingStyle</key>
-    <string>manual</string>
-    <key>provisioningProfiles</key>
-    <dict>
-        <key>com.boardsesh.app</key>
-        <string>Boardsesh App Store Distribution Second</string>
-    </dict>
+    <string>automatic</string>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
## Summary
- Switch `ExportOptions.plist` from `manual` to `automatic` signing style and remove the hardcoded `provisioningProfiles` dict
- The manual config only mapped the main app bundle (`com.boardsesh.app`), missing the new `BoardseshWidgets` extension (`com.boardsesh.app.widgets`) which requires App Groups
- Automatic signing lets xcodebuild resolve profiles for all targets via the App Store Connect API auth already configured in CI

## Test plan
- [ ] Verify the iOS TestFlight workflow passes the `Export archive` step
- [ ] Confirm the IPA is uploaded as an artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)