### PR TITLE
Rename 'Your Library' tab to 'Discover'

### DIFF
--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -59,7 +59,7 @@ This plan transforms Boardsesh's UI into a Spotify-like experience with a persis
 ├────────────────────────────────────┤
 │ [T] "Current Climb" V4  [Q] [✓]  │  ← Now Playing bar (~45px, compact)
 ├────────────────────────────────────┤
-│  🏠 Climb  📚 Your Library ✚ Create │  ← Bottom tab bar
+│  🏠 Climb  📚 Discover ✚ Create │  ← Bottom tab bar
 └────────────────────────────────────┘
 ```
 
@@ -141,7 +141,7 @@ This plan transforms Boardsesh's UI into a Spotify-like experience with a persis
 ## Phase 1: Bottom Tab Bar
 
 ### What changes
-Add a persistent bottom tab bar below the QueueControlBar with three tabs: **Climb**, **Your Library**, and **Create**.
+Add a persistent bottom tab bar below the QueueControlBar with three tabs: **Climb**, **Discover**, and **Create**.
 
 **Note:** Search functionality remains in the header on mobile list pages (search input + advanced search button). The bottom tab bar provides navigation, not search.
 
@@ -167,8 +167,8 @@ A new landing/home screen accessible via the first tab. This is a placeholder fo
 
 1. **New file: `packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx`**
    - Client component (`'use client'`)
-   - Three tabs: Climb (navigates to list), Your Library (navigates to playlists), Create (opens create drawer)
-   - Icons: Use AntD icons - `UnorderedListOutlined` for Climb, `TagOutlined` for Your Library, `PlusOutlined` for Create
+   - Three tabs: Climb (navigates to list), Discover (navigates to playlists), Create (opens create drawer)
+   - Icons: Use AntD icons - `UnorderedListOutlined` for Climb, `TagOutlined` for Discover, `PlusOutlined` for Create
    - Active state: Primary color (`themeTokens.colors.primary`) for active tab icon + label
    - Inactive state: `themeTokens.neutral[400]` color
    - Fixed at the bottom, full width
@@ -191,7 +191,7 @@ A new landing/home screen accessible via the first tab. This is a placeholder fo
 4. **Mobile search stays in header**
    - The `SearchClimbNameInput` (text input) and `SearchButton` (advanced filters icon) **remain in the header** on mobile list pages.
    - This keeps search easily accessible while browsing climbs.
-   - The bottom tab bar is for navigation only (Climb, Your Library, Create).
+   - The bottom tab bar is for navigation only (Climb, Discover, Create).
 
 5. **New file: `packages/web/app/components/create-drawer/create-drawer.tsx`**
    - Bottom drawer with creation options
@@ -205,9 +205,9 @@ A new landing/home screen accessible via the first tab. This is a placeholder fo
 
 ### Behavior
 - **Climb tab**: Navigates to the `/list` route (the climb list). This is the default/first tab.
-- **Your Library tab**: Navigates to the `/playlists` route. Shows as active when on playlists page.
+- **Discover tab**: Navigates to the `/playlists` route. Shows as active when on playlists page.
 - **Create tab**: Opens the CreateDrawer with options (Climb, Playlist). The Playlist option opens a Create Playlist form directly.
-- Active tab state reflects current context (Climb when on /list, Your Library when on /playlists, etc.)
+- Active tab state reflects current context (Climb when on /list, Discover when on /playlists, etc.)
 - On desktop (>= 768px): Tab bar is hidden. Search and create remain in header/sidebar.
 - **On play/view/create pages**: Tab bar remains visible. On play pages the user may want to quickly return to the list or access playlists.
 
@@ -899,7 +899,7 @@ Board layout.tsx (server component)
 │
 └── BottomTabBar [NEW] (mobile only)
     ├── Climb Tab → Navigate to /list
-    ├── Your Library Tab → Navigate to /playlists
+    ├── Discover Tab → Navigate to /playlists
     └── Create Tab → Open CreateDrawer [NEW]
         ├── Climb → /create route
         └── Playlist → Opens Create Playlist drawer (hidden for MoonBoard)
@@ -992,8 +992,8 @@ Board layout.tsx (server component)
 ### Phase 1
 - [x] Bottom tab bar renders on mobile, hidden on desktop
 - [x] Climb tab navigates to /list
-- [x] Your Library tab navigates to /playlists
-- [x] Your Library tab shows as active when on playlists page
+- [x] Discover tab navigates to /playlists
+- [x] Discover tab shows as active when on playlists page
 - [x] Create tab opens create drawer
 - [x] Create drawer options work (Climb navigates to /create, Playlist opens create playlist form)
 - [x] Create drawer hides playlist option for MoonBoard

--- a/docs/spotify-ui-redesign-plan.md
+++ b/docs/spotify-ui-redesign-plan.md
@@ -85,7 +85,7 @@ This plan transforms Boardsesh's UI into a Spotify-like experience with a persis
 ├────────────────────────────────────┤
 │ [T] "Current Climb" V4  [Q] [✓]  │  ← Compact now-playing bar (~45px)
 ├────────────────────────────────────┤
-│  🏠 Climb  📚 Your Library ✚ Create │
+│  🏠 Climb  📚 Discover ✚ Create │
 └────────────────────────────────────┘
 ```
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -538,7 +538,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           sx={actionSx}
         />
         <BottomNavigationAction
