### PR TITLE
Use compact number format for ascent counts, show board count

### DIFF
--- a/packages/web/app/components/board-scroll/board-scroll-card.tsx
+++ b/packages/web/app/components/board-scroll/board-scroll-card.tsx
@@ -74,9 +74,8 @@ export default function BoardScrollCard({
       }
       cardMeta += ` \u00B7 ${storedConfig.angle}\u00B0`;
     } else if (popularConfig) {
-      const label = BOARD_TYPE_LABELS[popularConfig.boardType] || popularConfig.boardType;
       cardName = popularConfig.displayName;
-      const parts = [label];
+      const parts: string[] = [];
       if (popularConfig.boardCount > 0) parts.push(`${formatAscents(popularConfig.boardCount)} boards`);
       parts.push(`${formatAscents(popularConfig.totalAscents)} sends`);
       cardMeta = parts.join(' \u00B7 ');

--- a/packages/web/app/lib/__tests__/format-climb-stats.test.ts
+++ b/packages/web/app/lib/__tests__/format-climb-stats.test.ts
@@ -27,6 +27,15 @@ describe('formatAscents', () => {
     expect(formatAscents(13200)).toBe('13k');
     expect(formatAscents(13800)).toBe('14k');
     expect(formatAscents(100000)).toBe('100k');
+    expect(formatAscents(999499)).toBe('999k');
+  });
+
+  it('formats ≥1000000 with 1 decimal + m', () => {
+    expect(formatAscents(1000000)).toBe('1m');
+    expect(formatAscents(1400000)).toBe('1.4m');
+    expect(formatAscents(2500000)).toBe('2.5m');
+    expect(formatAscents(10000000)).toBe('10m');
+    expect(formatAscents(15300000)).toBe('15.3m');
   });
 });
 


### PR DESCRIPTION
Reuse formatAscents from format-climb-stats for popular board card subtitles. Add million support (1.4m). Show board count alongside ascents: "3.2k boards · 1.4m sends". Drop board type label from the byline to keep it short.