### PR TITLE
fix(ble): improve adapter-factory test coverage and accuracy

### DIFF
--- a/packages/web/app/lib/ble/__tests__/adapter-factory.test.ts
+++ b/packages/web/app/lib/ble/__tests__/adapter-factory.test.ts
@@ -1,22 +1,27 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock capacitor-utils to allow per-test control over platform detection.
+// vi.mock is hoisted before imports, so adapter-factory sees the mocked version.
+vi.mock('../capacitor-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../capacitor-utils')>();
+  return {
+    ...actual,
+    isCapacitor: vi.fn().mockReturnValue(false),
+    isCapacitorWebView: vi.fn().mockReturnValue(false),
+    waitForCapacitor: vi.fn().mockResolvedValue(false),
+  };
+});
+
 import { createBluetoothAdapter, _resetFactoryCache } from '../adapter-factory';
+import { isCapacitor, isCapacitorWebView, waitForCapacitor } from '../capacitor-utils';
 
 describe('adapter-factory', () => {
-  let originalCapacitor: unknown;
-
   beforeEach(() => {
-    // Save original Capacitor state
-    originalCapacitor = (globalThis as unknown as Record<string, unknown>).Capacitor;
-  });
-
-  afterEach(() => {
-    // Restore original Capacitor state and reset cache
     _resetFactoryCache();
-    if (originalCapacitor === undefined) {
-      delete (globalThis as unknown as Record<string, unknown>).Capacitor;
-    } else {
-      (globalThis as unknown as Record<string, unknown>).Capacitor = originalCapacitor;
-    }
+    vi.clearAllMocks();
+    vi.mocked(isCapacitor).mockReturnValue(false);
+    vi.mocked(isCapacitorWebView).mockReturnValue(false);
+    vi.mocked(waitForCapacitor).mockResolvedValue(false);
   });
 
   describe('_resetFactoryCache', () => {
@@ -28,7 +33,6 @@ describe('adapter-factory', () => {
 
     it('allows multiple adapter detections by resetting cache state', async () => {
       // First call - should detect platform
-      delete (globalThis as unknown as Record<string, unknown>).Capacitor;
       const adapter1 = await createBluetoothAdapter('kilter');
       expect(adapter1).toBeDefined();
       expect(typeof adapter1.isAvailable).toBe('function');
@@ -45,9 +49,6 @@ describe('adapter-factory', () => {
 
   describe('createBluetoothAdapter', () => {
     it('returns an adapter with all required methods', async () => {
-      delete (globalThis as unknown as Record<string, unknown>).Capacitor;
-      _resetFactoryCache();
-
       const adapter = await createBluetoothAdapter('kilter');
 
       // Verify the adapter implements the BluetoothAdapter interface
@@ -58,15 +59,57 @@ describe('adapter-factory', () => {
       expect(typeof adapter.onDisconnect).toBe('function');
     });
 
-    it('returns consistent adapter instances from cache', async () => {
-      delete (globalThis as unknown as Record<string, unknown>).Capacitor;
-      _resetFactoryCache();
-
+    it('returns a WebBluetoothAdapter when Capacitor is not present', async () => {
       const adapter1 = await createBluetoothAdapter('kilter');
       const adapter2 = await createBluetoothAdapter('tension');
 
-      // Both should have the same constructor name (same adapter type, cached factory)
-      expect(adapter1.constructor.name).toBe(adapter2.constructor.name);
+      // Factory is cached after first detection — both board names get the same adapter type
+      expect(adapter1.constructor.name).toBe('WebBluetoothAdapter');
+      expect(adapter2.constructor.name).toBe('WebBluetoothAdapter');
+    });
+
+    it('returns a CapacitorBleAdapter when Capacitor is present', async () => {
+      vi.mocked(isCapacitor).mockReturnValue(true);
+
+      const adapter = await createBluetoothAdapter('kilter');
+
+      expect(adapter.constructor.name).toBe('CapacitorBleAdapter');
+    });
+
+    it('waits for Capacitor bridge when running in a WebView before selecting adapter', async () => {
+      // Simulate WebView context where bridge is not yet injected
+      vi.mocked(isCapacitorWebView).mockReturnValue(true);
+      // Bridge never becomes available (timeout)
+      vi.mocked(waitForCapacitor).mockResolvedValue(false);
+
+      const adapter = await createBluetoothAdapter('kilter');
+
+      expect(vi.mocked(waitForCapacitor)).toHaveBeenCalledOnce();
+      // Timed out waiting — falls back to WebBluetoothAdapter
+      expect(adapter.constructor.name).toBe('WebBluetoothAdapter');
+    });
+
+    it('uses CapacitorBleAdapter when WebView bridge becomes available after waiting', async () => {
+      // Simulate WebView context: isCapacitor() starts false, then true after wait
+      vi.mocked(isCapacitorWebView).mockReturnValue(true);
+      vi.mocked(waitForCapacitor).mockResolvedValue(true);
+      vi.mocked(isCapacitor)
+        .mockReturnValueOnce(false) // first check: !isCapacitor() → enters the wait branch
+        .mockReturnValue(true);     // second check: isCapacitor() → selects CapacitorBleAdapter
+
+      const adapter = await createBluetoothAdapter('kilter');
+
+      expect(vi.mocked(waitForCapacitor)).toHaveBeenCalledOnce();
+      expect(adapter.constructor.name).toBe('CapacitorBleAdapter');
+    });
+
+    it('skips WebView bridge wait when Capacitor is already present', async () => {
+      vi.mocked(isCapacitor).mockReturnValue(true);
+
+      await createBluetoothAdapter('kilter');
+
+      // Bridge is already ready — no need to poll for it
+      expect(vi.mocked(waitForCapacitor)).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
- Add vi.mock for capacitor-utils to enable per-test control over
  platform detection instead of manipulating globalThis.Capacitor
- Add test for CapacitorBleAdapter path when window.Capacitor is present
- Add tests for the WebView bridge waiting code path (both timeout and
  success scenarios), previously completely untested
- Add test verifying waitForCapacitor is skipped when Capacitor is ready
- Rename misleading test: factory caches the adapter class, not instances
- Remove unused afterEach/originalCapacitor boilerplate replaced by mocks
- Remove unused vi import (now properly used for mocking)

https://claude.ai/code/session_016Jq415X25LLHUxnwZtLd5L