### PR TITLE
Confirm board switches and validate queue adds in active sessions

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-status-store.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-status-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  registerBluetoothConnection,
+  disconnectAllBluetooth,
+} from '../bluetooth-status-store';
+
+// Track release functions so each test can clear its own registrations
+// (the store keeps module-level state).
+const pendingReleases: Array<() => void> = [];
+
+function register(disconnect: () => void): () => void {
+  const release = registerBluetoothConnection(disconnect);
+  pendingReleases.push(release);
+  return release;
+}
+
+afterEach(() => {
+  while (pendingReleases.length > 0) {
+    pendingReleases.pop()?.();
+  }
+});
+
+describe('bluetooth-status-store', () => {
+  describe('registerBluetoothConnection', () => {
+    it('returns a release function that is idempotent', () => {
+      const disconnect = vi.fn();
+      const release = register(disconnect);
+      release();
+      release();
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disconnectAllBluetooth', () => {
+    it('invokes every registered disconnect handler', () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      register(a);
+      register(b);
+
+      disconnectAllBluetooth();
+
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledOnce();
+    });
+
+    it('continues invoking handlers when one throws', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const broken = vi.fn(() => { throw new Error('boom'); });
+      const ok = vi.fn();
+      register(broken);
+      register(ok);
+
+      disconnectAllBluetooth();
+
+      expect(broken).toHaveBeenCalledOnce();
+      expect(ok).toHaveBeenCalledOnce();
+      consoleSpy.mockRestore();
+    });
+
+    it('is a no-op when nothing is registered', () => {
+      expect(() => disconnectAllBluetooth()).not.toThrow();
+    });
+  });
+});

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -6,6 +6,7 @@ import { useBoardBluetooth } from './use-board-bluetooth';
 import { useCurrentClimb } from '../graphql-queue';
 import type { BoardDetails } from '@/app/lib/types';
 import { isCapacitor, isCapacitorWebView, waitForCapacitor, CAPACITOR_BRIDGE_TIMEOUT_MS } from '@/app/lib/ble/capacitor-utils';
