### PR TITLE
Tighten queue control bar spacing and fix tick-mode alignment

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -170,37 +170,23 @@ describe('QuickTickBar', () => {
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
-      // Stars + comment toggle live in the same leftGroupRow wrapper.
-      const leftGroupRow = rating.parentElement!;
-      expect(commentToggle.parentElement).toBe(leftGroupRow);
-
-      // The leftGroupRow lives inside a leftGroup column, which sits inside
-      // the .controls flex row alongside the attempt and confirm buttons.
-      const leftGroup = leftGroupRow.parentElement!;
-      const controls = leftGroup.parentElement!;
+      // All controls are direct siblings inside a single flex row so they
+      // share a single vertically-centered baseline with the climb title.
+      const controls = rating.parentElement!;
+      expect(commentToggle.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
-      // Within the leftGroupRow, stars come before the comment toggle.
-      const innerSiblings = Array.from(leftGroupRow.children) as HTMLElement[];
-      expect(innerSiblings.indexOf(rating)).toBeLessThan(
-        innerSiblings.indexOf(commentToggle),
-      );
-
-      // Within the controls row, the leftGroup must come before the attempt
-      // button, and the X must be the immediate sibling before the tick.
-      const controlsSiblings = Array.from(controls.children) as HTMLElement[];
-      const leftGroupIdx = controlsSiblings.indexOf(leftGroup);
-      const attemptIdx = controlsSiblings.indexOf(attemptBtn);
-      const confirmIdx = controlsSiblings.indexOf(confirmBtn);
-      expect(leftGroupIdx).toBeLessThan(attemptIdx);
+      // The siblings must appear in this order: rating, ..., comment toggle,
+      // ..., attempt (X), confirm (tick) as the final pair.
+      const siblings = Array.from(controls.children) as HTMLElement[];
+      const ratingIdx = siblings.indexOf(rating);
+      const commentIdx = siblings.indexOf(commentToggle);
+      const attemptIdx = siblings.indexOf(attemptBtn);
+      const confirmIdx = siblings.indexOf(confirmBtn);
+      expect(ratingIdx).toBeLessThan(commentIdx);
+      expect(commentIdx).toBeLessThan(attemptIdx);
       expect(confirmIdx).toBe(attemptIdx + 1);
-    });
-
-    it('shows the "swipe left to dismiss" hint text by default', () => {
-      render(<QuickTickBar {...defaultProps} />);
-      const hint = screen.getByTestId('quick-tick-hint');
-      expect(hint.textContent).toMatch(/swipe left to dismiss/i);
     });
   });
 

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -23,34 +23,14 @@
 .controls {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: var(--space-1, 4px);
   flex: 1;
   min-width: 0;
 }
 
