### PR TITLE
Stop row click on climb list items from opening the play drawer

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -248,23 +248,39 @@ export default function LikedClimbsList({
     isFetching: isFetchingNextPage,
   });
 
-  const handleClimbDoubleClick = useCallback((climb: Climb) => {
+  // Row click: activates the climb but does NOT open the play drawer.
+  // Only the thumbnail (list mode) or card cover (grid mode) opens the drawer.
+  const handleClimbSelect = useCallback((climb: Climb) => {
+    setSelectedClimbUuid(climb.uuid);
+    setCurrentClimb(climb);
+  }, [setCurrentClimb]);
+
+  // Thumbnail / card-cover click: activates the climb and opens the play drawer.
+  const handleClimbOpenDrawer = useCallback((climb: Climb) => {
     setSelectedClimbUuid(climb.uuid);
     setCurrentClimb(climb);
     dispatchOpenPlayDrawer();
-    track('Liked Climb Card Double Clicked', {
+    track('Liked Climb Card Clicked', {
       climbUuid: climb.uuid,
       angle: climb.angle,
     });
   }, [setCurrentClimb]);
 
-  const climbHandlersMap = useMemo(() => {
+  const selectHandlersMap = useMemo(() => {
     const map = new Map<string, () => void>();
     visibleClimbs.forEach(climb => {
-      map.set(climb.uuid, () => handleClimbDoubleClick(climb));
+      map.set(climb.uuid, () => handleClimbSelect(climb));
     });
     return map;
-  }, [visibleClimbs, handleClimbDoubleClick]);
+  }, [visibleClimbs, handleClimbSelect]);
+
+  const openDrawerHandlersMap = useMemo(() => {
+    const map = new Map<string, () => void>();
+    visibleClimbs.forEach(climb => {
+      map.set(climb.uuid, () => handleClimbOpenDrawer(climb));
+    });
+    return map;
+  }, [visibleClimbs, handleClimbOpenDrawer]);
 
   const sentinelStyle = useMemo(
     () => ({ minHeight: '20px', marginTop: '16px' }),
@@ -357,7 +373,7 @@ export default function LikedClimbsList({
               <ClimbCard
                 climb={climb}
                 boardDetails={boardDetails}
-                onCoverClick={climbHandlersMap.get(climb.uuid)}
+                onCoverClick={openDrawerHandlersMap.get(climb.uuid)}
               />
             </Box>
           ))}
@@ -374,8 +390,8 @@ export default function LikedClimbsList({
               boardDetails={boardDetails}
               pathname={pathname}
               isDark={isDark}
-              onSelect={climbHandlersMap.get(climb.uuid)}
-              onThumbnailClick={climbHandlersMap.get(climb.uuid)}
+              onSelect={selectHandlersMap.get(climb.uuid)}
+              onThumbnailClick={openDrawerHandlersMap.get(climb.uuid)}
               onOpenActions={handleOpenActions}
               onOpenPlaylistSelector={handleOpenPlaylistSelector}
               addToQueue={addToQueue}

--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 
@@ -23,8 +23,28 @@ vi.mock('next/dynamic', () => ({
 }));
 
 vi.mock('../../climb-card/climb-list-item', () => ({
-  default: ({ climb }: { climb: Climb }) => (
+  default: ({
+    climb,
+    onSelect,
+    onThumbnailClick,
+  }: {
+    climb: Climb;
+    onSelect?: () => void;
+    onThumbnailClick?: () => void;
+  }) => (
     <div data-testid="climb-list-item" data-uuid={climb.uuid}>
+      <span
+        data-testid={`row-${climb.uuid}`}
+        role="button"
+        aria-hidden
+        onClick={() => onSelect?.()}
+      />
+      <span
+        data-testid={`thumb-${climb.uuid}`}
+        role="button"
+        aria-hidden
+        onClick={() => onThumbnailClick?.()}
+      />
       {climb.name}
     </div>
   ),
@@ -263,6 +283,65 @@ describe('ClimbsList virtualization', () => {
 
     const items = screen.getAllByTestId('climb-list-item');
     expect(items).toHaveLength(5);
+  });
+});
+
+describe('ClimbsList thumbnail vs row click', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastVirtualizerOpts = null;
+  });
+
+  it('row click activates the climb but does NOT open the play drawer', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    const onClimbSelect = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 3)}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onClimbSelect={onClimbSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('row-climb-0'));
+
+    expect(onClimbSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'climb-0' }),
+    );
+    const dispatched = dispatchSpy.mock.calls.some(
+      ([event]) => event instanceof CustomEvent && event.type === 'boardsesh:open-play-drawer',
+    );
+    expect(dispatched).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it('thumbnail click activates the climb AND opens the play drawer', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    const onClimbSelect = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 3)}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onClimbSelect={onClimbSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('thumb-climb-0'));
+
+    expect(onClimbSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'climb-0' }),
+    );
+    const dispatched = dispatchSpy.mock.calls.some(
+      ([event]) => event instanceof CustomEvent && event.type === 'boardsesh:open-play-drawer',
+    );
+    expect(dispatched).toBe(true);
+    dispatchSpy.mockRestore();
   });
 });
 

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -1,11 +1,10 @@
 'use client';
