### PR TITLE
Guard Aurora BLE packet generation against unmapped hold roles

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
@@ -723,6 +723,12 @@ describe('getBluetoothPacket — API level selection', () => {
     expect(() => getBluetoothPacket('p1r42p9999r42', sparse, 'kilter', 3))
       .toThrow('1 of 2 placements have no LED mapping');
   });
+
+  it('throws when a hold role is not mapped for the board', () => {
+    const positions: Record<number, number> = { 1: 39, 2: 40 };
+    expect(() => getBluetoothPacket('p1r42p2r1', positions, 'kilter', 3))
+      .toThrow('1 of 2 placements have no LED mapping');
+  });
 });
 
 // =============================================================================

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
@@ -162,7 +162,8 @@ export const getAuroraBluetoothPacket = (
 
   // Pre-collect LED entries for v2 power scaling
   const ledEntries: Array<{ position: number; color: string }> = [];
-  let skippedCount = 0;
+  let skippedPositionCount = 0;
+  let skippedRoleCount = 0;
 
   frames.split('p').forEach((frame) => {
     if (!frame) return;
@@ -171,15 +172,24 @@ export const getAuroraBluetoothPacket = (
     const ledPosition = placementPositions[placementId];
 
     if (ledPosition === undefined) {
-      skippedCount++;
+      skippedPositionCount++;
       return;
     }
 
-    const color = HOLD_STATE_MAP[boardName][Number(role)].color.replace('#', '');
+    const roleCode = Number(role);
+    const state = HOLD_STATE_MAP[boardName]?.[roleCode];
+
+    if (!state?.color) {
+      skippedRoleCount++;
+      return;
+    }
+
+    const color = state.color.replace('#', '');
     ledEntries.push({ position: ledPosition, color });
   });
 
-  if (skippedCount > 0) {
+  if (skippedPositionCount > 0 || skippedRoleCount > 0) {
+    const skippedCount = skippedPositionCount + skippedRoleCount;
     throw new Error(
       `[BLE] ${skippedCount} of ${skippedCount + ledEntries.length} placements have no LED mapping ` +
       `for this board configuration. The climb is incompatible with the connected board — ` +


### PR DESCRIPTION
### Motivation
- A Sentry trace showed a runtime `TypeError` at `HOLD_STATE_MAP[boardName][Number(role)].color` when a climb frame referenced a role not present for the connected board, causing crashes during Bluetooth frame sending. 
- The change aims to prevent UI-breaking exceptions and route invalid frames through the existing incompatibility error path.

### Description
- Added a defensive role lookup in `getAuroraBluetoothPacket` using `HOLD_STATE_MAP[boardName]?.[roleCode]` and skip frames that have no `color` mapping. 
- Replaced a single `skippedCount` with `skippedPositionCount` and `skippedRoleCount`, then aggregate them to preserve the existing controlled error message for incompatible climbs. 
- Added a regression test asserting that `getAuroraBluetoothPacket` throws the expected mapping error when a hold role is unmapped. 
- Modified files: `packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts` and `packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts`.

### Testing
- Attempted to run the unit tests with `bun run --filter=@boardsesh/web test:run app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts`, but the environment reported `vitest: command not found` so tests could not be executed here. 
- A new test was added to `__tests__/bluetooth-packet.test.ts` that verifies the unmapped-role failure path; this should be validated by CI or a local environment with `vitest` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ff8a9f5c8326a103ec4376d85849)