-          label="Your Library"
+          label="Discover"
           icon={<LocalOfferOutlined sx={{ fontSize: 20 }} />}
           value="library"
           sx={actionSx}

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -289,7 +289,7 @@ export default function LibraryPageContent({
         <ArrowBackOutlined />
       </IconButton>
       <Typography variant="h6" component="h1" sx={{ fontWeight: 600 }}>
-        Your Library
+        Discover
       </Typography>
     </div>
   );

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -79,11 +79,11 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     await expect(page.locator(bottomTabBar)).toBeVisible();
   });
 
-  test('Your Library tab should navigate to playlists page', async ({ page }) => {
+  test('Discover tab should navigate to playlists page', async ({ page }) => {
     await page.goto('/');
     await waitForPageReady(page);
 
-    await bottomTabButton(page, 'Your Library').click();
+    await bottomTabButton(page, 'Discover').click();
     await expect(page).toHaveURL(/\/playlists/, { timeout: 15000 });
     await expect(page.locator(bottomTabBar)).toBeVisible();
   });
@@ -138,11 +138,11 @@ test.describe('Bottom Tab Bar - Active State', () => {
     await expect(bottomTabButton(page, 'Climb', true)).toHaveClass(/Mui-selected/);
   });
 
-  test('Your Library tab should be active on playlists page', async ({ page }) => {
+  test('Discover tab should be active on playlists page', async ({ page }) => {
     await page.goto('/playlists');
     await waitForPageReady(page);
 
-    await expect(bottomTabButton(page, 'Your Library')).toHaveClass(/Mui-selected/);
+    await expect(bottomTabButton(page, 'Discover')).toHaveClass(/Mui-selected/);
   });
 
   test('Notifications tab should be active on notifications page', async ({ page }) => {
@@ -206,8 +206,8 @@ test.describe('Bottom Tab Bar - Queue Integration', () => {
     await expect(page).toHaveURL('/', { timeout: 15000 });
     await verifyBarsShowClimb();
 
-    // Navigate to Your Library
-    await bottomTabButton(page, 'Your Library').click();
+    // Navigate to Discover
+    await bottomTabButton(page, 'Discover').click();
     await expect(page).toHaveURL(/\/playlists/, { timeout: 15000 });
     await verifyBarsShowClimb();
 

--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -99,8 +99,8 @@ test.describe('Queue Persistence - Local Mode', () => {
     await Promise.all([page.waitForURL(/\/settings/, { timeout: 15000 }), settingsLink.click()]);
     await verifyQueueShowsClimb(page, climbName);
 
-    // 3. Navigate to Your Library via bottom tab bar
-    await bottomTabButton(page, 'Your Library').click();
+    // 3. Navigate to Discover via bottom tab bar
+    await bottomTabButton(page, 'Discover').click();
     await expect(page).toHaveURL(/\/playlists/, { timeout: 15000 });
     await verifyQueueShowsClimb(page, climbName);
 


### PR DESCRIPTION
Changed the bottom tab bar label from 'Your Library' to 'Discover' and updated all corresponding test references.

https://claude.ai/code/session_017trdNMyDrvbVr8AUATJAri