### PR TITLE
Refactor CSS pixel values to custom properties and harden Select type…

### DIFF
--- a/packages/web/app/components/board-scroll/board-scroll.module.css
+++ b/packages/web/app/components/board-scroll/board-scroll.module.css
@@ -1,5 +1,11 @@
 /* Board Scroll Section Styles */
 
+/* Card sizing tokens — 182px mobile, 208px desktop */
+:root {
+  --card-width-mobile: 182px;
+  --card-width-desktop: 208px;
+}
+
 .scrollSection {
   margin-bottom: 16px;
 }
@@ -26,7 +32,7 @@
 
 /* Board Card */
 .cardScroll {
-  width: 182px;
+  width: var(--card-width-mobile);
   flex-shrink: 0;
   scroll-snap-align: start;
   cursor: pointer;
@@ -186,7 +192,7 @@
   scroll-snap-align: start;
   width: 100px;
   /* Match the height of a normal card: square image + 8px margin + ~18px name + ~16px meta */
-  height: calc(182px + 8px + 18px + 16px);
+  height: calc(var(--card-width-mobile) + 8px + 18px + 16px);
 }
 
 .stackedCards .cardScroll {
@@ -225,7 +231,7 @@
 @media (min-width: 768px) {
   .stackedCards {
     width: 120px;
-    height: calc(208px + 8px + 18px + 16px);
+    height: calc(var(--card-width-desktop) + 8px + 18px + 16px);
   }
 }
 
@@ -266,20 +272,20 @@
 
 .myBoardCardFadeInVisible {
   opacity: 1;
-  width: 182px;
+  width: var(--card-width-mobile);
 }
 
 /* Mobile */
 @media (max-width: 767px) {
   .myBoardCardFadeInVisible {
-    width: 182px;
+    width: var(--card-width-mobile);
   }
 }
 
 /* Desktop */
 @media (min-width: 768px) {
   .myBoardCardFadeInVisible {
-    width: 208px;
+    width: var(--card-width-desktop);
   }
 }
 
@@ -366,7 +372,7 @@
 /* Mobile */
 @media (max-width: 767px) {
   .cardScroll {
-    width: 182px;
+    width: var(--card-width-mobile);
   }
 
   .cardScrollSmall {
@@ -383,7 +389,7 @@
 /* Desktop */
 @media (min-width: 768px) {
   .cardScroll {
-    width: 208px;
+    width: var(--card-width-desktop);
   }
 
   .cardScrollSmall {

--- a/packages/web/app/components/board-scroll/board-scroll.module.css
+++ b/packages/web/app/components/board-scroll/board-scroll.module.css
@@ -1,11 +1,5 @@
 /* Board Scroll Section Styles */
 
-/* Card sizing tokens — 182px mobile, 208px desktop */
-:root {
-  --card-width-mobile: 182px;
-  --card-width-desktop: 208px;
-}
-
 .scrollSection {
   margin-bottom: 16px;
 }

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -77,7 +77,7 @@ function BoardConfigSelects({
         <MuiSelect
           value={selectedLayout ?? ''}
           label="Layout"
-          onChange={(e: SelectChangeEvent<number | string>) => onLayoutChange(e.target.value as number)}
+          onChange={(e: SelectChangeEvent<number | string>) => onLayoutChange(Number(e.target.value))}
           disabled={!selectedBoard}
         >
           {layouts.map(({ id, name }) => (
@@ -92,7 +92,7 @@ function BoardConfigSelects({
           <MuiSelect
             value={selectedSize ?? ''}
             label="Size"
-            onChange={(e: SelectChangeEvent<number | string>) => onSizeChange(e.target.value as number)}
+            onChange={(e: SelectChangeEvent<number | string>) => onSizeChange(Number(e.target.value))}
             disabled={!selectedLayout}
           >
             {sizes.map(({ id, name, description }) => (

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -108,7 +108,7 @@ function BoardConfigSelects({
           multiple
           value={selectedSets}
           label="Hold Sets"
-          onChange={(e) => onSetsChange(e.target.value as number[])}
+          onChange={(e) => onSetsChange((e.target.value as number[]).map(Number))}
           disabled={!selectedSize}
         >
           {sets.map(({ id, name }) => (
@@ -122,7 +122,7 @@ function BoardConfigSelects({
         <MuiSelect
           value={selectedAngle}
           label="Angle"
-          onChange={(e: SelectChangeEvent<number>) => onAngleChange(e.target.value as number)}
+          onChange={(e: SelectChangeEvent<number>) => onAngleChange(Number(e.target.value))}
           disabled={!selectedBoard}
         >
           {selectedBoard &&

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -108,7 +108,7 @@ function BoardConfigSelects({
           multiple
           value={selectedSets}
           label="Hold Sets"
-          onChange={(e) => onSetsChange((e.target.value as number[]).map(Number))}
+          onChange={(e) => onSetsChange([e.target.value].flat().map(Number))}
           disabled={!selectedSize}
         >
           {sets.map(({ id, name }) => (

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -51,6 +51,8 @@
 
   /* Layout */
   --global-header-height: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
+  --card-width-mobile: 182px;
+  --card-width-desktop: 208px;
 }
 
 /* Dark mode overrides */

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -150,6 +150,10 @@ export const themeTokens = {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
     bottomNavSpacer: 'calc(80px + env(safe-area-inset-bottom, 0px))',
+    /** Width of a board scroll card on mobile (px). */
+    cardWidthMobile: 182,
+    /** Width of a board scroll card on desktop (px). */
+    cardWidthDesktop: 208,
   },
 } as const;
 


### PR DESCRIPTION
… coercions

Extract hardcoded 182px/208px card widths into --card-width-mobile/--card-width-desktop CSS custom properties in board-scroll.module.css for consistency. Replace unsafe `as number` casts in layout/size Select onChange handlers with Number() conversion.

https://claude.ai/code/session_01559VzERkKoiJyWgp3iMbzv