### PR TITLE
Tighten QuickTickBar layout and brighten dismiss hint

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -170,20 +170,30 @@ describe('QuickTickBar', () => {
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
-      // Same parent (the .controls flex row).
-      expect(rating.parentElement).toBe(commentToggle.parentElement);
-      expect(rating.parentElement).toBe(attemptBtn.parentElement);
-      expect(rating.parentElement).toBe(confirmBtn.parentElement);
+      // Stars + comment toggle live in the same leftGroupRow wrapper.
+      const leftGroupRow = rating.parentElement!;
+      expect(commentToggle.parentElement).toBe(leftGroupRow);
 
-      const siblings = Array.from(rating.parentElement!.children) as HTMLElement[];
-      const ratingIdx = siblings.indexOf(rating);
-      const commentIdx = siblings.indexOf(commentToggle);
-      const attemptIdx = siblings.indexOf(attemptBtn);
-      const confirmIdx = siblings.indexOf(confirmBtn);
+      // The leftGroupRow lives inside a leftGroup column, which sits inside
+      // the .controls flex row alongside the attempt and confirm buttons.
+      const leftGroup = leftGroupRow.parentElement!;
+      const controls = leftGroup.parentElement!;
+      expect(attemptBtn.parentElement).toBe(controls);
+      expect(confirmBtn.parentElement).toBe(controls);
 
-      expect(ratingIdx).toBeLessThan(commentIdx);
-      expect(commentIdx).toBeLessThan(attemptIdx);
-      // The X must be the DOM sibling immediately before the confirm tick.
+      // Within the leftGroupRow, stars come before the comment toggle.
+      const innerSiblings = Array.from(leftGroupRow.children) as HTMLElement[];
+      expect(innerSiblings.indexOf(rating)).toBeLessThan(
+        innerSiblings.indexOf(commentToggle),
+      );
+
+      // Within the controls row, the leftGroup must come before the attempt
+      // button, and the X must be the immediate sibling before the tick.
+      const controlsSiblings = Array.from(controls.children) as HTMLElement[];
+      const leftGroupIdx = controlsSiblings.indexOf(leftGroup);
+      const attemptIdx = controlsSiblings.indexOf(attemptBtn);
+      const confirmIdx = controlsSiblings.indexOf(confirmBtn);
+      expect(leftGroupIdx).toBeLessThan(attemptIdx);
       expect(confirmIdx).toBe(attemptIdx + 1);
     });
 

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -23,31 +23,32 @@
 .controls {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--space-1, 4px);
   flex: 1;
   min-width: 0;
 }
 
-.spacer {
-  flex: 1 1 auto;
+.leftGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   min-width: 0;
 }
 
-.hintRow {
-  /* Align the hint underneath the star rating. The MUI Rating small size sits
-     at the very start of the controls row, so no left padding is needed. */
+.leftGroupRow {
   display: flex;
   align-items: center;
-  padding-left: 2px;
-  margin-top: -2px;
-  line-height: 1;
+  gap: var(--space-1, 4px);
+  min-width: 0;
 }
 
 .hint {
-  font-size: 10px;
+  font-size: 11px;
   font-style: italic;
+  line-height: 1;
+  margin-top: 1px;
   color: var(--mui-palette-text-secondary, rgba(0, 0, 0, 0.6));
-  opacity: 0.7;
   user-select: none;
   pointer-events: none;
 }

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -239,63 +239,72 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Left group: rating, grade, comment toggle */}
-        <Rating
-          value={quality}
-          onChange={(_, val) => setQuality(val)}
-          size="small"
-          max={5}
-          sx={{ flexShrink: 0 }}
-          data-testid="quick-tick-rating"
-        />
+        {/* Left group packs rating + grade + comment toggle together and
+            keeps the dismiss hint aligned directly under the stars. The
+            whole group sits next to the attempt/confirm pair thanks to
+            `justify-content: flex-end` on .controls. */}
+        <div className={styles.leftGroup}>
+          <div className={styles.leftGroupRow}>
+            <Rating
+              value={quality}
+              onChange={(_, val) => setQuality(val)}
+              size="small"
+              max={5}
+              sx={{ flexShrink: 0 }}
+              data-testid="quick-tick-rating"
+            />
 