+import { registerBluetoothConnection } from './bluetooth-status-store';
 
 interface BluetoothContextValue {
   isConnected: boolean;
@@ -129,6 +130,15 @@ export function BluetoothProvider({
 
     return () => cancelPolling?.();
   }, []);
+
+  // Register with the module-level status store so consumers rendered
+  // outside this provider (the root bottom tab bar, board switch guard)
+  // can observe BT connection state and trigger disconnect.
+  useEffect(() => {
+    if (!isConnected) return;
+    const release = registerBluetoothConnection(disconnect);
+    return release;
+  }, [isConnected, disconnect]);
 
   const value = useMemo(
     () => ({

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-status-store.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-status-store.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Module-level store that tracks whether any mounted `BluetoothProvider`
+ * currently has a live connection. This lets consumers rendered outside
+ * any `BluetoothProvider` (e.g., the root bottom tab bar) observe BT
+ * connection state without requiring the provider to be an ancestor.
+ *
+ * The store is updated from `BluetoothProvider` via `setBluetoothConnected`.
+ */
+
+let connectedCount = 0;
+const listeners = new Set<() => void>();
+const activeDisconnects = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): boolean {
+  return connectedCount > 0;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Register a live Bluetooth connection along with its `disconnect`
+ * function. Called from `BluetoothProvider` whenever `isConnected`
+ * flips to `true`. Returns a cleanup function to call when it flips
+ * back to `false` or the provider unmounts.
+ */
+export function registerBluetoothConnection(disconnect: () => void): () => void {
+  connectedCount += 1;
+  activeDisconnects.add(disconnect);
+  notify();
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    connectedCount = Math.max(0, connectedCount - 1);
+    activeDisconnects.delete(disconnect);
+    notify();
+  };
+}
+
+/**
+ * Disconnect any and all currently-registered Bluetooth connections.
+ * Used by the board-switch guard to drop hardware connections before
+ * navigating to a different board.
+ */
+export function disconnectAllBluetooth(): void {
+  // Snapshot first — disconnect() typically triggers the cleanup
+  // function which mutates activeDisconnects during iteration.
+  const snapshot = Array.from(activeDisconnects);
+  for (const disconnect of snapshot) {
+    try {
+      disconnect();
+    } catch (err) {
+      console.error('Failed to disconnect bluetooth:', err);
+    }
+  }
+}
+
+/**
+ * Hook returning `true` when any BluetoothProvider reports an active
+ * connection. Works from any component in the tree.
+ */
+export function useBluetoothConnectedStatus(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/web/app/components/board-lock/__tests__/use-active-board-lock.test.tsx
+++ b/packages/web/app/components/board-lock/__tests__/use-active-board-lock.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails } from '@/app/lib/types';
+import type { ActiveSessionInfo } from '../../persistent-session/types';
+
+type SessionState = { activeSession: ActiveSessionInfo | null };
+
+let mockSessionState: SessionState = { activeSession: null };
+let mockBluetoothConnected = false;
+let mockBridgeBoardDetails: BoardDetails | null = null;
+
+vi.mock('../../persistent-session', () => ({
+  usePersistentSessionState: () => mockSessionState,
+}));
+
+vi.mock('../../board-bluetooth-control/bluetooth-status-store', () => ({
+  useBluetoothConnectedStatus: () => mockBluetoothConnected,
+}));
+
+vi.mock('../../queue-control/queue-bridge-context', () => ({
+  useQueueBridgeBoardInfo: () => ({
+    boardDetails: mockBridgeBoardDetails,
+    angle: 0,
+    hasActiveQueue: !!mockBridgeBoardDetails,
+  }),
+}));
+
+import { useActiveBoardLock } from '../use-active-board-lock';
+
+function makeBoard(partial: Partial<BoardDetails> = {}): BoardDetails {
+  return {
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 0,
+    boardWidth: 0,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    ...partial,
+  };
+}
+
+describe('useActiveBoardLock', () => {
+  beforeEach(() => {
+    mockSessionState = { activeSession: null };
+    mockBluetoothConnected = false;
+    mockBridgeBoardDetails = null;
+  });
+
+  it('returns no lock when nothing is active', () => {
+    const { result } = renderHook(() => useActiveBoardLock());
+    expect(result.current.lockedBoard).toBeNull();
+    expect(result.current.reason).toBeNull();
+  });
+
+  it('returns session lock when a party session is active', () => {
+    const sessionBoard = makeBoard({ board_name: 'tension', layout_id: 2 });
+    mockSessionState = {
+      activeSession: {
+        sessionId: 'session-1',
+        boardPath: '/tension/2/1/1/40',
+        boardDetails: sessionBoard,
+        parsedParams: { board_name: 'tension', layout_id: 2, size_id: 1, set_ids: [1], angle: 40 },
+      },
+    };
+
+    const { result } = renderHook(() => useActiveBoardLock());
+    expect(result.current.lockedBoard).toBe(sessionBoard);
+    expect(result.current.reason).toBe('session');
+  });
+
+  it('returns bluetooth lock when connected and a bridge board is known', () => {
+    const bridgeBoard = makeBoard({ board_name: 'kilter', layout_id: 1 });
+    mockBluetoothConnected = true;
+    mockBridgeBoardDetails = bridgeBoard;
+
+    const { result } = renderHook(() => useActiveBoardLock());
+    expect(result.current.lockedBoard).toBe(bridgeBoard);
+    expect(result.current.reason).toBe('bluetooth');
+  });
+
+  it('prefers session over bluetooth when both are present', () => {
+    const sessionBoard = makeBoard({ board_name: 'tension', layout_id: 2 });
+    mockSessionState = {
+      activeSession: {
+        sessionId: 'session-1',
+        boardPath: '/tension/2/1/1/40',
+        boardDetails: sessionBoard,
+        parsedParams: { board_name: 'tension', layout_id: 2, size_id: 1, set_ids: [1], angle: 40 },
+      },
+    };
+    mockBluetoothConnected = true;
+    mockBridgeBoardDetails = makeBoard({ board_name: 'kilter' });
+
+    const { result } = renderHook(() => useActiveBoardLock());
+    expect(result.current.lockedBoard).toBe(sessionBoard);
+    expect(result.current.reason).toBe('session');
+  });
+
+  it('returns no lock when bluetooth is connected but no bridge board is known', () => {
+    mockBluetoothConnected = true;
+    mockBridgeBoardDetails = null;
+
+    const { result } = renderHook(() => useActiveBoardLock());
+    expect(result.current.lockedBoard).toBeNull();
+    expect(result.current.reason).toBeNull();
+  });
+});

--- a/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
+++ b/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
+import type { ActiveBoardLock } from '../use-active-board-lock';
+
+let mockLock: ActiveBoardLock = { lockedBoard: null, reason: null };
+const mockConfirmBoardSwitch = vi.fn();
+let mockConfirmCtx: { confirmBoardSwitch: typeof mockConfirmBoardSwitch } | null = {
+  confirmBoardSwitch: mockConfirmBoardSwitch,
+};
+const mockDisconnectAll = vi.fn();
+
+vi.mock('../use-active-board-lock', () => ({
+  useActiveBoardLock: () => mockLock,
+}));
+
+vi.mock('../board-switch-confirm-provider', () => ({
+  useBoardSwitchConfirm: () => mockConfirmCtx,
+}));
+
+vi.mock('../../board-bluetooth-control/bluetooth-status-store', () => ({
+  disconnectAllBluetooth: () => mockDisconnectAll(),
+}));
+
+import { useBoardSwitchGuard } from '../use-board-switch-guard';
+
+function makeBoard(partial: Partial<BoardDetails> = {}): BoardDetails {
+  return {
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 0,
+    boardWidth: 0,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    ...partial,
+  };
+}
+
+function makeTarget(partial: Partial<BoardRouteIdentity> = {}): BoardRouteIdentity {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    ...partial,
+  };
+}
+
+describe('useBoardSwitchGuard', () => {
+  beforeEach(() => {
+    mockLock = { lockedBoard: null, reason: null };
+    mockConfirmBoardSwitch.mockReset();
+    mockConfirmCtx = { confirmBoardSwitch: mockConfirmBoardSwitch };
+    mockDisconnectAll.mockReset();
+  });
+
+  it('calls onConfirmed immediately when no lock is active', () => {
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'tension' }), onConfirmed);
+    });
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(mockConfirmBoardSwitch).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirmed immediately when switching to the same board', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1, size_id: 2, set_ids: [1, 2] }),
+      reason: 'session',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(
+        makeTarget({ board_name: 'kilter', layout_id: 1, size_id: 2, set_ids: [2, 1] }),
+        onConfirmed,
+      );
+    });
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(mockConfirmBoardSwitch).not.toHaveBeenCalled();
+  });
+
+  it('opens confirmation dialog when switching to a different board', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1 }),
+      reason: 'session',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'tension', layout_id: 2 }), onConfirmed);
+    });
+
+    expect(mockConfirmBoardSwitch).toHaveBeenCalledOnce();
+    expect(onConfirmed).not.toHaveBeenCalled();
+    const call = mockConfirmBoardSwitch.mock.calls[0][0];
+    expect(call.reason).toBe('session');
+  });
+
+  it('disconnects bluetooth and invokes onConfirmed when the dialog is confirmed', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1 }),
+      reason: 'bluetooth',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'tension', layout_id: 2 }), onConfirmed);
+    });
+
+    // Simulate the provider firing the dialog's confirm callback.
+    const args = mockConfirmBoardSwitch.mock.calls[0][0];
+    act(() => {
+      args.onConfirmed();
+    });
+
+    expect(mockDisconnectAll).toHaveBeenCalledOnce();
+    expect(onConfirmed).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to immediate call-through when the confirm provider is missing', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter' }),
+      reason: 'session',
+    };
+    mockConfirmCtx = null;
+
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'tension' }), onConfirmed);
+    });
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(mockConfirmBoardSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/board-lock/__tests__/use-queue-add-validator.test.tsx
+++ b/packages/web/app/components/board-lock/__tests__/use-queue-add-validator.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+import type { ActiveBoardLock } from '../use-active-board-lock';
+
+let mockLock: ActiveBoardLock = { lockedBoard: null, reason: null };
+let mockFallbackBoard: BoardDetails | null = null;
+const mockShowMessage = vi.fn();
+
+vi.mock('../use-active-board-lock', () => ({
+  useActiveBoardLock: () => mockLock,
+}));
+
+vi.mock('../../queue-control/queue-bridge-context', () => ({
+  useQueueBridgeBoardInfo: () => ({
+    boardDetails: mockFallbackBoard,
+    angle: 0,
+    hasActiveQueue: false,
+  }),
+}));
+
+vi.mock('../../providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+import { useQueueAddValidator } from '../use-queue-add-validator';
+
+function holdsData(ids: number[]) {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 0, cy: 0, r: 1 }));
+}
+
+function makeBoard(partial: Partial<BoardDetails> = {}): BoardDetails {
+  return {
+    images_to_holds: {},
+    holdsData: holdsData([1, 2, 3, 4]),
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 0,
+    boardWidth: 0,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    ...partial,
+  };
+}
+
+function makeClimb(partial: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'c1',
+    setter_username: 't',
+    name: 'T',
+    frames: 'p1r15p2r12',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: '',
+    quality_average: '',
+    stars: 0,
+    difficulty_error: '',
+    benchmark_difficulty: null,
+    ...partial,
+  };
+}
+
+describe('useQueueAddValidator', () => {
+  beforeEach(() => {
+    mockLock = { lockedBoard: null, reason: null };
+    mockFallbackBoard = null;
+    mockShowMessage.mockReset();
+  });
+
+  it('allows any add when no lock and no fallback board exist', () => {
+    const { result } = renderHook(() => useQueueAddValidator());
+    expect(result.current(makeClimb({ boardType: 'tension' }))).toBe(true);
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+
+  it('validates against the session-locked board before the fallback', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter' }),
+      reason: 'session',
+    };
+    mockFallbackBoard = makeBoard({ board_name: 'tension' });
+
+    const { result } = renderHook(() => useQueueAddValidator());
+
+    // Wrong board_name — rejected with message.
+    expect(result.current(makeClimb({ boardType: 'tension' }))).toBe(false);
+    expect(mockShowMessage).toHaveBeenCalledOnce();
+    expect(mockShowMessage.mock.calls[0][0]).toContain('Tension');
+    expect(mockShowMessage.mock.calls[0][1]).toBe('error');
+  });
+
+  it('uses the fallback board when there is no active lock', () => {
+    mockFallbackBoard = makeBoard({ board_name: 'kilter', holdsData: holdsData([1, 2, 3]) });
+
+    const { result } = renderHook(() => useQueueAddValidator());
+
+    // Climb referencing a hold not on the fallback board is rejected.
+    expect(result.current(makeClimb({ frames: 'p7r15' }))).toBe(false);
+    expect(mockShowMessage).toHaveBeenCalledOnce();
+    expect(mockShowMessage.mock.calls[0][0]).toMatch(/holds/);
+  });
+
+  it('allows compatible climbs without firing a Snackbar', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ holdsData: holdsData([1, 2, 3, 4, 5]) }),
+      reason: 'session',
+    };
+    const { result } = renderHook(() => useQueueAddValidator());
+    expect(result.current(makeClimb({ frames: 'p1r15p3r12p5r14' }))).toBe(true);
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -23,12 +23,15 @@ interface BoardSwitchConfirmContextValue {
 
 const BoardSwitchConfirmContext = createContext<BoardSwitchConfirmContextValue | null>(null);
 
-export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue {
-  const ctx = useContext(BoardSwitchConfirmContext);
-  if (!ctx) {
-    throw new Error('useBoardSwitchConfirm must be used within BoardSwitchConfirmProvider');
-  }
-  return ctx;
+/**
+ * Returns the board-switch confirmation context, or `null` when the
+ * provider isn't mounted. `useBoardSwitchGuard` falls back to an
+ * immediate call-through in that case so tests and non-app surfaces
+ * (Storybook, isolated components) don't need to wrap their render
+ * tree in the provider.
+ */
+export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue | null {
+  return useContext(BoardSwitchConfirmContext);
 }
 
 function formatBoardLabel(board: BoardDetails | BoardRouteIdentity): string {
@@ -44,31 +47,35 @@ interface DialogState {
   reason: BoardLockReason;
   lockedLabel: string;
   targetLabel: string;
-  onConfirmed: () => void;
 }
 
 export function BoardSwitchConfirmProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<DialogState | null>(null);
+  // Hold onConfirmed in a ref so handlers never read a stale closure and
+  // the render doesn't need to re-run when the callback changes.
+  const pendingConfirmRef = useRef<(() => void) | null>(null);
 
   const confirmBoardSwitch = useCallback((args: ConfirmArgs) => {
+    pendingConfirmRef.current = args.onConfirmed;
     setState({
       open: true,
       reason: args.reason,
       lockedLabel: formatBoardLabel(args.lockedBoard),
       targetLabel: formatBoardLabel(args.target),
-      onConfirmed: args.onConfirmed,
     });
   }, []);
 
   const handleCancel = useCallback(() => {
+    pendingConfirmRef.current = null;
     setState((prev) => (prev ? { ...prev, open: false } : prev));
   }, []);
 
   const handleConfirm = useCallback(() => {
-    const onConfirmed = state?.onConfirmed;
+    const callback = pendingConfirmRef.current;
+    pendingConfirmRef.current = null;
     setState((prev) => (prev ? { ...prev, open: false } : prev));
-    onConfirmed?.();
-  }, [state]);
+    callback?.();
+  }, []);
 
   const handleExited = useCallback(() => {
     setState(null);

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
+import type { BoardLockReason } from './use-active-board-lock';
+
+interface ConfirmArgs {
+  reason: BoardLockReason;
+  lockedBoard: BoardDetails;
+  target: BoardRouteIdentity | BoardDetails;
+  onConfirmed: () => void;
+}
+
+interface BoardSwitchConfirmContextValue {
+  confirmBoardSwitch: (args: ConfirmArgs) => void;
+}
+
+const BoardSwitchConfirmContext = createContext<BoardSwitchConfirmContextValue | null>(null);
+
+export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue {
+  const ctx = useContext(BoardSwitchConfirmContext);
+  if (!ctx) {
+    throw new Error('useBoardSwitchConfirm must be used within BoardSwitchConfirmProvider');
+  }
+  return ctx;
+}
+
+function formatBoardLabel(board: BoardDetails | BoardRouteIdentity): string {
+  const name = board.board_name.charAt(0).toUpperCase() + board.board_name.slice(1);
+  const parts = [name];
+  if (board.layout_name) parts.push(board.layout_name);
+  if (board.size_name) parts.push(board.size_name);
+  return parts.join(' · ');
+}
+
+interface DialogState {
+  open: boolean;
+  reason: BoardLockReason;
+  lockedLabel: string;
+  targetLabel: string;
+  onConfirmed: () => void;
+}
+
+export function BoardSwitchConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<DialogState | null>(null);
+
+  const confirmBoardSwitch = useCallback((args: ConfirmArgs) => {
+    setState({
+      open: true,
+      reason: args.reason,
+      lockedLabel: formatBoardLabel(args.lockedBoard),
+      targetLabel: formatBoardLabel(args.target),
+      onConfirmed: args.onConfirmed,
+    });
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setState((prev) => (prev ? { ...prev, open: false } : prev));
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    const onConfirmed = state?.onConfirmed;
+    setState((prev) => (prev ? { ...prev, open: false } : prev));
+    onConfirmed?.();
+  }, [state]);
+
+  const handleExited = useCallback(() => {
+    setState(null);
+  }, []);
+
+  const value = useMemo<BoardSwitchConfirmContextValue>(
+    () => ({ confirmBoardSwitch }),
+    [confirmBoardSwitch],
+  );
+
+  const title =
+    state?.reason === 'session' ? 'Leave your session?' : 'Disconnect your board?';
+  const body =
+    state?.reason === 'session'
+      ? `You're in a session on ${state?.lockedLabel}. Switching to ${state?.targetLabel} disconnects your board but keeps the session running.`
+      : `Your ${state?.lockedLabel} is still connected. Switching to ${state?.targetLabel} disconnects it.`;
+
+  return (
+    <BoardSwitchConfirmContext.Provider value={value}>
+      {children}
+      <Dialog
+        open={state?.open ?? false}
+        onClose={handleCancel}
+        TransitionProps={{ onExited: handleExited }}
+        maxWidth="xs"
+        fullWidth
+        aria-labelledby="board-switch-confirm-title"
+      >
+        <DialogTitle id="board-switch-confirm-title">{title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{body}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancel}>Stay</Button>
+          <Button variant="contained" onClick={handleConfirm} autoFocus>
+            Switch boards
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </BoardSwitchConfirmContext.Provider>
+  );
+}

--- a/packages/web/app/components/board-lock/queue-add-error-messages.ts
+++ b/packages/web/app/components/board-lock/queue-add-error-messages.ts
@@ -1,0 +1,43 @@
+import type { Climb, BoardDetails } from '@/app/lib/types';
+import type { BoardCompatibilityResult } from '@/app/lib/board-compatibility';
+
+type QueueAddFailure = Extract<BoardCompatibilityResult, { ok: false }>;
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function climbBoardLabel(climb: Climb): string {
+  if (climb.boardType) return titleCase(climb.boardType);
+  return 'a different board';
+}
+
+function targetBoardLabel(target: BoardDetails): string {
+  return titleCase(target.board_name);
+}
+
+function targetSizeLabel(target: BoardDetails): string {
+  if (target.size_name) return target.size_name;
+  return `${targetBoardLabel(target)} board`;
+}
+
+/**
+ * Build the user-facing Snackbar message for a queue-add compatibility
+ * failure. Shared by the board-route `QueueContext` validator hook and
+ * the root-level `queue-bridge-context` adapter so the copy stays in
+ * one place.
+ */
+export function queueAddErrorMessage(
+  climb: Climb,
+  target: BoardDetails,
+  failure: QueueAddFailure,
+): string {
+  switch (failure.reason) {
+    case 'board_name':
+      return `That climb is set on ${climbBoardLabel(climb)}. Your queue is on ${targetBoardLabel(target)}.`;
+    case 'layout':
+      return `That climb is on a different ${targetBoardLabel(target)} layout.`;
+    case 'holds_out_of_range':
+      return `That climb uses holds your ${targetSizeLabel(target)} doesn't have.`;
+  }
+}

--- a/packages/web/app/components/board-lock/use-active-board-lock.ts
+++ b/packages/web/app/components/board-lock/use-active-board-lock.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { usePersistentSessionState } from '../persistent-session';
+import { useBluetoothConnectedStatus } from '../board-bluetooth-control/bluetooth-status-store';
+import { useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
+import type { BoardDetails } from '@/app/lib/types';
+
+export type BoardLockReason = 'session' | 'bluetooth';
+
+export interface ActiveBoardLock {
+  lockedBoard: BoardDetails | null;
+  reason: BoardLockReason | null;
+}
+
+/**
+ * Reports whether the user's active board is anchored to something that
+ * would make an accidental board switch destructive — an active party
+ * session or a live Bluetooth connection. When neither is present, both
+ * fields are `null` and callers should allow free navigation.
+ *
+ * A session always wins over Bluetooth for labeling purposes (both point
+ * to the same board in practice, but session copy is the more accurate
+ * user-facing reason).
+ */
+export function useActiveBoardLock(): ActiveBoardLock {
+  const { activeSession } = usePersistentSessionState();
+  const isBluetoothConnected = useBluetoothConnectedStatus();
+  const { boardDetails: bridgeBoardDetails } = useQueueBridgeBoardInfo();
+
+  if (activeSession) {
+    return { lockedBoard: activeSession.boardDetails, reason: 'session' };
+  }
+
+  if (isBluetoothConnected && bridgeBoardDetails) {
+    return { lockedBoard: bridgeBoardDetails, reason: 'bluetooth' };
+  }
+
+  return { lockedBoard: null, reason: null };
+}

--- a/packages/web/app/components/board-lock/use-board-switch-guard.ts
+++ b/packages/web/app/components/board-lock/use-board-switch-guard.ts
@@ -39,7 +39,7 @@ export type BoardSwitchTarget = BoardDetails | BoardRouteIdentity;
  */
 export function useBoardSwitchGuard(): (target: BoardSwitchTarget, onConfirmed: () => void) => void {
   const { lockedBoard, reason } = useActiveBoardLock();
-  const { confirmBoardSwitch } = useBoardSwitchConfirm();
+  const confirmCtx = useBoardSwitchConfirm();
 
   return useCallback(
     (target, onConfirmed) => {
@@ -51,7 +51,13 @@ export function useBoardSwitchGuard(): (target: BoardSwitchTarget, onConfirmed: 
         onConfirmed();
         return;
       }
-      confirmBoardSwitch({
+      // No provider mounted (tests, isolated component rendering). Fall
+      // back to an immediate call-through rather than crashing.
+      if (!confirmCtx) {
+        onConfirmed();
+        return;
+      }
+      confirmCtx.confirmBoardSwitch({
         reason,
         lockedBoard,
         target,
@@ -65,6 +71,6 @@ export function useBoardSwitchGuard(): (target: BoardSwitchTarget, onConfirmed: 
         },
       });
     },
-    [lockedBoard, reason, confirmBoardSwitch],
+    [lockedBoard, reason, confirmCtx],
   );
 }

--- a/packages/web/app/components/board-lock/use-board-switch-guard.ts
+++ b/packages/web/app/components/board-lock/use-board-switch-guard.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
+import { useActiveBoardLock } from './use-active-board-lock';
+import { useBoardSwitchConfirm } from './board-switch-confirm-provider';
+import { disconnectAllBluetooth } from '../board-bluetooth-control/bluetooth-status-store';
+
+function sameSetIds(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort((x, y) => x - y);
+  const sb = [...b].sort((x, y) => x - y);
+  for (let i = 0; i < sa.length; i++) {
+    if (sa[i] !== sb[i]) return false;
+  }
+  return true;
+}
+
+function isSameBoard(
+  a: BoardDetails | BoardRouteIdentity,
+  b: BoardDetails | BoardRouteIdentity,
+): boolean {
+  return (
+    a.board_name === b.board_name &&
+    a.layout_id === b.layout_id &&
+    a.size_id === b.size_id &&
+    sameSetIds(a.set_ids, b.set_ids)
+  );
+}
+
+export type BoardSwitchTarget = BoardDetails | BoardRouteIdentity;
+
+/**
+ * Returns a function that intercepts a primary-board switch. If the user
+ * has an active session or a live Bluetooth connection AND the target
+ * board is different, a confirmation dialog is shown. On confirm,
+ * Bluetooth is disconnected (session is left alone) and `onConfirmed` is
+ * invoked. Otherwise `onConfirmed` runs immediately.
+ */
+export function useBoardSwitchGuard(): (target: BoardSwitchTarget, onConfirmed: () => void) => void {
+  const { lockedBoard, reason } = useActiveBoardLock();
+  const { confirmBoardSwitch } = useBoardSwitchConfirm();
+
+  return useCallback(
+    (target, onConfirmed) => {
+      if (!lockedBoard || !reason) {
+        onConfirmed();
+        return;
+      }
+      if (isSameBoard(lockedBoard, target)) {
+        onConfirmed();
+        return;
+      }
+      confirmBoardSwitch({
+        reason,
+        lockedBoard,
+        target,
+        onConfirmed: () => {
+          // Always drop any live Bluetooth connections so the board
+          // stops receiving frames for hardware it's not wired to.
+          // Session is intentionally left alive so the future
+          // multi-board session path can continue to work.
+          disconnectAllBluetooth();
+          onConfirmed();
+        },
+      });
+    },
+    [lockedBoard, reason, confirmBoardSwitch],
+  );
+}

--- a/packages/web/app/components/board-lock/use-queue-add-validator.ts
+++ b/packages/web/app/components/board-lock/use-queue-add-validator.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { Climb, BoardDetails } from '@/app/lib/types';
+import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
+import { useActiveBoardLock } from './use-active-board-lock';
+import { useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
+import { useSnackbar } from '../providers/snackbar-provider';
+
+function formatBoardName(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function formatClimbBoardName(climb: Climb): string {
+  if (climb.boardType) return formatBoardName(climb.boardType);
+  return 'a different board';
+}
+
+function sizeLabel(target: BoardDetails): string {
+  if (target.size_name) return target.size_name;
+  return `${formatBoardName(target.board_name)} board`;
+}
+
+/**
+ * Returns a validator that checks whether a climb can be added to the
+ * user's currently-anchored queue. If the climb isn't compatible, a
+ * Snackbar error is surfaced and the validator returns `false` so the
+ * caller can short-circuit.
+ *
+ * The validation target prefers the active session / Bluetooth lock,
+ * then falls back to the local queue's board details. When neither is
+ * present, all adds are allowed.
+ */
+export function useQueueAddValidator(): (climb: Climb) => boolean {
+  const { lockedBoard } = useActiveBoardLock();
+  const { boardDetails: fallbackBoard } = useQueueBridgeBoardInfo();
+  const { showMessage } = useSnackbar();
+
+  return useCallback(
+    (climb: Climb) => {
+      const target = lockedBoard ?? fallbackBoard;
+      if (!target) return true;
+      const result = canAddClimbToBoard(climb, target);
+      if (result.ok) return true;
+
+      const targetBoardLabel = formatBoardName(target.board_name);
+      switch (result.reason) {
+        case 'board_name':
+          showMessage(
+            `That climb is set on ${formatClimbBoardName(climb)}. Your queue is on ${targetBoardLabel}.`,
+            'error',
+          );
+          break;
+        case 'layout':
+          showMessage(
+            `That climb is on a different ${targetBoardLabel} layout.`,
+            'error',
+          );
+          break;
+        case 'holds_out_of_range':
+          showMessage(
+            `That climb uses holds your ${sizeLabel(target)} doesn't have.`,
+            'error',
+          );
+          break;
+      }
+      return false;
+    },
+    [lockedBoard, fallbackBoard, showMessage],
+  );
+}

--- a/packages/web/app/components/board-lock/use-queue-add-validator.ts
+++ b/packages/web/app/components/board-lock/use-queue-add-validator.ts
@@ -1,25 +1,12 @@
 'use client';
 
 import { useCallback } from 'react';
-import type { Climb, BoardDetails } from '@/app/lib/types';
+import type { Climb } from '@/app/lib/types';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
 import { useActiveBoardLock } from './use-active-board-lock';
 import { useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
 import { useSnackbar } from '../providers/snackbar-provider';
-
-function formatBoardName(name: string): string {
-  return name.charAt(0).toUpperCase() + name.slice(1);
-}
-
-function formatClimbBoardName(climb: Climb): string {
-  if (climb.boardType) return formatBoardName(climb.boardType);
-  return 'a different board';
-}
-
-function sizeLabel(target: BoardDetails): string {
-  if (target.size_name) return target.size_name;
-  return `${formatBoardName(target.board_name)} board`;
-}
+import { queueAddErrorMessage } from './queue-add-error-messages';
 
 /**
  * Returns a validator that checks whether a climb can be added to the
@@ -42,28 +29,7 @@ export function useQueueAddValidator(): (climb: Climb) => boolean {
       if (!target) return true;
       const result = canAddClimbToBoard(climb, target);
       if (result.ok) return true;
-
-      const targetBoardLabel = formatBoardName(target.board_name);
-      switch (result.reason) {
-        case 'board_name':
-          showMessage(
-            `That climb is set on ${formatClimbBoardName(climb)}. Your queue is on ${targetBoardLabel}.`,
-            'error',
-          );
-          break;
-        case 'layout':
-          showMessage(
-            `That climb is on a different ${targetBoardLabel} layout.`,
-            'error',
-          );
-          break;
-        case 'holds_out_of_range':
-          showMessage(
-            `That climb uses holds your ${sizeLabel(target)} doesn't have.`,
-            'error',
-          );
-          break;
-      }
+      showMessage(queueAddErrorMessage(climb, target, result), 'error');
       return false;
     },
     [lockedBoard, fallbackBoard, showMessage],

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -20,6 +20,8 @@ import { getDefaultSizeForLayout } from '@/app/lib/board-constants';
 import { constructClimbListWithSlugs, constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import { saveBoardConfig, StoredBoardConfig } from '@/app/lib/saved-boards-db';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
+import type { BoardRouteIdentity } from '@/app/lib/types';
 
 const CreateBoardForm = lazy(() => import('../board-entity/create-board-form'));
 
@@ -142,6 +144,7 @@ export default function BoardSelectorDrawer({
   onBoardSelected,
 }: BoardSelectorDrawerProps) {
   const router = useRouter();
+  const guardBoardSwitch = useBoardSwitchGuard();
   const [showCreateBoardForm, setShowCreateBoardForm] = useState(false);
 
   // Board config form state
@@ -256,16 +259,27 @@ export default function BoardSelectorDrawer({
       lastUsed: new Date().toISOString(),
     };
 
-    await saveBoardConfig(config);
+    const target: BoardRouteIdentity = {
+      board_name: selectedBoard,
+      layout_id: selectedLayout,
+      size_id: selectedSize,
+      set_ids: selectedSets,
+      layout_name: layout?.name,
+      size_name: size?.name,
+      size_description: size?.description,
+    };
 
-    if (onBoardSelected) {
-      onBoardSelected(targetUrl, config);
-      onClose();
-    } else {
-      router.push(targetUrl);
-      onClose();
-    }
-  }, [selectedBoard, selectedLayout, selectedSize, selectedSets, selectedAngle, targetUrl, layouts, sizes, onBoardSelected, onClose, router]);
+    guardBoardSwitch(target, async () => {
+      await saveBoardConfig(config);
+      if (onBoardSelected) {
+        onBoardSelected(targetUrl, config);
+        onClose();
+      } else {
+        router.push(targetUrl);
+        onClose();
+      }
+    });
+  }, [selectedBoard, selectedLayout, selectedSize, selectedSets, selectedAngle, targetUrl, layouts, sizes, onBoardSelected, onClose, router, guardBoardSwitch]);
 
   const isFormComplete = selectedBoard && selectedLayout && selectedSize && selectedSets.length > 0;
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -37,6 +37,8 @@ import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import type { StoredBoardConfig } from '@/app/lib/saved-boards-db';
 import { isValidHexColor } from '@/app/lib/color-utils';
+import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
+import type { BoardRouteIdentity } from '@/app/lib/types';
 
 type Tab = 'home' | 'climbs' | 'library' | 'feed' | 'create' | 'notifications';
 type PendingCreateAction = 'climb' | 'playlist' | null;
@@ -124,6 +126,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
 
   const pathname = usePathname();
   const router = useRouter();
+  const guardBoardSwitch = useBoardSwitchGuard();
 
   const notificationUnreadCount = useUnreadNotificationCount();
 
@@ -405,8 +408,18 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       return;
     }
 
-    router.push(url);
-  }, [pendingCreateAction, router, showMessage]);
+    if (config) {
+      const target: BoardRouteIdentity = {
+        board_name: config.board,
+        layout_id: config.layoutId,
+        size_id: config.sizeId,
+        set_ids: config.setIds,
+      };
+      guardBoardSwitch(target, () => router.push(url));
+    } else {
+      router.push(url);
+    }
+  }, [pendingCreateAction, router, showMessage, guardBoardSwitch]);
 
   const handleDiscoveryBoardClick = useCallback((board: UserBoard) => {
     if (board.slug) {
@@ -442,7 +455,16 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       url = tryConstructSlugListUrl(config.boardType, config.layoutId, config.sizeId, config.setIds, angle)
         ?? `/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`;
     }
-    handleBoardSelected(url);
+    const storedConfig: StoredBoardConfig = {
+      name: config.layoutName ?? `${config.boardType} board`,
+      board: config.boardType as BoardName,
+      layoutId: config.layoutId,
+      sizeId: config.sizeId,
+      setIds: config.setIds,
+      angle,
+      createdAt: new Date().toISOString(),
+    };
+    handleBoardSelected(url, storedConfig);
     setIsBoardSelectorOpen(false);
   }, [handleBoardSelected]);
 

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -25,6 +25,7 @@ import { usePendingUpdateCleanup } from './hooks/use-pending-update-cleanup';
 import { useMutationGuard } from './hooks/use-mutation-guard';
 import { useOfflineQueueBuffer } from './hooks/use-offline-queue-buffer';
 import { useOfflineReconciliation } from './hooks/use-offline-reconciliation';
+import { useQueueAddValidator } from '../board-lock/use-queue-add-validator';
 import type {
   GraphQLQueueContextType, GraphQLQueueActionsType, GraphQLQueueDataType, GraphQLQueueContextProps,
   CurrentClimbDataType, QueueListDataType, SearchDataType, SessionDataType,
@@ -231,6 +232,9 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
     }
   }, [suggestedClimbs.length, state.queue.length, hasMoreResults, isFetchingNextPage, fetchMoreClimbs, state.hasDoneFirstFetch]);
 
+  // --- Queue-add compatibility validator ---
+  const validateQueueAdd = useQueueAddValidator();
+
   // --- Ref holding latest values so action callbacks can be stable ---
   const latestRef = useRef({
     state, dispatch, isPersistentSessionActive, persistentSession,
@@ -239,7 +243,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
     climbSearchResults, suggestedClimbs, setCountSearchParams,
     correlationCounterRef,
     startSession, joinSession, endSession, dismissSessionSummary,
-    fetchMoreClimbs,
+    fetchMoreClimbs, validateQueueAdd,
   });
   // Sync ref every render (synchronous — safe for refs)
   latestRef.current = {
@@ -249,7 +253,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
     climbSearchResults, suggestedClimbs, setCountSearchParams,
     correlationCounterRef,
     startSession, joinSession, endSession, dismissSessionSummary,
-    fetchMoreClimbs,
+    fetchMoreClimbs, validateQueueAdd,
   };
 
   // --- Stable action callbacks (read from latestRef, never recreated) ---
@@ -257,6 +261,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
     const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    if (!r.validateQueueAdd(climb)) return;
     const mode: QueueOperationMode = !r.isPersistentSessionActive
       ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
@@ -299,6 +304,7 @@ export const GraphQLQueueProvider = ({ parsedParams, boardDetails, children, bas
     const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
+    if (!r.validateQueueAdd(climb)) return;
     const mode: QueueOperationMode = !r.isPersistentSessionActive
       ? 'local' : r.isDisconnected ? 'party-offline' : 'party';
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -25,6 +25,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { CreateHeaderBridgeProvider } from '../create-climb/create-header-bridge-context';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
 
 interface PersistentSessionWrapperProps {
   children: React.ReactNode;
@@ -43,14 +44,16 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
     <PartyProfileProvider>
       <PersistentSessionProvider>
         <QueueBridgeProvider>
-          <SearchDrawerBridgeProvider>
-            <CreateHeaderBridgeProvider>
-              <GlobalHeader boardConfigs={boardConfigs} />
-              {children}
-              <RootBottomBar boardConfigs={boardConfigs} />
-              <RootSessionSummaryDialog />
-            </CreateHeaderBridgeProvider>
-          </SearchDrawerBridgeProvider>
+          <BoardSwitchConfirmProvider>
+            <SearchDrawerBridgeProvider>
+              <CreateHeaderBridgeProvider>
+                <GlobalHeader boardConfigs={boardConfigs} />
+                {children}
+                <RootBottomBar boardConfigs={boardConfigs} />
+                <RootSessionSummaryDialog />
+              </CreateHeaderBridgeProvider>
+            </SearchDrawerBridgeProvider>
+          </BoardSwitchConfirmProvider>
         </QueueBridgeProvider>
       </PersistentSessionProvider>
     </PartyProfileProvider>

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -15,6 +15,8 @@ import type { BoardDetails, Angle, Climb, SearchRequestPagination } from '@/app/
 import type { ClimbQueueItem } from './types';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
+import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
+import { useSnackbar } from '../providers/snackbar-provider';
 
 const LiveActivityBridge = dynamic(
   () => import('@/app/lib/live-activity/live-activity-bridge'),
@@ -73,6 +75,10 @@ const QueueBridgeSetterContext = createContext<QueueBridgeSetters>({
 // Uses latestRef pattern for stable action callbacks (matches GraphQLQueueProvider).
 // -------------------------------------------------------------------
 
+function formatBoardName(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
 function usePersistentSessionQueueAdapter(): {
   context: GraphQLQueueContextType;
   actionsValue: GraphQLQueueActionsType;
@@ -83,6 +89,7 @@ function usePersistentSessionQueueAdapter(): {
   syncFromInjected: (q: ClimbQueueItem[], current: ClimbQueueItem | null, boardPath: string, bd: BoardDetails) => void;
 } {
   const ps = usePersistentSession();
+  const { showMessage } = useSnackbar();
 
   const isParty = !!ps.activeSession;
   const queue = isParty ? ps.queue : ps.localQueue;
@@ -115,8 +122,30 @@ function usePersistentSessionQueueAdapter(): {
   }, [boardDetails, angle]);
 
   // --- Ref holding latest values so action callbacks can be stable ---
-  const latestRef = useRef({ queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps });
-  latestRef.current = { queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps };
+  const latestRef = useRef({ queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, showMessage });
+  latestRef.current = { queue, currentClimbQueueItem, boardDetails, baseBoardPath, ps, showMessage };
+
+  // Validates a climb against the locked board (session) or the current
+  // adapter board. Shows a Snackbar error and returns false if not
+  // compatible.
+  const validateClimbForQueue = useCallback((climb: Climb): boolean => {
+    const r = latestRef.current;
+    const target = r.ps.activeSession?.boardDetails ?? r.boardDetails;
+    if (!target) return true;
+    const result = canAddClimbToBoard(climb, target);
+    if (result.ok) return true;
+    const targetLabel = formatBoardName(target.board_name);
+    if (result.reason === 'board_name') {
+      const climbLabel = climb.boardType ? formatBoardName(climb.boardType) : 'a different board';
+      r.showMessage(`That climb is set on ${climbLabel}. Your queue is on ${targetLabel}.`, 'error');
+    } else if (result.reason === 'layout') {
+      r.showMessage(`That climb is on a different ${targetLabel} layout.`, 'error');
+    } else {
+      const sizeLabel = target.size_name ?? `${targetLabel} board`;
+      r.showMessage(`That climb uses holds your ${sizeLabel} doesn't have.`, 'error');
+    }
+    return false;
+  }, []);
 
   const getNextClimbQueueItem = useCallback((): ClimbQueueItem | null => {
     const r = latestRef.current;
@@ -146,6 +175,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       const r = latestRef.current;
       if (!r.boardDetails) return;
+      if (!validateClimbForQueue(climb)) return;
       const newItem: ClimbQueueItem = {
         climb,
         addedBy: null,
@@ -156,7 +186,7 @@ function usePersistentSessionQueueAdapter(): {
       const current = r.currentClimbQueueItem ?? newItem;
       r.ps.setLocalQueueState(newQueue, current, r.baseBoardPath, r.boardDetails);
     },
-    [],
+    [validateClimbForQueue],
   );
 
   const removeFromQueue = useCallback(
@@ -202,6 +232,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       const r = latestRef.current;
       if (!r.boardDetails) return;
+      if (!validateClimbForQueue(climb)) return;
       const newItem: ClimbQueueItem = {
         climb,
         addedBy: null,
@@ -219,7 +250,7 @@ function usePersistentSessionQueueAdapter(): {
       }
       r.ps.setLocalQueueState(newQueue, newItem, r.baseBoardPath, r.boardDetails);
     },
-    [],
+    [validateClimbForQueue],
   );
 
   // No-op functions for fields not used by the bottom bar

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -17,6 +17,7 @@ import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
 import { useSnackbar } from '../providers/snackbar-provider';
+import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
 
 const LiveActivityBridge = dynamic(
   () => import('@/app/lib/live-activity/live-activity-bridge'),
@@ -75,10 +76,6 @@ const QueueBridgeSetterContext = createContext<QueueBridgeSetters>({
 // Uses latestRef pattern for stable action callbacks (matches GraphQLQueueProvider).
 // -------------------------------------------------------------------
 
-function formatBoardName(name: string): string {
-  return name.charAt(0).toUpperCase() + name.slice(1);
-}
-
 function usePersistentSessionQueueAdapter(): {
   context: GraphQLQueueContextType;
   actionsValue: GraphQLQueueActionsType;
@@ -127,23 +124,15 @@ function usePersistentSessionQueueAdapter(): {
 
   // Validates a climb against the locked board (session) or the current
   // adapter board. Shows a Snackbar error and returns false if not
-  // compatible.
+  // compatible. Message formatting lives in `queue-add-error-messages`
+  // so the board-route and root-level entry points speak the same copy.
   const validateClimbForQueue = useCallback((climb: Climb): boolean => {
     const r = latestRef.current;
     const target = r.ps.activeSession?.boardDetails ?? r.boardDetails;
     if (!target) return true;
     const result = canAddClimbToBoard(climb, target);
     if (result.ok) return true;
-    const targetLabel = formatBoardName(target.board_name);
-    if (result.reason === 'board_name') {
-      const climbLabel = climb.boardType ? formatBoardName(climb.boardType) : 'a different board';
-      r.showMessage(`That climb is set on ${climbLabel}. Your queue is on ${targetLabel}.`, 'error');
-    } else if (result.reason === 'layout') {
-      r.showMessage(`That climb is on a different ${targetLabel} layout.`, 'error');
-    } else {
-      const sizeLabel = target.size_name ?? `${targetLabel} board`;
-      r.showMessage(`That climb uses holds your ${sizeLabel} doesn't have.`, 'error');
-    }
+    r.showMessage(queueAddErrorMessage(climb, target, result), 'error');
     return false;
   }, []);
 

--- a/packages/web/app/lib/__tests__/board-compatibility.test.ts
+++ b/packages/web/app/lib/__tests__/board-compatibility.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { parseClimbFrameHoldIds, canAddClimbToBoard } from '@/app/lib/board-compatibility';
+import type { Climb, BoardDetails } from '@/app/lib/types';
+
+function holdsData(ids: number[]): BoardDetails['holdsData'] {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 0, cy: 0, r: 1 }));
+}
+
+function makeBoard(partial: Partial<BoardDetails>): BoardDetails {
+  return {
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 0,
+    boardWidth: 0,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    ...partial,
+  };
+}
+
+function makeClimb(partial: Partial<Climb>): Climb {
+  return {
+    uuid: 'climb-uuid',
+    setter_username: 'test',
+    name: 'Test',
+    frames: '',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: '',
+    quality_average: '',
+    stars: 0,
+    difficulty_error: '',
+    benchmark_difficulty: null,
+    ...partial,
+  };
+}
+
+describe('parseClimbFrameHoldIds', () => {
+  it('returns an empty array for empty or nullish input', () => {
+    expect(parseClimbFrameHoldIds('')).toEqual([]);
+    expect(parseClimbFrameHoldIds(null)).toEqual([]);
+    expect(parseClimbFrameHoldIds(undefined)).toEqual([]);
+  });
+
+  it('parses a single hold', () => {
+    expect(parseClimbFrameHoldIds('p1234r15')).toEqual([1234]);
+  });
+
+  it('parses multiple holds', () => {
+    expect(parseClimbFrameHoldIds('p1234r15p5678r12p9r14')).toEqual([1234, 5678, 9]);
+  });
+
+  it('handles negative state codes', () => {
+    expect(parseClimbFrameHoldIds('p100r-1p200r15')).toEqual([100, 200]);
+  });
+
+  it('returns an empty array for malformed input', () => {
+    expect(parseClimbFrameHoldIds('hello world')).toEqual([]);
+  });
+});
+
+describe('canAddClimbToBoard', () => {
+  it('allows a climb that fits on the target board', () => {
+    const board = makeBoard({ holdsData: holdsData([1, 2, 3, 4, 5]) });
+    const climb = makeClimb({ frames: 'p1r15p3r12p5r14' });
+    expect(canAddClimbToBoard(climb, board)).toEqual({ ok: true });
+  });
+
+  it('rejects climbs from a different board_name', () => {
+    const board = makeBoard({ board_name: 'kilter' });
+    const climb = makeClimb({ boardType: 'tension', frames: 'p1r15' });
+    expect(canAddClimbToBoard(climb, board)).toEqual({ ok: false, reason: 'board_name' });
+  });
+
+  it('rejects climbs from a different layout_id', () => {
+    const board = makeBoard({ layout_id: 1, holdsData: holdsData([1, 2]) });
+    const climb = makeClimb({ layoutId: 7, frames: 'p1r15' });
+    expect(canAddClimbToBoard(climb, board)).toEqual({ ok: false, reason: 'layout' });
+  });
+
+  it('ignores missing boardType / layoutId on legacy climbs', () => {
+    const board = makeBoard({ holdsData: holdsData([1, 2]) });
+    const climb = makeClimb({ frames: 'p1r15p2r14' });
+    expect(canAddClimbToBoard(climb, board)).toEqual({ ok: true });
+  });
+
+  it('allows a smaller-board climb on a larger board (subset of holds)', () => {
+    const smallBoard = makeBoard({ size_id: 1, holdsData: holdsData([1, 2, 3, 4]) });
+    const largeBoard = makeBoard({ size_id: 2, holdsData: holdsData([1, 2, 3, 4, 5, 6, 7, 8]) });
+    // Pretend this climb was set on the small board.
+    const climb = makeClimb({ frames: 'p1r15p3r12p4r14' });
+    expect(canAddClimbToBoard(climb, largeBoard)).toEqual({ ok: true });
+    // And adding it back to the small board still works.
+    expect(canAddClimbToBoard(climb, smallBoard)).toEqual({ ok: true });
+  });
+
+  it('rejects a larger-board climb on a smaller board when it uses out-of-range holds', () => {
+    const smallBoard = makeBoard({ size_id: 1, holdsData: holdsData([1, 2, 3, 4]) });
+    // A climb that uses a hold (7) not present on the small board.
+    const climb = makeClimb({ frames: 'p1r15p3r12p7r14' });
+    expect(canAddClimbToBoard(climb, smallBoard)).toEqual({
+      ok: false,
+      reason: 'holds_out_of_range',
+    });
+  });
+
+  it('treats empty frames as compatible', () => {
+    const board = makeBoard({ holdsData: holdsData([1, 2, 3]) });
+    const climb = makeClimb({ frames: '' });
+    expect(canAddClimbToBoard(climb, board)).toEqual({ ok: true });
+  });
+});

--- a/packages/web/app/lib/board-compatibility.ts
+++ b/packages/web/app/lib/board-compatibility.ts
@@ -1,0 +1,80 @@
+import type { Climb, BoardDetails } from './types';
+
+/**
+ * Parse an Aurora-format climb frames string into an array of hold IDs.
+ *
+ * Frames look like `p1234r15p5678r12...` where each `p{holdId}r{stateCode}`
+ * pair describes a single hold placement. Returns an empty array for
+ * empty, malformed, or nullish input.
+ */
+export function parseClimbFrameHoldIds(frames: string | null | undefined): number[] {
+  if (!frames) return [];
+  const ids: number[] = [];
+  const pattern = /p(\d+)r-?\d+/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(frames)) !== null) {
+    const id = Number(match[1]);
+    if (Number.isFinite(id)) ids.push(id);
+  }
+  return ids;
+}
+
+export type BoardCompatibilityResult =
+  | { ok: true }
+  | { ok: false; reason: 'board_name' | 'layout' | 'holds_out_of_range' };
+
+// Cache valid hold ID sets per BoardDetails object so repeated queue-add
+// validation doesn't rebuild the Set on every call.
+const validHoldIdCache = new WeakMap<BoardDetails, Set<number>>();
+
+function getValidHoldIds(target: BoardDetails): Set<number> | null {
+  // If the target board is missing holdsData (which can happen in tests or
+  // when a board is stubbed without render data), we can't run the hold-ID
+  // containment check. Callers treat a null set as "no per-hold check".
+  if (!target.holdsData || !Array.isArray(target.holdsData) || target.holdsData.length === 0) {
+    return null;
+  }
+  const cached = validHoldIdCache.get(target);
+  if (cached) return cached;
+  const set = new Set<number>();
+  for (const hold of target.holdsData) {
+    set.add(hold.id);
+  }
+  validHoldIdCache.set(target, set);
+  return set;
+}
+
+/**
+ * Determine whether a climb can be added to a queue bound to `target`.
+ *
+ * Rules:
+ *  1. `climb.boardType` must match `target.board_name` when set.
+ *  2. `climb.layoutId` must match `target.layout_id` when set.
+ *  3. Every hold ID referenced in `climb.frames` must exist on the target
+ *     board. This naturally allows smaller boards to be added to larger
+ *     queues (subset of holds) but rejects larger-board climbs that use
+ *     holds missing on a smaller board.
+ */
+export function canAddClimbToBoard(climb: Climb, target: BoardDetails): BoardCompatibilityResult {
+  if (climb.boardType && climb.boardType !== target.board_name) {
+    return { ok: false, reason: 'board_name' };
+  }
+  if (climb.layoutId != null && climb.layoutId !== target.layout_id) {
+    return { ok: false, reason: 'layout' };
+  }
+  const validIds = getValidHoldIds(target);
+  if (!validIds) {
+    // Target has no usable hold render data — accept the climb rather
+    // than blocking it. Layout/board_name already covers the common
+    // case, and the WASM renderer will ignore unknown hold IDs at draw
+    // time if something slips through.
+    return { ok: true };
+  }
+  const climbHoldIds = parseClimbFrameHoldIds(climb.frames);
+  for (const id of climbHoldIds) {
+    if (!validIds.has(id)) {
+      return { ok: false, reason: 'holds_out_of_range' };
+    }
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Prevents accidental board switches while in an active session or with
Bluetooth connected. Users can still browse climbs on other boards, but
switching the primary board now asks first and disconnects Bluetooth on
confirm (session stays alive). Queue adds of incompatible climbs surface
a friendly Snackbar error instead of silently putting the wrong frames
on the wall. Smaller-board climbs still fit on larger boards; climbs
using holds outside a smaller board's range are rejected.

https://claude.ai/code/session_01MZRxFwvQaKC9dC4KZ8ZyPJ