### PR TITLE
Allow collapsing active pill by clicking its header

### DIFF
--- a/packages/web/app/components/collapsible-section/collapsible-section.module.css
+++ b/packages/web/app/components/collapsible-section/collapsible-section.module.css
@@ -38,6 +38,7 @@
 
 .collapsedRowActive {
   padding: 24px 24px 4px 24px;
+  cursor: pointer;
 }
 
 .collapsedLabel {

--- a/packages/web/app/components/collapsible-section/collapsible-section.tsx
+++ b/packages/web/app/components/collapsible-section/collapsible-section.tsx
@@ -47,7 +47,10 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
             className={`${styles.sectionCard} ${isActive ? styles.sectionCardActive : ''}`}
             {...(!isActive ? { onClick: () => setActiveKey(section.key) } : {})}
           >
-            <div className={`${styles.collapsedRow} ${isActive ? styles.collapsedRowActive : ''}`}>
+            <div
+              className={`${styles.collapsedRow} ${isActive ? styles.collapsedRowActive : ''}`}
+              {...(isActive ? { onClick: () => setActiveKey(null) } : {})}
+            >
               <span className={styles.collapsedLabel}>{isActive ? section.title : section.label}</span>
               <span className={`${styles.collapsedSummary} ${isActive ? styles.collapsedSummaryHidden : ''}`}>
                 {summaryText}


### PR DESCRIPTION
The CollapsibleSection component now sets activeKey to null when the
header row of the currently open pill is clicked, toggling it closed.
A cursor: pointer style is added to the active header to signal
clickability.

https://claude.ai/code/session_01FHyNeAiQZ1G5TLcJrYsa75