### PR TITLE
Remove refs from useCallback/useEffect dependency arrays

### DIFF
--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -128,8 +128,8 @@ export function useSessionLifecycle({
   }, [setSessionExternal]);
 
   // Keep refs in sync
-  useEffect(() => { sessionRef.current = session; }, [session, sessionRef]);
-  useEffect(() => { activeSessionRef.current = activeSession; }, [activeSession, activeSessionRef]);
+  useEffect(() => { sessionRef.current = session; }, [session]);
+  useEffect(() => { activeSessionRef.current = activeSession; }, [activeSession]);
 
   // Session lifecycle functions
   const activateSession = useCallback((info: ActiveSessionInfo) => {
@@ -183,7 +183,7 @@ export function useSessionLifecycle({
           console.error('[PersistentSession] Failed to get session summary:', err);
         });
     }
-  }, [activeSessionRef, deactivateSession, wsAuthTokenRef]);
+  }, [deactivateSession]);
 
   // Connect to session when activeSession changes
   useEffect(() => {


### PR DESCRIPTION
Refs are stable objects that never change identity, so including them
in dependency arrays is misleading and would be flagged by exhaustive-deps.

https://claude.ai/code/session_01XUy4oh1VsqZvsNfkCri4Rc