### PR TITLE
Support forwarded headers for base URL detection

### DIFF
--- a/packages/web/app/join/[sessionId]/route.ts
+++ b/packages/web/app/join/[sessionId]/route.ts
@@ -34,6 +34,21 @@ function ensureViewSegment(path: string): string {
 }
 
 function getBaseUrl(request: Request): string {
+  const headers = request.headers;
+  const forwardedHost = headers.get('x-forwarded-host');
+  const forwardedProto = headers.get('x-forwarded-proto');
+  const host = headers.get('host');
+
+  if (forwardedHost) {
+    const proto = forwardedProto?.split(',')[0].trim() ?? 'https';
+    return `${proto}://${forwardedHost}`;
+  }
+
+  if (host) {
+    const url = new URL(request.url);
+    return `${url.protocol}//${host}`;
+  }
+
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }


### PR DESCRIPTION
## Summary
Enhanced the `getBaseUrl()` function to properly handle reverse proxy scenarios by checking for `x-forwarded-host` and `x-forwarded-proto` headers before falling back to the direct request headers.

## Key Changes
- Added support for `x-forwarded-host` header to detect the original host when behind a reverse proxy
- Added support for `x-forwarded-proto` header to detect the original protocol (with fallback to `https`)
- Implemented proper header precedence: forwarded headers → direct host header → request URL
- Handles comma-separated protocol values by extracting the first value (common in proxy chains)

## Implementation Details
The function now checks headers in order of preference:
1. If `x-forwarded-host` is present, use it with the protocol from `x-forwarded-proto` (defaulting to `https`)
2. If only `host` header is present, construct the URL using the request's protocol and the host header
3. Fall back to the original behavior of using the request URL directly

This ensures the base URL is correctly determined in both direct requests and reverse proxy scenarios (e.g., behind nginx, load balancers, or CDNs).

https://claude.ai/code/session_015HiZuzxfGDq6fHogoAHjA8