### PR TITLE
Fix stop session button and rename drawer to Session overview

### DIFF
--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -15,7 +15,7 @@ let mockSession: Record<string, unknown> | null = {
   goal: 'Send V5',
   startedAt: new Date(Date.now() - 30 * 60000).toISOString(),
 };
-const mockEndSessionWithSummary = vi.fn();
+const mockDeactivateSession = vi.fn();
 let mockAngle: number | undefined = 40;
 let mockBoardDetails: Record<string, unknown> | null = { board_name: 'kilter' };
 let mockSessionDetail: Record<string, unknown> | null = {
@@ -56,7 +56,7 @@ vi.mock('@/app/components/persistent-session/persistent-session-context', () => 
     activeSession: mockActiveSession,
     session: mockSession,
     users: [],
-    endSessionWithSummary: mockEndSessionWithSummary,
+    deactivateSession: mockDeactivateSession,
     liveSessionStats: null,
   }),
 }));
@@ -170,7 +170,7 @@ describe('SeshSettingsDrawer', () => {
 
   it('renders drawer title', () => {
     render(<SeshSettingsDrawer open={true} onClose={vi.fn()} />);
-    expect(screen.getByTestId('swipeable-drawer').getAttribute('data-title')).toBe('Sesh Settings');
+    expect(screen.getByTestId('swipeable-drawer').getAttribute('data-title')).toBe('Session overview');
   });
 
   it('renders session detail content', () => {
@@ -232,12 +232,29 @@ describe('SeshSettingsDrawer', () => {
   });
 
   describe('handleStopSession', () => {
-    it('calls endSessionWithSummary and onClose', () => {
+    it('calls deactivateSession but does not close the drawer', () => {
       const onClose = vi.fn();
       render(<SeshSettingsDrawer open={true} onClose={onClose} />);
 
       fireEvent.click(screen.getByText('Stop Session'));
-      expect(mockEndSessionWithSummary).toHaveBeenCalled();
+      expect(mockDeactivateSession).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('shows Dismiss button after stopping session', () => {
+      render(<SeshSettingsDrawer open={true} onClose={vi.fn()} />);
+
+      fireEvent.click(screen.getByText('Stop Session'));
+      expect(screen.getByText('Dismiss')).toBeTruthy();
+      expect(screen.queryByText('Stop Session')).toBeNull();
+    });
+
+    it('calls onClose when Dismiss is clicked', () => {
+      const onClose = vi.fn();
+      render(<SeshSettingsDrawer open={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByText('Stop Session'));
+      fireEvent.click(screen.getByText('Dismiss'));
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -30,12 +30,14 @@ interface SeshSettingsDrawerProps {
 }
 
 export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawerProps) {
-  const { activeSession, session, users, endSessionWithSummary, liveSessionStats } = usePersistentSession();
+  const { activeSession, session, users, deactivateSession, liveSessionStats } = usePersistentSession();
   const { boardDetails, angle } = useQueueBridgeBoardInfo();
   const { token: authToken } = useWsAuthToken();
   const router = useRouter();
   const pathname = usePathname();
   const sessionId = activeSession?.sessionId ?? null;
+  const [isStopped, setIsStopped] = useState(false);
+  const lastSessionRef = useRef<SessionDetail | null>(null);
 
   const handleAngleChange = useCallback((newAngle: number) => {
     if (!boardDetails || angle === undefined) return;
@@ -52,9 +54,14 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
   }, [boardDetails, angle, pathname, router]);
 
   const handleStopSession = useCallback(() => {
-    endSessionWithSummary();
+    deactivateSession();
+    setIsStopped(true);
+  }, [deactivateSession]);
+
+  const handleClose = useCallback(() => {
+    setIsStopped(false);
     onClose();
-  }, [endSessionWithSummary, onClose]);
+  }, [onClose]);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['activeSessionDetail', sessionId],
@@ -159,20 +166,33 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
     };
   }, [sessionDetail, fallbackSession, mergedStats]);
 
-  if (!activeSession) return null;
+  if (sessionForView) {
+    lastSessionRef.current = sessionForView;
+  }
+  const displaySession = sessionForView ?? lastSessionRef.current;
+
+  if (!activeSession && !isStopped) return null;
 
   return (
     <SwipeableDrawer
-      title="Sesh Settings"
+      title="Session overview"
       placement="top"
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       fullHeight
       styles={{
         wrapper: { height: '100dvh' },
         body: { padding: 0, paddingBottom: 0 },
       }}
-      footer={(
+      footer={isStopped ? (
+        <Button
+          variant="outlined"
+          onClick={handleClose}
+          fullWidth
+        >
+          Dismiss
+        </Button>
+      ) : (
         <Button
           variant="outlined"
           color="error"
@@ -193,7 +213,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
       )}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pb: 2 }}>
-        {isLoading && !sessionForView && (
+        {isLoading && !displaySession && (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress size={28} />
           </Box>
@@ -205,10 +225,10 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
           </Alert>
         )}
 
-        {sessionForView && (
+        {displaySession && (
           <SessionDetailContent
-            key={`${sessionForView.sessionId}:${sessionForView.ticks.length}:${sessionForView.ticks[0]?.uuid ?? ''}`}
-            session={sessionForView}
+            key={`${displaySession.sessionId}:${displaySession.ticks.length}:${displaySession.ticks[0]?.uuid ?? ''}`}
+            session={displaySession}
             embedded
             fallbackBoardDetails={boardDetails}
           />
@@ -216,7 +236,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
 
         <Divider />
 
-        {boardDetails && angle !== undefined && (
+        {!isStopped && boardDetails && angle !== undefined && (
           <Box sx={{ px: 1 }}>
             <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
               Angle


### PR DESCRIPTION
- Rename "Sesh Settings" to "Session overview"
- Fix stop button: use deactivateSession (leave) instead of endSessionWithSummary
  (which tried to end the entire session and failed silently)
- Keep drawer open after stopping with a "Dismiss" button to close it
- Preserve session data display after leaving via lastSessionRef
- Hide angle selector after session is stopped

https://claude.ai/code/session_01Agek8zmxNBAqsjyzA9i8wb