### PR TITLE
Consolidate iOS WebSocket into single native connection

### DIFF
--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -11,6 +11,7 @@ Control the climbing board from the lock screen while the app is backgrounded. T
 - All queue delta events (FullSync, ItemAdded, ItemRemoved, CurrentClimbChanged, Reordered) are processed natively and persisted to App Group
 - Message buffering when webview is backgrounded, with flush or resync on foreground
 - Rust board renderer (`packages/board-renderer-wasm/`) compiles to WASM, used in both Node.js backend (server-rendered thumbnails) and web frontend (Web Worker). Already has `HoldData` types, frame string parsing (`p<hold_id>r<state_code>`), and Aurora hold state color mapping
+- `bluetooth-central` background mode already declared in `Info.plist` -- CoreBluetooth can run while the app is backgrounded
 
 **What's missing for full lock-screen board control:**
 1. No native BLE (CoreBluetooth) -- LED commands can only be sent from the webview's JS context via `@capacitor-community/bluetooth-le`
@@ -43,111 +44,16 @@ Physical board LEDs update
 
 The main app process can maintain a CoreBluetooth connection in the background if it declares the `bluetooth-central` background mode. This is the critical enabler.
 
-## Phases
+## Customer Value Milestones
 
-### Phase 1: Native CoreBluetooth Manager
-
-Move BLE from JS-only to a native Swift layer that can run when the webview is suspended.
-
-**Files to create:**
-- `mobile/ios/App/App/BoardBleManager.swift` -- CoreBluetooth central manager, scan/connect/disconnect, UART write
-- `mobile/ios/App/App/BoardBlePlugin.swift` -- Capacitor plugin exposing native BLE to JS (replaces or wraps `@capacitor-community/bluetooth-le` on iOS)
-- `mobile/ios/App/App/BoardBlePlugin.m` -- ObjC bridge
-
-**Key work:**
-- Implement CoreBluetooth scan, connect, service/characteristic discovery for Aurora boards
-- Port the UART packet encoding from `packages/web/app/lib/ble/` (Aurora protocol: placement data → LED bytes)
-- Declare `bluetooth-central` in `Info.plist` background modes
-- Keep the existing JS Capacitor BLE adapter as a fallback for non-iOS or when native BLE is unavailable
-- `BoardBleManager` is a singleton like `SessionWebSocketManager`, owns the `CBCentralManager` and `CBPeripheral` connection
-
-**UART encoding approach -- Rust vs Swift:**
-
-The UART packet encoding (frame string → LED bytes) already exists in the TypeScript BLE layer (`packages/web/app/lib/ble/`). Two options for the native side:
-
-- **Option A: Rewrite in Swift.** The encoding is ~100-150 lines. Simple byte packing, no complex logic. Easiest to debug and maintain alongside the existing Swift codebase. No new build dependencies.
-- **Option B: Add UniFFI bindings to the Rust board-renderer crate.** The crate (`packages/board-renderer-wasm/`) already has `HoldData` types and frame string parsing. Adding a `ble_encode(frame_string, holds) -> Vec<u8>` function plus UniFFI `.udl` definition would generate Swift bindings automatically. This shares the frame parsing logic with the WASM build and creates a single source of truth for the Aurora protocol.
-
-Recommend **Option A** for Phase 1 -- keep it simple, ship fast. Revisit Option B if we add more shared logic to the Rust crate (see Phase 3b).
-
-**Hold data requirement:** To illuminate LEDs, the native layer needs hold positions and LED mappings. For Phase 1, the webview can write the current climb's hold data to App Group when the climb changes. Phase 3 replaces this with compiled-in static data generated from the same pipeline that produces the TypeScript and C++ constants, so the native layer can resolve any climb's LEDs independently.
-
-**Definition of done:** Board LEDs light up when navigating climbs via the Lock Screen widget while the app is in the background.
-
-### Phase 2: Background BLE Connection Persistence
-
-Ensure the CoreBluetooth connection survives app backgrounding and can recover.
-
-**Key work:**
-- `bluetooth-central` background mode in `Info.plist` (allows CoreBluetooth to run in background)
-- State preservation and restoration (`CBCentralManager` `restoreState` option)
-- Handle `centralManager(_:willRestoreState:)` to reconnect to known peripherals after process termination
-- Reconnection logic: if the BLE connection drops while backgrounded, attempt to reconnect with exponential backoff
-- Battery impact assessment: CoreBluetooth in background is efficient (no scanning needed, just maintaining an existing connection), but test real-world drain
-
-**Definition of done:** BLE connection persists through backgrounding and app suspension. LED writes work reliably after returning from background.
-
-### Phase 3: Embedded Hold/LED Placement Data in Native Code
-
-The native layer needs hold positions and LED mappings to illuminate the board. Rather than sending this over the WebSocket (which would bloat every message), embed the static board data directly in the compiled Swift code -- the same approach already used for TypeScript and the ESP32 controller.
-
-**Existing generated data pipeline:**
-- `packages/web/scripts/generate-size-edges.ts` queries PostgreSQL and generates:
-  - `packages/web/app/lib/__generated__/product-sizes-data.ts` -- hold placements as `HoldTuple[]` (`[placementId, mirroredPlacementId, x, y]`), indexed by `boardName` → `"layoutId-setId"`
-  - `packages/web/app/lib/__generated__/led-placements-data.ts` -- LED strip positions as `Record<placementId, ledIndex>`, indexed by `boardName` → `"layoutId-sizeId"`
-- `packages/board-controller/esp32/scripts/generate-led-mapping.js` reads the TS LED data and generates a C++ header (`led_placement_map.h`) for the embedded controller
-
-**Key work:**
-- Extend the generator script to also output a portable format (JSON) alongside the TypeScript files
-- Add a second codegen step that converts the JSON to a Swift file (e.g., `mobile/ios/App/App/__generated__/BoardPlacementData.swift`) with static dictionaries
-- Include both hole placements (for rendering/BLE) and LED placements (for UART packet encoding)
-- The Swift data is compiled into the app binary -- no runtime fetching, no App Group, no WebSocket overhead
-- Each climb's `frames` string (already in `SharedQueueItem`) contains `p<placementId>r<stateCode>` pairs. The native BLE manager looks up each placementId in the embedded data to get the LED index, then encodes the UART packet.
-
-**Generator output structure:**
-```
-packages/web/scripts/generate-size-edges.ts
-  → packages/web/app/lib/__generated__/product-sizes-data.ts     (existing, TypeScript)
-  �� packages/web/app/lib/__generated__/led-placements-data.ts    (existing, TypeScript)
-  → packages/shared-data/board-placements.json                   (new, portable)
-  → mobile/ios/App/App/__generated__/BoardPlacementData.swift    (new, from JSON)
-  → packages/board-controller/esp32/src/config/led_placement_map.h (existing, C++)
-```
-
-**Trade-off:** Board data changes require regenerating and recompiling the app. This is fine -- board hardware configurations are static and change at most once per board revision (years). The generator already runs manually (`bunx tsx scripts/generate-size-edges.ts`), adding one more output target is trivial.
-
-**Definition of done:** The native layer can look up LED positions for any hold placement without the webview, using data compiled into the app binary. `BoardBleManager` can encode a UART packet from a frames string alone.
-
-### Phase 4: Expanded Widget Controls
-
-Add more actions to the Lock Screen widget, including workout support.
-
-**Queue controls:**
-- Mirror toggle (flip the current climb)
-- Skip/remove current climb from queue
-- Tick/log the current climb as sent
-
-**Workout controls (future):**
-When workouts land in Boardsesh, the Live Activity becomes the primary workout interface on the wall. The widget will need to display and control:
-- Current set and rep within the workout (e.g., "Set 2/4, Rep 3/6")
-- Rest timer countdown between sets (Live Activities support timer rendering natively via `Text.DateStyle.timer`)
-- Start/complete rep buttons
-- Skip set or end workout early
-
-The workout state lives server-side and arrives via the same WebSocket subscription. The widget complexity grows (more UI states, timer logic, conditional layouts) but the underlying transport stays the same: WS event → `SessionWebSocketManager` → App Group → Live Activity update. The native Swift state machine may need a workout-specific event type alongside the existing queue events, but the plumbing is identical.
-
-**Design constraints:**
-- iOS widget interaction is buttons only, no complex input
-- Each action follows the same pattern: optimistic App Group update → Darwin notification → main app sends mutation → server confirms → all clients update
-- Lock Screen expanded view has ~160pt height -- plan layouts for queue mode and workout mode
-
-### Phase 5: Android Parity (Future)
-
-If/when the Android app needs the same capabilities:
-- Kotlin `BluetoothGattCallback` for BLE (mirrors `BoardBleManager`)
-- Android foreground service for background BLE persistence
-- Media notification or custom notification for lock-screen controls (Android doesn't have Live Activities)
-- Same WebSocket consolidation pattern as iOS (native WS → Capacitor bridge)
+| Phase | Deliverable | User Value |
+|-------|-------------|------------|
+| Pre-Phase 1 | Shared golden test suite for queue state machine | Developer confidence -- ensures the Swift reimplementation matches TypeScript before shipping. No direct user value. |
+| **Phase 1** | **Native BLE with background persistence + LED placement via App Group** | **Core deliverable: tap Next/Previous on the Lock Screen and the board lights up, even with the app backgrounded.** |
+| Phase 2 | Embedded hold/LED data compiled into the app binary | Removes the App Group workaround for LED mappings. Faster, more reliable, eliminates edge cases with stale data. No user-visible behavior change. |
+| Phase 3 | Expanded queue controls from Lock Screen | Mirror a climb, skip/remove, log a send -- all without unlocking. |
+| Phase 4 (future) | Workout widget on Lock Screen | Rest timers, set/rep tracking, start/complete buttons -- deferred until workouts ship. |
+| Phase 5 (future) | Android parity | Same lock-screen control experience on Android. |
 
 ## Pre-Phase 1: Golden Test Fixtures for Queue State Machine
 
@@ -164,6 +70,7 @@ The pure `queueReducer(state, action) => state` in `packages/web/app/components/
 | `DELTA_REORDER_QUEUE_ITEM` | Validate indices, splice-based reorder |
 | `DELTA_UPDATE_CURRENT_CLIMB` | Echo detection via correlationId/clientId |
 | `DELTA_MIRROR_CURRENT_CLIMB` | Toggle mirrored on current climb + queue copy |
+| `DELTA_REPLACE_QUEUE_ITEM` | Replace item in-place by uuid |
 | `INITIAL_QUEUE_DATA` | Full state replacement (maps to FullSync) |
 
 Secondary targets:
@@ -198,13 +105,116 @@ The fixture file lives in `packages/shared-schema/test-fixtures/queue-state-mach
 - `packages/web/app/components/persistent-session/__tests__/event-utils.test.ts` -- tests for utility functions
 - These should be refactored to load from the golden fixtures instead of inline test data
 
+## Phases
+
+### Phase 1: Native CoreBluetooth Manager with Background Persistence
+
+Move BLE from JS-only to a native Swift layer that can run when the webview is suspended, and ensure the connection survives app backgrounding.
+
+**Files to create:**
+- `mobile/ios/App/App/BoardBleManager.swift` -- CoreBluetooth central manager, scan/connect/disconnect, UART write
+- `mobile/ios/App/App/BoardBlePlugin.swift` -- Capacitor plugin exposing native BLE to JS (replaces or wraps `@capacitor-community/bluetooth-le` on iOS)
+- `mobile/ios/App/App/BoardBlePlugin.m` -- ObjC bridge
+
+**Key work:**
+- Implement CoreBluetooth scan, connect, service/characteristic discovery for Aurora boards
+- Port the UART packet encoding from `packages/web/app/components/board-bluetooth-control/bluetooth.ts` (Aurora protocol: placement data → LED bytes). The encoding logic is ~70 lines of byte packing -- checksum, position/color encoding, packet framing, and MTU splitting.
+- Keep the existing JS Capacitor BLE adapter as a fallback for non-iOS or when native BLE is unavailable
+- `BoardBleManager` is a singleton like `SessionWebSocketManager`, owns the `CBCentralManager` and `CBPeripheral` connection
+- State preservation and restoration (`CBCentralManager` `restoreState` option)
+- Handle `centralManager(_:willRestoreState:)` to reconnect to known peripherals after process termination
+- Reconnection logic: if the BLE connection drops while backgrounded, attempt to reconnect with exponential backoff
+- Battery impact assessment: CoreBluetooth in background is efficient (no scanning needed, just maintaining an existing connection), but test real-world drain
+
+Note: `bluetooth-central` background mode is already declared in `Info.plist`.
+
+**UART encoding approach -- Rust vs Swift:**
+
+The UART packet encoding (frame string → LED bytes) already exists in the TypeScript BLE layer (`packages/web/app/components/board-bluetooth-control/bluetooth.ts`). Two options for the native side:
+
+- **Option A: Rewrite in Swift.** The encoding is ~70 lines of simple byte packing. Easiest to debug and maintain alongside the existing Swift codebase. No new build dependencies.
+- **Option B: Add UniFFI bindings to the Rust board-renderer crate.** The crate (`packages/board-renderer-wasm/`) already has `HoldData` types and frame string parsing. Adding a `ble_encode(frame_string, holds) -> Vec<u8>` function plus UniFFI `.udl` definition would generate Swift bindings automatically. This shares the frame parsing logic with the WASM build and creates a single source of truth for the Aurora protocol.
+
+Recommend **Option A** for Phase 1 -- keep it simple, ship fast. Revisit Option B if we add more shared logic to the Rust crate.
+
+**Hold data requirement:** To illuminate LEDs, the native layer needs hold positions and LED mappings. The `frames` string in `SharedQueueItem` contains `p<placementId>r<stateCode>` pairs, but the native layer needs the `placementId → ledIndex` mapping to encode UART packets. For Phase 1, the webview writes the full LED placement map for the current board configuration to App Group once at session start (not per-climb). This is a small static dictionary keyed by `layoutId-sizeId`. Phase 2 replaces this with compiled-in static data so the native layer can resolve any board configuration independently.
+
+**Definition of done:** Board LEDs light up when navigating climbs via the Lock Screen widget while the app is in the background. BLE connection persists through backgrounding and app suspension. LED writes work reliably after returning from background.
+
+### Phase 2: Embedded Hold/LED Placement Data in Native Code
+
+The native layer needs hold positions and LED mappings to illuminate the board. Rather than relying on the webview to write LED mappings to App Group (Phase 1 workaround), embed the static board data directly in the compiled Swift code -- the same approach already used for TypeScript and the ESP32 controller.
+
+**Existing generated data pipeline:**
+- `packages/web/scripts/generate-size-edges.ts` queries PostgreSQL and generates:
+  - `packages/web/app/lib/__generated__/product-sizes-data.ts` -- hold placements as `HoldTuple[]` (`[placementId, mirroredPlacementId, x, y]`), indexed by `boardName` → `"layoutId-setId"`
+  - `packages/web/app/lib/__generated__/led-placements-data.ts` -- LED strip positions as `Record<placementId, ledIndex>`, indexed by `boardName` → `"layoutId-sizeId"`
+- `packages/board-controller/esp32/scripts/generate-led-mapping.js` reads the TS LED data and generates a C++ header (`led_placement_map.h`) for the embedded controller
+
+**Key work:**
+- Extend the generator script to also output a portable format (JSON) alongside the TypeScript files
+- Add a second codegen step that converts the JSON to a Swift file (e.g., `mobile/ios/App/App/__generated__/BoardPlacementData.swift`) with static dictionaries
+- Include both hole placements (for rendering/BLE) and LED placements (for UART packet encoding)
+- The Swift data is compiled into the app binary -- no runtime fetching, no App Group, no WebSocket overhead
+- Each climb's `frames` string (already in `SharedQueueItem`) contains `p<placementId>r<stateCode>` pairs. The native BLE manager looks up each placementId in the embedded data to get the LED index, then encodes the UART packet.
+
+**Generator output structure:**
+```
+packages/web/scripts/generate-size-edges.ts
+  → packages/web/app/lib/__generated__/product-sizes-data.ts     (existing, TypeScript)
+  → packages/web/app/lib/__generated__/led-placements-data.ts    (existing, TypeScript)
+  → packages/web/app/lib/__generated__/board-placements.json     (new, portable)
+  → mobile/ios/App/App/__generated__/BoardPlacementData.swift    (new, from JSON)
+  → packages/board-controller/esp32/src/config/led_placement_map.h (existing, C++)
+```
+
+**Trade-off:** Board data changes require regenerating and recompiling the app. This is fine -- board hardware configurations are static and change at most once per board revision (years). The generator already runs manually (`bunx tsx scripts/generate-size-edges.ts`), adding one more output target is trivial.
+
+**Definition of done:** The native layer can look up LED positions for any hold placement without the webview, using data compiled into the app binary. `BoardBleManager` can encode a UART packet from a frames string alone.
+
+### Phase 3: Expanded Widget Controls
+
+Add more queue actions to the Lock Screen widget.
+
+**Queue controls:**
+- Mirror toggle (flip the current climb)
+- Skip/remove current climb from queue
+- Tick/log the current climb as sent
+
+**Design constraints:**
+- iOS widget interaction is buttons only, no complex input
+- Each action follows the same pattern: optimistic App Group update → Darwin notification → main app sends mutation → server confirms → all clients update
+- Lock Screen expanded view has ~160pt height -- plan layouts accordingly
+
+### Phase 4: Workout Widget Controls (Future)
+
+Deferred until the workout feature ships in Boardsesh.
+
+When workouts land, the Live Activity becomes the primary workout interface on the wall. The widget will need to display and control:
+- Current set and rep within the workout (e.g., "Set 2/4, Rep 3/6")
+- Rest timer countdown between sets (Live Activities support timer rendering natively via `Text.DateStyle.timer`)
+- Start/complete rep buttons
+- Skip set or end workout early
+
+The workout state lives server-side and arrives via the same WebSocket subscription. The widget complexity grows (more UI states, timer logic, conditional layouts) but the underlying transport stays the same: WS event → `SessionWebSocketManager` → App Group → Live Activity update. The native Swift state machine may need a workout-specific event type alongside the existing queue events, but the plumbing is identical.
+
+Lock Screen expanded view has ~160pt height -- will need distinct layouts for queue mode and workout mode.
+
+### Phase 5: Android Parity (Future)
+
+If/when the Android app needs the same capabilities:
+- Kotlin `BluetoothGattCallback` for BLE (mirrors `BoardBleManager`)
+- Android foreground service for background BLE persistence
+- Media notification or custom notification for lock-screen controls (Android doesn't have Live Activities)
+- Same WebSocket consolidation pattern as iOS (native WS → Capacitor bridge)
+
 ## Technical Notes
 
 ### Aurora Board BLE Protocol
 
 The board BLE communication uses a UART service. Key characteristics:
-- Service UUID and characteristic UUIDs are in `packages/web/app/lib/ble/uuid.ts`
-- Packet format is in `packages/web/app/lib/ble/` -- holds are encoded as placement data with position, color, and role bytes
+- Service UUID and characteristic UUIDs are defined in `packages/web/app/components/board-bluetooth-control/bluetooth.ts`
+- Packet format is in the same file -- holds are encoded as placement data with position, color, and role bytes
 - The native Swift implementation needs to replicate this encoding exactly
 
 ### Background Execution Budget
@@ -230,4 +240,4 @@ The board renderer at `packages/board-renderer-wasm/` is a production Rust → W
 
 ### What We Decided Not To Do
 
-**Shared Rust/WASM state machine**: The queue state machine is ~200 lines in Swift and ~150 in TypeScript. The queue is an ordered list with a cursor -- comparable to a collaborative Spotify or YouTube playlist, not a document editor. Operations are add, remove, reorder, and change current position. The server is authoritative, conflicts resolve trivially (last write wins), and there are no concurrent character-level edits requiring OT or CRDTs. This will stay simple even with workouts (just another event type through the same transport). Maintaining two small, language-idiomatic implementations is simpler than UniFFI bindings and cross-compilation CI for code that rarely changes.
+**Shared Rust/WASM state machine**: The queue state machine will be ~200 lines in Swift and is ~150 in TypeScript. The queue is an ordered list with a cursor -- comparable to a collaborative Spotify or YouTube playlist, not a document editor. Operations are add, remove, reorder, and change current position. The server is authoritative, conflicts resolve trivially (last write wins), and there are no concurrent character-level edits requiring OT or CRDTs. This will stay simple even with workouts (just another event type through the same transport). Maintaining two small, language-idiomatic implementations is simpler than UniFFI bindings and cross-compilation CI for code that rarely changes.


### PR DESCRIPTION
Replace the dual WebSocket architecture (webview + native) with a single
native-owned URLSessionWebSocketTask that forwards raw graphql-ws messages
to the webview via Capacitor bridge. This halves server connection load
and enables lock-screen operation through message buffering.

Key changes:
- New NativeWebSocketPlugin Capacitor plugin bridging JS to SessionWebSocketManager
- SessionWebSocketManager extended with delegate protocol, multi-subscription
  support, generic operation sending, bounded message buffering (500 max),
  and thread-safe property accessors
- NativeWSClient adapter on web side providing subscribe/execute matching
  graphql-ws Client semantics
- use-session-lifecycle conditionally routes through native on iOS
- use-queue-mutations polymorphic dispatch via TransportClient union type
- WebSocketConnectionManager tracks native connection state
- LiveActivityPlugin decoupled from WS connect/disconnect lifecycle
- Delegate callbacks dispatched to main queue to avoid stateQueue contention
- Execute timeout properly cleans up handlers to prevent memory leaks

Tests: 28 web tests (Vitest), iOS XCTest suite for buffering, subscriptions,
operations, auth token, delegate forwarding, and reconnection.

https://claude.ai/code/session_01XCh4pJK7XyMovute3vqMe9