### PR TITLE
perf: instrument queue operations with latency tracking

### DIFF
--- a/packages/backend/src/graphql/resolvers/queue/mutation-metrics.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutation-metrics.ts
@@ -1,0 +1,24 @@
+const SLOW_MUTATION_THRESHOLD_MS = 200;
+
+export function logMutationMetrics(
+  operation: string,
+  durationMs: number,
+  sessionId: string,
+  extra?: Record<string, unknown>,
+) {
+  const rounded = Math.round(durationMs);
+  const payload = {
+    type: 'mutation_metrics',
+    operation,
+    durationMs: rounded,
+    sessionId,
+    slow: rounded > SLOW_MUTATION_THRESHOLD_MS,
+    ...extra,
+  };
+
+  if (rounded > SLOW_MUTATION_THRESHOLD_MS) {
+    console.warn(`[MutationMetrics] SLOW ${operation}: ${rounded}ms`, JSON.stringify(payload));
+  } else if (process.env.NODE_ENV === 'development') {
+    console.log(`[MutationMetrics] ${operation}: ${rounded}ms`, JSON.stringify(payload));
+  }
+}

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -8,6 +8,7 @@ import {
   QueueItemIdSchema,
   QueueArraySchema,
 } from '../../../validation/schemas';
+import { logMutationMetrics } from './mutation-metrics';
 
 // Debug logging flag - only log in development
 const DEBUG = process.env.NODE_ENV === 'development';
@@ -22,6 +23,7 @@ export const queueMutations = {
     { item, position }: { item: ClimbQueueItem; position?: number },
     ctx: ConnectionContext
   ) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx); // Apply default rate limit
     const sessionId = requireSession(ctx);
 
@@ -92,6 +94,7 @@ export const queueMutations = {
       });
     }
 
+    logMutationMetrics('addQueueItem', performance.now() - startTime, sessionId, { queueSize: originalQueueLength });
     return item;
   },
 
@@ -100,6 +103,7 @@ export const queueMutations = {
    * Also clears current climb if it was removed
    */
   removeQueueItem: async (_: unknown, { uuid }: { uuid: string }, ctx: ConnectionContext) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx);
     const sessionId = requireSession(ctx);
 
@@ -123,6 +127,7 @@ export const queueMutations = {
       uuid,
     });
 
+    logMutationMetrics('removeQueueItem', performance.now() - startTime, sessionId);
     return true;
   },
 
@@ -134,6 +139,7 @@ export const queueMutations = {
     { uuid, oldIndex, newIndex }: { uuid: string; oldIndex: number; newIndex: number },
     ctx: ConnectionContext
   ) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx);
     const sessionId = requireSession(ctx);
 
@@ -168,6 +174,7 @@ export const queueMutations = {
       newIndex,
     });
 
+    logMutationMetrics('reorderQueueItem', performance.now() - startTime, sessionId);
     return true;
   },
 
@@ -181,6 +188,7 @@ export const queueMutations = {
     { item, shouldAddToQueue, correlationId }: { item: ClimbQueueItem | null; shouldAddToQueue?: boolean; correlationId?: string },
     ctx: ConnectionContext
   ) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx);
     const sessionId = requireSession(ctx);
 
@@ -230,6 +238,7 @@ export const queueMutations = {
       correlationId: correlationId || null,
     });
 
+    logMutationMetrics('setCurrentClimb', performance.now() - startTime, sessionId, { shouldAddToQueue: !!shouldAddToQueue });
     return item;
   },
 
@@ -238,6 +247,7 @@ export const queueMutations = {
    * Updates both the current climb and the queue item if present
    */
   mirrorCurrentClimb: async (_: unknown, { mirrored }: { mirrored: boolean }, ctx: ConnectionContext) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx);
     const sessionId = requireSession(ctx);
 
@@ -267,6 +277,7 @@ export const queueMutations = {
       mirrored,
     });
 
+    logMutationMetrics('mirrorCurrentClimb', performance.now() - startTime, sessionId);
     return currentClimb;
   },
 
@@ -279,6 +290,7 @@ export const queueMutations = {
     { uuid, item }: { uuid: string; item: ClimbQueueItem },
     ctx: ConnectionContext
   ) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx);
     const sessionId = requireSession(ctx);
 
@@ -304,6 +316,7 @@ export const queueMutations = {
       state: { sequence, stateHash, queue, currentClimbQueueItem: currentClimb },
     });
 
+    logMutationMetrics('replaceQueueItem', performance.now() - startTime, sessionId);
     return item;
   },
 
