### PR TITLE
Limit climb-list search drawer categories and enable mobile close button

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -162,6 +162,9 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
       <UnifiedSearchDrawer
         boardDetails={boardDetails}
         defaultCategory="climbs"
+        allowedCategories={['climbs']}
+        showCloseButton
+        showCloseButtonOnMobile
         open={searchDropdownOpen}
         onClose={() => {
           if (hasActiveFilters(uiSearchParams)) {

--- a/packages/web/app/components/search-drawer/unified-search-drawer.tsx
+++ b/packages/web/app/components/search-drawer/unified-search-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
@@ -26,6 +26,12 @@ interface UnifiedSearchDrawerProps {
   renderClimbSearch?: () => React.ReactNode;
   /** Render prop for climb search footer (search/clear buttons). Only used when boardDetails is provided. */
   renderClimbFooter?: () => React.ReactNode;
+  /** Optional allow-list for category pills/results. */
+  allowedCategories?: SearchCategory[];
+  /** Show drawer close button on mobile devices. */
+  showCloseButtonOnMobile?: boolean;
+  /** Show drawer close button. */
+  showCloseButton?: boolean;
 }
 
 export default function UnifiedSearchDrawer({
@@ -36,6 +42,9 @@ export default function UnifiedSearchDrawer({
   boardDetails,
   renderClimbSearch,
   renderClimbFooter,
+  allowedCategories,
+  showCloseButtonOnMobile = false,
+  showCloseButton = false,
 }: UnifiedSearchDrawerProps) {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<SearchCategory>(defaultCategory);
@@ -61,7 +70,16 @@ export default function UnifiedSearchDrawer({
     { key: 'playlists', label: 'Playlists', visible: true },
   ];
 
-  const visibleCategories = categories.filter((c) => c.visible);
+  const allowedCategorySet = allowedCategories ? new Set(allowedCategories) : null;
+  const visibleCategories = categories.filter((c) => c.visible && (allowedCategorySet ? allowedCategorySet.has(c.key) : true));
+  const showCategoryChips = visibleCategories.length > 1;
+
+  useEffect(() => {
+    if (visibleCategories.length === 0) return;
+    if (!visibleCategories.some((c) => c.key === category)) {
+      setCategory(visibleCategories[0].key);
+    }
+  }, [category, visibleCategories]);
 
   return (
     <SwipeableDrawer
@@ -72,7 +90,8 @@ export default function UnifiedSearchDrawer({
       height={isClimbMode ? '100%' : '80vh'}
       fullHeight={isClimbMode}
       showDragHandle
-      showCloseButton={false}
+      showCloseButton={showCloseButton}
+      showCloseButtonOnMobile={showCloseButtonOnMobile}
       swipeEnabled
       footer={isClimbMode && renderClimbFooter ? renderClimbFooter() : undefined}
       styles={{
@@ -86,17 +105,19 @@ export default function UnifiedSearchDrawer({
       }}
     >
       {/* Category pills */}
-      <Box sx={{ display: 'flex', gap: 1, px: 2, py: 1, flexWrap: 'wrap' }}>
-        {visibleCategories.map((c) => (
-          <Chip
-            key={c.key}
-            label={c.label}
-            variant={category === c.key ? 'filled' : 'outlined'}
-            color={category === c.key ? 'primary' : 'default'}
-            onClick={() => handleCategoryChange(c.key)}
-          />
-        ))}
-      </Box>
+      {showCategoryChips && (
+        <Box sx={{ display: 'flex', gap: 1, px: 2, py: 1, flexWrap: 'wrap' }}>
+          {visibleCategories.map((c) => (
+            <Chip
+              key={c.key}
+              label={c.label}
+              variant={category === c.key ? 'filled' : 'outlined'}
+              color={category === c.key ? 'primary' : 'default'}
+              onClick={() => handleCategoryChange(c.key)}
+            />
+          ))}
+        </Box>
+      )}
 
       {/* Climb mode: render via parent's render prop (has access to queue context) */}
       {isClimbMode && renderClimbSearch()}

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -23,6 +23,7 @@ export interface SwipeableDrawerProps {
   placement?: Placement;
   title?: React.ReactNode;
   showCloseButton?: boolean;
+  showCloseButtonOnMobile?: boolean;
   disableBackdropClick?: boolean;
   onTransitionEnd?: (open: boolean) => void;
   styles?: {
@@ -52,6 +53,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   showDragHandle = true,
   placement = 'bottom',
   showCloseButton,
+  showCloseButtonOnMobile = false,
   onClose,
   onTransitionEnd: userOnTransitionEnd,
   styles: userStyles,
@@ -74,11 +76,13 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   // Otherwise, disable swipe when showCloseButton is explicitly false.
   const effectiveSwipeEnabled = swipeEnabled ?? (showCloseButton !== false);
 
-  const rootClassName = userRootClassName
-    ? `${styles.mobileHideClose} ${userRootClassName}`
-    : className
-      ? `${styles.mobileHideClose} ${className}`
-      : styles.mobileHideClose;
+  const rootClassName = showCloseButtonOnMobile
+    ? (userRootClassName ?? className ?? '')
+    : userRootClassName
+      ? `${styles.mobileHideClose} ${userRootClassName}`
+      : className
+        ? `${styles.mobileHideClose} ${className}`
+        : styles.mobileHideClose;
 
   const isVerticalPlacement = placement === 'top' || placement === 'bottom';
 
@@ -163,7 +167,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
 
     const positionMap: Record<Placement, Record<string, number | string>> = {
       bottom: { top: 8, left: 8 },
-      top: { bottom: 8, left: 8 },
+      top: { top: 8, right: 8 },
       left: { top: 8, right: 8 },
       right: { top: 8, left: 8 },
     };


### PR DESCRIPTION
### Motivation
- Remove unrelated search categories from the climb-list page drawer and allow the shared drawer to show a dismiss/close button on mobile for a better mobile UX.
- Move the close button for top-anchored drawers to the top-right corner for improved ergonomics.

### Description
- Add `allowedCategories?: SearchCategory[]`, `showCloseButton?: boolean`, and `showCloseButtonOnMobile?: boolean` props to `UnifiedSearchDrawer` and forward `showCloseButtonOnMobile` into the shared `SwipeableDrawer` to control category visibility and mobile close-button behavior.
- Hide the category chip row when only one category is visible and ensure the active category falls back to the first visible option.
- Restrict the board-list page search drawer to only the climbs experience by using `allowedCategories={['climbs']}` and enable both `showCloseButton` and `showCloseButtonOnMobile` at the board-list header (`packages/web/app/components/board-page/header.tsx`).
- Adjusted the `SwipeableDrawer` close-button position for top-placed drawers to render in the top-right instead of the left side.

### Testing
- Ran `pnpm -C packages/web exec tsc --noEmit`, which failed in this environment due to missing workspace dependencies and type declarations (these are global/multi-package issues, not introduced by these changes).
- Ran `pnpm -C packages/web exec eslint app/components/search-drawer/unified-search-drawer.tsx app/components/swipeable-drawer/swipeable-drawer.tsx app/components/board-page/header.tsx`, which failed in this environment because ESLint v9 expects an `eslint.config.*` file and the package setup here prevents running it.
- Verified the intended runtime wiring by inspecting the modified files and local diffs; no unit or e2e tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d823557ea88326a7fd529c2c0150d0)