### PR TITLE
fix: content-based dedup in FavoritesStore, useEffect ref update, add…

### DIFF
--- a/packages/web/app/components/climb-actions/__tests__/favorites-store.test.ts
+++ b/packages/web/app/components/climb-actions/__tests__/favorites-store.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Import a fresh instance per test by re-importing the module
+import { favoritesStore } from '../favorites-store';
+
+describe('FavoritesStore', () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    favoritesStore.setFavorites(new Set());
+  });
+
+  describe('getIsFavorited', () => {
+    it('returns false for unknown uuid', () => {
+      expect(favoritesStore.getIsFavorited('unknown')).toBe(false);
+    });
+
+    it('returns true for a uuid that is in the set', () => {
+      favoritesStore.setFavorites(new Set(['abc']));
+      expect(favoritesStore.getIsFavorited('abc')).toBe(true);
+    });
+
+    it('returns false for a uuid not in the set', () => {
+      favoritesStore.setFavorites(new Set(['abc']));
+      expect(favoritesStore.getIsFavorited('xyz')).toBe(false);
+    });
+  });
+
+  describe('subscribe / unsubscribe (listener cleanup)', () => {
+    it('calls the listener when favorites change', () => {
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      favoritesStore.setFavorites(new Set(['climb-1']));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the listener after unsubscribing', () => {
+      const listener = vi.fn();
+      const unsubscribe = favoritesStore.subscribe(listener);
+
+      unsubscribe();
+      favoritesStore.setFavorites(new Set(['climb-1']));
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('returns a cleanup function that removes only the unsubscribed listener', () => {
+      const listenerA = vi.fn();
+      const listenerB = vi.fn();
+
+      const unsubscribeA = favoritesStore.subscribe(listenerA);
+      favoritesStore.subscribe(listenerB);
+
+      unsubscribeA();
+      favoritesStore.setFavorites(new Set(['climb-1']));
+
+      expect(listenerA).not.toHaveBeenCalled();
+      expect(listenerB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('concurrent subscriptions (notify loop)', () => {
+    it('notifies all active listeners on change', () => {
+      const listeners = [vi.fn(), vi.fn(), vi.fn()];
+      listeners.forEach((l) => favoritesStore.subscribe(l));
+
+      favoritesStore.setFavorites(new Set(['climb-x']));
+
+      listeners.forEach((l) => expect(l).toHaveBeenCalledTimes(1));
+    });
+
+    it('notifies remaining listeners after one is removed mid-session', () => {
+      const listenerA = vi.fn();
+      const listenerB = vi.fn();
+      const listenerC = vi.fn();
+
+      favoritesStore.subscribe(listenerA);
+      const unsubscribeB = favoritesStore.subscribe(listenerB);
+      favoritesStore.subscribe(listenerC);
+
+      unsubscribeB();
+      favoritesStore.setFavorites(new Set(['climb-y']));
+
+      expect(listenerA).toHaveBeenCalledTimes(1);
+      expect(listenerB).not.toHaveBeenCalled();
+      expect(listenerC).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setFavorites content-based deduplication', () => {
+    it('does not notify when new set has identical contents', () => {
+      favoritesStore.setFavorites(new Set(['a', 'b']));
+
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      // New Set instance, same contents
+      favoritesStore.setFavorites(new Set(['a', 'b']));
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('notifies when an element is added', () => {
+      favoritesStore.setFavorites(new Set(['a']));
+
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      favoritesStore.setFavorites(new Set(['a', 'b']));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies when an element is removed', () => {
+      favoritesStore.setFavorites(new Set(['a', 'b']));
+
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      favoritesStore.setFavorites(new Set(['a']));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies when going from empty to non-empty', () => {
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      favoritesStore.setFavorites(new Set(['climb-1']));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies when going from non-empty to empty', () => {
+      favoritesStore.setFavorites(new Set(['climb-1']));
+
+      const listener = vi.fn();
+      favoritesStore.subscribe(listener);
+
+      favoritesStore.setFavorites(new Set());
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/web/app/components/climb-actions/favorites-store.ts
+++ b/packages/web/app/components/climb-actions/favorites-store.ts
@@ -25,8 +25,9 @@ class FavoritesStore {
 
   /** Bulk-replace the favorites set (called when React Query data changes). */
   setFavorites(next: Set<string>): void {
-    // Skip notification if the reference is identical (no change)
-    if (next === this.favorites) return;
+    // React Query creates new Set instances on each fetch, so reference equality
+    // almost never fires. Compare contents instead to avoid spurious notifications.
+    if (next.size === this.favorites.size && [...next].every((id) => this.favorites.has(id))) return;
     this.favorites = next;
     this.notify();
   }

--- a/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
+++ b/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useFavorite } from './use-favorite';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 
@@ -30,9 +30,12 @@ export function useDoubleTapFavorite({ climbUuid }: UseDoubleTapFavoriteOptions)
   const [showHeart, setShowHeart] = useState(false);
   const { openAuthModal } = useAuthModal();
 
-  // Read isFavorited via ref at call time so handleDoubleTap stays stable
+  // Read isFavorited via ref at call time so handleDoubleTap stays stable.
+  // useEffect ensures the ref only updates when isFavorited actually changes.
   const isFavoritedRef = useRef(isFavorited);
-  isFavoritedRef.current = isFavorited;
+  useEffect(() => {
+    isFavoritedRef.current = isFavorited;
+  }, [isFavorited]);
 
   const handleDoubleTap = useCallback(() => {
     if (!isAuthenticated) {


### PR DESCRIPTION
… store unit tests

- favorites-store: replace reference equality check with content comparison so React Query's new-Set-per-fetch doesn't cause spurious re-renders
- use-double-tap-favorite: move isFavoritedRef update into useEffect so the ref only writes when isFavorited actually changes
- add favorites-store.test.ts with 13 tests covering getIsFavorited, listener subscribe/unsubscribe, concurrent subscriptions, and content-based deduplication edge cases

https://claude.ai/code/session_01Hdjiw56iLMty49sqDPdBNL