### PR TITLE
Add ascent edit and delete functionality across profile, logbook, and…

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -4,7 +4,7 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
-import { SaveTickInputSchema } from '../../../validation/schemas';
+import { SaveTickInputSchema, UpdateTickInputSchema, DeleteTickInputSchema } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
 import { publishSocialEvent } from '../../../events';
 import { assignInferredSession } from '../../../jobs/inferred-session-builder';
@@ -115,6 +115,101 @@ export const tickMutations = {
     }
 
     return result;
+  },
+
+  /**
+   * Update an existing tick (owner only)
+   */
+  updateTick: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<unknown> => {
+    requireAuthenticated(ctx);
+
+    const validatedInput = validateInput(UpdateTickInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    // Build update fields
+    const updates: Record<string, unknown> = {
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (validatedInput.status !== undefined) updates.status = validatedInput.status;
+    if (validatedInput.attemptCount !== undefined) updates.attemptCount = validatedInput.attemptCount;
+    if (validatedInput.quality !== undefined) updates.quality = validatedInput.quality;
+    if (validatedInput.comment !== undefined) updates.comment = validatedInput.comment;
+
+    // Single UPDATE with ownership check — avoids extra SELECT round trip
+    const result = await db
+      .update(dbSchema.boardseshTicks)
+      .set(updates)
+      .where(
+        and(
+          eq(dbSchema.boardseshTicks.uuid, validatedInput.uuid),
+          eq(dbSchema.boardseshTicks.userId, userId),
+        ),
+      )
+      .returning();
+
+    const updatedTick = result[0];
+    if (!updatedTick) {
+      throw new Error('Tick not found or you do not have permission to edit it');
+    }
+
+    return {
+      uuid: updatedTick.uuid,
+      userId: updatedTick.userId,
+      boardType: updatedTick.boardType,
+      climbUuid: updatedTick.climbUuid,
+      angle: updatedTick.angle,
+      isMirror: updatedTick.isMirror,
+      status: updatedTick.status,
+      attemptCount: updatedTick.attemptCount,
+      quality: updatedTick.quality,
+      difficulty: updatedTick.difficulty,
+      isBenchmark: updatedTick.isBenchmark,
+      comment: updatedTick.comment,
+      climbedAt: updatedTick.climbedAt,
+      createdAt: updatedTick.createdAt,
+      updatedAt: updatedTick.updatedAt,
+      sessionId: updatedTick.sessionId,
+      boardId: updatedTick.boardId,
+      auroraType: updatedTick.auroraType,
+      auroraId: updatedTick.auroraId,
+      auroraSyncedAt: updatedTick.auroraSyncedAt,
+    };
+  },
+
+  /**
+   * Delete a tick (owner only)
+   */
+  deleteTick: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+
+    const validatedInput = validateInput(DeleteTickInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    // Delete only if the tick belongs to the authenticated user
+    const result = await db
+      .delete(dbSchema.boardseshTicks)
+      .where(
+        and(
+          eq(dbSchema.boardseshTicks.uuid, validatedInput.uuid),
+          eq(dbSchema.boardseshTicks.userId, userId),
+        ),
+      )
+      .returning({ uuid: dbSchema.boardseshTicks.uuid });
+
+    if (result.length === 0) {
+      throw new Error('Tick not found or you do not have permission to delete it');
+    }
+
+    return true;
   },
 };
 

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -43,6 +43,37 @@ export const SaveTickInputSchema = z.object({
 );
 
 /**
+ * Update tick input validation schema
+ */
+export const UpdateTickInputSchema = z.object({
+  uuid: z.string().min(1),
+  status: TickStatusSchema.optional(),
+  attemptCount: z.number().int().min(1).max(999).optional(),
+  quality: z.number().int().min(1).max(5).optional().nullable(),
+  comment: z.string().max(2000).optional(),
+}).refine(
+  (data) => {
+    if (data.status === 'flash' && data.attemptCount !== undefined && data.attemptCount !== 1) return false;
+    if (data.status === 'send' && data.attemptCount !== undefined && data.attemptCount <= 1) return false;
+    return true;
+  },
+  { message: 'Flash requires attemptCount of 1, send requires attemptCount > 1', path: ['attemptCount'] }
+).refine(
+  (data) => {
+    if (data.status === 'attempt' && data.quality !== undefined && data.quality !== null) return false;
+    return true;
+  },
+  { message: 'Attempts cannot have quality ratings', path: ['quality'] }
+);
+
+/**
+ * Delete tick input validation schema
+ */
+export const DeleteTickInputSchema = z.object({
+  uuid: z.string().min(1),
+});
+
+/**
  * Get ticks input validation schema
  */
 export const GetTicksInputSchema = z.object({

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -119,6 +119,16 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     saveTick(input: SaveTickInput!): Tick!
 
+    """
+    Update an existing tick (owner only).
+    """
+    updateTick(input: UpdateTickInput!): Tick!
+
+    """
+    Delete a tick (owner only).
+    """
+    deleteTick(input: DeleteTickInput!): Boolean!
+
     # ============================================
     # Climb Mutations (require auth)
     # ============================================

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -100,6 +100,30 @@ export const ticksTypeDefs = /* GraphQL */ `
   }
 
   """
+  Input for updating an existing tick.
+  """
+  input UpdateTickInput {
+    "UUID of the tick to update"
+    uuid: ID!
+    "New status (flash, send, attempt)"
+    status: TickStatus
+    "New attempt count"
+    attemptCount: Int
+    "New quality rating (1-5, or null to clear)"
+    quality: Int
+    "New comment"
+    comment: String
+  }
+
+  """
+  Input for deleting a tick.
+  """
+  input DeleteTickInput {
+    "UUID of the tick to delete"
+    uuid: ID!
+  }
+
+  """
   Input for fetching user's ticks.
   """
   input GetTicksInput {

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -44,6 +44,18 @@ export type SaveTickInput = {
   setIds?: string;
 };
 
+export type UpdateTickInput = {
+  uuid: string;
+  status?: TickStatus;
+  attemptCount?: number;
+  quality?: number | null;
+  comment?: string;
+};
+
+export type DeleteTickInput = {
+  uuid: string;
+};
+
 export type GetTicksInput = {
   boardType: string;
   climbUuids?: string[];

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -29,17 +29,8 @@ import {
 } from '@/app/lib/graphql/operations';
 import AscentThumbnail from './ascent-thumbnail';
 import AscentActionsMenu from '@/app/components/ascent-actions/ascent-actions-menu';
+import { useAscentActions } from '@/app/components/ascent-actions/use-ascent-actions';
 import type { EditAscentValues } from '@/app/components/ascent-actions/edit-ascent-dialog';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import {
-  UPDATE_TICK,
-  DELETE_TICK,
-  type UpdateTickMutationVariables,
-  type UpdateTickMutationResponse,
-  type DeleteTickMutationVariables,
-  type DeleteTickMutationResponse,
-} from '@/app/lib/graphql/operations';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
@@ -292,10 +283,19 @@ const GroupedFeedItem: React.FC<{
 };
 
 export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10, editable = false }) => {
-  const { token } = useWsAuthToken();
-  const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
-  const [mutatingUuid, setMutatingUuid] = useState<string | null>(null);
+
+  const invalidateFeed = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['ascentsFeed', userId] });
+  }, [queryClient, userId]);
+
+  // The feed shows ticks across all board types, but useAscentActions needs a boardName.
+  // We pass a generic placeholder — the hooks only use it for logbook cache keys,
+  // and onSettled handles feed-specific invalidation.
+  const { handleUpdate, handleDelete, mutatingUuid } = useAscentActions(
+    '' as never,
+    { onSettled: invalidateFeed },
+  );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useInfiniteQuery({
     queryKey: ['ascentsFeed', userId, pageSize],
@@ -329,50 +329,6 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10,
     hasMore: hasNextPage ?? false,
     isFetching: isFetchingNextPage,
   });
-
-  const handleUpdate = useCallback(async (uuid: string, values: EditAscentValues) => {
-    if (!token) return;
-    setMutatingUuid(uuid);
-    try {
-      const client = createGraphQLHttpClient(token);
-      const variables: UpdateTickMutationVariables = {
-        input: {
-          uuid,
-          status: values.status,
-          attemptCount: values.attemptCount,
-          quality: values.quality,
-          comment: values.comment,
-        },
-      };
-      await client.request<UpdateTickMutationResponse>(UPDATE_TICK, variables);
-      showMessage('Ascent updated', 'success');
-      queryClient.invalidateQueries({ queryKey: ['ascentsFeed', userId] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update ascent';
-      showMessage(message, 'error');
-    } finally {
-      setMutatingUuid(null);
-    }
-  }, [token, userId, queryClient, showMessage]);
-
-  const handleDelete = useCallback(async (uuid: string) => {
-    if (!token) return;
-    setMutatingUuid(uuid);
-    try {
-      const client = createGraphQLHttpClient(token);
-      const variables: DeleteTickMutationVariables = {
-        input: { uuid },
-      };
-      await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
-      showMessage('Ascent deleted', 'success');
-      queryClient.invalidateQueries({ queryKey: ['ascentsFeed', userId] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete ascent';
-      showMessage(message, 'error');
-    } finally {
-      setMutatingUuid(null);
-    }
-  }, [token, userId, queryClient, showMessage]);
 
   if (isLoading) {
     return (

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import MuiTypography from '@mui/material/Typography';
@@ -8,22 +8,38 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Rating from '@mui/material/Rating';
 import CircularProgress from '@mui/material/CircularProgress';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import ExpandMoreOutlined from '@mui/icons-material/ExpandMoreOutlined';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_USER_GROUPED_ASCENTS_FEED,
   type GroupedAscentFeedItem,
+  type AscentFeedItem,
   type GetUserGroupedAscentsFeedQueryVariables,
   type GetUserGroupedAscentsFeedQueryResponse,
 } from '@/app/lib/graphql/operations';
 import AscentThumbnail from './ascent-thumbnail';
+import AscentActionsMenu from '@/app/components/ascent-actions/ascent-actions-menu';
+import type { EditAscentValues } from '@/app/components/ascent-actions/edit-ascent-dialog';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import {
+  UPDATE_TICK,
+  DELETE_TICK,
+  type UpdateTickMutationVariables,
+  type UpdateTickMutationResponse,
+  type DeleteTickMutationVariables,
+  type DeleteTickMutationResponse,
+} from '@/app/lib/graphql/operations';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
@@ -34,6 +50,7 @@ dayjs.extend(relativeTime);
 interface AscentsFeedProps {
   userId: string;
   pageSize?: number;
+  editable?: boolean;
 }
 
 // Layout name mapping
@@ -86,7 +103,70 @@ const getGroupStatusSummary = (group: GroupedAscentFeedItem): { text: string; ic
   return { text: parts.join(', '), icon, color };
 };
 
-const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) => {
+function getStatusChipColor(status: string): 'success' | 'primary' | 'default' {
+  if (status === 'flash') return 'success';
+  if (status === 'send') return 'primary';
+  return 'default';
+}
+
+const AscentItemRow: React.FC<{
+  item: AscentFeedItem;
+  editable: boolean;
+  onUpdate: (uuid: string, values: EditAscentValues) => void;
+  onDelete: (uuid: string) => void;
+  mutatingUuid: string | null;
+}> = ({ item, editable, onUpdate, onDelete, mutatingUuid }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1,
+      py: 0.5,
+      borderTop: `1px solid ${themeTokens.neutral[100]}`,
+    }}
+  >
+    <Chip
+      label={item.status}
+      size="small"
+      color={getStatusChipColor(item.status)}
+      variant={item.status === 'attempt' ? 'outlined' : 'filled'}
+      sx={{ height: 20, '& .MuiChip-label': { px: 0.75, fontSize: themeTokens.typography.fontSize.xs - 1 } }}
+    />
+    <MuiTypography variant="caption" color="text.secondary">
+      {item.attemptCount} attempt{item.attemptCount !== 1 ? 's' : ''}
+    </MuiTypography>
+    {item.quality != null && item.quality > 0 && (
+      <Rating readOnly value={item.quality} max={5} size="small" sx={{ fontSize: 14 }} />
+    )}
+    <MuiTypography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+      {dayjs(item.climbedAt).format('MMM D, h:mm A')}
+    </MuiTypography>
+    {editable && (
+      <AscentActionsMenu
+        ascent={{
+          uuid: item.uuid,
+          status: item.status,
+          attemptCount: item.attemptCount,
+          quality: item.quality,
+          comment: item.comment,
+        }}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        updating={mutatingUuid === item.uuid}
+        deleting={mutatingUuid === item.uuid}
+      />
+    )}
+  </Box>
+);
+
+const GroupedFeedItem: React.FC<{
+  group: GroupedAscentFeedItem;
+  editable: boolean;
+  onUpdate: (uuid: string, values: EditAscentValues) => void;
+  onDelete: (uuid: string) => void;
+  mutatingUuid: string | null;
+}> = ({ group, editable, onUpdate, onDelete, mutatingUuid }) => {
+  const [expanded, setExpanded] = useState(false);
   const latestItem = group.items.reduce((latest, item) =>
     new Date(item.climbedAt) > new Date(latest.climbedAt) ? item : latest
   );
@@ -94,6 +174,7 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
   const boardDisplay = getLayoutDisplayName(group.boardType, group.layoutId);
   const statusSummary = getGroupStatusSummary(group);
   const hasSuccess = group.flashCount > 0 || group.sendCount > 0;
+  const hasMultipleItems = group.items.length > 1;
 
   return (
     <MuiCard className={styles.feedItem}>
@@ -126,9 +207,38 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
                 {group.climbName}
               </MuiTypography>
             </Box>
-            <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.timeAgo}>
-              {timeAgo}
-            </MuiTypography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.timeAgo}>
+                {timeAgo}
+              </MuiTypography>
+              {editable && !hasMultipleItems && group.items[0] && (
+                <AscentActionsMenu
+                  ascent={{
+                    uuid: group.items[0].uuid,
+                    status: group.items[0].status,
+                    attemptCount: group.items[0].attemptCount,
+                    quality: group.items[0].quality,
+                    comment: group.items[0].comment,
+                  }}
+                  onUpdate={onUpdate}
+                  onDelete={onDelete}
+                  updating={mutatingUuid === group.items[0].uuid}
+                  deleting={mutatingUuid === group.items[0].uuid}
+                />
+              )}
+              {(editable && hasMultipleItems) && (
+                <IconButton
+                  size="small"
+                  onClick={() => setExpanded((prev) => !prev)}
+                  sx={{
+                    transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                    transition: 'transform 0.2s',
+                  }}
+                >
+                  <ExpandMoreOutlined fontSize="small" />
+                </IconButton>
+              )}
+            </Box>
           </Box>
 
           <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
@@ -156,6 +266,24 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
           {group.latestComment && (
             <MuiTypography variant="body2" component="span" className={styles.comment}>{group.latestComment}</MuiTypography>
           )}
+
+          {/* Expandable individual items for edit/delete */}
+          {editable && hasMultipleItems && (
+            <Collapse in={expanded} unmountOnExit>
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                {group.items.map((item) => (
+                  <AscentItemRow
+                    key={item.uuid}
+                    item={item}
+                    editable
+                    onUpdate={onUpdate}
+                    onDelete={onDelete}
+                    mutatingUuid={mutatingUuid}
+                  />
+                ))}
+              </Box>
+            </Collapse>
+          )}
         </Box>
       </Box>
       </CardContent>
@@ -163,7 +291,12 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
   );
 };
 
-export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 }) => {
+export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10, editable = false }) => {
+  const { token } = useWsAuthToken();
+  const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
+  const [mutatingUuid, setMutatingUuid] = useState<string | null>(null);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useInfiniteQuery({
     queryKey: ['ascentsFeed', userId, pageSize],
     queryFn: async ({ pageParam }) => {
@@ -197,6 +330,50 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 
     isFetching: isFetchingNextPage,
   });
 
+  const handleUpdate = useCallback(async (uuid: string, values: EditAscentValues) => {
+    if (!token) return;
+    setMutatingUuid(uuid);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const variables: UpdateTickMutationVariables = {
+        input: {
+          uuid,
+          status: values.status,
+          attemptCount: values.attemptCount,
+          quality: values.quality,
+          comment: values.comment,
+        },
+      };
+      await client.request<UpdateTickMutationResponse>(UPDATE_TICK, variables);
+      showMessage('Ascent updated', 'success');
+      queryClient.invalidateQueries({ queryKey: ['ascentsFeed', userId] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update ascent';
+      showMessage(message, 'error');
+    } finally {
+      setMutatingUuid(null);
+    }
+  }, [token, userId, queryClient, showMessage]);
+
+  const handleDelete = useCallback(async (uuid: string) => {
+    if (!token) return;
+    setMutatingUuid(uuid);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const variables: DeleteTickMutationVariables = {
+        input: { uuid },
+      };
+      await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
+      showMessage('Ascent deleted', 'success');
+      queryClient.invalidateQueries({ queryKey: ['ascentsFeed', userId] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete ascent';
+      showMessage(message, 'error');
+    } finally {
+      setMutatingUuid(null);
+    }
+  }, [token, userId, queryClient, showMessage]);
+
   if (isLoading) {
     return (
       <div className={styles.loading}>
@@ -225,7 +402,14 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 
     <div className={styles.feed}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
         {groups.map((group) => (
-          <GroupedFeedItem key={group.key} group={group} />
+          <GroupedFeedItem
+            key={group.key}
+            group={group}
+            editable={editable}
+            onUpdate={handleUpdate}
+            onDelete={handleDelete}
+            mutatingUuid={mutatingUuid}
+          />
         ))}
       </Box>
 

--- a/packages/web/app/components/ascent-actions/__tests__/ascent-actions-menu.test.tsx
+++ b/packages/web/app/components/ascent-actions/__tests__/ascent-actions-menu.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import AscentActionsMenu, { type AscentData } from '../ascent-actions-menu';
+import type { EditAscentValues } from '../edit-ascent-dialog';
+
+// --- Mocks ---
+
+vi.mock('../edit-ascent-dialog', () => ({
+  default: ({
+    open,
+    onClose,
+    onSave,
+    initialValues,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSave: (values: EditAscentValues) => void;
+    saving?: boolean;
+    initialValues: EditAscentValues;
+  }) =>
+    open ? (
+      <div data-testid="edit-ascent-dialog">
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={() => onSave(initialValues)}>Save</button>
+      </div>
+    ) : null,
+}));
+
+// --- Test data ---
+
+const defaultAscent: AscentData = {
+  uuid: 'ascent-uuid-1',
+  status: 'send',
+  attemptCount: 3,
+  quality: 4,
+  comment: 'Great route',
+};
+
+// --- Helpers ---
+
+function renderMenu(props: Partial<React.ComponentProps<typeof AscentActionsMenu>> = {}) {
+  const onUpdate = vi.fn();
+  const onDelete = vi.fn();
+
+  const utils = render(
+    <AscentActionsMenu
+      ascent={defaultAscent}
+      onUpdate={onUpdate}
+      onDelete={onDelete}
+      {...props}
+    />,
+  );
+
+  return { onUpdate, onDelete, ...utils };
+}
+
+function openMenu() {
+  const button = screen.getByRole('button', { name: /ascent actions/i });
+  fireEvent.click(button);
+}
+
+// --- Tests ---
+
+describe('AscentActionsMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the actions button with correct aria-label', () => {
+    renderMenu();
+    expect(screen.getByRole('button', { name: /ascent actions/i })).toBeTruthy();
+  });
+
+  it('opens menu with Edit and Delete options when clicked', () => {
+    renderMenu();
+    openMenu();
+
+    expect(screen.getByRole('menuitem', { name: /edit/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /delete/i })).toBeTruthy();
+  });
+
+  it('opens edit dialog when Edit is clicked', () => {
+    renderMenu();
+    openMenu();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /edit/i }));
+
+    expect(screen.getByTestId('edit-ascent-dialog')).toBeTruthy();
+  });
+
+  it('shows confirm popover when Delete is clicked', () => {
+    renderMenu();
+    openMenu();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+
+    // ConfirmPopover renders a Popover with title and description
+    expect(screen.getByText("Delete this ascent?")).toBeTruthy();
+    expect(screen.getByText("This can't be undone.")).toBeTruthy();
+  });
+
+  it('calls onDelete with correct uuid after confirming delete', () => {
+    const { onDelete } = renderMenu();
+    openMenu();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+
+    // Click the confirm (Delete) button inside the popover
+    const deleteButton = screen.getByRole('button', { name: /^delete$/i });
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith('ascent-uuid-1');
+  });
+
+  it('disables actions button when updating=true', () => {
+    renderMenu({ updating: true });
+
+    const button = screen.getByRole('button', { name: /ascent actions/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('disables actions button when deleting=true', () => {
+    renderMenu({ deleting: true });
+
+    const button = screen.getByRole('button', { name: /ascent actions/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/packages/web/app/components/ascent-actions/__tests__/edit-ascent-dialog.test.tsx
+++ b/packages/web/app/components/ascent-actions/__tests__/edit-ascent-dialog.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import EditAscentDialog, { type EditAscentValues } from '../edit-ascent-dialog';
+
+const defaultValues: EditAscentValues = {
+  status: 'send',
+  attemptCount: 3,
+  quality: 4,
+  comment: 'Great route',
+};
+
+function renderDialog(
+  props?: Partial<React.ComponentProps<typeof EditAscentDialog>>,
+) {
+  const onClose = vi.fn();
+  const onSave = vi.fn();
+
+  const utils = render(
+    <EditAscentDialog
+      open={true}
+      onClose={onClose}
+      onSave={onSave}
+      initialValues={defaultValues}
+      {...props}
+    />,
+  );
+
+  return { onClose, onSave, ...utils };
+}
+
+describe('EditAscentDialog', () => {
+  it('renders dialog title "Edit ascent" when open', () => {
+    renderDialog();
+    expect(screen.getByText('Edit ascent')).toBeTruthy();
+  });
+
+  it('renders all three toggle buttons (Flash, Send, Attempt)', () => {
+    renderDialog();
+    expect(screen.getByRole('button', { name: /flash/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /send/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /attempt/i })).toBeTruthy();
+  });
+
+  it('shows attempts field when status is "send" but not for "flash"', () => {
+    const { rerender } = render(
+      <EditAscentDialog
+        open={true}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        initialValues={{ ...defaultValues, status: 'send' }}
+      />,
+    );
+
+    // Attempts field is visible for "send"
+    expect(screen.getByLabelText(/attempts/i)).toBeTruthy();
+
+    // Re-render with flash — attempts field should not appear
+    rerender(
+      <EditAscentDialog
+        open={true}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        initialValues={{ ...defaultValues, status: 'flash' }}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/attempts/i)).toBeNull();
+  });
+
+  it('hides quality rating when status is "attempt"', () => {
+    renderDialog({ initialValues: { ...defaultValues, status: 'attempt', quality: null } });
+    expect(screen.queryByText('Quality')).toBeNull();
+  });
+
+  it('shows quality rating when status is "send" or "flash"', () => {
+    renderDialog({ initialValues: { ...defaultValues, status: 'send' } });
+    expect(screen.getByText('Quality')).toBeTruthy();
+  });
+
+  it('calls onSave with correct values when Save is clicked', () => {
+    const { onSave } = renderDialog({
+      initialValues: {
+        status: 'send',
+        attemptCount: 5,
+        quality: 3,
+        comment: 'Solid climb',
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onSave).toHaveBeenCalledWith({
+      status: 'send',
+      attemptCount: 5,
+      quality: 3,
+      comment: 'Solid climb',
+    });
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    const { onClose } = renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('disables Save and Cancel buttons when saving=true', () => {
+    renderDialog({ saving: true });
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    expect((cancelButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('resets form values when re-opened with new initialValues', () => {
+    const { rerender } = render(
+      <EditAscentDialog
+        open={false}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        initialValues={{ status: 'send', attemptCount: 3, quality: 4, comment: 'Old comment' }}
+      />,
+    );
+
+    // Re-open with new initialValues
+    rerender(
+      <EditAscentDialog
+        open={true}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        initialValues={{ status: 'flash', attemptCount: 1, quality: 5, comment: 'New comment' }}
+      />,
+    );
+
+    // Attempts field should be hidden (flash hides it)
+    expect(screen.queryByLabelText(/attempts/i)).toBeNull();
+
+    // Comment field should show the new value
+    const commentField = screen.getByLabelText(/comment/i) as HTMLTextAreaElement;
+    expect(commentField.value).toBe('New comment');
+  });
+});

--- a/packages/web/app/components/ascent-actions/ascent-actions-menu.tsx
+++ b/packages/web/app/components/ascent-actions/ascent-actions-menu.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined';
+import EditOutlined from '@mui/icons-material/EditOutlined';
+import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
+import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
+import EditAscentDialog, { type EditAscentValues } from './edit-ascent-dialog';
+import type { TickStatus } from '@/app/hooks/use-logbook';
+
+export interface AscentData {
+  uuid: string;
+  status: TickStatus;
+  attemptCount: number;
+  quality: number | null;
+  comment: string;
+}
+
+interface AscentActionsMenuProps {
+  ascent: AscentData;
+  onUpdate: (uuid: string, values: EditAscentValues) => void;
+  onDelete: (uuid: string) => void;
+  updating?: boolean;
+  deleting?: boolean;
+}
+
+export default function AscentActionsMenu({
+  ascent,
+  onUpdate,
+  onDelete,
+  updating = false,
+  deleting = false,
+}: AscentActionsMenuProps) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+
+  const handleMenuOpen = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+  }, []);
+
+  const handleMenuClose = useCallback(() => {
+    setMenuAnchor(null);
+  }, []);
+
+  const handleEditClick = useCallback(() => {
+    handleMenuClose();
+    setEditOpen(true);
+  }, [handleMenuClose]);
+
+  const handleEditSave = useCallback((values: EditAscentValues) => {
+    onUpdate(ascent.uuid, values);
+    setEditOpen(false);
+  }, [onUpdate, ascent.uuid]);
+
+  const handleDelete = useCallback(() => {
+    handleMenuClose();
+    onDelete(ascent.uuid);
+  }, [handleMenuClose, onDelete, ascent.uuid]);
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={handleMenuOpen}
+        disabled={updating || deleting}
+        aria-label="Ascent actions"
+      >
+        <MoreVertOutlined fontSize="small" />
+      </IconButton>
+
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={handleMenuClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <MenuItem onClick={handleEditClick}>
+          <ListItemIcon>
+            <EditOutlined fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <ConfirmPopover
+          title="Delete this ascent?"
+          description="This can't be undone."
+          onConfirm={handleDelete}
+          okText="Delete"
+          okButtonProps={{ color: 'error' }}
+        >
+          <MenuItem sx={{ color: 'error.main' }}>
+            <ListItemIcon>
+              <DeleteOutlined fontSize="small" color="error" />
+            </ListItemIcon>
+            <ListItemText>Delete</ListItemText>
+          </MenuItem>
+        </ConfirmPopover>
+      </Menu>
+
+      {editOpen && (
+        <EditAscentDialog
+          open
+          onClose={() => setEditOpen(false)}
+          onSave={handleEditSave}
+          saving={updating}
+          initialValues={{
+            status: ascent.status ?? 'attempt',
+            attemptCount: ascent.attemptCount,
+            quality: ascent.quality,
+            comment: ascent.comment,
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/app/components/ascent-actions/edit-ascent-dialog.tsx
+++ b/packages/web/app/components/ascent-actions/edit-ascent-dialog.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import Rating from '@mui/material/Rating';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import CircularProgress from '@mui/material/CircularProgress';
+import type { TickStatus } from '@/app/hooks/use-logbook';
+
+export interface EditAscentValues {
+  status: TickStatus;
+  attemptCount: number;
+  quality: number | null;
+  comment: string;
+}
+
+interface EditAscentDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (values: EditAscentValues) => void;
+  saving?: boolean;
+  initialValues: EditAscentValues;
+}
+
+export default function EditAscentDialog({
+  open,
+  onClose,
+  onSave,
+  saving = false,
+  initialValues,
+}: EditAscentDialogProps) {
+  const [status, setStatus] = useState<TickStatus>(initialValues.status);
+  const [attemptCount, setAttemptCount] = useState(initialValues.attemptCount);
+  const [quality, setQuality] = useState<number | null>(initialValues.quality);
+  const [comment, setComment] = useState(initialValues.comment);
+
+  // Reset form when dialog opens with new values
+  useEffect(() => {
+    if (open) {
+      setStatus(initialValues.status);
+      setAttemptCount(initialValues.attemptCount);
+      setQuality(initialValues.quality);
+      setComment(initialValues.comment);
+    }
+    // Destructure to avoid re-firing when parent creates a new object with same values
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialValues.status, initialValues.attemptCount, initialValues.quality, initialValues.comment]);
+
+  const handleStatusChange = useCallback((_: React.MouseEvent<HTMLElement>, newStatus: TickStatus | null) => {
+    if (!newStatus) return;
+    setStatus(newStatus);
+    // Auto-adjust attempt count for flash
+    if (newStatus === 'flash') {
+      setAttemptCount(1);
+    } else if (newStatus === 'send' && attemptCount <= 1) {
+      setAttemptCount(2);
+    }
+    // Clear quality for attempts
+    if (newStatus === 'attempt') {
+      setQuality(null);
+    }
+  }, [attemptCount]);
+
+  const handleSave = useCallback(() => {
+    onSave({ status, attemptCount, quality, comment });
+  }, [onSave, status, attemptCount, quality, comment]);
+
+  const isAscent = status === 'flash' || status === 'send';
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Edit ascent</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          <div>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Result
+            </Typography>
+            <ToggleButtonGroup
+              value={status}
+              exclusive
+              onChange={handleStatusChange}
+              size="small"
+              fullWidth
+            >
+              <ToggleButton value="flash">Flash</ToggleButton>
+              <ToggleButton value="send">Send</ToggleButton>
+              <ToggleButton value="attempt">Attempt</ToggleButton>
+            </ToggleButtonGroup>
+          </div>
+
+          {status !== 'flash' && (
+            <TextField
+              label="Attempts"
+              type="number"
+              size="small"
+              fullWidth
+              value={attemptCount}
+              onChange={(e) => setAttemptCount(Math.max(status === 'send' ? 2 : 1, Number(e.target.value)))}
+              slotProps={{ htmlInput: { min: status === 'send' ? 2 : 1, max: 999 } }}
+            />
+          )}
+
+          {isAscent && (
+            <div>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                Quality
+              </Typography>
+              <Rating
+                value={quality}
+                onChange={(_, newValue) => setQuality(newValue)}
+                max={5}
+              />
+            </div>
+          )}
+
+          <TextField
+            label="Comment"
+            size="small"
+            fullWidth
+            multiline
+            minRows={2}
+            maxRows={4}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            slotProps={{ htmlInput: { maxLength: 2000 } }}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={saving}
+          startIcon={saving ? <CircularProgress size={16} /> : undefined}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/ascent-actions/use-ascent-actions.ts
+++ b/packages/web/app/components/ascent-actions/use-ascent-actions.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useUpdateTick } from '@/app/hooks/use-update-tick';
+import { useDeleteTick } from '@/app/hooks/use-delete-tick';
+import type { EditAscentValues } from './edit-ascent-dialog';
+import type { BoardName } from '@/app/lib/types';
+
+/**
+ * Hook providing update and delete actions for ascents.
+ * Wraps useUpdateTick and useDeleteTick with a simple interface
+ * compatible with AscentActionsMenu callbacks.
+ */
+export function useAscentActions(boardName: BoardName) {
+  const updateMutation = useUpdateTick(boardName);
+  const deleteMutation = useDeleteTick(boardName);
+
+  // Depend on .mutate (stable function ref) not the whole mutation object
+  const { mutate: updateMutate } = updateMutation;
+  const { mutate: deleteMutate } = deleteMutation;
+
+  const handleUpdate = useCallback(
+    (uuid: string, values: EditAscentValues) => {
+      updateMutate({
+        uuid,
+        status: values.status,
+        attemptCount: values.attemptCount,
+        quality: values.quality,
+        comment: values.comment,
+      });
+    },
+    [updateMutate],
+  );
+
+  const handleDelete = useCallback(
+    (uuid: string) => {
+      deleteMutate({ uuid });
+    },
+    [deleteMutate],
+  );
+
+  return {
+    handleUpdate,
+    handleDelete,
+    isUpdating: updateMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+  };
+}

--- a/packages/web/app/components/ascent-actions/use-ascent-actions.ts
+++ b/packages/web/app/components/ascent-actions/use-ascent-actions.ts
@@ -1,48 +1,67 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useUpdateTick } from '@/app/hooks/use-update-tick';
 import { useDeleteTick } from '@/app/hooks/use-delete-tick';
 import type { EditAscentValues } from './edit-ascent-dialog';
 import type { BoardName } from '@/app/lib/types';
 
+interface UseAscentActionsOptions {
+  /** Called after a successful update or delete (e.g., to invalidate queries). */
+  onSettled?: () => void;
+}
+
 /**
  * Hook providing update and delete actions for ascents.
  * Wraps useUpdateTick and useDeleteTick with a simple interface
  * compatible with AscentActionsMenu callbacks.
+ *
+ * Tracks the UUID of the currently mutating item so consumers
+ * can show per-item loading state.
  */
-export function useAscentActions(boardName: BoardName) {
+export function useAscentActions(boardName: BoardName, options?: UseAscentActionsOptions) {
   const updateMutation = useUpdateTick(boardName);
   const deleteMutation = useDeleteTick(boardName);
+  const [mutatingUuid, setMutatingUuid] = useState<string | null>(null);
 
-  // Depend on .mutate (stable function ref) not the whole mutation object
-  const { mutate: updateMutate } = updateMutation;
-  const { mutate: deleteMutate } = deleteMutation;
+  const { mutateAsync: updateAsync } = updateMutation;
+  const { mutateAsync: deleteAsync } = deleteMutation;
 
   const handleUpdate = useCallback(
-    (uuid: string, values: EditAscentValues) => {
-      updateMutate({
-        uuid,
-        status: values.status,
-        attemptCount: values.attemptCount,
-        quality: values.quality,
-        comment: values.comment,
-      });
+    async (uuid: string, values: EditAscentValues) => {
+      setMutatingUuid(uuid);
+      try {
+        await updateAsync({
+          uuid,
+          status: values.status,
+          attemptCount: values.attemptCount,
+          quality: values.quality,
+          comment: values.comment,
+        });
+        options?.onSettled?.();
+      } finally {
+        setMutatingUuid(null);
+      }
     },
-    [updateMutate],
+    [updateAsync, options?.onSettled],
   );
 
   const handleDelete = useCallback(
-    (uuid: string) => {
-      deleteMutate({ uuid });
+    async (uuid: string) => {
+      setMutatingUuid(uuid);
+      try {
+        await deleteAsync({ uuid });
+        options?.onSettled?.();
+      } finally {
+        setMutatingUuid(null);
+      }
     },
-    [deleteMutate],
+    [deleteAsync, options?.onSettled],
   );
 
   return {
     handleUpdate,
     handleDelete,
-    isUpdating: updateMutation.isPending,
-    isDeleting: deleteMutation.isPending,
+    mutatingUuid,
   };
 }

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -13,6 +13,8 @@ import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import { Climb } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
+import { useAscentActions } from '@/app/components/ascent-actions/use-ascent-actions';
+import AscentActionsMenu from '@/app/components/ascent-actions/ascent-actions-menu';
 import { themeTokens } from '@/app/theme/theme-config';
 import dayjs from 'dayjs';
 
@@ -21,16 +23,16 @@ interface LogbookViewProps {
 }
 
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
-  const { logbook, boardName } = useBoardProvider();
+  const { logbook, boardName, isAuthenticated } = useBoardProvider();
+  const { handleUpdate, handleDelete, isUpdating, isDeleting } = useAscentActions(boardName);
 
   // Filter ascents for current climb and sort by climbed_at
   const climbAscents = logbook
     .filter((ascent) => ascent.climb_uuid === currentClimb.uuid)
     .sort((a, b) => {
-      // Parse dates using dayjs and compare them
       const dateA = dayjs(a.climbed_at);
       const dateB = dayjs(b.climbed_at);
-      return dateB.valueOf() - dateA.valueOf(); // Descending order (newest first)
+      return dateB.valueOf() - dateA.valueOf();
     });
 
   const showMirrorTag = boardName === 'tension';
@@ -45,8 +47,10 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
         <Card key={`${ascent.climb_uuid}-${ascent.climbed_at}`} sx={{ width: '100%' }}>
           <CardContent sx={{ p: 1.5 }}>
             <Stack spacing={1} style={{ width: '100%' }}>
-              <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-                <Typography variant="body2" component="span" fontWeight={600}>{dayjs(ascent.climbed_at).format('MMM D, YYYY h:mm A')}</Typography>
+              <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
+                <Typography variant="body2" component="span" fontWeight={600} sx={{ flex: 1 }}>
+                  {dayjs(ascent.climbed_at).format('MMM D, YYYY h:mm A')}
+                </Typography>
                 {ascent.angle !== currentClimb.angle && (
                   <>
                     <Chip label={ascent.angle} size="small" color="primary" />
@@ -58,13 +62,26 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
                   </>
                 )}
                 {showMirrorTag && ascent.is_mirror && <Chip label="Mirrored" size="small" color="secondary" />}
+                {isAuthenticated && ascent.status && (
+                  <AscentActionsMenu
+                    ascent={{
+                      uuid: ascent.uuid,
+                      status: ascent.status,
+                      attemptCount: ascent.tries,
+                      quality: ascent.quality,
+                      comment: ascent.comment,
+                    }}
+                    onUpdate={handleUpdate}
+                    onDelete={handleDelete}
+                    updating={isUpdating}
+                    deleting={isDeleting}
+                  />
+                )}
               </Stack>
               {ascent.is_ascent && ascent.quality && (
-                <>
-                  <Stack direction="row" spacing={1}>
-                    <Rating readOnly value={ascent.quality} max={5} size="small" />
-                  </Stack>
-                </>
+                <Stack direction="row" spacing={1}>
+                  <Rating readOnly value={ascent.quality} max={5} size="small" />
+                </Stack>
               )}
               <Stack direction="row" spacing={1}>
                 <Typography variant="body2" component="span">Attempts: {ascent.tries}</Typography>

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -24,7 +24,7 @@ interface LogbookViewProps {
 
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const { logbook, boardName, isAuthenticated } = useBoardProvider();
-  const { handleUpdate, handleDelete, isUpdating, isDeleting } = useAscentActions(boardName);
+  const { handleUpdate, handleDelete, mutatingUuid } = useAscentActions(boardName);
 
   // Filter ascents for current climb and sort by climbed_at
   const climbAscents = logbook
@@ -73,8 +73,8 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
                     }}
                     onUpdate={handleUpdate}
                     onDelete={handleDelete}
-                    updating={isUpdating}
-                    deleting={isDeleting}
+                    updating={mutatingUuid === ascent.uuid}
+                    deleting={mutatingUuid === ascent.uuid}
                   />
                 )}
               </Stack>

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -149,7 +149,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
               <Typography variant="body2" component="span" color="text.secondary" className={styles.chartDescription}>
                 Latest ascents and attempts
               </Typography>
-              <AscentsFeed userId={userId} pageSize={10} />
+              <AscentsFeed userId={userId} pageSize={10} editable={isOwnProfile} />
             </CardContent>
           </MuiCard>
         )}

--- a/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  DELETE_TICK: 'DELETE_TICK_MUTATION',
+}));
+
+import { useWsAuthToken } from '../use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useDeleteTick, type DeleteTickOptions } from '../use-delete-tick';
+import type { LogbookEntry } from '../use-logbook';
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+const mockUseSession = vi.mocked(useSession);
+
+function createTestWrapper() {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+function createDeleteOptions(overrides: Partial<DeleteTickOptions> = {}): DeleteTickOptions {
+  return {
+    uuid: 'tick-uuid-1',
+    ...overrides,
+  };
+}
+
+function createLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
+  return {
+    uuid: 'tick-uuid-1',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    is_mirror: false,
+    status: 'send',
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    is_ascent: true,
+    climbed_at: '2024-01-01',
+    ...overrides,
+  };
+}
+
+describe('useDeleteTick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockReset();
+    mockShowMessage.mockReset();
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'test-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    mockUseSession.mockReturnValue({
+      status: 'authenticated',
+      data: { user: { id: '1' }, expires: '' },
+      update: vi.fn(),
+    });
+  });
+
+  it('throws when not authenticated', async () => {
+    mockUseSession.mockReturnValue({
+      status: 'unauthenticated',
+      data: null,
+      update: vi.fn(),
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Not authenticated');
+  });
+
+  it('throws when no token', async () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Auth token not available');
+  });
+
+  it('calls GraphQL mutation with correct variables', async () => {
+    mockRequest.mockResolvedValue({
+      deleteTick: { uuid: 'tick-uuid-1' },
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith('DELETE_TICK_MUTATION', {
+      input: { uuid: 'tick-uuid-1' },
+    });
+  });
+
+  it('optimistically removes entry from cache', async () => {
+    let resolveRequest: (value: unknown) => void;
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const entry = createLogbookEntry({ uuid: 'tick-uuid-1' });
+    queryClient.setQueryData(['logbook', 'kilter'], [entry]);
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    act(() => {
+      result.current.mutate(createDeleteOptions({ uuid: 'tick-uuid-1' }));
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+      expect(data?.length).toBe(0);
+    });
+
+    await act(async () => {
+      resolveRequest!({ deleteTick: { uuid: 'tick-uuid-1' } });
+    });
+  });
+
+  it('rolls back (restores entry) on error', async () => {
+    mockRequest.mockRejectedValue(new Error('Server error'));
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const entry = createLogbookEntry({ uuid: 'tick-uuid-1' });
+    queryClient.setQueryData(['logbook', 'kilter'], [entry]);
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions({ uuid: 'tick-uuid-1' }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+    expect(data?.length).toBe(1);
+    expect(data?.[0].uuid).toBe('tick-uuid-1');
+  });
+
+  it('shows success snackbar on success', async () => {
+    mockRequest.mockResolvedValue({
+      deleteTick: { uuid: 'tick-uuid-1' },
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Ascent deleted', 'success');
+  });
+
+  it('shows error snackbar on failure', async () => {
+    mockRequest.mockRejectedValue(new Error('Delete failed'));
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Delete failed', 'error');
+  });
+
+  it('extracts GraphQL error message from response', async () => {
+    const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
+    graphqlError.response = {
+      errors: [{ message: 'Tick not found' }],
+    };
+    mockRequest.mockRejectedValue(graphqlError);
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createDeleteOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Tick not found', 'error');
+  });
+
+  it('does not affect other entries in cache when deleting one', async () => {
+    let resolveRequest: (value: unknown) => void;
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const entryToDelete = createLogbookEntry({ uuid: 'tick-uuid-1', climb_uuid: 'climb-1' });
+    const otherEntry = createLogbookEntry({ uuid: 'tick-uuid-2', climb_uuid: 'climb-2' });
+    queryClient.setQueryData(['logbook', 'kilter'], [entryToDelete, otherEntry]);
+
+    const { result } = renderHook(() => useDeleteTick('kilter'), { wrapper });
+
+    act(() => {
+      result.current.mutate(createDeleteOptions({ uuid: 'tick-uuid-1' }));
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+      expect(data?.length).toBe(1);
+      expect(data?.[0].uuid).toBe('tick-uuid-2');
+    });
+
+    await act(async () => {
+      resolveRequest!({ deleteTick: { uuid: 'tick-uuid-1' } });
+    });
+  });
+});

--- a/packages/web/app/hooks/__tests__/use-update-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-update-tick.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  UPDATE_TICK: 'UPDATE_TICK_MUTATION',
+}));
+
+import { useWsAuthToken } from '../use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useUpdateTick, type UpdateTickOptions } from '../use-update-tick';
+import type { LogbookEntry } from '../use-logbook';
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+const mockUseSession = vi.mocked(useSession);
+
+function createTestWrapper() {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+function createUpdateOptions(overrides: Partial<UpdateTickOptions> = {}): UpdateTickOptions {
+  return {
+    uuid: 'tick-uuid-1',
+    status: 'send',
+    attemptCount: 3,
+    quality: 2,
+    comment: 'Solid climb',
+    ...overrides,
+  };
+}
+
+function createLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
+  return {
+    uuid: 'tick-uuid-1',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    is_mirror: false,
+    status: 'attempt',
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    is_ascent: false,
+    climbed_at: '2024-01-01',
+    ...overrides,
+  };
+}
+
+describe('useUpdateTick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockReset();
+    mockShowMessage.mockReset();
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'test-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    mockUseSession.mockReturnValue({
+      status: 'authenticated',
+      data: { user: { id: '1' }, expires: '' },
+      update: vi.fn(),
+    });
+  });
+
+  it('throws when not authenticated', async () => {
+    mockUseSession.mockReturnValue({
+      status: 'unauthenticated',
+      data: null,
+      update: vi.fn(),
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Not authenticated');
+  });
+
+  it('throws when no token', async () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Auth token not available');
+  });
+
+  it('calls GraphQL mutation with correct variables', async () => {
+    mockRequest.mockResolvedValue({
+      updateTick: {
+        uuid: 'tick-uuid-1',
+        status: 'send',
+        attemptCount: 3,
+        quality: 2,
+        comment: 'Solid climb',
+        updatedAt: '2024-01-01T12:00:00Z',
+      },
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith('UPDATE_TICK_MUTATION', {
+      input: {
+        uuid: 'tick-uuid-1',
+        status: 'send',
+        attemptCount: 3,
+        quality: 2,
+        comment: 'Solid climb',
+      },
+    });
+  });
+
+  it('optimistically updates existing entry in cache', async () => {
+    let resolveRequest: (value: unknown) => void;
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const existing = createLogbookEntry({ uuid: 'tick-uuid-1', status: 'attempt', tries: 1, is_ascent: false });
+    queryClient.setQueryData(['logbook', 'kilter'], [existing]);
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    act(() => {
+      result.current.mutate(createUpdateOptions({ status: 'send', attemptCount: 3 }));
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+      expect(data?.[0].status).toBe('send');
+      expect(data?.[0].tries).toBe(3);
+      expect(data?.[0].is_ascent).toBe(true);
+    });
+
+    await act(async () => {
+      resolveRequest!({
+        updateTick: {
+          uuid: 'tick-uuid-1',
+          status: 'send',
+          attemptCount: 3,
+          quality: 2,
+          comment: 'Solid climb',
+          updatedAt: '2024-01-01T12:00:00Z',
+        },
+      });
+    });
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    mockRequest.mockRejectedValue(new Error('Server error'));
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const existing = createLogbookEntry({ uuid: 'tick-uuid-1', status: 'attempt', tries: 1, is_ascent: false });
+    queryClient.setQueryData(['logbook', 'kilter'], [existing]);
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions({ status: 'send', attemptCount: 3 }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+    expect(data?.[0].status).toBe('attempt');
+    expect(data?.[0].tries).toBe(1);
+    expect(data?.[0].is_ascent).toBe(false);
+  });
+
+  it('shows success snackbar on success', async () => {
+    mockRequest.mockResolvedValue({
+      updateTick: {
+        uuid: 'tick-uuid-1',
+        status: 'send',
+        attemptCount: 3,
+        quality: 2,
+        comment: 'Solid climb',
+        updatedAt: '2024-01-01T12:00:00Z',
+      },
+    });
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Ascent updated', 'success');
+  });
+
+  it('shows error snackbar on failure', async () => {
+    mockRequest.mockRejectedValue(new Error('Update failed'));
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Update failed', 'error');
+  });
+
+  it('extracts GraphQL error message from response', async () => {
+    const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
+    graphqlError.response = {
+      errors: [{ message: 'Tick not found' }],
+    };
+    mockRequest.mockRejectedValue(graphqlError);
+
+    const { wrapper } = createTestWrapper();
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(createUpdateOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Tick not found', 'error');
+  });
+
+  it('correctly updates is_ascent when changing status to attempt', async () => {
+    let resolveRequest: (value: unknown) => void;
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const existing = createLogbookEntry({ uuid: 'tick-uuid-1', status: 'send', tries: 2, is_ascent: true });
+    queryClient.setQueryData(['logbook', 'kilter'], [existing]);
+
+    const { result } = renderHook(() => useUpdateTick('kilter'), { wrapper });
+
+    act(() => {
+      result.current.mutate(createUpdateOptions({ status: 'attempt' }));
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData(['logbook', 'kilter']) as LogbookEntry[];
+      expect(data?.[0].status).toBe('attempt');
+      expect(data?.[0].is_ascent).toBe(false);
+    });
+
+    await act(async () => {
+      resolveRequest!({
+        updateTick: {
+          uuid: 'tick-uuid-1',
+          status: 'attempt',
+          attemptCount: 3,
+          quality: null,
+          comment: '',
+          updatedAt: '2024-01-01T12:00:00Z',
+        },
+      });
+    });
+  });
+});

--- a/packages/web/app/hooks/use-delete-tick.ts
+++ b/packages/web/app/hooks/use-delete-tick.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useWsAuthToken } from './use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  DELETE_TICK,
+  type DeleteTickMutationVariables,
+  type DeleteTickMutationResponse,
+} from '@/app/lib/graphql/operations';
+import type { BoardName } from '@/app/lib/types';
+import type { LogbookEntry } from './use-logbook';
+
+export interface DeleteTickOptions {
+  uuid: string;
+}
+
+/**
+ * Hook to delete a tick via GraphQL mutation.
+ * Provides optimistic updates to the logbook cache.
+ */
+export function useDeleteTick(boardName: BoardName) {
+  const { token } = useWsAuthToken();
+  const { status: sessionStatus } = useSession();
+  const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (options: DeleteTickOptions) => {
+      if (sessionStatus !== 'authenticated') {
+        throw new Error('Not authenticated');
+      }
+      if (!token) {
+        throw new Error('Auth token not available');
+      }
+
+      const client = createGraphQLHttpClient(token);
+      const variables: DeleteTickMutationVariables = {
+        input: { uuid: options.uuid },
+      };
+
+      const response = await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
+      return response.deleteTick;
+    },
+    onMutate: async (options) => {
+      await queryClient.cancelQueries({ queryKey: ['logbook', boardName] });
+
+      // Snapshot for rollback
+      const previousData = queryClient.getQueriesData<LogbookEntry[]>({ queryKey: ['logbook', boardName] });
+
+      // Optimistically remove the entry
+      queryClient.setQueriesData<LogbookEntry[]>(
+        { queryKey: ['logbook', boardName] },
+        (old) => old?.filter((entry) => entry.uuid !== options.uuid),
+      );
+
+      return { previousData };
+    },
+    onError: (err, _options, context) => {
+      // Rollback
+      if (context?.previousData) {
+        for (const [key, data] of context.previousData) {
+          if (data) queryClient.setQueryData(key, data);
+        }
+      }
+
+      let errorMessage = 'Failed to delete ascent';
+      if (err instanceof Error) {
+        if ('response' in err && typeof err.response === 'object' && err.response !== null) {
+          const response = err.response as { errors?: Array<{ message: string }> };
+          if (response.errors && response.errors.length > 0) {
+            errorMessage = response.errors[0].message;
+          }
+        } else {
+          errorMessage = err.message;
+        }
+      }
+      showMessage(errorMessage, 'error');
+    },
+    onSuccess: () => {
+      showMessage('Ascent deleted', 'success');
+    },
+  });
+}

--- a/packages/web/app/hooks/use-update-tick.ts
+++ b/packages/web/app/hooks/use-update-tick.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useWsAuthToken } from './use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  UPDATE_TICK,
+  type UpdateTickMutationVariables,
+  type UpdateTickMutationResponse,
+} from '@/app/lib/graphql/operations';
+import type { BoardName } from '@/app/lib/types';
+import type { TickStatus, LogbookEntry } from './use-logbook';
+
+export interface UpdateTickOptions {
+  uuid: string;
+  status?: TickStatus;
+  attemptCount?: number;
+  quality?: number | null;
+  comment?: string;
+}
+
+/**
+ * Hook to update an existing tick via GraphQL mutation.
+ * Provides optimistic updates to the logbook cache.
+ */
+export function useUpdateTick(boardName: BoardName) {
+  const { token } = useWsAuthToken();
+  const { status: sessionStatus } = useSession();
+  const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (options: UpdateTickOptions) => {
+      if (sessionStatus !== 'authenticated') {
+        throw new Error('Not authenticated');
+      }
+      if (!token) {
+        throw new Error('Auth token not available');
+      }
+
+      const client = createGraphQLHttpClient(token);
+      const variables: UpdateTickMutationVariables = {
+        input: {
+          uuid: options.uuid,
+          status: options.status,
+          attemptCount: options.attemptCount,
+          quality: options.quality,
+          comment: options.comment,
+        },
+      };
+
+      const response = await client.request<UpdateTickMutationResponse>(UPDATE_TICK, variables);
+      return response.updateTick;
+    },
+    onMutate: async (options) => {
+      await queryClient.cancelQueries({ queryKey: ['logbook', boardName] });
+
+      // Snapshot current cache for rollback
+      const previousData = queryClient.getQueriesData<LogbookEntry[]>({ queryKey: ['logbook', boardName] });
+
+      // Optimistically update the entry
+      queryClient.setQueriesData<LogbookEntry[]>(
+        { queryKey: ['logbook', boardName] },
+        (old) =>
+          old?.map((entry) => {
+            if (entry.uuid !== options.uuid) return entry;
+            const newStatus = options.status ?? entry.status;
+            return {
+              ...entry,
+              status: newStatus,
+              tries: options.attemptCount ?? entry.tries,
+              quality: options.quality !== undefined ? options.quality : entry.quality,
+              comment: options.comment !== undefined ? options.comment : entry.comment,
+              is_ascent: newStatus === 'flash' || newStatus === 'send',
+            };
+          }),
+      );
+
+      return { previousData };
+    },
+    onError: (err, _options, context) => {
+      // Rollback optimistic update
+      if (context?.previousData) {
+        for (const [key, data] of context.previousData) {
+          if (data) queryClient.setQueryData(key, data);
+        }
+      }
+
+      let errorMessage = 'Failed to update ascent';
+      if (err instanceof Error) {
+        if ('response' in err && typeof err.response === 'object' && err.response !== null) {
+          const response = err.response as { errors?: Array<{ message: string }> };
+          if (response.errors && response.errors.length > 0) {
+            errorMessage = response.errors[0].message;
+          }
+        } else {
+          errorMessage = err.message;
+        }
+      }
+      showMessage(errorMessage, 'error');
+    },
+    onSuccess: () => {
+      showMessage('Ascent updated', 'success');
+    },
+  });
+}

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-request';
-import type { Tick, SaveTickInput, GetTicksInput } from '@boardsesh/shared-schema';
+import type { Tick, SaveTickInput, GetTicksInput, UpdateTickInput, DeleteTickInput } from '@boardsesh/shared-schema';
 
 export const GET_TICKS = gql`
   query GetTicks($input: GetTicksInput!) {
@@ -41,6 +41,25 @@ export const SAVE_TICK = gql`
   }
 `;
 
+export const UPDATE_TICK = gql`
+  mutation UpdateTick($input: UpdateTickInput!) {
+    updateTick(input: $input) {
+      uuid
+      status
+      attemptCount
+      quality
+      comment
+      updatedAt
+    }
+  }
+`;
+
+export const DELETE_TICK = gql`
+  mutation DeleteTick($input: DeleteTickInput!) {
+    deleteTick(input: $input)
+  }
+`;
+
 // Partial types matching the fields each query actually requests
 type TickFromGetTicks = Pick<Tick, 'uuid' | 'climbUuid' | 'angle' | 'isMirror' | 'status' | 'attemptCount' | 'quality' | 'difficulty' | 'isBenchmark' | 'comment' | 'climbedAt'>;
 type TickFromGetUserTicks = Pick<Tick, 'climbUuid' | 'angle' | 'status' | 'attemptCount' | 'difficulty' | 'climbedAt' | 'layoutId'>;
@@ -69,6 +88,24 @@ export interface SaveTickMutationVariables {
 
 export interface SaveTickMutationResponse {
   saveTick: TickFromSaveTick;
+}
+
+type TickFromUpdateTick = Pick<Tick, 'uuid' | 'status' | 'attemptCount' | 'quality' | 'comment' | 'updatedAt'>;
+
+export interface UpdateTickMutationVariables {
+  input: UpdateTickInput;
+}
+
+export interface UpdateTickMutationResponse {
+  updateTick: TickFromUpdateTick;
+}
+
+export interface DeleteTickMutationVariables {
+  input: DeleteTickInput;
+}
+
+export interface DeleteTickMutationResponse {
+  deleteTick: boolean;
 }
 
 // ============================================

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';
@@ -32,19 +33,9 @@ import { useBoardDetailsMap } from '@/app/hooks/use-board-details-map';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import AscentActionsMenu from '@/app/components/ascent-actions/ascent-actions-menu';
 import type { EditAscentValues } from '@/app/components/ascent-actions/edit-ascent-dialog';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
-import {
-  UPDATE_TICK,
-  DELETE_TICK,
-  type UpdateTickMutationVariables,
-  type UpdateTickMutationResponse,
-  type DeleteTickMutationVariables,
-  type DeleteTickMutationResponse,
-} from '@/app/lib/graphql/operations';
+import { useAscentActions } from '@/app/components/ascent-actions/use-ascent-actions';
 
-import { useSessionDetail } from '@/app/hooks/use-session-detail';
+import { useSessionDetail, SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import UserSearchDialog from './user-search-dialog';
@@ -242,7 +233,7 @@ function SessionTickItem({
                 uuid: tick.uuid,
                 status: tick.status as 'flash' | 'send' | 'attempt',
                 attemptCount: tick.attemptCount,
-                quality: tick.quality,
+                quality: tick.quality ?? null,
                 comment: tick.comment || '',
               }}
               onUpdate={onUpdate}
@@ -298,51 +289,18 @@ export default function SessionDetailContent({
 
   const saving = updateSessionMutation.isPending || addUserMutation.isPending;
 
-  const { token } = useWsAuthToken();
-  const { showMessage } = useSnackbar();
-  const [tickMutatingUuid, setTickMutatingUuid] = useState<string | null>(null);
-
-  const handleTickUpdate = useCallback(async (uuid: string, values: EditAscentValues) => {
-    if (!token) return;
-    setTickMutatingUuid(uuid);
-    try {
-      const client = createGraphQLHttpClient(token);
-      const variables: UpdateTickMutationVariables = {
-        input: {
-          uuid,
-          status: values.status,
-          attemptCount: values.attemptCount,
-          quality: values.quality,
-          comment: values.comment,
-        },
-      };
-      await client.request<UpdateTickMutationResponse>(UPDATE_TICK, variables);
-      showMessage('Ascent updated', 'success');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update ascent';
-      showMessage(message, 'error');
-    } finally {
-      setTickMutatingUuid(null);
+  const queryClient = useQueryClient();
+  const invalidateSession = useCallback(() => {
+    const sid = sessionIdProp ?? initialSession?.sessionId;
+    if (sid) {
+      queryClient.invalidateQueries({ queryKey: SESSION_DETAIL_QUERY_KEY(sid) });
     }
-  }, [token, showMessage]);
+  }, [queryClient, sessionIdProp, initialSession?.sessionId]);
 
-  const handleTickDelete = useCallback(async (uuid: string) => {
-    if (!token) return;
-    setTickMutatingUuid(uuid);
-    try {
-      const client = createGraphQLHttpClient(token);
-      const variables: DeleteTickMutationVariables = {
-        input: { uuid },
-      };
-      await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
-      showMessage('Ascent deleted', 'success');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete ascent';
-      showMessage(message, 'error');
-    } finally {
-      setTickMutatingUuid(null);
-    }
-  }, [token, showMessage]);
+  const { handleUpdate: handleTickUpdate, handleDelete: handleTickDelete, mutatingUuid: tickMutatingUuid } = useAscentActions(
+    '' as never,
+    { onSettled: invalidateSession },
+  );
 
   const { boards: myBoards } = useMyBoards(true);
 

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -30,6 +30,19 @@ import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useBoardDetailsMap } from '@/app/hooks/use-board-details-map';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import AscentActionsMenu from '@/app/components/ascent-actions/ascent-actions-menu';
+import type { EditAscentValues } from '@/app/components/ascent-actions/edit-ascent-dialog';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  UPDATE_TICK,
+  DELETE_TICK,
+  type UpdateTickMutationVariables,
+  type UpdateTickMutationResponse,
+  type DeleteTickMutationVariables,
+  type DeleteTickMutationResponse,
+} from '@/app/lib/graphql/operations';
 
 import { useSessionDetail } from '@/app/hooks/use-session-detail';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -157,10 +170,18 @@ function SessionTickItem({
   tick,
   isMultiUser,
   participant,
+  isOwnTick,
+  onUpdate,
+  onDelete,
+  mutatingUuid,
 }: {
   tick: SessionDetailTick;
   isMultiUser: boolean;
   participant: SessionFeedParticipant | null;
+  isOwnTick: boolean;
+  onUpdate: (uuid: string, values: EditAscentValues) => void;
+  onDelete: (uuid: string) => void;
+  mutatingUuid: string | null;
 }) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const attemptText = formatAttemptText(tick);
@@ -215,6 +236,21 @@ function SessionTickItem({
           >
             <ChatBubbleOutlineOutlined fontSize="small" />
           </IconButton>
+          {isOwnTick && (
+            <AscentActionsMenu
+              ascent={{
+                uuid: tick.uuid,
+                status: tick.status as 'flash' | 'send' | 'attempt',
+                attemptCount: tick.attemptCount,
+                quality: tick.quality,
+                comment: tick.comment || '',
+              }}
+              onUpdate={onUpdate}
+              onDelete={onDelete}
+              updating={mutatingUuid === tick.uuid}
+              deleting={mutatingUuid === tick.uuid}
+            />
+          )}
         </Box>
       </Box>
       {tick.comment && (
@@ -261,6 +297,52 @@ export default function SessionDetailContent({
   const [sessionCommentsOpen, setSessionCommentsOpen] = useState(false);
 
   const saving = updateSessionMutation.isPending || addUserMutation.isPending;
+
+  const { token } = useWsAuthToken();
+  const { showMessage } = useSnackbar();
+  const [tickMutatingUuid, setTickMutatingUuid] = useState<string | null>(null);
+
+  const handleTickUpdate = useCallback(async (uuid: string, values: EditAscentValues) => {
+    if (!token) return;
+    setTickMutatingUuid(uuid);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const variables: UpdateTickMutationVariables = {
+        input: {
+          uuid,
+          status: values.status,
+          attemptCount: values.attemptCount,
+          quality: values.quality,
+          comment: values.comment,
+        },
+      };
+      await client.request<UpdateTickMutationResponse>(UPDATE_TICK, variables);
+      showMessage('Ascent updated', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update ascent';
+      showMessage(message, 'error');
+    } finally {
+      setTickMutatingUuid(null);
+    }
+  }, [token, showMessage]);
+
+  const handleTickDelete = useCallback(async (uuid: string) => {
+    if (!token) return;
+    setTickMutatingUuid(uuid);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const variables: DeleteTickMutationVariables = {
+        input: { uuid },
+      };
+      await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
+      showMessage('Ascent deleted', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete ascent';
+      showMessage(message, 'error');
+    } finally {
+      setTickMutatingUuid(null);
+    }
+  }, [token, showMessage]);
 
   const { boards: myBoards } = useMyBoards(true);
 
@@ -385,12 +467,16 @@ export default function SessionDetailContent({
               tick={tick}
               isMultiUser={isMultiUser}
               participant={participant ?? null}
+              isOwnTick={tick.userId === currentUserId}
+              onUpdate={handleTickUpdate}
+              onDelete={handleTickDelete}
+              mutatingUuid={tickMutatingUuid}
             />
           );
         })}
       </Box>
     );
-  }, [ticksByClimb, participantMap, isMultiUser]);
+  }, [ticksByClimb, participantMap, isMultiUser, currentUserId, handleTickUpdate, handleTickDelete, tickMutatingUuid]);
 
   const handleStartEdit = useCallback(() => {
     setEditName(sessionName || '');


### PR DESCRIPTION
… session views

Users can now edit (status, attempts, quality, comment) or delete their own ascents from three places: the climb logbook, the profile activity feed, and the session detail page. All three share the same AscentActionsMenu and EditAscentDialog components.

Backend: updateTick and deleteTick GraphQL mutations with ownership checks. Frontend: useUpdateTick/useDeleteTick hooks with optimistic cache updates, shared UI components, and per-item mutation state tracking.

Includes 34 new tests across 4 test files (hooks + components).

https://claude.ai/code/session_017oThoycYCyKqF4vmK3s39m