### PR TITLE
Lazily mount UserDrawer sub-drawers to reduce home-page render cost

### DIFF
--- a/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
+++ b/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
@@ -30,9 +30,10 @@ interface MyBoardsDrawerProps {
   open: boolean;
   onClose: () => void;
   onCreateBoard?: () => void;
+  onTransitionEnd?: (open: boolean) => void;
 }
 
-export default function MyBoardsDrawer({ open, onClose, onCreateBoard }: MyBoardsDrawerProps) {
+export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransitionEnd }: MyBoardsDrawerProps) {
   const { boards, isLoading, error } = useMyBoards(open);
   const { token } = useWsAuthToken();
   const [view, setView] = useState<DrawerView>({ type: 'list' });
@@ -121,6 +122,7 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard }: MyBoard
       placement="bottom"
       open={open}
       onClose={handleClose}
+      onTransitionEnd={onTransitionEnd}
       height="100%"
       fullHeight
       extra={headerExtra}

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -60,8 +60,11 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const { openAuthModal } = useAuthModal();
   const [showHoldClassification, setShowHoldClassification] = useState(false);
   const [showBoardSelector, setShowBoardSelector] = useState(false);
+  const [boardSelectorRendered, setBoardSelectorRendered] = useState(false);
   const [showCustomBoard, setShowCustomBoard] = useState(false);
+  const [customBoardRendered, setCustomBoardRendered] = useState(false);
   const [showMyBoards, setShowMyBoards] = useState(false);
+  const [myBoardsRendered, setMyBoardsRendered] = useState(false);
   const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
 
   const { mode, toggleMode } = useColorMode();
@@ -83,6 +86,15 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const handleClose = () => setIsOpen(false);
   const handleDrawerTransitionEnd = useCallback((open: boolean) => {
     if (!open) setDrawerRendered(false);
+  }, []);
+  const handleBoardSelectorTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setBoardSelectorRendered(false);
+  }, []);
+  const handleCustomBoardTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setCustomBoardRendered(false);
+  }, []);
+  const handleMyBoardsTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setMyBoardsRendered(false);
   }, []);
 
   const handleChangeBoardClick = useCallback((board: UserBoard) => {
@@ -198,6 +210,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               className={styles.menuItem}
               onClick={() => {
                 handleClose();
+                setBoardSelectorRendered(true);
                 setShowBoardSelector(true);
               }}
             >
@@ -211,6 +224,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 className={styles.menuItem}
                 onClick={() => {
                   handleClose();
+                  setMyBoardsRendered(true);
                   setShowMyBoards(true);
                 }}
               >
@@ -358,26 +372,31 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
         />
       )}
 
-      <SwipeableDrawer
-        title="Pick a board"
-        placement="bottom"
-        open={showBoardSelector}
-        onClose={() => setShowBoardSelector(false)}
-      >
-        <BoardDiscoveryScroll
-          onBoardClick={handleChangeBoardClick}
-          onConfigClick={handleChangeConfigClick}
-          onCustomClick={() => {
-            setShowBoardSelector(false);
-            setShowCustomBoard(true);
-          }}
-        />
-      </SwipeableDrawer>
+      {boardSelectorRendered && (
+        <SwipeableDrawer
+          title="Pick a board"
+          placement="bottom"
+          open={showBoardSelector}
+          onClose={() => setShowBoardSelector(false)}
+          onTransitionEnd={handleBoardSelectorTransitionEnd}
+        >
+          <BoardDiscoveryScroll
+            onBoardClick={handleChangeBoardClick}
+            onConfigClick={handleChangeConfigClick}
+            onCustomClick={() => {
+              setShowBoardSelector(false);
+              setCustomBoardRendered(true);
+              setShowCustomBoard(true);
+            }}
+          />
+        </SwipeableDrawer>
+      )}
 
-      {boardConfigs && (
+      {boardConfigs && customBoardRendered && (
         <BoardSelectorDrawer
           open={showCustomBoard}
           onClose={() => setShowCustomBoard(false)}
+          onTransitionEnd={handleCustomBoardTransitionEnd}
           boardConfigs={boardConfigs}
           placement="bottom"
           onBoardSelected={(url) => {
@@ -387,14 +406,18 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
         />
       )}
 
-      <MyBoardsDrawer
-        open={showMyBoards}
-        onClose={() => setShowMyBoards(false)}
-        onCreateBoard={() => {
-          setShowMyBoards(false);
-          setShowCustomBoard(true);
-        }}
-      />
+      {myBoardsRendered && (
+        <MyBoardsDrawer
+          open={showMyBoards}
+          onClose={() => setShowMyBoards(false)}
+          onTransitionEnd={handleMyBoardsTransitionEnd}
+          onCreateBoard={() => {
+            setShowMyBoards(false);
+            setCustomBoardRendered(true);
+            setShowCustomBoard(true);
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
UserDrawer unconditionally rendered three drawers (BoardSelector,
BoardSelectorDrawer, MyBoardsDrawer) even when closed. On the home page
this meant mounting two BoardDiscoveryScroll instances with their own
IntersectionObserver setups (one in HomePageContent, one hidden inside
the closed UserDrawer board selector), plus a full MyBoardsDrawer tree.

Gate all three behind *Rendered state flags following the pattern
already used by HomePageContent and BottomTabBar: set Rendered=true
on open, reset on onTransitionEnd after close. This removes the hidden
IntersectionObserver that sits inside a display:none drawer on every
home-page render, which is a plausible trigger for iOS WebKit stack
overflows on iOS 26.

Also add onTransitionEnd support to MyBoardsDrawer so the unmount-
after-close-animation pattern works uniformly across all three.