### PR TITLE
Add Claude Code web session-start hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "bash .claude/setup.sh"
+      }
+    ]
+  }
+}

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing dependencies..."
+bun install --frozen-lockfile 2>/dev/null || bun install
+
+echo "==> Ensuring gh CLI is installed..."
+if ! command -v gh &>/dev/null; then
+  GH_VERSION=$(curl -sI https://github.com/cli/cli/releases/latest | grep -i '^location:' | sed 's|.*/tag/v||;s/\r//')
+  echo "  Installing gh v${GH_VERSION}..."
+  curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  sudo mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+  rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
+  echo "  gh installed: $(gh --version | head -1)"
+else
+  echo "  gh already installed: $(gh --version | head -1)"
+fi
+
+echo "==> Checking gh authentication..."
+if [ -n "${GH_TOKEN:-}" ]; then
+  if gh auth status &>/dev/null; then
+    echo "  gh authenticated successfully"
+  else
+    echo "  Warning: GH_TOKEN is set but gh auth status failed"
+  fi
+else
+  echo "  Note: GH_TOKEN not set — set it as a secret in Claude Code web settings for GitHub access"
+fi
+
+echo "==> Session setup complete"


### PR DESCRIPTION
Installs bun dependencies and gh CLI automatically when a Claude Code
web session starts. gh authenticates via GH_TOKEN environment variable.

https://claude.ai/code/session_01H1uiYGh7ek4yop7sA2cjMg