### PR TITLE
Fix foreground sluggishness: remove ActivityKit IPC and fix WebSocket…

### DIFF
--- a/mobile/ios/App/App/SceneDelegate.swift
+++ b/mobile/ios/App/App/SceneDelegate.swift
@@ -75,14 +75,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {}
     func sceneWillResignActive(_ scene: UIScene) {}
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Dismiss any Live Activities left over from a force-quit or crash.
-        // Use Task.detached to avoid inheriting MainActor context.
-        if #available(iOS 16.1, *) {
-            Task.detached(priority: .utility) {
-                await LiveActivityManager.shared.endStaleActivities()
-                await LiveActivityManager.shared.cleanupOrphanedActivities()
-            }
-        }
+        // Live Activities auto-dismiss after their 3-minute stale date.
+        // Cold-start cleanup in scene(_:willConnectTo:) handles the rest.
+        // No work needed here — avoids ActivityKit IPC on every foreground.
     }
     func sceneDidEnterBackground(_ scene: UIScene) {}
 }

--- a/mobile/ios/App/App/SessionWebSocketManager.swift
+++ b/mobile/ios/App/App/SessionWebSocketManager.swift
@@ -295,6 +295,10 @@ final class SessionWebSocketManager {
     private func _openConnectionOnQueue() {
         guard let serverUrl = self.serverUrl else { return }
 
+        // Cancel any existing connection before opening a new one to prevent
+        // leaked tasks (e.g. multiple reconnects firing after backgrounding).
+        self.webSocketTask?.cancel(with: .goingAway, reason: nil)
+
         let urlString: String
         if let wsUrl = self.wsUrl, !wsUrl.isEmpty {
             urlString = wsUrl
@@ -699,6 +703,10 @@ final class SessionWebSocketManager {
 
             let delay = self.reconnectDelay()
             self.reconnectAttempt += 1
+
+            // Cancel any previously scheduled reconnect to prevent duplicate
+            // connections piling up (e.g. rapid disconnect/reconnect during background).
+            self.reconnectWorkItem?.cancel()
 
             let workItem = DispatchWorkItem { [weak self] in
                 self?.openConnection()


### PR DESCRIPTION
… leak

Two issues causing sluggishness when returning from background:

1. sceneWillEnterForeground called Activity<>.activities (system IPC) on every foreground transition. Removed — stale activities auto-dismiss after 3 minutes, and cold-start cleanup handles the rest.

2. SessionWebSocketManager leaked connections on background/foreground cycles: handleDisconnect didn't cancel the previous reconnectWorkItem before scheduling a new one, and _openConnectionOnQueue didn't cancel the existing task before creating a replacement. Multiple WebSocket connections piled up, only the last tracked.

https://claude.ai/code/session_01Ej75v21gzUfMudhzyYkJj3