-.leftGroup {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  min-width: 0;
-}
-
-.leftGroupRow {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1, 4px);
-  min-width: 0;
-}
-
-.hint {
-  font-size: 11px;
-  font-style: italic;
-  line-height: 1;
-  margin-top: 1px;
-  color: var(--mui-palette-text-secondary, rgba(0, 0, 0, 0.6));
-  user-select: none;
-  pointer-events: none;
+.spacer {
+  flex: 1;
+  min-width: var(--space-1, 4px);
 }
 
 .commentRow {

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -239,83 +239,75 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Left group packs rating + grade + comment toggle together and
-            keeps the dismiss hint aligned directly under the stars. The
-            whole group sits next to the attempt/confirm pair thanks to
-            `justify-content: flex-end` on .controls. */}
-        <div className={styles.leftGroup}>
-          <div className={styles.leftGroupRow}>
-            <Rating
-              value={quality}
-              onChange={(_, val) => setQuality(val)}
-              size="small"
-              max={5}
-              sx={{ flexShrink: 0 }}
-              data-testid="quick-tick-rating"
-            />
+        {/* Single horizontal row: rating, grade, comment toggle, then attempt (X)
+            and confirm (tick). All elements center-align vertically. */}
+        <Rating
+          value={quality}
+          onChange={(_, val) => setQuality(val)}
+          size="small"
+          max={5}
+          sx={{ flexShrink: 0 }}
+          data-testid="quick-tick-rating"
+        />
 
-            <Chip
-              label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
-              size="small"
-              variant={difficulty ? 'filled' : 'outlined'}
-              className={styles.gradeChip}
-              onClick={(e) => setGradeAnchorEl(e.currentTarget)}
-            />
-            <Menu
-              anchorEl={gradeAnchorEl}
-              open={Boolean(gradeAnchorEl)}
-              onClose={() => setGradeAnchorEl(null)}
-              slotProps={{ paper: { sx: { maxHeight: 240 } } }}
+        <Chip
+          label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
+          size="small"
+          variant={difficulty ? 'filled' : 'outlined'}
+          className={styles.gradeChip}
+          onClick={(e) => setGradeAnchorEl(e.currentTarget)}
+        />
+        <Menu
+          anchorEl={gradeAnchorEl}
+          open={Boolean(gradeAnchorEl)}
+          onClose={() => setGradeAnchorEl(null)}
+          slotProps={{ paper: { sx: { maxHeight: 240 } } }}
+        >
+          <MenuItem
+            onClick={() => {
+              setDifficulty(undefined);
+              setGradeAnchorEl(null);
+            }}
+          >
+            —
+          </MenuItem>
+          {grades.map((grade) => (
+            <MenuItem
+              key={grade.difficulty_id}
+              selected={grade.difficulty_id === difficulty}
+              onClick={() => {
+                setDifficulty(grade.difficulty_id);
+                setGradeAnchorEl(null);
+              }}
             >
-              <MenuItem
-                onClick={() => {
-                  setDifficulty(undefined);
-                  setGradeAnchorEl(null);
-                }}
-              >
-                —
-              </MenuItem>
-              {grades.map((grade) => (
-                <MenuItem
-                  key={grade.difficulty_id}
-                  selected={grade.difficulty_id === difficulty}
-                  onClick={() => {
-                    setDifficulty(grade.difficulty_id);
-                    setGradeAnchorEl(null);
-                  }}
-                >
-                  {grade.v_grade}
-                </MenuItem>
-              ))}
-            </Menu>
+              {grade.v_grade}
+            </MenuItem>
+          ))}
+        </Menu>
 
-            <IconButton
-              size="small"
-              onClick={() => setShowComment((prev) => !prev)}
-              color={showComment ? 'primary' : 'default'}
-              aria-label="Toggle comment"
-            >
-              <ChatBubbleOutlineOutlined fontSize="small" />
-            </IconButton>
-          </div>
-
-          {!showComment && (
-            <span className={styles.hint} data-testid="quick-tick-hint">
-              swipe left to dismiss
-            </span>
-          )}
-        </div>
-
-        {/* Right group: attempt (X) immediately next to confirm (tick) */}
         <IconButton
           size="small"
+          onClick={() => setShowComment((prev) => !prev)}
+          color={showComment ? 'primary' : 'default'}
+          aria-label="Toggle comment"
+        >
+          <ChatBubbleOutlineOutlined fontSize="small" />
+        </IconButton>
+
+        <span className={styles.spacer} />
+
+        <IconButton
           onClick={handleFail}
           disabled={isSaving}
-          sx={{ color: themeTokens.colors.error }}
+          sx={{
+            backgroundColor: themeTokens.colors.error,
+            color: 'common.white',
+            '&:hover': { backgroundColor: themeTokens.colors.error },
+          }}
           aria-label="Log attempt"
           data-testid="quick-tick-attempt"
         >
-          <CloseOutlined fontSize="small" />
+          <CloseOutlined />
         </IconButton>
 
         <IconButton

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -411,7 +411,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
           <div
             className={styles.swipeContainer}
             style={{
-              padding: `6px ${themeTokens.spacing[3]}px 6px ${themeTokens.spacing[3]}px`,
+              padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
               backgroundColor: gradeTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
             }}
           >
@@ -478,7 +478,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
             {...swipeHandlers}
             className={styles.swipeContainer}
             style={{
-              padding: `6px ${themeTokens.spacing[3]}px 6px ${themeTokens.spacing[3]}px`,
+              padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
               backgroundColor: gradeTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
             }}
           >
@@ -549,8 +549,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
               {/* Button cluster — hidden when tick bar is active to give full width */}
               {!tickBarActive && (
-              <Box sx={{ flex: 'none', marginLeft: `${themeTokens.spacing[2]}px` }}>
-                <Stack direction="row" spacing={1}>
+              <Box sx={{ flex: 'none', marginLeft: `${themeTokens.spacing[1]}px` }}>
+                <Stack direction="row" spacing={0.5}>
                   {/* Mirror button - desktop only */}
                   {boardDetails.supportsMirroring ? (
                     <span className={styles.desktopOnly}>
@@ -591,7 +591,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   )}
                   {/* Navigation buttons - desktop only */}
                   <span className={styles.navButtons}>
-                    <Stack direction="row" spacing={1}>
+                    <Stack direction="row" spacing={0.5}>
                       <PreviousClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                       <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                     </Stack>


### PR DESCRIPTION
Shrink the gap between the V-grade and the right-side buttons in the
queue control bar, and give the bar a little more vertical room so the
tick-mode row can sit on a single horizontally-centered baseline with
the climb title. Flatten the QuickTickBar into a single flex row (no
more stacked hint) and render the attempt X as a filled red circle
matching the green confirm tick.