### PR TITLE
feat: add delete button for ascents on profile and session pages

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -37,7 +37,21 @@ export const tickMutations = {
     }
 
     await db.transaction(async (tx) => {
-      // Delete related social data
+      // Collect comment IDs on this tick so we can clean up their notifications
+      const tickComments = await tx
+        .select({ id: dbSchema.comments.id })
+        .from(dbSchema.comments)
+        .where(and(eq(dbSchema.comments.entityType, 'tick'), eq(dbSchema.comments.entityId, uuid)));
+      const commentIds = tickComments.map((c) => c.id);
+
+      // Delete notifications referencing these comments (commentId FK is SET NULL, so we must delete explicitly)
+      if (commentIds.length > 0) {
+        await tx.delete(dbSchema.notifications).where(
+          inArray(dbSchema.notifications.commentId, commentIds)
+        );
+      }
+
+      // Delete related social data for the tick itself
       await tx.delete(dbSchema.feedItems).where(
         and(eq(dbSchema.feedItems.entityType, 'tick'), eq(dbSchema.feedItems.entityId, uuid))
       );

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -12,6 +12,55 @@ import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publis
 
 export const tickMutations = {
   /**
+   * Delete a tick (climb attempt/ascent) for the authenticated user.
+   * Only the owner can delete their own ticks.
+   */
+  deleteTick: async (
+    _: unknown,
+    { uuid }: { uuid: string },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    const userId = ctx.userId!;
+
+    const [tick] = await db
+      .select({ uuid: dbSchema.boardseshTicks.uuid, userId: dbSchema.boardseshTicks.userId })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.uuid, uuid))
+      .limit(1);
+
+    if (!tick) {
+      throw new Error('Tick not found');
+    }
+    if (tick.userId !== userId) {
+      throw new Error('You can only delete your own ticks');
+    }
+
+    await db.transaction(async (tx) => {
+      // Delete related social data
+      await tx.delete(dbSchema.feedItems).where(
+        and(eq(dbSchema.feedItems.entityType, 'tick'), eq(dbSchema.feedItems.entityId, uuid))
+      );
+      await tx.delete(dbSchema.votes).where(
+        and(eq(dbSchema.votes.entityType, 'tick'), eq(dbSchema.votes.entityId, uuid))
+      );
+      await tx.delete(dbSchema.voteCounts).where(
+        and(eq(dbSchema.voteCounts.entityType, 'tick'), eq(dbSchema.voteCounts.entityId, uuid))
+      );
+      await tx.delete(dbSchema.comments).where(
+        and(eq(dbSchema.comments.entityType, 'tick'), eq(dbSchema.comments.entityId, uuid))
+      );
+      await tx.delete(dbSchema.notifications).where(
+        and(eq(dbSchema.notifications.entityType, 'tick'), eq(dbSchema.notifications.entityId, uuid))
+      );
+      // Delete the tick itself
+      await tx.delete(dbSchema.boardseshTicks).where(eq(dbSchema.boardseshTicks.uuid, uuid));
+    });
+
+    return true;
+  },
+
+  /**
    * Save a tick (climb attempt/ascent) for the authenticated user
    */
   saveTick: async (

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -119,6 +119,11 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     saveTick(input: SaveTickInput!): Tick!
 
+    """
+    Delete a tick (climb attempt record). Only the owner can delete.
+    """
+    deleteTick(uuid: ID!): Boolean!
+
     # ============================================
     # Climb Mutations (require auth)
     # ============================================

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -98,7 +98,7 @@ const getItemStatusColor = (status: string): 'success' | 'primary' | 'default' =
   return 'default';
 };
 
-const TickItemRow: React.FC<{ item: AscentFeedItem; onDelete: (uuid: string) => void }> = ({ item, onDelete }) => {
+const TickItemRow: React.FC<{ item: AscentFeedItem; onDelete: (uuid: string) => void; isDeleting: boolean }> = ({ item, onDelete, isDeleting }) => {
   const timeAgo = dayjs(item.climbedAt).fromNow();
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
@@ -119,7 +119,7 @@ const TickItemRow: React.FC<{ item: AscentFeedItem; onDelete: (uuid: string) => 
         okText="Delete"
         okButtonProps={{ color: 'error' }}
       >
-        <IconButton size="small" sx={{ color: 'text.secondary' }}>
+        <IconButton size="small" disabled={isDeleting} sx={{ color: 'text.secondary' }}>
           <DeleteOutlined sx={{ fontSize: 16 }} />
         </IconButton>
       </ConfirmPopover>
@@ -127,7 +127,7 @@ const TickItemRow: React.FC<{ item: AscentFeedItem; onDelete: (uuid: string) => 
   );
 };
 
-const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem; isOwnProfile?: boolean; onDeleteTick?: (uuid: string) => void }> = ({ group, isOwnProfile = false, onDeleteTick }) => {
+const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem; isOwnProfile?: boolean; onDeleteTick?: (uuid: string) => void; isDeleting?: boolean }> = ({ group, isOwnProfile = false, onDeleteTick, isDeleting = false }) => {
   const latestItem = group.items.reduce((latest, item) =>
     new Date(item.climbedAt) > new Date(latest.climbedAt) ? item : latest
   );
@@ -201,7 +201,7 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem; isOwnProfile?: b
           {isOwnProfile && onDeleteTick && (
             <Box sx={{ display: 'flex', flexDirection: 'column', borderTop: `1px solid ${themeTokens.neutral[100]}`, mt: 0.5, pt: 0.5 }}>
               {group.items.map((item) => (
-                <TickItemRow key={item.uuid} item={item} onDelete={onDeleteTick} />
+                <TickItemRow key={item.uuid} item={item} onDelete={onDeleteTick} isDeleting={isDeleting} />
               ))}
             </Box>
           )}
@@ -275,7 +275,7 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10,
     <div className={styles.feed}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
         {groups.map((group) => (
-          <GroupedFeedItem key={group.key} group={group} isOwnProfile={isOwnProfile} onDeleteTick={isOwnProfile ? (uuid) => deleteTick.mutate(uuid) : undefined} />
+          <GroupedFeedItem key={group.key} group={group} isOwnProfile={isOwnProfile} onDeleteTick={isOwnProfile ? (uuid) => deleteTick.mutate(uuid) : undefined} isDeleting={deleteTick.isPending} />
         ))}
       </Box>
 

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -8,11 +8,13 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Rating from '@mui/material/Rating';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -20,10 +22,13 @@ import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_USER_GROUPED_ASCENTS_FEED,
   type GroupedAscentFeedItem,
+  type AscentFeedItem,
   type GetUserGroupedAscentsFeedQueryVariables,
   type GetUserGroupedAscentsFeedQueryResponse,
 } from '@/app/lib/graphql/operations';
 import AscentThumbnail from './ascent-thumbnail';
+import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
+import { useDeleteTick } from '@/app/hooks/use-delete-tick';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
@@ -34,6 +39,7 @@ dayjs.extend(relativeTime);
 interface AscentsFeedProps {
   userId: string;
   pageSize?: number;
+  isOwnProfile?: boolean;
 }
 
 // Layout name mapping
@@ -86,7 +92,42 @@ const getGroupStatusSummary = (group: GroupedAscentFeedItem): { text: string; ic
   return { text: parts.join(', '), icon, color };
 };
 
-const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) => {
+const getItemStatusColor = (status: string): 'success' | 'primary' | 'default' => {
+  if (status === 'flash') return 'success';
+  if (status === 'send') return 'primary';
+  return 'default';
+};
+
+const TickItemRow: React.FC<{ item: AscentFeedItem; onDelete: (uuid: string) => void }> = ({ item, onDelete }) => {
+  const timeAgo = dayjs(item.climbedAt).fromNow();
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
+      <Chip
+        label={item.status}
+        size="small"
+        color={getItemStatusColor(item.status)}
+        variant={item.status === 'attempt' ? 'outlined' : 'filled'}
+        sx={{ height: 20, '& .MuiChip-label': { px: 0.75, fontSize: themeTokens.typography.fontSize.xs - 1 } }}
+      />
+      <MuiTypography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+        {item.attemptCount > 1 ? `${item.attemptCount} attempts` : null} {timeAgo}
+      </MuiTypography>
+      <ConfirmPopover
+        title="Delete ascent"
+        description="Are you sure? This cannot be undone."
+        onConfirm={() => onDelete(item.uuid)}
+        okText="Delete"
+        okButtonProps={{ color: 'error' }}
+      >
+        <IconButton size="small" sx={{ color: 'text.secondary' }}>
+          <DeleteOutlined sx={{ fontSize: 16 }} />
+        </IconButton>
+      </ConfirmPopover>
+    </Box>
+  );
+};
+
+const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem; isOwnProfile?: boolean; onDeleteTick?: (uuid: string) => void }> = ({ group, isOwnProfile = false, onDeleteTick }) => {
   const latestItem = group.items.reduce((latest, item) =>
     new Date(item.climbedAt) > new Date(latest.climbedAt) ? item : latest
   );
@@ -156,6 +197,14 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
           {group.latestComment && (
             <MuiTypography variant="body2" component="span" className={styles.comment}>{group.latestComment}</MuiTypography>
           )}
+
+          {isOwnProfile && onDeleteTick && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', borderTop: `1px solid ${themeTokens.neutral[100]}`, mt: 0.5, pt: 0.5 }}>
+              {group.items.map((item) => (
+                <TickItemRow key={item.uuid} item={item} onDelete={onDeleteTick} />
+              ))}
+            </Box>
+          )}
         </Box>
       </Box>
       </CardContent>
