### PR TITLE
Fix swipe-to-queue animation: replace blank flash with peek-and-confirm

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
+import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbThumbnail from './climb-thumbnail';
@@ -73,9 +74,15 @@ const longSwipeLayerInitialStyle: React.CSSProperties = {
   opacity: 0,
 };
 
-const rightActionLayerInitialStyle: React.CSSProperties = {
+const rightActionLayerDefaultStyle: React.CSSProperties = {
   ...rightSwipeActionLayerBaseStyle,
   backgroundColor: themeTokens.colors.primary,
+  opacity: 0,
+};
+
+const rightActionLayerConfirmedStyle: React.CSSProperties = {
+  ...rightSwipeActionLayerBaseStyle,
+  backgroundColor: themeTokens.colors.success,
   opacity: 0,
 };
 
@@ -285,7 +292,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       }
     }, []);
 
-    const { swipeHandlers, isSwipeComplete, contentRef, leftActionRef, rightActionRef } = useSwipeActions({
+    const { swipeHandlers, swipeLeftConfirmed, contentRef, leftActionRef, rightActionRef } = useSwipeActions({
       onSwipeLeft: resolvedSwipeLeft,
       onSwipeRight: handleDefaultSwipeRight,
       onSwipeRightLong: useSimpleSwipe ? undefined : handleDefaultSwipeRightLong,
@@ -380,9 +387,9 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
         borderBottom: `1px solid var(--neutral-200)`,
         cursor: 'pointer' as const,
         userSelect: 'none' as const,
-        opacity: isSwipeComplete ? 0 : (contentOpacity ?? 1),
+        opacity: contentOpacity ?? 1,
       }),
-      [resolvedBg, isSwipeComplete, contentOpacity],
+      [resolvedBg, contentOpacity],
     );
 
     // Default ClimbTitle props when no override is provided
@@ -422,8 +429,12 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
                 </div>
               ) : (
                 <div ref={rightActionRef} style={defaultRightActionStyle}>
-                  <div ref={rightActionLayerRef} style={rightActionLayerInitialStyle}>
-                    <AddOutlined style={iconStyle} />
+                  <div ref={rightActionLayerRef} style={swipeLeftConfirmed ? rightActionLayerConfirmedStyle : rightActionLayerDefaultStyle}>
+                    {swipeLeftConfirmed ? (
+                      <CheckOutlined style={iconStyle} />
+                    ) : (
+                      <AddOutlined style={iconStyle} />
+                    )}
                   </div>
                 </div>
               )}

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/app/hooks/use-swipe-actions', () => ({
     capturedSwipeOptions = options;
     return {
       swipeHandlers: { ref: vi.fn() },
-      isSwipeComplete: false,
+      swipeLeftConfirmed: false,
       contentRef: vi.fn(),
       leftActionRef: vi.fn(),
       rightActionRef: vi.fn(),

--- a/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
+++ b/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
@@ -44,11 +44,11 @@ describe('useSwipeActions', () => {
     vi.useRealTimers();
   });
 
-  it('returns swipeHandlers, isSwipeComplete, contentRef, leftActionRef, rightActionRef', () => {
+  it('returns swipeHandlers, swipeLeftConfirmed, contentRef, leftActionRef, rightActionRef', () => {
     const { result } = renderHook(() => useSwipeActions(createDefaultOptions()));
 
     expect(result.current.swipeHandlers).toBeDefined();
-    expect(result.current.isSwipeComplete).toBe(false);
+    expect(result.current.swipeLeftConfirmed).toBe(false);
     expect(typeof result.current.contentRef).toBe('function');
     expect(typeof result.current.leftActionRef).toBe('function');
     expect(typeof result.current.rightActionRef).toBe('function');
@@ -69,15 +69,13 @@ describe('useSwipeActions', () => {
     expect(mockDetect).not.toHaveBeenCalled();
   });
 
-  it('calls onSwipeLeft when swiped left past threshold and detected horizontal', () => {
+  it('calls onSwipeLeft immediately when swiped left past threshold', () => {
     const options = createDefaultOptions();
     renderHook(() => useSwipeActions(options));
 
-    // Set direction to horizontal
     mockIsHorizontalRef.current = true;
     mockDetect.mockReturnValue(true);
 
-    // Simulate swiping
     act(() => {
       capturedSwipeableConfig.onSwiping({
         deltaX: -110,
@@ -86,16 +84,11 @@ describe('useSwipeActions', () => {
       });
     });
 
-    // Trigger onSwipedLeft with sufficient delta
     act(() => {
       capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
     });
 
-    // Wait for the completion animation timeout (default 200ms)
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-
+    // Action fires immediately — no timer advance needed
     expect(options.onSwipeLeft).toHaveBeenCalledTimes(1);
   });
 
@@ -146,14 +139,14 @@ describe('useSwipeActions', () => {
     expect(mockReset).toHaveBeenCalled();
   });
 
-  it('isSwipeComplete becomes true during left swipe animation', () => {
+  it('swipeLeftConfirmed becomes true immediately and resets after 600ms', () => {
     const options = createDefaultOptions();
     const { result } = renderHook(() => useSwipeActions(options));
 
     mockIsHorizontalRef.current = true;
     mockDetect.mockReturnValue(true);
 
-    expect(result.current.isSwipeComplete).toBe(false);
+    expect(result.current.swipeLeftConfirmed).toBe(false);
 
     act(() => {
       capturedSwipeableConfig.onSwiping({
@@ -167,15 +160,21 @@ describe('useSwipeActions', () => {
       capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
     });
 
-    // During the animation, isSwipeComplete should be true
-    expect(result.current.isSwipeComplete).toBe(true);
+    // Action fires immediately and confirmation is active
+    expect(options.onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(result.current.swipeLeftConfirmed).toBe(true);
 
-    // After animation completes
+    // Still active before 600ms
     act(() => {
-      vi.advanceTimersByTime(200);
+      vi.advanceTimersByTime(500);
     });
+    expect(result.current.swipeLeftConfirmed).toBe(true);
 
-    expect(result.current.isSwipeComplete).toBe(false);
+    // Resets after 600ms
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current.swipeLeftConfirmed).toBe(false);
   });
 
   it('does not trigger action for vertical swipes (isHorizontalRef.current = false)', () => {
@@ -272,11 +271,7 @@ describe('useSwipeActions', () => {
       capturedSwipeableConfig.onSwipedLeft({ deltaX: -60 });
     });
 
-    // Wait for the animation
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-
+    // Action fires immediately
     expect(options.onSwipeLeft).toHaveBeenCalledTimes(1);
   });
 
@@ -382,10 +377,7 @@ describe('useSwipeActions', () => {
       capturedSwipeableConfig.onSwipedLeft({ deltaX: -100 });
     });
 
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-
+    // Action fires immediately
     expect(options.onSwipeLeft).toHaveBeenCalledTimes(1);
     expect(options.onSwipeLeftLong).not.toHaveBeenCalled();
   });
@@ -428,5 +420,124 @@ describe('useSwipeActions', () => {
     expect(onSwipeZoneChange).toHaveBeenCalledWith('right-long');
     expect(onSwipeZoneChange).toHaveBeenCalledWith('none');
     expect(options.onSwipeRightLong).toHaveBeenCalledTimes(1);
+  });
+
+  it('peeks content and keeps action layer visible during left swipe confirmation', () => {
+    const options = createDefaultOptions();
+    const { result } = renderHook(() => useSwipeActions(options));
+
+    const mockContent = {
+      style: { transform: '', transition: '', opacity: '', visibility: '' },
+    } as unknown as HTMLElement;
+    const mockRightAction = {
+      style: { transform: '', transition: '', opacity: '', visibility: '' },
+    } as unknown as HTMLElement;
+
+    act(() => {
+      result.current.contentRef(mockContent);
+      result.current.rightActionRef(mockRightAction);
+    });
+
+    mockIsHorizontalRef.current = true;
+    mockDetect.mockReturnValue(true);
+
+    act(() => {
+      capturedSwipeableConfig.onSwiping({
+        deltaX: -110,
+        deltaY: 0,
+        event: { nativeEvent: { preventDefault: vi.fn() } },
+      });
+    });
+
+    act(() => {
+      capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
+    });
+
+    // Content should be at peek offset
+    expect(mockContent.style.transform).toBe('translateX(-56px)');
+    expect(mockContent.style.transition).toBe('transform 150ms ease');
+    // Right action layer should be fully visible
+    expect(mockRightAction.style.opacity).toBe('1');
+    expect(mockRightAction.style.visibility).toBe('visible');
+
+    // After confirmation timer, content snaps back
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(mockContent.style.transform).toBe('translateX(0px)');
+  });
+
+  it('handles rapid double-swipe without duplicate actions', () => {
+    const options = createDefaultOptions();
+    renderHook(() => useSwipeActions(options));
+
+    mockIsHorizontalRef.current = true;
+    mockDetect.mockReturnValue(true);
+
+    // First swipe
+    act(() => {
+      capturedSwipeableConfig.onSwiping({
+        deltaX: -110,
+        deltaY: 0,
+        event: { nativeEvent: { preventDefault: vi.fn() } },
+      });
+    });
+    act(() => {
+      capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
+    });
+
+    // Second swipe immediately after (before timer fires)
+    act(() => {
+      capturedSwipeableConfig.onSwiping({
+        deltaX: -110,
+        deltaY: 0,
+        event: { nativeEvent: { preventDefault: vi.fn() } },
+      });
+    });
+    act(() => {
+      capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
+    });
+
+    // Action fires twice (once per swipe) — that's correct
+    expect(options.onSwipeLeft).toHaveBeenCalledTimes(2);
+
+    // But only one timer should be pending — advance and confirm single reset
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // No additional calls after timer
+    expect(options.onSwipeLeft).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up confirmation timer on unmount', () => {
+    const options = createDefaultOptions();
+    const { result, unmount } = renderHook(() => useSwipeActions(options));
+
+    mockIsHorizontalRef.current = true;
+    mockDetect.mockReturnValue(true);
+
+    act(() => {
+      capturedSwipeableConfig.onSwiping({
+        deltaX: -110,
+        deltaY: 0,
+        event: { nativeEvent: { preventDefault: vi.fn() } },
+      });
+    });
+
+    act(() => {
+      capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
+    });
+
+    expect(result.current.swipeLeftConfirmed).toBe(true);
+
+    // Unmount before timer fires — should not throw
+    unmount();
+
+    // Advancing timers should not cause errors
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
   });
 });

--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback, useState } from 'react';
+import { useRef, useCallback, useState, useEffect } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { useSwipeDirection } from './use-swipe-direction';
 
@@ -8,6 +8,10 @@ import { useSwipeDirection } from './use-swipe-direction';
 const DEFAULT_SWIPE_THRESHOLD = 100;
 // Maximum swipe distance
 const DEFAULT_MAX_SWIPE = 120;
+// Peek offset shown during left-swipe confirmation (enough to reveal the action icon)
+const CONFIRMATION_PEEK_OFFSET = -56;
+// Duration the confirmation checkmark is shown before snapping back
+const CONFIRMATION_DISPLAY_MS = 600;
 
 export type SwipeZone = 'none' | 'left-short' | 'left-long' | 'right-short' | 'right-long';
 
@@ -45,8 +49,8 @@ export interface UseSwipeActionsOptions {
 export interface UseSwipeActionsReturn {
   /** Spread onto the swipeable container element */
   swipeHandlers: ReturnType<typeof useSwipeable>;
-  /** Whether the swipe-off animation is in progress (item fading out) */
-  isSwipeComplete: boolean;
+  /** Whether a left-swipe action was just confirmed (checkmark peek is visible) */
+  swipeLeftConfirmed: boolean;
   /** Ref for the swipeable content element (applies transform) */
   contentRef: React.RefCallback<HTMLElement>;
   /** Ref for the left action background (visible on swipe right) */
@@ -79,12 +83,20 @@ export function useSwipeActions({
   disabled = false,
   completionAnimationMs = 200,
 }: UseSwipeActionsOptions): UseSwipeActionsReturn {
-  const [isSwipeComplete, setIsSwipeComplete] = useState(false);
+  const [swipeLeftConfirmed, setSwipeLeftConfirmed] = useState(false);
+  const confirmationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // DOM element refs (set via ref callbacks)
   const contentEl = useRef<HTMLElement | null>(null);
   const leftActionEl = useRef<HTMLElement | null>(null);
   const rightActionEl = useRef<HTMLElement | null>(null);
+
+  // Clean up confirmation timer on unmount
+  useEffect(() => {
+    return () => {
+      if (confirmationTimerRef.current) clearTimeout(confirmationTimerRef.current);
+    };
+  }, []);
 
   // Gesture state (not React state -- no re-renders)
   const offsetRef = useRef(0);
@@ -143,21 +155,33 @@ export function useSwipeActions({
   }, [applyOffset, updateSwipeZone]);
 
   const handleSwipeLeftComplete = useCallback(() => {
-    setIsSwipeComplete(true);
+    // Guard against rapid double-swipes
+    if (confirmationTimerRef.current) clearTimeout(confirmationTimerRef.current);
+
+    // Fire action immediately — no delay
+    onSwipeLeft();
+    setSwipeLeftConfirmed(true);
+
+    // Animate content to a peek offset so the action layer (checkmark) stays visible
     if (contentEl.current) {
-      contentEl.current.style.opacity = '0';
-      contentEl.current.style.transition = 'transform 150ms ease, opacity 150ms ease';
+      contentEl.current.style.transition = 'transform 150ms ease';
+      contentEl.current.style.transform = `translateX(${CONFIRMATION_PEEK_OFFSET}px)`;
     }
-    setTimeout(() => {
-      onSwipeLeft();
+
+    // Keep the right action layer fully visible during confirmation
+    if (rightActionEl.current) {
+      rightActionEl.current.style.opacity = '1';
+      rightActionEl.current.style.visibility = 'visible';
+    }
+
+    // After the confirmation display, snap back
+    confirmationTimerRef.current = setTimeout(() => {
+      confirmationTimerRef.current = null;
       applyOffset(0);
       updateSwipeZone('none');
-      if (contentEl.current) {
-        contentEl.current.style.opacity = '';
-      }
-      setIsSwipeComplete(false);
-    }, completionAnimationMs);
-  }, [onSwipeLeft, applyOffset, completionAnimationMs, updateSwipeZone]);
+      setSwipeLeftConfirmed(false);
+    }, CONFIRMATION_DISPLAY_MS);
+  }, [onSwipeLeft, applyOffset, updateSwipeZone]);
 
   const handleSwipeRightComplete = useCallback(() => {
     applyOffset(0);
@@ -262,7 +286,7 @@ export function useSwipeActions({
 
   return {
     swipeHandlers,
-    isSwipeComplete,
+    swipeLeftConfirmed,
     contentRef,
     leftActionRef,
     rightActionRef,


### PR DESCRIPTION
The swipe-left-to-add-to-queue gesture previously faded the list item
to opacity 0 for 200ms, causing a jarring blank flash. Now the item
stays visible: the content peeks at -56px to reveal a green checkmark
icon for 600ms, then smoothly slides back. The action fires immediately
instead of after a delay.

- Replace isSwipeComplete with swipeLeftConfirmed in useSwipeActions hook
- Remove content opacity suppression from climb-list-item
- Swap AddOutlined for CheckOutlined with success color during confirmation
- Add timer cleanup on unmount and rapid double-swipe guard
- Update all tests (18 hook + 27 list item + 18 queue item = 63 passing)

https://claude.ai/code/session_01XBbEcHLLjEMQgJHM4qd5GX