### PR TITLE
Treat Capacitor webviews as native to avoid iOS Safari bottom offset

### DIFF
--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -24,7 +24,7 @@ import GlobalHeader from '../global-header/global-header';
 import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { CreateHeaderBridgeProvider } from '../create-climb/create-header-bridge-context';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { isCapacitorWebView, isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
 interface PersistentSessionWrapperProps {
   children: React.ReactNode;
@@ -78,7 +78,9 @@ const HIDE_TAB_BAR_PAGES = ['/aurora-migration'];
 export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData }) {
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathname();
-  const isNative = isNativeApp();
+  // Use both bridge-aware and UA-heuristic checks so native webviews get native layout
+  // even before Capacitor bridge initialization completes on first render.
+  const isNative = isNativeApp() || isCapacitorWebView();
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;


### PR DESCRIPTION
### Motivation
- On iOS Safari we apply a small bottom offset to avoid a grey rectangle from the browser chrome, but that offset should not be applied inside the Capacitor app WebView where there is no browser chrome, so the bottom bar must be treated as native earlier.

### Description
- Update `packages/web/app/components/providers/persistent-session-wrapper.tsx` to import `isCapacitorWebView` and compute `isNative` as `isNativeApp() || isCapacitorWebView()` so Capacitor webviews receive the `nativeApp` layout class before the Capacitor bridge finishes initializing.

### Testing
- Attempted to run the focused unit test `app/components/providers/__tests__/persistent-session-wrapper.test.tsx` via the workspace test scripts, but running `vitest` failed in this environment (`vitest: command not found`) and `bunx vitest` could not resolve dependencies due to npm registry access returning `403`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64d5be6b08326baec32aa44d73efb)