### PR TITLE
Remove y-axis legend and reduce left margin on V-Points chart

### DIFF
--- a/packages/web/app/crusher/[user_id]/components/v-points-chart.tsx
+++ b/packages/web/app/crusher/[user_id]/components/v-points-chart.tsx
@@ -43,11 +43,10 @@ export default function VPointsChart({ data }: VPointsChartProps) {
           tickInterval: (_value: string, index: number) => index % labelInterval === 0,
         }]}
         yAxis={[{
-          label: 'V-Points',
           tickLabelStyle: { fontSize: 10 },
         }]}
         height={200}
-        margin={{ top: 10, bottom: 30, left: 50, right: 10 }}
+        margin={{ top: 10, bottom: 30, left: 35, right: 10 }}
         hideLegend={series.length <= 1}
         slotProps={{
           legend: {


### PR DESCRIPTION
The rotated "V-Points" axis label was redundant with the heading above
and pushed the chart data too far right, creating blank space. Removed
the label and reduced left margin from 50px to 35px.

https://claude.ai/code/session_01WPUjc6VY2QL4VtqncwAoTk