### PR TITLE
ci: add structured JUnit test reporting to GitHub Actions

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     services:
       postgres:
@@ -73,7 +76,24 @@ jobs:
         run: bun run --filter=@boardsesh/db build
 
       - name: Run backend integration tests
-        run: bun run --filter=boardsesh-backend test:run
+        run: bun run --filter=boardsesh-backend test:run -- --reporter=verbose --reporter=junit --outputFile.junit=./test-results/junit.xml
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5433/boardsesh_backend_test
           REDIS_URL: redis://localhost:6380
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-test-results
+          path: packages/backend/test-results/junit.xml
+          retention-days: 7
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Backend Integration Tests
+          path: packages/backend/test-results/junit.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,9 @@ jobs:
   test:
     needs: setup
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v6
 
@@ -132,4 +135,21 @@ jobs:
         name: built-packages
 
     - name: Run tests
-      run: bun run --filter=@boardsesh/web test:run -- --reporter=verbose --reporter=github-actions
+      run: bun run --filter=@boardsesh/web test:run -- --reporter=verbose --reporter=github-actions --reporter=junit --outputFile.junit=./test-results/junit.xml
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: web-test-results
+        path: packages/web/test-results/junit.xml
+        retention-days: 7
+
+    - name: Publish test report
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: Web Unit Tests
+        path: packages/web/test-results/junit.xml
+        reporter: java-junit
+        fail-on-error: false


### PR DESCRIPTION
Adds dorny/test-reporter to web and backend test workflows so that test
failures appear as rich Check Runs in the PR UI instead of requiring
users to dig through raw logs.

- Web tests: append --reporter=junit to existing vitest reporters
- Backend tests: add --reporter=verbose --reporter=junit with -- passthrough
- Both workflows: upload JUnit XML as artifact (if: always), publish
  Check Run via dorny/test-reporter@v1 (fail-on-error: false)
- Add checks: write + pull-requests: write permissions to test jobs

https://claude.ai/code/session_01Gxj4SyV98dg7UXWM24kYgd