### PR TITLE
Update webViewConfiguration to match new Capacitor API signature

### DIFF
--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -9,8 +9,8 @@ class BoardseshViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(LiveActivityPlugin())
     }
 
-    override open func webViewConfiguration() -> WKWebViewConfiguration {
-        let config = super.webViewConfiguration()
+    override open func webViewConfiguration(for webView: WKWebView) -> WKWebViewConfiguration {
+        let config = super.webViewConfiguration(for: webView)
 
         // Enable inline media playback (avoids fullscreen video takeover)
         config.allowsInlineMediaPlayback = true


### PR DESCRIPTION
Add `for webView: WKWebView` parameter to the method signature and pass
it through to the parent class call, resolving compilation errors from
the updated Capacitor API.

https://claude.ai/code/session_01LyeDwiYVW7iotZ14biCUX8