### PR TITLE
Increase swipe confirmation peek duration from 600ms to 1400ms

### DIFF
--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -11,7 +11,7 @@ const DEFAULT_MAX_SWIPE = 120;
 // Peek offset shown during left-swipe confirmation (enough to reveal the action icon)
 const CONFIRMATION_PEEK_OFFSET = -56;
 // Duration the confirmation checkmark is shown before snapping back
-const CONFIRMATION_DISPLAY_MS = 600;
+const CONFIRMATION_DISPLAY_MS = 1400;
 
 export type SwipeZone = 'none' | 'left-short' | 'left-long' | 'right-short' | 'right-long';
 


### PR DESCRIPTION
The confirmation checkmark after swiping to add a climb to the queue
was disappearing too quickly for users to register the feedback.

https://claude.ai/code/session_01TUaqmbNzN77smC3oBVPZDe