### PR TITLE
Avoid queue bridge re-sync on pathname-only transitions

### DIFF
--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -812,6 +812,29 @@ describe('queue-bridge-context', () => {
       );
     });
 
+    it('does not run clear/re-sync just because pathname changes before unmount', () => {
+      const item = createTestQueueItem();
+      const fakeCtx = createFakeQueueContext({
+        queue: [item],
+        currentClimbQueueItem: item,
+      });
+
+      mockSetLocalQueueState.mockClear();
+      mockPathname = '/kilter/1/10/1,2/40/list';
+
+      const rendered = renderInjector(fakeCtx);
+
+      // Simulate pathname changing during navigation transition.
+      // Injector should not tear down and re-sync until actual unmount.
+      mockPathname = '/sessions';
+      rendered.rerender();
+
+      expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+
+      rendered.unmount();
+      expect(mockSetLocalQueueState).toHaveBeenCalledTimes(1);
+    });
+
     it('does not sync to local queue when party session is active', () => {
       const item = createTestQueueItem();
       const fakeCtx = createFakeQueueContext({

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -586,10 +586,15 @@ export function QueueBridgeInjector({ boardDetails, angle }: QueueBridgeInjector
   // Track whether we've done the initial injection
   const hasInjectedRef = useRef(false);
 
+  // Keep latest base board path in a ref so mount/unmount cleanup can read it
+  // without forcing the setup/cleanup effect to rerun on pathname changes.
+  const baseBoardPathRef = useRef(baseBoardPath);
+  baseBoardPathRef.current = baseBoardPath;
+
   // Initial injection: set board details + context on mount
   useLayoutEffect(() => {
     if (queueContext && queueActions && queueData) {
-      inject(queueContext, queueActions, queueData, boardDetails, angle, baseBoardPath);
+      inject(queueContext, queueActions, queueData, boardDetails, angle, baseBoardPathRef.current);
       hasInjectedRef.current = true;
     }
     // Only clean up on unmount (navigating away from board route)
@@ -598,8 +603,9 @@ export function QueueBridgeInjector({ boardDetails, angle }: QueueBridgeInjector
       clear();
     };
   // Only re-run when board details or angle change (navigation between boards)
+  // and not when pathname changes during transition off the board route.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [boardDetails, angle, baseBoardPath, inject, clear]);
+  }, [boardDetails, angle, inject, clear]);
 
   // Update the context ref whenever any of the queue context values change.
   // Also handles deferred injection if contexts were null during the useLayoutEffect.


### PR DESCRIPTION
### Motivation
- The persistent queue regressed where non-board or non-list pages lost the ability to manipulate the queue due to the bridge re-syncing at the wrong time during navigation transitions.
- The root cause was the board-route injector effect depending on `baseBoardPath` (derived from `usePathname`), causing intermediate pathname updates to trigger an early `clear()`/re-inject cycle and flush/sync stale queue state.

### Description
- Prevent `QueueBridgeInjector` from tearing down/re-injecting on pathname-only changes by storing the computed `baseBoardPath` in a ref and using that ref during injection/cleanup instead of the reactive value.
- Remove `baseBoardPath` from the `useLayoutEffect` dependency list so the injector's mount/unmount effect only responds to real board identity changes (`boardDetails`/`angle`) and true unmounts.
- Keep the existing `useEffect` that updates injected context values (it still listens to `baseBoardPath`) so runtime context updates continue to flow correctly.
- Add a regression test to `queue-bridge-context.test.tsx` that simulates a pathname change before unmount and asserts the bridge does not clear/resync until actual unmount.

### Testing
- Added a focused unit test `does not run clear/re-sync just because pathname changes before unmount` under `packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx` to validate the fix.
- Attempted to run the test via `pnpm -C packages/web test -- --run packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx`, but `vitest` / `node_modules` are not installed in this environment so the run failed with `vitest: not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d832f4573c8326b8cc2ba234d40fa6)