### PR TITLE
Refactor climb search cache to use stable module-level function reference

### DIFF
--- a/packages/web/app/lib/__tests__/climb-search-cache.server.test.ts
+++ b/packages/web/app/lib/__tests__/climb-search-cache.server.test.ts
@@ -21,7 +21,7 @@ describe('revalidateClimbSearchTags', () => {
     mockTrack.mockResolvedValue(undefined);
   });
 
-  it('revalidates board and layout tags and emits a metric', async () => {
+  it('revalidates the board tag and emits a metric (layoutId is informational only)', async () => {
     const headers = new Headers({
       cookie: 'session=test',
       'user-agent': 'vitest',
@@ -35,15 +35,14 @@ describe('revalidateClimbSearchTags', () => {
       source: 'internal-route',
     });
 
-    expect(mockRevalidateTag).toHaveBeenNthCalledWith(1, 'climb-search:moonboard', { expire: 0 });
-    expect(mockRevalidateTag).toHaveBeenNthCalledWith(2, 'climb-search:moonboard:3', { expire: 0 });
+    expect(mockRevalidateTag).toHaveBeenCalledTimes(1);
+    expect(mockRevalidateTag).toHaveBeenCalledWith('climb-search:moonboard', { expire: 0 });
     expect(mockTrack).toHaveBeenCalledWith(
       'Climb Search Cache Invalidated',
       {
         boardName: 'moonboard',
         layoutId: 3,
         source: 'internal-route',
-        tagCount: 2,
       },
       { headers },
     );
@@ -69,7 +68,6 @@ describe('revalidateClimbSearchTags', () => {
         boardName: 'kilter',
         layoutId: null,
         source: 'save-climb-proxy',
-        tagCount: 1,
       },
       { headers },
     );

--- a/packages/web/app/lib/climb-search-cache.server.ts
+++ b/packages/web/app/lib/climb-search-cache.server.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { track } from '@vercel/analytics/server';
 import { revalidateTag } from 'next/cache';
 import type { BoardName } from '@/app/lib/types';
-import { getBoardClimbSearchTag, getLayoutClimbSearchTag } from '@/app/lib/climb-search-cache';
+import { getBoardClimbSearchTag } from '@/app/lib/climb-search-cache';
 
 export type ClimbSearchInvalidationSource = 'internal-route' | 'save-climb-proxy';
 
@@ -20,11 +20,9 @@ export async function revalidateClimbSearchTags({
   requestHeaders,
   source,
 }: RevalidateClimbSearchTagsOptions): Promise<void> {
+  // Cache entries are tagged at board level (not layout level), so board-level
+  // invalidation covers all layouts including the one a climb was just saved to.
   revalidateTag(getBoardClimbSearchTag(boardName), { expire: 0 });
-
-  if (layoutId) {
-    revalidateTag(getLayoutClimbSearchTag(boardName, layoutId), { expire: 0 });
-  }
 
   if (!requestHeaders) {
     return;
@@ -36,7 +34,6 @@ export async function revalidateClimbSearchTags({
       boardName,
       layoutId: layoutId ?? null,
       source,
-      tagCount: layoutId ? 2 : 1,
     },
     { headers: requestHeaders },
   );

--- a/packages/web/app/lib/climb-search-cache.ts
+++ b/packages/web/app/lib/climb-search-cache.ts
@@ -7,10 +7,6 @@ export function getBoardClimbSearchTag(boardName: BoardName): string {
   return `${CLIMB_SEARCH_TAG}:${boardName}`;
 }
 
-export function getLayoutClimbSearchTag(boardName: BoardName, layoutId: number): string {
-  return `${getBoardClimbSearchTag(boardName)}:${layoutId}`;
-}
-
 export async function invalidateClimbSearchQueries(
   queryClient: QueryClient,
   boardName: BoardName,

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -1,9 +1,9 @@
 import 'server-only';
 import { unstable_cache } from 'next/cache';
 import { getDb } from '@/app/lib/db/db';
-import { searchClimbs as sharedSearchClimbs, type ClimbSearchResult } from '@boardsesh/db/queries';
-import { getBoardClimbSearchTag, getLayoutClimbSearchTag } from '@/app/lib/climb-search-cache';
-import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+import { searchClimbs as sharedSearchClimbs } from '@boardsesh/db/queries';
+import { getBoardClimbSearchTag } from '@/app/lib/climb-search-cache';
+import type { ParsedBoardRouteParameters, SearchRequestPagination, BoardName } from '@/app/lib/types';
 import type { Climb } from '@/app/lib/types';
 import { sortObjectKeys } from '@/app/lib/cache-utils';
 
@@ -11,8 +11,107 @@ import { sortObjectKeys } from '@/app/lib/cache-utils';
  * Cache durations for climb search queries (in seconds)
  */
 const CACHE_DURATION_DEFAULT_SEARCH = 24 * 60 * 60; // 24 hours for default searches
-const CACHE_DURATION_DEFAULT_SEARCH_MOONBOARD = 15 * 60; // 15 minutes while MoonBoard data is still growing quickly
 const CACHE_DURATION_FILTERED_SEARCH = 60 * 60; // 1 hour for filtered searches
+
+/**
+ * Module-level query function with explicit arguments so unstable_cache holds a
+ * stable function reference across requests. The board params are passed as
+ * primitives and the search params as a pre-sorted JSON string to guarantee
+ * deterministic cache key generation.
+ */
+async function _executeClimbSearch(
+  boardName: string,
+  layoutId: number,
+  sizeId: number,
+  setIdsStr: string,
+  angle: number,
+  searchParamsJson: string,
+  userId: string | undefined,
+): Promise<{ climbs: Climb[]; hasMore: boolean }> {
+  const params: ParsedBoardRouteParameters = {
+    board_name: boardName as BoardName,
+    layout_id: layoutId,
+    size_id: sizeId,
+    set_ids: setIdsStr.split(',').map(Number),
+    angle,
+  };
+  const searchParams = JSON.parse(searchParamsJson) as SearchRequestPagination;
+
+  const db = getDb();
+  const result = await sharedSearchClimbs(db, params, {
+    page: searchParams.page,
+    pageSize: searchParams.pageSize,
+    gradeAccuracy: searchParams.gradeAccuracy ? Number(searchParams.gradeAccuracy) : undefined,
+    minGrade: searchParams.minGrade || undefined,
+    maxGrade: searchParams.maxGrade || undefined,
+    minAscents: searchParams.minAscents || undefined,
+    minRating: searchParams.minRating || undefined,
+    sortBy: searchParams.sortBy || 'ascents',
+    sortOrder: searchParams.sortOrder || 'desc',
+    name: searchParams.name || undefined,
+    settername: searchParams.settername && searchParams.settername.length > 0 ? searchParams.settername : undefined,
+    onlyTallClimbs: searchParams.onlyTallClimbs || undefined,
+    holdsFilter: searchParams.holdsFilter && Object.keys(searchParams.holdsFilter).length > 0
+      ? Object.fromEntries(
+          Object.entries(searchParams.holdsFilter).map(([key, value]) => [
+            key.replace('hold_', ''),
+            typeof value === 'object' && value !== null ? (value as { state: string }).state : value,
+          ])
+        )
+      : undefined,
+    hideAttempted: searchParams.hideAttempted || undefined,
+    hideCompleted: searchParams.hideCompleted || undefined,
+    showOnlyAttempted: searchParams.showOnlyAttempted || undefined,
+    showOnlyCompleted: searchParams.showOnlyCompleted || undefined,
+    onlyDrafts: searchParams.onlyDrafts || undefined,
+  }, userId);
+
+  const climbs: Climb[] = result.climbs.map((row) => ({
+    ...row,
+    mirrored: undefined,
+    is_no_match: /^no match/i.test(row.description || ''),
+  }));
+
+  return { climbs, hasMore: result.hasMore };
+}
+
+type CachedClimbSearchFn = (
+  boardName: string,
+  layoutId: number,
+  sizeId: number,
+  setIdsStr: string,
+  angle: number,
+  searchParamsJson: string,
+  userId: string | undefined,
+) => Promise<{ climbs: Climb[]; hasMore: boolean }>;
+
+/**
+ * Lazily-created unstable_cache instances, one per (boardName, revalidate) pair.
+ * Keeping them board-scoped preserves board-specific cache tag invalidation:
+ * revalidateTag('climb-search:kilter') still targets only kilter entries.
+ *
+ * Layout-level tags are dropped (they were previously used for per-layout
+ * invalidation on climb save). Board-level invalidation covers that use case —
+ * revalidateClimbSearchTags always calls the board-level revalidateTag too.
+ */
+const _cacheRegistry = new Map<string, CachedClimbSearchFn>();
+
+function _getCachedFn(boardName: BoardName, revalidate: number): CachedClimbSearchFn {
+  const key = `${boardName}:${revalidate}`;
+  let fn = _cacheRegistry.get(key);
+  if (!fn) {
+    fn = unstable_cache(
+      _executeClimbSearch,
+      [`climb-search-v3:${boardName}`],
+      {
+        revalidate,
+        tags: ['climb-search', getBoardClimbSearchTag(boardName)],
+      },
+    );
+    _cacheRegistry.set(key, fn);
+  }
+  return fn;
+}
 
 /**
  * Search for climbs directly from the database (no GraphQL round-trip).
@@ -34,95 +133,48 @@ export async function cachedSearchClimbs(
   // the server cache there to surface new climbs immediately.
   const cacheable = (options?.cacheable ?? !userId) && params.board_name !== 'moonboard';
 
-  const revalidate = isDefaultSearch
-    ? (params.board_name === 'moonboard' ? CACHE_DURATION_DEFAULT_SEARCH_MOONBOARD : CACHE_DURATION_DEFAULT_SEARCH)
-    : CACHE_DURATION_FILTERED_SEARCH;
-
-  const executeQuery = async () => {
-    const db = getDb();
-    const result = await sharedSearchClimbs(db, params, {
-      page: searchParams.page,
-      pageSize: searchParams.pageSize,
-      gradeAccuracy: searchParams.gradeAccuracy ? Number(searchParams.gradeAccuracy) : undefined,
-      minGrade: searchParams.minGrade || undefined,
-      maxGrade: searchParams.maxGrade || undefined,
-      minAscents: searchParams.minAscents || undefined,
-      minRating: searchParams.minRating || undefined,
-      sortBy: searchParams.sortBy || 'ascents',
-      sortOrder: searchParams.sortOrder || 'desc',
-      name: searchParams.name || undefined,
-      settername: searchParams.settername && searchParams.settername.length > 0 ? searchParams.settername : undefined,
-      onlyTallClimbs: searchParams.onlyTallClimbs || undefined,
-      holdsFilter: searchParams.holdsFilter && Object.keys(searchParams.holdsFilter).length > 0
-        ? Object.fromEntries(
-            Object.entries(searchParams.holdsFilter).map(([key, value]) => [
-              key.replace('hold_', ''),
-              typeof value === 'object' && value !== null ? (value as { state: string }).state : value,
-            ])
-          )
-        : undefined,
-      hideAttempted: searchParams.hideAttempted || undefined,
-      hideCompleted: searchParams.hideCompleted || undefined,
-      showOnlyAttempted: searchParams.showOnlyAttempted || undefined,
-      showOnlyCompleted: searchParams.showOnlyCompleted || undefined,
-      onlyDrafts: searchParams.onlyDrafts || undefined,
-    }, userId);
-
-    // Map ClimbRow to the web Climb type
-    const climbs: Climb[] = result.climbs.map((row) => ({
-      ...row,
-      mirrored: undefined,
-      is_no_match: /^no match/i.test(row.description || ''),
-    }));
-
-    return { climbs, hasMore: result.hasMore };
-  };
+  const setIdsStr = [...params.set_ids].sort((a, b) => a - b).join(',');
+  const searchParamsJson = JSON.stringify(sortObjectKeys({
+    page: searchParams.page,
+    pageSize: searchParams.pageSize,
+    gradeAccuracy: searchParams.gradeAccuracy,
+    minGrade: searchParams.minGrade,
+    maxGrade: searchParams.maxGrade,
+    minAscents: searchParams.minAscents,
+    minRating: searchParams.minRating,
+    sortBy: searchParams.sortBy,
+    sortOrder: searchParams.sortOrder,
+    name: searchParams.name,
+    setter: searchParams.settername,
+    onlyTallClimbs: searchParams.onlyTallClimbs,
+    holdsFilter: searchParams.holdsFilter,
+    hideAttempted: searchParams.hideAttempted,
+    hideCompleted: searchParams.hideCompleted,
+    showOnlyAttempted: searchParams.showOnlyAttempted,
+    showOnlyCompleted: searchParams.showOnlyCompleted,
+    onlyDrafts: searchParams.onlyDrafts,
+  }));
 
   if (!cacheable) {
-    return executeQuery();
+    return _executeClimbSearch(
+      params.board_name,
+      params.layout_id,
+      params.size_id,
+      setIdsStr,
+      params.angle,
+      searchParamsJson,
+      userId,
+    );
   }
 
-  const cacheKey = [
-    'climb-search-direct-v2',
+  const revalidate = isDefaultSearch ? CACHE_DURATION_DEFAULT_SEARCH : CACHE_DURATION_FILTERED_SEARCH;
+  return _getCachedFn(params.board_name, revalidate)(
     params.board_name,
-    String(params.layout_id),
-    String(params.size_id),
-    params.set_ids.join(','),
-    String(params.angle),
-    JSON.stringify(sortObjectKeys({
-      page: searchParams.page,
-      pageSize: searchParams.pageSize,
-      gradeAccuracy: searchParams.gradeAccuracy,
-      minGrade: searchParams.minGrade,
-      maxGrade: searchParams.maxGrade,
-      minAscents: searchParams.minAscents,
-      minRating: searchParams.minRating,
-      sortBy: searchParams.sortBy,
-      sortOrder: searchParams.sortOrder,
-      name: searchParams.name,
-      setter: searchParams.settername,
-      onlyTallClimbs: searchParams.onlyTallClimbs,
-      holdsFilter: searchParams.holdsFilter,
-      hideAttempted: searchParams.hideAttempted,
-      hideCompleted: searchParams.hideCompleted,
-      showOnlyAttempted: searchParams.showOnlyAttempted,
-      showOnlyCompleted: searchParams.showOnlyCompleted,
-      onlyDrafts: searchParams.onlyDrafts,
-    })),
-  ];
-
-  const cachedFn = unstable_cache(
-    executeQuery,
-    cacheKey,
-    {
-      revalidate,
-      tags: [
-        'climb-search',
-        getBoardClimbSearchTag(params.board_name),
-        getLayoutClimbSearchTag(params.board_name, params.layout_id),
-      ],
-    },
+    params.layout_id,
+    params.size_id,
+    setIdsStr,
+    params.angle,
+    searchParamsJson,
+    userId,
   );
-
-  return cachedFn();
 }

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -145,7 +145,7 @@ export async function cachedSearchClimbs(
     sortBy: searchParams.sortBy,
     sortOrder: searchParams.sortOrder,
     name: searchParams.name,
-    setter: searchParams.settername,
+    settername: searchParams.settername,
     onlyTallClimbs: searchParams.onlyTallClimbs,
     holdsFilter: searchParams.holdsFilter,
     hideAttempted: searchParams.hideAttempted,


### PR DESCRIPTION
Previously, unstable_cache was called on every request with a per-request
closure, causing the serialized function body to appear in the cache key.
Now _executeClimbSearch is defined at module level and receives all params
as explicit primitives/JSON strings, so unstable_cache holds a stable
reference and cache key generation is deterministic.

Cache instances are lazily created per (boardName, revalidate) pair so
board-specific revalidateTag('climb-search:kilter') still targets only
that board's entries. Layout-level tags are dropped — board-level
invalidation covers the save-climb use case already.

Also removes the unused CACHE_DURATION_DEFAULT_SEARCH_MOONBOARD constant
(moonboard is bypassed via cacheable=false before reaching unstable_cache).

https://claude.ai/code/session_013zJLu3yjerqTB3zGEi7ijT