### PR TITLE
Move database migrations to GitHub Actions workflow

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,28 @@
+name: Production Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  migrate-and-deploy:
+    name: Run migrations and deploy to Vercel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run database migrations
+        run: bun run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+
+      - name: Trigger Vercel deploy
+        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,11 @@
 {
   "installCommand": "bun install --frozen-lockfile",
-  "buildCommand": "if [ \"$VERCEL_ENV\" != \"preview\" ]; then bun run db:migrate; fi && bun run --filter=@boardsesh/web build",
+  "buildCommand": "bun run --filter=@boardsesh/web build",
   "outputDirectory": "packages/web/.next",
   "framework": "nextjs",
+  "github": {
+    "enabled": false
+  },
   "crons": [
     {
       "path": "/api/internal/shared-sync/tension",


### PR DESCRIPTION
## Summary
Refactored the deployment pipeline to run database migrations as a separate step in a GitHub Actions workflow instead of during the Vercel build process. This improves separation of concerns and provides better control over the migration execution.

## Key Changes
- **Added GitHub Actions workflow** (`production-deploy.yml`): New workflow that runs on pushes to `main` branch to:
  - Install dependencies using Bun
  - Execute database migrations with production database credentials
  - Trigger Vercel deployment via webhook
  
- **Updated Vercel configuration** (`vercel.json`):
  - Removed conditional database migration logic from `buildCommand` - now only runs the web build
  - Disabled Vercel's native GitHub integration since deployments are now triggered via webhook from the Actions workflow

## Implementation Details
- Database migrations now run before the Vercel deployment is triggered, ensuring schema changes are applied before the new code is deployed
- Uses GitHub secrets for `PROD_DATABASE_URL` and `VERCEL_DEPLOY_HOOK` to securely manage sensitive credentials
- Simplifies the Vercel build command by removing conditional logic, making the build process more straightforward and predictable

https://claude.ai/code/session_01C2g9PLv6Xu6vu6troNnPqo