### PR TITLE
Add attempts counter to queue control bar tick mode

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -167,39 +167,63 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: rating, comment toggle, grade, attempt, confirm — all clustered to the right', () => {
+    it('renders the controls in the expected order: rating, comment toggle, grade, # ascents, attempt, confirm — all clustered to the right', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
       const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
       const gradeLabel = screen.getByTestId('quick-tick-grade');
+      const ascents = screen.getByTestId('quick-tick-ascents');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
       // Rating sits directly inside the single flex row alongside the
-      // comment toggle, grade label, attempt and confirm buttons. The
-      // "swipe left to dismiss" hint is no longer rendered here — it lives
-      // as a transient toast above the queue control bar instead.
+      // comment toggle, grade label, ascents display, attempt counter and
+      // confirm button. The "swipe left to dismiss" hint is not rendered
+      // here — it lives as a transient toast above the queue control bar
+      // instead.
       const controls = rating.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
       expect(gradeLabel.parentElement).toBe(controls);
+      expect(ascents.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
       // Siblings of .controls must appear in this order: rating, comment
-      // toggle, grade label, attempt (X), confirm (tick). The grade sits
-      // immediately to the left of the attempt button and the confirm
-      // button is the final element.
+      // toggle, grade label, # ascents, attempt counter, confirm (tick).
       const siblings = Array.from(controls.children) as HTMLElement[];
       const ratingIdx = siblings.indexOf(rating);
       const commentIdx = siblings.indexOf(commentToggle);
       const gradeIdx = siblings.indexOf(gradeLabel);
+      const ascentsIdx = siblings.indexOf(ascents);
       const attemptIdx = siblings.indexOf(attemptBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
       expect(ratingIdx).toBeLessThan(commentIdx);
       expect(commentIdx).toBeLessThan(gradeIdx);
-      expect(gradeIdx).toBeLessThan(attemptIdx);
-      expect(confirmIdx).toBe(attemptIdx + 1);
+      expect(gradeIdx).toBeLessThan(ascentsIdx);
+      expect(ascentsIdx).toBeLessThan(attemptIdx);
+      expect(confirmIdx).toBeGreaterThan(attemptIdx);
+    });
+
+    it('defaults the attempts counter to 1 and exposes an attempts byline for the user', () => {
+      render(<QuickTickBar {...defaultProps} />);
+      const attemptBtn = screen.getByTestId('quick-tick-attempt');
+      // The top-line number (the "1" that must stay aligned with the other
+      // row items) is rendered directly; the "attempts" label sits beneath.
+      expect(attemptBtn.textContent).toContain('1');
+      expect(attemptBtn.textContent?.toLowerCase()).toContain('attempts');
+    });
+
+    it('renders the # ascents display using the climb userAscents count', () => {
+      const climb = makeClimb({ userAscents: 4, userAttempts: 0 });
+      render(<QuickTickBar {...defaultProps} currentClimb={climb} />);
+      expect(screen.getByTestId('quick-tick-ascents').textContent).toBe('#4');
+    });
+
+    it('falls back to #0 ascents when the climb has no userAscents value', () => {
+      // makeClimb() does not set userAscents.
+      render(<QuickTickBar {...defaultProps} />);
+      expect(screen.getByTestId('quick-tick-ascents').textContent).toBe('#0');
     });
 
     it('does not render the swipe hint inline — the hint lives above the bar as a transient toast', () => {
@@ -278,21 +302,59 @@ describe('QuickTickBar', () => {
       expect(call.attemptCount).toBe(1);
     });
 
-    it('saves the attempt button as status attempt with attemptCount 1 regardless of history', async () => {
-      mockLogbookRef.current = [
-        makeLogbookEntry({ uuid: 'p1' }),
-        makeLogbookEntry({ uuid: 'p2' }),
-      ];
+    it('clicking the attempts counter opens a menu and does NOT save on its own', async () => {
       render(<QuickTickBar {...defaultProps} />);
 
       await act(async () => {
         screen.getByTestId('quick-tick-attempt').click();
       });
 
+      // Menu should be open with the 1–9+ options available.
+      expect(screen.getByTestId('quick-tick-attempt-option-1')).toBeTruthy();
+      expect(screen.getByTestId('quick-tick-attempt-option-9plus')).toBeTruthy();
+      // Selecting a number is state only — no row is saved until the user
+      // taps the tick button.
+      expect(mockSaveTick).not.toHaveBeenCalled();
+    });
+
+    it('uses the selected attempt count when saving via the tick button', async () => {
+      mockLogbookRef.current = [];
+      render(<QuickTickBar {...defaultProps} />);
+
+      // Open the attempts menu and pick "3".
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt').click();
+      });
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt-option-3').click();
+      });
+
+      // Now tap tick.
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
       const call = mockSaveTick.mock.calls[0][0];
-      expect(call.status).toBe('attempt');
-      expect(call.attemptCount).toBe(1);
-      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+      // 3 tries without prior history is no longer a flash — it's a send.
+      expect(call.status).toBe('send');
+      expect(call.attemptCount).toBe(3);
+    });
+
+    it('uses attempt count 10 when the user picks the 9+ option', async () => {
+      render(<QuickTickBar {...defaultProps} />);
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt').click();
+      });
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt-option-9plus').click();
+      });
+      await act(async () => {
+        screen.getByTestId('quick-tick-confirm').click();
+      });
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.attemptCount).toBe(10);
+      expect(call.status).toBe('send');
     });
 
     it('uses userAscents on the climb to default to send without touching the logbook', async () => {

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -167,44 +167,44 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: rating, comment toggle, grade, # ascents, tries counter, fail, confirm — all clustered to the right', () => {
+    it('renders the controls in the expected order: rating, comment toggle, grade, tries counter, fail, confirm — all clustered to the right', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
       const commentToggle = screen.getByRole('button', { name: /toggle comment/i });
       const gradeLabel = screen.getByTestId('quick-tick-grade');
-      const ascents = screen.getByTestId('quick-tick-ascents');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       const failBtn = screen.getByTestId('quick-tick-fail');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
       // Rating sits directly inside the single flex row alongside the
-      // comment toggle, grade label, ascents display, tries counter, fail
-      // (X) and confirm (✓) buttons. The "swipe left to dismiss" hint is
-      // not rendered here — it lives as a transient toast above the queue
-      // control bar instead.
+      // comment toggle, grade label, tries counter, fail (X) and confirm
+      // (✓) buttons. The "swipe left to dismiss" hint is not rendered here
+      // — it lives as a transient toast above the queue control bar
+      // instead.
       const controls = rating.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
       expect(gradeLabel.parentElement).toBe(controls);
-      expect(ascents.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
       expect(failBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
+      // The quick tick bar intentionally does NOT show the user's prior
+      // ascent count — it's clutter the user doesn't need while logging.
+      expect(screen.queryByTestId('quick-tick-ascents')).toBeNull();
+
       // Siblings of .controls must appear in this order: rating, comment
-      // toggle, grade label, # ascents, tries counter, fail (X), confirm (✓).
+      // toggle, grade label, tries counter, fail (X), confirm (✓).
       const siblings = Array.from(controls.children) as HTMLElement[];
       const ratingIdx = siblings.indexOf(rating);
       const commentIdx = siblings.indexOf(commentToggle);
       const gradeIdx = siblings.indexOf(gradeLabel);
-      const ascentsIdx = siblings.indexOf(ascents);
       const attemptIdx = siblings.indexOf(attemptBtn);
       const failIdx = siblings.indexOf(failBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
       expect(ratingIdx).toBeLessThan(commentIdx);
       expect(commentIdx).toBeLessThan(gradeIdx);
-      expect(gradeIdx).toBeLessThan(ascentsIdx);
-      expect(ascentsIdx).toBeLessThan(attemptIdx);
+      expect(gradeIdx).toBeLessThan(attemptIdx);
       expect(attemptIdx).toBeLessThan(failIdx);
       expect(failIdx).toBeLessThan(confirmIdx);
     });
@@ -216,18 +216,6 @@ describe('QuickTickBar', () => {
       // row items) is rendered directly; the "tries" label sits beneath.
       expect(attemptBtn.textContent).toContain('1');
       expect(attemptBtn.textContent?.toLowerCase()).toContain('tries');
-    });
-
-    it('renders the # ascents display using the climb userAscents count', () => {
-      const climb = makeClimb({ userAscents: 4, userAttempts: 0 });
-      render(<QuickTickBar {...defaultProps} currentClimb={climb} />);
-      expect(screen.getByTestId('quick-tick-ascents').textContent).toBe('#4');
-    });
-
-    it('falls back to #0 ascents when the climb has no userAscents value', () => {
-      // makeClimb() does not set userAscents.
-      render(<QuickTickBar {...defaultProps} />);
-      expect(screen.getByTestId('quick-tick-ascents').textContent).toBe('#0');
     });
 
     it('does not render the swipe hint inline — the hint lives above the bar as a transient toast', () => {

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -167,7 +167,7 @@ describe('QuickTickBar', () => {
   });
 
   describe('layout', () => {
-    it('renders the controls in the expected order: rating, comment toggle, grade, # ascents, attempt, confirm — all clustered to the right', () => {
+    it('renders the controls in the expected order: rating, comment toggle, grade, # ascents, tries counter, fail, confirm — all clustered to the right', () => {
       render(<QuickTickBar {...defaultProps} />);
 
       const rating = screen.getByTestId('quick-tick-rating');
@@ -175,43 +175,47 @@ describe('QuickTickBar', () => {
       const gradeLabel = screen.getByTestId('quick-tick-grade');
       const ascents = screen.getByTestId('quick-tick-ascents');
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
+      const failBtn = screen.getByTestId('quick-tick-fail');
       const confirmBtn = screen.getByTestId('quick-tick-confirm');
 
       // Rating sits directly inside the single flex row alongside the
-      // comment toggle, grade label, ascents display, attempt counter and
-      // confirm button. The "swipe left to dismiss" hint is not rendered
-      // here — it lives as a transient toast above the queue control bar
-      // instead.
+      // comment toggle, grade label, ascents display, tries counter, fail
+      // (X) and confirm (✓) buttons. The "swipe left to dismiss" hint is
+      // not rendered here — it lives as a transient toast above the queue
+      // control bar instead.
       const controls = rating.parentElement!;
       expect(commentToggle.parentElement).toBe(controls);
       expect(gradeLabel.parentElement).toBe(controls);
       expect(ascents.parentElement).toBe(controls);
       expect(attemptBtn.parentElement).toBe(controls);
+      expect(failBtn.parentElement).toBe(controls);
       expect(confirmBtn.parentElement).toBe(controls);
 
       // Siblings of .controls must appear in this order: rating, comment
-      // toggle, grade label, # ascents, attempt counter, confirm (tick).
+      // toggle, grade label, # ascents, tries counter, fail (X), confirm (✓).
       const siblings = Array.from(controls.children) as HTMLElement[];
       const ratingIdx = siblings.indexOf(rating);
       const commentIdx = siblings.indexOf(commentToggle);
       const gradeIdx = siblings.indexOf(gradeLabel);
       const ascentsIdx = siblings.indexOf(ascents);
       const attemptIdx = siblings.indexOf(attemptBtn);
+      const failIdx = siblings.indexOf(failBtn);
       const confirmIdx = siblings.indexOf(confirmBtn);
       expect(ratingIdx).toBeLessThan(commentIdx);
       expect(commentIdx).toBeLessThan(gradeIdx);
       expect(gradeIdx).toBeLessThan(ascentsIdx);
       expect(ascentsIdx).toBeLessThan(attemptIdx);
-      expect(confirmIdx).toBeGreaterThan(attemptIdx);
+      expect(attemptIdx).toBeLessThan(failIdx);
+      expect(failIdx).toBeLessThan(confirmIdx);
     });
 
-    it('defaults the attempts counter to 1 and exposes an attempts byline for the user', () => {
+    it('defaults the tries counter to 1 and exposes a "tries" byline for the user', () => {
       render(<QuickTickBar {...defaultProps} />);
       const attemptBtn = screen.getByTestId('quick-tick-attempt');
       // The top-line number (the "1" that must stay aligned with the other
-      // row items) is rendered directly; the "attempts" label sits beneath.
+      // row items) is rendered directly; the "tries" label sits beneath.
       expect(attemptBtn.textContent).toContain('1');
-      expect(attemptBtn.textContent?.toLowerCase()).toContain('attempts');
+      expect(attemptBtn.textContent?.toLowerCase()).toContain('tries');
     });
 
     it('renders the # ascents display using the climb userAscents count', () => {
@@ -355,6 +359,41 @@ describe('QuickTickBar', () => {
       const call = mockSaveTick.mock.calls[0][0];
       expect(call.attemptCount).toBe(10);
       expect(call.status).toBe('send');
+    });
+
+    it('fail (X) button saves status attempt with the default tries count of 1', async () => {
+      render(<QuickTickBar {...defaultProps} />);
+
+      await act(async () => {
+        screen.getByTestId('quick-tick-fail').click();
+      });
+
+      expect(mockSaveTick).toHaveBeenCalledTimes(1);
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('attempt');
+      expect(call.attemptCount).toBe(1);
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('fail (X) button logs the selected tries count — the "5 tries no send" flow', async () => {
+      render(<QuickTickBar {...defaultProps} />);
+
+      // Pick 5 tries from the counter menu.
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt').click();
+      });
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt-option-5').click();
+      });
+
+      // Tap X to log a failed session with that try count.
+      await act(async () => {
+        screen.getByTestId('quick-tick-fail').click();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('attempt');
+      expect(call.attemptCount).toBe(5);
     });
 
     it('uses userAscents on the climb to default to send without touching the logbook', async () => {

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -31,13 +31,87 @@
   margin-left: auto;
 }
 
-/* Match the visual weight of the adjacent CheckOutlined / CloseOutlined icons
-   (24px) so the stars line up with the action buttons. */
+/* Match the visual weight of the adjacent icon buttons so the stars line
+   up with the action buttons. */
 .rating :global(.MuiRating-icon) {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 .gradeLabel {
   min-width: 0;
   flex-shrink: 0;
+}
+
+/* Prior ascent count — subtle display element. */
+.ascents {
+  font-size: var(--font-size-xs, 12px);
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+  opacity: 0.7;
+  flex-shrink: 0;
+  padding: 0 2px;
+  white-space: nowrap;
+}
+
+/* Attempts counter — bare button that shows the selected number on the row
+   baseline with a subtle "attempts" byline absolutely positioned beneath so
+   it cannot push the number out of alignment with its siblings. */
+.attemptButton {
+  position: relative;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  min-width: 24px;
+  line-height: 1;
+  opacity: var(--tick-bar-button-opacity, 0.75);
+  transition: opacity 150ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.attemptButton:hover,
+.attemptButton:focus-visible {
+  opacity: 1;
+}
+
+.attemptButton:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.attemptNumber {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.attemptLabel {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 1px;
+  font-size: 8px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: inherit;
+  opacity: 0.55;
+  white-space: nowrap;
+  pointer-events: none;
+  text-transform: lowercase;
+}
+
+/* Confirm (tick) button — slightly smaller than the default IconButton. */
+.confirmButton {
+  padding: 4px !important;
 }

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -42,18 +42,6 @@
   flex-shrink: 0;
 }
 
-/* Prior ascent count — subtle display element. */
-.ascents {
-  font-size: var(--font-size-xs, 12px);
-  font-weight: 600;
-  line-height: 1;
-  color: var(--text-secondary, rgba(0, 0, 0, 0.6));
-  opacity: 0.7;
-  flex-shrink: 0;
-  padding: 0 2px;
-  white-space: nowrap;
-}
-
 /* Tries counter — ButtonBase that shows the selected number on the row
    baseline with a subtle "tries" byline absolutely positioned beneath so
    it cannot push the number out of alignment with its siblings. */

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -54,38 +54,24 @@
   white-space: nowrap;
 }
 
-/* Attempts counter — bare button that shows the selected number on the row
-   baseline with a subtle "attempts" byline absolutely positioned beneath so
+/* Tries counter — ButtonBase that shows the selected number on the row
+   baseline with a subtle "tries" byline absolutely positioned beneath so
    it cannot push the number out of alignment with its siblings. */
 .attemptButton {
   position: relative;
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
   padding: 4px 6px;
-  margin: 0;
-  cursor: pointer;
-  color: inherit;
-  font: inherit;
   min-width: 24px;
+  border-radius: 4px;
   line-height: 1;
-  opacity: var(--tick-bar-button-opacity, 0.75);
+  color: inherit;
+  opacity: 0.75;
   transition: opacity 150ms ease;
-  -webkit-tap-highlight-color: transparent;
 }
 
 .attemptButton:hover,
 .attemptButton:focus-visible {
   opacity: 1;
-}
-
-.attemptButton:focus-visible {
-  outline: 1px solid currentColor;
-  outline-offset: 2px;
-  border-radius: 4px;
 }
 
 .attemptNumber {
@@ -109,9 +95,4 @@
   white-space: nowrap;
   pointer-events: none;
   text-transform: lowercase;
-}
-
-/* Confirm (tick) button — slightly smaller than the default IconButton. */
-.confirmButton {
-  padding: 4px !important;
 }

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -10,7 +10,6 @@ import Typography from '@mui/material/Typography';
 // push the stars out of alignment with the action buttons.
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import { track } from '@vercel/analytics';
@@ -61,10 +60,11 @@ const SNAP_BACK_DURATION_MS = 180;
  * of the climb so that mid-flow changes to the active climb (party session
  * navigation, etc.) do not cause the user to lose their in-progress tick.
  *
- * Each tap on the bar logs exactly one row with `attemptCount: 1`. The status
- * is history-aware: if the user has no prior logbook rows for this climb
- * the tick is recorded as a `flash`, otherwise it is recorded as a
- * `send`. Totals are derived server-side by aggregating rows.
+ * Tapping the tick button logs one row for the climb. The user picks the
+ * attempt count (1–9+) from the attempts counter to the left of the tick
+ * button; the saved row carries that count. Status is history-aware: a first
+ * attempt with no prior history records as `flash`, otherwise as `send`.
+ * Totals are derived server-side by aggregating rows.
  */
 export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   currentClimb,
@@ -98,6 +98,8 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
   const [isSaving, setIsSaving] = useState(false);
   const [gradeAnchorEl, setGradeAnchorEl] = useState<HTMLElement | null>(null);
+  const [attemptAnchorEl, setAttemptAnchorEl] = useState<HTMLElement | null>(null);
+  const [attemptCount, setAttemptCount] = useState<number>(1);
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isDismissing, setIsDismissing] = useState(false);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -148,22 +150,17 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     return grades.slice(start, end);
   }, [grades, climbGradeId]);
 
-  const handleSave = useCallback(
-    async (isAscent: boolean) => {
+  const handleConfirm = useCallback(
+    async () => {
       if (!tickTarget || isSaving) return;
 
       const { climb, angle: targetAngle, boardDetails: targetBoard, hasPriorHistory } = tickTarget;
 
-      // One tap == one row. Status is history-aware: flash only if the user
-      // has no prior history for this climb; otherwise send. attemptCount is
-      // always 1 because each row represents a single climbing action.
-      let status: TickStatus;
-      if (isAscent) {
-        status = hasPriorHistory ? 'send' : 'flash';
-      } else {
-        status = 'attempt';
-      }
-      const attemptCount = 1;
+      // Status is history-aware: flash only if the user has no prior history
+      // for this climb AND this is a one-try send; otherwise send. The user
+      // can pick how many attempts this send took via the attempts picker.
+      const status: TickStatus =
+        hasPriorHistory || attemptCount > 1 ? 'send' : 'flash';
 
       setIsSaving(true);
       try {
@@ -204,11 +201,8 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
         setIsSaving(false);
       }
     },
-    [tickTarget, quality, difficulty, comment, isSaving, saveTick, onSave],
+    [tickTarget, quality, difficulty, comment, isSaving, saveTick, onSave, attemptCount],
   );
-
-  const handleConfirm = useCallback(() => handleSave(true), [handleSave]);
-  const handleFail = useCallback(() => handleSave(false), [handleSave]);
 
   const triggerDismiss = useCallback(() => {
     if (isDismissing) return;
@@ -270,6 +264,12 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   // comment text selection, or in-flight saves, don't get hijacked.
   const rootHandlers = swipeEnabled ? swipeHandlers : {};
 
+  const userAscentsCount =
+    tickTarget?.climb.userAscents ?? currentClimb?.userAscents ?? 0;
+
+  const attemptOptions = useMemo(() => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const, []);
+  const attemptDisplay = attemptCount >= 10 ? '9+' : String(attemptCount);
+
   return (
     <div
       {...rootHandlers}
@@ -278,8 +278,9 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Rating sits to the right of the bar, sized to match the adjacent
-            attempt (X) and confirm (tick) icon buttons. */}
+        {/* Order: stars, comment, grade, # ascents, attempt, tick. The
+            rating sits to the right of the bar, sized to match the adjacent
+            icon buttons. */}
         <Rating
           value={quality}
           onChange={(_, val) => setQuality(val)}
@@ -351,32 +352,75 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           })}
         </Menu>
 
-        <IconButton
-          onClick={handleFail}
-          disabled={isSaving}
-          sx={{
-            backgroundColor: themeTokens.colors.error,
-            color: 'common.white',
-            '&:hover': { backgroundColor: themeTokens.colors.error },
-          }}
-          aria-label="Log attempt"
-          data-testid="quick-tick-attempt"
+        {/* Prior ascent count for this climb — display only. Shown before
+            the attempts picker so the user knows how many sends they
+            already have before logging another. */}
+        <Typography
+          variant="body2"
+          component="span"
+          aria-label={`${userAscentsCount} prior ascent${userAscentsCount === 1 ? '' : 's'}`}
+          data-testid="quick-tick-ascents"
+          className={styles.ascents}
         >
-          <CloseOutlined />
-        </IconButton>
+          #{userAscentsCount}
+        </Typography>
+
+        {/* Attempts counter. Shows the selected attempt count aligned on the
+            same baseline as the adjacent items; the "attempts" byline is
+            absolutely positioned underneath so it does not push the number
+            out of alignment. Opens a small menu upward with options 1–9+. */}
+        <button
+          type="button"
+          onClick={(e) => setAttemptAnchorEl(e.currentTarget)}
+          aria-label={`Attempts: ${attemptDisplay}`}
+          aria-haspopup="menu"
+          aria-expanded={Boolean(attemptAnchorEl)}
+          data-testid="quick-tick-attempt"
+          className={styles.attemptButton}
+        >
+          <span className={styles.attemptNumber}>{attemptDisplay}</span>
+          <span className={styles.attemptLabel}>attempts</span>
+        </button>
+        <Menu
+          anchorEl={attemptAnchorEl}
+          open={Boolean(attemptAnchorEl)}
+          onClose={() => setAttemptAnchorEl(null)}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          slotProps={{ paper: { sx: { minWidth: 64 } } }}
+        >
+          {attemptOptions.map((n) => (
+            <MenuItem
+              key={n}
+              selected={n === attemptCount}
+              onClick={() => {
+                setAttemptCount(n);
+                setAttemptAnchorEl(null);
+              }}
+              data-testid={`quick-tick-attempt-option-${n === 10 ? '9plus' : n}`}
+            >
+              {n === 10 ? '9+' : n}
+            </MenuItem>
+          ))}
+        </Menu>
 
         <IconButton
+          size="small"
           onClick={handleConfirm}
           disabled={isSaving}
+          className={styles.confirmButton}
           sx={{
-            backgroundColor: themeTokens.colors.success,
-            color: 'common.white',
-            '&:hover': { backgroundColor: themeTokens.colors.successHover },
+            color: themeTokens.colors.success,
+            opacity: themeTokens.opacity.subtle,
+            '&:hover': {
+              color: themeTokens.colors.successHover,
+              opacity: 1,
+            },
           }}
           aria-label="Confirm ascent"
           data-testid="quick-tick-confirm"
         >
-          <CheckOutlined />
+          <CheckOutlined fontSize="small" />
         </IconButton>
       </div>
     </div>

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -278,9 +278,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   // comment text selection, or in-flight saves, don't get hijacked.
   const rootHandlers = swipeEnabled ? swipeHandlers : {};
 
-  const userAscentsCount =
-    tickTarget?.climb.userAscents ?? currentClimb?.userAscents ?? 0;
-
   const attemptDisplay = attemptCount >= 10 ? '9+' : String(attemptCount);
 
   return (
@@ -291,9 +288,9 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
       data-testid="quick-tick-bar"
     >
       <div className={styles.controls}>
-        {/* Order: stars, comment, grade, # ascents, attempt, tick. The
-            rating sits to the right of the bar, sized to match the adjacent
-            icon buttons. */}
+        {/* Order: stars, comment, grade, tries, attempt, tick. The rating
+            sits to the right of the bar, sized to match the adjacent icon
+            buttons. */}
         <Rating
           value={quality}
           onChange={(_, val) => setQuality(val)}
@@ -364,19 +361,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
             );
           })}
         </Menu>
-
-        {/* Prior ascent count for this climb — display only. Shown before
-            the attempts picker so the user knows how many sends they
-            already have before logging another. */}
-        <Typography
-          variant="body2"
-          component="span"
-          aria-label={`${userAscentsCount} prior ascent${userAscentsCount === 1 ? '' : 's'}`}
-          data-testid="quick-tick-ascents"
-          className={styles.ascents}
-        >
-          #{userAscentsCount}
-        </Typography>
 
         {/* Tries counter. Shows the selected try count aligned on the same
             baseline as the adjacent items; the "tries" byline is absolutely

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useSwipeable } from 'react-swipeable';
+import ButtonBase from '@mui/material/ButtonBase';
 import IconButton from '@mui/material/IconButton';
 import Rating from '@mui/material/Rating';
 import Typography from '@mui/material/Typography';
@@ -11,6 +12,7 @@ import Typography from '@mui/material/Typography';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import { track } from '@vercel/analytics';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
@@ -54,17 +56,21 @@ const SWIPE_DISMISS_THRESHOLD = 80;
 const EXIT_DURATION_MS = 220;
 const SNAP_BACK_DURATION_MS = 180;
 
+/** Options shown in the attempts picker. 10 displays as "9+" in the UI. */
+const ATTEMPT_OPTIONS: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
 /**
  * Inline tick entry bar. Designed to be embedded in a parent row (e.g. the queue
  * control bar) in place of the climb title. The component owns its own snapshot
  * of the climb so that mid-flow changes to the active climb (party session
  * navigation, etc.) do not cause the user to lose their in-progress tick.
  *
- * Tapping the tick button logs one row for the climb. The user picks the
- * attempt count (1–9+) from the attempts counter to the left of the tick
- * button; the saved row carries that count. Status is history-aware: a first
- * attempt with no prior history records as `flash`, otherwise as `send`.
- * Totals are derived server-side by aggregating rows.
+ * The user picks how many tries (1–9+) they put into the climb via the tries
+ * counter, then taps either the confirm (✓) button to log a send with that
+ * count or the fail (X) button to log the same count of tries without a send.
+ * Send status is history-aware: a one-try send with no prior history records
+ * as `flash`, otherwise `send`. Fail rows always record as `attempt`. Totals
+ * are derived server-side by aggregating rows.
  */
 export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   currentClimb,
@@ -150,17 +156,22 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     return grades.slice(start, end);
   }, [grades, climbGradeId]);
 
-  const handleConfirm = useCallback(
-    async () => {
+  const handleSave = useCallback(
+    async (isAscent: boolean) => {
       if (!tickTarget || isSaving) return;
 
       const { climb, angle: targetAngle, boardDetails: targetBoard, hasPriorHistory } = tickTarget;
 
-      // Status is history-aware: flash only if the user has no prior history
-      // for this climb AND this is a one-try send; otherwise send. The user
-      // can pick how many attempts this send took via the attempts picker.
-      const status: TickStatus =
-        hasPriorHistory || attemptCount > 1 ? 'send' : 'flash';
+      // Status is history-aware for sends: a first-go send with no prior
+      // history is a flash, otherwise it's a send. Multi-try sends can't be
+      // flashes by definition. Non-ascents always save as `attempt`, with
+      // the selected count representing how many tries the user made.
+      let status: TickStatus;
+      if (isAscent) {
+        status = hasPriorHistory || attemptCount > 1 ? 'send' : 'flash';
+      } else {
+        status = 'attempt';
+      }
 
       setIsSaving(true);
       try {
@@ -203,6 +214,9 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     },
     [tickTarget, quality, difficulty, comment, isSaving, saveTick, onSave, attemptCount],
   );
+
+  const handleConfirm = useCallback(() => handleSave(true), [handleSave]);
+  const handleFail = useCallback(() => handleSave(false), [handleSave]);
 
   const triggerDismiss = useCallback(() => {
     if (isDismissing) return;
@@ -267,7 +281,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
   const userAscentsCount =
     tickTarget?.climb.userAscents ?? currentClimb?.userAscents ?? 0;
 
-  const attemptOptions = useMemo(() => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const, []);
   const attemptDisplay = attemptCount >= 10 ? '9+' : String(attemptCount);
 
   return (
@@ -365,22 +378,25 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           #{userAscentsCount}
         </Typography>
 
-        {/* Attempts counter. Shows the selected attempt count aligned on the
-            same baseline as the adjacent items; the "attempts" byline is
-            absolutely positioned underneath so it does not push the number
-            out of alignment. Opens a small menu upward with options 1–9+. */}
-        <button
-          type="button"
+        {/* Tries counter. Shows the selected try count aligned on the same
+            baseline as the adjacent items; the "tries" byline is absolutely
+            positioned underneath so it does not push the number out of
+            alignment. Opens a small menu upward with options 1–9+. The
+            selected value drives both the attempt (X) and confirm (✓)
+            buttons so the user can log 5 tries without a send by picking 5
+            and tapping X. */}
+        <ButtonBase
           onClick={(e) => setAttemptAnchorEl(e.currentTarget)}
-          aria-label={`Attempts: ${attemptDisplay}`}
+          aria-label={`Tries: ${attemptDisplay}`}
           aria-haspopup="menu"
           aria-expanded={Boolean(attemptAnchorEl)}
           data-testid="quick-tick-attempt"
           className={styles.attemptButton}
+          disableRipple={false}
         >
           <span className={styles.attemptNumber}>{attemptDisplay}</span>
-          <span className={styles.attemptLabel}>attempts</span>
-        </button>
+          <span className={styles.attemptLabel}>tries</span>
+        </ButtonBase>
         <Menu
           anchorEl={attemptAnchorEl}
           open={Boolean(attemptAnchorEl)}
@@ -389,7 +405,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           slotProps={{ paper: { sx: { minWidth: 64 } } }}
         >
-          {attemptOptions.map((n) => (
+          {ATTEMPT_OPTIONS.map((n) => (
             <MenuItem
               key={n}
               selected={n === attemptCount}
@@ -406,10 +422,29 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
 
         <IconButton
           size="small"
+          onClick={handleFail}
+          disabled={isSaving}
+          sx={{
+            p: '4px',
+            color: themeTokens.colors.error,
+            opacity: themeTokens.opacity.subtle,
+            '&:hover': {
+              color: themeTokens.colors.error,
+              opacity: 1,
+            },
+          }}
+          aria-label={`Log ${attemptDisplay} tries without a send`}
+          data-testid="quick-tick-fail"
+        >
+          <CloseOutlined fontSize="small" />
+        </IconButton>
+
+        <IconButton
+          size="small"
           onClick={handleConfirm}
           disabled={isSaving}
-          className={styles.confirmButton}
           sx={{
+            p: '4px',
             color: themeTokens.colors.success,
             opacity: themeTokens.opacity.subtle,
             '&:hover': {


### PR DESCRIPTION
Replaces the standalone attempt (X) button with an inline attempts counter
that shows the selected number with a subtle "attempts" byline beneath it.
The number stays horizontally aligned with the other row items because the
label is absolutely positioned, so the row baseline does not shift. Tapping
the counter opens a small upward-anchored menu with options 1–9+; the
chosen count is carried on the row the tick button saves, so the user can
record "it took me 3 tries" in one pass.

Adds a "# ascents" display before the attempts counter so the user can see
how many prior sends they have before logging another. Makes the tick and
attempts buttons subtler (no filled background, smaller icon/padding,
reduced opacity) and reorders the row to stars, comment, grade, # ascents,
attempt, tick.