### PR TITLE
Fix Apple OAuth PKCE cookie error in native app flow

### DIFF
--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -29,6 +29,7 @@ if (process.env.APPLE_ID && process.env.APPLE_SECRET) {
     AppleProvider({
       clientId: process.env.APPLE_ID,
       clientSecret: process.env.APPLE_SECRET,
+      checks: ["state"],
     })
   );
 }


### PR DESCRIPTION
Apple's form_post response mode sends auth codes via cross-site POST,
causing SameSite=Lax PKCE cookies to be stripped. Switch to state-based
verification which travels in the POST body instead of cookies.

https://claude.ai/code/session_01KazKStzwVQNkLWPZdPTMJ8