### PR TITLE
Memoize hot-path components to cut play drawer open time

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2634,6 +2634,10 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@boardsesh/db/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+
+    "@boardsesh/web/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+
     "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": "bin/esbuild" }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],

--- a/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mock heavy deps that PlayViewActionBar imports transitively.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/app/components/board-page/share-button', () => ({
+  ShareBoardButton: () => React.createElement('button', { 'data-testid': 'share-button' }),
+}));
+
+// MUI icons — keep as simple SVG stubs so we don't need a full MUI theme
+vi.mock('@mui/icons-material/SkipPreviousOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-skip-prev' }),
+}));
+vi.mock('@mui/icons-material/SkipNextOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-skip-next' }),
+}));
+vi.mock('@mui/icons-material/SyncOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-mirror' }),
+}));
+vi.mock('@mui/icons-material/Favorite', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-favorited' }),
+}));
+vi.mock('@mui/icons-material/FavoriteBorderOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-unfavorited' }),
+}));
+vi.mock('@mui/icons-material/MoreHorizOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-more' }),
+}));
+vi.mock('@mui/icons-material/FormatListBulletedOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-queue' }),
+}));
+
+// Import after mocks
+import { PlayViewActionBar } from '../play-view-drawer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildProps(overrides: Partial<React.ComponentProps<typeof PlayViewActionBar>> = {}): React.ComponentProps<typeof PlayViewActionBar> {
+  return {
+    canSwipePrevious: true,
+    canSwipeNext: true,
+    isMirrored: false,
+    supportsMirroring: false,
+    isFavorited: false,
+    remainingQueueCount: 0,
+    onPrevClick: vi.fn(),
+    onNextClick: vi.fn(),
+    onMirror: vi.fn(),
+    onToggleFavorite: vi.fn(),
+    onOpenActions: vi.fn(),
+    onOpenQueue: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PlayViewActionBar', () => {
+  it('renders prev and next buttons', () => {
+    render(<PlayViewActionBar {...buildProps()} />);
+    expect(screen.getByLabelText('Open queue')).toBeTruthy();
+    expect(screen.getByTestId('icon-skip-prev')).toBeTruthy();
+    expect(screen.getByTestId('icon-skip-next')).toBeTruthy();
+  });
+
+  it('disables prev button when canSwipePrevious=false', () => {
+    render(<PlayViewActionBar {...buildProps({ canSwipePrevious: false })} />);
+    // The icon-skip-prev button's parent IconButton should be disabled
+    const prevBtn = screen.getByTestId('icon-skip-prev').closest('button');
+    expect(prevBtn?.disabled).toBe(true);
+  });
+
+  it('disables next button when canSwipeNext=false', () => {
+    render(<PlayViewActionBar {...buildProps({ canSwipeNext: false })} />);
+    const nextBtn = screen.getByTestId('icon-skip-next').closest('button');
+    expect(nextBtn?.disabled).toBe(true);
+  });
+
+  it('hides mirror button when supportsMirroring=false', () => {
+    render(<PlayViewActionBar {...buildProps({ supportsMirroring: false })} />);
+    expect(screen.queryByTestId('icon-mirror')).toBeNull();
+  });
+
+  it('shows mirror button when supportsMirroring=true', () => {
+    render(<PlayViewActionBar {...buildProps({ supportsMirroring: true })} />);
+    expect(screen.getByTestId('icon-mirror')).toBeTruthy();
+  });
+
+  it('shows unfavorited icon when isFavorited=false', () => {
+    render(<PlayViewActionBar {...buildProps({ isFavorited: false })} />);
+    expect(screen.getByTestId('icon-unfavorited')).toBeTruthy();
+    expect(screen.queryByTestId('icon-favorited')).toBeNull();
+  });
+
+  it('shows favorited icon when isFavorited=true', () => {
+    render(<PlayViewActionBar {...buildProps({ isFavorited: true })} />);
+    expect(screen.getByTestId('icon-favorited')).toBeTruthy();
+    expect(screen.queryByTestId('icon-unfavorited')).toBeNull();
+  });
+
+  it('calls onPrevClick when prev button clicked', () => {
+    const onPrevClick = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ onPrevClick })} />);
+    fireEvent.click(screen.getByTestId('icon-skip-prev').closest('button')!);
+    expect(onPrevClick).toHaveBeenCalledOnce();
+  });
+
+  it('calls onNextClick when next button clicked', () => {
+    const onNextClick = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ onNextClick })} />);
+    fireEvent.click(screen.getByTestId('icon-skip-next').closest('button')!);
+    expect(onNextClick).toHaveBeenCalledOnce();
+  });
+
+  it('calls onMirror when mirror button clicked', () => {
+    const onMirror = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ supportsMirroring: true, onMirror })} />);
+    fireEvent.click(screen.getByTestId('icon-mirror').closest('button')!);
+    expect(onMirror).toHaveBeenCalledOnce();
+  });
+
+  it('calls onToggleFavorite when favorite button clicked', () => {
+    const onToggleFavorite = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ onToggleFavorite })} />);
+    fireEvent.click(screen.getByTestId('icon-unfavorited').closest('button')!);
+    expect(onToggleFavorite).toHaveBeenCalledOnce();
+  });
+
+  it('calls onOpenActions when actions button clicked', () => {
+    const onOpenActions = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ onOpenActions })} />);
+    fireEvent.click(screen.getByLabelText('Climb actions'));
+    expect(onOpenActions).toHaveBeenCalledOnce();
+  });
+
+  it('calls onOpenQueue when queue button clicked', () => {
+    const onOpenQueue = vi.fn();
+    render(<PlayViewActionBar {...buildProps({ onOpenQueue })} />);
+    fireEvent.click(screen.getByLabelText('Open queue'));
+    expect(onOpenQueue).toHaveBeenCalledOnce();
+  });
+
+  it('shows queue badge count', () => {
+    render(<PlayViewActionBar {...buildProps({ remainingQueueCount: 5 })} />);
+    // MUI Badge renders the count as text
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -96,7 +96,7 @@ interface PlayViewActionBarProps {
   onOpenQueue: () => void;
 }
 
-const PlayViewActionBar = React.memo(function PlayViewActionBar({
+export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   canSwipePrevious,
   canSwipeNext,
   isMirrored,
@@ -469,12 +469,14 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
   }, [currentFrames, currentMirrored, boardDetails]);
 
-  const aboveFold = useMemo(() => (
+  const aboveFold = useMemo(() => {
+    if (!currentClimb) return null;
+    return (
     <>
       {/* Header: Grade | Name | Angle Selector */}
       <div className={styles.headerSection}>
         <ClimbDetailHeader
-          climb={currentClimb!}
+          climb={currentClimb}
           boardDetails={boardDetails}
           angle={currentAngle}
           isAngleAdjustable={true}
@@ -538,7 +540,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         />
       )}
     </>
-  ), [
+    );
+  }, [
     currentClimb,
     boardDetails,
     currentAngle,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -81,6 +81,73 @@ const PlayDrawerContent = React.memo<PlayDrawerContentProps>(({ climb, boardType
 });
 PlayDrawerContent.displayName = 'PlayDrawerContent';
 
+interface PlayViewActionBarProps {
+  canSwipePrevious: boolean;
+  canSwipeNext: boolean;
+  isMirrored: boolean;
+  supportsMirroring: boolean;
+  isFavorited: boolean;
+  remainingQueueCount: number;
+  onPrevClick: () => void;
+  onNextClick: () => void;
+  onMirror: () => void;
+  onToggleFavorite: () => void;
+  onOpenActions: () => void;
+  onOpenQueue: () => void;
+}
+
+const PlayViewActionBar = React.memo(function PlayViewActionBar({
+  canSwipePrevious,
+  canSwipeNext,
+  isMirrored,
+  supportsMirroring,
+  isFavorited,
+  remainingQueueCount,
+  onPrevClick,
+  onNextClick,
+  onMirror,
+  onToggleFavorite,
+  onOpenActions,
+  onOpenQueue,
+}: PlayViewActionBarProps) {
+  return (
+    <div className={styles.actionBar}>
+      <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
+        <SkipPreviousOutlined />
+      </IconButton>
+      {supportsMirroring && (
+        <IconButton
+          color={isMirrored ? 'primary' : 'default'}
+          onClick={onMirror}
+          sx={
+            isMirrored
+              ? { backgroundColor: themeTokens.colors.purple, borderColor: themeTokens.colors.purple, color: 'common.white', '&:hover': { backgroundColor: themeTokens.colors.purple } }
+              : undefined
+          }
+        >
+          <SyncOutlined />
+        </IconButton>
+      )}
+      <IconButton onClick={onToggleFavorite}>
+        {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
+      </IconButton>
+      <ShareBoardButton />
+      <IconButton onClick={onOpenActions} aria-label="Climb actions">
+        <MoreHorizOutlined />
+      </IconButton>
+      <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
+        <IconButton onClick={onOpenQueue} aria-label="Open queue">
+          <FormatListBulletedOutlined />
+        </IconButton>
+      </MuiBadge>
+      <IconButton disabled={!canSwipeNext} onClick={onNextClick}>
+        <SkipNextOutlined />
+      </IconButton>
+    </div>
+  );
+});
+PlayViewActionBar.displayName = 'PlayViewActionBar';
+
 interface PlayViewDrawerProps {
   activeDrawer: ActiveDrawer;
   setActiveDrawer: (drawer: ActiveDrawer) => void;
@@ -301,6 +368,27 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const canSwipeNext = !viewOnlyMode && !!nextItem;
   const canSwipePrevious = !viewOnlyMode && !!prevItem;
 
+  const handleTickFabClick = useCallback(() => setIsTickDrawerOpen(true), []);
+  const handlePrevNavClick = useCallback(() => {
+    const prev = getPreviousClimbQueueItem();
+    if (prev) setCurrentClimbQueueItem(prev);
+  }, [getPreviousClimbQueueItem, setCurrentClimbQueueItem]);
+  const handleNextNavClick = useCallback(() => {
+    const next = getNextClimbQueueItem();
+    if (next) setCurrentClimbQueueItem(next);
+  }, [getNextClimbQueueItem, setCurrentClimbQueueItem]);
+  const handleOpenActionsMenu = useCallback(() => {
+    setIsQueueOpen(false);
+    setIsPlaylistSelectorOpen(false);
+    setIsActionsOpen(true);
+  }, []);
+  const handleOpenQueueDrawer = useCallback(() => {
+    setIsActionsOpen(false);
+    setIsPlaylistSelectorOpen(false);
+    setQueueMounted(true);
+    setIsQueueOpen(true);
+  }, []);
+
   const isMirrored = !!currentClimb?.mirrored;
 
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -318,11 +406,11 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     };
     const w = window as WindowWithIdleCallback;
     if (w.requestIdleCallback) {
-      const id = w.requestIdleCallback(setReady, { timeout: 2000 });
+      const id = w.requestIdleCallback(setReady, { timeout: 500 });
       return () => window.cancelIdleCallback(id);
     }
-    const id = setTimeout(setReady, 100);
-    return () => clearTimeout(id);
+    const id = requestAnimationFrame(setReady);
+    return () => cancelAnimationFrame(id);
   }, []);
 
   // Close path: runs before paint so the Slide exit animation starts immediately
@@ -380,6 +468,104 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
   }, [currentFrames, currentMirrored, boardDetails]);
+
+  const aboveFold = useMemo(() => (
+    <>
+      {/* Header: Grade | Name | Angle Selector */}
+      <div className={styles.headerSection}>
+        <ClimbDetailHeader
+          climb={currentClimb!}
+          boardDetails={boardDetails}
+          angle={currentAngle}
+          isAngleAdjustable={true}
+        />
+      </div>
+
+      {/* Board renderer with card-swipe and floating Tick FAB */}
+      <div className={styles.boardSectionWrapper}>
+        {currentClimb && (
+          <SwipeBoardCarousel
+            boardDetails={boardDetails}
+            currentClimb={currentClimb}
+            nextClimb={nextItem?.climb}
+            previousClimb={prevItem?.climb}
+            onSwipeNext={handleSwipeNext}
+            onSwipePrevious={handleSwipePrevious}
+            canSwipeNext={canSwipeNext}
+            canSwipePrevious={canSwipePrevious}
+            className={styles.boardSection}
+            boardContainerClassName={styles.swipeCardContainer}
+            fillContainer
+            onDoubleTap={handleDoubleTap}
+            showZoomHint
+            isDrawerOpen={isOpen}
+            overlay={<HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} />}
+          />
+        )}
+
+        {/* Floating Tick FAB - only when drawer is open */}
+        {isOpen && (
+          <div className={styles.tickFabContainer}>
+            <button
+              className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''}`}
+              onClick={handleTickFabClick}
+              aria-label="Log ascent"
+            >
+              <CheckOutlined className={styles.tickFabIcon} />
+              {ascentCount > 0 && (
+                <span className={styles.tickFabBadge}>{ascentCount}</span>
+              )}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Action bar - only rendered when drawer is open */}
+      {isOpen && (
+        <PlayViewActionBar
+          canSwipePrevious={canSwipePrevious}
+          canSwipeNext={canSwipeNext}
+          isMirrored={isMirrored}
+          supportsMirroring={!!boardDetails.supportsMirroring}
+          isFavorited={isFavorited}
+          remainingQueueCount={remainingQueueCount}
+          onPrevClick={handlePrevNavClick}
+          onNextClick={handleNextNavClick}
+          onMirror={mirrorClimb}
+          onToggleFavorite={toggleFavorite}
+          onOpenActions={handleOpenActionsMenu}
+          onOpenQueue={handleOpenQueueDrawer}
+        />
+      )}
+    </>
+  ), [
+    currentClimb,
+    boardDetails,
+    currentAngle,
+    nextItem,
+    prevItem,
+    handleSwipeNext,
+    handleSwipePrevious,
+    canSwipeNext,
+    canSwipePrevious,
+    handleDoubleTap,
+    showHeart,
+    dismissHeart,
+    isOpen,
+    hasSuccessfulAscent,
+    ascentCount,
+    handleTickFabClick,
+    isMirrored,
+    isFavorited,
+    remainingQueueCount,
+    handlePrevNavClick,
+    handleNextNavClick,
+    mirrorClimb,
+    toggleFavorite,
+    handleOpenActionsMenu,
+    handleOpenQueueDrawer,
+  ]);
+
   return (
     <>
     <SwipeableDrawer
@@ -405,136 +591,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             boardType={boardDetails.board_name}
             angle={currentAngle}
             sectionsEnabled={sectionsEverEnabled && isOpen}
-            aboveFold={
-            <>
-              {/* Header: Grade | Name | Angle Selector */}
-              <div className={styles.headerSection}>
-                <ClimbDetailHeader
-                  climb={currentClimb}
-                  boardDetails={boardDetails}
-                  angle={currentAngle}
-                  isAngleAdjustable={true}
-                />
-              </div>
-
-              {/* Board renderer with card-swipe and floating Tick FAB */}
-              <div className={styles.boardSectionWrapper}>
-                {currentClimb && (
-                  <SwipeBoardCarousel
-                    boardDetails={boardDetails}
-                    currentClimb={currentClimb}
-                    nextClimb={nextItem?.climb}
-                    previousClimb={prevItem?.climb}
-                    onSwipeNext={handleSwipeNext}
-                    onSwipePrevious={handleSwipePrevious}
-                    canSwipeNext={canSwipeNext}
-                    canSwipePrevious={canSwipePrevious}
-                    className={styles.boardSection}
-                    boardContainerClassName={styles.swipeCardContainer}
-                    fillContainer
-                    onDoubleTap={handleDoubleTap}
-                    showZoomHint
-                    isDrawerOpen={isOpen}
-                    overlay={<HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} />}
-                  />
-                )}
-
-                {/* Floating Tick FAB - only when drawer is open */}
-                {isOpen && (
-                <div className={styles.tickFabContainer}>
-                  <button
-                    className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''}`}
-                    onClick={() => setIsTickDrawerOpen(true)}
-                    aria-label="Log ascent"
-                  >
-                    <CheckOutlined className={styles.tickFabIcon} />
-                    {ascentCount > 0 && (
-                      <span className={styles.tickFabBadge}>{ascentCount}</span>
-                    )}
-                  </button>
-                </div>
-                )}
-              </div>
-
-              {/* Action bar - only rendered when drawer is open. When closed, only
-                  the header and board renderer update (for pre-warming). */}
-              {isOpen && (
-              <div className={styles.actionBar}>
-            <IconButton
-              disabled={!canSwipePrevious}
-              onClick={() => {
-                const prev = getPreviousClimbQueueItem();
-                if (prev) setCurrentClimbQueueItem(prev);
-              }}
-            >
-              <SkipPreviousOutlined />
-            </IconButton>
-
-            {/* Mirror */}
-            {boardDetails.supportsMirroring && (
-              <IconButton
-                color={isMirrored ? 'primary' : 'default'}
-                onClick={() => mirrorClimb()}
-                sx={
-                  isMirrored
-                    ? { backgroundColor: themeTokens.colors.purple, borderColor: themeTokens.colors.purple, color: 'common.white', '&:hover': { backgroundColor: themeTokens.colors.purple } }
-                    : undefined
-                }
-              >
-                <SyncOutlined />
-              </IconButton>
-            )}
-
-            {/* Favorite */}
-            <IconButton
-              onClick={() => toggleFavorite()}
-            >
-              {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
-            </IconButton>
-
-            {/* Party / LED */}
-            <ShareBoardButton />
-
-            {/* More actions */}
-            <IconButton
-              onClick={() => {
-                setIsQueueOpen(false);
-                setIsPlaylistSelectorOpen(false);
-                setIsActionsOpen(true);
-              }}
-              aria-label="Climb actions"
-            >
-              <MoreHorizOutlined />
-            </IconButton>
-
-            {/* Queue */}
-            <MuiBadge badgeContent={remainingQueueCount} max={99} sx={{ '& .MuiBadge-badge': { backgroundColor: themeTokens.colors.primary, color: 'common.white' } }}>
-              <IconButton
-                onClick={() => {
-                  setIsActionsOpen(false);
-                  setIsPlaylistSelectorOpen(false);
-                  setQueueMounted(true);
-                  setIsQueueOpen(true);
-                }}
-                aria-label="Open queue"
-              >
-                <FormatListBulletedOutlined />
-              </IconButton>
-            </MuiBadge>
-
-            <IconButton
-              disabled={!canSwipeNext}
-              onClick={() => {
-                const next = getNextClimbQueueItem();
-                if (next) setCurrentClimbQueueItem(next);
-              }}
-            >
-              <SkipNextOutlined />
-            </IconButton>
-              </div>
-              )}
-            </>
-            }
+            aboveFold={aboveFold}
           />
         ) : (
           <ClimbDetailShellClient mode="play" sections={[]} aboveFold={null} />

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -322,15 +322,18 @@ describe('QueueControlBar offline UI', () => {
 
     // Simulate reconnection — pass a new boardDetails object so React.memo re-renders
     // and the useEffect that resets dismissedDisconnect can fire.
+    // (defaultProps.boardDetails is cast `as never` for the prop type; we need a
+    // plain object reference to spread, so we re-cast to unknown first.)
+    const bd = defaultProps.boardDetails as unknown as Record<string, unknown>;
     mockQueueContext = { ...baseQueueContext, isDisconnected: false, connectionState: 'connected' };
     act(() => {
-      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...defaultProps.boardDetails }} />);
+      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...bd } as never} />);
     });
 
     // Simulate disconnection again
     mockQueueContext = { ...baseQueueContext, isDisconnected: true, connectionState: 'reconnecting' };
     act(() => {
-      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...defaultProps.boardDetails }} />);
+      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...bd } as never} />);
     });
 
     expect(screen.getByText(/Offline/i)).toBeTruthy();

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 
 // -- All mocks before imports --
