### PR TITLE
Use X icon for drawer close and drop redundant Climb label

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -1,3 +1,25 @@
+/* Form wrapper: primary climb content above collapsible sections */
+.formWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Primary content shown inline (no collapsible header) */
+.primaryContent {
+  background: var(--semantic-surface, #FFFFFF);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.08);
+  padding: 20px 24px;
+  margin: 4px 0 12px;
+}
+
+@media (max-width: 767px) {
+  .primaryContent {
+    padding: 16px 20px;
+    margin-bottom: 10px;
+  }
+}
+
 /* Panel content sections */
 .panelContent {
   display: flex;

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -23,7 +23,6 @@ import { BoardDetails } from '@/app/lib/types';
 import { buildGradeRangeUpdate } from './grade-range-utils';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import {
-  getClimbPanelSummary,
   getQualityPanelSummary,
   getUserPanelSummary,
   getHoldsPanelSummary,
@@ -42,7 +41,7 @@ interface AccordionSearchFormProps {
 
 const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
   boardDetails,
-  defaultActiveKey = ['climb'],
+  defaultActiveKey,
 }) => {
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
@@ -70,123 +69,116 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
   const minGradeBg = getGradeSelectBackground(uiSearchParams.minGrade);
   const maxGradeBg = getGradeSelectBackground(uiSearchParams.maxGrade);
 
-  const sections: CollapsibleSectionConfig[] = [
-    {
-      key: 'climb',
-      label: 'Climb',
-      title: 'Climb',
-      defaultSummary: 'All climbs',
-      getSummary: () => getClimbPanelSummary(uiSearchParams),
-      content: (
-        <div className={styles.panelContent}>
-          <div className={styles.inputGroup}>
-            <span className={styles.fieldLabel}>Climb Name</span>
-            <SearchClimbNameInput />
-          </div>
+  const climbContent = (
+    <div className={styles.panelContent}>
+      <div className={styles.inputGroup}>
+        <span className={styles.fieldLabel}>Climb Name</span>
+        <SearchClimbNameInput />
+      </div>
 
-          <div className={styles.inputGroup}>
-            <span className={styles.fieldLabel}>Grade Range</span>
-            <div className={styles.gradeRow}>
-              <MuiSelect
-                value={uiSearchParams.minGrade || 0}
-                onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', e.target.value as number || undefined)}
-                className={`${styles.fullWidth} ${minGradeBg ? styles.gradeSelectColored : ''}`}
-                sx={minGradeBg ? { '--grade-bg': minGradeBg } as React.CSSProperties : undefined}
-                size="small"
-                displayEmpty
-                MenuProps={{ disableScrollLock: true }}
-              >
-                <MenuItem value={0}>Min</MenuItem>
-                {grades.map((grade) => (
-                  <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
-                    {grade.difficulty_name}
-                  </MenuItem>
-                ))}
-              </MuiSelect>
-              <MuiSelect
-                value={uiSearchParams.maxGrade || 0}
-                onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', e.target.value as number || undefined)}
-                className={`${styles.fullWidth} ${maxGradeBg ? styles.gradeSelectColored : ''}`}
-                sx={maxGradeBg ? { '--grade-bg': maxGradeBg } as React.CSSProperties : undefined}
-                size="small"
-                displayEmpty
-                MenuProps={{ disableScrollLock: true }}
-              >
-                <MenuItem value={0}>Max</MenuItem>
-                {grades.map((grade) => (
-                  <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
-                    {grade.difficulty_name}
-                  </MenuItem>
-                ))}
-              </MuiSelect>
-            </div>
-          </div>
-
-          {showTallClimbsFilter && (
-            <div className={styles.switchGroup}>
-              <div className={styles.switchRow}>
-                <MuiTooltip title="Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)">
-                  <MuiTypography variant="body2" component="span">Tall Climbs Only</MuiTypography>
-                </MuiTooltip>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.onlyTallClimbs}
-                  onChange={(_, checked) => updateFilters({ onlyTallClimbs: checked })}
-                />
-              </div>
-            </div>
-          )}
-
-          <div className={styles.inputGroup}>
-            <span className={styles.fieldLabel}>Setter</span>
-            <SetterNameSelect />
-          </div>
-
-          <MuiButton
-            variant="text"
+      <div className={styles.inputGroup}>
+        <span className={styles.fieldLabel}>Grade Range</span>
+        <div className={styles.gradeRow}>
+          <MuiSelect
+            value={uiSearchParams.minGrade || 0}
+            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', e.target.value as number || undefined)}
+            className={`${styles.fullWidth} ${minGradeBg ? styles.gradeSelectColored : ''}`}
+            sx={minGradeBg ? { '--grade-bg': minGradeBg } as React.CSSProperties : undefined}
             size="small"
-            startIcon={<ArrowUpwardOutlined />}
-            className={styles.sortToggle}
-            onClick={() => setShowSort(!showSort)}
+            displayEmpty
+            MenuProps={{ disableScrollLock: true }}
           >
-            Sort
-          </MuiButton>
-
-          {showSort && (
-            <div className={styles.inputGroup}>
-              <div className={styles.sortRow}>
-                <MuiSelect
-                  value={uiSearchParams.sortBy}
-                  onChange={(e) => updateFilters({ sortBy: e.target.value as typeof uiSearchParams.sortBy })}
-                  className={styles.fullWidth}
-                  size="small"
-                  MenuProps={{ disableScrollLock: true }}
-                >
-                  <MenuItem value="ascents">Ascents</MenuItem>
-                  <MenuItem value="popular">Popular</MenuItem>
-                  <MenuItem value="difficulty">Difficulty</MenuItem>
-                  <MenuItem value="name">Name</MenuItem>
-                  <MenuItem value="quality">Quality</MenuItem>
-                  <MenuItem value="creation">Creation</MenuItem>
-                </MuiSelect>
-                <MuiSelect
-                  value={uiSearchParams.sortOrder}
-                  onChange={(e) => updateFilters({ sortOrder: e.target.value as typeof uiSearchParams.sortOrder })}
-                  className={styles.fullWidth}
-                  size="small"
-                  MenuProps={{ disableScrollLock: true }}
-                >
-                  <MenuItem value="desc">Desc</MenuItem>
-                  <MenuItem value="asc">Asc</MenuItem>
-                </MuiSelect>
-              </div>
-            </div>
-          )}
-
+            <MenuItem value={0}>Min</MenuItem>
+            {grades.map((grade) => (
+              <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
+                {grade.difficulty_name}
+              </MenuItem>
+            ))}
+          </MuiSelect>
+          <MuiSelect
+            value={uiSearchParams.maxGrade || 0}
+            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', e.target.value as number || undefined)}
+            className={`${styles.fullWidth} ${maxGradeBg ? styles.gradeSelectColored : ''}`}
+            sx={maxGradeBg ? { '--grade-bg': maxGradeBg } as React.CSSProperties : undefined}
+            size="small"
+            displayEmpty
+            MenuProps={{ disableScrollLock: true }}
+          >
+            <MenuItem value={0}>Max</MenuItem>
+            {grades.map((grade) => (
+              <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
+                {grade.difficulty_name}
+              </MenuItem>
+            ))}
+          </MuiSelect>
         </div>
-      ),
-    },
+      </div>
+
+      {showTallClimbsFilter && (
+        <div className={styles.switchGroup}>
+          <div className={styles.switchRow}>
+            <MuiTooltip title="Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)">
+              <MuiTypography variant="body2" component="span">Tall Climbs Only</MuiTypography>
+            </MuiTooltip>
+            <MuiSwitch
+              size="small"
+              color="primary"
+              checked={uiSearchParams.onlyTallClimbs}
+              onChange={(_, checked) => updateFilters({ onlyTallClimbs: checked })}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className={styles.inputGroup}>
+        <span className={styles.fieldLabel}>Setter</span>
+        <SetterNameSelect />
+      </div>
+
+      <MuiButton
+        variant="text"
+        size="small"
+        startIcon={<ArrowUpwardOutlined />}
+        className={styles.sortToggle}
+        onClick={() => setShowSort(!showSort)}
+      >
+        Sort
+      </MuiButton>
+
+      {showSort && (
+        <div className={styles.inputGroup}>
+          <div className={styles.sortRow}>
+            <MuiSelect
+              value={uiSearchParams.sortBy}
+              onChange={(e) => updateFilters({ sortBy: e.target.value as typeof uiSearchParams.sortBy })}
+              className={styles.fullWidth}
+              size="small"
+              MenuProps={{ disableScrollLock: true }}
+            >
+              <MenuItem value="ascents">Ascents</MenuItem>
+              <MenuItem value="popular">Popular</MenuItem>
+              <MenuItem value="difficulty">Difficulty</MenuItem>
+              <MenuItem value="name">Name</MenuItem>
+              <MenuItem value="quality">Quality</MenuItem>
+              <MenuItem value="creation">Creation</MenuItem>
+            </MuiSelect>
+            <MuiSelect
+              value={uiSearchParams.sortOrder}
+              onChange={(e) => updateFilters({ sortOrder: e.target.value as typeof uiSearchParams.sortOrder })}
+              className={styles.fullWidth}
+              size="small"
+              MenuProps={{ disableScrollLock: true }}
+            >
+              <MenuItem value="desc">Desc</MenuItem>
+              <MenuItem value="asc">Asc</MenuItem>
+            </MuiSelect>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  const sections: CollapsibleSectionConfig[] = [
     {
       key: 'quality',
       label: 'Quality',
@@ -349,10 +341,13 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
   ];
 
   return (
-    <CollapsibleSection
-      sections={sections}
-      defaultActiveKey={defaultActiveKey[0] || 'climb'}
-    />
+    <div className={styles.formWrapper}>
+      <div className={styles.primaryContent}>{climbContent}</div>
+      <CollapsibleSection
+        sections={sections}
+        defaultActiveKey={defaultActiveKey?.[0]}
+      />
+    </div>
   );
 };
 

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -5,10 +5,7 @@ import MuiSwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
-import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
-import KeyboardArrowLeftOutlined from '@mui/icons-material/KeyboardArrowLeftOutlined';
-import KeyboardArrowRightOutlined from '@mui/icons-material/KeyboardArrowRightOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './swipeable-drawer.module.css';
 
@@ -161,13 +158,6 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   const closeButton = useMemo(() => {
     if (showCloseButton === false) return null;
 
-    const iconMap: Record<Placement, React.ReactElement> = {
-      bottom: <KeyboardArrowDownOutlined />,
-      top: <KeyboardArrowUpOutlined />,
-      left: <KeyboardArrowLeftOutlined />,
-      right: <KeyboardArrowRightOutlined />,
-    };
-
     const positionMap: Record<Placement, Record<string, number | string>> = {
       bottom: { top: 8, left: 8 },
       top: { top: 8, right: 8 },
@@ -180,15 +170,17 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
         className="drawer-close-btn"
         size="small"
         onClick={(e) => onClose?.(e)}
+        aria-label="Close"
         sx={{
           position: 'absolute',
           zIndex: 2,
           ...positionMap[placement],
-          backgroundColor: themeTokens.neutral[100],
-          '&:hover': { backgroundColor: themeTokens.neutral[200] },
+          color: 'text.primary',
+          backgroundColor: 'action.selected',
+          '&:hover': { backgroundColor: 'action.focus' },
         }}
       >
-        {iconMap[placement]}
+        <CloseOutlined />
       </IconButton>
     );
   }, [showCloseButton, placement, onClose]);


### PR DESCRIPTION
Swap the directional arrow icons on SwipeableDrawer's close button for a
single CloseOutlined (X) and switch its colors to theme-aware palette
tokens so it isn't washed out in dark mode.

Pull the Climb filters out of AccordionSearchForm's collapsible list and
render them inline at the top. The drawer's single-category climb search
no longer shows the redundant "Climb" header.