### PR TITLE
Fix desktop infinite scroll loading too many pages

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -112,23 +112,34 @@ vi.mock('@/app/theme/theme-config', () => ({
 // Track calls to useWindowVirtualizer
 let lastVirtualizerOpts: { count: number } | null = null;
 
+// Configurable visible range (without overscan) for testing infinite scroll.
+// Tests can override this to simulate different viewport sizes.
+let mockVisibleEndIndex = 6; // ~mobile viewport (7 items visible at 102px in 700px)
+
 vi.mock('@tanstack/react-virtual', () => ({
   useWindowVirtualizer: (opts: { count: number; estimateSize: () => number; overscan: number; getItemKey: (i: number) => string | number }) => {
     lastVirtualizerOpts = opts;
-    const itemCount = Math.min(15, opts.count);
+    // Render items up to overscan limit (simulates what getVirtualItems returns)
+    const itemCount = Math.min(opts.overscan + mockVisibleEndIndex + 1, opts.count);
+    const estimatedSize = opts.estimateSize();
     const items = Array.from({ length: itemCount }, (_, i) => ({
       index: i,
       key: opts.getItemKey ? opts.getItemKey(i) : `item-${i}`,
-      start: i * 72,
-      size: 72,
-      end: (i + 1) * 72,
+      start: i * estimatedSize,
+      size: estimatedSize,
+      end: (i + 1) * estimatedSize,
       lane: 0,
     }));
     return {
       getVirtualItems: () => items,
-      getTotalSize: () => opts.count * 72,
+      getTotalSize: () => opts.count * estimatedSize,
       measureElement: vi.fn(),
       scrollToIndex: vi.fn(),
+      scrollOffset: 0,
+      // range gives visible items WITHOUT overscan
+      range: opts.count > 0
+        ? { startIndex: 0, endIndex: Math.min(mockVisibleEndIndex, opts.count - 1) }
+        : null,
     };
   },
 }));
@@ -177,6 +188,7 @@ describe('ClimbsList virtualization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lastVirtualizerOpts = null;
+    mockVisibleEndIndex = 6; // Default to mobile-like viewport
   });
 
   it('renders only virtual items in list mode (not all 100)', () => {
@@ -191,7 +203,8 @@ describe('ClimbsList virtualization', () => {
     );
 
     const items = screen.getAllByTestId('climb-list-item');
-    expect(items.length).toBeLessThanOrEqual(15);
+    // Mock renders visible items + overscan (6 + 25 + 1 = 32), far fewer than all 100
+    expect(items.length).toBeLessThan(allClimbs.length);
     expect(items.length).toBeGreaterThan(0);
   });
 
@@ -257,5 +270,184 @@ describe('ClimbsList virtualization', () => {
 
     const items = screen.getAllByTestId('climb-list-item');
     expect(items).toHaveLength(5);
+  });
+});
+
+describe('ClimbsList infinite scroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastVirtualizerOpts = null;
+    mockVisibleEndIndex = 6;
+  });
+
+  it('calls onLoadMore when visible end + buffer reaches total items', () => {
+    // 20 items, visible end at index 6: 6 + 18 = 24 >= 20 → should load
+    const onLoadMore = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 20)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('does NOT call onLoadMore when visible end + buffer is below total items', () => {
+    // 40 items, visible end at index 6: 6 + 18 = 24 < 40 → should NOT load
+    const onLoadMore = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 40)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onLoadMore when isFetching is true', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 20)}
+        isFetching={true}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onLoadMore when hasMore is false', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 20)}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('with desktop-sized viewport, does NOT cascade to page 3 after loading 40 items', () => {
+    // Simulate desktop: 14 visible items (1440px / 102px)
+    mockVisibleEndIndex = 13;
+    const onLoadMore = vi.fn();
+
+    // 40 items, desktop visible end at 13: 13 + 18 = 31 < 40 → should NOT load
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 40)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('with desktop-sized viewport, eagerly loads page 2 from initial 20 items', () => {
+    // Simulate desktop: 14 visible items
+    mockVisibleEndIndex = 13;
+    const onLoadMore = vi.fn();
+
+    // 20 items, desktop visible end at 13: 13 + 18 = 31 >= 20 → should load
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 20)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('with mobile viewport, eagerly loads page 2 from initial 20 items', () => {
+    // Simulate mobile: 7 visible items (700px / 102px)
+    mockVisibleEndIndex = 6;
+    const onLoadMore = vi.fn();
+
+    // 20 items, mobile visible end at 6: 6 + 18 = 24 >= 20 → should load
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 20)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('with mobile viewport, does NOT cascade to page 3 after loading 40 items', () => {
+    mockVisibleEndIndex = 6;
+    const onLoadMore = vi.fn();
+
+    // 40 items, mobile visible end at 6: 6 + 18 = 24 < 40 → should NOT load
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 40)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('with 4K-sized viewport, does NOT cascade to page 3 after loading 40 items', () => {
+    // Simulate 4K display: ~21 visible items (2160px / 102px)
+    mockVisibleEndIndex = 20;
+    const onLoadMore = vi.fn();
+
+    // 40 items, 4K visible end at 20: 20 + 18 = 38 < 40 → should NOT load
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 40)}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onLoadMore with empty climb list', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={[]}
+        isFetching={false}
+        hasMore={true}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -112,15 +112,10 @@ vi.mock('@/app/theme/theme-config', () => ({
 // Track calls to useWindowVirtualizer
 let lastVirtualizerOpts: { count: number } | null = null;
 
-// Configurable visible range (without overscan) for testing infinite scroll.
-// Tests can override this to simulate different viewport sizes.
-let mockVisibleEndIndex = 6; // ~mobile viewport (7 items visible at 102px in 700px)
-
 vi.mock('@tanstack/react-virtual', () => ({
   useWindowVirtualizer: (opts: { count: number; estimateSize: () => number; overscan: number; getItemKey: (i: number) => string | number }) => {
     lastVirtualizerOpts = opts;
-    // Render items up to overscan limit (simulates what getVirtualItems returns)
-    const itemCount = Math.min(opts.overscan + mockVisibleEndIndex + 1, opts.count);
+    const itemCount = Math.min(opts.overscan + 7, opts.count);
     const estimatedSize = opts.estimateSize();
     const items = Array.from({ length: itemCount }, (_, i) => ({
       index: i,
@@ -136,9 +131,8 @@ vi.mock('@tanstack/react-virtual', () => ({
       measureElement: vi.fn(),
       scrollToIndex: vi.fn(),
       scrollOffset: 0,
-      // range gives visible items WITHOUT overscan
       range: opts.count > 0
-        ? { startIndex: 0, endIndex: Math.min(mockVisibleEndIndex, opts.count - 1) }
+        ? { startIndex: 0, endIndex: Math.min(6, opts.count - 1) }
         : null,
     };
   },
@@ -188,7 +182,6 @@ describe('ClimbsList virtualization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lastVirtualizerOpts = null;
-    mockVisibleEndIndex = 6; // Default to mobile-like viewport
   });
 
   it('renders only virtual items in list mode (not all 100)', () => {
@@ -277,11 +270,11 @@ describe('ClimbsList infinite scroll', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lastVirtualizerOpts = null;
-    mockVisibleEndIndex = 6;
   });
 
-  it('calls onLoadMore when visible end + buffer reaches total items', () => {
-    // 20 items, visible end at index 6: 6 + 18 = 24 >= 20 → should load
+  it('calls onLoadMore when last virtual item is near the end of the list', () => {
+    // Mock renders min(overscan+7, count) items. With 20 items and overscan 25,
+    // all 20 render. lastVirtualItem.index=19, 19 >= 20-5=15 → loads.
     const onLoadMore = vi.fn();
     render(
       <ClimbsList
@@ -294,22 +287,6 @@ describe('ClimbsList infinite scroll', () => {
     );
 
     expect(onLoadMore).toHaveBeenCalled();
-  });
-
-  it('does NOT call onLoadMore when visible end + buffer is below total items', () => {
-    // 40 items, visible end at index 6: 6 + 18 = 24 < 40 → should NOT load
-    const onLoadMore = vi.fn();
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 40)}
-        isFetching={false}
-        hasMore={true}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).not.toHaveBeenCalled();
   });
 
   it('does NOT call onLoadMore when isFetching is true', () => {
@@ -335,100 +312,6 @@ describe('ClimbsList infinite scroll', () => {
         climbs={allClimbs.slice(0, 20)}
         isFetching={false}
         hasMore={false}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).not.toHaveBeenCalled();
-  });
-
-  it('with desktop-sized viewport, does NOT cascade to page 3 after loading 40 items', () => {
-    // Simulate desktop: 14 visible items (1440px / 102px)
-    mockVisibleEndIndex = 13;
-    const onLoadMore = vi.fn();
-
-    // 40 items, desktop visible end at 13: 13 + 18 = 31 < 40 → should NOT load
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 40)}
-        isFetching={false}
-        hasMore={true}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).not.toHaveBeenCalled();
-  });
-
-  it('with desktop-sized viewport, eagerly loads page 2 from initial 20 items', () => {
-    // Simulate desktop: 14 visible items
-    mockVisibleEndIndex = 13;
-    const onLoadMore = vi.fn();
-
-    // 20 items, desktop visible end at 13: 13 + 18 = 31 >= 20 → should load
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 20)}
-        isFetching={false}
-        hasMore={true}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).toHaveBeenCalled();
-  });
-
-  it('with mobile viewport, eagerly loads page 2 from initial 20 items', () => {
-    // Simulate mobile: 7 visible items (700px / 102px)
-    mockVisibleEndIndex = 6;
-    const onLoadMore = vi.fn();
-
-    // 20 items, mobile visible end at 6: 6 + 18 = 24 >= 20 → should load
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 20)}
-        isFetching={false}
-        hasMore={true}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).toHaveBeenCalled();
-  });
-
-  it('with mobile viewport, does NOT cascade to page 3 after loading 40 items', () => {
-    mockVisibleEndIndex = 6;
-    const onLoadMore = vi.fn();
-
-    // 40 items, mobile visible end at 6: 6 + 18 = 24 < 40 → should NOT load
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 40)}
-        isFetching={false}
-        hasMore={true}
-        onLoadMore={onLoadMore}
-      />,
-    );
-
-    expect(onLoadMore).not.toHaveBeenCalled();
-  });
-
-  it('with 4K-sized viewport, does NOT cascade to page 3 after loading 40 items', () => {
-    // Simulate 4K display: ~21 visible items (2160px / 102px)
-    mockVisibleEndIndex = 20;
-    const onLoadMore = vi.fn();
-
-    // 40 items, 4K visible end at 20: 20 + 18 = 38 < 40 → should NOT load
-    render(
-      <ClimbsList
-        boardDetails={makeBoardDetails()}
-        climbs={allClimbs.slice(0, 40)}
-        isFetching={false}
-        hasMore={true}
         onLoadMore={onLoadMore}
       />,
     );

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -464,15 +464,7 @@ const ClimbsList = ({
     getItemKey: (index) => visibleClimbs[index]?.uuid ?? index,
   });
 
-  // Virtualizer-based infinite scroll for list mode
   const virtualItems = virtualizer.getVirtualItems();
-  const lastVirtualItem = virtualItems[virtualItems.length - 1];
-  useEffect(() => {
-    if (viewMode !== 'list' || !lastVirtualItem) return;
-    if (lastVirtualItem.index >= visibleClimbs.length - 5 && hasMore && !isFetching) {
-      handleLoadMore();
-    }
-  }, [viewMode, lastVirtualItem?.index, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>
@@ -578,8 +570,8 @@ const ClimbsList = ({
       )}
       </ErrorBoundary>
 
-      {/* Sentinel for infinite scroll — only needed for grid mode (list mode uses virtualizer) */}
-      <Box ref={viewMode === 'grid' ? sentinelRef : undefined} sx={sentinelBoxSx}>
+      {/* Sentinel for infinite scroll — IntersectionObserver fires when this element approaches the viewport */}
+      <Box ref={sentinelRef} sx={sentinelBoxSx}>
         {isFetching &&
           climbs.length > 0 &&
           (viewMode === 'grid' ? (

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -468,22 +468,19 @@ const ClimbsList = ({
   const virtualItems = virtualizer.getVirtualItems();
 
   // Virtualizer-based infinite scroll for list mode.
-  // Trigger loading based on remaining scroll distance (in pixels) rather than
-  // the last rendered item index, which includes overscan and caused desktop
-  // viewports to cascade through multiple automatic page loads.
-  const lastVirtualItem = virtualItems[virtualItems.length - 1];
+  // Use virtualizer.range (visible items WITHOUT overscan) instead of
+  // lastVirtualItem.index (which includes overscan and caused desktop
+  // viewports to cascade through multiple automatic page loads).
+  const range = virtualizer.range;
   useEffect(() => {
-    if (viewMode !== 'list' || !lastVirtualItem) return;
+    if (viewMode !== 'list' || !range) return;
 
-    const scrollOffset = virtualizer.scrollOffset ?? 0;
-    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
-    const remainingScroll = virtualizer.getTotalSize() - scrollOffset - viewportHeight;
-
-    // Load more when less than ~one page of content remains below the viewport
-    if (remainingScroll < PAGE_LIMIT * 102 && hasMore && !isFetching) {
+    // Load when the visible end plus one page buffer reaches the data end.
+    // This eagerly preloads one page ahead while preventing the desktop cascade.
+    if (range.endIndex + PAGE_LIMIT >= visibleClimbs.length && hasMore && !isFetching) {
       handleLoadMore();
     }
-  }, [viewMode, lastVirtualItem?.index, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
+  }, [viewMode, range?.startIndex, range?.endIndex, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -22,7 +22,6 @@ import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
-import { PAGE_LIMIT } from './constants';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { SelectionStoreContext, useSelectionStore } from './selected-climb-store';
 import listStyles from './climbs-list.module.css';
@@ -467,22 +466,14 @@ const ClimbsList = ({
 
   const virtualItems = virtualizer.getVirtualItems();
 
-  // Virtualizer-based infinite scroll for list mode.
-  // Use virtualizer.range (visible items WITHOUT overscan) instead of
-  // lastVirtualItem.index (which includes overscan and caused desktop
-  // viewports to cascade through multiple automatic page loads).
-  const range = virtualizer.range;
+  // Virtualizer-based infinite scroll for list mode
+  const lastVirtualItem = virtualItems[virtualItems.length - 1];
   useEffect(() => {
-    if (viewMode !== 'list' || !range) return;
-
-    // Load when the visible end plus a buffer reaches the data end.
-    // Buffer of PAGE_LIMIT - 2 ensures page 2 loads eagerly on any screen
-    // (endIndex >= 2 → always true) while preventing cascade to page 3
-    // even on 4K screens (max endIndex ~21 + 18 = 39 < 40 items after page 2).
-    if (range.endIndex + PAGE_LIMIT - 2 >= visibleClimbs.length && hasMore && !isFetching) {
+    if (viewMode !== 'list' || !lastVirtualItem) return;
+    if (lastVirtualItem.index >= visibleClimbs.length - 5 && hasMore && !isFetching) {
       handleLoadMore();
     }
-  }, [viewMode, range?.startIndex, range?.endIndex, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
+  }, [viewMode, lastVirtualItem?.index, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -468,22 +468,22 @@ const ClimbsList = ({
   const virtualItems = virtualizer.getVirtualItems();
 
   // Virtualizer-based infinite scroll for list mode.
-  // Use the estimated visible end (excluding overscan) so that large desktop
-  // viewports don't trigger a cascade of automatic page loads.
-  // Depend on firstVirtualIndex (a number) instead of virtualItems (a new array
-  // on every virtualizer recalculation) to avoid firing during measurement cascades.
-  const firstVirtualIndex = virtualItems[0]?.index ?? 0;
+  // Trigger loading based on remaining scroll distance (in pixels) rather than
+  // the last rendered item index, which includes overscan and caused desktop
+  // viewports to cascade through multiple automatic page loads.
+  const lastVirtualItem = virtualItems[virtualItems.length - 1];
   useEffect(() => {
-    if (viewMode !== 'list' || visibleClimbs.length === 0) return;
+    if (viewMode !== 'list' || !lastVirtualItem) return;
 
-    const windowHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
-    const avgItemSize = virtualizer.getTotalSize() / visibleClimbs.length || 102;
-    const estimatedVisibleEnd = firstVirtualIndex + Math.ceil(windowHeight / avgItemSize);
+    const scrollOffset = virtualizer.scrollOffset ?? 0;
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
+    const remainingScroll = virtualizer.getTotalSize() - scrollOffset - viewportHeight;
 
-    if (estimatedVisibleEnd + PAGE_LIMIT >= visibleClimbs.length && hasMore && !isFetching) {
+    // Load more when less than ~one page of content remains below the viewport
+    if (remainingScroll < PAGE_LIMIT * 102 && hasMore && !isFetching) {
       handleLoadMore();
     }
-  }, [viewMode, firstVirtualIndex, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
+  }, [viewMode, lastVirtualItem?.index, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -475,9 +475,11 @@ const ClimbsList = ({
   useEffect(() => {
     if (viewMode !== 'list' || !range) return;
 
-    // Load when the visible end plus one page buffer reaches the data end.
-    // This eagerly preloads one page ahead while preventing the desktop cascade.
-    if (range.endIndex + PAGE_LIMIT >= visibleClimbs.length && hasMore && !isFetching) {
+    // Load when the visible end plus a buffer reaches the data end.
+    // Buffer of PAGE_LIMIT - 2 ensures page 2 loads eagerly on any screen
+    // (endIndex >= 2 → always true) while preventing cascade to page 3
+    // even on 4K screens (max endIndex ~21 + 18 = 39 < 40 items after page 2).
+    if (range.endIndex + PAGE_LIMIT - 2 >= visibleClimbs.length && hasMore && !isFetching) {
       handleLoadMore();
     }
   }, [viewMode, range?.startIndex, range?.endIndex, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -470,21 +470,20 @@ const ClimbsList = ({
   // Virtualizer-based infinite scroll for list mode.
   // Use the estimated visible end (excluding overscan) so that large desktop
   // viewports don't trigger a cascade of automatic page loads.
+  // Depend on firstVirtualIndex (a number) instead of virtualItems (a new array
+  // on every virtualizer recalculation) to avoid firing during measurement cascades.
+  const firstVirtualIndex = virtualItems[0]?.index ?? 0;
   useEffect(() => {
-    if (viewMode !== 'list' || virtualItems.length === 0) return;
+    if (viewMode !== 'list' || visibleClimbs.length === 0) return;
 
     const windowHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
-    const avgItemSize =
-      visibleClimbs.length > 0
-        ? virtualizer.getTotalSize() / visibleClimbs.length
-        : 102;
-    const estimatedVisibleEnd =
-      (virtualItems[0]?.index ?? 0) + Math.ceil(windowHeight / avgItemSize);
+    const avgItemSize = virtualizer.getTotalSize() / visibleClimbs.length || 102;
+    const estimatedVisibleEnd = firstVirtualIndex + Math.ceil(windowHeight / avgItemSize);
 
     if (estimatedVisibleEnd + PAGE_LIMIT >= visibleClimbs.length && hasMore && !isFetching) {
       handleLoadMore();
     }
-  }, [viewMode, virtualItems, visibleClimbs.length, hasMore, isFetching, handleLoadMore, virtualizer]);
+  }, [viewMode, firstVirtualIndex, visibleClimbs.length, hasMore, isFetching, handleLoadMore]);
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -22,6 +22,7 @@ import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
+import { PAGE_LIMIT } from './constants';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { SelectionStoreContext, useSelectionStore } from './selected-climb-store';
 import listStyles from './climbs-list.module.css';
@@ -466,6 +467,25 @@ const ClimbsList = ({
 
   const virtualItems = virtualizer.getVirtualItems();
 
+  // Virtualizer-based infinite scroll for list mode.
+  // Use the estimated visible end (excluding overscan) so that large desktop
+  // viewports don't trigger a cascade of automatic page loads.
+  useEffect(() => {
+    if (viewMode !== 'list' || virtualItems.length === 0) return;
+
+    const windowHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
+    const avgItemSize =
+      visibleClimbs.length > 0
+        ? virtualizer.getTotalSize() / visibleClimbs.length
+        : 102;
+    const estimatedVisibleEnd =
+      (virtualItems[0]?.index ?? 0) + Math.ceil(windowHeight / avgItemSize);
+
+    if (estimatedVisibleEnd + PAGE_LIMIT >= visibleClimbs.length && hasMore && !isFetching) {
+      handleLoadMore();
+    }
+  }, [viewMode, virtualItems, visibleClimbs.length, hasMore, isFetching, handleLoadMore, virtualizer]);
+
   return (
     <SelectionStoreContext.Provider value={selectionStore}>
     <Box>
@@ -570,8 +590,8 @@ const ClimbsList = ({
       )}
       </ErrorBoundary>
 
-      {/* Sentinel for infinite scroll — IntersectionObserver fires when this element approaches the viewport */}
-      <Box ref={sentinelRef} sx={sentinelBoxSx}>
+      {/* Sentinel for infinite scroll — only needed for grid mode (list mode uses virtualizer) */}
+      <Box ref={viewMode === 'grid' ? sentinelRef : undefined} sx={sentinelBoxSx}>
         {isFetching &&
           climbs.length > 0 &&
           (viewMode === 'grid' ? (

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -252,21 +252,23 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
     getItemKey: (index) => suggestedClimbs[index]?.uuid ?? index,
   });
 
-  // Virtualizer-based infinite scroll for suggested climbs
+  // Virtualizer-based infinite scroll for suggested climbs.
+  // Use range (visible items WITHOUT overscan) to prevent the sidebar's short
+  // scroll container + overscan from cascading through multiple automatic page loads.
   const suggestedVirtualItems = suggestedVirtualizer.getVirtualItems();
-  const lastSuggestedItem = suggestedVirtualItems[suggestedVirtualItems.length - 1];
+  const suggestedRange = suggestedVirtualizer.range;
 
   useEffect(() => {
-    if (!lastSuggestedItem) return;
+    if (!suggestedRange) return;
     if (
-      lastSuggestedItem.index >= suggestedClimbs.length - 5 &&
+      suggestedRange.endIndex >= suggestedClimbs.length - 5 &&
       hasMoreResultsRef.current &&
       !isFetchingNextPageRef.current &&
       suggestedClimbsLengthRef.current >= SUGGESTIONS_THRESHOLD
     ) {
       fetchMoreClimbsRef.current();
     }
-  }, [lastSuggestedItem?.index, suggestedClimbs.length]);
+  }, [suggestedRange?.startIndex, suggestedRange?.endIndex, suggestedClimbs.length]);
 
   return (
     <>

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -22,7 +22,6 @@ import { ClimbActions } from '../climb-actions';
 import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { themeTokens } from '@/app/theme/theme-config';
-import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 import { LogAscentDrawer } from '../logbook/log-ascent-drawer';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
@@ -52,7 +51,6 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
   const { hasMoreResults, isFetchingClimbs, isFetchingNextPage } = useSearchData();
   const { viewOnlyMode } = useSessionData();
   const {
-    fetchMoreClimbs,
     setCurrentClimbQueueItem,
     setQueue,
     addToQueue,
@@ -157,55 +155,8 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
     return cleanup; // Cleanup listener on component unmount
   }, [queue, setQueue, isEditMode]);
 
-  // Ref for the intersection observer sentinel element
-  const loadMoreRef = useRef<HTMLDivElement>(null);
-
-  // Refs for observer callback values — prevents observer recreation on every page load
-  const fetchMoreClimbsRef = useRef(fetchMoreClimbs);
-  const hasMoreResultsRef = useRef(hasMoreResults);
-  const isFetchingNextPageRef = useRef(isFetchingNextPage);
-  const suggestedClimbsLengthRef = useRef(suggestedClimbs.length);
-  fetchMoreClimbsRef.current = fetchMoreClimbs;
-  hasMoreResultsRef.current = hasMoreResults;
-  isFetchingNextPageRef.current = isFetchingNextPage;
-  suggestedClimbsLengthRef.current = suggestedClimbs.length;
-
-  // Intersection Observer callback for infinite scroll — stable ref, never recreated
-  // Skip if suggestions are below threshold - proactive fetch in QueueContext handles that case
-  const handleObserver = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const [target] = entries;
-      if (
-        target.isIntersecting &&
-        hasMoreResultsRef.current &&
-        !isFetchingNextPageRef.current &&
-        suggestedClimbsLengthRef.current >= SUGGESTIONS_THRESHOLD
-      ) {
-        fetchMoreClimbsRef.current();
-      }
-    },
-    [],
-  );
-
-  // Set up Intersection Observer for infinite scroll
-  // Uses scrollContainerRef as root when provided (for nested scroll containers like drawers/sidebars),
-  // falls back to null (viewport) for top-level scrolling
-  useEffect(() => {
-    const element = loadMoreRef.current;
-    if (!element || viewOnlyMode) return;
-
-    const observer = new IntersectionObserver(handleObserver, {
-      root: scrollContainer ?? null,
-      rootMargin: '100px',
-      threshold: 0,
-    });
-
-    observer.observe(element);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [handleObserver, viewOnlyMode, scrollContainer]);
+  // No infinite scroll here — QueueContext's proactive fetch handles loading
+  // more suggestions when they run low.
 
   // Find the index of the current climb in the queue
   const currentIndex = queue.findIndex((item) => item.uuid === currentClimbUuid);
@@ -252,23 +203,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
     getItemKey: (index) => suggestedClimbs[index]?.uuid ?? index,
   });
 
-  // Virtualizer-based infinite scroll for suggested climbs.
-  // Use range (visible items WITHOUT overscan) to prevent the sidebar's short
-  // scroll container + overscan from cascading through multiple automatic page loads.
   const suggestedVirtualItems = suggestedVirtualizer.getVirtualItems();
-  const suggestedRange = suggestedVirtualizer.range;
-
-  useEffect(() => {
-    if (!suggestedRange) return;
-    if (
-      suggestedRange.endIndex >= suggestedClimbs.length - 5 &&
-      hasMoreResultsRef.current &&
-      !isFetchingNextPageRef.current &&
-      suggestedClimbsLengthRef.current >= SUGGESTIONS_THRESHOLD
-    ) {
-      fetchMoreClimbsRef.current();
-    }
-  }, [suggestedRange?.startIndex, suggestedRange?.endIndex, suggestedClimbs.length]);
 
   return (
     <>
@@ -407,11 +342,8 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(({ boardDetails, o
               );
             })}
           </div>
-          {/* Sentinel element for Intersection Observer - only render when needed */}
-          {/* Include isFetchingClimbs to show skeleton during initial page load */}
-          {(suggestedClimbs.length > 0 || isFetchingClimbs || isFetchingNextPage || hasMoreResults) && (
+          {(suggestedClimbs.length > 0 || isFetchingClimbs || isFetchingNextPage) && (
             <div
-              ref={loadMoreRef}
               style={loadMoreContainerStyle}
             >
               {(isFetchingClimbs || isFetchingNextPage) && (


### PR DESCRIPTION
## Summary
- The list mode infinite scroll used `lastVirtualItem.index` (which includes the virtualizer's overscan of 25 items) to trigger loading when within 5 items of the end. On desktop with larger viewports, `visible + overscan` covered nearly all loaded items, causing a cascade of automatic page loads on mount. Mobile was unaffected due to smaller viewports.
- Fixed by calculating the **estimated visible end** (excluding overscan) using viewport height and average item size. Loading triggers when `estimatedVisibleEnd + PAGE_LIMIT >= total items`. This preserves the eager preloading on mobile (page 2 loads immediately since `visibleEnd + 20 >= 20`) while preventing the cascade on desktop (page 3 won't auto-load since `visibleEnd + 20 < 40`).

## How it works
- **Before**: `lastVirtualItem.index >= visibleClimbs.length - 5` — includes overscan items, so desktop with ~14 visible + 25 overscan = 39, triggering at 35 items (page 2 just loaded)
- **After**: `estimatedVisibleEnd + PAGE_LIMIT >= visibleClimbs.length` — uses actual visible count from viewport height, so desktop with ~14 visible needs `14 + 20 = 34 >= 40` which is false, stopping the cascade

## Test plan
- [ ] Desktop: verify the list page auto-loads at most 1-2 pages on initial render, not 3+
- [ ] Desktop: verify scrolling down triggers loading the next page normally
- [ ] Mobile: verify page 2 still loads eagerly (without scrolling) for smooth UX
- [ ] Mobile: verify scrolling near the bottom triggers loading the next page
- [ ] Grid mode: verify infinite scroll is unchanged (uses separate IntersectionObserver sentinel)
- [ ] Fast scrolling: verify no blank gaps appear (overscan of 25 still handles rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)