### PR TITLE
Fix webViewConfiguration override to match updated Capacitor API

### DIFF
--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -9,8 +9,8 @@ class BoardseshViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(LiveActivityPlugin())
     }
 
-    override open func webViewConfiguration(for webView: WKWebView) -> WKWebViewConfiguration {
-        let config = super.webViewConfiguration(for: webView)
+    override open func webViewConfiguration(for instanceConfiguration: InstanceConfiguration) -> WKWebViewConfiguration {
+        let config = super.webViewConfiguration(for: instanceConfiguration)
 
         // Enable inline media playback (avoids fullscreen video takeover)
         config.allowsInlineMediaPlayback = true


### PR DESCRIPTION
Capacitor changed the method signature from `webViewConfiguration(for: WKWebView)`
to `webViewConfiguration(for: InstanceConfiguration)`. Update the override in
BoardseshViewController to match so the iOS build compiles against Xcode 26.2.

https://claude.ai/code/session_014Rp8TLHfxXEV21nLvhPdiF