### PR TITLE
Improve quick tick bar UX and snapshot the target climb

### DIFF
--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -29,11 +29,15 @@ export const SaveTickInputSchema = z.object({
   setIds: z.string().min(1).optional(),
 }).refine(
   (data) => {
+    // A flash is by definition a first-try ascent, so attemptCount must be 1.
+    // A send is any successful ascent — the attempt count on the row just
+    // records how many tries that particular log represents (e.g. 1 when the
+    // user is logging a single successful action, >1 when they're
+    // back-filling a redpoint that took multiple tries). Both are valid.
     if (data.status === 'flash' && data.attemptCount !== 1) return false;
-    if (data.status === 'send' && data.attemptCount <= 1) return false;
     return true;
   },
-  { message: 'Flash requires attemptCount of 1, send requires attemptCount > 1', path: ['attemptCount'] }
+  { message: 'Flash requires attemptCount of 1', path: ['attemptCount'] }
 ).refine(
   (data) => {
     if (data.status === 'attempt' && data.quality !== undefined && data.quality !== null) return false;

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@vercel/analytics', () => ({
 }));
 
 // Import after mocks.
-import { QuickTickBar, countPriorLogs } from '../quick-tick-bar';
+import { QuickTickBar, hasPriorHistoryForClimb } from '../quick-tick-bar';
 
 // --- Fixtures ---
 
@@ -134,17 +134,30 @@ describe('QuickTickBar', () => {
     vi.useRealTimers();
   });
 
