### PR TITLE
Fix review feedback: document effect ordering and extract dedup constant

### DIFF
--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -280,10 +280,10 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
         Task {
             // Skip the ActivityKit push if the native WebSocket callback already
-            // updated the Live Activity within the last 500ms. The UserDefaults
+            // updated the Live Activity within the dedup window. The UserDefaults
             // write above still runs to keep state consistent.
             let elapsed = await activityManager.timeSinceLastUpdate()
-            if let elapsed, elapsed < 0.5 {
+            if let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
                 self.logger.debug("Skipping redundant ActivityKit push (\(Int(elapsed * 1000))ms since last native update)")
             } else {
                 await activityManager.updateActivity(state: state)
@@ -333,7 +333,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
         Task {
             let elapsed = await activityManager.timeSinceLastUpdate()
-            if let elapsed, elapsed < 0.5 {
+            if let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
                 self.logger.debug("Skipping redundant climb ActivityKit push (\(Int(elapsed * 1000))ms since last native update)")
             } else {
                 await activityManager.updateActivity(state: state)

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -21,6 +21,13 @@ enum SharedConstants {
 
     static let queueNavigateNotification = "com.boardsesh.app.queueNavigate"
 
+    // MARK: Live Activity
+
+    /// Minimum seconds between consecutive ActivityKit pushes.
+    /// Redundant JS-side updates that arrive within this window are skipped
+    /// because the native WebSocket callback already applied the state.
+    static let liveActivityDedupWindow: TimeInterval = 0.5
+
     // MARK: Helpers
 
     static var sharedDefaults: UserDefaults? {

--- a/packages/web/app/lib/live-activity/use-live-activity.ts
+++ b/packages/web/app/lib/live-activity/use-live-activity.ts
@@ -147,8 +147,12 @@ export function useLiveActivity({
 
     // Mark that we already sent a full update this cycle.
     queueSyncedRef.current = true;
-    // Reset on next microtask so the climb-nav effect (same render) sees it,
-    // but future renders start clean.
+    // Reset on the next microtask so Effect 2 (climb-nav, declared below) sees
+    // queueSyncedRef.current === true during this render's synchronous effect
+    // flush, then starts the next render clean.
+    // IMPORTANT: Effect 1 (queue-sync) MUST remain declared before Effect 2
+    // (climb-nav) in source order. React runs effects top-to-bottom within a
+    // render, so reversing the order would cause Effect 2 to always read false.
     queueMicrotask(() => { queueSyncedRef.current = false; });
 
     updateLiveActivity({


### PR DESCRIPTION
- use-live-activity.ts: add a clear comment explaining that the queue-sync
  effect (Effect 1) MUST be declared before the climb-nav effect (Effect 2)
  in source order. The queueMicrotask coordination only works because React
  runs effects top-to-bottom within a render; reversing the declaration order
  would break the dedup entirely.

- SharedConstants.swift: extract the 500ms ActivityKit dedup threshold into
  SharedConstants.liveActivityDedupWindow so it has one canonical home and
  can be tuned without hunting for both occurrences.

- LiveActivityPlugin.swift: replace both hardcoded `0.5` literals with
  SharedConstants.liveActivityDedupWindow.

https://claude.ai/code/session_014k5Mck7wsRd3urf5DzCrnF