### PR TITLE
Clean up useEffect dependency array in use-session-lifecycle

### DIFF
--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -550,12 +550,7 @@ export function useSessionLifecycle({
         clearTimeout(retryConnectTimeout);
       }
     };
-  // Note: username, avatarUrl, wsAuthToken are accessed via refs to prevent reconnection on changes
-  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setSession,
-      mountedRef, connectionGenerationRef, isConnectingRef, isReconnectingRef,
-      wsAuthTokenRef, usernameRef, avatarUrlRef, sessionRef, activeSessionRef,
-      queueRef, currentClimbQueueItemRef, triggerResyncRef, lastReceivedSequenceRef,
-      queueUnsubscribeRef, sessionUnsubscribeRef, pendingInitialQueue]);
+  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setSession, pendingInitialQueue]);
 
   return {
     activeSession,


### PR DESCRIPTION
Remove unnecessary refs from dependency array. Refs have stable identity and don't trigger re-runs when their .current value changes - only actual dependencies (activeSession, isAuthLoading, callbacks, setSession, pendingInitialQueue) should be included.