### PR TITLE
Export DOUBLE_TAP_THRESHOLD to avoid duplication

### DIFF
--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -64,6 +64,7 @@ let capturedDoubleTapCallback: (() => void) | undefined;
 const mockOnDoubleClick = vi.fn();
 
 vi.mock('@/app/lib/hooks/use-double-tap', () => ({
+  DOUBLE_TAP_THRESHOLD: 300,
   useDoubleTap: (callback: (() => void) | undefined) => {
     capturedDoubleTapCallback = callback;
     mockOnDoubleClick.mockImplementation(() => callback?.());

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -18,7 +18,7 @@ import HeartAnimationOverlay from './heart-animation-overlay';
 import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
 import { useOptionalQueueContext } from '../graphql-queue';
 import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
-import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
+import { useDoubleTap, DOUBLE_TAP_THRESHOLD } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
@@ -419,7 +419,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
                       clickTimeoutRef.current = setTimeout(() => {
                         clickTimeoutRef.current = null;
                         onThumbnailClick();
-                      }, 300);
+                      }, DOUBLE_TAP_THRESHOLD);
                     }
                   : undefined
               }

--- a/packages/web/app/lib/hooks/use-double-tap.ts
+++ b/packages/web/app/lib/hooks/use-double-tap.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback, type RefCallback } from 'react';
 
-const DOUBLE_TAP_THRESHOLD = 300;
+export const DOUBLE_TAP_THRESHOLD = 300;
 
 /**
  * Hook that handles double-tap on touch devices without triggering iOS Safari's


### PR DESCRIPTION
climb-list-item.tsx used a hardcoded 300ms delay for its single-click timeout that mirrors the constant in use-double-tap.ts. Export the constant from use-double-tap.ts and import it in climb-list-item.tsx so both values stay in sync automatically.

https://claude.ai/code/session_01WamWQGns32de2rankRK1ox