### PR TITLE
Fix lightbulb spinner stuck after ending session from sesh-settings

### DIFF
--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
 import { getBaseBoardPath } from '@/app/lib/url-utils';
@@ -63,6 +63,21 @@ export function useSessionIdManagement({
     if (!isOffBoardMode) return;
     setActiveSessionId(persistentSessionId);
   }, [isOffBoardMode, persistentSessionId]);
+
+  // Sync when persistent session is deactivated externally (e.g. sesh-settings-drawer
+  // calling deactivateSession() directly). We track the previous persistentSessionId
+  // so we only clear on an active→inactive transition, not on initial mount where
+  // persistentSessionId starts null before IndexedDB loads.
+  const prevPersistentSessionIdRef = useRef(persistentSessionId);
+  useEffect(() => {
+    const prev = prevPersistentSessionIdRef.current;
+    prevPersistentSessionIdRef.current = persistentSessionId;
+
+    if (prev && !persistentSessionId) {
+      clearClimbSessionCookie();
+      setActiveSessionId(null);
+    }
+  }, [persistentSessionId]);
 
   const sessionId = activeSessionId;
 


### PR DESCRIPTION
When ending a session via sesh-settings-drawer, deactivateSession() was
called directly on the persistent session context, but the GraphQL queue
context's local activeSessionId state was never cleared. This left
sessionId stale while hasConnected became false, making isConnecting
permanently true and showing an infinite spinner on the lightbulb icon.

Add an effect that detects when persistentSessionId transitions from
active to inactive and syncs the local state accordingly. Uses a ref to
track the previous value so initial mount (where persistentSessionId
starts null before IndexedDB loads) is not affected.

https://claude.ai/code/session_01R1L5ygLGoUH6byRaiQfoYS