### PR TITLE
Fix library tabs being hidden under global header

### DIFF
--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -2,6 +2,7 @@
 
 .pageContainer {
   padding: 16px;
+  padding-top: calc(var(--global-header-height) + 16px);
   min-height: 100vh;
   background-color: var(--neutral-50);
   max-width: 800px;

--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -2,6 +2,7 @@
 
 .pageContainer {
   padding: 16px;
+  padding-top: calc(var(--global-header-height) + 16px);
   min-height: 100vh;
   background-color: var(--neutral-50);
   max-width: 1400px;
@@ -196,6 +197,7 @@
 @media (max-width: 767px) {
   .pageContainer {
     padding: 12px;
+    padding-top: calc(var(--global-header-height) + 12px);
   }
 
   .actionsSection {

--- a/packages/web/app/playlists/layout.tsx
+++ b/packages/web/app/playlists/layout.tsx
@@ -6,7 +6,7 @@ export default function MyLibraryLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <div style={{ minHeight: '100dvh', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {children}
     </div>
   );


### PR DESCRIPTION
### Motivation
- After removing the sub-header/angle row the Library tabs and playlist/logbook content could render beneath the fixed global header, making tabs unresponsive on some routes.

### Description
- Removed the inline `paddingTop: 'var(--global-header-height)'` from the library route wrapper in `packages/web/app/playlists/layout.tsx` so per-page containers control header spacing.
- Added header-aware top padding to the shared library page container in `packages/web/app/components/library/library.module.css` via `padding-top: calc(var(--global-header-height) + 16px)` so tabs and content appear below the global header.
- Added matching header-aware top padding to the playlist detail page in `packages/web/app/components/library/playlist-view.module.css`, including a mobile override using `padding-top: calc(var(--global-header-height) + 12px)`.

### Testing
- Ran `pnpm -C packages/web exec eslint app/playlists/layout.tsx`, which failed due to missing ESLint config in this environment (ESLint reported no `eslint.config.*` file).
- Ran `pnpm -C packages/web lint`, which failed because `oxlint` is unavailable / `node_modules` are not installed in this environment, so automated linting could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ba95b9a08326b2931572f5b038a8)