### PR TITLE
Fix queue drawer scroll and close in play view

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -120,7 +120,8 @@
 .queueBodyLayout {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -55,7 +55,7 @@ const QUEUE_DRAWER_STYLES = {
     touchAction: 'pan-y' as const,
     transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
   },
-  body: { padding: 0, touchAction: 'pan-y' as const },
+  body: { padding: 0, overflow: 'hidden', touchAction: 'pan-y' as const },
 } as const;
 
 interface PlayDrawerContentProps {


### PR DESCRIPTION
The SwipeableDrawer body Box had overflow:auto which created a competing
scroll container with the inner queueScrollContainer. Combined with
queueBodyLayout using height:100% (which overflows when added to the drag
header height), touch events were captured by the outer container —
blocking both queue list scrolling and the drag-header swipe-to-close.

- Add overflow:hidden to QUEUE_DRAWER_STYLES.body so only the inner
  queueScrollContainer handles scrolling
- Replace height:100% with flex:1 + min-height:0 on queueBodyLayout so
  it fills remaining space after the drag header instead of overflowing

https://claude.ai/code/session_01NZtEDfS4sEEWuPkNdt5UJK