### PR TITLE
Fix hardcoded shadow values and update stale documentation

### DIFF
--- a/docs/social-features-plan.md
+++ b/docs/social-features-plan.md
@@ -2380,7 +2380,7 @@ The search drawer is extended with a **search category pill bar** at the top, al
 The existing search system consists of:
 - `SearchDrawerBridgeInjector` (in `header.tsx`) -- registers the search drawer opener with `GlobalHeader` via bridge context
 - `SearchDropdown` -- full-screen swipeable drawer with `AccordionSearchForm`
-- `AccordionSearchForm` -- 4 collapsible filter panels (Climb, Quality, Progress, Holds)
+- `AccordionSearchForm` -- 3 collapsible filter panels (Quality, Progress, Holds) with a primary Climb filter section
 - `UISearchParamsProvider` -- manages filter state with 500ms debounce
 - `ClimbsList` -- renders climb results with infinite scroll
 

--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -8,7 +8,7 @@
 .primaryContent {
   background: var(--semantic-surface, #FFFFFF);
   border-radius: 16px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-xs);
   padding: 20px 24px;
   margin: 4px 0 12px;
 }


### PR DESCRIPTION
- Replace hardcoded shadow values (0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.08)) with CSS variable --shadow-xs in accordion-search-form.module.css for consistency with theme tokens
- Update social-features-plan.md documentation to reflect that Climb filter is no longer collapsible, changing from "4 collapsible filter panels (Climb, Quality, Progress, Holds)" to "3 collapsible filter panels (Quality, Progress, Holds) with a primary Climb filter section"

https://claude.ai/code/session_016SAiENFJRXDMqFA7wYPy3P