### PR TITLE
Serialize setCurrentClimb mutations to prevent out-of-order execution

### DIFF
--- a/packages/web/app/components/persistent-session/hooks/__tests__/use-queue-mutations-serialization.test.ts
+++ b/packages/web/app/components/persistent-session/hooks/__tests__/use-queue-mutations-serialization.test.ts
@@ -111,7 +111,7 @@ describe('executeWithLatestWins', () => {
     expect(refs.inFlightRef.current).toBe(false);
   });
 
-  it('drains pending after the first call errors', async () => {
+  it('drains pending after the first call errors, then re-throws', async () => {
     const { executeFn, calls } = createDeferredExecute();
 
     const promise1 = executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn);
@@ -126,8 +126,11 @@ describe('executeWithLatestWins', () => {
     expect(executeFn).toHaveBeenCalledTimes(2);
     expect(calls[1].args).toEqual({ id: 'b', value: 2 });
 
+    // Complete the drain so promise1 settles
     calls[1].resolve();
-    await promise1;
+
+    // promise1 should reject with the original error
+    await expect(promise1).rejects.toThrow('network error');
 
     expect(refs.inFlightRef.current).toBe(false);
   });
@@ -232,6 +235,36 @@ describe('executeWithLatestWins', () => {
     calls[2].resolve();
     await promise1;
 
+    expect(refs.inFlightRef.current).toBe(false);
+  });
+
+  it('propagates initial error to caller after drain completes', async () => {
+    const { executeFn, calls } = createDeferredExecute();
+
+    const promise1 = executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn);
+
+    // No pending calls - just error the initial one
+    calls[0].reject(new Error('server unavailable'));
+
+    await expect(promise1).rejects.toThrow('server unavailable');
+    expect(refs.inFlightRef.current).toBe(false);
+  });
+
+  it('does not propagate drain errors to the initial caller', async () => {
+    const { executeFn, calls } = createDeferredExecute();
+
+    const promise1 = executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn);
+    executeWithLatestWins(refs, { id: 'b', value: 2 }, executeFn);
+
+    // Initial call succeeds
+    calls[0].resolve();
+    await waitForCall(calls, 1);
+
+    // Drain call errors
+    calls[1].reject(new Error('drain failure'));
+
+    // promise1 should resolve (not reject) because the initial call succeeded
+    await expect(promise1).resolves.toBeUndefined();
     expect(refs.inFlightRef.current).toBe(false);
   });
 });

--- a/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
@@ -57,13 +57,16 @@ export async function executeWithLatestWins<TArgs>(
   }
 
   refs.inFlightRef.current = true;
+  let initialError: unknown;
   try {
     await executeFn(args);
   } catch (error) {
-    console.error('Failed to send mutation:', error);
+    initialError = error;
   }
 
-  // Drain: keep sending until no more pending args
+  // Drain: keep sending until no more pending args.
+  // Errors during drain are logged but not propagated since the original
+  // caller's context (correlation ID, analytics) doesn't apply to coalesced calls.
   while (refs.pendingRef.current !== null) {
     const next = refs.pendingRef.current;
     refs.pendingRef.current = null;
@@ -75,6 +78,12 @@ export async function executeWithLatestWins<TArgs>(
   }
 
   refs.inFlightRef.current = false;
+
+  // Re-throw the initial error so the direct caller can handle it
+  // (e.g. clean up pending correlation IDs, track error analytics).
+  if (initialError) {
+    throw initialError;
+  }
 }
 
 export function useQueueMutations({ client, session }: UseQueueMutationsArgs): QueueMutationsActions {


### PR DESCRIPTION
When users rapidly change the active climb, multiple mutations fire concurrently and can arrive at the server out of order, causing the wrong climb to be set as active. This adds a serialize-and-supersede pattern: only one setCurrentClimb mutation is in-flight at a time, and intermediate calls are coalesced so only the latest state is sent.

https://claude.ai/code/session_01LU4yEb6uhc1Z1okocDcKcg