### PR TITLE
perf: replace queue drawer height state with ref + DOM manipulation

### DIFF
--- a/docs/react-performance-audit.md
+++ b/docs/react-performance-audit.md
@@ -112,9 +112,11 @@ Not wrapped in `React.memo`. Receives callback props (`onSwipeNext`, `onDoubleTa
 
 ### Queue drawer height state cascade
 **File:** `packages/web/app/components/play-view/play-view-drawer.tsx:90,183-194,501`
-**Status:** Open
+**Status:** Fixed
 
 `queueDrawerHeight` state updates during drag gestures trigger parent re-renders, which cascade to the canvas renderer. Should use a ref + CSS variable instead of state.
+
+**Fix applied:** Replaced `queueDrawerHeight` state with a ref (`queueDrawerHeightRef`) and direct DOM manipulation via a `paperRef` on the queue `SwipeableDrawer`. The `updateQueueDrawerHeight` helper writes to both the ref and the Paper element's inline `style.height`, bypassing React reconciliation entirely. Drag gestures no longer trigger re-renders of `PlayViewDrawer`, `SwipeBoardCarousel`, or `PlayDrawerContent`. The queue drawer's `styles` object was also extracted to a module-level constant (`QUEUE_DRAWER_STYLES`) to prevent object recreation on every render.
 
 ### Beta API queries fire unconditionally
 **File:** `packages/web/app/components/play-view/play-view-beta-slider.tsx:36-45`
@@ -151,7 +153,7 @@ Refilters and resorts the logbook array on every parent re-render.
 | P1 | Shared drawer state re-renders | Climb List | **Fixed** |
 | P1 | O(n^2) dedup filter | Climb List | **Fixed** |
 | P1 | Unmemoized PlayDrawerContent | Play View Drawer | **Fixed** |
-| P2 | Queue height via state | Play View Drawer | Open |
+| P2 | Queue height via state | Play View Drawer | **Fixed** |
 | P2 | Canvas thumbnails for all items | Climb List | Mitigated |
 | P2 | Beta API queries unconditional | Play View Drawer | Open |
 | P2 | Logbook filtering no memo | Play View Drawer | **Fixed** |

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -44,6 +44,14 @@ import { useBuildClimbDetailSections } from '@/app/components/climb-detail/build
 
 
 
+const QUEUE_DRAWER_STYLES = {
+  wrapper: {
+    touchAction: 'pan-y' as const,
+    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  },
+  body: { padding: 0, touchAction: 'pan-y' as const },
+} as const;
+
 interface PlayDrawerContentProps {
   climb: Climb;
   boardType: string;
@@ -86,7 +94,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const [isEditMode, setIsEditMode] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
-  const [queueDrawerHeight, setQueueDrawerHeight] = useState<string>('60%');
+  const queueDrawerHeightRef = useRef('60%');
+  const queuePaperRef = useRef<HTMLDivElement>(null);
+
+  const updateQueueDrawerHeight = useCallback((height: string) => {
+    queueDrawerHeightRef.current = height;
+    if (queuePaperRef.current) {
+      queuePaperRef.current.style.height = height;
+    }
+  }, []);
   const pathname = usePathname();
   const queueListRef = useRef<QueueListHandle>(null);
   const queueScrollRef = useRef<HTMLDivElement>(null);
@@ -162,9 +178,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
 
   const handleQueueDragStart = useCallback((e: React.TouchEvent) => {
     dragStartY.current = e.touches[0].clientY;
-    dragStartHeightRef.current = queueDrawerHeight;
+    dragStartHeightRef.current = queueDrawerHeightRef.current;
     isDragGestureRef.current = false;
-  }, [queueDrawerHeight]);
+  }, []);
 
   const handleQueueDragMove = useCallback((e: React.TouchEvent) => {
     const delta = Math.abs(e.touches[0].clientY - dragStartY.current);
@@ -181,11 +197,11 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
 
     if (deltaY < -THRESHOLD) {
       // Dragged up → expand to 100%
-      setQueueDrawerHeight('100%');
+      updateQueueDrawerHeight('100%');
     } else if (deltaY > THRESHOLD) {
       if (dragStartHeightRef.current === '100%') {
         // Dragged down from 100% → collapse to 60%
-        setQueueDrawerHeight('60%');
+        updateQueueDrawerHeight('60%');
       } else {
         // Dragged down from 60% → close drawer
         setIsQueueOpen(false);
@@ -193,14 +209,14 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         setShowHistory(false);
       }
     }
-  }, [handleExitEditMode]);
+  }, [handleExitEditMode, updateQueueDrawerHeight]);
 
   // Reset drawer height when queue drawer closes
   useEffect(() => {
     if (!isQueueOpen) {
-      setQueueDrawerHeight('60%');
+      updateQueueDrawerHeight('60%');
     }
-  }, [isQueueOpen]);
+  }, [isQueueOpen, updateQueueDrawerHeight]);
 
   // Hash-based back button support
   useEffect(() => {
@@ -483,7 +499,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         {/* Queue list drawer */}
         <SwipeableDrawer
           placement="bottom"
-          height={queueDrawerHeight}
+          height="60%"
+          paperRef={queuePaperRef}
           open={isQueueOpen}
           showCloseButton={false}
           swipeEnabled={false}
@@ -501,14 +518,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               }, 100);
             }
           }}
-          styles={{
-            wrapper: {
-              height: queueDrawerHeight,
-              touchAction: 'pan-y',
-              transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-            },
-            body: { padding: 0, touchAction: 'pan-y' },
-          }}
+          styles={QUEUE_DRAWER_STYLES}
         >
           {/* Custom drag header — resize only on deliberate drag, not scroll */}
           <div

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -42,6 +42,8 @@ export interface SwipeableDrawerProps {
   footer?: React.ReactNode;
   disablePortal?: boolean;
   keepMounted?: boolean;
+  /** Ref forwarded to the MUI Paper element inside the drawer. */
+  paperRef?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
 }
 
@@ -63,6 +65,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   footer,
   disablePortal,
   keepMounted = false,
+  paperRef,
   disableBackdropClick,
   open,
   children,
@@ -297,8 +300,8 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   );
 
   const muiPaperProps = useMemo(
-    () => ({ sx: paperSx, 'data-swipeable-drawer': 'true' }),
-    [paperSx],
+    () => ({ ref: paperRef, sx: paperSx, 'data-swipeable-drawer': 'true' }),
+    [paperRef, paperSx],
   );
 
   const bodyContent = (


### PR DESCRIPTION
Drag gestures on the queue drawer were updating queueDrawerHeight state, re-rendering the entire PlayViewDrawer including the expensive canvas renderer. Now uses a ref + direct style.height writes on the Paper element, bypassing React reconciliation. Also extracts the queue drawer styles to a module-level constant to avoid object recreation per render.

https://claude.ai/code/session_014xqosL9txeA4JNeeDGxYJr