### PR TITLE
Fix climb list performance: remove QueueContext subscription from ClimbListItem

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -70,7 +70,7 @@ export default function LikedClimbsList({
   angle,
 }: LikedClimbsListProps) {
   const { token, isLoading: tokenLoading } = useWsAuthToken();
-  const { setCurrentClimb } = useQueueContext();
+  const { setCurrentClimb, addToQueue } = useQueueContext();
   const { showMessage } = useSnackbar();
   const [selectedClimbUuid, setSelectedClimbUuid] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('list');
@@ -300,6 +300,7 @@ export default function LikedClimbsList({
               disableThumbnailNavigation
               onOpenActions={handleOpenActions}
               onOpenPlaylistSelector={handleOpenPlaylistSelector}
+              addToQueue={addToQueue}
             />
           ))}
         </Box>

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -24,6 +24,7 @@ const BoardPageClimbsList = ({
 }: BoardPageClimbsListProps) => {
   const {
     setCurrentClimb,
+    addToQueue,
     climbSearchResults,
     hasMoreResults,
     fetchMoreClimbs,
@@ -84,6 +85,7 @@ const BoardPageClimbsList = ({
       isFetching={isFetchingClimbs}
       hasMore={hasMoreResults}
       onClimbSelect={setCurrentClimb}
+      addToQueue={addToQueue}
       onLoadMore={fetchMoreClimbs}
       headerInline={headerInline}
       angleSelector={angleSelectorElement}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -51,6 +51,7 @@ export type ClimbsListProps = {
   isFetching: boolean;
   hasMore: boolean;
   onClimbSelect?: (climb: Climb) => void;
+  addToQueue?: (climb: Climb) => void;
   onLoadMore: () => void;
   header?: React.ReactNode;
   headerInline?: React.ReactNode;
@@ -82,6 +83,7 @@ const ClimbsList = ({
   isFetching,
   hasMore,
   onClimbSelect,
+  addToQueue,
   onLoadMore,
   header,
   headerInline,
@@ -406,6 +408,7 @@ const ClimbsList = ({
                     unsupported={unsupportedClimbs?.has(climb.uuid)}
                     onOpenActions={handleOpenActions}
                     onOpenPlaylistSelector={handleOpenPlaylistSelector}
+                    addToQueue={addToQueue}
                   />
                 </div>
                 {renderItemExtra?.(climb)}

--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -15,10 +15,6 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-vi.mock('../../graphql-queue', () => ({
-  useOptionalQueueContext: () => null,
-}));
-
 vi.mock('../../climb-actions', () => ({
   ClimbActions: () => <div data-testid="climb-actions" />,
 }));

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -16,7 +16,6 @@ import { ClimbActions } from '../climb-actions';
 import { useDoubleTapFavorite } from '../climb-actions/use-double-tap-favorite';
 import HeartAnimationOverlay from './heart-animation-overlay';
 import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
-import { useOptionalQueueContext } from '../graphql-queue';
 import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -161,6 +160,9 @@ type ClimbListItemProps = {
   onOpenPlaylistSelector?: (climb: Climb) => void;
   /** Callback invoked when the user navigates via the thumbnail link (e.g., to close a drawer). Forwarded to ClimbThumbnail. */
   onNavigate?: () => void;
+  /** Optional callback to add the climb to the queue (default swipe-left action).
+   *  When not provided, swipe-left is a no-op. Pass from a parent that subscribes to QueueContext. */
+  addToQueue?: (climb: Climb) => void;
 };
 
 const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
@@ -182,6 +184,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     onOpenActions,
     onOpenPlaylistSelector,
     onNavigate,
+    addToQueue,
   }) => {
     const pathname = usePathname();
     const isDark = useIsDarkMode();
@@ -195,8 +198,10 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     const longSwipeLayerRef = useRef<HTMLDivElement>(null);
     const rightActionLayerRef = useRef<HTMLDivElement>(null);
     const leftActionContainerRef = useRef<HTMLDivElement>(null);
-    const queueContext = useOptionalQueueContext();
-    const addToQueue = queueContext?.addToQueue;
+    // Store addToQueue in a ref so the memoized handler always reads the latest
+    // value without requiring addToQueue in the memo comparator.
+    const addToQueueRef = useRef(addToQueue);
+    addToQueueRef.current = addToQueue;
     const {
       handleDoubleTap,
       showHeart,
@@ -223,8 +228,8 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     // Default swipe handlers
     // Swipe left (right action): add to queue
     const handleDefaultSwipeLeft = useCallback(() => {
-      addToQueue?.(climb);
-    }, [climb, addToQueue]);
+      addToQueueRef.current?.(climb);
+    }, [climb]);
 
     // Swipe right short (left action): open playlist selector
     const handleDefaultSwipeRight = useCallback(() => {

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -22,10 +22,6 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-vi.mock('../../graphql-queue', () => ({
-  useOptionalQueueContext: () => null,
-}));
-
 vi.mock('../../climb-actions', () => ({
   useFavorite: () => ({
     isFavorited: false,

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -294,6 +294,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
                   boardDetails={boardDetails}
                   titleProps={suggestedTitleProps}
                   onNavigate={onClimbNavigate}
+                  addToQueue={addToQueue}
                 />
               </div>
             ))}


### PR DESCRIPTION
Every ClimbListItem subscribed to QueueContext via useOptionalQueueContext()
to get addToQueue for the swipe-left action. This caused all 50-100+ list
items to re-render when setting a climb active, bypassing React.memo since
context changes trigger re-renders regardless of memoization.

Fix: accept addToQueue as an optional prop instead. Parents that already
subscribe to QueueContext pass it down. Uses a ref pattern (like
onThumbnailClickRef) so addToQueue doesn't need to be in the memo comparator.

https://claude.ai/code/session_01LvaG5NcaXvQP79LfiQhiv1