### PR TITLE
Fix docstring/ternary readability and add null tickTarget tests

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -339,6 +339,45 @@ describe('QuickTickBar', () => {
     });
   });
 
+  describe('null currentClimb on mount', () => {
+    it('renders without crashing when currentClimb is initially null', () => {
+      render(<QuickTickBar {...defaultProps} currentClimb={null} />);
+      expect(screen.getByTestId('quick-tick-bar')).toBeTruthy();
+    });
+
+    it('does not call saveTick when currentClimb is null and confirm is clicked', async () => {
+      render(<QuickTickBar {...defaultProps} currentClimb={null} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).not.toHaveBeenCalled();
+      expect(defaultProps.onSave).not.toHaveBeenCalled();
+    });
+
+    it('defers the snapshot until a non-null climb arrives', async () => {
+      const climb = makeClimb({ uuid: 'deferred-climb' });
+      const { rerender } = render(<QuickTickBar {...defaultProps} currentClimb={null} />);
+
+      // Snapshot should be absent — confirm should be a no-op.
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+      expect(mockSaveTick).not.toHaveBeenCalled();
+
+      // Now provide a climb — the snapshot should be initialized.
+      rerender(<QuickTickBar {...defaultProps} currentClimb={climb} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
+      expect(mockSaveTick.mock.calls[0][0].climbUuid).toBe('deferred-climb');
+    });
+  });
+
   describe('climb snapshot', () => {
     it('keeps ticking the original climb even when currentClimb prop changes', async () => {
       const originalClimb = makeClimb({ uuid: 'original-climb' });

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -47,8 +47,8 @@ const SNAP_BACK_DURATION_MS = 180;
  * navigation, etc.) do not cause the user to lose their in-progress tick.
  *
  * Each tap on the bar logs exactly one row with `attemptCount: 1`. The status
- * is history-aware: if the user has no prior logbook rows for this climb +
- * angle the tick is recorded as a `flash`, otherwise it is recorded as a
+ * is history-aware: if the user has no prior logbook rows for this climb
+ * the tick is recorded as a `flash`, otherwise it is recorded as a
  * `send`. Totals are derived server-side by aggregating rows.
  */
 export const QuickTickBar: React.FC<QuickTickBarProps> = ({

--- a/packages/web/app/components/play-view/play-view-comments.tsx
+++ b/packages/web/app/components/play-view/play-view-comments.tsx
@@ -11,6 +11,14 @@ import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
 import dayjs from 'dayjs';
+import type { LogbookEntry } from '@/app/hooks/use-logbook';
+
+function getAscentChipLabel(ascent: LogbookEntry): string {
+  if (ascent.status === 'flash') return 'Flash';
+  if (ascent.status === 'send') return 'Send';
+  if (ascent.is_ascent) return ascent.tries === 1 ? 'Flash' : 'Send';
+  return 'Attempt';
+}
 
 interface PlayViewCommentsProps {
   climbUuid: string | undefined;
@@ -77,17 +85,7 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
                   {dayjs(ascent.climbed_at).format('MMM D, YYYY')}
                 </Typography>
                 <Chip
-                  label={
-                    ascent.status === 'flash'
-                      ? 'Flash'
-                      : ascent.status === 'send'
-                        ? 'Send'
-                        : ascent.is_ascent
-                          ? ascent.tries === 1
-                            ? 'Flash'
-                            : 'Send'
-                          : 'Attempt'
-                  }
+                  label={getAscentChipLabel(ascent)}
                   size="small"
                   sx={{
                     height: themeTokens.spacing[5],


### PR DESCRIPTION
- quick-tick-bar.tsx: remove incorrect "+ angle" from the history-aware
  flash/send docstring; hasPriorHistoryForClimb only filters by climb UUID
- play-view-comments.tsx: extract 4-level nested ternary chip label into
  getAscentChipLabel helper for readability
- quick-tick-bar.test.tsx: add three tests covering null currentClimb on
  mount (renders without crash, confirm is a no-op, deferred snapshot init)

https://claude.ai/code/session_011i3EDiuHNLgh4N97EPU2kf