### PR TITLE
Fix handleOpenPlaylistFromActions callback dependency

### DIFF
--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -78,10 +78,10 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
     setPlaylistClimb(climb);
   }, []);
   const handleCloseActions = useCallback(() => setActionsClimb(null), []);
-  const handleOpenPlaylistFromActions = useCallback((climb: Climb) => {
+  const handleOpenPlaylistFromActions = useCallback(() => {
     setActionsClimb(null);
-    setPlaylistClimb(climb);
-  }, []);
+    setPlaylistClimb(actionsClimb);
+  }, [actionsClimb]);
   const handleClosePlaylist = useCallback(() => setPlaylistClimb(null), []);
 
   // Stabilize onClimbNavigate via ref to prevent suggested ClimbListItems from
@@ -424,7 +424,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
             currentPathname={pathname}
             viewMode="list"
             exclude={excludeActions}
-            onOpenPlaylistSelector={() => handleOpenPlaylistFromActions(actionsClimb)}
+            onOpenPlaylistSelector={handleOpenPlaylistFromActions}
             onActionComplete={handleCloseActions}
           />
         </SwipeableDrawer>


### PR DESCRIPTION
## Summary
Fixed a callback function to properly use closure state instead of relying on stale parameters, and updated the dependency array to reflect the actual dependencies.

## Key Changes
- Modified `handleOpenPlaylistFromActions` to remove the `climb` parameter and instead reference `actionsClimb` from closure
- Updated the callback's dependency array from `[]` to `[actionsClimb]` to ensure the callback is recreated when `actionsClimb` changes
- Simplified the caller by passing the callback directly instead of wrapping it in an arrow function

## Implementation Details
This change ensures that when the playlist selector is opened from the actions menu, it uses the current value of `actionsClimb` at the time of execution rather than a potentially stale parameter value. The updated dependency array prevents bugs where the callback would capture outdated state values.

https://claude.ai/code/session_01Y1ij2CzAzrgiqVvz4j3N5k