-import React, { useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueActions, useCurrentClimb, useSearchData } from '../graphql-queue';
 import ClimbsList from './climbs-list';
 import { stabilizeClimbArrayRef } from './climb-list-utils';
-import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
 import RecentSearchPills from '../search-drawer/recent-search-pills';
 import AngleSelector from './angle-selector';
 
@@ -70,13 +69,6 @@ const BoardPageClimbsList = ({
     return deduped;
   }, [hasDoneFirstFetch, initialClimbs, climbSearchResults]);
 
-  // Clicking a climb in the list activates it and opens the play view drawer.
-  // Matches queue items, queue suggestions, and liked list behavior.
-  const handleClimbSelect = useCallback((climb: Climb) => {
-    setCurrentClimb(climb);
-    dispatchOpenPlayDrawer();
-  }, [setCurrentClimb]);
-
   const headerInline = useMemo(() => <RecentSearchPills />, []);
 
   const angleSelectorElement = useMemo(
@@ -99,7 +91,7 @@ const BoardPageClimbsList = ({
       selectedClimbUuid={currentClimb?.uuid}
       isFetching={isFetchingClimbs}
       hasMore={hasMoreResults}
-      onClimbSelect={handleClimbSelect}
+      onClimbSelect={setCurrentClimb}
       addToQueue={addToQueue}
       onLoadMore={fetchMoreClimbs}
       headerInline={headerInline}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -24,6 +24,7 @@ import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { SelectionStoreContext, useSelectionStore } from './selected-climb-store';
+import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
 import listStyles from './climbs-list.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), { ssr: false });
@@ -336,10 +337,22 @@ const ClimbsList = ({
     isFetching,
   });
 
+  // Row click: activates the climb but does NOT open the play drawer.
+  // Only the thumbnail (list mode) or card cover (grid mode) opens the drawer.
   const handleClimbClickByIndex = useCallback((index: number) => {
     const climb = climbs[index];
     if (climb) {
       onClimbSelectRef.current?.(climb);
+      track('Climb List Item Clicked', { climbUuid: climb.uuid });
+    }
+  }, [climbs]);
+
+  // Thumbnail / card-cover click: activates the climb and opens the play drawer.
+  const handleClimbThumbnailClickByIndex = useCallback((index: number) => {
+    const climb = climbs[index];
+    if (climb) {
+      onClimbSelectRef.current?.(climb);
+      dispatchOpenPlayDrawer();
       track('Climb List Item Clicked', { climbUuid: climb.uuid });
     }
   }, [climbs]);
@@ -519,7 +532,7 @@ const ClimbsList = ({
                 boardDetails={resolveBoardDetails(climb)}
                 preferImageLayers={index < initialImageCount}
                 unsupported={unsupportedClimbs?.has(climb.uuid)}
-                onClimbClickByIndex={handleClimbClickByIndex}
+                onClimbClickByIndex={handleClimbThumbnailClickByIndex}
                 renderItemExtra={renderItemExtra}
               />
             </Box>
@@ -561,7 +574,7 @@ const ClimbsList = ({
                       isDark={isDark}
                       preferImageLayers={index < initialImageCount}
                       onSelect={() => handleClimbClickByIndex(index)}
-                      onThumbnailClick={() => handleClimbClickByIndex(index)}
+                      onThumbnailClick={() => handleClimbThumbnailClickByIndex(index)}
                       disableSwipe={!hydrated}
                       unsupported={unsupportedClimbs?.has(climb.uuid)}
                       onOpenActions={handleOpenActions}


### PR DESCRIPTION
The list-standardization commit (0df9d9a) wired both onSelect (row
click) and onThumbnailClick to the same handler that activates the
climb AND dispatches the play drawer event. That made any press on a
list row open the drawer, which is not the intended behavior.

Restore the original split: row click only activates the climb,
while the thumbnail (in list mode) or card cover (in grid mode) also
opens the play drawer. The drawer dispatch now lives inside
ClimbsList / LikedClimbsList so the parent's onClimbSelect prop is
back to being a pure "set active climb" callback.

- board-page-climbs-list.tsx: onClimbSelect reverts to setCurrentClimb.
- climbs-list.tsx: new handleClimbThumbnailClickByIndex that sets the
  climb and dispatches the play drawer event. Wired into the grid
  card cover click and the list item onThumbnailClick; row onSelect
  keeps calling the activate-only handler.
- liked-climbs-list.tsx: split into handleClimbSelect (row) and
  handleClimbOpenDrawer (thumbnail / grid card cover).
- climbs-list-virtualization.test.tsx: regression tests asserting
  that the row click does not dispatch boardsesh:open-play-drawer
  and the thumbnail click does.

https://claude.ai/code/session_0158iY8HXAA5vztzKucRjJRY