### PR TITLE
Standardize playlist climb list row and thumbnail interaction

### DIFF
--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -92,8 +92,9 @@ export default function MultiboardClimbList({
   });
   const queueActions = useOptionalQueueActions();
 
-  // Default climb navigation via redirect API
-  const defaultNavigateToClimb = useCallback(async (climb: Climb) => {
+  // Fallback for the rare case with no queue bridge (e.g. mid-hydration): navigate
+  // to the climb's view page so the user is never stranded.
+  const navigateToClimb = useCallback(async (climb: Climb) => {
     try {
       const bt = climb.boardType || selectedBoard?.boardType;
       if (!bt) return;
@@ -107,7 +108,24 @@ export default function MultiboardClimbList({
     }
   }, [selectedBoard]);
 
-  const handleClimbSelect = onClimbSelect ?? defaultNavigateToClimb;
+  // Internal selection state drives the visual highlight. A caller-supplied
+  // selectedClimbUuid takes precedence so controlled usage still works.
+  const [internalSelectedUuid, setInternalSelectedUuid] = useState<string | null>(null);
+  const effectiveSelectedUuid = selectedClimbUuid ?? internalSelectedUuid;
+
+  // Row click: activate the climb (visual highlight + set as queue's current climb).
+  // Thumbnail click reuses this via ClimbsList and additionally dispatches the
+  // PLAY_DRAWER_EVENT so the play view drawer opens. Mirrors the pattern in
+  // liked-climbs-list.tsx and board-page-climbs-list.tsx.
+  const handleClimbSelect = useCallback((climb: Climb) => {
+    setInternalSelectedUuid(climb.uuid);
+    if (queueActions?.setCurrentClimb) {
+      queueActions.setCurrentClimb(climb);
+    } else {
+      navigateToClimb(climb);
+    }
+    onClimbSelect?.(climb);
+  }, [queueActions, navigateToClimb, onClimbSelect]);
 
   const handleSortChange = (_: React.MouseEvent<HTMLElement>, value: SortBy | null) => {
     if (value && onSortChange) {
@@ -167,7 +185,7 @@ export default function MultiboardClimbList({
               boardDetailsMap={boardDetailsMap}
               unsupportedClimbs={unsupportedClimbs}
               climbs={climbs}
-              selectedClimbUuid={selectedClimbUuid}
+              selectedClimbUuid={effectiveSelectedUuid}
               isFetching={isFetching}
               hasMore={hasMore}
               onClimbSelect={handleClimbSelect}


### PR DESCRIPTION
MultiboardClimbList — the list powering both the playlist view and setter
pages — still used a single defaultNavigateToClimb handler for row and
thumbnail clicks. Rows never showed an active state and thumbnails did a
full page transition instead of opening the play view drawer, diverging
from the board page and liked list after the standardization in 0df9d9a
and 76cd3fc.

Make MultiboardClimbList replicate the standardized pattern:

- Track selectedClimbUuid internally so row presses highlight immediately
  (callers can still pass a controlled value).
- Default onClimbSelect sets the visual highlight and calls setCurrentClimb
  from the globally-bridged queue actions (c969143). ClimbsList already
  wraps the thumbnail path with dispatchOpenPlayDrawer(), so tapping a
  thumbnail now activates the climb and opens the play drawer in place.
- Fall back to the legacy /view redirect only when no queue bridge is
  available so users are never stranded.

PlaylistDetailContent and SetterClimbList both inherit the fix without
changes.

https://claude.ai/code/session_01QFkgevyQy4bi6zfkoG3EPT