### PR TITLE
Fix start session: auto-select current board and show collapsed pill

### DIFF
--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -8,6 +8,12 @@ const mockSetInitialQueueForSession = vi.fn();
 let mockLocalQueue: unknown[] = [];
 let mockLocalCurrentClimbQueueItem: unknown = null;
 let mockLocalBoardPath: string | null = null;
+let mockLocalBoardDetails: {
+  board_name: string;
+  layout_id: number;
+  size_id: number;
+  set_ids: number[];
+} | null = null;
 
 vi.mock('@/app/components/persistent-session/persistent-session-context', () => ({
   usePersistentSession: () => ({
@@ -15,6 +21,7 @@ vi.mock('@/app/components/persistent-session/persistent-session-context', () => 
     localQueue: mockLocalQueue,
     localCurrentClimbQueueItem: mockLocalCurrentClimbQueueItem,
     localBoardPath: mockLocalBoardPath,
+    localBoardDetails: mockLocalBoardDetails,
   }),
 }));
 
@@ -50,8 +57,8 @@ vi.mock('@/app/lib/climb-session-cookie', () => ({
 vi.mock('@/app/hooks/use-my-boards', () => ({
   useMyBoards: () => ({
     boards: [
-      { uuid: 'board-1', slug: 'kilter-original-12x12', name: 'Kilter', angle: 40 },
-      { uuid: 'board-2', slug: 'tension-board-8x10', name: 'Tension', angle: 30 },
+      { uuid: 'board-1', slug: 'kilter-original-12x12', name: 'Kilter', angle: 40, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+      { uuid: 'board-2', slug: 'tension-board-8x10', name: 'Tension', angle: 30, boardType: 'tension', layoutId: 2, sizeId: 20, setIds: '3,4' },
     ],
     isLoading: false,
     error: null,
@@ -64,7 +71,7 @@ vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
 }));
 
 vi.mock('@/app/components/board-scroll/board-scroll-section', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="board-scroll-section">{children}</div>,
 }));
 
 vi.mock('@/app/components/board-scroll/board-scroll-card', () => ({
@@ -104,18 +111,96 @@ describe('StartSeshDrawer', () => {
     mockLocalQueue = [];
     mockLocalCurrentClimbQueueItem = null;
     mockLocalBoardPath = null;
+    mockLocalBoardDetails = null;
     mockCreateSession.mockResolvedValue('new-session-id');
   });
 
-  async function selectBoardAndSubmit(boardName: string) {
+  async function expandBoardSelectorAndSelect(boardName: string) {
+    // If the board selector is collapsed (pill shown), expand it first
+    const changeButton = screen.queryByText('Change');
+    if (changeButton) {
+      fireEvent.click(changeButton);
+    }
+
     const boardCard = screen.getByTestId(`board-card-${boardName}`);
     fireEvent.click(boardCard);
+  }
 
+  async function submitSesh() {
     const submitButton = screen.getByRole('button', { name: /sesh/i });
     await act(async () => {
       fireEvent.click(submitButton);
     });
   }
+
+  async function selectBoardAndSubmit(boardName: string) {
+    await expandBoardSelectorAndSelect(boardName);
+    await submitSesh();
+  }
+
+  it('auto-selects board from localBoardPath and starts session without manual selection', async () => {
+    const item1 = makeQueueItem('q1', 'Boulder 1');
+    mockLocalQueue = [item1];
+    mockLocalCurrentClimbQueueItem = item1;
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Board should be auto-selected — just press submit
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+
+    expect(mockSetInitialQueueForSession).toHaveBeenCalledWith(
+      'new-session-id',
+      [item1],
+      item1,
+      undefined,
+    );
+    expect(mockRouterPush).toHaveBeenCalled();
+  });
+
+  it('auto-selects board from localBoardDetails (generic route)', async () => {
+    mockLocalBoardPath = '/kilter/original/12x12/screw_bolt/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Board should be auto-selected via strategy 2
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+    expect(mockRouterPush).toHaveBeenCalled();
+  });
+
+  it('shows collapsed pill when board is auto-selected', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Should show the board name in a pill and "Change" link
+    expect(screen.getByText('Kilter')).toBeTruthy();
+    expect(screen.getByText('Change')).toBeTruthy();
+
+    // Board scroll section should not be visible
+    expect(screen.queryByTestId('board-scroll-section')).toBeNull();
+  });
+
+  it('expands board selector when Change is clicked', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Click Change to expand
+    fireEvent.click(screen.getByText('Change'));
+
+    // Board scroll section should now be visible
+    expect(screen.getByTestId('board-scroll-section')).toBeTruthy();
+  });
 
   it('transfers local queue when board matches', async () => {
     const item1 = makeQueueItem('q1', 'Boulder 1');
@@ -126,7 +211,8 @@ describe('StartSeshDrawer', () => {
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
-    await selectBoardAndSubmit('Kilter');
+    // Board is auto-selected, just submit
+    await submitSesh();
 
     await waitFor(() => {
       expect(mockSetInitialQueueForSession).toHaveBeenCalledWith(
@@ -148,6 +234,7 @@ describe('StartSeshDrawer', () => {
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
+    // Tension is auto-selected, expand and select Kilter instead
     await selectBoardAndSubmit('Kilter');
 
     await waitFor(() => {
@@ -165,7 +252,7 @@ describe('StartSeshDrawer', () => {
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
-    await selectBoardAndSubmit('Kilter');
+    await submitSesh();
 
     await waitFor(() => {
       expect(mockCreateSession).toHaveBeenCalled();
@@ -182,6 +269,7 @@ describe('StartSeshDrawer', () => {
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
+    // No auto-selection, manually select a board
     await selectBoardAndSubmit('Kilter');
 
     await waitFor(() => {
@@ -199,7 +287,8 @@ describe('StartSeshDrawer', () => {
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
-    await selectBoardAndSubmit('Kilter');
+    // Board is auto-selected, just submit
+    await submitSesh();
 
     await waitFor(() => {
       expect(mockSetInitialQueueForSession).toHaveBeenCalledWith(
@@ -209,5 +298,16 @@ describe('StartSeshDrawer', () => {
         undefined,
       );
     });
+  });
+
+  it('shows full board scroll when no board context is available', async () => {
+    mockLocalBoardPath = null;
+    mockLocalBoardDetails = null;
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // No auto-selection, full scroll should show
+    expect(screen.getByTestId('board-scroll-section')).toBeTruthy();
+    expect(screen.queryByText('Change')).toBeNull();
   });
 });

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -310,4 +310,40 @@ describe('StartSeshDrawer', () => {
     expect(screen.getByTestId('board-scroll-section')).toBeTruthy();
     expect(screen.queryByText('Change')).toBeNull();
   });
+
+  it('matches board details even when set_ids are in different order', async () => {
+    // localBoardDetails has set_ids in reverse order compared to UserBoard.setIds "1,2"
+    mockLocalBoardPath = '/kilter/original/12x12/screw_bolt/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [2, 1] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Should auto-select Kilter despite reversed set_ids order
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+    expect(mockRouterPush).toHaveBeenCalled();
+  });
+
+  it('prioritizes slug match over board details match', async () => {
+    // localBoardPath matches Kilter by slug, but localBoardDetails matches Tension by IDs
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'tension', layout_id: 2, size_id: 20, set_ids: [3, 4] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Should show Kilter (slug match wins), not Tension
+    expect(screen.getByText('Kilter')).toBeTruthy();
+
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.anything(),
+        '/b/kilter-original-12x12',
+      );
+    });
+  });
 });

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
+import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import SessionCreationForm from './session-creation-form';
 import type { SessionCreationFormData } from './session-creation-form';
@@ -40,6 +41,7 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     localQueue,
     localCurrentClimbQueueItem,
     localBoardPath,
+    localBoardDetails,
   } = usePersistentSession();
   const { boards, isLoading: isLoadingBoards, error: boardsError } = useMyBoards(open);
 
@@ -49,6 +51,37 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
   const { openAuthModal } = useAuthModal();
   const [showBoardDrawer, setShowBoardDrawer] = useState(false);
   const [formKey, setFormKey] = useState(0);
+  const [boardSelectorExpanded, setBoardSelectorExpanded] = useState(false);
+
+  // Auto-select the current board when the drawer opens
+  useEffect(() => {
+    if (open && boards.length > 0 && !selectedBoard && !selectedCustomPath) {
+      let match: (typeof boards)[number] | undefined;
+
+      // Strategy 1: Match by slug from /b/{slug} routes
+      if (localBoardPath) {
+        const basePath = getBaseBoardPath(localBoardPath);
+        match = boards.find((b) => `/b/${b.slug}` === basePath);
+      }
+
+      // Strategy 2: Match by numeric board identity from localBoardDetails
+      // Handles generic routes like /kilter/original/16x12/screw_bolt/40/list
+      if (!match && localBoardDetails) {
+        match = boards.find(
+          (b) =>
+            b.boardType === localBoardDetails.board_name &&
+            b.layoutId === localBoardDetails.layout_id &&
+            b.sizeId === localBoardDetails.size_id &&
+            b.setIds === localBoardDetails.set_ids.join(','),
+        );
+      }
+
+      if (match) {
+        setSelectedBoard(match);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, boards, localBoardPath, localBoardDetails]);
 
   const isLoggedIn = status === 'authenticated';
 
@@ -57,6 +90,7 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     setSelectedBoard(null);
     setSelectedCustomPath(null);
     setSelectedCustomConfig(null);
+    setBoardSelectorExpanded(false);
     setFormKey((k) => k + 1);
   }, [onClose]);
 
@@ -64,6 +98,7 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     setSelectedBoard(board);
     setSelectedCustomPath(null);
     setSelectedCustomConfig(null);
+    setBoardSelectorExpanded(false);
   };
 
   const handleCustomSelect = (url: string, config?: StoredBoardConfig) => {
@@ -71,6 +106,7 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     setSelectedCustomConfig(config ?? null);
     setSelectedBoard(null);
     setShowBoardDrawer(false);
+    setBoardSelectorExpanded(false);
   };
 
   const handleSubmit = async (formData: SessionCreationFormData) => {
@@ -118,31 +154,60 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     }
   };
 
+  const hasSelection = selectedBoard || selectedCustomConfig;
+  const selectedName = selectedBoard?.name ?? selectedCustomConfig?.name;
+
   const boardSelector = (
     <Box>
-      <BoardScrollSection title="Select a board" loading={isLoadingBoards}>
-        <CreateBoardCard
-          onClick={() => setShowBoardDrawer(true)}
-          label="Custom"
-        />
-        {selectedCustomConfig && (
-          <BoardScrollCard
-            key={`custom-${selectedCustomConfig.name}`}
-            storedConfig={selectedCustomConfig}
-            boardConfigs={boardConfigs}
-            selected
+      {hasSelection && !boardSelectorExpanded ? (
+        <Box
+          onClick={() => setBoardSelectorExpanded(true)}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 2,
+            py: 1.5,
+            borderRadius: 2,
+            bgcolor: 'action.hover',
+            cursor: 'pointer',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <DashboardOutlined sx={{ fontSize: 20, color: 'text.secondary' }} />
+            <Typography variant="body2" fontWeight={600}>
+              {selectedName}
+            </Typography>
+          </Box>
+          <Typography variant="body2" color="primary" fontWeight={500}>
+            Change
+          </Typography>
+        </Box>
+      ) : (
+        <BoardScrollSection title="Select a board" loading={isLoadingBoards}>
+          <CreateBoardCard
             onClick={() => setShowBoardDrawer(true)}
+            label="Custom"
           />
-        )}
-        {boards.map((board) => (
-          <BoardScrollCard
-            key={board.uuid}
-            userBoard={board}
-            selected={selectedBoard?.uuid === board.uuid}
-            onClick={() => handleBoardSelect(board)}
-          />
-        ))}
-      </BoardScrollSection>
+          {selectedCustomConfig && (
+            <BoardScrollCard
+              key={`custom-${selectedCustomConfig.name}`}
+              storedConfig={selectedCustomConfig}
+              boardConfigs={boardConfigs}
+              selected
+              onClick={() => setShowBoardDrawer(true)}
+            />
+          )}
+          {boards.map((board) => (
+            <BoardScrollCard
+              key={board.uuid}
+              userBoard={board}
+              selected={selectedBoard?.uuid === board.uuid}
+              onClick={() => handleBoardSelect(board)}
+            />
+          ))}
+        </BoardScrollSection>
+      )}
       {boardsError && (
         <Typography variant="body2" color="error" sx={{ mt: 0.5 }}>
           {boardsError}

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -52,35 +53,43 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
   const [showBoardDrawer, setShowBoardDrawer] = useState(false);
   const [formKey, setFormKey] = useState(0);
   const [boardSelectorExpanded, setBoardSelectorExpanded] = useState(false);
+  const hasAutoSelectedRef = useRef(false);
+
+  // Reset auto-selection tracking when drawer closes
+  useEffect(() => {
+    if (!open) {
+      hasAutoSelectedRef.current = false;
+    }
+  }, [open]);
 
   // Auto-select the current board when the drawer opens
   useEffect(() => {
-    if (open && boards.length > 0 && !selectedBoard && !selectedCustomPath) {
-      let match: (typeof boards)[number] | undefined;
+    if (!open || boards.length === 0 || hasAutoSelectedRef.current) return;
 
-      // Strategy 1: Match by slug from /b/{slug} routes
-      if (localBoardPath) {
-        const basePath = getBaseBoardPath(localBoardPath);
-        match = boards.find((b) => `/b/${b.slug}` === basePath);
-      }
+    let match: (typeof boards)[number] | undefined;
 
-      // Strategy 2: Match by numeric board identity from localBoardDetails
-      // Handles generic routes like /kilter/original/16x12/screw_bolt/40/list
-      if (!match && localBoardDetails) {
-        match = boards.find(
-          (b) =>
-            b.boardType === localBoardDetails.board_name &&
-            b.layoutId === localBoardDetails.layout_id &&
-            b.sizeId === localBoardDetails.size_id &&
-            b.setIds === localBoardDetails.set_ids.join(','),
-        );
-      }
-
-      if (match) {
-        setSelectedBoard(match);
-      }
+    // Strategy 1: Match by slug from /b/{slug} routes
+    if (localBoardPath) {
+      const basePath = getBaseBoardPath(localBoardPath);
+      match = boards.find((b) => `/b/${b.slug}` === basePath);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // Strategy 2: Match by numeric board identity from localBoardDetails
+    // Handles generic routes like /kilter/original/16x12/screw_bolt/40/list
+    if (!match && localBoardDetails) {
+      match = boards.find(
+        (b) =>
+          b.boardType === localBoardDetails.board_name &&
+          b.layoutId === localBoardDetails.layout_id &&
+          b.sizeId === localBoardDetails.size_id &&
+          b.setIds === localBoardDetails.set_ids.join(','),
+      );
+    }
+
+    hasAutoSelectedRef.current = true;
+    if (match) {
+      setSelectedBoard(match);
+    }
   }, [open, boards, localBoardPath, localBoardDetails]);
 
   const isLoggedIn = status === 'authenticated';
@@ -160,17 +169,18 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
   const boardSelector = (
     <Box>
       {hasSelection && !boardSelectorExpanded ? (
-        <Box
+        <ButtonBase
           onClick={() => setBoardSelectorExpanded(true)}
           sx={{
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            width: '100%',
             px: 2,
             py: 1.5,
             borderRadius: 2,
             bgcolor: 'action.hover',
-            cursor: 'pointer',
+            textAlign: 'left',
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -182,7 +192,7 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
           <Typography variant="body2" color="primary" fontWeight={500}>
             Change
           </Typography>
-        </Box>
+        </ButtonBase>
       ) : (
         <BoardScrollSection title="Select a board" loading={isLoadingBoards}>
           <CreateBoardCard

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -77,12 +77,13 @@ export default function StartSeshDrawer({ open, onClose, boardConfigs }: StartSe
     // Strategy 2: Match by numeric board identity from localBoardDetails
     // Handles generic routes like /kilter/original/16x12/screw_bolt/40/list
     if (!match && localBoardDetails) {
+      const sortedLocalSetIds = [...localBoardDetails.set_ids].sort((a, b) => a - b).join(',');
       match = boards.find(
         (b) =>
           b.boardType === localBoardDetails.board_name &&
           b.layoutId === localBoardDetails.layout_id &&
           b.sizeId === localBoardDetails.size_id &&
-          b.setIds === localBoardDetails.set_ids.join(','),
+          b.setIds.split(',').map(Number).sort((a, b) => a - b).join(',') === sortedLocalSetIds,
       );
     }
 


### PR DESCRIPTION
When opening the Start Sesh drawer from a board page, the board selector
now auto-selects the current board using two strategies: slug matching
for /b/{slug} routes, and numeric identity matching via localBoardDetails
for generic routes. The selected board displays as a collapsed pill with
a "Change" action, so users can start a session immediately without
manually selecting a board.

https://claude.ai/code/session_01ViY5CLRSnTbEDwRT3EAzNC