@@ -163,7 +212,8 @@ const GroupedFeedItem: React.FC<{ group: GroupedAscentFeedItem }> = ({ group }) 
   );
 };
 
-export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 }) => {
+export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10, isOwnProfile = false }) => {
+  const deleteTick = useDeleteTick();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useInfiniteQuery({
     queryKey: ['ascentsFeed', userId, pageSize],
     queryFn: async ({ pageParam }) => {
@@ -225,7 +275,7 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10 
     <div className={styles.feed}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
         {groups.map((group) => (
-          <GroupedFeedItem key={group.key} group={group} />
+          <GroupedFeedItem key={group.key} group={group} isOwnProfile={isOwnProfile} onDeleteTick={isOwnProfile ? (uuid) => deleteTick.mutate(uuid) : undefined} />
         ))}
       </Box>
 

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -90,7 +90,7 @@ describe('ClimbTitle', () => {
 
     it('renders setter info when showSetterInfo is true', () => {
       render(<ClimbTitle climb={makeClimb()} showSetterInfo />);
-      expect(screen.getByText('By setter_joe - 10 ascents')).toBeTruthy();
+      expect(screen.getByText('By setter_joe - 10 sends')).toBeTruthy();
     });
 
     it('does not render setter info when showSetterInfo is false', () => {
@@ -163,20 +163,20 @@ describe('ClimbTitle', () => {
       expect(screen.getByText(/DanielBolts/)).toBeTruthy();
     });
 
-    it('renders subtitle as "ascents · stars · setter_name" format', () => {
+    it('renders subtitle as "sends · stars · setter_name" format', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '3.5', setter_username: 'alice' })} gradePosition="right" showSetterInfo />);
-      expect(screen.getByText('10 ascents · 3.5★ · alice')).toBeTruthy();
+      expect(screen.getByText('10 sends · 3.5★ · alice')).toBeTruthy();
     });
 
-    it('renders only ascents and stars when showSetterInfo is false', () => {
+    it('renders only sends and stars when showSetterInfo is false', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '3.5' })} gradePosition="right" />);
-      expect(screen.getByText('10 ascents · 3.5★')).toBeTruthy();
+      expect(screen.getByText('10 sends · 3.5★')).toBeTruthy();
       expect(screen.queryByText(/setter_joe/)).toBeNull();
     });
 
-    it('renders only ascents and stars when setter_username is missing', () => {
+    it('renders only sends and stars when setter_username is missing', () => {
       render(<ClimbTitle climb={makeClimb({ setter_username: undefined })} gradePosition="right" showSetterInfo />);
-      expect(screen.getByText('10 ascents · 3.5★')).toBeTruthy();
+      expect(screen.getByText('10 sends · 3.5★')).toBeTruthy();
     });
 
     it('does not render angle even when showAngle is true', () => {
@@ -184,19 +184,19 @@ describe('ClimbTitle', () => {
       expect(screen.queryByText(/@ 40°/)).toBeNull();
     });
 
-    it('renders ascent count', () => {
+    it('renders send count', () => {
       render(<ClimbTitle climb={makeClimb({ ascensionist_count: 72 })} gradePosition="right" showSetterInfo />);
-      expect(screen.getByText(/72 ascents/)).toBeTruthy();
+      expect(screen.getByText(/72 sends/)).toBeTruthy();
     });
 
-    it('renders only ascent count when no grade quality', () => {
+    it('renders only send count when no grade quality', () => {
       render(<ClimbTitle climb={makeClimb({ quality_average: '0' })} gradePosition="right" />);
-      expect(screen.getByText('10 ascents')).toBeTruthy();
+      expect(screen.getByText('10 sends')).toBeTruthy();
     });
 
-    it('renders only ascent count when difficulty is null', () => {
+    it('renders only send count when difficulty is null', () => {
       render(<ClimbTitle climb={makeClimb({ difficulty: null, quality_average: null })} gradePosition="right" />);
-      expect(screen.getByText('10 ascents')).toBeTruthy();
+      expect(screen.getByText('10 sends')).toBeTruthy();
     });
 
     it('renders "project" when no grade and no ascents', () => {
@@ -209,9 +209,9 @@ describe('ClimbTitle', () => {
       expect(screen.getByText('project')).toBeTruthy();
     });
 
-    it('renders singular "ascent" when ascensionist_count is 1', () => {
+    it('renders singular "send" when ascensionist_count is 1', () => {
       render(<ClimbTitle climb={makeClimb({ ascensionist_count: 1 })} gradePosition="right" />);
-      expect(screen.getByText(/1 ascent(?!s)/)).toBeTruthy();
+      expect(screen.getByText(/1 send(?!s)/)).toBeTruthy();
     });
 
     it('renders benchmark icon after climb name', () => {

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -149,7 +149,7 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
               <Typography variant="body2" component="span" color="text.secondary" className={styles.chartDescription}>
                 Latest ascents and attempts
               </Typography>
-              <AscentsFeed userId={userId} pageSize={10} />
+              <AscentsFeed userId={userId} pageSize={10} isOwnProfile={isOwnProfile} />
             </CardContent>
           </MuiCard>
         )}

--- a/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  DELETE_TICK: 'DELETE_TICK_MUTATION',
+}));
+
+import { useWsAuthToken } from '../use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useDeleteTick } from '../use-delete-tick';
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+const mockUseSession = vi.mocked(useSession);
+
+function createTestWrapper() {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+describe('useDeleteTick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockReset();
+    mockShowMessage.mockReset();
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'test-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    mockUseSession.mockReturnValue({
+      status: 'authenticated',
+      data: { user: { id: '1' }, expires: '' },
+      update: vi.fn(),
+    });
+  });
+
+  it('throws when not authenticated', async () => {
+    mockUseSession.mockReturnValue({
+      status: 'unauthenticated',
+      data: null,
+      update: vi.fn(),
+    });
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Not authenticated');
+  });
+
+  it('throws when no token', async () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Auth token not available');
+  });
+
+  it('calls GraphQL mutation with correct uuid', async () => {
+    mockRequest.mockResolvedValue({ deleteTick: true });
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-123');
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith('DELETE_TICK_MUTATION', {
+      uuid: 'tick-uuid-123',
+    });
+  });
+
+  it('invalidates relevant query caches on success', async () => {
+    mockRequest.mockResolvedValue({ deleteTick: true });
+
+    const { wrapper, queryClient } = createTestWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    // Seed some cache data
+    queryClient.setQueryData(['ascentsFeed', 'user-1', 10], { pages: [] });
+    queryClient.setQueryData(['logbook', 'kilter', 'accumulated'], []);
+    queryClient.setQueryData(['sessionDetail', 'session-1'], {});
+
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(invalidatedKeys).toContainEqual(['ascentsFeed']);
+    expect(invalidatedKeys).toContainEqual(['logbook']);
+    expect(invalidatedKeys).toContainEqual(['sessionDetail']);
+    expect(invalidatedKeys).toContainEqual(['userProfileStats']);
+  });
+
+  it('shows error snackbar on failure', async () => {
+    mockRequest.mockRejectedValue(new Error('Delete failed'));
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Delete failed', 'error');
+  });
+
+  it('extracts GraphQL error message from response', async () => {
+    const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
+    graphqlError.response = {
+      errors: [{ message: 'You can only delete your own ticks' }],
+    };
+    mockRequest.mockRejectedValue(graphqlError);
+
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('You can only delete your own ticks', 'error');
+  });
+});

--- a/packages/web/app/hooks/use-delete-tick.ts
+++ b/packages/web/app/hooks/use-delete-tick.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useWsAuthToken } from './use-ws-auth-token';
+import { useSession } from 'next-auth/react';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  DELETE_TICK,
+  type DeleteTickMutationVariables,
+  type DeleteTickMutationResponse,
+} from '@/app/lib/graphql/operations';
+
+/**
+ * Hook to delete a tick (logbook entry) via GraphQL mutation.
+ * Invalidates relevant caches on success.
+ */
+export function useDeleteTick() {
+  const { token } = useWsAuthToken();
+  const { status: sessionStatus } = useSession();
+  const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (uuid: string) => {
+      if (sessionStatus !== 'authenticated') {
+        throw new Error('Not authenticated');
+      }
+      if (!token) {
+        throw new Error('Auth token not available');
+      }
+
+      const client = createGraphQLHttpClient(token);
+      const variables: DeleteTickMutationVariables = { uuid };
+      const response = await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
+      return response.deleteTick;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ascentsFeed'] });
+      queryClient.invalidateQueries({ queryKey: ['logbook'] });
+      queryClient.invalidateQueries({ queryKey: ['sessionDetail'] });
+      queryClient.invalidateQueries({ queryKey: ['userProfileStats'] });
+    },
+    onError: (err) => {
+      let errorMessage = 'Failed to delete tick';
+      if (err instanceof Error) {
+        if ('response' in err && typeof err.response === 'object' && err.response !== null) {
+          const response = err.response as { errors?: Array<{ message: string }> };
+          if (response.errors && response.errors.length > 0) {
+            errorMessage = response.errors[0].message;
+          }
+        } else {
+          errorMessage = err.message;
+        }
+      }
+      showMessage(errorMessage, 'error');
+    },
+  });
+}

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -71,6 +71,20 @@ export interface SaveTickMutationResponse {
   saveTick: TickFromSaveTick;
 }
 
+export const DELETE_TICK = gql`
+  mutation DeleteTick($uuid: ID!) {
+    deleteTick(uuid: $uuid)
+  }
+`;
+
+export interface DeleteTickMutationVariables {
+  uuid: string;
+}
+
+export interface DeleteTickMutationResponse {
+  deleteTick: boolean;
+}
+
 // ============================================
 // Activity Feed Operations
 // ============================================

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -163,12 +163,14 @@ function SessionTickItem({
   participant,
   currentUserId,
   onDelete,
+  isDeleting,
 }: {
   tick: SessionDetailTick;
   isMultiUser: boolean;
   participant: SessionFeedParticipant | null;
   currentUserId?: string;
   onDelete?: (uuid: string) => void;
+  isDeleting?: boolean;
 }) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const attemptText = formatAttemptText(tick);
@@ -231,7 +233,7 @@ function SessionTickItem({
               okText="Delete"
               okButtonProps={{ color: 'error' }}
             >
-              <IconButton size="small" sx={{ color: 'text.secondary' }}>
+              <IconButton size="small" disabled={isDeleting} sx={{ color: 'text.secondary' }}>
                 <DeleteOutlined fontSize="small" />
               </IconButton>
             </ConfirmPopover>
@@ -414,12 +416,13 @@ export default function SessionDetailContent({
               participant={participant ?? null}
               currentUserId={currentUserId}
               onDelete={handleDeleteTick}
+              isDeleting={deleteTick.isPending}
             />
           );
         })}
       </Box>
     );
-  }, [ticksByClimb, participantMap, isMultiUser, currentUserId, handleDeleteTick]);
+  }, [ticksByClimb, participantMap, isMultiUser, currentUserId, handleDeleteTick, deleteTick.isPending]);
 
   const handleStartEdit = useCallback(() => {
     setEditName(sessionName || '');

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -16,6 +16,7 @@ import EditOutlined from '@mui/icons-material/EditOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
@@ -36,6 +37,8 @@ import { themeTokens } from '@/app/theme/theme-config';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import UserSearchDialog from './user-search-dialog';
 import SessionOverviewPanel from '@/app/components/session-details/session-overview-panel';
+import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
+import { useDeleteTick } from '@/app/hooks/use-delete-tick';
 
 interface SessionDetailContentProps {
   session: SessionDetail | null;
@@ -158,10 +161,14 @@ function SessionTickItem({
   tick,
   isMultiUser,
   participant,
+  currentUserId,
+  onDelete,
 }: {
   tick: SessionDetailTick;
   isMultiUser: boolean;
   participant: SessionFeedParticipant | null;
+  currentUserId?: string;
+  onDelete?: (uuid: string) => void;
 }) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const attemptText = formatAttemptText(tick);
@@ -216,6 +223,19 @@ function SessionTickItem({
           >
             <ChatBubbleOutlineOutlined fontSize="small" />
           </IconButton>
+          {currentUserId && tick.userId === currentUserId && onDelete && (
+            <ConfirmPopover
+              title="Delete ascent"
+              description="Are you sure? This cannot be undone."
+              onConfirm={() => onDelete(tick.uuid)}
+              okText="Delete"
+              okButtonProps={{ color: 'error' }}
+            >
+              <IconButton size="small" sx={{ color: 'text.secondary' }}>
+                <DeleteOutlined fontSize="small" />
+              </IconButton>
+            </ConfirmPopover>
+          )}
         </Box>
       </Box>
       {tick.comment && (
@@ -241,6 +261,7 @@ export default function SessionDetailContent({
 }: SessionDetailContentProps) {
   const { data: authSession } = useSession();
   const router = useRouter();
+  const deleteTick = useDeleteTick();
 
   const {
     session: hookSession,
@@ -372,6 +393,10 @@ export default function SessionDetailContent({
     }
   }, [router]);
 
+  const handleDeleteTick = useCallback((uuid: string) => {
+    deleteTick.mutate(uuid);
+  }, [deleteTick]);
+
   // Render tick details below each climb item (per-user rows for multi-user, status/attempts for single-user)
   const renderTickDetails = useCallback((climb: Climb) => {
     const climbTicks = ticksByClimb.get(climb.uuid);
@@ -387,12 +412,14 @@ export default function SessionDetailContent({
               tick={tick}
               isMultiUser={isMultiUser}
               participant={participant ?? null}
+              currentUserId={currentUserId}
+              onDelete={handleDeleteTick}
             />
           );
         })}
       </Box>
     );
-  }, [ticksByClimb, participantMap, isMultiUser]);
+  }, [ticksByClimb, participantMap, isMultiUser, currentUserId, handleDeleteTick]);
 
   const handleStartEdit = useCallback(() => {
     setEditName(sessionName || '');


### PR DESCRIPTION
Add a deleteTick GraphQL mutation with server-side ownership check
that cleans up related feed items, votes, comments, and notifications
in a transaction. Show delete buttons per-tick on the user's own
profile ascents feed and on session detail tick items.

https://claude.ai/code/session_01KpudvDC5kpHLVmw1orRQUD