### PR TITLE
Fix BLE hex string format for Capacitor plugin v8+

### DIFF
--- a/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
@@ -166,7 +166,7 @@ describe('CapacitorBleAdapter', () => {
         deviceId: 'dev-1',
         service: '6e400001-b5a3-f393-e0a9-e50e24dcca9e',
         characteristic: '6e400002-b5a3-f393-e0a9-e50e24dcca9e',
-        value: '01 02 03 04 05',
+        value: '0102030405',
       });
     });
 
@@ -193,14 +193,14 @@ describe('CapacitorBleAdapter', () => {
       expect(mockBlePlugin.write).toHaveBeenCalledTimes(3);
     });
 
-    it('encodes bytes as space-separated hex string', async () => {
+    it('encodes bytes as continuous hex string', async () => {
       await adapter.requestAndConnect();
 
       const data = new Uint8Array([0x01, 0x02, 0xff]);
       await adapter.write(data);
 
       const writtenValue = mockBlePlugin.write.mock.calls[0][0].value;
-      expect(writtenValue).toBe('01 02 ff');
+      expect(writtenValue).toBe('0102ff');
     });
   });
 

--- a/packages/web/app/lib/ble/capacitor-adapter.ts
+++ b/packages/web/app/lib/ble/capacitor-adapter.ts
@@ -7,7 +7,7 @@ const UART_WRITE_UUID = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 
 // Raw Capacitor plugin interface as exposed via window.Capacitor.Plugins.BluetoothLe.
 // The plugin JS is injected by the native shell. We type only the methods we use.
-// IMPORTANT: The raw plugin's write() expects `value` as a hex string, not DataView.
+// IMPORTANT: The raw plugin's write() expects `value` as a continuous hex string (no spaces), not DataView.
 // The BleClient npm wrapper normally handles this conversion, but we bypass it.
 
 interface PluginListenerHandle {
@@ -31,7 +31,7 @@ interface CapacitorBlePlugin {
     deviceId: string;
     service: string;
     characteristic: string;
-    value: string; // Hex string, e.g. "01 02 ff"
+    value: string; // Continuous hex string, e.g. "0102ff"
   }): Promise<void>;
   requestMtu(options: {
     deviceId: string;
@@ -51,11 +51,11 @@ function getBlePlugin(): CapacitorBlePlugin {
   return plugin as CapacitorBlePlugin;
 }
 
-/** Convert a Uint8Array to the space-separated hex string the raw plugin expects */
+/** Convert a Uint8Array to the continuous hex string the raw plugin expects (v8+) */
 function toHexString(data: Uint8Array): string {
   return Array.from(data)
     .map((b) => b.toString(16).padStart(2, '0'))
-    .join(' ');
+    .join('');
 }
 
 export class CapacitorBleAdapter implements BluetoothAdapter {


### PR DESCRIPTION
## Summary
Updated the Capacitor BLE adapter to generate continuous hex strings (without spaces) instead of space-separated hex strings, aligning with the expected format in Capacitor plugin v8+.

## Key Changes
- Modified `toHexString()` function to join hex bytes without spaces (e.g., `"0102ff"` instead of `"01 02 ff"`)
- Updated JSDoc comments to clarify that the raw plugin expects continuous hex strings
- Updated interface documentation and test cases to reflect the new format

## Implementation Details
- The change affects how `Uint8Array` data is converted before being passed to the native Capacitor BLE plugin's `write()` method
- This is a breaking change for the native plugin interface, but the adapter now correctly handles the v8+ format
- All related tests have been updated to verify the continuous hex string format

https://claude.ai/code/session_01EAsaHAWhHdQaMvrYzFsC9H