### PR TITLE
Fix duplicate analytics event names for climb list clicks

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -343,7 +343,7 @@ const ClimbsList = ({
     const climb = climbs[index];
     if (climb) {
       onClimbSelectRef.current?.(climb);
-      track('Climb List Item Clicked', { climbUuid: climb.uuid });
+      track('Climb List Row Clicked', { climbUuid: climb.uuid });
     }
   }, [climbs]);
 
@@ -353,7 +353,7 @@ const ClimbsList = ({
     if (climb) {
       onClimbSelectRef.current?.(climb);
       dispatchOpenPlayDrawer();
-      track('Climb List Item Clicked', { climbUuid: climb.uuid });
+      track('Climb List Cover Clicked', { climbUuid: climb.uuid });
     }
   }, [climbs]);
 


### PR DESCRIPTION
Replace ambiguous 'Climb List Item Clicked' event with distinct event names:
- 'Climb List Row Clicked' for row clicks (list view, no drawer open)
- 'Climb List Cover Clicked' for thumbnail/cover clicks (opens play drawer)

This allows analytics to distinguish between different interaction types on the climb list.

https://claude.ai/code/session_01SqFKoUd8fKhWeHgM9bpsAX