### PR TITLE
Remove unused getLogbookBasePath export

### DIFF
--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -769,13 +769,6 @@ export const getPlaylistsBasePath = (pathname: string): string => {
 };
 
 /**
- * Extract the logbook base path from the current pathname.
- * Mirrors getPlaylistsBasePath but targets /logbook routes.
- */
-export const getLogbookBasePath = (pathname: string): string =>
-  getPlaylistsBasePath(pathname).replace(/\/playlists$/, '/logbook');
-
-/**
  * Build a context-aware URL for a specific playlist detail page.
  * Uses the current pathname to determine whether to use board-scoped or global URL.
  */


### PR DESCRIPTION
The getLogbookBasePath function was no longer imported anywhere after
removing its usage from bottom-tab-bar.tsx. Removing dead code to keep
the codebase clean.

https://claude.ai/code/session_01JbXYFW2N19kX7DxmEY7Yk2