### PR TITLE
Display V-grades in Live Activity Dynamic Island

### DIFF
--- a/mobile/ios/App/App/LiveActivityManager.swift
+++ b/mobile/ios/App/App/LiveActivityManager.swift
@@ -149,7 +149,7 @@ final class LiveActivityManager {
 
         return ClimbSessionAttributes.ContentState(
             climbName: item.climbName,
-            climbDifficulty: item.difficulty,
+            climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
             angle: item.angle,
             currentIndex: currentIndex,
             totalClimbs: items.count,

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -261,7 +261,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         // Build and push the new content state to the Live Activity.
         let state = ClimbSessionAttributes.ContentState(
             climbName: climbName,
-            climbDifficulty: climbDifficulty,
+            climbDifficulty: VGradeFormatter.formatVGrade(climbDifficulty),
             angle: angle,
             currentIndex: currentIndex,
             totalClimbs: totalClimbs,

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -97,3 +97,46 @@ enum SharedQueueState {
         return components?.url
     }
 }
+
+// MARK: - V-Grade Formatting
+
+enum VGradeFormatter {
+    /// V-grades that map from more than one Font grade.
+    /// When the Font grade has "+", these V-grades get a "+" suffix for disambiguation.
+    /// Derived from BOULDER_GRADES in packages/web/app/lib/board-data.ts:
+    ///   V0 (4a,4b,4c), V1 (5a,5b), V3 (6a,6a+), V4 (6b,6b+), V5 (6c,6c+), V8 (7b,7b+)
+    private static let vGradesWithMultipleFontGrades: Set<String> = [
+        "V0", "V1", "V3", "V4", "V5", "V8"
+    ]
+
+    private static let vGradeRegex = try! NSRegularExpression(pattern: "V\\d+", options: .caseInsensitive)
+
+    /// Format a raw difficulty string to a V-grade display label.
+    ///
+    /// Examples:
+    /// - "6c+/V5" -> "V5+"  (V5 has multiple font grades, font part has "+")
+    /// - "7a+/V7" -> "V7"   (V7 has only one font grade)
+    /// - "6c/V5"  -> "V5"   (font part has no "+")
+    /// - "V3"     -> "V3"   (bare V-grade)
+    /// - ""       -> ""     (empty input)
+    static func formatVGrade(_ difficulty: String) -> String {
+        guard !difficulty.isEmpty else { return "" }
+
+        let nsRange = NSRange(difficulty.startIndex..<difficulty.endIndex, in: difficulty)
+        guard let match = vGradeRegex.firstMatch(in: difficulty, range: nsRange),
+              let range = Range(match.range, in: difficulty)
+        else {
+            return difficulty
+        }
+        let vGrade = String(difficulty[range]).uppercased()
+
+        if let slashIndex = difficulty.firstIndex(of: "/"), slashIndex > difficulty.startIndex {
+            let fontPart = String(difficulty[difficulty.startIndex..<slashIndex])
+            if fontPart.hasSuffix("+") && vGradesWithMultipleFontGrades.contains(vGrade) {
+                return "\(vGrade)+"
+            }
+        }
+
+        return vGrade
+    }
+}

--- a/mobile/ios/App/AppTests/LiveActivityManagerTests.swift
+++ b/mobile/ios/App/AppTests/LiveActivityManagerTests.swift
@@ -147,4 +147,30 @@ final class LiveActivityManagerTests: XCTestCase {
         XCTAssertEqual(state?.currentIndex, 0)
         XCTAssertEqual(state?.totalClimbs, 1)
     }
+
+    func testBuildContentStateFormatsVGradeFromCombinedDifficulty() {
+        let item = makeQueueItem(
+            climbName: "Font Grade Climb",
+            difficulty: "6c+/V5",
+            angle: 40
+        )
+
+        let state = LiveActivityManager.buildContentState(items: [item], currentIndex: 0)
+
+        XCTAssertNotNil(state)
+        XCTAssertEqual(state?.climbDifficulty, "V5+")
+    }
+
+    func testBuildContentStateFormatsVGradeNoPlusForSingleFontGrade() {
+        let item = makeQueueItem(
+            climbName: "Single Font Grade",
+            difficulty: "7a+/V7",
+            angle: 40
+        )
+
+        let state = LiveActivityManager.buildContentState(items: [item], currentIndex: 0)
+
+        XCTAssertNotNil(state)
+        XCTAssertEqual(state?.climbDifficulty, "V7")
+    }
 }

--- a/mobile/ios/App/AppTests/SessionWebSocketManagerTests.swift
+++ b/mobile/ios/App/AppTests/SessionWebSocketManagerTests.swift
@@ -965,4 +965,49 @@ final class SessionWebSocketManagerTests: XCTestCase {
         XCTAssertEqual(GQLMessageType.ping.rawValue, "ping")
         XCTAssertEqual(GQLMessageType.pong.rawValue, "pong")
     }
+
+    // MARK: - VGradeFormatter
+
+    func testFormatVGradeExtractsVGrade() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6a/V3"), "V3")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6b/V4"), "V4")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("7a/V6"), "V6")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("5c/V2"), "V2")
+    }
+
+    func testFormatVGradeAddsPlusForMultipleFontGrades() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6a+/V3"), "V3+")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6b+/V4"), "V4+")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6c+/V5"), "V5+")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("7b+/V8"), "V8+")
+    }
+
+    func testFormatVGradeNoPlusForSingleFontGrade() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("7a+/V7"), "V7")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("7c+/V10"), "V10")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("8a+/V12"), "V12")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("8b+/V14"), "V14")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("8c+/V16"), "V16")
+    }
+
+    func testFormatVGradeNoPlusWhenFontGradeHasNone() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6c/V5"), "V5")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6a/V3"), "V3")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("7b/V8"), "V8")
+    }
+
+    func testFormatVGradeBareVGrade() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("V3"), "V3")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("V10"), "V10")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("V0"), "V0")
+    }
+
+    func testFormatVGradeEmptyString() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade(""), "")
+    }
+
+    func testFormatVGradeNoVGradeFound() {
+        XCTAssertEqual(VGradeFormatter.formatVGrade("6a"), "6a")
+        XCTAssertEqual(VGradeFormatter.formatVGrade("unknown"), "unknown")
+    }
 }

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -25,7 +25,7 @@ struct NextClimbIntent: LiveActivityIntent {
         let nextItem = items[nextIndex]
         let newState = ClimbSessionAttributes.ContentState(
             climbName: nextItem.climbName,
-            climbDifficulty: nextItem.difficulty,
+            climbDifficulty: VGradeFormatter.formatVGrade(nextItem.difficulty),
             angle: nextItem.angle,
             currentIndex: nextIndex,
             totalClimbs: items.count,

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -25,7 +25,7 @@ struct PreviousClimbIntent: LiveActivityIntent {
         let prevItem = items[prevIndex]
         let newState = ClimbSessionAttributes.ContentState(
             climbName: prevItem.climbName,
-            climbDifficulty: prevItem.difficulty,
+            climbDifficulty: VGradeFormatter.formatVGrade(prevItem.difficulty),
             angle: prevItem.angle,
             currentIndex: prevIndex,
             totalClimbs: items.count,


### PR DESCRIPTION
## Summary
- Add `VGradeFormatter` in Swift to convert raw difficulty strings (e.g., "6c+/V5") to V-grade display labels (e.g., "V5+"), matching the format used in the web climbs list
- Apply formatting at all 4 `ContentState` construction points: `LiveActivityManager`, `LiveActivityPlugin`, `NextClimbIntent`, and `PreviousClimbIntent`
- Raw difficulty preserved in `SharedQueueItem.difficulty` so WebSocket mutations back to the server remain correct

## Test plan
- [ ] Verify V-grade formatting unit tests pass (VGradeFormatter tests in SessionWebSocketManagerTests)
- [ ] Verify integration tests pass (LiveActivityManagerTests with combined difficulty strings)
- [ ] Manual: add climbs with various difficulties (6c, 6c+, 7a+) to queue, confirm Dynamic Island and lock screen show V-grades (V5, V5+, V7)
- [ ] Manual: test prev/next navigation from Dynamic Island — grades should stay in V-grade format

🤖 Generated with [Claude Code](https://claude.com/claude-code)