### PR TITLE
Polish tick mode: colourised grade, overhead comment bar, matching hint color

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -94,6 +94,10 @@ const defaultProps = {
   boardDetails: makeBoardDetails(),
   onSave: vi.fn(),
   onCancel: vi.fn(),
+  comment: '',
+  commentOpen: false,
+  onCommentToggle: vi.fn(),
+  commentFocused: false,
 };
 
 /**
@@ -128,6 +132,7 @@ describe('QuickTickBar', () => {
     mockSaveTick.mockResolvedValue(undefined);
     defaultProps.onSave = vi.fn();
     defaultProps.onCancel = vi.fn();
+    defaultProps.onCommentToggle = vi.fn();
   });
 
   afterEach(() => {
@@ -162,11 +167,12 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: stars, grade, comment toggle, attempt, confirm', () => {
+    it('renders the controls in the expected order: stars + comment toggle on the left, then grade, attempt, confirm', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
       const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
+      const gradeLabel = screen.getByTestId('quick-tick-grade');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
@@ -174,19 +180,40 @@ describe('QuickTickBar', () => {
       // share a single vertically-centered baseline with the climb title.
       const controls = rating.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
+      expect(gradeLabel.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
-      // The siblings must appear in this order: rating, ..., comment toggle,
-      // ..., attempt (X), confirm (tick) as the final pair.
+      // The siblings must appear in this order: rating, comment toggle,
+      // ..., grade label, attempt (X), confirm (tick) as the final pair.
+      // The grade sits immediately to the left of the attempt button.
       const siblings = Array.from(controls.children) as HTMLElement[];
       const ratingIdx = siblings.indexOf(rating);
       const commentIdx = siblings.indexOf(commentToggle);
+      const gradeIdx = siblings.indexOf(gradeLabel);
       const attemptIdx = siblings.indexOf(attemptBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
       expect(ratingIdx).toBeLessThan(commentIdx);
-      expect(commentIdx).toBeLessThan(attemptIdx);
+      expect(commentIdx).toBeLessThan(gradeIdx);
+      expect(gradeIdx).toBeLessThan(attemptIdx);
       expect(confirmIdx).toBe(attemptIdx + 1);
+    });
+
+    it('shows the "swipe left to dismiss" hint text by default', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      const hint = screen.getByTestId('quick-tick-hint');
+      expect(hint.textContent).toMatch(/swipe left to dismiss/i);
+    });
+
+    it('hides the swipe hint when the comment field is open', () => {
+      render(<QuickTickBar {...defaultProps} commentOpen={true} />);
+      expect(screen.queryByTestId('quick-tick-hint')).toBeNull();
+    });
+
+    it('invokes onCommentToggle when the comment button is tapped', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /toggle comment/i }));
+      expect(defaultProps.onCommentToggle).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -440,13 +467,10 @@ describe('QuickTickBar', () => {
       expect(defaultProps.onCancel).not.toHaveBeenCalled();
     });
 
-    it('ignores swipes while the comment field is focused', () => {
-      render(<QuickTickBar {...defaultProps} />);
-
-      // Open and focus the comment input.
-      fireEvent.click(screen.getByRole('button', { name: /toggle comment/i }));
-      const commentInput = screen.getByPlaceholderText('Comment...');
-      fireEvent.focus(commentInput);
+    it('ignores swipes while the commentFocused prop is true', () => {
+      // The comment TextField lives in the parent QueueControlBar, so the
+      // bar learns that the user is typing via the `commentFocused` prop.
+      render(<QuickTickBar {...defaultProps} commentFocused={true} />);
 
       const bar = screen.getByTestId('quick-tick-bar');
       simulateSwipe(bar, -200);
@@ -456,6 +480,19 @@ describe('QuickTickBar', () => {
       });
 
       expect(defaultProps.onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled comment prop', () => {
+    it('forwards the comment prop in the save payload', async () => {
+      render(<QuickTickBar {...defaultProps} comment="sick send" />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
+      expect(mockSaveTick.mock.calls[0][0].comment).toBe('sick send');
     });
   });
 });

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -33,28 +33,19 @@
   min-width: var(--space-1, 4px);
 }
 
-.commentRow {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1, 4px);
-  width: 100%;
-  animation: commentExpand 150ms ease-out;
+.hint {
+  font-size: 11px;
+  font-style: italic;
+  line-height: 1;
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
-@keyframes commentExpand {
-  from {
-    opacity: 0;
-    max-height: 0;
-  }
-  to {
-    opacity: 1;
-    max-height: 48px;
-  }
-}
-
-.gradeChip {
-  cursor: pointer;
-  font-weight: 600;
+.gradeLabel {
   min-width: 0;
   flex-shrink: 0;
 }

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -4,8 +4,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useSwipeable } from 'react-swipeable';
 import IconButton from '@mui/material/IconButton';
 import Rating from '@mui/material/Rating';
-import Chip from '@mui/material/Chip';
-import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
@@ -17,6 +16,8 @@ import { useBoardProvider } from '../board-provider/board-provider-context';
 import type { LogbookEntry, TickStatus } from '@/app/hooks/use-logbook';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { themeTokens } from '@/app/theme/theme-config';
+import { formatVGrade, getSoftVGradeColor } from '@/app/lib/grade-colors';
+import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import styles from './quick-tick-bar.module.css';
 
 /** Snapshot of the tick target taken when the bar is first opened with a valid climb. */
