### PR TITLE
Fix playlist swipe-to-queue wiring

### DIFF
--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -14,6 +14,7 @@ import ClimbsList from '@/app/components/board-page/climbs-list';
 import { FavoritesProvider } from '@/app/components/climb-actions/favorites-batch-context';
 import { PlaylistsProvider } from '@/app/components/climb-actions/playlists-batch-context';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import { useOptionalQueueActions } from '@/app/components/graphql-queue';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { Climb } from '@/app/lib/types';
 
@@ -89,6 +90,7 @@ export default function MultiboardClimbList({
     angle: actionsAngle,
     climbUuids,
   });
+  const queueActions = useOptionalQueueActions();
 
   // Default climb navigation via redirect API
   const defaultNavigateToClimb = useCallback(async (climb: Climb) => {
@@ -170,6 +172,7 @@ export default function MultiboardClimbList({
               hasMore={hasMore}
               onClimbSelect={handleClimbSelect}
               onLoadMore={onLoadMore}
+              addToQueue={queueActions?.addToQueue}
               header={header}
               headerInline={headerInline}
               hideEndMessage={hideEndMessage}


### PR DESCRIPTION
### Motivation
- Playlist climb swipe gestures were not adding climbs to the queue because `MultiboardClimbList` did not forward an `addToQueue` callback into the underlying `ClimbsList`.

### Description
- Import and use `useOptionalQueueActions` in `packages/web/app/components/climb-list/multiboard-climb-list.tsx`.
- Pass `queueActions?.addToQueue` into the `ClimbsList` component as the `addToQueue` prop so swipe-left will enqueue playlist climbs when a queue provider is available.
- Use the optional hook variant so the component remains safe outside of queue-enabled contexts and does not throw when the queue provider is absent.

### Testing
- Ran `bun run typecheck:web`, which failed in this environment due to missing web dependencies/type declarations (failure unrelated to this change).
- No automated unit tests were modified or executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d842d99ce483268d9b5ca408754505)