### PR TITLE
Temporarily disable e2e tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,21 +1,22 @@
 name: E2E Tests
 
-on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'packages/web/**'
-      - 'packages/backend/**'
-      - 'packages/shared-schema/**'
-      - 'packages/db/**'
-      - '.github/workflows/e2e-tests.yml'
-  pull_request:
-    paths:
-      - 'packages/web/**'
-      - 'packages/backend/**'
-      - 'packages/shared-schema/**'
-      - 'packages/db/**'
-      - '.github/workflows/e2e-tests.yml'
+# Temporarily disabled - workflow is broken
+# on:
+#   push:
+#     branches: [ main, develop ]
+#     paths:
+#       - 'packages/web/**'
+#       - 'packages/backend/**'
+#       - 'packages/shared-schema/**'
+#       - 'packages/db/**'
+#       - '.github/workflows/e2e-tests.yml'
+#   pull_request:
+#     paths:
+#       - 'packages/web/**'
+#       - 'packages/backend/**'
+#       - 'packages/shared-schema/**'
+#       - 'packages/db/**'
+#       - '.github/workflows/e2e-tests.yml'
 
 jobs:
   e2e:


### PR DESCRIPTION
The e2e tests workflow is currently broken and needs to be fixed.
This commit disables the workflow by commenting out the trigger.

https://claude.ai/code/session_01AHnXuiruDmrxvnHoaQxEfd