-  describe('countPriorLogs helper', () => {
-    it('counts entries matching climb uuid and angle', () => {
-      const logbook = [
-        makeLogbookEntry({ uuid: 'a', climb_uuid: 'climb-1', angle: 40 }),
-        makeLogbookEntry({ uuid: 'b', climb_uuid: 'climb-1', angle: 40 }),
-        makeLogbookEntry({ uuid: 'c', climb_uuid: 'climb-1', angle: 30 }),
-        makeLogbookEntry({ uuid: 'd', climb_uuid: 'climb-2', angle: 40 }),
-      ];
-      expect(countPriorLogs(logbook, 'climb-1', 40 as Angle)).toBe(2);
-      expect(countPriorLogs(logbook, 'climb-2', 40 as Angle)).toBe(1);
-      expect(countPriorLogs(logbook, 'climb-3', 40 as Angle)).toBe(0);
+  describe('hasPriorHistoryForClimb helper', () => {
+    it('prefers userAscents/userAttempts on the climb when present', () => {
+      const climbFresh = makeClimb({ uuid: 'c1', userAscents: 0, userAttempts: 0 });
+      const climbAttempted = makeClimb({ uuid: 'c2', userAscents: 0, userAttempts: 3 });
+      const climbSent = makeClimb({ uuid: 'c3', userAscents: 1, userAttempts: 0 });
+
+      // Logbook contents should be ignored when the climb carries counts.
+      const logbook = [makeLogbookEntry({ climb_uuid: 'c1' })];
+
+      expect(hasPriorHistoryForClimb(climbFresh, logbook)).toBe(false);
+      expect(hasPriorHistoryForClimb(climbAttempted, [])).toBe(true);
+      expect(hasPriorHistoryForClimb(climbSent, [])).toBe(true);
+    });
+
+    it('falls back to the logbook when the climb has no counts', () => {
+      const climb = makeClimb({ uuid: 'c1' });
+      // Climb is created via makeClimb without userAscents / userAttempts.
+      expect(hasPriorHistoryForClimb(climb, [])).toBe(false);
+      expect(
+        hasPriorHistoryForClimb(climb, [makeLogbookEntry({ climb_uuid: 'c1' })]),
+      ).toBe(true);
+      expect(
+        hasPriorHistoryForClimb(climb, [makeLogbookEntry({ climb_uuid: 'other' })]),
+      ).toBe(false);
     });
   });
 
@@ -198,7 +211,7 @@ describe('QuickTickBar', () => {
       expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
     });
 
-    it('saves as send with attemptCount 2 when there is one prior log', async () => {
+    it('saves as send with attemptCount 1 when there is one prior log', async () => {
       mockLogbookRef.current = [
         makeLogbookEntry({ uuid: 'p1', climb_uuid: 'climb-1', angle: 40 }),
       ];
@@ -210,14 +223,14 @@ describe('QuickTickBar', () => {
 
       const call = mockSaveTick.mock.calls[0][0];
       expect(call.status).toBe('send');
-      expect(call.attemptCount).toBe(2);
+      expect(call.attemptCount).toBe(1);
     });
 
-    it('saves as send with attemptCount 4 when there are three prior logs', async () => {
+    it('still logs a single send row (attemptCount 1) when there are multiple prior logs', async () => {
       mockLogbookRef.current = [
         makeLogbookEntry({ uuid: 'p1', status: 'attempt' }),
         makeLogbookEntry({ uuid: 'p2', status: 'attempt' }),
-        makeLogbookEntry({ uuid: 'p3', status: 'send' }),
+        makeLogbookEntry({ uuid: 'p3', status: 'attempt' }),
       ];
       render(<QuickTickBar {...defaultProps} />);
 
@@ -227,13 +240,12 @@ describe('QuickTickBar', () => {
 
       const call = mockSaveTick.mock.calls[0][0];
       expect(call.status).toBe('send');
-      expect(call.attemptCount).toBe(4);
+      expect(call.attemptCount).toBe(1);
     });
 
-    it('ignores logbook rows for other climbs or angles when deciding flash vs send', async () => {
+    it('ignores logbook rows for other climbs when deciding flash vs send', async () => {
       mockLogbookRef.current = [
         makeLogbookEntry({ uuid: 'other-climb', climb_uuid: 'climb-other', angle: 40 }),
-        makeLogbookEntry({ uuid: 'other-angle', climb_uuid: 'climb-1', angle: 30 }),
       ];
       render(<QuickTickBar {...defaultProps} />);
 
@@ -263,6 +275,38 @@ describe('QuickTickBar', () => {
       expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
     });
 
+    it('uses userAscents on the climb to default to send without touching the logbook', async () => {
+      // Logbook is intentionally empty — the fast path should look at the
+      // climb's own counts and still treat this as a send.
+      mockLogbookRef.current = [];
+      const climbWithHistory = makeClimb({ userAscents: 2, userAttempts: 0 });
+
+      render(<QuickTickBar {...defaultProps} currentClimb={climbWithHistory} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('send');
+      expect(call.attemptCount).toBe(1);
+    });
+
+    it('uses userAttempts on the climb to default to send without touching the logbook', async () => {
+      mockLogbookRef.current = [];
+      const climbWithAttempts = makeClimb({ userAscents: 0, userAttempts: 1 });
+
+      render(<QuickTickBar {...defaultProps} currentClimb={climbWithAttempts} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('send');
+      expect(call.attemptCount).toBe(1);
+    });
+
     it('reflects the quality rating in the save payload', async () => {
       render(<QuickTickBar {...defaultProps} />);
 
@@ -276,6 +320,22 @@ describe('QuickTickBar', () => {
 
       const call = mockSaveTick.mock.calls[0][0];
       expect(call.quality).toBe(3);
+    });
+
+    it('does not call onSave when saveTick rejects and leaves the bar mounted', async () => {
+      mockSaveTick.mockRejectedValueOnce(new Error('network down'));
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onSave).not.toHaveBeenCalled();
+      // Bar should still be mounted and usable for a retry.
+      expect(screen.getByTestId('quick-tick-bar')).toBeTruthy();
+      const confirm = screen.getByTestId('quick-tick-confirm') as HTMLButtonElement;
+      expect(confirm.disabled).toBe(false);
     });
   });
 

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { Angle, BoardDetails, BoardName, Climb } from '@/app/lib/types';
+import type { LogbookEntry } from '@/app/hooks/use-logbook';
+
+// --- Mocks (must be hoisted before imports of the component under test) ---
+
+const mockSaveTick = vi.fn();
+const mockLogbookRef: { current: LogbookEntry[] } = { current: [] };
+
+vi.mock('../../board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({
+    saveTick: mockSaveTick,
+    logbook: mockLogbookRef.current,
+    boardName: 'kilter' as BoardName,
+    isAuthenticated: true,
+    isLoading: false,
+    error: null,
+    isInitialized: true,
+    getLogbook: vi.fn(),
+    saveClimb: vi.fn(),
+  }),
+}));
+
+vi.mock('@vercel/analytics', () => ({
+  track: vi.fn(),
+}));
+
+// Import after mocks.
+import { QuickTickBar, countPriorLogs } from '../quick-tick-bar';
+
+// --- Fixtures ---
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    name: 'Test Climb',
+    difficulty: 'V5',
+    frames: 'p1r42',
+    quality_average: '3.5',
+    angle: 40,
+    ascensionist_count: 10,
+    display_difficulty: 5,
+    difficulty_average: 12.5,
+    setter_username: 'setter',
+    ...overrides,
+  } as Climb;
+}
+
+function makeBoardDetails(overrides: Partial<BoardDetails> = {}): BoardDetails {
+  return {
+    board_name: 'kilter' as BoardName,
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 2],
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Full',
+    set_names: ['Standard'],
+    supportsMirroring: true,
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 100,
+    boardWidth: 100,
+    ...overrides,
+  } as BoardDetails;
+}
+
+function makeLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
+  return {
+    uuid: 'log-1',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    is_mirror: false,
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    climbed_at: '2025-01-01T00:00:00Z',
+    is_ascent: false,
+    status: 'attempt',
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  currentClimb: makeClimb(),
+  angle: 40 as Angle,
+  boardDetails: makeBoardDetails(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+/**
+ * Simulate a horizontal swipe on the bar root.
+ * react-swipeable uses touch events internally, so we dispatch native touch
+ * events with TouchEvent-shaped fields that the library reads.
+ */
+function simulateSwipe(el: HTMLElement, deltaX: number) {
+  const startX = 200;
+  const startY = 100;
+  const endX = startX + deltaX;
+
+  fireEvent.touchStart(el, {
+    touches: [{ clientX: startX, clientY: startY }],
+  });
+  // A couple of intermediate points so react-swipeable recognises a swipe.
+  fireEvent.touchMove(el, {
+    touches: [{ clientX: startX + deltaX / 2, clientY: startY }],
+  });
+  fireEvent.touchMove(el, {
+    touches: [{ clientX: endX, clientY: startY }],
+  });
+  fireEvent.touchEnd(el, {
+    changedTouches: [{ clientX: endX, clientY: startY }],
+  });
+}
+
+describe('QuickTickBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogbookRef.current = [];
+    mockSaveTick.mockResolvedValue(undefined);
+    defaultProps.onSave = vi.fn();
+    defaultProps.onCancel = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('countPriorLogs helper', () => {
+    it('counts entries matching climb uuid and angle', () => {
+      const logbook = [
+        makeLogbookEntry({ uuid: 'a', climb_uuid: 'climb-1', angle: 40 }),
+        makeLogbookEntry({ uuid: 'b', climb_uuid: 'climb-1', angle: 40 }),
+        makeLogbookEntry({ uuid: 'c', climb_uuid: 'climb-1', angle: 30 }),
+        makeLogbookEntry({ uuid: 'd', climb_uuid: 'climb-2', angle: 40 }),
+      ];
+      expect(countPriorLogs(logbook, 'climb-1', 40 as Angle)).toBe(2);
+      expect(countPriorLogs(logbook, 'climb-2', 40 as Angle)).toBe(1);
+      expect(countPriorLogs(logbook, 'climb-3', 40 as Angle)).toBe(0);
+    });
+  });
+
+  describe('layout', () => {
+    it('renders the controls in the expected order: stars, grade, comment toggle, attempt, confirm', () => {
+      render(<QuickTickBar {...defaultProps} />);
+
+      const rating = screen.getByTestId('quick-tick-rating');
+      const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
+      const attemptBtn = screen.getByTestId('quick-tick-attempt');
+      const confirmBtn = screen.getByTestId('quick-tick-confirm');
+
+      // Same parent (the .controls flex row).
+      expect(rating.parentElement).toBe(commentToggle.parentElement);
+      expect(rating.parentElement).toBe(attemptBtn.parentElement);
+      expect(rating.parentElement).toBe(confirmBtn.parentElement);
+
+      const siblings = Array.from(rating.parentElement!.children) as HTMLElement[];
+      const ratingIdx = siblings.indexOf(rating);
+      const commentIdx = siblings.indexOf(commentToggle);
+      const attemptIdx = siblings.indexOf(attemptBtn);
+      const confirmIdx = siblings.indexOf(confirmBtn);
+
+      expect(ratingIdx).toBeLessThan(commentIdx);
+      expect(commentIdx).toBeLessThan(attemptIdx);
+      // The X must be the DOM sibling immediately before the confirm tick.
+      expect(confirmIdx).toBe(attemptIdx + 1);
+    });
+
+    it('shows the "swipe left to dismiss" hint text by default', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      const hint = screen.getByTestId('quick-tick-hint');
+      expect(hint.textContent).toMatch(/swipe left to dismiss/i);
+    });
+  });
+
+  describe('save behaviour — history-aware default', () => {
+    it('saves as flash with attemptCount 1 when the logbook is empty', async () => {
+      mockLogbookRef.current = [];
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('flash');
+      expect(call.attemptCount).toBe(1);
+      expect(call.climbUuid).toBe('climb-1');
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('saves as send with attemptCount 2 when there is one prior log', async () => {
+      mockLogbookRef.current = [
+        makeLogbookEntry({ uuid: 'p1', climb_uuid: 'climb-1', angle: 40 }),
+      ];
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('send');
+      expect(call.attemptCount).toBe(2);
+    });
+
+    it('saves as send with attemptCount 4 when there are three prior logs', async () => {
+      mockLogbookRef.current = [
+        makeLogbookEntry({ uuid: 'p1', status: 'attempt' }),
+        makeLogbookEntry({ uuid: 'p2', status: 'attempt' }),
+        makeLogbookEntry({ uuid: 'p3', status: 'send' }),
+      ];
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('send');
+      expect(call.attemptCount).toBe(4);
+    });
+
+    it('ignores logbook rows for other climbs or angles when deciding flash vs send', async () => {
+      mockLogbookRef.current = [
+        makeLogbookEntry({ uuid: 'other-climb', climb_uuid: 'climb-other', angle: 40 }),
+        makeLogbookEntry({ uuid: 'other-angle', climb_uuid: 'climb-1', angle: 30 }),
+      ];
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('flash');
+      expect(call.attemptCount).toBe(1);
+    });
+
+    it('saves the attempt button as status attempt with attemptCount 1 regardless of history', async () => {
+      mockLogbookRef.current = [
+        makeLogbookEntry({ uuid: 'p1' }),
+        makeLogbookEntry({ uuid: 'p2' }),
+      ];
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('attempt');
+      expect(call.attemptCount).toBe(1);
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('reflects the quality rating in the save payload', async () => {
+      render(<QuickTickBar {...defaultProps} />);
+
+      // MUI Rating renders radio inputs for each star value.
+      const threeStars = screen.getAllByRole('radio', { name: /3 star/i })[0];
+      fireEvent.click(threeStars);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.quality).toBe(3);
+    });
+  });
+
+  describe('climb snapshot', () => {
+    it('keeps ticking the original climb even when currentClimb prop changes', async () => {
+      const originalClimb = makeClimb({ uuid: 'original-climb' });
+      const newClimb = makeClimb({ uuid: 'new-climb' });
+
+      // Original climb has no prior history.
+      // The new climb has 5 prior rows — if the component ever resolved the
+      // "live" props instead of its snapshot, we would see send/6 below.
+      mockLogbookRef.current = [
+        makeLogbookEntry({ uuid: 'n1', climb_uuid: 'new-climb' }),
+        makeLogbookEntry({ uuid: 'n2', climb_uuid: 'new-climb' }),
+        makeLogbookEntry({ uuid: 'n3', climb_uuid: 'new-climb' }),
+        makeLogbookEntry({ uuid: 'n4', climb_uuid: 'new-climb' }),
+        makeLogbookEntry({ uuid: 'n5', climb_uuid: 'new-climb' }),
+      ];
+
+      const { rerender } = render(
+        <QuickTickBar {...defaultProps} currentClimb={originalClimb} />,
+      );
+
+      // Simulate another party member advancing the queue mid-tick.
+      rerender(<QuickTickBar {...defaultProps} currentClimb={newClimb} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.climbUuid).toBe('original-climb');
+      expect(call.status).toBe('flash');
+      expect(call.attemptCount).toBe(1);
+    });
+  });
+
+  describe('swipe to dismiss', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it('calls onCancel when swiped left past the threshold', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      const bar = screen.getByTestId('quick-tick-bar');
+
+      simulateSwipe(bar, -120);
+
+      // Exit animation is scheduled via setTimeout — advance to flush it.
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onCancel when swipe is below the threshold', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      const bar = screen.getByTestId('quick-tick-bar');
+
+      simulateSwipe(bar, -40);
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(defaultProps.onCancel).not.toHaveBeenCalled();
+    });
+
+    it('ignores swipes while the comment field is focused', () => {
+      render(<QuickTickBar {...defaultProps} />);
+
+      // Open and focus the comment input.
+      fireEvent.click(screen.getByRole('button', { name: /toggle comment/i }));
+      const commentInput = screen.getByPlaceholderText('Comment...');
+      fireEvent.focus(commentInput);
+
+      const bar = screen.getByTestId('quick-tick-bar');
+      simulateSwipe(bar, -200);
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(defaultProps.onCancel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -5,6 +5,8 @@
   min-width: 0;
   flex: 1;
   animation: tickBarEnter 150ms ease-out;
+  will-change: transform, opacity;
+  touch-action: pan-y;
 }
 
 @keyframes tickBarEnter {
@@ -24,6 +26,30 @@
   gap: var(--space-1, 4px);
   flex: 1;
   min-width: 0;
+}
+
+.spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hintRow {
+  /* Align the hint underneath the star rating. The MUI Rating small size sits
+     at the very start of the controls row, so no left padding is needed. */
+  display: flex;
+  align-items: center;
+  padding-left: 2px;
+  margin-top: -2px;
+  line-height: 1;
+}
+
+.hint {
+  font-size: 10px;
+  font-style: italic;
+  color: var(--mui-palette-text-secondary, rgba(0, 0, 0, 0.6));
+  opacity: 0.7;
+  user-select: none;
+  pointer-events: none;
 }
 
 .commentRow {

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -24,8 +24,8 @@ interface TickTarget {
   climb: Climb;
   angle: Angle;
   boardDetails: BoardDetails;
-  /** Number of prior logbook rows (any status) for this climb + angle at open time. */
-  priorCount: number;
+  /** Whether the user has any prior logbook history for this climb at open time. */
+  hasPriorHistory: boolean;
 }
 
 export interface QuickTickBarProps {
@@ -46,10 +46,10 @@ const SNAP_BACK_DURATION_MS = 180;
  * of the climb so that mid-flow changes to the active climb (party session
  * navigation, etc.) do not cause the user to lose their in-progress tick.
  *
- * The confirm status is history-aware: if the user has no prior logbook rows
- * for this climb + angle the tick is recorded as a `flash`, otherwise it is
- * recorded as a `send` with `attemptCount = priorCount + 1`. This matches what
- * a climber would expect when tapping a single "I sent it" button.
+ * Each tap on the bar logs exactly one row with `attemptCount: 1`. The status
+ * is history-aware: if the user has no prior logbook rows for this climb +
+ * angle the tick is recorded as a `flash`, otherwise it is recorded as a
+ * `send`. Totals are derived server-side by aggregating rows.
  */
 export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   currentClimb,
@@ -113,24 +113,18 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     async (isAscent: boolean) => {
       if (!tickTarget || isSaving) return;
 
-      const { climb, angle: targetAngle, boardDetails: targetBoard, priorCount } = tickTarget;
+      const { climb, angle: targetAngle, boardDetails: targetBoard, hasPriorHistory } = tickTarget;
 
-      // History-aware status: flash only if no prior logs for this climb+angle.
-      // Attempts always record as a single attempt row.
+      // One tap == one row. Status is history-aware: flash only if the user
+      // has no prior history for this climb; otherwise send. attemptCount is
+      // always 1 because each row represents a single climbing action.
       let status: TickStatus;
-      let attemptCount: number;
       if (isAscent) {
-        if (priorCount === 0) {
-          status = 'flash';
-          attemptCount = 1;
-        } else {
-          status = 'send';
-          attemptCount = priorCount + 1;
-        }
+        status = hasPriorHistory ? 'send' : 'flash';
       } else {
         status = 'attempt';
-        attemptCount = 1;
       }
+      const attemptCount = 1;
 
       setIsSaving(true);
       try {
@@ -360,16 +354,27 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   );
 };
 
-/** Count prior logbook rows for a given climb + angle. Exposed for tests. */
-export function countPriorLogs(
+/**
+ * Decide whether the user has any prior history for a climb at open time.
+ *
+ * Fast path: the climb payload already carries `userAscents` and
+ * `userAttempts` counts from the climb list query, so in the common case we
+ * avoid walking the logbook entirely. When those fields are missing (e.g. the
+ * climb was fetched through a slim query that does not include the user
+ * aggregation), we fall back to filtering the in-memory logbook by climb
+ * uuid. Exposed for tests.
+ */
+export function hasPriorHistoryForClimb(
+  climb: Climb,
   logbook: LogbookEntry[],
-  climbUuid: string,
-  angle: Angle,
-): number {
-  const numericAngle = Number(angle);
-  return logbook.filter(
-    (entry) => entry.climb_uuid === climbUuid && Number(entry.angle) === numericAngle,
-  ).length;
+): boolean {
+  const ascents = climb.userAscents;
+  const attempts = climb.userAttempts;
+  if (ascents != null || attempts != null) {
+    return (ascents ?? 0) + (attempts ?? 0) > 0;
+  }
+  // Fallback: slim climb payload — consult the local logbook instead.
+  return logbook.some((entry) => entry.climb_uuid === climb.uuid);
 }
 
 function buildTickTarget(
@@ -382,6 +387,6 @@ function buildTickTarget(
     climb,
     angle,
     boardDetails,
-    priorCount: countPriorLogs(logbook, climb.uuid, angle),
+    hasPriorHistory: hasPriorHistoryForClimb(climb, logbook),
   };
 }

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useSwipeable } from 'react-swipeable';
 import IconButton from '@mui/material/IconButton';
 import Rating from '@mui/material/Rating';
 import Chip from '@mui/material/Chip';
@@ -13,11 +14,21 @@ import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutl
 import { track } from '@vercel/analytics';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
+import type { LogbookEntry, TickStatus } from '@/app/hooks/use-logbook';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './quick-tick-bar.module.css';
 
-interface QuickTickBarProps {
+/** Snapshot of the tick target taken when the bar is first opened with a valid climb. */
+interface TickTarget {
+  climb: Climb;
+  angle: Angle;
+  boardDetails: BoardDetails;
+  /** Number of prior logbook rows (any status) for this climb + angle at open time. */
+  priorCount: number;
+}
+
+export interface QuickTickBarProps {
   currentClimb: Climb | null;
   angle: Angle;
   boardDetails: BoardDetails;
@@ -25,6 +36,21 @@ interface QuickTickBarProps {
   onCancel: () => void;
 }
 
+const SWIPE_DISMISS_THRESHOLD = 80;
+const EXIT_DURATION_MS = 220;
+const SNAP_BACK_DURATION_MS = 180;
+
+/**
+ * Inline tick entry bar. Designed to be embedded in a parent row (e.g. the queue
+ * control bar) in place of the climb title. The component owns its own snapshot
+ * of the climb so that mid-flow changes to the active climb (party session
+ * navigation, etc.) do not cause the user to lose their in-progress tick.
+ *
+ * The confirm status is history-aware: if the user has no prior logbook rows
+ * for this climb + angle the tick is recorded as a `flash`, otherwise it is
+ * recorded as a `send` with `attemptCount = priorCount + 1`. This matches what
+ * a climber would expect when tapping a single "I sent it" button.
+ */
 export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   currentClimb,
   angle,
@@ -32,99 +58,203 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   onSave,
   onCancel,
 }) => {
-  const { saveTick } = useBoardProvider();
+  const { saveTick, logbook } = useBoardProvider();
+
+  // Snapshot the target climb the first time we get a non-null climb.
+  // All subsequent saves use this snapshot, not the live props.
+  const [tickTarget, setTickTarget] = useState<TickTarget | null>(() =>
+    currentClimb ? buildTickTarget(currentClimb, angle, boardDetails, logbook) : null,
+  );
+  useEffect(() => {
+    if (!tickTarget && currentClimb) {
+      setTickTarget(buildTickTarget(currentClimb, angle, boardDetails, logbook));
+    }
+    // Intentionally only re-runs while we have no snapshot yet. Once set, the
+    // snapshot is intentionally sticky until the component unmounts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentClimb, tickTarget]);
+
   const [quality, setQuality] = useState<number | null>(null);
   const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
   const [comment, setComment] = useState('');
   const [showComment, setShowComment] = useState(false);
+  const [commentFocused, setCommentFocused] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [gradeAnchorEl, setGradeAnchorEl] = useState<HTMLElement | null>(null);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [isDismissing, setIsDismissing] = useState(false);
   const commentRef = useRef<HTMLInputElement>(null);
+  const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const grades = TENSION_KILTER_GRADES;
 
-  // Focus comment field when shown
   useEffect(() => {
     if (showComment && commentRef.current) {
       commentRef.current.focus();
     }
   }, [showComment]);
 
+  useEffect(() => {
+    return () => {
+      if (dismissTimeoutRef.current) {
+        clearTimeout(dismissTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const selectedGrade = difficulty
     ? grades.find((g) => g.difficulty_id === difficulty)
     : undefined;
 
-  // Default grade from the climb's difficulty
-  const defaultGradeLabel = currentClimb?.difficulty ?? '';
+  // Default grade label falls back to the snapshot climb's own difficulty.
+  const defaultGradeLabel = tickTarget?.climb.difficulty ?? currentClimb?.difficulty ?? '';
 
-  const handleSave = useCallback(async (isAscent: boolean) => {
-    if (!currentClimb?.uuid || isSaving) return;
+  const handleSave = useCallback(
+    async (isAscent: boolean) => {
+      if (!tickTarget || isSaving) return;
 
-    setIsSaving(true);
-    try {
-      await saveTick({
-        climbUuid: currentClimb.uuid,
-        angle: Number(angle),
-        isMirror: !!currentClimb.mirrored,
-        status: isAscent ? 'flash' : 'attempt',
-        attemptCount: 1,
-        quality: quality ?? undefined,
-        difficulty,
-        isBenchmark: false,
-        comment: comment || '',
-        climbedAt: new Date().toISOString(),
-        layoutId: boardDetails.layout_id,
-        sizeId: boardDetails.size_id,
-        setIds: Array.isArray(boardDetails.set_ids)
-          ? boardDetails.set_ids.join(',')
-          : String(boardDetails.set_ids),
-      });
+      const { climb, angle: targetAngle, boardDetails: targetBoard, priorCount } = tickTarget;
 
-      track('Quick Tick Saved', {
-        boardLayout: boardDetails.layout_name || '',
-        status: isAscent ? 'flash' : 'attempt',
-        hasQuality: quality !== null,
-        hasDifficulty: difficulty !== undefined,
-        hasComment: comment.length > 0,
-      });
+      // History-aware status: flash only if no prior logs for this climb+angle.
+      // Attempts always record as a single attempt row.
+      let status: TickStatus;
+      let attemptCount: number;
+      if (isAscent) {
+        if (priorCount === 0) {
+          status = 'flash';
+          attemptCount = 1;
+        } else {
+          status = 'send';
+          attemptCount = priorCount + 1;
+        }
+      } else {
+        status = 'attempt';
+        attemptCount = 1;
+      }
 
-      onSave();
-    } catch (error) {
-      // Error is already shown via snackbar in useSaveTick
-      track('Quick Tick Failed', {
-        boardLayout: boardDetails.layout_name || '',
-      });
-    } finally {
-      setIsSaving(false);
-    }
-  }, [currentClimb, angle, quality, difficulty, comment, boardDetails, isSaving, saveTick, onSave]);
+      setIsSaving(true);
+      try {
+        await saveTick({
+          climbUuid: climb.uuid,
+          angle: Number(targetAngle),
+          isMirror: !!climb.mirrored,
+          status,
+          attemptCount,
+          quality: quality ?? undefined,
+          difficulty,
+          isBenchmark: false,
+          comment: comment || '',
+          climbedAt: new Date().toISOString(),
+          layoutId: targetBoard.layout_id,
+          sizeId: targetBoard.size_id,
+          setIds: Array.isArray(targetBoard.set_ids)
+            ? targetBoard.set_ids.join(',')
+            : String(targetBoard.set_ids),
+        });
+
+        track('Quick Tick Saved', {
+          boardLayout: targetBoard.layout_name || '',
+          status,
+          attemptCount,
+          hasQuality: quality !== null,
+          hasDifficulty: difficulty !== undefined,
+          hasComment: comment.length > 0,
+        });
+
+        onSave();
+      } catch {
+        // Error surfaced via snackbar inside useSaveTick.
+        track('Quick Tick Failed', {
+          boardLayout: targetBoard.layout_name || '',
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [tickTarget, quality, difficulty, comment, isSaving, saveTick, onSave],
+  );
 
   const handleConfirm = useCallback(() => handleSave(true), [handleSave]);
   const handleFail = useCallback(() => handleSave(false), [handleSave]);
 
-  return (
-    <div className={styles.tickBar}>
-      <div className={styles.controls}>
-        {/* Fail / log attempt */}
-        <IconButton
-          size="small"
-          onClick={handleFail}
-          disabled={isSaving}
-          sx={{ color: themeTokens.colors.error }}
-        >
-          <CloseOutlined fontSize="small" />
-        </IconButton>
+  const triggerDismiss = useCallback(() => {
+    if (isDismissing) return;
+    setIsDismissing(true);
+    // Slide the bar fully off-screen to the left, then tell the parent to close.
+    setSwipeOffset(-window.innerWidth);
+    dismissTimeoutRef.current = setTimeout(() => {
+      onCancel();
+    }, EXIT_DURATION_MS);
+  }, [isDismissing, onCancel]);
 
-        {/* Star rating */}
+  const swipeEnabled = !commentFocused && !isSaving && !isDismissing;
+
+  const swipeHandlers = useSwipeable({
+    onSwiping: (eventData) => {
+      if (!swipeEnabled) return;
+      // Only track horizontal left drags.
+      if (Math.abs(eventData.deltaY) > Math.abs(eventData.deltaX)) return;
+      if (eventData.deltaX > 0) {
+        setSwipeOffset(0);
+        return;
+      }
+      setSwipeOffset(eventData.deltaX);
+    },
+    onSwipedLeft: (eventData) => {
+      if (!swipeEnabled) return;
+      if (Math.abs(eventData.deltaX) >= SWIPE_DISMISS_THRESHOLD) {
+        triggerDismiss();
+      } else {
+        setSwipeOffset(0);
+      }
+    },
+    onSwiped: (eventData) => {
+      if (!swipeEnabled) return;
+      // Reset if we ended on any non-left direction.
+      if (eventData.dir !== 'Left') {
+        setSwipeOffset(0);
+      }
+    },
+    trackMouse: false,
+    preventScrollOnSwipe: true,
+    delta: 10,
+  });
+
+  const rootStyle = useMemo<React.CSSProperties>(() => {
+    const transition = isDismissing
+      ? `transform ${EXIT_DURATION_MS}ms ease-out, opacity ${EXIT_DURATION_MS}ms ease-out`
+      : swipeOffset === 0
+        ? `transform ${SNAP_BACK_DURATION_MS}ms ease-out`
+        : 'none';
+    return {
+      transform: `translateX(${swipeOffset}px)`,
+      opacity: isDismissing ? 0 : 1,
+      transition,
+    };
+  }, [swipeOffset, isDismissing]);
+
+  // Apply swipe handlers only when gesture capture is allowed so focused
+  // comment text selection, or in-flight saves, don't get hijacked.
+  const rootHandlers = swipeEnabled ? swipeHandlers : {};
+
+  return (
+    <div
+      {...rootHandlers}
+      className={styles.tickBar}
+      style={rootStyle}
+      data-testid="quick-tick-bar"
+    >
+      <div className={styles.controls}>
+        {/* Left group: rating, grade, comment toggle */}
         <Rating
           value={quality}
           onChange={(_, val) => setQuality(val)}
           size="small"
           max={5}
           sx={{ flexShrink: 0 }}
+          data-testid="quick-tick-rating"
         />
 
-        {/* Grade chip */}
         <Chip
           label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
           size="small"
@@ -139,7 +269,10 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           slotProps={{ paper: { sx: { maxHeight: 240 } } }}
         >
           <MenuItem
-            onClick={() => { setDifficulty(undefined); setGradeAnchorEl(null); }}
+            onClick={() => {
+              setDifficulty(undefined);
+              setGradeAnchorEl(null);
+            }}
           >
             —
           </MenuItem>
@@ -147,34 +280,66 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
             <MenuItem
               key={grade.difficulty_id}
               selected={grade.difficulty_id === difficulty}
-              onClick={() => { setDifficulty(grade.difficulty_id); setGradeAnchorEl(null); }}
+              onClick={() => {
+                setDifficulty(grade.difficulty_id);
+                setGradeAnchorEl(null);
+              }}
             >
               {grade.v_grade}
             </MenuItem>
           ))}
         </Menu>
 
-        {/* Comment toggle */}
         <IconButton
           size="small"
           onClick={() => setShowComment((prev) => !prev)}
           color={showComment ? 'primary' : 'default'}
+          aria-label="Toggle comment"
         >
           <ChatBubbleOutlineOutlined fontSize="small" />
         </IconButton>
 
-        {/* Confirm / save ascent */}
+        {/* Spacer pushes the attempt + confirm pair to the right edge so the
+            confirm icon lines up with the original tick button position. */}
+        <div className={styles.spacer} />
+
+        {/* Right group: attempt (X) immediately next to confirm (tick) */}
         <IconButton
           size="small"
+          onClick={handleFail}
+          disabled={isSaving}
+          sx={{ color: themeTokens.colors.error }}
+          aria-label="Log attempt"
+          data-testid="quick-tick-attempt"
+        >
+          <CloseOutlined fontSize="small" />
+        </IconButton>
+
+        <IconButton
           onClick={handleConfirm}
           disabled={isSaving}
-          sx={{ color: themeTokens.colors.success }}
+          sx={{
+            backgroundColor: themeTokens.colors.success,
+            color: 'common.white',
+            '&:hover': { backgroundColor: themeTokens.colors.successHover },
+          }}
+          aria-label="Confirm ascent"
+          data-testid="quick-tick-confirm"
         >
-          <CheckOutlined fontSize="small" />
+          <CheckOutlined />
         </IconButton>
       </div>
 
-      {/* Inline comment field */}
+      {/* Dismiss hint sits under the stars. Hidden while the comment field
+          is open to keep the bar compact. */}
+      {!showComment && (
+        <div className={styles.hintRow}>
+          <span className={styles.hint} data-testid="quick-tick-hint">
+            swipe left to dismiss
+          </span>
+        </div>
+      )}
+
       {showComment && (
         <div className={styles.commentRow}>
           <TextField
@@ -183,6 +348,8 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
             placeholder="Comment..."
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            onFocus={() => setCommentFocused(true)}
+            onBlur={() => setCommentFocused(false)}
             variant="standard"
             slotProps={{ htmlInput: { maxLength: 2000 } }}
             sx={{ flex: 1 }}
@@ -192,3 +359,29 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     </div>
   );
 };
+
+/** Count prior logbook rows for a given climb + angle. Exposed for tests. */
+export function countPriorLogs(
+  logbook: LogbookEntry[],
+  climbUuid: string,
+  angle: Angle,
+): number {
+  const numericAngle = Number(angle);
+  return logbook.filter(
+    (entry) => entry.climb_uuid === climbUuid && Number(entry.angle) === numericAngle,
+  ).length;
+}
+
+function buildTickTarget(
+  climb: Climb,
+  angle: Angle,
+  boardDetails: BoardDetails,
+  logbook: LogbookEntry[],
+): TickTarget {
+  return {
+    climb,
+    angle,
+    boardDetails,
+    priorCount: countPriorLogs(logbook, climb.uuid, angle),
+  };
+}

--- a/packages/web/app/components/play-view/play-view-comments.tsx
+++ b/packages/web/app/components/play-view/play-view-comments.tsx
@@ -77,7 +77,17 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
                   {dayjs(ascent.climbed_at).format('MMM D, YYYY')}
                 </Typography>
                 <Chip
-                  label={ascent.is_ascent ? (ascent.tries === 1 ? 'Flash' : 'Send') : 'Attempt'}
+                  label={
+                    ascent.status === 'flash'
+                      ? 'Flash'
+                      : ascent.status === 'send'
+                        ? 'Send'
+                        : ascent.is_ascent
+                          ? ascent.tries === 1
+                            ? 'Flash'
+                            : 'Send'
+                          : 'Attempt'
+                  }
                   size="small"
                   sx={{
                     height: themeTokens.spacing[5],

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -124,11 +124,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [dismissedDisconnect, setDismissedDisconnect] = useState(false);
 
-  // Close tick bar when climb changes (e.g. party session navigation)
-  const currentClimbUuid = currentClimb?.uuid;
-  useEffect(() => {
-    setActiveDrawer((prev) => prev === 'tick' ? 'none' : prev);
-  }, [currentClimbUuid]);
+  // Note: the tick bar intentionally stays open when the active climb changes
+  // (e.g. party session navigation). QuickTickBar snapshots its target climb
+  // internally so the user can finish ticking the climb they opened the bar
+  // for, even after someone else advances the queue.
 
   // Reset dismissed state when connection is restored so banner reappears on next disconnect
   useEffect(() => {

--- a/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
@@ -244,12 +244,15 @@ export function buildFlashRedpointBars(filteredLogbook: LogbookEntry[]): Grouped
   filteredLogbook.forEach((entry) => {
     if (entry.difficulty === null) return;
     const difficulty = difficultyMapping[entry.difficulty];
-    if (difficulty) {
-      if (entry.tries === 1) {
-        flash[difficulty] = (flash[difficulty] || 0) + 1;
-      } else if (entry.tries > 1) {
-        redpoint[difficulty] = (redpoint[difficulty] || 0) + entry.tries;
-      }
+    if (!difficulty) return;
+    // Prefer the canonical status field when available. Fall back to the old
+    // tries-based heuristic for legacy rows that don't have status set.
+    const isFlash = entry.status === 'flash' || (entry.status == null && entry.tries === 1);
+    const isRedpoint = entry.status === 'send' || (entry.status == null && entry.tries > 1);
+    if (isFlash) {
+      flash[difficulty] = (flash[difficulty] || 0) + 1;
+    } else if (isRedpoint) {
+      redpoint[difficulty] = (redpoint[difficulty] || 0) + Math.max(entry.tries, 1);
     }
   });
 


### PR DESCRIPTION
- Reorder the controls so the attempt (X) and confirm (check) buttons sit
  together at the right edge, matching the original tick button position.
- Add a subtle italic "swipe left to dismiss" hint under the stars and
  implement left-swipe dismissal via react-swipeable.
- Snapshot the climb, angle, board details and prior tick count when the
  bar opens so a party-session navigation no longer discards an
  in-progress tick.
- Make the confirm status history-aware: flash with attemptCount 1 for a
  first-ever send on a climb+angle, otherwise send with attemptCount =
  priorCount + 1.
- Remove the queue-control-bar effect that force-closed the bar on climb
  change; the new snapshot guarantees the correct climb is ticked.
- Add unit tests covering layout order, history-aware save, climb
  snapshot, and swipe-dismiss behaviour.