### PR TITLE
fix: add missing graphql-queue hook mocks to fix failing tests

### DIFF
--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -45,6 +45,8 @@ vi.mock('../../graphql-queue', () => ({
   useQueueContext: () => mockQueueContext,
   useQueueData: () => mockQueueContext,
   useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({ currentClimb: mockQueueContext.currentClimb }),
+  useQueueList: () => ({ queue: mockQueueContext.queue, suggestedClimbs: [] }),
 }));
 
 vi.mock('../../queue-control/queue-control-bar', () => ({

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -14,6 +14,24 @@ vi.mock('@/app/components/graphql-queue', () => ({
   useQueueContext: () => mockQueueContext,
   useQueueData: () => mockQueueContext,
   useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({ currentClimb: (mockQueueContext as Record<string, unknown>).currentClimb }),
+  useQueueList: () => ({ queue: (mockQueueContext as Record<string, unknown>).queue, suggestedClimbs: [] }),
+  useSessionData: () => ({
+    viewOnlyMode: (mockQueueContext as Record<string, unknown>).viewOnlyMode ?? false,
+    isSessionActive: !!(mockQueueContext as Record<string, unknown>).sessionId,
+    sessionId: (mockQueueContext as Record<string, unknown>).sessionId ?? null,
+    sessionSummary: null,
+    sessionGoal: null,
+    connectionState: (mockQueueContext as Record<string, unknown>).connectionState ?? 'idle',
+    canMutate: (mockQueueContext as Record<string, unknown>).canMutate ?? true,
+    isDisconnected: (mockQueueContext as Record<string, unknown>).isDisconnected ?? false,
+    users: (mockQueueContext as Record<string, unknown>).users ?? [],
+    clientId: null,
+    isLeader: true,
+    isBackendMode: false,
+    hasConnected: true,
+    connectionError: null,
+  }),
 }));
 
 vi.mock('next/navigation', () => ({


### PR DESCRIPTION
useCurrentClimb, useQueueList, and useSessionData were added to graphql-queue but not included in the vi.mock() calls in the persistent-session-wrapper and queue-control-bar-offline tests.

https://claude.ai/code/session_01Xq2G8GYjKg9NiuG13sKqrY