-        <Chip
-          label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
-          size="small"
-          variant={difficulty ? 'filled' : 'outlined'}
-          className={styles.gradeChip}
-          onClick={(e) => setGradeAnchorEl(e.currentTarget)}
-        />
-        <Menu
-          anchorEl={gradeAnchorEl}
-          open={Boolean(gradeAnchorEl)}
-          onClose={() => setGradeAnchorEl(null)}
-          slotProps={{ paper: { sx: { maxHeight: 240 } } }}
-        >
-          <MenuItem
-            onClick={() => {
-              setDifficulty(undefined);
-              setGradeAnchorEl(null);
-            }}
-          >
-            —
-          </MenuItem>
-          {grades.map((grade) => (
-            <MenuItem
-              key={grade.difficulty_id}
-              selected={grade.difficulty_id === difficulty}
-              onClick={() => {
-                setDifficulty(grade.difficulty_id);
-                setGradeAnchorEl(null);
-              }}
+            <Chip
+              label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
+              size="small"
+              variant={difficulty ? 'filled' : 'outlined'}
+              className={styles.gradeChip}
+              onClick={(e) => setGradeAnchorEl(e.currentTarget)}
+            />
+            <Menu
+              anchorEl={gradeAnchorEl}
+              open={Boolean(gradeAnchorEl)}
+              onClose={() => setGradeAnchorEl(null)}
+              slotProps={{ paper: { sx: { maxHeight: 240 } } }}
             >
-              {grade.v_grade}
-            </MenuItem>
-          ))}
-        </Menu>
+              <MenuItem
+                onClick={() => {
+                  setDifficulty(undefined);
+                  setGradeAnchorEl(null);
+                }}
+              >
+                —
+              </MenuItem>
+              {grades.map((grade) => (
+                <MenuItem
+                  key={grade.difficulty_id}
+                  selected={grade.difficulty_id === difficulty}
+                  onClick={() => {
+                    setDifficulty(grade.difficulty_id);
+                    setGradeAnchorEl(null);
+                  }}
+                >
+                  {grade.v_grade}
+                </MenuItem>
+              ))}
+            </Menu>
 
-        <IconButton
-          size="small"
-          onClick={() => setShowComment((prev) => !prev)}
-          color={showComment ? 'primary' : 'default'}
-          aria-label="Toggle comment"
-        >
-          <ChatBubbleOutlineOutlined fontSize="small" />
-        </IconButton>
+            <IconButton
+              size="small"
+              onClick={() => setShowComment((prev) => !prev)}
+              color={showComment ? 'primary' : 'default'}
+              aria-label="Toggle comment"
+            >
+              <ChatBubbleOutlineOutlined fontSize="small" />
+            </IconButton>
+          </div>
 
-        {/* Spacer pushes the attempt + confirm pair to the right edge so the
-            confirm icon lines up with the original tick button position. */}
-        <div className={styles.spacer} />
+          {!showComment && (
+            <span className={styles.hint} data-testid="quick-tick-hint">
+              swipe left to dismiss
+            </span>
+          )}
+        </div>
 
         {/* Right group: attempt (X) immediately next to confirm (tick) */}
         <IconButton
@@ -323,16 +332,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           <CheckOutlined />
         </IconButton>
       </div>
-
-      {/* Dismiss hint sits under the stars. Hidden while the comment field
-          is open to keep the bar compact. */}
-      {!showComment && (
-        <div className={styles.hintRow}>
-          <span className={styles.hint} data-testid="quick-tick-hint">
-            swipe left to dismiss
-          </span>
-        </div>
-      )}
 
       {showComment && (
         <div className={styles.commentRow}>


### PR DESCRIPTION
Packs the rating, grade chip, and comment toggle next to the X/check
buttons via a leftGroup wrapper and justify-content: flex-end, so the
whole control cluster sits on the right next to the thumbnail's empty
space. The "swipe left to dismiss" hint now lives inside the same
wrapper as the stars, keeping it aligned without a brittle padding
hack, and drops the extra opacity multiplier + bumps to 11px so it's
actually readable on dark backgrounds.

https://claude.ai/code/session_01WAegj28ELz1dJ78Fjt5Wq5