### PR TITLE
Float swipe-dismiss hint above queue bar as fading toast

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -167,53 +167,43 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: rating stack, comment toggle, grade, attempt, confirm — all clustered to the right', () => {
+    it('renders the controls in the expected order: rating, comment toggle, grade, attempt, confirm — all clustered to the right', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
-      const hint = screen.getByTestId('quick-tick-hint');
       const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
       const gradeLabel = screen.getByTestId('quick-tick-grade');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
-      // The rating sits inside a small stack with the swipe hint rendered as
-      // a byline directly underneath it. That stack is then a sibling of
-      // the comment toggle, grade label, attempt and confirm buttons inside
-      // the single flex row.
-      const ratingStack = rating.parentElement!;
-      expect(hint.parentElement).toBe(ratingStack);
-
-      const controls = ratingStack.parentElement!;
+      // Rating sits directly inside the single flex row alongside the
+      // comment toggle, grade label, attempt and confirm buttons. The
+      // "swipe left to dismiss" hint is no longer rendered here — it lives
+      // as a transient toast above the queue control bar instead.
+      const controls = rating.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
       expect(gradeLabel.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
-      // Siblings of .controls must appear in this order: rating stack,
-      // comment toggle, grade label, attempt (X), confirm (tick). The
-      // grade sits immediately to the left of the attempt button and the
-      // confirm button is the final element.
+      // Siblings of .controls must appear in this order: rating, comment
+      // toggle, grade label, attempt (X), confirm (tick). The grade sits
+      // immediately to the left of the attempt button and the confirm
+      // button is the final element.
       const siblings = Array.from(controls.children) as HTMLElement[];
-      const stackIdx = siblings.indexOf(ratingStack);
+      const ratingIdx = siblings.indexOf(rating);
       const commentIdx = siblings.indexOf(commentToggle);
       const gradeIdx = siblings.indexOf(gradeLabel);
       const attemptIdx = siblings.indexOf(attemptBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
-      expect(stackIdx).toBeLessThan(commentIdx);
+      expect(ratingIdx).toBeLessThan(commentIdx);
       expect(commentIdx).toBeLessThan(gradeIdx);
       expect(gradeIdx).toBeLessThan(attemptIdx);
       expect(confirmIdx).toBe(attemptIdx + 1);
     });
 
-    it('shows the "swipe left to dismiss" hint text by default', () => {
+    it('does not render the swipe hint inline — the hint lives above the bar as a transient toast', () => {
       render(<QuickTickBar {...defaultProps} />);
-      const hint = screen.getByTestId('quick-tick-hint');
-      expect(hint.textContent).toMatch(/swipe left to dismiss/i);
-    });
-
-    it('hides the swipe hint when the comment field is open', () => {
-      render(<QuickTickBar {...defaultProps} commentOpen={true} />);
       expect(screen.queryByTestId('quick-tick-hint')).toBeNull();
     });
 

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -1,7 +1,5 @@
 .tickBar {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1, 4px);
   min-width: 0;
   flex: 1;
   animation: tickBarEnter 150ms ease-out;
@@ -28,25 +26,15 @@
   min-width: 0;
 }
 
-.ratingStack {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-1, 4px);
+.rating {
   flex-shrink: 0;
-  min-width: 0;
   margin-left: auto;
 }
 
-.hint {
-  font-size: 11px;
-  font-style: italic;
-  user-select: none;
-  pointer-events: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+/* Match the visual weight of the adjacent CheckOutlined / CloseOutlined icons
+   (24px) so the stars line up with the action buttons. */
+.rating :global(.MuiRating-icon) {
+  font-size: 22px;
 }
 
 .gradeLabel {

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -5,6 +5,9 @@ import { useSwipeable } from 'react-swipeable';
 import IconButton from '@mui/material/IconButton';
 import Rating from '@mui/material/Rating';
 import Typography from '@mui/material/Typography';
+// NOTE: the "swipe left to dismiss" hint is intentionally NOT rendered here —
+// it lives above the queue control bar as a transient toast so it doesn't
+// push the stars out of alignment with the action buttons.
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
@@ -275,30 +278,15 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* The rating stack + comment button float to the right of the bar,
-            immediately next to the colourised V-grade, attempt (X) and
-            confirm (tick). The "swipe to dismiss" hint sits as a byline
-            directly underneath the stars. */}
-        <div className={styles.ratingStack}>
-          <Rating
-            value={quality}
-            onChange={(_, val) => setQuality(val)}
-            size="small"
-            max={5}
-            data-testid="quick-tick-rating"
-          />
-          {!commentOpen && (
-            <Typography
-              variant="caption"
-              component="span"
-              color="text.secondary"
-              className={styles.hint}
-              data-testid="quick-tick-hint"
-            >
-              swipe left to dismiss
-            </Typography>
-          )}
-        </div>
+        {/* Rating sits to the right of the bar, sized to match the adjacent
+            attempt (X) and confirm (tick) icon buttons. */}
+        <Rating
+          value={quality}
+          onChange={(_, val) => setQuality(val)}
+          max={5}
+          data-testid="quick-tick-rating"
+          className={styles.rating}
+        />
 
         <IconButton
           size="small"

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -124,6 +124,47 @@
   }
 }
 
+/* Transient "swipe left to dismiss" hint — floats above the tick bar for a
+   few seconds after tick mode opens, then fades out. Uses a small pill with
+   a blurred backdrop so it reads as a system hint without competing with
+   the action buttons below. */
+.swipeHint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  margin: 0 auto 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background-color: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 11px;
+  font-style: italic;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 300ms ease-out, transform 300ms ease-out;
+  will-change: opacity, transform;
+}
+
+.swipeHintVisible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+:global(html[data-theme="dark"]) .swipeHint {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
 /* Tick-mode comment bar — sits above the main control bar so the queue bar
    doesn't reflow when the comment button is tapped. Lines up visually with
    the main card padding + desktop max-width. */

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -149,6 +149,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const handleTickCommentFocus = useCallback(() => setTickCommentFocused(true), []);
   const handleTickCommentBlur = useCallback(() => setTickCommentFocused(false), []);
 
+  // Transient "swipe left to dismiss" hint that floats above the queue
+  // control bar whenever the tick bar opens. Visible for 3s then fades out.
+  const [swipeHintVisible, setSwipeHintVisible] = useState(false);
+
   // Note: the tick bar intentionally stays open when the active climb changes
   // (e.g. party session navigation). QuickTickBar snapshots its target climb
   // internally so the user can finish ticking the climb they opened the bar
@@ -280,6 +284,18 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       setTickCommentOpen(false);
       setTickCommentFocused(false);
     }
