### PR TITLE
perf: eliminate cascade re-renders on favorite toggle with useSyncExternalStore

### DIFF
--- a/packages/web/app/components/climb-actions/__tests__/use-favorite.test.ts
+++ b/packages/web/app/components/climb-actions/__tests__/use-favorite.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { FavoritesContext } from '../favorites-batch-context';
+import { favoritesStore } from '../favorites-store';
 import { useFavorite } from '../use-favorite';
 
 // Helper to create a wrapper with FavoritesContext.Provider
@@ -12,11 +13,9 @@ function createWrapper(contextValue: React.ContextType<typeof FavoritesContext>)
 }
 
 describe('useFavorite', () => {
-  const mockIsFavorited = vi.fn().mockReturnValue(false);
   const mockToggleFavorite = vi.fn().mockResolvedValue(true);
 
   const defaultContext = {
-    isFavorited: mockIsFavorited,
     toggleFavorite: mockToggleFavorite,
     isLoading: false,
     isAuthenticated: true,
@@ -24,17 +23,20 @@ describe('useFavorite', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsFavorited.mockReturnValue(false);
     mockToggleFavorite.mockResolvedValue(true);
+    // Reset the store to empty before each test
+    favoritesStore.setFavorites(new Set());
   });
 
   describe('with FavoritesProvider', () => {
-    it('calls isFavorited with climbUuid', () => {
-      renderHook(() => useFavorite({ climbUuid: 'climb-123' }), {
+    it('reads isFavorited from the external store', () => {
+      favoritesStore.setFavorites(new Set(['climb-123']));
+
+      const { result } = renderHook(() => useFavorite({ climbUuid: 'climb-123' }), {
         wrapper: createWrapper(defaultContext),
       });
 
-      expect(mockIsFavorited).toHaveBeenCalledWith('climb-123');
+      expect(result.current.isFavorited).toBe(true);
     });
 
     it('calls toggleFavorite with climbUuid when toggle invoked', async () => {
@@ -66,7 +68,7 @@ describe('useFavorite', () => {
     });
 
     it('returns isFavorited result for the specific climb', () => {
-      mockIsFavorited.mockReturnValue(true);
+      favoritesStore.setFavorites(new Set(['climb-123']));
 
       const { result } = renderHook(() => useFavorite({ climbUuid: 'climb-123' }), {
         wrapper: createWrapper(defaultContext),
@@ -76,7 +78,7 @@ describe('useFavorite', () => {
     });
 
     it('handles different climbUuids correctly', () => {
-      mockIsFavorited.mockImplementation((uuid: string) => uuid === 'climb-A');
+      favoritesStore.setFavorites(new Set(['climb-A']));
 
       const { result: resultA } = renderHook(() => useFavorite({ climbUuid: 'climb-A' }), {
         wrapper: createWrapper(defaultContext),
@@ -87,8 +89,6 @@ describe('useFavorite', () => {
 
       expect(resultA.current.isFavorited).toBe(true);
       expect(resultB.current.isFavorited).toBe(false);
-      expect(mockIsFavorited).toHaveBeenCalledWith('climb-A');
-      expect(mockIsFavorited).toHaveBeenCalledWith('climb-B');
     });
   });
 

--- a/packages/web/app/components/climb-actions/favorites-batch-context.tsx
+++ b/packages/web/app/components/climb-actions/favorites-batch-context.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useLayoutEffect } from 'react';
 import { createTypedContext } from '@/app/lib/create-typed-context';
+import { favoritesStore } from './favorites-store';
 
 interface FavoritesContextValue {
-  isFavorited: (uuid: string) => boolean;
   toggleFavorite: (uuid: string) => Promise<boolean>;
   isLoading: boolean;
   isAuthenticated: boolean;
@@ -17,7 +17,6 @@ export { useFavoritesContext };
 
 interface FavoritesProviderProps {
   favorites: Set<string>;
-  isFavorited: (uuid: string) => boolean;
   toggleFavorite: (uuid: string) => Promise<boolean>;
   isLoading: boolean;
   isAuthenticated: boolean;
@@ -25,20 +24,28 @@ interface FavoritesProviderProps {
 }
 
 export function FavoritesProvider({
-  isFavorited,
+  favorites,
   toggleFavorite,
   isLoading,
   isAuthenticated,
   children,
 }: FavoritesProviderProps) {
+  // Sync React Query data into the external store before children render.
+  // useLayoutEffect ensures the store is up-to-date in the same commit.
+  useLayoutEffect(() => {
+    favoritesStore.setFavorites(favorites);
+  }, [favorites]);
+
+  // Context now only carries callbacks and auth state — these references
+  // are stable so the context value rarely changes, preventing cascade
+  // re-renders in all consumers.
   const value = useMemo<FavoritesContextValue>(
     () => ({
-      isFavorited,
       toggleFavorite,
       isLoading,
       isAuthenticated,
     }),
-    [isFavorited, toggleFavorite, isLoading, isAuthenticated]
+    [toggleFavorite, isLoading, isAuthenticated]
   );
 
   return <FavoritesContext.Provider value={value}>{children}</FavoritesContext.Provider>;

--- a/packages/web/app/components/climb-actions/favorites-store.ts
+++ b/packages/web/app/components/climb-actions/favorites-store.ts
@@ -1,0 +1,41 @@
+/**
+ * External store for favorites data, enabling per-UUID subscriptions via
+ * `useSyncExternalStore`. This avoids the React Context "all consumers
+ * re-render" problem — each component only re-renders when its specific
+ * climb's favorited status flips.
+ */
+class FavoritesStore {
+  private favorites: Set<string> = new Set();
+  private listeners: Set<() => void> = new Set();
+
+  /** Subscribe to store changes (signature expected by useSyncExternalStore). */
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /** Check if a specific UUID is favorited. Returns a primitive boolean
+   *  so `Object.is` comparison in useSyncExternalStore works correctly —
+   *  components only re-render when their specific value flips. */
+  getIsFavorited = (uuid: string): boolean => {
+    return this.favorites.has(uuid);
+  };
+
+  /** Bulk-replace the favorites set (called when React Query data changes). */
+  setFavorites(next: Set<string>): void {
+    // Skip notification if the reference is identical (no change)
+    if (next === this.favorites) return;
+    this.favorites = next;
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const favoritesStore = new FavoritesStore();

--- a/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
+++ b/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useFavorite } from './use-favorite';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 
@@ -30,6 +30,10 @@ export function useDoubleTapFavorite({ climbUuid }: UseDoubleTapFavoriteOptions)
   const [showHeart, setShowHeart] = useState(false);
   const { openAuthModal } = useAuthModal();
 
+  // Read isFavorited via ref at call time so handleDoubleTap stays stable
+  const isFavoritedRef = useRef(isFavorited);
+  isFavoritedRef.current = isFavorited;
+
   const handleDoubleTap = useCallback(() => {
     if (!isAuthenticated) {
       openAuthModal({
@@ -43,10 +47,10 @@ export function useDoubleTapFavorite({ climbUuid }: UseDoubleTapFavoriteOptions)
     setShowHeart(true);
 
     // Only toggle if not already favorited (Instagram behavior)
-    if (!isFavorited) {
+    if (!isFavoritedRef.current) {
       toggleFavorite();
     }
-  }, [isAuthenticated, isFavorited, toggleFavorite, openAuthModal]);
+  }, [isAuthenticated, toggleFavorite, openAuthModal]);
 
   const dismissHeart = useCallback(() => {
     setShowHeart(false);

--- a/packages/web/app/components/climb-actions/use-favorite.ts
+++ b/packages/web/app/components/climb-actions/use-favorite.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { FavoritesContext } from './favorites-batch-context';
+import { favoritesStore } from './favorites-store';
 
 type UseFavoriteOptions = {
   climbUuid: string;
@@ -19,12 +20,22 @@ const noopToggle = async () => false;
 /**
  * Hook to check and toggle favorite status for a climb.
  *
- * Uses the hoisted favorites query from FavoritesProvider when available.
+ * Uses `useSyncExternalStore` for the favorited boolean so only THIS
+ * component re-renders when its specific climb's status changes —
+ * not every consumer in the tree.
+ *
  * When rendered outside a FavoritesProvider (e.g. on the home page proposals feed),
  * returns safe defaults — favorite actions will be unavailable but won't crash.
  */
 export function useFavorite({ climbUuid }: UseFavoriteOptions): UseFavoriteReturn {
   const context = useContext(FavoritesContext);
+
+  // Per-UUID subscription — only re-renders when THIS climb's boolean flips
+  const isFavorited = useSyncExternalStore(
+    favoritesStore.subscribe,
+    () => favoritesStore.getIsFavorited(climbUuid),
+    () => false, // server snapshot
+  );
 
   const handleToggle = useCallback(async (): Promise<boolean> => {
     if (!context) return false;
@@ -41,7 +52,7 @@ export function useFavorite({ climbUuid }: UseFavoriteOptions): UseFavoriteRetur
   }
 
   return {
-    isFavorited: context.isFavorited(climbUuid),
+    isFavorited,
     isLoading: context.isLoading,
     toggleFavorite: handleToggle,
     isAuthenticated: context.isAuthenticated,

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -68,7 +68,7 @@ describe('useClimbActionsData', () => {
     const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
     });
   });
 
@@ -109,8 +109,8 @@ describe('useClimbActionsData', () => {
     const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-2')).toBe(true);
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(false);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-2')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(false);
     });
   });
 
@@ -168,7 +168,7 @@ describe('useClimbActionsData', () => {
 
     // Optimistic update should show climb-1 as favorited
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
     });
 
     // Resolve the mutation
@@ -187,7 +187,7 @@ describe('useClimbActionsData', () => {
     const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
     });
 
     // Mock the toggle mutation to fail
@@ -204,7 +204,7 @@ describe('useClimbActionsData', () => {
 
     // Should roll back to original state
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
     });
 
     vi.restoreAllMocks();
@@ -383,7 +383,7 @@ describe('useClimbActionsData', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
     });
 
     const callCountAfterInit = mockRequest.mock.calls.length;
@@ -395,7 +395,7 @@ describe('useClimbActionsData', () => {
     rerender({ ...defaultOptions, climbUuids: ['climb-1', 'climb-2', 'climb-3'] });
 
     await waitFor(() => {
-      expect(result.current.favoritesProviderProps.isFavorited('climb-3')).toBe(true);
+      expect(result.current.favoritesProviderProps.favorites.has('climb-3')).toBe(true);
     });
 
     // The favorites fetch should only include climb-3 (not climb-1, climb-2)
@@ -407,7 +407,7 @@ describe('useClimbActionsData', () => {
     expect(lastFavCall[1].climbUuids).toEqual(['climb-3']);
 
     // Original favorites should still be available
-    expect(result.current.favoritesProviderProps.isFavorited('climb-1')).toBe(true);
+    expect(result.current.favoritesProviderProps.favorites.has('climb-1')).toBe(true);
   });
 
   it('does not refetch when UUIDs are reordered', async () => {

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -158,11 +158,6 @@ export function useClimbActionsData({
     [isAuthenticated, toggleFavoriteMutation],
   );
 
-  const isFavorited = useCallback(
-    (climbUuid: string): boolean => favorites.has(climbUuid),
-    [favorites],
-  );
-
   // === Playlists ===
 
   // Fetch user's playlists (all boards) — not incremental, just a simple query
@@ -312,7 +307,6 @@ export function useClimbActionsData({
   return {
     favoritesProviderProps: {
       favorites,
-      isFavorited,
       toggleFavorite,
       isLoading: isLoadingFavorites,
       isAuthenticated,


### PR DESCRIPTION
Replace React Context-based isFavorited lookups with an external store
using useSyncExternalStore. Previously, toggling any single favorite
caused ALL climb list items to re-render because the context value
changed. Now each component subscribes per-UUID and only re-renders
when its specific climb's favorited status flips.

- Add FavoritesStore class with per-UUID subscription support
- Sync React Query data into store via useLayoutEffect in provider
- Remove isFavorited from context (only toggleFavorite/auth remain)
- Stabilize handleDoubleTap callback with ref to avoid recreations

https://claude.ai/code/session_01M6JZnaQoeJoL4nATJ6JwCF