### PR TITLE
Remove unnecessary artifact download from lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
         retention-days: 1
 
   lint:
-    needs: setup
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -68,11 +67,6 @@ jobs:
 
     - name: Install dependencies
       run: bun install --frozen-lockfile
-
-    - name: Download built packages
-      uses: actions/download-artifact@v4
-      with:
-        name: built-packages
 
     - name: Run linting
       run: bun run lint


### PR DESCRIPTION
The lint job uses oxlint which only needs source files, not compiled
dist/ output. Removing the artifact download step saves ~5s per lint run.

Also removed the dependency on the setup job since the lint job doesn't
need built packages, allowing it to run independently and in parallel.

https://claude.ai/code/session_01MHkkGFoLrQMxwSDwnSBqJ4