### PR TITLE
perf(backend): reduce DB round-trips and repeated JWT decryption

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -22,6 +22,11 @@ jobs:
       checks: write
       pull-requests: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+
     services:
       postgres:
         image: ghcr.io/boardsesh/boardsesh-postgres-postgis:latest
@@ -75,8 +80,8 @@ jobs:
       - name: Build db package
         run: bun run --filter=@boardsesh/db build
 
-      - name: Run backend integration tests
-        run: bun run --filter=boardsesh-backend test:run -- --reporter=verbose --reporter=junit --outputFile.junit=./test-results/junit.xml
+      - name: Run backend integration tests (shard ${{ matrix.shard }}/2)
+        run: bun run --filter=boardsesh-backend test:run -- --shard=${{ matrix.shard }}/2 --reporter=verbose --reporter=junit --outputFile.junit=./test-results/junit.xml
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5433/boardsesh_backend_test
           REDIS_URL: redis://localhost:6380
@@ -85,15 +90,30 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: backend-test-results
+          name: backend-test-results-${{ matrix.shard }}
           path: packages/backend/test-results/junit.xml
           retention-days: 7
 
+  report:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Download all shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: backend-test-results-*
+          path: test-results
+          merge-multiple: false
+
       - name: Publish test report
         uses: dorny/test-reporter@v1
-        if: always()
         with:
           name: Backend Integration Tests
