### PR TITLE
Make Playlists the default Library tab and fix logbook issues

### DIFF
--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -202,6 +202,8 @@ const createTablesSQL = `
     "created_at" timestamp DEFAULT now() NOT NULL,
     "updated_at" timestamp DEFAULT now() NOT NULL,
     "session_id" text,
+    "inferred_session_id" text,
+    "previous_inferred_session_id" text,
     "board_id" bigint,
     "aurora_type" text,
     "aurora_id" text,

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db } from '../db/client';
+import { tickQueries } from '../graphql/resolvers/ticks/queries';
+
+/**
+ * Integration tests for the tick query resolvers, covering the three behavior
+ * fixes added in the playlists-default-logbook PR:
+ *
+ *   1. `flashOnly: true` returns ONLY flashes (not flashes + attempts).
+ *   2. `climbName` searches escape LIKE wildcards (`%` / `_` are literal).
+ *   3. `userGroupedAscentsFeed` paginates groups in SQL with the correct
+ *      totalCount and bucket-by-day grouping (no UTC timezone shifts).
+ */
+
+const TEST_USER_ID = 'tick-queries-test-user';
+const OTHER_USER_ID = 'tick-queries-other-user';
+const CLIMB_PREFIX = 'tick-queries-test-climb-';
+
+type FeedItem = {
+  uuid: string;
+  status: string;
+  climbName: string;
+  climbedAt: string;
+};
+
+type FeedResult = {
+  items: FeedItem[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+type GroupedItem = {
+  uuid: string;
+  status: string;
+  climbedAt: string;
+};
+
+type Group = {
+  climbUuid: string;
+  climbName: string;
+  date: string;
+  items: GroupedItem[];
+  flashCount: number;
+  sendCount: number;
+  attemptCount: number;
+};
+
+type GroupedResult = {
+  groups: Group[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+const callUserAscentsFeed = (userId: string, input: Record<string, unknown>) =>
+  tickQueries.userAscentsFeed(undefined, { userId, input }) as Promise<FeedResult>;
+
+const callUserGroupedAscentsFeed = (userId: string, input: Record<string, unknown>) =>
+  tickQueries.userGroupedAscentsFeed(undefined, { userId, input }) as Promise<GroupedResult>;
+
+const insertUser = async (id: string) => {
+  await db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'Test ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+};
+
+const insertClimb = async (uuid: string, name: string) => {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${uuid}, 'kilter', 1, 'test-setter', ${name}, 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+};
+
+const insertTick = async (params: {
+  uuid: string;
+  userId?: string;
+  climbUuid: string;
+  climbedAt: string;
+  status: 'flash' | 'send' | 'attempt';
+  attemptCount?: number;
+}) => {
+  const userId = params.userId ?? TEST_USER_ID;
+  const attemptCount = params.attemptCount ?? 1;
+  await db.execute(sql`
+    INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, climbed_at)
+    VALUES (${params.uuid}, ${userId}, 'kilter', ${params.climbUuid}, 40, ${params.status}, ${attemptCount}, ${params.climbedAt})
+  `);
+};
+
+const cleanup = async () => {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${CLIMB_PREFIX + '%'}`);
+};
+
+describe('tickQueries — behavior fixes', () => {
+  beforeAll(async () => {
+    await insertUser(TEST_USER_ID);
+    await insertUser(OTHER_USER_ID);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe('userAscentsFeed — flashOnly filter', () => {
+    it('returns only flashes when flashOnly=true regardless of statusMode', async () => {
+      const climbUuid = CLIMB_PREFIX + 'flash-only';
+      await insertClimb(climbUuid, 'Flash Only Test');
+
+      await insertTick({ uuid: 'tick-flash-1', climbUuid, climbedAt: '2026-01-01 10:00:00', status: 'flash' });
+      await insertTick({ uuid: 'tick-send-1', climbUuid, climbedAt: '2026-01-02 10:00:00', status: 'send', attemptCount: 3 });
+      await insertTick({ uuid: 'tick-attempt-1', climbUuid, climbedAt: '2026-01-03 10:00:00', status: 'attempt', attemptCount: 5 });
+
+      // statusMode=both + flashOnly=true: previously this returned flash + attempts.
+      const result = await callUserAscentsFeed(TEST_USER_ID, { statusMode: 'both', flashOnly: true, limit: 50 });
+
+      expect(result.items.every((item) => item.status === 'flash')).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('returns flash+send when flashOnly=false and statusMode=send', async () => {
+      const climbUuid = CLIMB_PREFIX + 'send-mode';
+      await insertClimb(climbUuid, 'Send Mode Test');
+
+      await insertTick({ uuid: 'tick-flash-2', climbUuid, climbedAt: '2026-01-01 10:00:00', status: 'flash' });
+      await insertTick({ uuid: 'tick-send-2', climbUuid, climbedAt: '2026-01-02 10:00:00', status: 'send', attemptCount: 2 });
+      await insertTick({ uuid: 'tick-attempt-2', climbUuid, climbedAt: '2026-01-03 10:00:00', status: 'attempt', attemptCount: 4 });
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { statusMode: 'send', flashOnly: false, limit: 50 });
+
+      const statuses = result.items.map((item) => item.status).sort();
+      expect(statuses).toEqual(['flash', 'send']);
+    });
+
+    it('returns only attempts when statusMode=attempt', async () => {
+      const climbUuid = CLIMB_PREFIX + 'attempt-mode';
+      await insertClimb(climbUuid, 'Attempt Mode Test');
+
+      await insertTick({ uuid: 'tick-flash-3', climbUuid, climbedAt: '2026-01-01 10:00:00', status: 'flash' });
+      await insertTick({ uuid: 'tick-attempt-3', climbUuid, climbedAt: '2026-01-02 10:00:00', status: 'attempt', attemptCount: 2 });
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { statusMode: 'attempt', limit: 50 });
+
+      expect(result.items.every((item) => item.status === 'attempt')).toBe(true);
+      expect(result.items).toHaveLength(1);
+    });
+  });
+
+  describe('userAscentsFeed — climbName LIKE escaping', () => {
+    it('matches a literal % in the search string instead of treating it as a wildcard', async () => {
+      const literalUuid = CLIMB_PREFIX + 'literal-percent';
+      const decoyUuid = CLIMB_PREFIX + 'decoy';
+      await insertClimb(literalUuid, '100% Crimps');
+      await insertClimb(decoyUuid, 'All Jugs');
+
+      await insertTick({ uuid: 'tick-literal-1', climbUuid: literalUuid, climbedAt: '2026-01-01 10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-decoy-1', climbUuid: decoyUuid, climbedAt: '2026-01-02 10:00:00', status: 'send' });
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { climbName: '100%', limit: 50 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].climbName).toBe('100% Crimps');
+    });
+
+    it('treats _ as a literal underscore, not a single-char wildcard', async () => {
+      const literalUuid = CLIMB_PREFIX + 'literal-underscore';
+      const decoyUuid = CLIMB_PREFIX + 'decoy-underscore';
+      await insertClimb(literalUuid, 'V_Five');
+      await insertClimb(decoyUuid, 'VxFive'); // would match `V_Five` if _ were a wildcard
+
+      await insertTick({ uuid: 'tick-underscore-1', climbUuid: literalUuid, climbedAt: '2026-01-01 10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-underscore-2', climbUuid: decoyUuid, climbedAt: '2026-01-02 10:00:00', status: 'send' });
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { climbName: 'V_Five', limit: 50 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].climbName).toBe('V_Five');
+    });
+
+    it('still matches plain substrings', async () => {
+      const climbUuid = CLIMB_PREFIX + 'plain-substring';
+      await insertClimb(climbUuid, 'Sloper Madness');
+
+      await insertTick({ uuid: 'tick-plain-1', climbUuid, climbedAt: '2026-01-01 10:00:00', status: 'send' });
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { climbName: 'Sloper', limit: 50 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].climbName).toBe('Sloper Madness');
+    });
+  });
+
+  describe('userGroupedAscentsFeed — pagination & grouping', () => {
+    it('returns empty groups + totalCount=0 when the user has no ticks', async () => {
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.groups).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns one group with one item for a single tick', async () => {
+      const climbUuid = CLIMB_PREFIX + 'single-tick';
+      await insertClimb(climbUuid, 'Single Tick Climb');
+      await insertTick({ uuid: 'tick-single-1', climbUuid, climbedAt: '2026-02-01 10:00:00', status: 'send' });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.totalCount).toBe(1);
+      expect(result.hasMore).toBe(false);
+      expect(result.groups[0].climbUuid).toBe(climbUuid);
+      expect(result.groups[0].items).toHaveLength(1);
+      expect(result.groups[0].sendCount).toBe(1);
+      expect(result.groups[0].date).toBe('2026-02-01');
+    });
+
+    it('groups multiple ticks on the same climb on the same day into a single group', async () => {
+      const climbUuid = CLIMB_PREFIX + 'multi-attempt';
+      await insertClimb(climbUuid, 'Project');
+
+      await insertTick({ uuid: 'tick-proj-1', climbUuid, climbedAt: '2026-02-05 09:00:00', status: 'attempt', attemptCount: 3 });
+      await insertTick({ uuid: 'tick-proj-2', climbUuid, climbedAt: '2026-02-05 14:00:00', status: 'attempt', attemptCount: 2 });
+      await insertTick({ uuid: 'tick-proj-3', climbUuid, climbedAt: '2026-02-05 16:00:00', status: 'send', attemptCount: 4 });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.totalCount).toBe(1);
+      expect(result.groups[0].items).toHaveLength(3);
+      expect(result.groups[0].sendCount).toBe(1);
+      expect(result.groups[0].attemptCount).toBe(2);
+      expect(result.groups[0].date).toBe('2026-02-05');
+    });
+
+    it('keeps ticks on the same climb on different days as separate groups', async () => {
+      const climbUuid = CLIMB_PREFIX + 'multi-day';
+      await insertClimb(climbUuid, 'Multi Day Project');
+
+      await insertTick({ uuid: 'tick-md-1', climbUuid, climbedAt: '2026-03-01 11:00:00', status: 'attempt', attemptCount: 3 });
+      await insertTick({ uuid: 'tick-md-2', climbUuid, climbedAt: '2026-03-02 11:00:00', status: 'attempt', attemptCount: 2 });
+      await insertTick({ uuid: 'tick-md-3', climbUuid, climbedAt: '2026-03-03 11:00:00', status: 'send', attemptCount: 1 });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.groups).toHaveLength(3);
+      expect(result.totalCount).toBe(3);
+      // Newest first
+      expect(result.groups.map((g) => g.date)).toEqual(['2026-03-03', '2026-03-02', '2026-03-01']);
+    });
+
+    it('does NOT shift the day for ticks logged late at night (no UTC timezone bug)', async () => {
+      // The previous implementation used `to_char(...AT TIME ZONE 'UTC', 'YYYY-MM-DD')`
+      // which could shift wall-clock-late-at-night ticks into the next UTC day.
+      // climbed_at is `timestamp without time zone` and stores wall-clock time, so
+      // grouping should reflect the literal stored date with no zone math.
+      const climbUuid = CLIMB_PREFIX + 'late-night';
+      await insertClimb(climbUuid, 'Late Night Send');
+
+      await insertTick({ uuid: 'tick-late-1', climbUuid, climbedAt: '2026-04-01 23:30:00', status: 'send', attemptCount: 1 });
+      await insertTick({ uuid: 'tick-late-2', climbUuid, climbedAt: '2026-04-02 00:30:00', status: 'send', attemptCount: 1 });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.groups).toHaveLength(2);
+      expect(result.groups.map((g) => g.date).sort()).toEqual(['2026-04-01', '2026-04-02']);
+    });
+
+    it('paginates groups in SQL with correct totalCount and hasMore', async () => {
+      // Create 5 distinct (climb, day) groups with one tick each.
+      for (let i = 0; i < 5; i++) {
+        const climbUuid = `${CLIMB_PREFIX}page-${i}`;
+        await insertClimb(climbUuid, `Page Climb ${i}`);
+        await insertTick({
+          uuid: `tick-page-${i}`,
+          climbUuid,
+          // i=0 is oldest, i=4 is newest — descending order in the response should be 4,3,2,1,0
+          climbedAt: `2026-05-0${i + 1} 12:00:00`,
+          status: 'send',
+        });
+      }
+
+      const page1 = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 2, offset: 0 });
+      expect(page1.groups).toHaveLength(2);
+      expect(page1.totalCount).toBe(5);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.groups.map((g) => g.date)).toEqual(['2026-05-05', '2026-05-04']);
+
+      const page2 = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 2, offset: 2 });
+      expect(page2.groups).toHaveLength(2);
+      expect(page2.totalCount).toBe(5);
+      expect(page2.hasMore).toBe(true);
+      expect(page2.groups.map((g) => g.date)).toEqual(['2026-05-03', '2026-05-02']);
+
+      const page3 = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 2, offset: 4 });
+      expect(page3.groups).toHaveLength(1);
+      expect(page3.totalCount).toBe(5);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.groups.map((g) => g.date)).toEqual(['2026-05-01']);
+    });
+
+    it('only returns groups for the requested user', async () => {
+      const climbUuid = CLIMB_PREFIX + 'multi-user';
+      await insertClimb(climbUuid, 'Shared Climb');
+
+      await insertTick({ uuid: 'tick-mine', userId: TEST_USER_ID, climbUuid, climbedAt: '2026-06-01 10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-theirs', userId: OTHER_USER_ID, climbUuid, climbedAt: '2026-06-01 10:00:00', status: 'send' });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+
+      expect(result.totalCount).toBe(1);
+      expect(result.groups).toHaveLength(1);
+      expect(result.groups[0].items).toHaveLength(1);
+      expect(result.groups[0].items[0].uuid).toBe('tick-mine');
+    });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -220,7 +220,7 @@ export const tickQueries = {
           : inArray(dbSchema.boardseshTicks.status, ['flash', 'send'])
       );
     } else if (flashOnly) {
-      tickConditions.push(inArray(dbSchema.boardseshTicks.status, ['flash', 'attempt']));
+      tickConditions.push(eq(dbSchema.boardseshTicks.status, 'flash'));
     }
 
     if (benchmarkOnly) {
@@ -264,11 +264,15 @@ export const tickQueries = {
         )
       );
 
