### PR TITLE
Reduce mobile WASM worker pool from 5 to 2

### DIFF
--- a/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
+++ b/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
@@ -675,7 +675,7 @@ describe('worker pool size', () => {
     });
   });
 
-  it('creates 5 workers in a Capacitor environment', async () => {
+  it('creates 2 workers in a Capacitor environment', async () => {
     stubGlobals();
 
     // Override isCapacitor to return true before importing worker-manager
@@ -691,7 +691,7 @@ describe('worker pool size', () => {
     });
 
     await vi.waitFor(() => {
-      expect(fakeWorkerInstances.length).toBe(5);
+      expect(fakeWorkerInstances.length).toBe(2);
     });
   });
 });

--- a/packages/web/app/lib/board-render-worker/worker-manager.ts
+++ b/packages/web/app/lib/board-render-worker/worker-manager.ts
@@ -39,11 +39,11 @@ function cachePut(key: string, bitmap: ImageBitmap): void {
 }
 
 // --- Worker pool ---
-// Capacitor WebView is a dedicated app context — can afford more workers.
-// Browser tabs share resources, so keep it lighter.
+// Mobile (Capacitor) has constrained memory and CPU — keep workers low.
+// Browser tabs share resources, so also keep it light.
 function getPoolSize(): number {
   if (typeof window === 'undefined') return 1;
-  return isCapacitor() ? 5 : 3;
+  return isCapacitor() ? 2 : 3;
 }
 
 type PendingRequest = {


### PR DESCRIPTION
Mobile (Capacitor) devices have constrained memory and CPU compared to
desktop. Aligns the pool size with the browser default (3→2 for mobile).

https://claude.ai/code/session_01PrCTQBthjKfM3yJxVBbMux