### PR TITLE
Fix tabs hidden behind header on playlist/logbook pages

### DIFF
--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -37,6 +37,8 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
   const [searchDropdownOpen, setSearchDropdownOpen] = useState(false);
   const isCreatePage = pathname.includes('/create');
   const isListPage = pathname.includes('/list');
+  const isPlaylistPage = pathname.includes('/playlists');
+  const isLogbookPage = pathname.includes('/logbook');
   const isPlayPage = pathname.includes('/play/');
   const isViewPage = pathname.includes('/view/');
 
@@ -79,8 +81,8 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
   const hasBackButton = isPlayPage;
   // Angle selector is only needed on play/view pages
   const hasAngleSelector = angle !== undefined && (isPlayPage || isViewPage);
-  // Create button is only shown on desktop, so skip rendering the container on list pages
-  const hasCreateButton = !!createClimbUrl && !isListPage;
+  // Create button is only shown on desktop; skip on list, playlist, and logbook pages
+  const hasCreateButton = !!createClimbUrl && !isListPage && !isPlaylistPage && !isLogbookPage;
 
   return (
     <>

--- a/packages/web/app/logbook/layout.tsx
+++ b/packages/web/app/logbook/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function LogbookLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ minHeight: '100dvh', paddingTop: 'var(--global-header-height)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Two issues caused the Logbook/Playlists tabs to render under the
global header bar:

1. BoardSeshHeader was rendering a 40px empty toolbar on mobile for
   playlist and logbook pages because hasCreateButton was true (the
   '/list' substring check missed '/playlists' and '/logbook'). Added
   explicit isPlaylistPage/isLogbookPage guards so the toolbar is
   correctly suppressed on those pages.

2. The standalone /logbook route had no layout file, so it received no
   paddingTop for the fixed global header. On taller/notched devices
   (where --global-header-height can exceed 100px) the tabs were
   physically behind the header. Added logbook/layout.tsx matching the
   existing playlists/layout.tsx.

https://claude.ai/code/session_01FkWEDK3MHErem44ufjq7U7