### PR TITLE
Optimize climb list performance: CSS containment, drawer isolation, O…

### DIFF
--- a/docs/react-performance-audit.md
+++ b/docs/react-performance-audit.md
@@ -1,0 +1,152 @@
+# React Performance Audit: Core Experience
+
+Audit of queue control bar, climb list, and play view drawer — April 2026.
+
+---
+
+## 1. Queue Control Bar
+
+### Unstable adapter context object
+**File:** `packages/web/app/components/queue-control/queue-bridge-context.tsx:204-281`
+**Status:** Open
+
+The `usePersistentSessionQueueAdapter()` creates a context object with 20+ properties. Even though it's wrapped in `useMemo`, the dependency array includes derived values (`parsedParams`, `queue`, `currentClimbQueueItem`) that change frequently. Every change recreates the entire context object, causing all consumers to re-render.
+
+**Fix:** Split the adapter context into stable (actions) and volatile (data) parts, matching the split already done in `QueueContext.tsx`.
+
+### Overly broad context subscription
+**File:** `packages/web/app/components/queue-control/queue-control-bar.tsx:96-111`
+**Status:** Open
+
+The bar calls `useQueueContext()` which subscribes to the combined context (data + actions). The codebase already has split hooks (`useQueueData()` + `useQueueActions()` in `QueueContext.tsx:467-489`), but the control bar doesn't use them. Any data change (connection state, suggested climbs, user list) triggers a full bar re-render even when only action callbacks are needed.
+
+**Fix:** Migrate to `useQueueData()` + `useQueueActions()` in queue-control-bar and other consumers.
+
+### Color mode coupling
+**File:** `packages/web/app/components/queue-control/queue-control-bar.tsx:124-126`
+**Status:** Open
+
+`useColorMode()` subscribes to theme changes, causing the entire bar to re-render on dark/light toggle.
+
+### URL callback instability
+**File:** `packages/web/app/components/queue-control/queue-control-bar.tsx:137-184`
+**Status:** Open
+
+`buildClimbUrl` depends on `boardDetails` and `params` which may not be referentially stable across renders.
+
+### Inline style recreation
+**File:** `packages/web/app/components/queue-control/queue-control-bar.tsx:452-455`
+**Status:** Open
+
+Dynamic style objects created every render. Should be memoized or moved to CSS.
+
+---
+
+## 2. Climb List
+
+### No list virtualization / native paint skipping
+**Files:** `packages/web/app/components/board-page/climbs-list.tsx:368-419`
+**Status:** Fixed
+
+Both grid and list modes used `.map()` directly — all items rendered to DOM at once. With infinite scroll, lists can grow to 200+ items.
+
+**Fix applied:** Added `content-visibility: auto` with `contain-intrinsic-size` via CSS classes on each list/grid item wrapper. The browser natively skips layout and paint for off-screen items while keeping them in the DOM for native scroll feel.
+
+### O(n^2) deduplication
+**File:** `packages/web/app/components/board-page/board-page-climbs-list.tsx:54`
+**Status:** Fixed
+
+Used `findIndex` inside `filter` — quadratic complexity. Replaced with a `Set`-based O(n) approach.
+
+### Shared drawer state causes full list re-renders
+**Files:** `packages/web/app/components/board-page/climbs-list.tsx`, `liked-climbs-list.tsx`
+**Status:** Fixed
+
+`activeDrawerClimb` and `drawerMode` state lived in the list parent. Opening/closing any item's action drawer re-rendered the entire list (200+ items). Extracted drawers into a separate `SharedDrawers` component with an imperative handle (`useImperativeHandle`). Drawer state now lives in the sibling component, so open/close never triggers a list re-render.
+
+### Handler map recreation
+**File:** `packages/web/app/components/board-page/climbs-list.tsx:197-203`
+**Status:** Analyzed — low impact
+
+Creates a new `Map` of click handlers for every climb on each `climbs` change (100+ closures). However, `ClimbListItem`'s custom memo comparator (line 560-578) does not check `onSelect`, and uses a ref pattern for callbacks. The map changing doesn't actually cause child re-renders. Cost is O(n) closure allocation only — not a bottleneck.
+
+### Canvas thumbnails for most items
+**Files:** `packages/web/app/components/climb-card/climb-thumbnail.tsx`, `climbs-list.tsx:377,402`
+**Status:** Open
+
+Only first N items use image layers; the rest use expensive canvas rendering. With `content-visibility: auto`, off-screen canvas items are now skipped by the browser, which mitigates the impact. Further optimization: consider lazy-loading canvas renderers only when items enter the viewport.
+
+### ClimbsList component not memoized
+**File:** `packages/web/app/components/board-page/climbs-list.tsx`
+**Status:** Open
+
+The `ClimbsList` component itself is not wrapped in `React.memo`. Parent re-renders cascade through to all children. The `content-visibility` CSS fix mitigates the DOM cost, but React still reconciles the full VDOM.
+
+---
+
+## 3. Play View Drawer
+
+### keepMounted with heavy children
+**File:** `packages/web/app/components/play-view/play-view-drawer.tsx:273`
+**Status:** Open
+
+The main drawer uses `keepMounted={true}`, meaning `SwipeBoardCarousel` (canvas rendering), `ClimbDetailShellClient`, and API queries (beta videos, logbook) all run continuously even when the drawer is closed.
+
+**Fix:** Either conditionally render content based on `isOpen`, or add visibility gating so queries and canvas rendering pause when the drawer is not visible.
+
+### PlayDrawerContent not memoized
+**File:** `packages/web/app/components/play-view/play-view-drawer.tsx:55-66`
+**Status:** Open
+
+Called on every render without `React.memo`. `useBuildClimbDetailSections` re-evaluates unconditionally, triggering section queries and CollapsibleSection rebuilds.
+
+### SwipeBoardCarousel receives fresh callback props
+**File:** `packages/web/app/components/play-view/play-view-drawer.tsx:302-318`
+**Status:** Open
+
+Not wrapped in `React.memo`. Receives callback props (`onSwipeNext`, `onDoubleTap`) that are new references on parent re-render, potentially causing canvas re-initialization.
+
+### Queue drawer height state cascade
+**File:** `packages/web/app/components/play-view/play-view-drawer.tsx:90,183-194,501`
+**Status:** Open
+
+`queueDrawerHeight` state updates during drag gestures trigger parent re-renders, which cascade to the canvas renderer. Should use a ref + CSS variable instead of state.
+
+### Beta API queries fire unconditionally
+**File:** `packages/web/app/components/play-view/play-view-beta-slider.tsx:36-45`
+**Status:** Open
+
+No visibility gating — queries run even when the section is collapsed or the drawer is closed.
+
+### Logbook filtering not memoized
+**File:** `packages/web/app/components/play-view/play-view-comments.tsx:24-26`
+**Status:** Open
+
+Refilters and resorts the logbook array on every parent re-render. Should be wrapped in `useMemo`.
+
+### Unused dynamic import
+**File:** `packages/web/app/components/play-view/play-view-drawer.tsx:20`
+**Status:** Open
+
+`import dynamic from 'next/dynamic'` is imported but never used — dead code.
+
+---
+
+## Priority Summary
+
+| Priority | Issue | Component | Status |
+|----------|-------|-----------|--------|
+| P0 | CSS content-visibility for paint skipping | Climb List | **Fixed** |
+| P0 | keepMounted with canvas | Play View Drawer | Open |
+| P0 | Unstable bridge context | Queue Control Bar | Open |
+| P1 | Combined context subscription | Queue Control Bar | Open |
+| P1 | Shared drawer state re-renders | Climb List | **Fixed** |
+| P1 | O(n^2) dedup filter | Climb List | **Fixed** |
+| P1 | Unmemoized PlayDrawerContent | Play View Drawer | Open |
+| P2 | Queue height via state | Play View Drawer | Open |
+| P2 | Canvas thumbnails for all items | Climb List | Mitigated |
+| P2 | Beta API queries unconditional | Play View Drawer | Open |
+| P2 | Logbook filtering no memo | Play View Drawer | Open |
+| P3 | Color mode coupling | Queue Control Bar | Open |
+| P3 | Inline style recreation | Queue Control Bar | Open |
+| P3 | Unused dynamic import | Play View Drawer | Open |

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useCallback, useState, useMemo } from 'react';
+import React, { useEffect, useCallback, useState, useMemo, useRef, useImperativeHandle, forwardRef } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import { FormatListBulletedOutlined, AppsOutlined } from '@mui/icons-material';
@@ -30,6 +30,7 @@ import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from '@/app/components/library/playlist-view.module.css';
+import listStyles from '@/app/components/board-page/climbs-list.module.css';
 
 type ViewMode = 'grid' | 'list';
 
