### PR TITLE
Hide feed tab in iOS native app pending compliance

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useContext } from 'react';
+import React, { useState, useCallback, useContext, useMemo } from 'react';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
@@ -34,6 +34,7 @@ import { useUnreadNotificationCount } from '@/app/hooks/use-unread-notification-
 import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import type { StoredBoardConfig } from '@/app/lib/saved-boards-db';
 import { isValidHexColor } from '@/app/lib/color-utils';
+import { getPlatform } from '@/app/lib/ble/capacitor-utils';
 
 type Tab = 'home' | 'climbs' | 'library' | 'feed' | 'create' | 'notifications';
 type PendingCreateAction = 'climb' | 'playlist' | null;
@@ -138,6 +139,9 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
 
   // Hide playlists for moonboard (not yet supported)
   const isMoonboard = playlistBoardName === 'moonboard';
+
+  // Hide feed tab in iOS native app (pending block/report functionality for app store compliance)
+  const isIOSNativeApp = useMemo(() => getPlatform() === 'ios', []);
 
   // Determine active tab from pathname
   const activeTabFromPath = getActiveTab(pathname);
@@ -465,12 +469,14 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           value="library"
           sx={actionSx}
         />
-        <BottomNavigationAction
-          label="Feed"
-          icon={<DynamicFeedOutlined sx={{ fontSize: 20 }} />}
-          value="feed"
-          sx={actionSx}
-        />
+        {!isIOSNativeApp && (
+          <BottomNavigationAction
+            label="Feed"
+            icon={<DynamicFeedOutlined sx={{ fontSize: 20 }} />}
+            value="feed"
+            sx={actionSx}
+          />
+        )}
         <BottomNavigationAction
           label="Create"
           icon={<AddOutlined sx={{ fontSize: 20 }} />}


### PR DESCRIPTION
## Summary
Hide the feed tab from the bottom navigation bar in iOS native app builds pending implementation of block/report functionality required for App Store compliance.

## Key Changes
- Import `getPlatform` utility from capacitor-utils to detect the platform
- Add `useMemo` hook to memoize the iOS platform detection check
- Conditionally render the Feed tab only when not running on iOS native app
- Feed tab remains visible on web and Android platforms

## Implementation Details
- Uses `getPlatform() === 'ios'` to detect iOS native app environment
- The check is memoized with `useMemo` to avoid unnecessary recalculations
- The Feed navigation action is wrapped in a conditional render that excludes it for iOS
- This is a temporary measure until block/report functionality is implemented to meet App Store requirements

https://claude.ai/code/session_019XaP7RTUEz5y42KxATsVQk