### PR TITLE
Speed up add-to-queue swipe confirmation

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -79,14 +79,14 @@ const rightActionLayerDefaultStyle: React.CSSProperties = {
   ...rightSwipeActionLayerBaseStyle,
   backgroundColor: themeTokens.colors.primary,
   opacity: 0,
-  transition: 'opacity 200ms ease-out',
+  transition: 'opacity 120ms ease-out',
 };
 
 const rightActionLayerConfirmedStyle: React.CSSProperties = {
   ...rightSwipeActionLayerBaseStyle,
   backgroundColor: themeTokens.colors.success,
   opacity: 0,
-  transition: 'opacity 200ms ease-out',
+  transition: 'opacity 120ms ease-out',
 };
 
 const defaultLeftActionStyle: React.CSSProperties = {

--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -9,7 +9,7 @@ const DEFAULT_SWIPE_THRESHOLD = 100;
 // Maximum swipe distance
 const DEFAULT_MAX_SWIPE = 120;
 // Duration the confirmation checkmark is shown before snapping back
-const CONFIRMATION_DISPLAY_MS = 1500;
+const CONFIRMATION_DISPLAY_MS = 600;
 
 export type SwipeZone = 'none' | 'left-short' | 'left-long' | 'right-short' | 'right-long';
 
@@ -128,7 +128,7 @@ export function useSwipeActions({
     if (contentEl.current) {
       contentEl.current.style.transform = `translateX(${offset}px)`;
       // Only apply transition when snapping back to zero
-      contentEl.current.style.transition = offset === 0 ? 'transform 250ms ease-out, opacity 250ms ease-out' : 'none';
+      contentEl.current.style.transition = offset === 0 ? 'transform 150ms ease-out, opacity 150ms ease-out' : 'none';
     }
 
     const absOffset = Math.abs(offset);
@@ -163,7 +163,7 @@ export function useSwipeActions({
 
     // Animate content to a peek offset so the action layer (checkmark) stays visible
     if (contentEl.current) {
-      contentEl.current.style.transition = 'transform 200ms ease-out';
+      contentEl.current.style.transition = 'transform 120ms ease-out';
       contentEl.current.style.transform = `translateX(${-confirmationPeekOffset}px)`;
     }
 
@@ -178,12 +178,12 @@ export function useSwipeActions({
       confirmationTimerRef.current = null;
       // Set transition on right action before applyOffset changes values so it fades out smoothly
       if (rightActionEl.current) {
-        rightActionEl.current.style.transition = 'opacity 350ms ease-out, visibility 0s 350ms';
+        rightActionEl.current.style.transition = 'opacity 200ms ease-out, visibility 0s 200ms';
       }
       applyOffset(0);
       // Override content transition with a gentler one for the confirmation snap-back
       if (contentEl.current) {
-        contentEl.current.style.transition = 'transform 350ms ease-out';
+        contentEl.current.style.transition = 'transform 200ms ease-out';
       }
       updateSwipeZone('none');
       setSwipeLeftConfirmed(false);


### PR DESCRIPTION
- Reduce confirmation display from 1500ms to 600ms
- Shorten peek-in animation from 200ms to 120ms
- Shorten snap-back animations from 350ms to 200ms
- Shorten idle snap-back from 250ms to 150ms
- Shorten action layer crossfade from 200ms to 120ms

https://claude.ai/code/session_01E2zkFnfMBSPJSQbespzqDa