### PR TITLE
Fix coalesced setCurrentClimb mutations silently dropping shouldAddToQueue

### DIFF
--- a/packages/web/app/components/persistent-session/hooks/__tests__/use-queue-mutations-serialization.test.ts
+++ b/packages/web/app/components/persistent-session/hooks/__tests__/use-queue-mutations-serialization.test.ts
@@ -269,6 +269,68 @@ describe('executeWithLatestWins', () => {
   });
 });
 
+describe('onSupersede callback', () => {
+  let refs: LatestWinsMutationRefs<TestArgs>;
+
+  beforeEach(() => {
+    refs = createLatestWinsMutationRefs<TestArgs>();
+  });
+
+  it('does not call onSupersede when there is no pending to replace', async () => {
+    const { executeFn, calls } = createDeferredExecute();
+    const onSupersede = vi.fn();
+
+    executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn, onSupersede);
+    // Second call stores as pending (nothing to supersede)
+    executeWithLatestWins(refs, { id: 'b', value: 2 }, executeFn, onSupersede);
+
+    expect(onSupersede).not.toHaveBeenCalled();
+
+    calls[0].resolve();
+    await waitForCall(calls, 1);
+    calls[1].resolve();
+  });
+
+  it('calls onSupersede with the old pending args when superseded', async () => {
+    const { executeFn, calls } = createDeferredExecute();
+    const onSupersede = vi.fn();
+
+    executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn, onSupersede);
+    // First pending - no supersede
+    executeWithLatestWins(refs, { id: 'b', value: 2 }, executeFn, onSupersede);
+    expect(onSupersede).not.toHaveBeenCalled();
+
+    // Second pending supersedes 'b'
+    executeWithLatestWins(refs, { id: 'c', value: 3 }, executeFn, onSupersede);
+    expect(onSupersede).toHaveBeenCalledTimes(1);
+    expect(onSupersede).toHaveBeenCalledWith({ id: 'b', value: 2 });
+
+    calls[0].resolve();
+    await waitForCall(calls, 1);
+    calls[1].resolve();
+  });
+
+  it('calls onSupersede for each superseded pending', async () => {
+    const { executeFn, calls } = createDeferredExecute();
+    const onSupersede = vi.fn();
+
+    executeWithLatestWins(refs, { id: 'a', value: 1 }, executeFn, onSupersede);
+    executeWithLatestWins(refs, { id: 'b', value: 2 }, executeFn, onSupersede);
+    executeWithLatestWins(refs, { id: 'c', value: 3 }, executeFn, onSupersede);
+    executeWithLatestWins(refs, { id: 'd', value: 4 }, executeFn, onSupersede);
+
+    expect(onSupersede).toHaveBeenCalledTimes(2);
+    expect(onSupersede).toHaveBeenNthCalledWith(1, { id: 'b', value: 2 });
+    expect(onSupersede).toHaveBeenNthCalledWith(2, { id: 'c', value: 3 });
+
+    // Only 'a' (in-flight) and 'd' (final pending) are sent
+    calls[0].resolve();
+    await waitForCall(calls, 1);
+    expect(calls[1].args).toEqual({ id: 'd', value: 4 });
+    calls[1].resolve();
+  });
+});
+
 describe('createLatestWinsMutationRefs', () => {
   it('creates refs with correct initial state', () => {
     const refs = createLatestWinsMutationRefs<TestArgs>();

--- a/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
@@ -49,9 +49,15 @@ export async function executeWithLatestWins<TArgs>(
   refs: LatestWinsMutationRefs<TArgs>,
   args: TArgs,
   executeFn: (args: TArgs) => Promise<void>,
+  onSupersede?: (superseded: TArgs) => void,
 ): Promise<void> {
   if (refs.inFlightRef.current) {
-    // A mutation is already in-flight. Store the latest args, superseding any prior pending.
+    // If there are already pending args being superseded, notify the caller
+    // so it can handle side effects that shouldn't be silently dropped.
+    if (refs.pendingRef.current !== null && onSupersede) {
+      onSupersede(refs.pendingRef.current);
+    }
+    // Store the latest args, superseding any prior pending.
     refs.pendingRef.current = args;
     return;
   }
@@ -138,6 +144,17 @@ export function useQueueMutations({ client, session }: UseQueueMutationsArgs): Q
               correlationId: args.correlationId,
             },
           });
+        },
+        (superseded) => {
+          // When a pending mutation is superseded, its setCurrentClimb is correctly
+          // dropped (only the latest matters). But if it carried shouldAddToQueue,
+          // the queue-add side effect must still reach the server.
+          if (superseded.shouldAddToQueue && superseded.item && clientRef.current) {
+            execute(clientRef.current, {
+              query: ADD_QUEUE_ITEM,
+              variables: { item: toClimbQueueItemInput(superseded.item) },
+            }).catch((err: unknown) => console.error('Failed to add superseded queue item:', err));
+          }
         },
       );
     },


### PR DESCRIPTION
When rapid setCurrentClimb calls are coalesced by the latest-wins pattern,
intermediate calls with shouldAddToQueue=true were silently dropped — the
server never received the queue-add. This adds an onSupersede callback to
executeWithLatestWins that issues a standalone addQueueItem for superseded
items, keeping client and server queue state in sync.

https://claude.ai/code/session_01RnWWMC87iti7NLSpcxJVPZ