### PR TITLE
Fix iOS export: install provisioning profiles for app and widget

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -91,6 +91,17 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
           security list-keychains -d user -s "$KEYCHAIN_NAME" $(security list-keychains -d user | tr -d '"')
 
+      - name: Install provisioning profiles
+        env:
+          APP_PROFILE_BASE64: ${{ secrets.IOS_APP_PROVISIONING_PROFILE_BASE64 }}
+          WIDGETS_PROFILE_BASE64: ${{ secrets.IOS_WIDGETS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$APP_PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/app.mobileprovision
+          echo "$WIDGETS_PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/widgets.mobileprovision
+
       - name: Setup App Store Connect API key
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}

--- a/mobile/ios/ExportOptions.plist
+++ b/mobile/ios/ExportOptions.plist
@@ -7,7 +7,14 @@
     <key>teamID</key>
     <string>9L3HKPZBH3</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.boardsesh.app</key>
+        <string>Boardsesh App Store Distribution Second</string>
+        <key>com.boardsesh.app.widgets</key>
+        <string>Boardsesh Widgets App Store Distribution</string>
+    </dict>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
Automatic signing failed due to missing cloud signing permissions on the App Store Connect API key. Revert to manual signing with both profiles (main app + BoardseshWidgets) listed in ExportOptions.plist, and add a CI step to install provisioning profiles from GitHub secrets before archiving.