### PR TITLE
Allow OAuth sign-in to auto-link with existing email/password accounts

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -70,7 +70,7 @@ Boardsesh uses NextAuth.js v4 for authentication with the following components:
 
 - **Conditional Providers**: OAuth buttons only appear when provider credentials are configured
 - **Email Verification**: New email/password accounts require email verification
-- **Account Linking**: OAuth users can add passwords; password users cannot add OAuth (security)
+- **Account Linking**: Accounts are automatically linked by email — signing in with OAuth using an email that already has a password account links both methods to the same user
 - **JWT Sessions**: Stateless authentication with 5-minute refresh interval
 - **Rate Limiting**: In-memory rate limiting on auth endpoints (best-effort in serverless)
 
@@ -464,14 +464,11 @@ curl http://localhost:3000/api/auth/providers-config
 
 ### "OAuthAccountNotLinked" Error
 
-**Cause**: User already has an account with different auth method
+**Cause**: User already has an account with a different auth method and auto-linking failed
 
 **Example**: User registered with email/password, then tried Google sign-in with same email
 
-**Solution**:
-- Users must sign in with their original method
-- Account linking from OAuth to password is supported
-- Account linking from password to OAuth is blocked (security)
+**Note**: This error should not normally occur. OAuth providers (Google, Apple, Facebook) verify emails, so accounts are automatically linked when the email matches an existing user. If you see this error, check that `allowDangerousEmailAccountLinking: true` is set on the OAuth provider in `auth-options.ts`.
 
 ### Social Buttons Not Appearing
 

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -19,6 +19,7 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
     })
   );
 }
@@ -30,6 +31,7 @@ if (process.env.APPLE_ID && process.env.APPLE_SECRET) {
       clientId: process.env.APPLE_ID,
       clientSecret: process.env.APPLE_SECRET,
       checks: ["pkce"],
+      allowDangerousEmailAccountLinking: true,
     })
   );
 }
@@ -40,6 +42,7 @@ if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
     FacebookProvider({
       clientId: process.env.FACEBOOK_CLIENT_ID,
       clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
     })
   );
 }
@@ -200,6 +203,14 @@ export const authOptions: NextAuthOptions = {
     async signIn({ user, account }) {
       // OAuth providers - allow sign in (emails are pre-verified by provider)
       if (account?.provider !== "credentials") {
+        // Auto-verify email for OAuth users (provider already verified it)
+        if (user.id) {
+          const db = getDb();
+          await db
+            .update(schema.users)
+            .set({ emailVerified: new Date() })
+            .where(eq(schema.users.id, user.id));
+        }
         return true;
       }
 

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -6,7 +6,7 @@ import FacebookProvider from "next-auth/providers/facebook";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { getDb } from "@/app/lib/db/db";
 import * as schema from "@/app/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { verifyNativeOAuthTransferToken } from "@/app/lib/auth/native-oauth-transfer";
 
@@ -202,15 +202,25 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       // OAuth providers - allow sign in (emails are pre-verified by provider)
-      if (account?.provider !== "credentials") {
-        // Auto-verify email for OAuth users (provider already verified it)
+      // Skip native-oauth (transfer token flow) — email is already verified
+      if (account?.provider !== "credentials" && account?.provider !== "native-oauth") {
+        // Mark email as verified if not already (provider already verified it)
         if (user.id) {
-          const db = getDb();
-          await db
-            .update(schema.users)
-            .set({ emailVerified: new Date() })
-            .where(eq(schema.users.id, user.id));
+          try {
+            const db = getDb();
+            await db
+              .update(schema.users)
+              .set({ emailVerified: new Date() })
+              .where(and(eq(schema.users.id, user.id), isNull(schema.users.emailVerified)));
+          } catch {
+            // Best-effort — don't block sign-in if this fails
+          }
         }
+        return true;
+      }
+
+      // Native OAuth transfer tokens — already authenticated, allow through
+      if (account?.provider === "native-oauth") {
         return true;
       }
 

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -212,8 +212,9 @@ export const authOptions: NextAuthOptions = {
               .update(schema.users)
               .set({ emailVerified: new Date() })
               .where(and(eq(schema.users.id, user.id), isNull(schema.users.emailVerified)));
-          } catch {
+          } catch (error) {
             // Best-effort — don't block sign-in if this fails
+            console.warn("Failed to mark email as verified during OAuth sign-in:", error);
           }
         }
         return true;


### PR DESCRIPTION
Social auth providers (Apple, Google, Facebook) verify emails, so we can
trust them and automatically link OAuth accounts to existing users with
matching emails. Also marks email as verified on OAuth sign-in.

https://claude.ai/code/session_015RRK95VKBBBbYoLL2NUyyz