@@ -45,6 +46,91 @@ const sharedPlaylistDrawerStyles = {
   body: { padding: 0 },
   header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
 } as const;
+
+// --- Shared drawers extracted to isolate state from list re-renders ---
+type LikedDrawerHandle = {
+  openActions: (climb: Climb) => void;
+  openPlaylistSelector: (climb: Climb) => void;
+};
+
+type LikedDrawersProps = {
+  boardDetails: BoardDetails;
+};
+
+const LikedDrawers = forwardRef<LikedDrawerHandle, LikedDrawersProps>(
+  ({ boardDetails }, ref) => {
+    const pathname = usePathname();
+    const [activeDrawerClimb, setActiveDrawerClimb] = useState<Climb | null>(null);
+    const [drawerMode, setDrawerMode] = useState<'actions' | 'playlist' | null>(null);
+
+    useImperativeHandle(ref, () => ({
+      openActions: (climb: Climb) => {
+        setActiveDrawerClimb(climb);
+        setDrawerMode('actions');
+      },
+      openPlaylistSelector: (climb: Climb) => {
+        setActiveDrawerClimb(climb);
+        setDrawerMode('playlist');
+      },
+    }), []);
+
+    const handleCloseDrawer = useCallback(() => setDrawerMode(null), []);
+    const handleSwitchToPlaylist = useCallback(() => setDrawerMode('playlist'), []);
+    const handleDrawerTransitionEnd = useCallback((open: boolean) => {
+      if (!open) setActiveDrawerClimb(null);
+    }, []);
+
+    const excludeActions = useMemo(
+      () => getExcludedClimbActions(boardDetails.board_name, 'list'),
+      [boardDetails.board_name],
+    );
+
+    return (
+      <>
+        <SwipeableDrawer
+          title={activeDrawerClimb ? <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={boardDetails} /> : undefined}
+          placement="bottom"
+          open={drawerMode === 'actions'}
+          onClose={handleCloseDrawer}
+          onTransitionEnd={handleDrawerTransitionEnd}
+          styles={sharedDrawerStyles}
+        >
+          {activeDrawerClimb && (
+            <ClimbActions
+              climb={activeDrawerClimb}
+              boardDetails={boardDetails}
+              angle={activeDrawerClimb.angle}
+              currentPathname={pathname}
+              viewMode="list"
+              exclude={excludeActions}
+              onOpenPlaylistSelector={handleSwitchToPlaylist}
+              onActionComplete={handleCloseDrawer}
+            />
+          )}
+        </SwipeableDrawer>
+
+        <SwipeableDrawer
+          title={activeDrawerClimb ? <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={boardDetails} /> : undefined}
+          placement="bottom"
+          open={drawerMode === 'playlist'}
+          onClose={handleCloseDrawer}
+          onTransitionEnd={handleDrawerTransitionEnd}
+          styles={sharedPlaylistDrawerStyles}
+        >
+          {activeDrawerClimb && (
+            <PlaylistSelectionContent
+              climbUuid={activeDrawerClimb.uuid}
+              boardDetails={boardDetails}
+              angle={activeDrawerClimb.angle}
+              onDone={handleCloseDrawer}
+            />
+          )}
+        </SwipeableDrawer>
+      </>
+    );
+  },
+);
+LikedDrawers.displayName = 'LikedDrawers';
 
 type LikedClimbsListProps = {
   boardDetails: BoardDetails;
@@ -190,37 +276,16 @@ export default function LikedClimbsList({
 
   const aspectRatio = boardDetails.boardWidth / boardDetails.boardHeight;
 
-  // --- Shared drawer state (one pair for all list items) ---
-  const pathname = usePathname();
-  const [activeDrawerClimb, setActiveDrawerClimb] = useState<Climb | null>(null);
-  const [drawerMode, setDrawerMode] = useState<'actions' | 'playlist' | null>(null);
+  // --- Shared drawers via imperative handle (state lives in LikedDrawers, not here) ---
+  const drawerRef = useRef<LikedDrawerHandle>(null);
 
   const handleOpenActions = useCallback((climb: Climb) => {
-    setActiveDrawerClimb(climb);
-    setDrawerMode('actions');
+    drawerRef.current?.openActions(climb);
   }, []);
 
   const handleOpenPlaylistSelector = useCallback((climb: Climb) => {
-    setActiveDrawerClimb(climb);
-    setDrawerMode('playlist');
+    drawerRef.current?.openPlaylistSelector(climb);
   }, []);
-
-  const handleCloseDrawer = useCallback(() => {
-    setDrawerMode(null);
-  }, []);
-
-  const handleSwitchToPlaylist = useCallback(() => {
-    setDrawerMode('playlist');
-  }, []);
-
-  const handleDrawerTransitionEnd = useCallback((open: boolean) => {
-    if (!open) setActiveDrawerClimb(null);
-  }, []);
-
-  const excludeActions = useMemo(
-    () => getExcludedClimbActions(boardDetails.board_name, 'list'),
-    [boardDetails.board_name],
-  );
 
   if ((isLoading || tokenLoading) && allClimbs.length === 0) {
     return (
@@ -274,7 +339,7 @@ export default function LikedClimbsList({
       {viewMode === 'grid' ? (
         <Box sx={gridContainerSx}>
           {visibleClimbs.map((climb) => (
-            <Box sx={cardBoxSx} key={climb.uuid}>
+            <Box sx={cardBoxSx} key={climb.uuid} className={listStyles.gridItem}>
               <ClimbCard
                 climb={climb}
                 boardDetails={boardDetails}
@@ -290,8 +355,8 @@ export default function LikedClimbsList({
       ) : (
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           {visibleClimbs.map((climb) => (
+            <div key={climb.uuid} className={listStyles.listItem}>
             <ClimbListItem
-              key={climb.uuid}
               climb={climb}
               boardDetails={boardDetails}
               selected={selectedClimbUuid === climb.uuid}
@@ -302,6 +367,7 @@ export default function LikedClimbsList({
               onOpenPlaylistSelector={handleOpenPlaylistSelector}
               addToQueue={addToQueue}
             />
+            </div>
           ))}
         </Box>
       )}
@@ -320,46 +386,8 @@ export default function LikedClimbsList({
         )}
       </div>
 
-      {/* Shared drawers for all list items */}
-      <SwipeableDrawer
-        title={activeDrawerClimb ? <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={boardDetails} /> : undefined}
-        placement="bottom"
-        open={drawerMode === 'actions'}
-        onClose={handleCloseDrawer}
-        onTransitionEnd={handleDrawerTransitionEnd}
-        styles={sharedDrawerStyles}
-      >
-        {activeDrawerClimb && (
-          <ClimbActions
-            climb={activeDrawerClimb}
-            boardDetails={boardDetails}
-            angle={activeDrawerClimb.angle}
-            currentPathname={pathname}
-            viewMode="list"
-            exclude={excludeActions}
-            onOpenPlaylistSelector={handleSwitchToPlaylist}
-            onActionComplete={handleCloseDrawer}
-          />
-        )}
-      </SwipeableDrawer>
-
-      <SwipeableDrawer
-        title={activeDrawerClimb ? <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={boardDetails} /> : undefined}
-        placement="bottom"
-        open={drawerMode === 'playlist'}
-        onClose={handleCloseDrawer}
-        onTransitionEnd={handleDrawerTransitionEnd}
-        styles={sharedPlaylistDrawerStyles}
-      >
-        {activeDrawerClimb && (
-          <PlaylistSelectionContent
-            climbUuid={activeDrawerClimb.uuid}
-            boardDetails={boardDetails}
-            angle={activeDrawerClimb.angle}
-            onDone={handleCloseDrawer}
-          />
-        )}
-      </SwipeableDrawer>
+      {/* Shared drawers — owns its own state so open/close doesn't re-render the list */}
+      <LikedDrawers ref={drawerRef} boardDetails={boardDetails} />
     </div>
   );
 }

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -51,7 +51,12 @@ const BoardPageClimbsList = ({
   const prevClimbsRef = useRef<Climb[]>([]);
   const climbs = useMemo(() => {
     const rawClimbs = !hasDoneFirstFetch ? initialClimbs : climbSearchResults || [];
-    const deduped = rawClimbs.filter((climb, index, self) => index === self.findIndex((c) => c.uuid === climb.uuid));
+    const seen = new Set<string>();
+    const deduped = rawClimbs.filter((climb) => {
+      if (seen.has(climb.uuid)) return false;
+      seen.add(climb.uuid);
+      return true;
+    });
 
     // Return the previous reference when content hasn't changed to avoid
     // triggering downstream progressive rendering during SSR→client handoff.

--- a/packages/web/app/components/board-page/climbs-list.module.css
+++ b/packages/web/app/components/board-page/climbs-list.module.css
@@ -1,0 +1,14 @@
+/* Native browser paint-skipping for off-screen list items.
+ * content-visibility: auto tells the browser to skip layout & paint
+ * for items outside the viewport. contain-intrinsic-size provides a
+ * placeholder height so the scrollbar stays stable. */
+
+.listItem {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 72px;
+}
+
+.gridItem {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 300px;
+}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useCallback, useState, useMemo, useRef } from 'react';
+import React, { useEffect, useCallback, useState, useMemo, useRef, useImperativeHandle, forwardRef } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
@@ -21,6 +21,7 @@ import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
+import listStyles from './climbs-list.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), { ssr: false });
 
@@ -40,6 +41,106 @@ const sharedPlaylistDrawerStyles = {
   body: { padding: 0 },
   header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
 } as const;
+
+// --- Shared drawers extracted into a sibling component ---
+// Owns its own state so drawer open/close never re-renders the item list.
+export type SharedDrawerHandle = {
+  openActions: (climb: Climb) => void;
+  openPlaylistSelector: (climb: Climb) => void;
+};
+
+type SharedDrawersProps = {
+  boardDetails: BoardDetails;
+  resolveBoardDetails: (climb: Climb) => BoardDetails;
+};
+
+const SharedDrawers = forwardRef<SharedDrawerHandle, SharedDrawersProps>(
+  ({ boardDetails, resolveBoardDetails }, ref) => {
+    const pathname = usePathname();
+    const [activeDrawerClimb, setActiveDrawerClimb] = useState<Climb | null>(null);
+    const [drawerMode, setDrawerMode] = useState<'actions' | 'playlist' | null>(null);
+
+    useImperativeHandle(ref, () => ({
+      openActions: (climb: Climb) => {
+        setActiveDrawerClimb(climb);
+        setDrawerMode('actions');
+      },
+      openPlaylistSelector: (climb: Climb) => {
+        setActiveDrawerClimb(climb);
+        setDrawerMode('playlist');
+      },
+    }), []);
+
+    const handleCloseDrawer = useCallback(() => setDrawerMode(null), []);
+    const handleSwitchToPlaylist = useCallback(() => setDrawerMode('playlist'), []);
+    const handleDrawerTransitionEnd = useCallback((open: boolean) => {
+      if (!open) setActiveDrawerClimb(null);
+    }, []);
+
+    const excludeActions = useMemo(
+      () => getExcludedClimbActions(boardDetails.board_name, 'list'),
+      [boardDetails.board_name],
+    );
+
+    const activeDrawerBoardDetails = useMemo(
+      () => (activeDrawerClimb ? resolveBoardDetails(activeDrawerClimb) : boardDetails),
+      [activeDrawerClimb, resolveBoardDetails, boardDetails],
+    );
+
+    return (
+      <>
+        <SwipeableDrawer
+          title={
+            activeDrawerClimb ? (
+              <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={activeDrawerBoardDetails} />
+            ) : undefined
+          }
+          placement="bottom"
+          open={drawerMode === 'actions'}
+          onClose={handleCloseDrawer}
+          onTransitionEnd={handleDrawerTransitionEnd}
+          styles={sharedDrawerStyles}
+        >
+          {activeDrawerClimb && (
+            <ClimbActions
+              climb={activeDrawerClimb}
+              boardDetails={activeDrawerBoardDetails}
+              angle={activeDrawerClimb.angle}
+              currentPathname={pathname}
+              viewMode="list"
+              exclude={excludeActions}
+              onOpenPlaylistSelector={handleSwitchToPlaylist}
+              onActionComplete={handleCloseDrawer}
+            />
+          )}
+        </SwipeableDrawer>
+
+        <SwipeableDrawer
+          title={
+            activeDrawerClimb ? (
+              <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={activeDrawerBoardDetails} />
+            ) : undefined
+          }
+          placement="bottom"
+          open={drawerMode === 'playlist'}
+          onClose={handleCloseDrawer}
+          onTransitionEnd={handleDrawerTransitionEnd}
+          styles={sharedPlaylistDrawerStyles}
+        >
+          {activeDrawerClimb && (
+            <PlaylistSelectionContent
+              climbUuid={activeDrawerClimb.uuid}
+              boardDetails={activeDrawerBoardDetails}
+              angle={activeDrawerClimb.angle}
+              onDone={handleCloseDrawer}
+            />
+          )}
+        </SwipeableDrawer>
+      </>
+    );
+  },
+);
+SharedDrawers.displayName = 'SharedDrawers';
 
 export type ClimbsListProps = {
   boardDetails: BoardDetails;
@@ -213,42 +314,16 @@ const ClimbsList = ({
     [boardDetails, boardDetailsMap],
   );
 
-  // --- Shared drawer state (one pair of drawers for all list items) ---
-  const pathname = usePathname();
-  const [activeDrawerClimb, setActiveDrawerClimb] = useState<Climb | null>(null);
-  const [drawerMode, setDrawerMode] = useState<'actions' | 'playlist' | null>(null);
+  // --- Shared drawers via imperative handle (state lives in SharedDrawers, not here) ---
+  const drawerRef = useRef<SharedDrawerHandle>(null);
 
   const handleOpenActions = useCallback((climb: Climb) => {
-    setActiveDrawerClimb(climb);
-    setDrawerMode('actions');
+    drawerRef.current?.openActions(climb);
   }, []);
 
   const handleOpenPlaylistSelector = useCallback((climb: Climb) => {
-    setActiveDrawerClimb(climb);
-    setDrawerMode('playlist');
+    drawerRef.current?.openPlaylistSelector(climb);
   }, []);
-
-  const handleCloseDrawer = useCallback(() => {
-    setDrawerMode(null);
-  }, []);
-
-  const handleSwitchToPlaylist = useCallback(() => {
-    setDrawerMode('playlist');
-  }, []);
-
-  const handleDrawerTransitionEnd = useCallback((open: boolean) => {
-    if (!open) setActiveDrawerClimb(null);
-  }, []);
-
-  const excludeActions = useMemo(
-    () => getExcludedClimbActions(boardDetails.board_name, 'list'),
-    [boardDetails.board_name],
-  );
-
-  const activeDrawerBoardDetails = useMemo(
-    () => (activeDrawerClimb ? resolveBoardDetails(activeDrawerClimb) : boardDetails),
-    [activeDrawerClimb, resolveBoardDetails, boardDetails],
-  );
 
   // Memoize sx prop objects to prevent recreation on every render
   const headerContainerSx = useMemo(
@@ -369,7 +444,7 @@ const ClimbsList = ({
         /* Grid (card) mode — not virtualized */
         <Box sx={gridContainerSx} translate="no">
           {visibleClimbs.map((climb, index) => (
-            <Box key={climb.uuid} sx={cardBoxSx}>
+            <Box key={climb.uuid} sx={cardBoxSx} className={listStyles.gridItem}>
               <div {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}>
                 <ClimbCard
                   climb={climb}
@@ -394,7 +469,7 @@ const ClimbsList = ({
             <ClimbsListSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} viewMode="list" />
           ) : (
             visibleClimbs.map((climb, index) => (
-              <div key={climb.uuid}>
+              <div key={climb.uuid} className={listStyles.listItem}>
                 <div {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}>
                   <ClimbListItem
                     climb={climb}
@@ -435,54 +510,8 @@ const ClimbsList = ({
 
       {showBottomSpacer && <Box sx={{ height: themeTokens.layout.bottomNavSpacer }} aria-hidden />}
 
-      {/* Shared drawers for all list items (actions + playlist selector) */}
-      <SwipeableDrawer
-        title={
-          activeDrawerClimb ? (
-            <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={activeDrawerBoardDetails} />
-          ) : undefined
-        }
-        placement="bottom"
-        open={drawerMode === 'actions'}
-        onClose={handleCloseDrawer}
-        onTransitionEnd={handleDrawerTransitionEnd}
-        styles={sharedDrawerStyles}
-      >
-        {activeDrawerClimb && (
-          <ClimbActions
-            climb={activeDrawerClimb}
-            boardDetails={activeDrawerBoardDetails}
-            angle={activeDrawerClimb.angle}
-            currentPathname={pathname}
-            viewMode="list"
-            exclude={excludeActions}
-            onOpenPlaylistSelector={handleSwitchToPlaylist}
-            onActionComplete={handleCloseDrawer}
-          />
-        )}
-      </SwipeableDrawer>
-
-      <SwipeableDrawer
-        title={
-          activeDrawerClimb ? (
-            <DrawerClimbHeader climb={activeDrawerClimb} boardDetails={activeDrawerBoardDetails} />
-          ) : undefined
-        }
-        placement="bottom"
-        open={drawerMode === 'playlist'}
-        onClose={handleCloseDrawer}
-        onTransitionEnd={handleDrawerTransitionEnd}
-        styles={sharedPlaylistDrawerStyles}
-      >
-        {activeDrawerClimb && (
-          <PlaylistSelectionContent
-            climbUuid={activeDrawerClimb.uuid}
-            boardDetails={activeDrawerBoardDetails}
-            angle={activeDrawerClimb.angle}
-            onDone={handleCloseDrawer}
-          />
-        )}
-      </SwipeableDrawer>
+      {/* Shared drawers — owns its own state so open/close doesn't re-render the list */}
+      <SharedDrawers ref={drawerRef} boardDetails={boardDetails} resolveBoardDetails={resolveBoardDetails} />
     </Box>
   );
 };


### PR DESCRIPTION
…(n) dedup

- Add content-visibility: auto to list/grid items so the browser skips layout and paint for off-screen items (native scroll, no virtualization)
- Extract shared drawers into sibling component with imperative handle so drawer open/close never re-renders the 200+ item list
- Replace O(n²) findIndex dedup with Set-based O(n) filter
- Apply same fixes to liked-climbs-list
- Add docs/react-performance-audit.md with full findings

https://claude.ai/code/session_01SsGkJj1D4L8LaeFX86LLKK