### PR TITLE
web: disable worker renderer after worker load/runtime failures

### DIFF
--- a/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
@@ -7,8 +7,10 @@ import type { BoardDetails } from '@/app/lib/types';
 // --- Mocks ---
 
 let resolveRenderBoard: (bitmap: ImageBitmap) => void;
+const isWorkerRenderingSupportedMock = vi.fn(() => true);
 
 vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({
+  isWorkerRenderingSupported: isWorkerRenderingSupportedMock,
   renderBoard: vi.fn(
     () =>
       new Promise<ImageBitmap>((resolve) => {
@@ -47,6 +49,7 @@ const mockBoardDetails: BoardDetails = {
 describe('BoardCanvasRenderer cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isWorkerRenderingSupportedMock.mockReturnValue(true);
   });
 
   it('sets initial canvas dimensions from board details', () => {
@@ -148,5 +151,20 @@ describe('BoardCanvasRenderer cleanup', () => {
     const expectedHeight = Math.round((200 * mockBoardDetails.boardHeight) / mockBoardDetails.boardWidth);
     expect(canvas.width).toBe(200);
     expect(canvas.height).toBe(expectedHeight);
+  });
+
+  it('falls back to image layers immediately when worker rendering is unavailable', () => {
+    isWorkerRenderingSupportedMock.mockReturnValue(false);
+
+    const { queryByTestId, container } = render(
+      <BoardCanvasRenderer
+        boardDetails={mockBoardDetails}
+        frames="p1r42p2r43"
+        mirrored={false}
+      />,
+    );
+
+    expect(queryByTestId('board-image-layers')).toBeTruthy();
+    expect(container.querySelector('canvas')).toBeNull();
   });
 });

--- a/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
@@ -6,14 +6,27 @@ import type { BoardDetails } from '@/app/lib/types';
 
 // --- Mocks ---
 
-let resolveRenderBoard: (bitmap: ImageBitmap) => void;
-const isWorkerRenderingSupportedMock = vi.fn(() => true);
-const renderBoardMock = vi.fn(
-  () =>
-    new Promise<ImageBitmap>((resolve) => {
-      resolveRenderBoard = resolve;
-    }),
-);
+const {
+  isWorkerRenderingSupportedMock,
+  renderBoardMock,
+  setResolveRenderBoard,
+  getResolveRenderBoard,
+} = vi.hoisted(() => {
+  let resolveRenderBoard: ((bitmap: ImageBitmap) => void) | undefined;
+  return {
+    isWorkerRenderingSupportedMock: vi.fn(() => true),
+    renderBoardMock: vi.fn(
+      () =>
+        new Promise<ImageBitmap>((resolve) => {
+          resolveRenderBoard = resolve;
+        }),
+    ),
+    setResolveRenderBoard: (fn?: (bitmap: ImageBitmap) => void) => {
+      resolveRenderBoard = fn;
+    },
+    getResolveRenderBoard: () => resolveRenderBoard,
+  };
+});
 
 vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({
   isWorkerRenderingSupported: isWorkerRenderingSupportedMock,
@@ -50,6 +63,7 @@ const mockBoardDetails: BoardDetails = {
 describe('BoardCanvasRenderer cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setResolveRenderBoard(undefined);
     isWorkerRenderingSupportedMock.mockReturnValue(true);
   });
 
@@ -100,9 +114,11 @@ describe('BoardCanvasRenderer cleanup', () => {
       height: 1350,
       close: vi.fn(),
     } as unknown as ImageBitmap;
+    const resolve = getResolveRenderBoard();
+    expect(resolve).toBeTypeOf('function');
 
     await act(async () => {
-      resolveRenderBoard(mockBitmap);
+      resolve?.(mockBitmap);
       // Allow microtask to flush
       await Promise.resolve();
     });

--- a/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
@@ -8,15 +8,16 @@ import type { BoardDetails } from '@/app/lib/types';
 
 let resolveRenderBoard: (bitmap: ImageBitmap) => void;
 const isWorkerRenderingSupportedMock = vi.fn(() => true);
+const renderBoardMock = vi.fn(
+  () =>
+    new Promise<ImageBitmap>((resolve) => {
+      resolveRenderBoard = resolve;
+    }),
+);
 
 vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({
   isWorkerRenderingSupported: isWorkerRenderingSupportedMock,
-  renderBoard: vi.fn(
-    () =>
-      new Promise<ImageBitmap>((resolve) => {
-        resolveRenderBoard = resolve;
-      }),
-  ),
+  renderBoard: renderBoardMock,
 }));
 
 vi.mock('@/app/lib/rendering-metrics', () => ({
@@ -166,5 +167,6 @@ describe('BoardCanvasRenderer cleanup', () => {
 
     expect(queryByTestId('board-image-layers')).toBeTruthy();
     expect(container.querySelector('canvas')).toBeNull();
+    expect(renderBoardMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import type { BoardDetails } from '@/app/lib/types';
-import { renderBoard } from '@/app/lib/board-render-worker/worker-manager';
+import { isWorkerRenderingSupported, renderBoard } from '@/app/lib/board-render-worker/worker-manager';
 import { trackRenderComplete, trackRenderError, type RenderContext } from '@/app/lib/rendering-metrics';
 import { THUMBNAIL_WIDTH } from './types';
 import BoardImageLayers from './board-image-layers';
@@ -49,6 +49,14 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+
+    // If worker rendering is unavailable (or has been disabled after a prior
+    // worker load/runtime failure), switch immediately to image URL layers —
+    // the same path used for SSR output.
+    if (!isWorkerRenderingSupported()) {
+      setFailed(true);
+      return;
+    }
 
     let cancelled = false;
     // Capture context and time at effect start so metrics are never stale

--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -36,6 +36,7 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hasFired = useRef(false);
   const [failed, setFailed] = useState(false);
+  const workerSupported = isWorkerRenderingSupported();
 
   // Compute initial canvas dimensions to match worker output, so the element
   // has a correct intrinsic aspect ratio before the bitmap arrives. Older
@@ -51,9 +52,8 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
     if (!canvas) return;
 
     // If worker rendering is unavailable (or has been disabled after a prior
-    // worker load/runtime failure), switch immediately to image URL layers —
-    // the same path used for SSR output.
-    if (!isWorkerRenderingSupported()) {
+    // worker load/runtime failure), skip worker calls.
+    if (!workerSupported) {
       setFailed(true);
       return;
     }
@@ -93,10 +93,10 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
         canvas.height = 0;
       }
     };
-  }, [boardDetails, frames, mirrored, thumbnail, contain]);
+  }, [boardDetails, frames, mirrored, thumbnail, contain, workerSupported]);
 
   // Fall back to server-rendered image layers if the worker render fails
-  if (failed) {
+  if (failed || !workerSupported) {
     return (
       <BoardImageLayers
         boardDetails={boardDetails}

--- a/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
+++ b/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
@@ -585,6 +585,37 @@ describe('renderBoard', () => {
     await expect(renderPromise).rejects.toThrow('WASM init failed');
   });
 
+  it('disables worker rendering after worker onerror and prevents default bubbling', async () => {
+    const { renderBoard, isWorkerRenderingSupported } = await import('../worker-manager');
+
+    const renderPromise = renderBoard({
+      boardDetails: mockBoardDetails,
+      frames: 'p77r42',
+      mirrored: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(findWorkerWithRenderMsg('p77r42')).toBeTruthy();
+    });
+
+    const worker = findWorkerWithRenderMsg('p77r42')!;
+    const preventDefault = vi.fn();
+
+    worker.onerror?.({ message: 'Load failed', preventDefault } as unknown as ErrorEvent);
+
+    await expect(renderPromise).rejects.toThrow('Worker error: Load failed');
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(isWorkerRenderingSupported()).toBe(false);
+
+    await expect(
+      renderBoard({
+        boardDetails: mockBoardDetails,
+        frames: 'p78r42',
+        mirrored: false,
+      }),
+    ).rejects.toThrow('Worker rendering is disabled');
+  });
+
   it('sends the correct render request shape to the worker', async () => {
     const { renderBoard } = await import('../worker-manager');
 

--- a/packages/web/app/lib/board-render-worker/worker-manager.ts
+++ b/packages/web/app/lib/board-render-worker/worker-manager.ts
@@ -54,15 +54,26 @@ let nextRequestId = 0;
 const pendingRequests = new Map<number, PendingRequest>();
 // Track which request IDs are assigned to which worker index
 const workerRequestIds = new Map<number, Set<number>>();
+let workerPoolDisabled = false;
 
 // Deduplication: in-flight requests by cache key
 const inflightRequests = new Map<string, Promise<ImageBitmap>>();
 
 function getWorkerPool(): Worker[] {
+  if (workerPoolDisabled) {
+    throw new Error('Worker rendering is disabled after a worker load/runtime failure');
+  }
   if (!workers) {
     workers = Array.from({ length: getPoolSize() }, (_, workerIdx) => {
       workerRequestIds.set(workerIdx, new Set());
-      const w = new Worker(new URL('./board-render.worker.ts', import.meta.url));
+      let w: Worker;
+      try {
+        w = new Worker(new URL('./board-render.worker.ts', import.meta.url));
+      } catch (err) {
+        workerPoolDisabled = true;
+        markCanvasNotReady();
+        throw err;
+      }
       w.onmessage = (event: MessageEvent<RenderResponse>) => {
         const response = event.data;
         const pending = pendingRequests.get(response.id);
@@ -77,6 +88,15 @@ function getWorkerPool(): Worker[] {
         }
       };
       w.onerror = (event) => {
+        // Prevent worker script-load/runtime errors from bubbling to
+        // global window.onerror (notably in some WKWebView contexts).
+        event.preventDefault();
+
+        // Disable worker rendering for this session to avoid retry loops
+        // when worker loading is broken in this runtime.
+        workerPoolDisabled = true;
+        markCanvasNotReady();
+
         // Only reject requests assigned to this worker, not the entire pool
         const ids = workerRequestIds.get(workerIdx);
         if (!ids) return;
@@ -177,6 +197,7 @@ export interface RenderBoardOptions {
  */
 export function isWorkerRenderingSupported(): boolean {
   if (typeof window === 'undefined') return false;
+  if (workerPoolDisabled) return false;
   return typeof OffscreenCanvas !== 'undefined' && typeof Worker !== 'undefined';
 }
 
@@ -199,6 +220,12 @@ function subscribeCanvasReady(listener: () => void): () => void {
 function markCanvasReady(): void {
   if (globalCanvasReady) return;
   globalCanvasReady = true;
+  canvasReadyListeners.forEach((listener) => listener());
+}
+
+function markCanvasNotReady(): void {
+  if (!globalCanvasReady) return;
+  globalCanvasReady = false;
   canvasReadyListeners.forEach((listener) => listener());
 }
 


### PR DESCRIPTION
### Motivation
- Prevent repetitive failures and noisy global errors when Web Worker script loading or runtime throws (observed as `NetworkError: Load failed` in WKWebView/Mobile Safari contexts). 
- Ensure the UI falls back to the existing SSR image-layer renderer instead of retrying a broken worker runtime.

### Description
- Add a session-level kill switch `workerPoolDisabled` to short-circuit worker pool creation and subsequent render attempts when a worker creation or runtime failure occurs (`packages/web/app/lib/board-render-worker/worker-manager.ts`).
- Wrap worker construction in a `try/catch` that marks the pool disabled and flips canvas readiness off when `new Worker(...)` throws, so creation failures are handled gracefully.
- In the worker `onerror` handler call `event.preventDefault()`, set `workerPoolDisabled = true`, call `markCanvasNotReady()`, and reject only the requests assigned to the failing worker to avoid bubbling to `window.onerror` and avoid retry loops.
- Add `markCanvasNotReady()` and update `isWorkerRenderingSupported()` to return `false` once the pool has been disabled so downstream code falls back immediately.
- Add a unit test that simulates `worker.onerror` and asserts the pending render rejects, that `preventDefault()` is invoked, that worker support is reported disabled afterward, and that subsequent `renderBoard()` calls reject with the worker-disabled error (`packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts`).

### Testing
- Added a unit test exercising the new behavior (see updated test file at `packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts`).
- Attempted to run the tests with `cd packages/web && npm run test:run -- app/lib/board-render-worker/__tests__/worker-manager.test.ts`, but the environment lacks the `vitest` binary so the test run failed with `vitest: not found`.
- No other automated test failures were observed in this environment because the test runner could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82015880c8326bb202c1655a3f11a)