### PR TITLE
Enable WKWebView JIT and optimize iOS WebView performance

### DIFF
--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -11,6 +11,7 @@ const config: CapacitorConfig = {
     contentInset: 'never',
     preferredContentMode: 'mobile',
     backgroundColor: '#0A0A0A',
+    limitsNavigationsToAppBoundDomains: true,
   },
   android: {
     backgroundColor: '#0A0A0A',

--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -1,11 +1,35 @@
 import UIKit
 import Capacitor
+import WebKit
 
 class BoardseshViewController: CAPBridgeViewController {
 
     override func capacitorDidLoad() {
         super.capacitorDidLoad()
         bridge?.registerPluginInstance(LiveActivityPlugin())
+    }
+
+    override open func webViewConfiguration() -> WKWebViewConfiguration {
+        let config = super.webViewConfiguration()
+
+        // Enable inline media playback (avoids fullscreen video takeover)
+        config.allowsInlineMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
+
+        // Pre-warm the default data store to avoid cold-start penalty
+        // on the first navigation that accesses cookies/IndexedDB.
+        _ = WKWebsiteDataStore.default()
+
+        // Show content as it arrives instead of waiting for full render.
+        config.suppressesIncrementalRendering = false
+
+        // Explicitly set desktop/mobile content mode via preferences.
+        let prefs = WKWebpagePreferences()
+        prefs.allowsContentJavaScript = true
+        prefs.preferredContentMode = .mobile
+        config.defaultWebpagePreferences = prefs
+
+        return config
     }
 
     override func viewDidLoad() {
@@ -17,6 +41,15 @@ class BoardseshViewController: CAPBridgeViewController {
         // any native bounce reveals matching black — not a jarring white.
         // Previously bounces=false was set here, but it degrades momentum
         // scrolling and touch responsiveness vs Safari.
+
+        // UIScrollView adds ~150ms delay to disambiguate taps from scrolls.
+        // Since the web layer handles its own scroll/tap detection via
+        // touch-action: manipulation, this native delay just makes taps
+        // feel sluggish compared to Safari (which doesn't apply it).
+        if let scrollView = webView?.scrollView {
+            scrollView.delaysContentTouches = false
+            scrollView.canCancelContentTouches = true
+        }
 
         // If a universal link triggered a cold start, navigate to it now
         // that the bridge and WebView are ready.

--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -55,6 +55,11 @@
 	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>WKAppBoundDomains</key>
+	<array>
+		<string>boardsesh.com</string>
+		<string>www.boardsesh.com</string>
+	</array>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Boardsesh uses Bluetooth to connect to your Kilter Board, Tension Board, or MoonBoard and light up climbing holds. No personal data is sent over Bluetooth.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
Without WKAppBoundDomains, WKWebView runs in restricted mode with
JavaScript JIT (Nitro) disabled — making JS execution up to 10x slower
than Safari. This adds app-bound domains and limitsNavigationsToAppBoundDomains
to unlock full JIT compilation.

Also tunes WKWebView configuration (pre-warm data store, explicit JS
preferences, inline media), debounces Live Activity bridge calls to
reduce serialization overhead, caches getBoundingClientRect during
gestures to avoid layout thrashing, and adds CSS containment to
isolate paint/layout on climb cards and the board SVG.

https://claude.ai/code/session_01KnrRYMnTuLzuTP8BxPbNjk