### PR TITLE
Extract shared listElementSx constant for action list-mode styling

### DIFF
--- a/packages/web/app/components/climb-actions/action-view-renderer.tsx
+++ b/packages/web/app/components/climb-actions/action-view-renderer.tsx
@@ -91,6 +91,24 @@ export function ActionButtonElement({
 }
 
 /**
+ * Shared sx styles for list-mode action buttons.
+ * Used by ActionListElement and Link-wrapped action variants.
+ */
+export const listElementSx = {
+  height: 48,
+  justifyContent: 'flex-start',
+  paddingLeft: `${themeTokens.spacing[4]}px`,
+  fontSize: themeTokens.typography.fontSize.base,
+  color: 'text.primary',
+  '& .MuiButton-startIcon': {
+    color: 'text.secondary',
+  },
+  '&:hover': {
+    backgroundColor: 'action.hover',
+  },
+} as const;
+
+/**
  * Standard list element for action components (list mode / drawer menus).
  * All actions share identical styling for list mode.
  */
@@ -115,19 +133,7 @@ export function ActionListElement({
         fullWidth
         onClick={onClick}
         disabled={disabled}
-        sx={{
-          height: 48,
-          justifyContent: 'flex-start',
-          paddingLeft: `${themeTokens.spacing[4]}px`,
-          fontSize: themeTokens.typography.fontSize.base,
-          color: 'text.primary',
-          '& .MuiButton-startIcon': {
-            color: 'text.secondary',
-          },
-          '&:hover': {
-            backgroundColor: 'action.hover',
-          },
-        }}
+        sx={listElementSx}
       >
         {label}
       </MuiButton>

--- a/packages/web/app/components/climb-actions/actions/fork-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/fork-action.tsx
@@ -8,8 +8,7 @@ import Link from 'next/link';
 import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import { constructCreateClimbUrl } from '@/app/lib/url-utils';
-import { themeTokens } from '@/app/theme/theme-config';
-import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
+import { buildActionResult, computeActionDisplay, listElementSx } from '../action-view-renderer';
 
 const linkResetStyle: React.CSSProperties = { color: 'inherit', textDecoration: 'none' };
 
@@ -92,19 +91,7 @@ export function ForkAction({
           startIcon={icon}
           fullWidth
           disabled={disabled}
-          sx={{
-            height: 48,
-            justifyContent: 'flex-start',
-            paddingLeft: `${themeTokens.spacing[4]}px`,
-            fontSize: themeTokens.typography.fontSize.base,
-            color: 'text.primary',
-            '& .MuiButton-startIcon': {
-              color: 'text.secondary',
-            },
-            '&:hover': {
-              backgroundColor: 'action.hover',
-            },
-          }}
+          sx={listElementSx}
         >
           {label}
         </MuiButton>

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -21,6 +21,7 @@ import { usePlaylists } from '../use-playlists';
 import AuthModal from '../../auth/auth-modal';
 import type { Playlist } from '../playlists-batch-context';
 import { themeTokens } from '@/app/theme/theme-config';
+import { listElementSx } from '../action-view-renderer';
 import { useSnackbar } from '../../providers/snackbar-provider';
 
 // Validate hex color format to prevent CSS injection
@@ -382,12 +383,7 @@ export function PlaylistAction({
         fullWidth
         onClick={handleClick}
         disabled={disabled}
-        sx={{
-          height: 48,
-          justifyContent: 'flex-start',
-          paddingLeft: `${themeTokens.spacing[4]}px`,
-          fontSize: themeTokens.typography.fontSize.base,
-        }}
+        sx={listElementSx}
       >
         {inPlaylistCount > 0 ? `${label} (${inPlaylistCount})` : label}
       </MuiButton>

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -19,6 +19,7 @@ import { track } from '@vercel/analytics';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
+import { listElementSx } from '../action-view-renderer';
 import { useAlwaysTickInApp } from '@/app/hooks/use-always-tick-in-app';
 import { useSession } from 'next-auth/react';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
@@ -339,12 +340,7 @@ export function TickAction({
         fullWidth
         onClick={handleClick}
         disabled={disabled}
-        sx={{
-          height: 48,
-          justifyContent: 'flex-start',
-          paddingLeft: `${themeTokens.spacing[4]}px`,
-          fontSize: themeTokens.typography.fontSize.base,
-        }}
+        sx={listElementSx}
       >
         {badgeCount > 0 ? `${label} (${badgeCount})` : label}
       </MuiButton>

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -10,8 +10,7 @@ import { ClimbActionProps, ClimbActionResult } from '../types';
 import {
   getContextAwareClimbViewUrl,
 } from '@/app/lib/url-utils';
-import { themeTokens } from '@/app/theme/theme-config';
-import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
+import { buildActionResult, computeActionDisplay, listElementSx } from '../action-view-renderer';
 
 const linkResetStyle: React.CSSProperties = { color: 'inherit', textDecoration: 'none' };
 
@@ -86,19 +85,7 @@ export function ViewDetailsAction({
           startIcon={icon}
           fullWidth
           disabled={disabled}
-          sx={{
-            height: 48,
-            justifyContent: 'flex-start',
-            paddingLeft: `${themeTokens.spacing[4]}px`,
-            fontSize: themeTokens.typography.fontSize.base,
-            color: 'text.primary',
-            '& .MuiButton-startIcon': {
-              color: 'text.secondary',
-            },
-            '&:hover': {
-              backgroundColor: 'action.hover',
-            },
-          }}
+          sx={listElementSx}
         >
           {label}
         </MuiButton>


### PR DESCRIPTION
The 7-line sx styling block was duplicated across fork-action, view-details-action, tick-action, and playlist-action. Extracted to a shared listElementSx constant in action-view-renderer.tsx, which ActionListElement also now uses.

https://claude.ai/code/session_01U49cxwwGoB86wyBFCwi6Ad