### PR TITLE
Match Safari tab-bar filler frost with tab bar styling

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -38,10 +38,16 @@
       top: 100%;
       height: 2dvh;
       border-radius: 0 0 16px 16px;
-      background: color-mix(in srgb, var(--neutral-100) 24%, transparent);
-      -webkit-backdrop-filter: blur(8px);
-      backdrop-filter: blur(8px);
+      background: rgba(255, 255, 255, 0.3);
+      -webkit-backdrop-filter: blur(5px);
+      backdrop-filter: blur(5px);
       pointer-events: none;
+    }
+
+    :global(html[data-theme='dark']) .bottomBarWrapper:not(.nativeApp)::after {
+      background: rgba(0, 0, 0, 0.4);
+      -webkit-backdrop-filter: blur(20px);
+      backdrop-filter: blur(20px);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure Safari's touch-only 2dvh chrome-gap filler visually matches the bottom tab bar frosted glass while preserving the non-native `bottom: 2dvh` offset to avoid Safari's grey chrome artifact.

### Description
- Updated the Safari-only `.bottomBarWrapper:not(.nativeApp)::after` in `packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css` to use `background: rgba(255, 255, 255, 0.3)` with `-webkit-backdrop-filter: blur(5px)` / `backdrop-filter: blur(5px)` for light mode and added a dark-theme override `:global(html[data-theme='dark'])` that uses `background: rgba(0, 0, 0, 0.4)` with `blur(20px)`, while keeping the existing `bottom: 2dvh` behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d650fe1dd483268d41bb45aead66a9)