### PR TITLE
Fix iOS Live Activity cards not showing during active sessions

### DIFF
--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -413,12 +413,12 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
             <QueueContext.Provider value={effectiveContext}>
               {/* Sync queue state to iOS Live Activity (code-split, no-op on non-iOS) */}
               <LiveActivityBridge
-                queue={adapter.context.queue}
-                currentClimbQueueItem={adapter.context.currentClimbQueueItem}
-                boardDetails={adapter.boardDetails}
-                sessionId={adapter.context.sessionId}
-                isSessionActive={adapter.context.isSessionActive}
-                onSetCurrentClimb={adapter.context.setCurrentClimbQueueItem}
+                queue={effectiveContext.queue}
+                currentClimbQueueItem={effectiveContext.currentClimbQueueItem}
+                boardDetails={effectiveBoardDetails}
+                sessionId={effectiveContext.sessionId}
+                isSessionActive={effectiveContext.isSessionActive}
+                onSetCurrentClimb={effectiveContext.setCurrentClimbQueueItem}
               />
               {children}
             </QueueContext.Provider>

--- a/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
+++ b/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
@@ -224,7 +224,7 @@ describe('useLiveActivity', () => {
     await hook.unmount();
   });
 
-  it('calls endSession when queue is cleared', async () => {
+  it('keeps Live Activity running when queue is cleared but session is active', async () => {
     mockIsNativeApp.mockReturnValue(true);
     mockGetPlatform.mockReturnValue('ios');
 
@@ -247,7 +247,28 @@ describe('useLiveActivity', () => {
     });
 
     await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
-    expect(mockEndLiveActivitySession).toHaveBeenCalled();
+    // Live Activity stays running — only session deactivation ends it
+    expect(mockEndLiveActivitySession).not.toHaveBeenCalled();
+
+    await hook.unmount();
+  });
+
+  it('starts Live Activity with empty queue when session is active', async () => {
+    mockIsNativeApp.mockReturnValue(true);
+    mockGetPlatform.mockReturnValue('ios');
+
+    const hook = await renderLiveActivityHook({
+      ...defaultProps(),
+      queue: [],
+      currentClimbQueueItem: null,
+      boardDetails: makeBoardDetails(),
+      isSessionActive: true,
+      sessionId: 'test-session',
+    });
+
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+    // Live Activity starts immediately — native side shows "Loading..."
+    expect(mockStartLiveActivitySession).toHaveBeenCalledTimes(1);
 
     await hook.unmount();
   });

--- a/packages/web/app/lib/live-activity/use-live-activity.ts
+++ b/packages/web/app/lib/live-activity/use-live-activity.ts
@@ -73,10 +73,11 @@ export function useLiveActivity({
     return () => { cancelled = true; };
   }, []);
 
-  // Start/end session — reacts to session activation, content presence, and board config.
+  // Start/end session — reacts to session activation and board config.
   // Does NOT restart when the current climb changes.
-  const hasContent = queue.length > 0 || currentClimbQueueItem !== null;
-  const shouldBeActive = isSessionActive && hasContent && stableBoardDetails !== null && available === true;
+  // No content check here: the native Live Activity shows "Loading..." until the first
+  // climb update arrives, so we start as soon as the session is active.
+  const shouldBeActive = isSessionActive && stableBoardDetails !== null && available === true;
 
   useEffect(() => {
     if (!isNativeApp() || getPlatform() !== 'ios') return;


### PR DESCRIPTION
LiveActivityBridge was reading session state from the PersistentSession adapter context, which could have timing issues after the context split. Switch to effectiveContext so the bridge reads from the same data source as the rest of the UI (injected GraphQL context on board routes, adapter fallback otherwise).

Also remove the hasContent requirement from shouldBeActive — the native Live Activity already handles empty state ("Loading..."), so it should start as soon as the session connects rather than waiting for queue content to arrive.

https://claude.ai/code/session_019MYhtrTDYYdY2u9JgczKLX