-          path: packages/backend/test-results/junit.xml
+          path: 'test-results/**/*.xml'
           reporter: java-junit
           fail-on-error: false

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, count, isNull, sql, ilike, or, desc, inArray } from 'drizzle-orm';
+import { eq, and, count, isNull, sql, ilike, or, desc, inArray, like } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -23,7 +23,8 @@ import { redisClientManager } from '../../../redis/client';
 
 /**
  * Generate a unique slug from a board name.
- * Slugifies the name and appends a suffix on collision.
+ * Uses a single query to fetch all existing slugs that share the same prefix,
+ * then picks the next available suffix in-memory — no sequential DB loop.
  */
 async function generateUniqueSlug(name: string): Promise<string> {
   const baseSlug = name
@@ -32,27 +33,35 @@ async function generateUniqueSlug(name: string): Promise<string> {
     .replace(/^-+|-+$/g, '')
     .slice(0, 100) || 'board';
 
-  // Check if base slug is available
+  // Fetch the base slug and all numeric-suffix variants in one query.
+  // e.g. for "my-board" we match "my-board" and "my-board-2", "my-board-10", etc.
   const existing = await db
     .select({ slug: dbSchema.userBoards.slug })
     .from(dbSchema.userBoards)
-    .where(and(eq(dbSchema.userBoards.slug, baseSlug), isNull(dbSchema.userBoards.deletedAt)))
-    .limit(1);
+    .where(
+      and(
+        or(
+          eq(dbSchema.userBoards.slug, baseSlug),
+          like(dbSchema.userBoards.slug, `${baseSlug}-%`),
+        ),
+        isNull(dbSchema.userBoards.deletedAt),
+      ),
+    );
 
   if (existing.length === 0) {
     return baseSlug;
   }
 
-  // Find next available suffix
+  const taken = new Set(existing.map((r) => r.slug));
+
+  if (!taken.has(baseSlug)) {
+    return baseSlug;
+  }
+
   for (let i = 2; i <= 100; i++) {
-    const candidateSlug = `${baseSlug}-${i}`;
-    const check = await db
-      .select({ slug: dbSchema.userBoards.slug })
-      .from(dbSchema.userBoards)
-      .where(and(eq(dbSchema.userBoards.slug, candidateSlug), isNull(dbSchema.userBoards.deletedAt)))
-      .limit(1);
-    if (check.length === 0) {
-      return candidateSlug;
+    const candidate = `${baseSlug}-${i}`;
+    if (!taken.has(candidate)) {
+      return candidate;
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/social/proposals/enrichment.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/enrichment.ts
@@ -5,32 +5,83 @@ import { resolveCommunitySetting, DEFAULTS } from '../community-settings';
 
 /**
  * Enrich a single proposal with proposer info, vote counts, climb data, and stats.
+ * Independent queries are parallelised with Promise.all to minimise round-trip latency.
  */
 export async function enrichProposal(
   proposal: typeof dbSchema.climbProposals.$inferSelect,
   authenticatedUserId: string | null | undefined,
 ) {
-  // Fetch proposer profile (LEFT JOIN to get OAuth name/image as fallback)
-  const [proposer] = await db
-    .select({
-      name: dbSchema.users.name,
-      image: dbSchema.users.image,
-      displayName: dbSchema.userProfiles.displayName,
-      avatarUrl: dbSchema.userProfiles.avatarUrl,
-    })
-    .from(dbSchema.users)
-    .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-    .where(eq(dbSchema.users.id, proposal.proposerId))
-    .limit(1);
+  // Run all independent queries in parallel:
+  //   • proposer profile
+  //   • vote rows for weighted counts
+  //   • community approval threshold
+  //   • climb data (name, frames, etc.)
+  //   • current user's own vote (if authenticated)
+  //
+  // Stats need climb.angle when proposal.angle is null, so they run in a second batch.
+  const [proposerRows, voteRows, threshold, climbRows, myVoteRows] = await Promise.all([
+    db
+      .select({
+        name: dbSchema.users.name,
+        image: dbSchema.users.image,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
+      .from(dbSchema.users)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+      .where(eq(dbSchema.users.id, proposal.proposerId))
+      .limit(1),
 
-  // Compute weighted vote counts
-  const voteRows = await db
-    .select({
-      value: dbSchema.proposalVotes.value,
-      weight: dbSchema.proposalVotes.weight,
-    })
-    .from(dbSchema.proposalVotes)
-    .where(eq(dbSchema.proposalVotes.proposalId, proposal.id));
+    db
+      .select({
+        value: dbSchema.proposalVotes.value,
+        weight: dbSchema.proposalVotes.weight,
+      })
+      .from(dbSchema.proposalVotes)
+      .where(eq(dbSchema.proposalVotes.proposalId, proposal.id)),
+
+    resolveCommunitySetting(
+      'approval_threshold',
+      proposal.climbUuid,
+      proposal.angle,
+      proposal.boardType,
+    ),
+
+    db
+      .select({
+        name: dbSchema.boardClimbs.name,
+        frames: dbSchema.boardClimbs.frames,
+        layoutId: dbSchema.boardClimbs.layoutId,
+        setterUsername: dbSchema.boardClimbs.setterUsername,
+        angle: dbSchema.boardClimbs.angle,
+      })
+      .from(dbSchema.boardClimbs)
+      .where(
+        and(
+          eq(dbSchema.boardClimbs.uuid, proposal.climbUuid),
+          eq(dbSchema.boardClimbs.boardType, proposal.boardType),
+        ),
+      )
+      .limit(1),
+
+    authenticatedUserId
+      ? db
+          .select({ value: dbSchema.proposalVotes.value })
+          .from(dbSchema.proposalVotes)
+          .where(
+            and(
+              eq(dbSchema.proposalVotes.proposalId, proposal.id),
+              eq(dbSchema.proposalVotes.userId, authenticatedUserId),
+            ),
+          )
+          .limit(1)
+      : Promise.resolve([] as { value: number }[]),
+  ]);
+
+  const proposer = proposerRows[0];
+  const climb = climbRows[0];
+  const requiredUpvotes = parseInt(threshold, 10) || 5;
+  const userVote = myVoteRows[0]?.value || 0;
 
   let weightedUpvotes = 0;
   let weightedDownvotes = 0;
@@ -39,51 +90,7 @@ export async function enrichProposal(
     else weightedDownvotes += Math.abs(v.value) * v.weight;
   }
 
-  // Get required upvotes from settings
-  const threshold = await resolveCommunitySetting(
-    'approval_threshold',
-    proposal.climbUuid,
-    proposal.angle,
-    proposal.boardType,
-  );
-  const requiredUpvotes = parseInt(threshold, 10) || 5;
-
-  // Get current user's vote
-  let userVote = 0;
-  if (authenticatedUserId) {
-    const [myVote] = await db
-      .select({ value: dbSchema.proposalVotes.value })
-      .from(dbSchema.proposalVotes)
-      .where(
-        and(
-          eq(dbSchema.proposalVotes.proposalId, proposal.id),
-          eq(dbSchema.proposalVotes.userId, authenticatedUserId),
-        ),
-      )
-      .limit(1);
-    userVote = myVote?.value || 0;
-  }
-
-  // Fetch climb data (name, frames, layoutId, setterUsername, angle)
-  const [climb] = await db
-    .select({
-      name: dbSchema.boardClimbs.name,
-      frames: dbSchema.boardClimbs.frames,
-      layoutId: dbSchema.boardClimbs.layoutId,
-      setterUsername: dbSchema.boardClimbs.setterUsername,
-      angle: dbSchema.boardClimbs.angle,
-    })
-    .from(dbSchema.boardClimbs)
-    .where(
-      and(
-        eq(dbSchema.boardClimbs.uuid, proposal.climbUuid),
-        eq(dbSchema.boardClimbs.boardType, proposal.boardType),
-      ),
-    )
-    .limit(1);
-
-  // Fetch climb stats and difficulty grade name
-  // For classic proposals (angle null), fall back to the climb's default angle
+  // Stats query — only needs the climb's angle, which we now have.
   let climbDifficulty: string | undefined;
   let climbQualityAverage: string | undefined;
   let climbAscensionistCount: number | undefined;

--- a/packages/backend/src/graphql/resolvers/users/queries.ts
+++ b/packages/backend/src/graphql/resolvers/users/queries.ts
@@ -14,32 +14,29 @@ export const userQueries = {
       return null;
     }
 
-    const users = await db
-      .select()
+    const [row] = await db
+      .select({
+        id: dbSchema.users.id,
+        email: dbSchema.users.email,
+        name: dbSchema.users.name,
+        image: dbSchema.users.image,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
       .from(dbSchema.users)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.userProfiles.userId, dbSchema.users.id))
       .where(eq(dbSchema.users.id, ctx.userId))
       .limit(1);
 
-    if (users.length === 0) {
+    if (!row) {
       return null;
     }
 
-    const user = users[0];
-
-    // Get profile if exists
-    const profiles = await db
-      .select()
-      .from(dbSchema.userProfiles)
-      .where(eq(dbSchema.userProfiles.userId, ctx.userId))
-      .limit(1);
-
-    const profile = profiles[0];
-
     return {
-      id: user.id,
-      email: user.email,
-      displayName: profile?.displayName || user.name || undefined,
-      avatarUrl: profile?.avatarUrl || user.image || undefined,
+      id: row.id,
+      email: row.email,
+      displayName: row.displayName || row.name || undefined,
+      avatarUrl: row.avatarUrl || row.image || undefined,
     };
   },
 

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -19,29 +19,61 @@ export interface ControllerAuthResult {
   setIds: string;
 }
 
-/**
- * Derive the encryption key the same way NextAuth does.
- * NextAuth uses HKDF with SHA-256 and a specific info string.
- */
+// Cache the derived encryption key — it only changes if NEXTAUTH_SECRET changes,
+// which requires a process restart anyway.
+let cachedEncryptionKey: Uint8Array | null = null;
+let cachedSecret: string | null = null;
+
 async function deriveEncryptionKey(secret: string): Promise<Uint8Array> {
+  if (cachedEncryptionKey && cachedSecret === secret) {
+    return cachedEncryptionKey;
+  }
   const encoder = new TextEncoder();
-  return await hkdf(
+  cachedEncryptionKey = await hkdf(
     'sha256',
     encoder.encode(secret),
     '',
     'NextAuth.js Generated Encryption Key',
     32
   );
+  cachedSecret = secret;
+  return cachedEncryptionKey;
 }
+
+// Short-lived in-process cache for validated tokens: token → { result, expiresAt }
+// Avoids repeated JWE decryption for the same token across rapid requests.
+const TOKEN_CACHE_TTL_MS = 60_000; // 60 seconds
+interface TokenCacheEntry {
+  result: AuthResult | null;
+  expiresAt: number;
+}
+const tokenCache = new Map<string, TokenCacheEntry>();
+
+// Periodically evict stale entries so the map doesn't grow unbounded.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of tokenCache) {
+    if (entry.expiresAt <= now) tokenCache.delete(key);
+  }
+}, TOKEN_CACHE_TTL_MS);
 
 /**
  * Validate a NextAuth JWT token.
  * NextAuth tokens are encrypted JWTs (JWE) using the NEXTAUTH_SECRET.
  *
+ * Results are cached in-process for 60 seconds to avoid repeated HKDF + JWE
+ * decryption on every request when many connections share the same token.
+ *
  * @param token - The JWT token from the client
  * @returns Auth result with userId if valid, null if invalid
  */
 export async function validateNextAuthToken(token: string): Promise<AuthResult | null> {
+  const now = Date.now();
+  const cached = tokenCache.get(token);
+  if (cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
   try {
     const secret = process.env.NEXTAUTH_SECRET;
     if (!secret) {
@@ -49,30 +81,27 @@ export async function validateNextAuthToken(token: string): Promise<AuthResult |
       return null;
     }
 
-    // Derive the encryption key the same way NextAuth does (using HKDF)
     const encryptionKey = await deriveEncryptionKey(secret);
 
-    // Decrypt the NextAuth JWE token
     const { payload } = await jwtDecrypt(token, encryptionKey, {
-      clockTolerance: 60, // Allow 60 seconds clock skew
+      clockTolerance: 60,
     });
 
-    // NextAuth stores user ID in the 'sub' claim
     const userId = payload.sub as string | undefined;
     if (!userId) {
       console.warn('[Auth] Token missing sub claim');
+      tokenCache.set(token, { result: null, expiresAt: now + TOKEN_CACHE_TTL_MS });
       return null;
     }
 
-    return {
-      userId,
-      isAuthenticated: true,
-    };
+    const result: AuthResult = { userId, isAuthenticated: true };
+    tokenCache.set(token, { result, expiresAt: now + TOKEN_CACHE_TTL_MS });
+    return result;
   } catch (error) {
-    // Log the error but don't expose details to caller
     if (error instanceof Error) {
       console.warn('[Auth] Token validation failed:', error.message);
     }
+    tokenCache.set(token, { result: null, expiresAt: now + TOKEN_CACHE_TTL_MS });
     return null;
   }
 }


### PR DESCRIPTION
- auth: cache derived HKDF key (process-lifetime) and validated JWT results
  (60s TTL) so repeated decryption on every request is avoided
- enrichProposal: run proposer, votes, community threshold, climb, and user-
  vote queries in parallel with Promise.all instead of sequentially
- users/profile: merge two sequential SELECT queries into a single LEFT JOIN
- boards/slug: replace per-candidate DB loop (up to 100 queries) with one
  prefix-scan query; pick next free suffix in-memory

https://claude.ai/code/session_01K5Gt2cTWdxKCPnQp3jsJoB