### PR TITLE
Disable branch deploy workflows

### DIFF
--- a/.github/workflows/branch-deploy-cleanup.yml
+++ b/.github/workflows/branch-deploy-cleanup.yml
@@ -1,8 +1,10 @@
 name: Branch Deploy Cleanup
 
 on:
-  pull_request:
-    types: [closed]
+  # Disabled - branch deploys are currently disabled
+  # pull_request:
+  #   types: [closed]
+  workflow_dispatch:
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/branch-deploy-sweep.yml
+++ b/.github/workflows/branch-deploy-sweep.yml
@@ -1,11 +1,13 @@
 name: Branch Deploy Sweep
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    # Run daily at 3am UTC
-    - cron: '0 3 * * *'
+  # Disabled - branch deploys are currently disabled
+  # push:
+  #   branches: [main]
+  # schedule:
+  #   # Run daily at 3am UTC
+  #   - cron: '0 3 * * *'
+  workflow_dispatch:
 
 jobs:
   sweep:

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -1,10 +1,11 @@
 name: Branch Deploy
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'mobile/**'
+  # Disabled until branch deploys are fixed
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  #   paths-ignore:
+  #     - 'mobile/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
- Comment out pull_request triggers in branch-deploy.yml, branch-deploy-cleanup.yml, and branch-deploy-sweep.yml
- Keep workflow_dispatch available for manual triggers when ready
- These workflows are currently broken and will be fixed later

https://claude.ai/code/session_013Th7A1Kxb1jsiZXpocWf6Z