### PR TITLE
Fix tick action drawer closing immediately when opened from actions d…

### DIFF
--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -106,13 +106,13 @@ export function TickAction({
     }
 
     setDrawerVisible(true);
-    onComplete?.();
-  }, [boardDetails, badgeCount, onComplete, isAuthenticated, alwaysUseApp, loaded, climb.uuid, angle]);
+  }, [boardDetails, badgeCount, isAuthenticated, alwaysUseApp, loaded, climb.uuid, angle]);
 
   const closeDrawer = useCallback(() => {
     setDrawerVisible(false);
     setSelectedBoard(null);
-  }, []);
+    onComplete?.();
+  }, [onComplete]);
 
   // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
   const openInAppUrl = useMemo(() => constructClimbInfoUrl(boardDetails, climb.uuid), [boardDetails, climb.uuid]);


### PR DESCRIPTION
…rawer

The tick action was calling onComplete() immediately after opening its drawer. In list/dropdown viewMode, onComplete closes the parent actions drawer, which unmounts the TickAction component and destroys its drawerVisible state. Moved the onComplete call to closeDrawer so the parent drawer closes after the tick flow completes instead.

https://claude.ai/code/session_01LpH828PNwH8BPSFyPbaagF