### PR TITLE
Fix Apple login handover by adding callbackUrl cookie SameSite override

### DIFF
--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -149,7 +149,7 @@ providers.push(
 
 // Apple Sign-In posts its callback cross-origin (response_mode=form_post),
 // so verification cookies need SameSite=None (which requires Secure).
-// We override state, nonce, and pkceCodeVerifier cookies for this reason.
+// We override callbackUrl, state, nonce, and pkceCodeVerifier cookies for this reason.
 const useSecureCookies =
   process.env.NEXTAUTH_URL?.startsWith("https://") ??
   !!process.env.VERCEL_URL;
@@ -163,6 +163,15 @@ export const authOptions: NextAuthOptions = {
   }),
   providers,
   cookies: {
+    callbackUrl: {
+      name: `${useSecureCookies ? "__Secure-" : ""}next-auth.callback-url`,
+      options: {
+        httpOnly: true,
+        sameSite: useSecureCookies ? "none" : "lax",
+        path: "/",
+        secure: useSecureCookies,
+      },
+    },
     state: {
       name: `${useSecureCookies ? "__Secure-" : ""}next-auth.state`,
       options: {


### PR DESCRIPTION
Apple Sign-In uses response_mode=form_post, so Apple's servers POST cross-origin back to our callback. The next-auth.callback-url cookie defaults to SameSite=Lax, which browsers strip on cross-origin POST requests. Without it, NextAuth falls back to redirecting to / instead of /api/auth/native/callback, so the transfer token deep link never fires and the iOS app stays logged out.

The state, nonce, and pkceCodeVerifier cookies already had this override — callbackUrl was simply missed.

https://claude.ai/code/session_0177oQNtfM9V6ghrGsWLtTRG