### PR TITLE
Remove dead handleTransitionEnd callback

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -322,11 +322,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     return () => cancelAnimationFrame(openRafRef.current);
   }, [isOpen]);
 
-  const handleTransitionEnd = useCallback((_open: boolean) => {
-    // Content stays mounted for instant re-opens.
-    // useDeferredValue already deprioritizes background updates when closed.
-  }, []);
-
   return (
     <>
     <SwipeableDrawer
@@ -335,7 +330,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       fullHeight
       open={drawerOpen}
       onClose={handleClose}
-      onTransitionEnd={handleTransitionEnd}
       keepMounted
       swipeEnabled={!isActionsOpen && !isQueueOpen && !isPlaylistSelectorOpen}
       showDragHandle={true}


### PR DESCRIPTION
The callback was a no-op with an empty dependency array and never actually used. Content stays mounted for instant re-opens and useDeferredValue already deprioritizes background updates when closed, so this callback served no purpose.

https://claude.ai/code/session_013AfyXBK7z3dBSRanBxyfek