### PR TITLE
Add back NSLocationAlwaysAndWhenInUseUsageDescription for Capacitor G…

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -59,6 +59,8 @@
 	<string>Boardsesh uses Bluetooth to connect to your Kilter Board, Tension Board, or MoonBoard and light up climbing holds. No personal data is sent over Bluetooth.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Boardsesh uses your location to find nearby boards to climb on and to discover nearby climbing sessions in Party Mode.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Boardsesh uses your location to find nearby boards to climb on and to discover nearby climbing sessions in Party Mode.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
…eolocation plugin

Apple's ITMS-90683 warning: the Capacitor Geolocation plugin binary references CLLocationManager Always authorization APIs, so the key is required in Info.plist even though the app only uses foreground location.

https://claude.ai/code/session_01EyeBgnHnzhpQDT1kHP9E41