### PR TITLE
Fix play drawer janky open animation and swipe-to-close

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -303,7 +303,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       onClose={handleClose}
       onTransitionEnd={handleTransitionEnd}
       keepMounted
-      swipeEnabled={!isActionsOpen && !isQueueOpen && !isPlaylistSelectorOpen}
+      swipeEnabled={!isActionsOpen && !isQueueOpen && !isPlaylistSelectorOpen && !isTickDrawerOpen}
       showDragHandle={true}
       styles={{
         body: { padding: 0, overflow: 'hidden' },


### PR DESCRIPTION
- Replace useEffect-based showContent with synchronous setState-during-render
  pattern so content appears in the same frame as the drawer opening, eliminating
  the one-frame empty flash that caused janky animations and stale MUI measurements
- Add isTickDrawerOpen to swipeEnabled check so MUI doesn't attempt swipe-to-close
  when the tick drawer is open (previously caused gesture to silently fail)

https://claude.ai/code/session_01PkfuGgmDNEa6aC5QeSeDPS