### PR TITLE
Fix zoom reset button position and zoom hint visibility in play view

### DIFF
--- a/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.module.css
@@ -29,7 +29,7 @@
 
 .zoomResetButton {
   position: absolute;
-  bottom: 12px;
+  bottom: 62px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 5;

--- a/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
+++ b/packages/web/app/components/board-renderer/swipe-board-carousel.tsx
@@ -35,6 +35,7 @@ export interface SwipeBoardCarouselProps {
   fillContainer?: boolean;
   onDoubleTap?: () => void;
   showZoomHint?: boolean;
+  isDrawerOpen?: boolean;
   overlay?: React.ReactNode;
 }
 
@@ -52,6 +53,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
   fillContainer,
   onDoubleTap,
   showZoomHint,
+  isDrawerOpen,
   overlay,
 }) => {
   const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
@@ -165,7 +167,7 @@ const SwipeBoardCarousel: React.FC<SwipeBoardCarouselProps> = ({
         </ZoomableBoard>
       </div>
       {overlay}
-      {showZoomHint && <ZoomHint visible={!isZoomed} />}
+      {showZoomHint && <ZoomHint visible={!isZoomed && !!isDrawerOpen} />}
       {showPeek && peekClimb && (
         <div
           className={styles.peekBoardContainer}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -313,6 +313,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                     fillContainer
                     onDoubleTap={handleDoubleTap}
                     showZoomHint
+                    isDrawerOpen={isOpen}
                     overlay={<HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} />}
                   />
                 )}


### PR DESCRIPTION
Move the zoom reset button 50px higher (bottom: 62px) so it's not
obscured by the tick FAB. Fix the zoom hint never showing by gating
it on the drawer's open state — previously keepMounted caused it to
fire and auto-dismiss while the drawer was still closed.

https://claude.ai/code/session_012vbTNrM1CnqhuKpWAxacC7