@@ -320,13 +320,18 @@ describe('QueueControlBar offline UI', () => {
     fireEvent.click(banner);
     expect(screen.queryByText(/Offline/i)).toBeNull();
 
-    // Simulate reconnection
+    // Simulate reconnection — pass a new boardDetails object so React.memo re-renders
+    // and the useEffect that resets dismissedDisconnect can fire.
     mockQueueContext = { ...baseQueueContext, isDisconnected: false, connectionState: 'connected' };
-    rerender(<QueueControlBar {...defaultProps} />);
+    act(() => {
+      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...defaultProps.boardDetails }} />);
+    });
 
     // Simulate disconnection again
     mockQueueContext = { ...baseQueueContext, isDisconnected: true, connectionState: 'reconnecting' };
-    rerender(<QueueControlBar {...defaultProps} />);
+    act(() => {
+      rerender(<QueueControlBar {...defaultProps} boardDetails={{ ...defaultProps.boardDetails }} />);
+    });
 
     expect(screen.getByText(/Offline/i)).toBeTruthy();
   });

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -39,6 +39,8 @@ import styles from './queue-control-bar.module.css';
 
 export type ActiveDrawer = 'none' | 'play' | 'queue';
 
+const QUEUE_DRAWER_STYLES = { wrapper: { height: '70%' }, body: { padding: 0 } } as const;
+
 export interface QueueControlBarProps {
   boardDetails: BoardDetails;
   angle: Angle;
@@ -572,7 +574,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         open={activeDrawer === 'queue'}
         onClose={handleCloseDrawer}
         onTransitionEnd={handleDrawerOpenChange}
-        styles={{ wrapper: { height: '70%' }, body: { padding: 0 } }}
+        styles={QUEUE_DRAWER_STYLES}
         extra={
           queue.length > 0 && (
             <ConfirmPopover
@@ -602,4 +604,4 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   );
 };
 
-export default QueueControlBar;
+export default React.memo(QueueControlBar);

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -91,6 +91,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, []);
 
   const handleCloseDrawer = useCallback(() => setActiveDrawer('none'), []);
