### PR TITLE
Remove excess disconnect property from data contexts

### DIFF
--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -267,7 +267,6 @@ function usePersistentSessionQueueAdapter(): {
       isBackendMode: true,
       hasConnected: ps.hasConnected,
       connectionError: ps.error,
-      disconnect: ps.deactivateSession,
       isDisconnected: false,
     }),
     [
@@ -277,7 +276,6 @@ function usePersistentSessionQueueAdapter(): {
       isParty,
       ps.hasConnected,
       ps.activeSession?.sessionId,
-      ps.deactivateSession,
       ps.session?.goal,
       ps.users,
       ps.clientId,
@@ -381,7 +379,6 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       isBackendMode: ctx.isBackendMode,
       hasConnected: ctx.hasConnected,
       connectionError: ctx.connectionError,
-      disconnect: ctx.disconnect,
       isDisconnected: ctx.isDisconnected,
     };
   }, [isInjected, adapter.dataValue, effectiveContext]);


### PR DESCRIPTION
disconnect belongs in QueueActionsType, not QueueDataType. Remove it from dataValue and effectiveData to fix duplicate property build error and keep type boundaries clean.

https://claude.ai/code/session_015cEiq3eGr24wjMjBTbgtc9