### PR TITLE
Fix deployment URL not appearing on PRs

### DIFF
--- a/.github/workflows/branch-deploy-cleanup.yml
+++ b/.github/workflows/branch-deploy-cleanup.yml
@@ -51,3 +51,10 @@ jobs:
               --field state="inactive" \
               --field description="PR closed, preview torn down" || true
           done
+
+      - name: Delete preview environment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/environments/preview-pr-${{ env.PR_NUMBER }}" \
+            --method DELETE || echo "Environment not found or already deleted"

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -219,8 +219,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DEPLOYMENT_ID=$(printf '{"ref":"%s","environment":"preview-pr-%s","description":"Preview deployment for PR #%s","auto_merge":false,"required_contexts":[]}' \
-            "${{ github.sha }}" "${{ env.PR_NUMBER }}" "${{ env.PR_NUMBER }}" | \
+          DEPLOYMENT_ID=$(jq -n \
+            --arg ref "${{ github.sha }}" \
+            --arg env "preview-pr-${{ env.PR_NUMBER }}" \
+            --arg desc "Preview deployment for PR #${{ env.PR_NUMBER }}" \
+            '{ref: $ref, environment: $env, description: $desc, auto_merge: false, required_contexts: []}' | \
             gh api repos/${{ github.repository }}/deployments \
               --method POST --input - --jq '.id')
           if [ -z "$DEPLOYMENT_ID" ]; then
@@ -240,7 +243,7 @@ jobs:
 
   deployment-status:
     needs: [deploy, create-deployment]
-    if: github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && needs.create-deployment.result == 'success' && needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       deployments: write
@@ -258,7 +261,7 @@ jobs:
 
   deployment-failure:
     needs: [deploy, create-deployment]
-    if: github.event_name == 'pull_request' && failure() && needs.create-deployment.result == 'success'
+    if: always() && github.event_name == 'pull_request' && needs.create-deployment.result == 'success' && needs.deploy.result != 'success'
     runs-on: ubuntu-latest
     permissions:
       deployments: write


### PR DESCRIPTION
The deployment-status job lacked always(), so GitHub Actions silently
skipped it whenever the deploy job was cancelled (e.g. by
cancel-in-progress on rapid pushes). This left deployments stuck at
in_progress with no environment_url set.

- Add always() + explicit result checks to deployment-status and
  deployment-failure jobs so they run reliably
- Replace printf JSON construction with jq for safer escaping
- Delete preview environment on PR close to prevent clutter

https://claude.ai/code/session_01MaemdgoW5RZ51bNksjYi7a