@@ -316,6 +329,7 @@ export const queueMutations = {
     { queue, currentClimbQueueItem }: { queue: ClimbQueueItem[]; currentClimbQueueItem?: ClimbQueueItem },
     ctx: ConnectionContext
   ) => {
+    const startTime = performance.now();
     await applyRateLimit(ctx, 30); // Lower limit for bulk operations
     const sessionId = requireSession(ctx);
 
@@ -340,6 +354,7 @@ export const queueMutations = {
       state,
     });
 
+    logMutationMetrics('setQueue', performance.now() - startTime, sessionId, { queueSize: queue.length });
     return state;
   },
 };

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -16,6 +16,7 @@ import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useSnackbar } from '../providers/snackbar-provider';
 import SessionSummaryDialog from '../session-summary/session-summary-dialog';
+import { trackQueueOperation, trackQueueOperationError, type QueueOperationMode } from '@/app/lib/queue-metrics';
 
 import { useSessionIdManagement } from './hooks/use-session-id-management';
 import { useQueueRestoration } from './hooks/use-queue-restoration';
@@ -253,33 +254,58 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
 
   // --- Stable action callbacks (read from latestRef, never recreated) ---
   const addToQueue = useCallback((climb: Climb) => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
     r.dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item: newItem } });
     if (r.isDisconnected && r.isPersistentSessionActive) {
       r.offlineBuffer.bufferAddition(newItem);
+      trackQueueOperation('addToQueue', performance.now() - startTime, mode);
     } else if (r.hasConnected && r.isPersistentSessionActive) {
-      r.persistentSession.addQueueItem(newItem).catch((error: unknown) => console.error('Failed to add queue item:', error));
+      r.persistentSession.addQueueItem(newItem)
+        .then(() => trackQueueOperation('addToQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error('Failed to add queue item:', error);
+          trackQueueOperationError('addToQueue', mode);
+        });
+    } else {
+      trackQueueOperation('addToQueue', performance.now() - startTime, mode);
     }
   }, []);
 
   const removeFromQueue = useCallback((item: ClimbQueueItem) => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     r.dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: item.uuid } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {
-      r.persistentSession.removeQueueItem(item.uuid).catch((error: unknown) => console.error('Failed to remove queue item:', error));
+      r.persistentSession.removeQueueItem(item.uuid)
+        .then(() => trackQueueOperation('removeFromQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error('Failed to remove queue item:', error);
+          trackQueueOperationError('removeFromQueue', mode);
+        });
+    } else {
+      trackQueueOperation('removeFromQueue', performance.now() - startTime, mode);
     }
   }, []);
 
   const setCurrentClimb = useCallback(async (climb: Climb) => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
     r.dispatch({ type: 'SET_CURRENT_CLIMB', payload: newItem });
     if (r.isDisconnected && r.isPersistentSessionActive) {
       r.offlineBuffer.bufferAddition(newItem);
+      trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
     } else if (r.hasConnected && r.isPersistentSessionActive) {
       const previousQueue = [...r.state.queue];
       const previousCurrentClimb = r.state.currentClimbQueueItem;
@@ -290,32 +316,54 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
       try {
         await r.persistentSession.addQueueItem(newItem, position);
         await r.persistentSession.setCurrentClimb(newItem, false);
+        trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
       } catch (error: unknown) {
         console.error('Failed to set current climb, rolling back:', error);
         r.dispatch({ type: 'UPDATE_QUEUE', payload: { queue: previousQueue, currentClimbQueueItem: previousCurrentClimb } });
+        trackQueueOperationError('setCurrentClimb', mode);
       }
+    } else {
+      trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
     }
   }, []);
 
   const setQueue = useCallback((queue: ClimbQueueItem[]) => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     r.dispatch({ type: 'UPDATE_QUEUE', payload: { queue, currentClimbQueueItem: r.state.currentClimbQueueItem } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {
-      r.persistentSession.setQueue(queue, r.state.currentClimbQueueItem).catch((error: unknown) => console.error('Failed to set queue:', error));
+      r.persistentSession.setQueue(queue, r.state.currentClimbQueueItem)
+        .then(() => trackQueueOperation('setQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error('Failed to set queue:', error);
+          trackQueueOperationError('setQueue', mode);
+        });
+    } else {
+      trackQueueOperation('setQueue', performance.now() - startTime, mode);
     }
   }, []);
 
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const correlationId = r.clientId ? `${r.clientId}-${++r.correlationCounterRef.current}` : undefined;
     r.dispatch({ type: 'DELTA_UPDATE_CURRENT_CLIMB', payload: { item, shouldAddToQueue: item.suggested, correlationId } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {
-      r.persistentSession.setCurrentClimb(item, item.suggested, correlationId).catch((error: unknown) => {
-        console.error('Failed to set current climb:', error);
-        if (correlationId) r.dispatch({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
-      });
+      r.persistentSession.setCurrentClimb(item, item.suggested, correlationId)
+        .then(() => trackQueueOperation('setCurrentClimbQueueItem', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error('Failed to set current climb:', error);
+          if (correlationId) r.dispatch({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
+          trackQueueOperationError('setCurrentClimbQueueItem', mode);
+        });
+    } else {
+      trackQueueOperation('setCurrentClimbQueueItem', performance.now() - startTime, mode);
     }
   }, []);
 
@@ -335,13 +383,23 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
   }, []);
 
   const mirrorClimb = useCallback(() => {
+    const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
     if (!r.state.currentClimbQueueItem?.climb) return;
+    const mode: QueueOperationMode = !r.isPersistentSessionActive
+      ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const newMirroredState = !r.state.currentClimbQueueItem.climb?.mirrored;
     r.dispatch({ type: 'DELTA_MIRROR_CURRENT_CLIMB', payload: { mirrored: newMirroredState } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {
-      r.persistentSession.mirrorCurrentClimb(newMirroredState).catch((error: unknown) => console.error('Failed to mirror climb:', error));
+      r.persistentSession.mirrorCurrentClimb(newMirroredState)
+        .then(() => trackQueueOperation('mirrorClimb', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error('Failed to mirror climb:', error);
+          trackQueueOperationError('mirrorClimb', mode);
+        });
+    } else {
+      trackQueueOperation('mirrorClimb', performance.now() - startTime, mode);
     }
   }, []);
 

--- a/packages/web/app/lib/queue-metrics.ts
+++ b/packages/web/app/lib/queue-metrics.ts
@@ -1,0 +1,48 @@
+import { track } from '@vercel/analytics';
+
+export type QueueOperation =
+  | 'setCurrentClimbQueueItem'
+  | 'setCurrentClimb'
+  | 'addToQueue'
+  | 'removeFromQueue'
+  | 'mirrorClimb'
+  | 'setQueue';
+
+export type QueueOperationMode = 'local' | 'party' | 'party-offline';
+
+// Per-operation caps to ensure coverage of all operation types.
+// With 6 operations, worst case is 30 events per session.
+const MAX_EVENTS_PER_OPERATION = 5;
+const operationEventCounts = new Map<QueueOperation, number>();
+
+const MAX_ERROR_EVENTS = 10;
+let errorEventCount = 0;
+
+export function trackQueueOperation(
+  operation: QueueOperation,
+  durationMs: number,
+  mode: QueueOperationMode,
+) {
+  const count = operationEventCounts.get(operation) ?? 0;
+  if (count >= MAX_EVENTS_PER_OPERATION) return;
+  operationEventCounts.set(operation, count + 1);
+
+  track('Queue Operation', {
+    operation,
+    durationMs: Math.round(durationMs),
+    mode,
+  });
+}
+
+export function trackQueueOperationError(
+  operation: QueueOperation,
+  mode: QueueOperationMode,
+) {
+  if (errorEventCount >= MAX_ERROR_EVENTS) return;
+  errorEventCount++;
+
+  track('Queue Operation Error', {
+    operation,
+    mode,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds client-side timing to all 6 queue action callbacks (addToQueue, removeFromQueue, setCurrentClimb, setQueue, setCurrentClimbQueueItem, mirrorClimb) via Vercel Analytics `track()` with per-operation event caps
- Adds backend timing to all 7 mutation resolvers with structured `console.warn` for slow mutations (>200ms)
- Tracks operation mode (local/party/party-offline) to distinguish local dispatches from WebSocket roundtrips

## Context
Setting an active climb regressed from <200ms to 400ms, requiring a rollback to `25e3538`. This instrumentation would have caught that regression in Vercel Analytics and backend logs.

## Test plan
- [ ] `bun run typecheck` passes
- [ ] In dev mode, trigger queue operations and verify backend console shows `[MutationMetrics]` lines
- [ ] Verify Vercel Analytics receives `Queue Operation` events (check network tab for analytics beacon)
- [ ] Confirm event caps work (6th event for same operation type is dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)