### PR TITLE
Optimize play drawer and queue bridge context performance

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -262,6 +262,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
 
   const isMirrored = !!currentClimb?.mirrored;
 
+  // Keep content mounted during the close animation so the slide-out is smooth.
+  // `showContent` stays true while isOpen OR while the exit transition is running.
+  const [showContent, setShowContent] = useState(isOpen);
+  useEffect(() => {
+    if (isOpen) setShowContent(true);
+  }, [isOpen]);
+
+  const handleTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setShowContent(false);
+  }, []);
 
   return (
     <>
@@ -271,6 +281,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       fullHeight
       open={isOpen}
       onClose={handleClose}
+      onTransitionEnd={handleTransitionEnd}
       keepMounted
       swipeEnabled={!isActionsOpen && !isQueueOpen && !isPlaylistSelectorOpen}
       showDragHandle={true}
@@ -279,7 +290,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         wrapper: { height: '100%', backgroundColor: 'var(--semantic-background)' },
       }}
     >
-      <>
+      {showContent ? (<>
       <div className={styles.drawerContent}>
         {currentClimb ? (
           <PlayDrawerContent
@@ -476,7 +487,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             boardDetails={boardDetails}
           />
         )}
-      </>
+      </>) : null}
 
         {/* Queue list drawer */}
         <SwipeableDrawer

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -217,6 +217,7 @@ function usePersistentSessionQueueAdapter(): {
       getNextClimbQueueItem,
       getPreviousClimbQueueItem,
       setQueue,
+      disconnect: ps.deactivateSession,
       startSession: noopStartSession,
       joinSession: noopJoinSession,
       endSession: ps.deactivateSession,
@@ -233,9 +234,9 @@ function usePersistentSessionQueueAdapter(): {
       getNextClimbQueueItem,
       getPreviousClimbQueueItem,
       setQueue,
+      ps.deactivateSession,
       noopStartSession,
       noopJoinSession,
-      ps.deactivateSession,
     ],
   );
 
@@ -343,6 +344,7 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       getNextClimbQueueItem: ctx.getNextClimbQueueItem,
       getPreviousClimbQueueItem: ctx.getPreviousClimbQueueItem,
       setQueue: ctx.setQueue,
+      disconnect: ctx.disconnect,
       startSession: ctx.startSession,
       joinSession: ctx.joinSession,
       endSession: ctx.endSession,


### PR DESCRIPTION
- Gate play drawer content on isOpen: heavy children (canvas, API queries,
  detail sections) unmount when drawer is closed while keepMounted keeps the
  shell for smooth animations
- Split queue bridge adapter into stable actions + volatile data contexts,
  matching GraphQLQueueProvider's split pattern so useQueueActions() works
  through the bridge without unnecessary re-renders
- Wrap SwipeBoardCarousel and PlayDrawerContent in React.memo
- Memoize logbook filtering in PlayViewComments
- Remove unused dynamic import

https://claude.ai/code/session_01XfmSztt4beZSYfaVsdx8SE