+    // Escape LIKE wildcards so user input is treated as a literal substring,
+    // not a SQL pattern (e.g. typing "100%" should match the literal string).
+    const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (char) => `\\${char}`);
+
     // Full conditions including climb name filter (requires JOIN)
     const allConditions = [
       ...tickConditions,
       ...(layoutIds && layoutIds.length > 0 ? [inArray(dbSchema.boardClimbs.layoutId, layoutIds)] : []),
-      ...(climbName ? [ilike(dbSchema.boardClimbs.name, `%${climbName}%`)] : []),
+      ...(climbName ? [ilike(dbSchema.boardClimbs.name, `%${escapeLikePattern(climbName)}%`)] : []),
     ];
 
     // Get total count
@@ -380,7 +384,11 @@ export const tickQueries = {
 
   /**
    * Get ascent activity feed grouped by climb and day (public query)
-   * Groups multiple attempts on the same climb on the same day into a single entry
+   * Groups multiple attempts on the same climb on the same day into a single entry.
+   *
+   * Pagination is applied to (climbUuid, day) groups directly in SQL so the
+   * resolver returns the correct totalCount and never silently truncates a
+   * user's history.
    */
   userGroupedAscentsFeed: async (
     _: unknown,
@@ -395,11 +403,56 @@ export const tickQueries = {
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
 
-    // Fetch recent ticks with climb and grade data
-    // We limit to 500 most recent ticks to prevent memory issues for very active users
-    // This provides enough data for typical pagination while keeping memory usage bounded
-    const MAX_FETCH_LIMIT = 500;
-    const results = await db
+    const dayExpr = sql<string>`to_char(${dbSchema.boardseshTicks.climbedAt}::timestamptz AT TIME ZONE 'UTC', 'YYYY-MM-DD')`;
+
+    // 1) Page of (climbUuid, day) keys, ordered by latest activity in that group.
+    //    Bounds the SQL fetch to exactly the groups we'll return.
+    const pageGroups = await db
+      .select({
+        climbUuid: dbSchema.boardseshTicks.climbUuid,
+        day: dayExpr.as('day'),
+        latestClimbedAt: sql<string>`max(${dbSchema.boardseshTicks.climbedAt})`.as('latest_climbed_at'),
+      })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.userId, userId))
+      .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
+      .orderBy(sql`max(${dbSchema.boardseshTicks.climbedAt}) desc`)
+      .limit(limit)
+      .offset(offset);
+
+    // 2) True total group count — runs in parallel with the data fetch below.
+    const totalCountPromise = db
+      .select({ count: count() })
+      .from(
+        db
+          .select({
+            climbUuid: dbSchema.boardseshTicks.climbUuid,
+            day: dayExpr.as('day'),
+          })
+          .from(dbSchema.boardseshTicks)
+          .where(eq(dbSchema.boardseshTicks.userId, userId))
+          .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
+          .as('group_keys'),
+      );
+
+    if (pageGroups.length === 0) {
+      const totalCountResult = await totalCountPromise;
+      const totalCount = Number(totalCountResult[0]?.count ?? 0);
+      return { groups: [], totalCount, hasMore: false };
+    }
+
+    // 3) Fetch every tick belonging to this page of groups in a single query.
+    //    We narrow by climbUuid + a date window first, then refilter by the
+    //    exact (climbUuid, day) tuples in JS — Drizzle has no clean tuple-IN
+    //    helper, and pages are small (≤ limit groups) so the over-fetch is
+    //    bounded.
+    const climbUuidsInPage = Array.from(new Set(pageGroups.map((g) => g.climbUuid)));
+    const daysInPage = pageGroups.map((g) => g.day).sort();
+    const minDay = daysInPage[0];
+    const maxDay = daysInPage[daysInPage.length - 1];
+    const pageKeySet = new Set(pageGroups.map((g) => `${g.climbUuid}-${g.day}`));
+
+    const tickRows = await db
       .select({
         tick: dbSchema.boardseshTicks,
         climbName: dbSchema.boardClimbs.name,
@@ -407,6 +460,7 @@ export const tickQueries = {
         layoutId: dbSchema.boardClimbs.layoutId,
         frames: dbSchema.boardClimbs.frames,
         difficultyName: dbSchema.boardDifficultyGrades.boulderName,
+        day: dayExpr.as('day'),
       })
       .from(dbSchema.boardseshTicks)
       .leftJoin(
@@ -423,11 +477,16 @@ export const tickQueries = {
           eq(dbSchema.boardseshTicks.boardType, dbSchema.boardDifficultyGrades.boardType)
         )
       )
-      .where(eq(dbSchema.boardseshTicks.userId, userId))
-      .orderBy(desc(dbSchema.boardseshTicks.climbedAt))
-      .limit(MAX_FETCH_LIMIT);
+      .where(
+        and(
+          eq(dbSchema.boardseshTicks.userId, userId),
+          inArray(dbSchema.boardseshTicks.climbUuid, climbUuidsInPage),
+          gte(dayExpr, minDay),
+          lte(dayExpr, maxDay),
+        )
+      )
+      .orderBy(desc(dbSchema.boardseshTicks.climbedAt));
 
-    // Group items by climbUuid and day
     type AscentItem = {
       uuid: string;
       climbUuid: string;
@@ -467,15 +526,14 @@ export const tickQueries = {
       attemptCount: number;
       bestQuality: number | null;
       latestComment: string | null;
-      latestClimbedAt: string;
     };
 
     const groupMap = new Map<string, GroupedAscent>();
 
-    for (const { tick, climbName, setterUsername, layoutId, frames, difficultyName } of results) {
-      // Extract date from climbedAt (YYYY-MM-DD)
-      const date = tick.climbedAt.split('T')[0];
-      const key = `${tick.climbUuid}-${date}`;
+    for (const { tick, climbName, setterUsername, layoutId, frames, difficultyName, day } of tickRows) {
+      const key = `${tick.climbUuid}-${day}`;
+      // Skip ticks that fell inside the date window but belong to a different group.
+      if (!pageKeySet.has(key)) continue;
 
       const item: AscentItem = {
         uuid: tick.uuid,
@@ -497,8 +555,9 @@ export const tickQueries = {
         frames,
       };
 
-      if (!groupMap.has(key)) {
-        groupMap.set(key, {
+      let group = groupMap.get(key);
+      if (!group) {
+        group = {
           key,
           climbUuid: tick.climbUuid,
           climbName: climbName || 'Unknown Climb',
@@ -510,21 +569,19 @@ export const tickQueries = {
           frames,
           difficultyName,
           isBenchmark: tick.isBenchmark ?? false,
-          date,
+          date: day,
           items: [],
           flashCount: 0,
           sendCount: 0,
           attemptCount: 0,
           bestQuality: null,
           latestComment: null,
-          latestClimbedAt: tick.climbedAt,
-        });
+        };
+        groupMap.set(key, group);
       }
 
-      const group = groupMap.get(key)!;
       group.items.push(item);
 
-      // Update counts
       if (tick.status === 'flash') {
         group.flashCount++;
       } else if (tick.status === 'send') {
@@ -533,36 +590,24 @@ export const tickQueries = {
         group.attemptCount++;
       }
 
-      // Track best quality rating
       if (tick.quality !== null) {
         if (group.bestQuality === null || tick.quality > group.bestQuality) {
           group.bestQuality = tick.quality;
         }
       }
 
-      // Track latest comment (prefer non-empty)
       if (tick.comment && !group.latestComment) {
         group.latestComment = tick.comment;
       }
-
-      // Track latest climbedAt for sorting
-      if (tick.climbedAt > group.latestClimbedAt) {
-        group.latestClimbedAt = tick.climbedAt;
-      }
     }
 
-    // Convert to array and sort by latest activity
-    const allGroups = Array.from(groupMap.values()).sort(
-      (a, b) => new Date(b.latestClimbedAt).getTime() - new Date(a.latestClimbedAt).getTime()
-    );
+    // Preserve the SQL-decided page ordering (by latest activity).
+    const groups = pageGroups
+      .map((pg) => groupMap.get(`${pg.climbUuid}-${pg.day}`))
+      .filter((g): g is GroupedAscent => g !== undefined);
 
-    const totalCount = allGroups.length;
-
-    // Apply pagination to groups
-    const paginatedGroups = allGroups.slice(offset, offset + limit);
-
-    // Remove latestClimbedAt from final output (internal use only)
-    const groups = paginatedGroups.map(({ latestClimbedAt, ...rest }) => rest);
+    const totalCountResult = await totalCountPromise;
+    const totalCount = Number(totalCountResult[0]?.count ?? 0);
 
     return {
       groups,

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -403,7 +403,12 @@ export const tickQueries = {
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
 
-    const dayExpr = sql<string>`to_char(${dbSchema.boardseshTicks.climbedAt}::timestamptz AT TIME ZONE 'UTC', 'YYYY-MM-DD')`;
+    // boardsesh_ticks.climbed_at is `timestamp without time zone` storing the
+    // climber's wall-clock time at the moment of the tick (the rest of the
+    // codebase reads it back via `dayjs(...).utc(true)` to preserve that wall
+    // clock — see ascents-feed.tsx). Group by the literal stored date so a
+    // session ending at 11pm local doesn't bleed into the next day.
+    const dayExpr = sql<string>`to_char(${dbSchema.boardseshTicks.climbedAt}, 'YYYY-MM-DD')`;
 
     // 1) Page of (climbUuid, day) keys, ordered by latest activity in that group.
     //    Bounds the SQL fetch to exactly the groups we'll return.

--- a/packages/web/app/components/activity-feed/ascents-feed.module.css
+++ b/packages/web/app/components/activity-feed/ascents-feed.module.css
@@ -6,6 +6,8 @@
 
 .feed {
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .feedItem {
@@ -91,6 +93,8 @@
   border-radius: 4px; /* borderRadius.sm */
   margin-top: 4px;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .loading {

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -20,7 +20,7 @@ import Badge from '@mui/material/Badge';
 import { usePathname, useRouter } from 'next/navigation';
 import { track } from '@vercel/analytics';
 import { BoardDetails, BoardName } from '@/app/lib/types';
-import { constructClimbListWithSlugs, constructBoardSlugListUrl, tryConstructSlugListUrl, generateLayoutSlug, generateSizeSlug, generateSetSlug, searchParamsToUrlParams, getContextAwarePlaylistUrl, getLogbookBasePath } from '@/app/lib/url-utils';
+import { constructClimbListWithSlugs, constructBoardSlugListUrl, tryConstructSlugListUrl, generateLayoutSlug, generateSizeSlug, generateSetSlug, searchParamsToUrlParams, getContextAwarePlaylistUrl, getPlaylistsBasePath } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { PlaylistsContext } from '../climb-actions/playlists-batch-context';
@@ -277,14 +277,14 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     track('Bottom Tab Bar', { tab: 'climbs' });
   };
 
-  const logbookUrl = getLogbookBasePath(pathname);
+  const playlistsUrl = getPlaylistsBasePath(pathname);
 
   const handleLibraryTab = () => {
     setIsCreateOpen(false);
     setIsCreatePlaylistOpen(false);
     const currentUrl = pathname + (typeof window !== 'undefined' ? window.location.search : '');
-    if (logbookUrl !== currentUrl) {
-      router.push(logbookUrl);
+    if (playlistsUrl !== currentUrl) {
+      router.push(playlistsUrl);
     }
     track('Bottom Tab Bar', { tab: 'library' });
   };

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -90,7 +90,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
   return (
     <MuiCard className={styles.feedItem}>
       <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
-        <Box sx={{ display: 'flex', gap: '12px' }}>
+        <Box sx={{ display: 'flex', gap: 1.5 }}>
           {item.frames && item.layoutId && (
             <AscentThumbnail
               boardType={item.boardType}
@@ -103,9 +103,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
             />
           )}
 
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, minWidth: 0 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '4px' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px', flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 0.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, minWidth: 0 }}>
                 <Chip
                   icon={statusDisplay.icon as React.ReactElement}
                   label={statusDisplay.label}
@@ -118,7 +118,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
                   {item.climbName}
                 </MuiTypography>
               </Box>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px', flexShrink: 0 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, flexShrink: 0 }}>
                 <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.timeAgo}>
                   {timeAgo}
                 </MuiTypography>
@@ -144,7 +144,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
               </Box>
             </Box>
 
-            <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
               {item.consensusDifficultyName && (
                 <Chip label={`Consensus ${item.consensusDifficultyName}`} size="small" variant="outlined" />
               )}

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -127,14 +127,14 @@ function LogbookItemSkeleton() {
   return (
     <MuiCard className={feedStyles.feedItem}>
       <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
-        <Box sx={{ display: 'flex', gap: '12px' }}>
+        <Box sx={{ display: 'flex', gap: 1.5 }}>
           <Skeleton variant="rounded" width={64} height={64} animation="wave" sx={{ flexShrink: 0 }} />
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, minWidth: 0 }}>
-            <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
               <Skeleton variant="rounded" width={80} height={24} animation="wave" />
               <Skeleton variant="rounded" width={100} height={16} animation="wave" />
             </Box>
-            <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
               <Skeleton variant="rounded" width={40} height={24} animation="wave" />
               <Skeleton variant="rounded" width={48} height={24} animation="wave" />
             </Box>
@@ -241,6 +241,20 @@ export default function LogbookFeed() {
   const closeFilterMenu = useCallback(() => setFilterAnchorEl(null), []);
   const closeSortMenu = useCallback(() => setSortAnchorEl(null), []);
   const closeBoardMenu = useCallback(() => setBoardAnchorEl(null), []);
+
+  const handleBoardChipClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const value = event.currentTarget.dataset.boardFilter as BoardFilter | undefined;
+      if (!value) return;
+      setBoardFilter(value);
+      if (value !== 'all' && BOARD_LAYOUT_OPTIONS[value].length > 1) {
+        setBoardAnchorEl(event.currentTarget);
+      } else {
+        setBoardAnchorEl(null);
+      }
+    },
+    [],
+  );
 
   const applyFilters = useCallback(() => {
     setFilters({
@@ -392,7 +406,7 @@ export default function LogbookFeed() {
       />
 
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap' }}>
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', flex: 1, minWidth: 220 }}>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
           {BOARD_OPTIONS.map((opt) => (
             <Chip
               key={opt.value}
@@ -400,14 +414,8 @@ export default function LogbookFeed() {
               size="small"
               variant={boardFilter === opt.value ? 'filled' : 'outlined'}
               color={boardFilter === opt.value ? 'primary' : 'default'}
-              onClick={(event) => {
-                setBoardFilter(opt.value);
-                if (opt.value !== 'all' && BOARD_LAYOUT_OPTIONS[opt.value].length > 1) {
-                  setBoardAnchorEl(event.currentTarget);
-                } else {
-                  setBoardAnchorEl(null);
-                }
-              }}
+              data-board-filter={opt.value}
+              onClick={handleBoardChipClick}
             />
           ))}
         </Box>
@@ -442,7 +450,7 @@ export default function LogbookFeed() {
     return (
       <>
         {filterBar}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
           {Array.from({ length: 5 }).map((_, i) => (
             <LogbookItemSkeleton key={i} />
           ))}
@@ -497,7 +505,7 @@ export default function LogbookFeed() {
     <>
       {filterBar}
       <div className={feedStyles.feed}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
           {items.map((item) => (
             <LogbookFeedItem key={item.uuid} item={item} showBoardType={showBoardType} onDelete={handleDelete} />
           ))}

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -54,8 +54,8 @@ export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
 
   if (!summary) {
     return (
-      <Typography variant="body2" component="span" color="text.secondary" sx={{ display: 'block', textAlign: 'center', padding: '16px 0' }}>
-        <BookOutlined style={{ marginRight: 8 }} />
+      <Typography variant="body2" component="span" color="text.secondary" sx={{ display: 'block', textAlign: 'center', py: 2 }}>
+        <BookOutlined sx={{ mr: 1, verticalAlign: 'middle' }} />
         No ascents logged for this climb
       </Typography>
     );

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -23,15 +23,14 @@ interface LogbookViewProps {
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const { logbook, boardName } = useBoardProvider();
 
-  // Filter ascents for current climb and sort by climbed_at
-  const climbAscents = logbook
-    .filter((ascent) => ascent.climb_uuid === currentClimb.uuid)
-    .sort((a, b) => {
-      // Parse dates using dayjs and compare them
-      const dateA = dayjs(a.climbed_at);
-      const dateB = dayjs(b.climbed_at);
-      return dateB.valueOf() - dateA.valueOf(); // Descending order (newest first)
-    });
+  // Filter ascents for current climb and sort by climbed_at (newest first)
+  const climbAscents = useMemo(
+    () =>
+      logbook
+        .filter((ascent) => ascent.climb_uuid === currentClimb.uuid)
+        .sort((a, b) => dayjs(b.climbed_at).valueOf() - dayjs(a.climbed_at).valueOf()),
+    [logbook, currentClimb.uuid],
+  );
 
   const showMirrorTag = boardName === 'tension';
 

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -70,7 +70,7 @@ export default function LibraryPageContent({
   const hasInitialDiscoverData = initialDiscoverPlaylists != null;
 
   const [hasMounted, setHasMounted] = useState(false);
-  const [activeTab, setActiveTab] = useState<'playlists' | 'logbook'>('logbook');
+  const [activeTab, setActiveTab] = useState<'playlists' | 'logbook'>('playlists');
   // Initialize selectedBoard from SSR data immediately when boardSlug is provided
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
     () => findMatchingBoard(initialMyBoards, boardSlug),
@@ -97,7 +97,7 @@ export default function LibraryPageContent({
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    document.title = activeTab === 'logbook' ? 'Logbook | Boardsesh' : 'Playlists | Boardsesh';
+    document.title = activeTab === 'playlists' ? 'Playlists | Boardsesh' : 'Logbook | Boardsesh';
   }, [activeTab]);
 
   // Auto-select the matching board once boards finish loading (fallback for non-SSR paths)
@@ -329,8 +329,8 @@ export default function LibraryPageContent({
         onChange={handleTabChange}
         sx={{ mb: 2, minHeight: 36, '& .MuiTab-root': { minHeight: 36, textTransform: 'none', fontWeight: 500 } }}
       >
-        <Tab value="logbook" label="Logbook" />
         <Tab value="playlists" label="Playlists" />
+        <Tab value="logbook" label="Logbook" />
       </Tabs>
 
       {/* Board Selector */}


### PR DESCRIPTION
- Tapping the Library bottom-tab now lands on /playlists instead of
  /logbook, and Playlists is the first/default internal tab. Users with
  a saved 'libraryTab' preference still land on whichever tab they last
  picked.
- Fix horizontal scrolling on the logbook view: drop the 220px minWidth
  on the board-chip row, add overflow-wrap to .comment so long URLs in
  tick comments don't blow out card width, and add a max-width guard on
  the .feed wrapper.
- Audit/clean up the contributed logbook code:
  * Backend: 'flashOnly' was returning flashes plus attempts when status
    mode was 'both' — now it returns only flashes.
  * Backend: escape % / _ / \\ in climb-name search so user input is
    treated as a literal substring instead of a LIKE pattern.
  * Backend: rewrite userGroupedAscentsFeed to do (climbUuid, day)
    grouping in SQL with a real total count, removing the silent 500-row
    truncation that dropped history for active users.
  * Frontend: useMemo the per-climb logbook filter/sort, and replace
    inline chip onClick closures with a single delegated handler.
  * Replace hardcoded px gaps in the logbook feed with MUI spacing
    tokens per project guidelines.

https://claude.ai/code/session_01T1idGaNoQgVknJVq5fkh3m