### PR TITLE
Double peek delay from 1400ms to 2800ms in swipe actions

### DIFF
--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -11,7 +11,7 @@ const DEFAULT_MAX_SWIPE = 120;
 // Peek offset shown during left-swipe confirmation (enough to reveal the action icon)
 const CONFIRMATION_PEEK_OFFSET = -56;
 // Duration the confirmation checkmark is shown before snapping back
-const CONFIRMATION_DISPLAY_MS = 1400;
+const CONFIRMATION_DISPLAY_MS = 2800;
 
 export type SwipeZone = 'none' | 'left-short' | 'left-long' | 'right-short' | 'right-long';
 


### PR DESCRIPTION
Increases the duration that the confirmation checkmark is visible after
a swipe-left action completes, giving users more time to see the feedback.

https://claude.ai/code/session_01R45rVbCahbT3hgbK4qgSck