### PR TITLE
Remove unused completionAnimationMs parameter from useSwipeActions

### DIFF
--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -42,8 +42,6 @@ export interface UseSwipeActionsOptions {
   maxSwipeRight?: number;
   /** Whether swipe is disabled (e.g. in edit mode) */
   disabled?: boolean;
-  /** Duration of the completion animation in ms (default: 200) */
-  completionAnimationMs?: number;
 }
 
 export interface UseSwipeActionsReturn {
@@ -81,7 +79,6 @@ export function useSwipeActions({
   maxSwipeLeft,
   maxSwipeRight,
   disabled = false,
-  completionAnimationMs = 200,
 }: UseSwipeActionsOptions): UseSwipeActionsReturn {
   const [swipeLeftConfirmed, setSwipeLeftConfirmed] = useState(false);
   const confirmationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);


### PR DESCRIPTION
The parameter was destructured with a default value but never referenced
in the function body after a previous refactor. Removing it eliminates
dead code and avoids misleading callers into thinking it has an effect.

https://claude.ai/code/session_01VvEzZ92H3YFhKN1kxggNmZ