### PR TITLE
Disable iOS zoom to prevent accidental zoom in webview

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -40,6 +40,8 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
   viewportFit: 'cover',
   themeColor: '#0A0A0A',
 };


### PR DESCRIPTION
Add maximumScale=1 and userScalable=false to viewport config.
Combined with the existing touch-action: manipulation on html,
this prevents double-tap and pinch zoom on iOS webviews.

https://claude.ai/code/session_013HbgAM6d8U5raFWPf4a2cB