### PR TITLE
fix(climb-detail): clarify enabled prop JSDoc — only beta-links fetch is gated

### DIFF
--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -19,8 +19,11 @@ interface BuildClimbDetailSectionsProps {
   betaLinks?: BetaLink[];
   currentClimbDifficulty?: string;
   boardName?: string;
-  /** When false, skips data fetching and returns empty sections. Used to defer
-   *  below-fold work until after the drawer open animation completes. */
+  /** When false, returns empty sections immediately. Used to defer below-fold
+   *  rendering until after the drawer open animation completes.
+   *  Note: only the beta-links network fetch is gated by this flag (via the
+   *  `enabled` option on `useQuery`). `useLogbookSummary` is always called
+   *  unconditionally because it reads from in-memory context — no network cost. */
   enabled?: boolean;
 }
 


### PR DESCRIPTION
useLogbookSummary reads from in-memory context and is called unconditionally
(React rules of hooks). The previous comment implied all data fetching was
deferred, which was misleading. Also confirm play-view-drawer already has
an explanatory comment for the intentional optional-chaining dep array.

https://claude.ai/code/session_01MED63MC3iKtGrhyLyDCoiV