+  // Stable callback for thumbnail navigation — avoids inline () => setActiveDrawer('none')
+  // which would create a new reference on every render and break Card memoization.
+  const handleNavigateClose = useCallback(() => setActiveDrawer('none'), []);
 
   const isViewPage = pathname.includes('/view/');
   const isListPage = pathname.includes('/list');

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -91,9 +91,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, []);
 
   const handleCloseDrawer = useCallback(() => setActiveDrawer('none'), []);
-  // Stable callback for thumbnail navigation — avoids inline () => setActiveDrawer('none')
-  // which would create a new reference on every render and break Card memoization.
-  const handleNavigateClose = useCallback(() => setActiveDrawer('none'), []);
 
   const isViewPage = pathname.includes('/view/');
   const isListPage = pathname.includes('/list');

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -450,5 +450,6 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   );
 };
 
-export { SwipeableDrawer };
-export default SwipeableDrawer;
+const MemoSwipeableDrawer = React.memo(SwipeableDrawer);
+export { MemoSwipeableDrawer as SwipeableDrawer };
+export default MemoSwipeableDrawer;


### PR DESCRIPTION
## Summary

- **`React.memo(SwipeableDrawer)`** — the component had full internal `useMemo`/`useCallback` coverage but was itself unmemoized, causing 406 re-renders (5,355ms total) in the React profiler. Wrapping it means parent re-renders no longer cascade through the entire MUI drawer chain.
- **`React.memo(QueueControlBar)`** + hoisted `QUEUE_DRAWER_STYLES` — stops router update re-renders from cascading into the queue bar, and prevents the inline styles object from bypassing the new SwipeableDrawer memo on every render.
- **`requestIdleCallback` timeout 2000→500ms + `rAF` fallback** — the pre-warm timer was allowed to wait up to 2 seconds before marking content ready. Reducing to 500ms + using `requestAnimationFrame` as the non-idle fallback means pre-warming fires after first paint (~16ms) instead of up to 2s later.
- **`PlayViewActionBar` React.memo component** + `useCallback` wrappers on all action bar handlers — stable prop references mean the action bar skips re-rendering on parent state changes.
- **`aboveFold` `useMemo`** — `PlayDrawerContent` is already `React.memo` but received a new JSX reference on every parent render, bypassing the memo. Wrapping in `useMemo` lets it skip the re-render when only the MUI transition animates open/closed.

## Context

Profiled using React DevTools on a play drawer open (~1s total, 525ms in commit 0). The profile showed QueueControlBar responsible for 1,416ms across 12 renders and SwipeableDrawer at 5,355ms across 406 renders — even though the actual content (PlayDrawerContent, SwipeBoardCarousel) was only ~50ms and ~4ms respectively.

Builds on #1305 (lazy-mount queue drawer) and #1304/#1306 (fix_app_perf).

## Test plan

- [ ] Open play drawer — should animate open without visible jank
- [ ] Navigate between climbs in queue — drawer content updates without full re-render cascade
- [ ] Open queue sub-drawer — still lazy-mounts on first open
- [ ] `bunx vitest run app/components/play-view/__tests__/` — 13 tests pass
- [ ] `bun run typecheck:web` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)