### PR TITLE
Fix 7x10 board showing climbs with unowned hold sets

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { searchClimbs, countClimbs, getClimbByUuid } from '../db/queries/climbs/index';
 import type { ParsedBoardRouteParameters, ClimbSearchParams } from '../db/queries/climbs/index';
 import { getSizeEdges } from '../db/queries/util/product-sizes-data';
+import { db } from '../db/client';
+import { sql } from 'drizzle-orm';
 
 describe('Climb Query Functions', () => {
   const testParams: ParsedBoardRouteParameters = {
@@ -255,6 +257,126 @@ describe('Climb Query Functions', () => {
       // Both should execute without errors (may return null if no data)
       expect(kilterResult === null || typeof kilterResult === 'object').toBe(true);
       expect(tensionResult === null || typeof tensionResult === 'object').toBe(true);
+    });
+  });
+
+  describe('set_ids filtering', () => {
+    // Seed data for set_ids tests
+    // - Placement 100 belongs to set 1 (mainline), layout 1
+    // - Placement 200 belongs to set 2 (full ride), layout 1
+    // - Climb "mainline-only" uses only placement 100 (set 1)
+    // - Climb "full-ride-only" uses only placement 200 (set 2)
+    // - Climb "mixed-sets" uses both placement 100 (set 1) and 200 (set 2)
+    const SET_IDS_TEST_PREFIX = 'set-ids-test-';
+
+    beforeAll(async () => {
+      // Insert placements for two different sets
+      await db.execute(sql`
+        INSERT INTO board_placements (board_type, id, layout_id, hole_id, set_id, default_placement_role_id)
+        VALUES
+          ('kilter', 100, 1, 100, 1, NULL),
+          ('kilter', 200, 1, 200, 2, NULL)
+        ON CONFLICT DO NOTHING
+      `);
+
+      // Insert test climbs that fit within size 7 edges
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+        VALUES
+          (${SET_IDS_TEST_PREFIX + 'mainline'}, 'kilter', 1, 'test-setter', 'Mainline Only', 'p100r43', 1, false, true, 10, 100, 10, 150, '2024-01-01'),
+          (${SET_IDS_TEST_PREFIX + 'fullride'}, 'kilter', 1, 'test-setter', 'Full Ride Only', 'p200r43', 1, false, true, 10, 100, 10, 150, '2024-01-01'),
+          (${SET_IDS_TEST_PREFIX + 'mixed'}, 'kilter', 1, 'test-setter', 'Mixed Sets', 'p100r43p200r44', 1, false, true, 10, 100, 10, 150, '2024-01-01')
+        ON CONFLICT DO NOTHING
+      `);
+
+      // Insert climb holds matching the frames
+      await db.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES
+          ('kilter', ${SET_IDS_TEST_PREFIX + 'mainline'}, 100, 0, 'HAND'),
+          ('kilter', ${SET_IDS_TEST_PREFIX + 'fullride'}, 200, 0, 'HAND'),
+          ('kilter', ${SET_IDS_TEST_PREFIX + 'mixed'}, 100, 0, 'HAND'),
+          ('kilter', ${SET_IDS_TEST_PREFIX + 'mixed'}, 200, 0, 'FINISH')
+        ON CONFLICT DO NOTHING
+      `);
+    });
+
+    afterAll(async () => {
+      // Clean up test data
+      await db.execute(sql`DELETE FROM board_climb_holds WHERE climb_uuid LIKE ${SET_IDS_TEST_PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${SET_IDS_TEST_PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_placements WHERE board_type = 'kilter' AND id IN (100, 200)`);
+    });
+
+    it('should only return climbs whose holds all belong to selected sets', async () => {
+      const params: ParsedBoardRouteParameters = {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 7,
+        set_ids: [1], // mainline only
+        angle: 40,
+      };
+
+      const result = await searchClimbs(params, { page: 0, pageSize: 100, sortBy: 'creation', sortOrder: 'desc' });
+      const uuids = result.climbs.map((c) => c.uuid);
+
+      // Should include mainline-only climb
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'mainline');
+      // Should NOT include full-ride-only or mixed (has a full-ride hold)
+      expect(uuids).not.toContain(SET_IDS_TEST_PREFIX + 'fullride');
+      expect(uuids).not.toContain(SET_IDS_TEST_PREFIX + 'mixed');
+    });
+
+    it('should return climbs from all selected sets', async () => {
+      const params: ParsedBoardRouteParameters = {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 7,
+        set_ids: [1, 2], // both mainline and full ride
+        angle: 40,
+      };
+
+      const result = await searchClimbs(params, { page: 0, pageSize: 100, sortBy: 'creation', sortOrder: 'desc' });
+      const uuids = result.climbs.map((c) => c.uuid);
+
+      // All three climbs should appear when both sets are selected
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'mainline');
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'fullride');
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'mixed');
+    });
+
+    it('should skip set_ids filter for moonboard', async () => {
+      const params: ParsedBoardRouteParameters = {
+        board_name: 'moonboard',
+        layout_id: 1,
+        size_id: 1,
+        set_ids: [1],
+        angle: 40,
+      };
+
+      // Should not throw (the filter is skipped for moonboard)
+      const result = await searchClimbs(params, { page: 0, pageSize: 10 });
+      expect(result).toBeDefined();
+      expect(result.climbs).toBeInstanceOf(Array);
+    });
+
+    it('should skip set_ids filter when set_ids is empty', async () => {
+      const params: ParsedBoardRouteParameters = {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 7,
+        set_ids: [],
+        angle: 40,
+      };
+
+      // Should not throw and should return results (no set filtering applied)
+      const result = await searchClimbs(params, { page: 0, pageSize: 100, sortBy: 'creation', sortOrder: 'desc' });
+      const uuids = result.climbs.map((c) => c.uuid);
+
+      // All test climbs should appear since no set filter is applied
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'mainline');
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'fullride');
+      expect(uuids).toContain(SET_IDS_TEST_PREFIX + 'mixed');
     });
   });
 

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -196,6 +196,30 @@ const createTablesSQL = `
     "aurora_sync_error" text
   );
 
+  -- Create board_placements table (needed for set_ids filtering in climb queries)
+  DROP TABLE IF EXISTS "board_placements" CASCADE;
+  CREATE TABLE IF NOT EXISTS "board_placements" (
+    "board_type" text NOT NULL,
+    "id" integer NOT NULL,
+    "layout_id" integer,
+    "hole_id" integer,
+    "set_id" integer,
+    "default_placement_role_id" integer,
+    PRIMARY KEY ("board_type", "id")
+  );
+
+  -- Create board_climb_holds table (needed for set_ids filtering in climb queries)
+  DROP TABLE IF EXISTS "board_climb_holds" CASCADE;
+  CREATE TABLE IF NOT EXISTS "board_climb_holds" (
+    "board_type" text NOT NULL,
+    "climb_uuid" text NOT NULL,
+    "hold_id" integer NOT NULL,
+    "frame_number" integer NOT NULL,
+    "hold_state" text NOT NULL,
+    "created_at" timestamp DEFAULT now(),
+    PRIMARY KEY ("board_type", "climb_uuid", "hold_id")
+  );
+
   -- Insert common test users (needed for FK constraints in session tests)
   INSERT INTO "users" (id, email, name, created_at, updated_at)
   VALUES ('user-123', 'user-123@test.com', 'Test User 123', now(), now())

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -5,6 +5,7 @@ import {
   boardseshTicks,
   boardProductSizes,
   boardClimbHolds,
+  boardPlacements,
 } from '../../schema/index';
 import type { BoardRouteParams, ClimbSearchParams, SizeEdges } from './types';
 
@@ -160,6 +161,24 @@ export const createClimbFilters = (
     );
   }
 
+  // Set membership filter: exclude climbs that use holds from sets the user doesn't own.
+  // Uses double-NOT-EXISTS: "no hold of this climb lacks a placement in the selected sets."
+  // MoonBoard has no board_placements data, so skip (same pattern as edge filtering).
+  const setIdsConditions: SQL[] = params.board_name === 'moonboard' || params.set_ids.length === 0 ? [] : [
+    sql`NOT EXISTS (
+      SELECT 1 FROM ${boardClimbHolds} bch_set
+      WHERE bch_set.climb_uuid = ${boardClimbs.uuid}
+        AND bch_set.board_type = ${params.board_name}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${boardPlacements} bp_set
+          WHERE bp_set.board_type = ${params.board_name}
+            AND bp_set.layout_id = ${params.layout_id}
+            AND bp_set.id = bch_set.hold_id
+            AND bp_set.set_id IN (${sql.join(params.set_ids.map(id => sql`${id}`), sql`, `)})
+        )
+    )`,
+  ];
+
   // Personal progress filter conditions
   const personalProgressConditions: SQL[] = [];
   if (userId) {
@@ -224,6 +243,7 @@ export const createClimbFilters = (
       ...holdConditions,
       ...holdStateConditions,
       ...tallClimbsConditions,
+      ...setIdsConditions,
       ...personalProgressConditions,
     ],
     getSizeConditions: () => sizeConditions,

--- a/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
+++ b/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
@@ -175,11 +175,11 @@ export const createClimbFilters = (
   // MoonBoard has no board_placements data, so skip (same pattern as edge filtering).
   const setIdsConditions: SQL[] = params.board_name === 'moonboard' || params.set_ids.length === 0 ? [] : [
     sql`NOT EXISTS (
-      SELECT 1 FROM board_climb_holds bch_set
+      SELECT 1 FROM ${tables.climbHolds} bch_set
       WHERE bch_set.climb_uuid = ${tables.climbs.uuid}
         AND bch_set.board_type = ${params.board_name}
         AND NOT EXISTS (
-          SELECT 1 FROM board_placements bp_set
+          SELECT 1 FROM ${tables.placements} bp_set
           WHERE bp_set.board_type = ${params.board_name}
             AND bp_set.layout_id = ${params.layout_id}
             AND bp_set.id = bch_set.hold_id

--- a/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
+++ b/packages/web/app/lib/db/queries/climbs/create-climb-filters.ts
@@ -170,6 +170,24 @@ export const createClimbFilters = (
     );
   }
 
+  // Set membership filter: exclude climbs that use holds from sets the user doesn't own.
+  // Uses double-NOT-EXISTS: "no hold of this climb lacks a placement in the selected sets."
+  // MoonBoard has no board_placements data, so skip (same pattern as edge filtering).
+  const setIdsConditions: SQL[] = params.board_name === 'moonboard' || params.set_ids.length === 0 ? [] : [
+    sql`NOT EXISTS (
+      SELECT 1 FROM board_climb_holds bch_set
+      WHERE bch_set.climb_uuid = ${tables.climbs.uuid}
+        AND bch_set.board_type = ${params.board_name}
+        AND NOT EXISTS (
+          SELECT 1 FROM board_placements bp_set
+          WHERE bp_set.board_type = ${params.board_name}
+            AND bp_set.layout_id = ${params.layout_id}
+            AND bp_set.id = bch_set.hold_id
+            AND bp_set.set_id IN (${sql.join(params.set_ids.map(id => sql`${id}`), sql`, `)})
+        )
+    )`,
+  ];
+
   // Personal progress filter conditions (only apply if userId is provided)
   // Uses boardsesh_ticks with NextAuth userId
   const personalProgressConditions: SQL[] = [];
@@ -277,7 +295,7 @@ export const createClimbFilters = (
 
   return {
     // Helper function to get all climb filtering conditions
-    getClimbWhereConditions: () => [...baseConditions, ...nameCondition, ...setterNameCondition, ...holdConditions, ...holdStateConditions, ...tallClimbsConditions, ...personalProgressConditions],
+    getClimbWhereConditions: () => [...baseConditions, ...nameCondition, ...setterNameCondition, ...holdConditions, ...holdStateConditions, ...tallClimbsConditions, ...setIdsConditions, ...personalProgressConditions],
 
     // Size-specific conditions
     getSizeConditions: () => sizeConditions,
@@ -319,6 +337,7 @@ export const createClimbFilters = (
     holdConditions,
     holdStateConditions,
     tallClimbsConditions,
+    setIdsConditions,
     sizeConditions,
     personalProgressConditions,
     anyHolds,


### PR DESCRIPTION
## Summary
- **Bug**: Users with a 7x10 Kilter homewall and mainline-only holds see climbs that require full ride holds they don't have installed
- **Root cause**: `set_ids` was parsed from the URL but never used in the SQL WHERE clause — only edge bounds filtered by size, not by hold set membership
- **Fix**: Add a double-NOT-EXISTS filter to `createClimbFilters` (both `packages/db` and `packages/web` copies) that excludes any climb containing a hold not in the user's selected sets. This is the same pattern already used in the backend's popular board configs query.

## Test plan
- [ ] Search climbs on a 7x10 Kilter board with mainline-only set_ids — full ride climbs should no longer appear
- [ ] Verify MoonBoard search still works (filter is skipped since MoonBoard has no `board_placements` data)
- [ ] Verify heatmap query still works (uses same `createClimbFilters`)
- [ ] Verify climb count is correct (uses same `createClimbFilters`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)