### PR TITLE
Fix action drawer contrast: use text.primary/secondary instead of inherited primary color

### DIFF
--- a/packages/web/app/components/climb-actions/action-view-renderer.tsx
+++ b/packages/web/app/components/climb-actions/action-view-renderer.tsx
@@ -120,6 +120,13 @@ export function ActionListElement({
           justifyContent: 'flex-start',
           paddingLeft: `${themeTokens.spacing[4]}px`,
           fontSize: themeTokens.typography.fontSize.base,
+          color: 'text.primary',
+          '& .MuiButton-startIcon': {
+            color: 'text.secondary',
+          },
+          '&:hover': {
+            backgroundColor: 'action.hover',
+          },
         }}
       >
         {label}

--- a/packages/web/app/components/climb-actions/actions/fork-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/fork-action.tsx
@@ -97,6 +97,13 @@ export function ForkAction({
             justifyContent: 'flex-start',
             paddingLeft: `${themeTokens.spacing[4]}px`,
             fontSize: themeTokens.typography.fontSize.base,
+            color: 'text.primary',
+            '& .MuiButton-startIcon': {
+              color: 'text.secondary',
+            },
+            '&:hover': {
+              backgroundColor: 'action.hover',
+            },
           }}
         >
           {label}

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -91,6 +91,13 @@ export function ViewDetailsAction({
             justifyContent: 'flex-start',
             paddingLeft: `${themeTokens.spacing[4]}px`,
             fontSize: themeTokens.typography.fontSize.base,
+            color: 'text.primary',
+            '& .MuiButton-startIcon': {
+              color: 'text.secondary',
+            },
+            '&:hover': {
+              backgroundColor: 'action.hover',
+            },
           }}
         >
           {label}

--- a/packages/web/app/components/climb-actions/climb-actions.tsx
+++ b/packages/web/app/components/climb-actions/climb-actions.tsx
@@ -173,7 +173,7 @@ export function ClimbActions({
   // List mode - render each action as a full-width row (for drawer menus)
   if (viewMode === 'list') {
     return (
-      <Box sx={{ display: 'flex', flexDirection: 'column' }} className={className}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', py: 1 }} className={className}>
         {actionsToShow.map((actionType) => {
           const Renderer = ACTION_RENDERERS[actionType];
           if (!Renderer) return null;


### PR DESCRIPTION
The drawer action buttons used MUI's primary color (#8C4A52) for text, which
had ~2.5:1 contrast ratio against the dark mode paper background. Now uses
text.primary for labels and text.secondary for icons, passing WCAG AA in both
light and dark mode.

https://claude.ai/code/session_01E1VnxfkhaX4DJmE9WTfuPf