### PR TITLE
Polish quick tick bar layout and grade picker

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -167,33 +167,40 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: stars + comment toggle on the left, then grade, attempt, confirm', () => {
+    it('renders the controls in the expected order: rating stack, comment toggle, grade, attempt, confirm — all clustered to the right', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
+      const hint = screen.getByTestId('quick-tick-hint');
       const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
       const gradeLabel = screen.getByTestId('quick-tick-grade');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
-      // All controls are direct siblings inside a single flex row so they
-      // share a single vertically-centered baseline with the climb title.
-      const controls = rating.parentElement!;
+      // The rating sits inside a small stack with the swipe hint rendered as
+      // a byline directly underneath it. That stack is then a sibling of
+      // the comment toggle, grade label, attempt and confirm buttons inside
+      // the single flex row.
+      const ratingStack = rating.parentElement!;
+      expect(hint.parentElement).toBe(ratingStack);
+
+      const controls = ratingStack.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
       expect(gradeLabel.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
-      // The siblings must appear in this order: rating, comment toggle,
-      // ..., grade label, attempt (X), confirm (tick) as the final pair.
-      // The grade sits immediately to the left of the attempt button.
+      // Siblings of .controls must appear in this order: rating stack,
+      // comment toggle, grade label, attempt (X), confirm (tick). The
+      // grade sits immediately to the left of the attempt button and the
+      // confirm button is the final element.
       const siblings = Array.from(controls.children) as HTMLElement[];
-      const ratingIdx = siblings.indexOf(rating);
+      const stackIdx = siblings.indexOf(ratingStack);
       const commentIdx = siblings.indexOf(commentToggle);
       const gradeIdx = siblings.indexOf(gradeLabel);
       const attemptIdx = siblings.indexOf(attemptBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
-      expect(ratingIdx).toBeLessThan(commentIdx);
+      expect(stackIdx).toBeLessThan(commentIdx);
       expect(commentIdx).toBeLessThan(gradeIdx);
       expect(gradeIdx).toBeLessThan(attemptIdx);
       expect(confirmIdx).toBe(attemptIdx + 1);

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -28,15 +28,19 @@
   min-width: 0;
 }
 
-.spacer {
-  flex: 1;
-  min-width: var(--space-1, 4px);
+.ratingStack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  flex-shrink: 0;
+  min-width: 0;
+  margin-left: auto;
 }
 
 .hint {
   font-size: 11px;
   font-style: italic;
-  line-height: 1;
   user-select: none;
   pointer-events: none;
   white-space: nowrap;

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -32,7 +32,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
+  gap: var(--space-1, 4px);
   flex-shrink: 0;
   min-width: 0;
   margin-left: auto;

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -335,7 +335,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           anchorEl={gradeAnchorEl}
           open={Boolean(gradeAnchorEl)}
           onClose={() => setGradeAnchorEl(null)}
-          MenuListProps={{ autoFocusItem: true }}
+          slotProps={{ paper: { sx: { maxHeight: 240 } } }}
         >
           <MenuItem
             onClick={() => {
@@ -345,18 +345,22 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           >
             —
           </MenuItem>
-          {displayedGrades.map((grade) => (
-            <MenuItem
-              key={grade.difficulty_id}
-              selected={grade.difficulty_id === currentGradeId}
-              onClick={() => {
-                setDifficulty(grade.difficulty_id);
-                setGradeAnchorEl(null);
-              }}
-            >
-              {grade.v_grade}
-            </MenuItem>
-          ))}
+          {displayedGrades.map((grade) => {
+            const isCurrent = grade.difficulty_id === currentGradeId;
+            return (
+              <MenuItem
+                key={grade.difficulty_id}
+                selected={isCurrent}
+                autoFocus={isCurrent}
+                onClick={() => {
+                  setDifficulty(grade.difficulty_id);
+                  setGradeAnchorEl(null);
+                }}
+              >
+                {grade.v_grade}
+              </MenuItem>
+            );
+          })}
         </Menu>
 
         <IconButton

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -122,6 +122,16 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   const gradeLabel = vGrade ?? (displayDifficulty || '—');
   const gradeColor = getSoftVGradeColor(vGrade, isDark);
 
+  // Fall back to matching the climb's own difficulty string against the
+  // grade list so the menu can highlight + scroll to the "current" grade
+  // even before the user picks an override.
+  const climbGradeId = useMemo(() => {
+    const source = tickTarget?.climb.difficulty ?? currentClimb?.difficulty;
+    if (!source) return undefined;
+    return grades.find((g) => g.difficulty_name === source)?.difficulty_id;
+  }, [tickTarget, currentClimb, grades]);
+  const currentGradeId = difficulty ?? climbGradeId;
+
   const handleSave = useCallback(
     async (isAscent: boolean) => {
       if (!tickTarget || isSaving) return;
@@ -252,18 +262,30 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Single horizontal row: rating, comment toggle, "swipe to dismiss"
-            hint, spacer, colourised V-grade, attempt (X) and confirm (tick).
-            The grade sits immediately to the left of the attempt button and
-            opens a grade override menu on click. */}
-        <Rating
-          value={quality}
-          onChange={(_, val) => setQuality(val)}
-          size="small"
-          max={5}
-          sx={{ flexShrink: 0 }}
-          data-testid="quick-tick-rating"
-        />
+        {/* The rating stack + comment button float to the right of the bar,
+            immediately next to the colourised V-grade, attempt (X) and
+            confirm (tick). The "swipe to dismiss" hint sits as a byline
+            directly underneath the stars. */}
+        <div className={styles.ratingStack}>
+          <Rating
+            value={quality}
+            onChange={(_, val) => setQuality(val)}
+            size="small"
+            max={5}
+            data-testid="quick-tick-rating"
+          />
+          {!commentOpen && (
+            <Typography
+              variant="caption"
+              component="span"
+              color="text.secondary"
+              className={styles.hint}
+              data-testid="quick-tick-hint"
+            >
+              swipe left to dismiss
+            </Typography>
+          )}
+        </div>
 
         <IconButton
           size="small"
@@ -273,20 +295,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
         >
           <ChatBubbleOutlineOutlined fontSize="small" />
         </IconButton>
-
-        {!commentOpen && (
-          <Typography
-            variant="body2"
-            component="span"
-            color="text.secondary"
-            className={styles.hint}
-            data-testid="quick-tick-hint"
-          >
-            swipe left to dismiss
-          </Typography>
-        )}
-
-        <span className={styles.spacer} />
 
         {/* Colourised V-grade, matching the styling used by ClimbTitle's
             right-aligned large grade. Click opens the override menu. */}
@@ -315,6 +323,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           open={Boolean(gradeAnchorEl)}
           onClose={() => setGradeAnchorEl(null)}
           slotProps={{ paper: { sx: { maxHeight: 240 } } }}
+          MenuListProps={{ autoFocusItem: true }}
         >
           <MenuItem
             onClick={() => {
@@ -324,18 +333,26 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           >
             —
           </MenuItem>
-          {grades.map((grade) => (
-            <MenuItem
-              key={grade.difficulty_id}
-              selected={grade.difficulty_id === difficulty}
-              onClick={() => {
-                setDifficulty(grade.difficulty_id);
-                setGradeAnchorEl(null);
-              }}
-            >
-              {grade.v_grade}
-            </MenuItem>
-          ))}
+          {grades.map((grade) => {
+            const isCurrent = grade.difficulty_id === currentGradeId;
+            return (
+              <MenuItem
+                key={grade.difficulty_id}
+                selected={isCurrent}
+                ref={(el) => {
+                  if (el && isCurrent) {
+                    el.scrollIntoView({ block: 'center' });
+                  }
+                }}
+                onClick={() => {
+                  setDifficulty(grade.difficulty_id);
+                  setGradeAnchorEl(null);
+                }}
+              >
+                {grade.v_grade}
+              </MenuItem>
+            );
+          })}
         </Menu>
 
         <IconButton

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -123,14 +123,27 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   const gradeColor = getSoftVGradeColor(vGrade, isDark);
 
   // Fall back to matching the climb's own difficulty string against the
-  // grade list so the menu can highlight + scroll to the "current" grade
-  // even before the user picks an override.
+  // grade list so the menu can highlight the "current" grade even before
+  // the user picks an override.
   const climbGradeId = useMemo(() => {
     const source = tickTarget?.climb.difficulty ?? currentClimb?.difficulty;
     if (!source) return undefined;
     return grades.find((g) => g.difficulty_name === source)?.difficulty_id;
   }, [tickTarget, currentClimb, grades]);
   const currentGradeId = difficulty ?? climbGradeId;
+
+  // When the climb already has an established grade, only show a narrow
+  // window of 5 grades (two softer, two harder) around it so the user can
+  // nudge up or down without scrolling through the full V0 → V16 list.
+  // Projects without a grade still see every option.
+  const displayedGrades = useMemo(() => {
+    if (climbGradeId === undefined) return grades;
+    const idx = grades.findIndex((g) => g.difficulty_id === climbGradeId);
+    if (idx === -1) return grades;
+    const start = Math.max(0, idx - 2);
+    const end = Math.min(grades.length, idx + 3);
+    return grades.slice(start, end);
+  }, [grades, climbGradeId]);
 
   const handleSave = useCallback(
     async (isAscent: boolean) => {
@@ -322,7 +335,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           anchorEl={gradeAnchorEl}
           open={Boolean(gradeAnchorEl)}
           onClose={() => setGradeAnchorEl(null)}
-          slotProps={{ paper: { sx: { maxHeight: 240 } } }}
           MenuListProps={{ autoFocusItem: true }}
         >
           <MenuItem
@@ -333,26 +345,18 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           >
             —
           </MenuItem>
-          {grades.map((grade) => {
-            const isCurrent = grade.difficulty_id === currentGradeId;
-            return (
-              <MenuItem
-                key={grade.difficulty_id}
-                selected={isCurrent}
-                ref={(el) => {
-                  if (el && isCurrent) {
-                    el.scrollIntoView({ block: 'center' });
-                  }
-                }}
-                onClick={() => {
-                  setDifficulty(grade.difficulty_id);
-                  setGradeAnchorEl(null);
-                }}
-              >
-                {grade.v_grade}
-              </MenuItem>
-            );
-          })}
+          {displayedGrades.map((grade) => (
+            <MenuItem
+              key={grade.difficulty_id}
+              selected={grade.difficulty_id === currentGradeId}
+              onClick={() => {
+                setDifficulty(grade.difficulty_id);
+                setGradeAnchorEl(null);
+              }}
+            >
+              {grade.v_grade}
+            </MenuItem>
+          ))}
         </Menu>
 
         <IconButton


### PR DESCRIPTION
Float the stars, swipe hint and comment button right against the grade
pill so the tick row reads as one cluster, put the "swipe left to
dismiss" copy as a byline under the stars instead of inline, and make
the grade override menu open with the climb's current grade highlighted
and scrolled into view so users don't have to hunt through the full V0
to V16 list.