@@ -34,6 +35,17 @@ export interface QuickTickBarProps {
   boardDetails: BoardDetails;
   onSave: () => void;
   onCancel: () => void;
+  /** Current comment text. Owned by the parent so the comment field can live
+   *  outside this bar (above the queue control bar) without causing reflow. */
+  comment: string;
+  /** Whether the parent is currently rendering the comment input. */
+  commentOpen: boolean;
+  /** Called when the user taps the comment button inside this bar. */
+  onCommentToggle: () => void;
+  /** Whether the parent's comment input currently has focus. Used to disable
+   *  the swipe-to-dismiss gesture so the user can type without the bar
+   *  sliding away under them. */
+  commentFocused: boolean;
 }
 
 const SWIPE_DISMISS_THRESHOLD = 80;
@@ -57,8 +69,13 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   boardDetails,
   onSave,
   onCancel,
+  comment,
+  commentOpen,
+  onCommentToggle,
+  commentFocused,
 }) => {
   const { saveTick, logbook } = useBoardProvider();
+  const isDark = useIsDarkMode();
 
   // Snapshot the target climb the first time we get a non-null climb.
   // All subsequent saves use this snapshot, not the live props.
@@ -76,23 +93,13 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
 
   const [quality, setQuality] = useState<number | null>(null);
   const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
-  const [comment, setComment] = useState('');
-  const [showComment, setShowComment] = useState(false);
-  const [commentFocused, setCommentFocused] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [gradeAnchorEl, setGradeAnchorEl] = useState<HTMLElement | null>(null);
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isDismissing, setIsDismissing] = useState(false);
-  const commentRef = useRef<HTMLInputElement>(null);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const grades = TENSION_KILTER_GRADES;
-
-  useEffect(() => {
-    if (showComment && commentRef.current) {
-      commentRef.current.focus();
-    }
-  }, [showComment]);
 
   useEffect(() => {
     return () => {
@@ -106,8 +113,14 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     ? grades.find((g) => g.difficulty_id === difficulty)
     : undefined;
 
-  // Default grade label falls back to the snapshot climb's own difficulty.
-  const defaultGradeLabel = tickTarget?.climb.difficulty ?? currentClimb?.difficulty ?? '';
+  // Prefer the user's override (which carries the full "font/v" difficulty
+  // name so formatVGrade can disambiguate V5 vs V5+), otherwise fall back
+  // to the snapshot climb's own difficulty string.
+  const displayDifficulty =
+    selectedGrade?.difficulty_name ?? tickTarget?.climb.difficulty ?? currentClimb?.difficulty ?? '';
+  const vGrade = formatVGrade(displayDifficulty);
+  const gradeLabel = vGrade ?? (displayDifficulty || '—');
+  const gradeColor = getSoftVGradeColor(vGrade, isDark);
 
   const handleSave = useCallback(
     async (isAscent: boolean) => {
@@ -239,8 +252,10 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Single horizontal row: rating, grade, comment toggle, then attempt (X)
-            and confirm (tick). All elements center-align vertically. */}
+        {/* Single horizontal row: rating, comment toggle, "swipe to dismiss"
+            hint, spacer, colourised V-grade, attempt (X) and confirm (tick).
+            The grade sits immediately to the left of the attempt button and
+            opens a grade override menu on click. */}
         <Rating
           value={quality}
           onChange={(_, val) => setQuality(val)}
@@ -250,13 +265,51 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           data-testid="quick-tick-rating"
         />
 
-        <Chip
-          label={selectedGrade?.v_grade ?? defaultGradeLabel ?? '—'}
+        <IconButton
           size="small"
-          variant={difficulty ? 'filled' : 'outlined'}
-          className={styles.gradeChip}
+          onClick={onCommentToggle}
+          color={commentOpen ? 'primary' : 'default'}
+          aria-label="Toggle comment"
+        >
+          <ChatBubbleOutlineOutlined fontSize="small" />
+        </IconButton>
+
+        {!commentOpen && (
+          <Typography
+            variant="body2"
+            component="span"
+            color="text.secondary"
+            className={styles.hint}
+            data-testid="quick-tick-hint"
+          >
+            swipe left to dismiss
+          </Typography>
+        )}
+
+        <span className={styles.spacer} />
+
+        {/* Colourised V-grade, matching the styling used by ClimbTitle's
+            right-aligned large grade. Click opens the override menu. */}
+        <Typography
+          variant="body2"
+          component="span"
           onClick={(e) => setGradeAnchorEl(e.currentTarget)}
-        />
+          role="button"
+          aria-label="Select logged grade"
+          data-testid="quick-tick-grade"
+          className={styles.gradeLabel}
+          sx={{
+            fontSize: themeTokens.typography.fontSize.sm,
+            fontWeight: themeTokens.typography.fontWeight.bold,
+            lineHeight: 1,
+            color: gradeColor ?? 'text.secondary',
+            cursor: 'pointer',
+            flexShrink: 0,
+            px: '4px',
+          }}
+        >
+          {gradeLabel}
+        </Typography>
         <Menu
           anchorEl={gradeAnchorEl}
           open={Boolean(gradeAnchorEl)}
@@ -286,17 +339,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
         </Menu>
 
         <IconButton
-          size="small"
-          onClick={() => setShowComment((prev) => !prev)}
-          color={showComment ? 'primary' : 'default'}
-          aria-label="Toggle comment"
-        >
-          <ChatBubbleOutlineOutlined fontSize="small" />
-        </IconButton>
-
-        <span className={styles.spacer} />
-
-        <IconButton
           onClick={handleFail}
           disabled={isSaving}
           sx={{
@@ -324,23 +366,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           <CheckOutlined />
         </IconButton>
       </div>
-
-      {showComment && (
-        <div className={styles.commentRow}>
-          <TextField
-            inputRef={commentRef}
-            size="small"
-            placeholder="Comment..."
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            onFocus={() => setCommentFocused(true)}
-            onBlur={() => setCommentFocused(false)}
-            variant="standard"
-            slotProps={{ htmlInput: { maxLength: 2000 } }}
-            sx={{ flex: 1 }}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -124,6 +124,40 @@
   }
 }
 
+/* Tick-mode comment bar — sits above the main control bar so the queue bar
+   doesn't reflow when the comment button is tapped. Lines up visually with
+   the main card padding + desktop max-width. */
+.commentBar {
+  display: flex;
+  align-items: center;
+  padding: var(--space-1, 4px) var(--space-3, 12px);
+  background-color: rgba(245, 245, 245, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  margin-bottom: 4px;
+}
+
+:global(html[data-theme="dark"]) .commentBar {
+  background-color: rgba(0, 0, 0, 0.6);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 767px) {
+  .commentBar {
+    margin: 0 5px 4px;
+  }
+}
+
+@media (min-width: 768px) {
+  .commentBar {
+    max-width: 480px;
+    margin: 0 auto 4px;
+    border-radius: 12px;
+  }
+}
+
 .swipeWrapper {
   position: relative;
   overflow: hidden;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -6,6 +6,7 @@ import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import SyncOutlined from '@mui/icons-material/SyncOutlined';
 import CloudOffOutlined from '@mui/icons-material/CloudOffOutlined';
@@ -138,6 +139,16 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [dismissedDisconnect, setDismissedDisconnect] = useState(false);
 
+  // Tick-bar comment state lives here so the comment field can render in a
+  // separate bar *above* the queue control bar without reflowing the main bar.
+  // QuickTickBar reads the value back out via props when saving the tick.
+  const [tickComment, setTickComment] = useState('');
+  const [tickCommentOpen, setTickCommentOpen] = useState(false);
+  const [tickCommentFocused, setTickCommentFocused] = useState(false);
+  const handleTickCommentToggle = useCallback(() => setTickCommentOpen((prev) => !prev), []);
+  const handleTickCommentFocus = useCallback(() => setTickCommentFocused(true), []);
+  const handleTickCommentBlur = useCallback(() => setTickCommentFocused(false), []);
+
   // Note: the tick bar intentionally stays open when the active climb changes
   // (e.g. party session navigation). QuickTickBar snapshots its target climb
   // internally so the user can finish ticking the climb they opened the bar
@@ -260,6 +271,16 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const tickBarActive = activeDrawer === 'tick';
   const canSwipeNext = !viewOnlyMode && !!nextClimb && !tickBarActive;
   const canSwipePrevious = !viewOnlyMode && !!previousClimb && !tickBarActive;
+
+  // Clear tick-bar comment state whenever the tick bar closes so a fresh
+  // activation always starts empty.
+  useEffect(() => {
+    if (!tickBarActive) {
+      setTickComment('');
+      setTickCommentOpen(false);
+      setTickCommentFocused(false);
+    }
+  }, [tickBarActive]);
 
   const { swipeHandlers, swipeOffset, isAnimating, animationDirection, enterDirection, clearEnterAnimation } = useCardSwipeNavigation({
     onSwipeNext: handleSwipeNext,
@@ -469,6 +490,24 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
           </span>
         </div>
       )}
+      {/* Tick-mode comment bar — rendered above the main card so tapping the
+          comment button doesn't reflow the queue control bar. */}
+      {tickBarActive && tickCommentOpen && (
+        <div className={styles.commentBar}>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            variant="standard"
+            placeholder="Comment..."
+            value={tickComment}
+            onChange={(e) => setTickComment(e.target.value)}
+            onFocus={handleTickCommentFocus}
+            onBlur={handleTickCommentBlur}
+            slotProps={{ htmlInput: { maxLength: 2000, 'aria-label': 'Tick comment' } }}
+          />
+        </div>
+      )}
       {/* Main Control Bar */}
       <MuiCard variant="outlined" className={styles.card} sx={{ border: 'none', backgroundColor: 'transparent' }}>
         <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
@@ -505,6 +544,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         boardDetails={boardDetails}
                         onSave={() => setActiveDrawer('none')}
                         onCancel={() => setActiveDrawer('none')}
+                        comment={tickComment}
+                        commentOpen={tickCommentOpen}
+                        onCommentToggle={handleTickCommentToggle}
+                        commentFocused={tickCommentFocused}
                       />
                     ) : (
                       <>


### PR DESCRIPTION
Replace the tick bar's plain grade Chip with a colourised V-grade Typography
that matches ClimbTitle's right-aligned large grade styling, and move it next
to the attempt button so the left group can focus on rating + comment toggle
with the "swipe left to dismiss" hint beneath.

Lift the comment TextField out of QuickTickBar into QueueControlBar so the
field renders in a new bar above the queue control bar instead of expanding
the main bar and causing a reflow. QuickTickBar now takes the comment value,
open state, and focus state as props and calls an onCommentToggle callback.

Use MUI Typography with color="text.secondary" for the swipe hint so it
resolves through the same palette token as the ClimbTitle byline.