### PR TITLE
Fix session re-activation after stop by clearing session cookie

### DIFF
--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -68,6 +68,11 @@ vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({
   }),
 }));
 
+const mockClearClimbSessionCookie = vi.fn();
+vi.mock('@/app/lib/climb-session-cookie', () => ({
+  clearClimbSessionCookie: (...args: unknown[]) => mockClearClimbSessionCookie(...args),
+}));
+
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: () => ({ token: null }),
 }));
@@ -232,12 +237,13 @@ describe('SeshSettingsDrawer', () => {
   });
 
   describe('handleStopSession', () => {
-    it('calls deactivateSession but does not close the drawer', () => {
+    it('calls deactivateSession, clears cookie, but does not close the drawer', () => {
       const onClose = vi.fn();
       render(<SeshSettingsDrawer open={true} onClose={onClose} />);
 
       fireEvent.click(screen.getByText('Stop Session'));
       expect(mockDeactivateSession).toHaveBeenCalled();
+      expect(mockClearClimbSessionCookie).toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
     });
 

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -21,6 +21,7 @@ import {
   GET_SESSION_DETAIL,
   type GetSessionDetailQueryResponse,
 } from '@/app/lib/graphql/operations/activity-feed';
+import { clearClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import type { SessionDetail } from '@boardsesh/shared-schema';
 import SessionDetailContent from '@/app/session/[sessionId]/session-detail-content';
 
@@ -55,6 +56,7 @@ export default function SeshSettingsDrawer({ open, onClose }: SeshSettingsDrawer
 
   const handleStopSession = useCallback(() => {
     deactivateSession();
+    clearClimbSessionCookie();
     setIsStopped(true);
   }, [deactivateSession]);
 


### PR DESCRIPTION
BoardSessionBridge watches the session cookie and re-activates the session whenever activeSession becomes null but the cookie still exists. The stop button was calling deactivateSession() (which clears in-memory state and IndexedDB) but not clearing the cookie, so the bridge immediately re-activated the session.

Now also calls clearClimbSessionCookie() alongside deactivateSession().

https://claude.ai/code/session_01Agek8zmxNBAqsjyzA9i8wb