+  }, [tickBarActive]);
+
+  // Show the swipe hint every time the tick bar opens, then auto-fade it
+  // after 3 seconds so it stays out of the user's way.
+  useEffect(() => {
+    if (!tickBarActive) {
+      setSwipeHintVisible(false);
+      return;
+    }
+    setSwipeHintVisible(true);
+    const timer = setTimeout(() => setSwipeHintVisible(false), 3000);
+    return () => clearTimeout(timer);
   }, [tickBarActive]);
 
   const { swipeHandlers, swipeOffset, isAnimating, animationDirection, enterDirection, clearEnterAnimation } = useCardSwipeNavigation({
@@ -488,6 +504,18 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 : 'Offline. Changes will sync when you reconnect.'
               : 'Offline'}
           </span>
+        </div>
+      )}
+      {/* Transient "swipe left to dismiss" hint — floats above the queue
+          control bar the first 3 seconds after tick mode opens, then fades
+          away so it doesn't interfere with the stars or action buttons. */}
+      {tickBarActive && (
+        <div
+          className={`${styles.swipeHint} ${swipeHintVisible ? styles.swipeHintVisible : ''}`}
+          aria-hidden="true"
+          data-testid="quick-tick-swipe-hint"
+        >
+          swipe left to dismiss
         </div>
       )}
       {/* Tick-mode comment bar — rendered above the main card so tapping the


### PR DESCRIPTION
The inline "swipe left to dismiss" caption under the rating stars was
pushing the stars up and breaking horizontal alignment with the comment,
grade, attempt and confirm controls inside the tick bar. Moving the hint
out lets the stars sit on the same row as the action buttons and lets
them size up to match the adjacent icons.

- Remove the hint + rating stack wrapper from QuickTickBar and bump the
  rating stars to ~22px so they read at roughly the same weight as the
  CheckOutlined / CloseOutlined icons next to them.
- Render a small transient pill above the queue control bar instead.
  It shows every time tick mode opens, fades out after 3 seconds, uses
  a blurred backdrop and a dark-mode variant so it reads as a subtle
  system hint rather than a persistent label.
- Update the quick-tick-bar layout tests to reflect the flatter control
  row and the fact that the hint no longer lives inside the bar.