### PR TITLE
Fix left swipe overscrolling past queue action panel

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -192,6 +192,8 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       swipeThreshold: hasSwipeOverrides ? SIMPLE_SWIPE_THRESHOLD : SHORT_SWIPE_THRESHOLD,
       longSwipeRightThreshold: hasSwipeOverrides ? undefined : LONG_SWIPE_THRESHOLD,
       maxSwipe: hasSwipeOverrides ? SIMPLE_MAX_SWIPE : MAX_GESTURE_SWIPE,
+      // Cap left swipe (queue action) at the panel width — no long-swipe left exists
+      maxSwipeLeft: hasSwipeOverrides ? undefined : SHORT_ACTION_WIDTH,
       disabled: disableSwipe,
     });
 

--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -32,6 +32,10 @@ export interface UseSwipeActionsOptions {
   onSwipeOffsetChange?: (offset: number) => void;
   /** Maximum swipe distance in pixels (default: 120) */
   maxSwipe?: number;
+  /** Maximum left swipe distance in pixels (overrides maxSwipe for left direction) */
+  maxSwipeLeft?: number;
+  /** Maximum right swipe distance in pixels (overrides maxSwipe for right direction) */
+  maxSwipeRight?: number;
   /** Whether swipe is disabled (e.g. in edit mode) */
   disabled?: boolean;
   /** Duration of the completion animation in ms (default: 200) */
@@ -70,6 +74,8 @@ export function useSwipeActions({
   onSwipeZoneChange,
   onSwipeOffsetChange,
   maxSwipe = DEFAULT_MAX_SWIPE,
+  maxSwipeLeft,
+  maxSwipeRight,
   disabled = false,
   completionAnimationMs = 200,
 }: UseSwipeActionsOptions): UseSwipeActionsReturn {
@@ -194,7 +200,9 @@ export function useSwipeActions({
         event.preventDefault();
       }
 
-      const clampedOffset = Math.max(-maxSwipe, Math.min(maxSwipe, deltaX));
+      const maxLeft = maxSwipeLeft ?? maxSwipe;
+      const maxRight = maxSwipeRight ?? maxSwipe;
+      const clampedOffset = Math.max(-maxLeft, Math.min(maxRight, deltaX));
       applyOffset(clampedOffset);
 
       const absOffset = Math.abs(clampedOffset);


### PR DESCRIPTION
The queue action panel (right side, revealed on left swipe) is 120px
wide but maxSwipe was 180px, so the content would keep sliding past
the panel boundary. Adds maxSwipeLeft/maxSwipeRight options to
useSwipeActions and caps the left swipe at SHORT_ACTION_WIDTH (120px)
since there is no long-swipe-left action.

https://claude.ai/code/session_01H8HabjSRr5Fe7SqGJbtixi