### PR TITLE
ci: re-enable e2e tests workflow with shard matrix and sticky PR comment

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,27 +1,71 @@
 name: E2E Tests
 
-# Temporarily disabled - workflow is broken
-# on:
-#   push:
-#     branches: [ main, develop ]
-#     paths:
-#       - 'packages/web/**'
-#       - 'packages/backend/**'
-#       - 'packages/shared-schema/**'
-#       - 'packages/db/**'
-#       - '.github/workflows/e2e-tests.yml'
-#   pull_request:
-#     paths:
-#       - 'packages/web/**'
-#       - 'packages/backend/**'
-#       - 'packages/shared-schema/**'
-#       - 'packages/db/**'
-#       - '.github/workflows/e2e-tests.yml'
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'packages/web/**'
+      - 'packages/backend/**'
+      - 'packages/shared-schema/**'
+      - 'packages/db/**'
+      - '.github/workflows/e2e-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/web/**'
+      - 'packages/backend/**'
+      - 'packages/shared-schema/**'
+      - 'packages/db/**'
+      - '.github/workflows/e2e-tests.yml'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  e2e:
-    timeout-minutes: 30
+  typecheck:
+    name: Typecheck (fail-fast)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build shared packages
+        run: |
+          bun run --filter=@boardsesh/shared-schema build
+          bun run --filter=@boardsesh/crypto build
+          bun run --filter=@boardsesh/board-constants build
+          bun run --filter=@boardsesh/db build
+          bun run --filter=@boardsesh/aurora-sync build
+
+      - name: Typecheck web
+        run: bun run typecheck:web
+
+      - name: Typecheck backend
+        run: bun run typecheck:backend
+
+  e2e:
+    name: E2E (shard ${{ matrix.shard }})
+    needs: typecheck
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
 
@@ -46,90 +90,189 @@ jobs:
           POSTGRES_DB: main
 
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Point db.localtest.me to neon-proxy service
-      run: |
-        # Resolve the neon-proxy service IP and add a hosts entry so the
-        # Neon driver's fetchEndpoint (http://db.localtest.me:4444/sql) reaches
-        # the proxy container instead of localhost.
-        PROXY_IP=$(getent hosts neon-proxy | awk '{ print $1 }')
-        echo "$PROXY_IP db.localtest.me" >> /etc/hosts
+      - name: Point db.localtest.me to neon-proxy service
+        run: |
+          # Resolve the neon-proxy service IP and add a hosts entry so the
+          # Neon driver's fetchEndpoint (http://db.localtest.me:4444/sql) reaches
+          # the proxy container instead of localhost.
+          PROXY_IP=$(getent hosts neon-proxy | awk '{ print $1 }')
+          echo "$PROXY_IP db.localtest.me" >> /etc/hosts
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
-    - name: Install unzip (required by setup-bun)
-      run: apt-get update && apt-get install -y unzip
+      - name: Install unzip (required by setup-bun)
+        run: apt-get update && apt-get install -y unzip
 
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
-    - name: Cache bun dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-bun-
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
-    - name: Install dependencies
-      run: bun install --frozen-lockfile
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: packages/web/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ hashFiles('packages/web/**/*.ts', 'packages/web/**/*.tsx', 'packages/web/**/*.js', 'packages/web/**/*.jsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-nextjs-
 
-    - name: Build shared-schema
-      run: bun run --filter=@boardsesh/shared-schema build
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
-    - name: Build db package
-      run: bun run --filter=@boardsesh/db build
+      - name: Build packages needed for e2e
+        # board-renderer-wasm ships pre-built pkg/ in git, so skip its bash build.sh
+        # (needs wasm-pack). Build the rest explicitly so we don't run every
+        # workspace's build script.
+        run: |
+          bun run --filter=@boardsesh/shared-schema build
+          bun run --filter=@boardsesh/crypto build
+          bun run --filter=@boardsesh/board-constants build
+          bun run --filter=@boardsesh/db build
+          bun run --filter=@boardsesh/aurora-sync build
+          bun run --filter=boardsesh-backend build
+          bun run --filter=@boardsesh/web build
+        env:
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000
+          DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
+          NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
-    - name: Build backend
-      run: bun run --filter=boardsesh-backend build
+      - name: Run database migrations
+        run: bunx drizzle-kit migrate
+        working-directory: packages/db
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/main
 
-    - name: Build web application
-      run: bun run --filter=@boardsesh/web build
-      env:
-        # Provide minimal env vars needed for build
-        NEXTAUTH_SECRET: test-secret-for-ci
-        NEXTAUTH_URL: http://localhost:3000
-        DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
-        NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
+      - name: Start backend and web servers
+        run: |
+          bun run --filter=boardsesh-backend start > backend.log 2>&1 &
+          bun run --filter=@boardsesh/web start > web.log 2>&1 &
+          # Wait for both endpoints in parallel. Backend runs in local-only
+          # pub/sub mode without REDIS_URL, which is fine for e2e coverage.
+          bunx wait-on http-get://localhost:8080/health http://localhost:3000 --timeout 90000
+        env:
+          DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
-    - name: Run database migrations
-      run: bunx drizzle-kit migrate
-      working-directory: packages/db
-      env:
-        DATABASE_URL: postgresql://postgres:password@postgres:5432/main
+      - name: Run Playwright shard ${{ matrix.shard }}/4
+        run: bunx playwright test --shard=${{ matrix.shard }}/4
+        working-directory: packages/web
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
+          DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
+          TEST_USER_EMAIL: test@boardsesh.com
+          TEST_USER_PASSWORD: test
 
-    - name: Start backend and web server, then run E2E tests
-      run: |
-        bun run --filter=boardsesh-backend start &
-        bunx wait-on http-get://localhost:8080/health --timeout 30000
-        bun run --filter=@boardsesh/web start &
-        bunx wait-on http://localhost:3000 --timeout 60000
-        bun run --filter=@boardsesh/web test:e2e
-      env:
-        PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
-        DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
-        NEXTAUTH_SECRET: test-secret-for-ci
-        NEXTAUTH_URL: http://localhost:3000
-        NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
-        TEST_USER_EMAIL: test@boardsesh.com
-        TEST_USER_PASSWORD: test
+      - name: Dump server logs on failure
+        if: failure()
+        run: |
+          echo "=== backend.log ==="
+          cat backend.log || true
+          echo "=== web.log ==="
+          cat web.log || true
 
-    - name: Upload Playwright Report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: packages/web/playwright-report/
-        retention-days: 7
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-shard-${{ matrix.shard }}
+          path: packages/web/playwright-report/
+          retention-days: 7
 
-    - name: Upload Playwright Screenshots
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: playwright-screenshots
-        path: packages/web/test-results/
-        retention-days: 7
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-results-shard-${{ matrix.shard }}
+          path: packages/web/test-results/
+          retention-days: 7
+
+      - name: Upload rendered screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: screenshots-shard-${{ matrix.shard }}
+          path: |
+            mobile/screenshots/
+            packages/web/help-screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  report-screenshots:
+    name: Report screenshots on PR
+    needs: e2e
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download screenshot artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: screenshot-artifacts
+          pattern: screenshots-shard-*
+          merge-multiple: false
+
+      - name: Build screenshot summary
+        id: summary
+        run: |
+          set -e
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SHA="${{ github.event.pull_request.head.sha }}"
+          {
+            echo "### Playwright screenshot specs"
+            echo ""
+            echo "Run: [\`${SHA:0:7}\`]($RUN_URL)"
+            echo ""
+            if [ ! -d screenshot-artifacts ] || [ -z "$(ls -A screenshot-artifacts 2>/dev/null)" ]; then
+              echo "_No screenshot artifacts were uploaded by this run._"
+            else
+              total=0
+              for shard_dir in screenshot-artifacts/screenshots-shard-*; do
+                [ -d "$shard_dir" ] || continue
+                shard=$(basename "$shard_dir" | sed 's/screenshots-shard-//')
+                count=$(find "$shard_dir" -type f -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+                total=$((total + count))
+                echo "<details><summary><strong>Shard $shard</strong> — $count PNG(s)</summary>"
+                echo ""
+                if [ "$count" -gt 0 ]; then
+                  find "$shard_dir" -type f -name '*.png' \
+                    | sed "s|$shard_dir/||" \
+                    | sort \
+                    | sed 's/^/- /'
+                else
+                  echo "_No screenshots rendered._"
+                fi
+                echo ""
+                echo "</details>"
+                echo ""
+              done
+              echo "**Total rendered:** $total screenshot(s) across 4 shards."
+              echo ""
+              echo "Download them from the [run artifacts]($RUN_URL#artifacts)."
+            fi
+          } > summary.md
+          cat summary.md
+
+      - name: Upsert sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: e2e-screenshots
+          path: summary.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules
 
 # testing
 coverage
+packages/web/playwright-report
+packages/web/test-results
 
 # next.js
 .next/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ The `boardsesh-dev-db` image is published to GHCR and contains PostgreSQL 17 + P
 - `bun run backend:start` - Start backend in production mode
 - `bun run db:up` - Start development databases, run migrations, and import MoonBoard data (uses pre-built image with Kilter/Tension data)
 
+### Running E2E Tests
+
+- `bun run test:e2e` - Full Playwright run: brings up the pre-built dev DB, exports the seeded test user, and runs every spec in `packages/web/e2e/`. Playwright's `webServer` config auto-starts `bun run dev` (backend + web) for you.
+- `bun run test:e2e:setup` - Only bring up the dev DB. Useful when iterating on a single spec: after setup, run `bun run --filter=@boardsesh/web test:e2e -- e2e/<spec>.spec.ts` (or use `test:e2e:ui` for the Playwright UI).
+- The seeded test user is `test@boardsesh.com` / `test`, exported as `TEST_USER_EMAIL`/`TEST_USER_PASSWORD` by the script so screenshot specs (`app-store-screenshots`, `help-screenshots`) run end-to-end without 1Password.
+
 ### Database Commands (run from root or packages/db/)
 
 - `bun run db:migrate` - Apply migrations (also runs on Vercel build)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "typecheck:shared": "bun run --filter=@boardsesh/shared-schema typecheck",
     "test": "bun run --filter='*' test",
     "test:run": "bun run --filter='*' test:run",
+    "test:e2e:setup": "sh scripts/dev-db-up.sh",
+    "test:e2e": "bun run test:e2e:setup && TEST_USER_EMAIL=test@boardsesh.com TEST_USER_PASSWORD=test bun run --filter=@boardsesh/web test:e2e",
     "test:help-screenshots": "TEST_USER_EMAIL=$(op read 'op://Boardsesh/Boardsesh local/username') TEST_USER_PASSWORD=$(op read 'op://Boardsesh/Boardsesh local/password') bunx playwright test --project=chromium e2e/help-screenshots.spec.ts --config=packages/web/playwright.config.ts",
     "backend:dev": "bun run --filter=boardsesh-backend dev",
     "backend:start": "bun run --filter=boardsesh-backend start",

--- a/packages/web/e2e/activity-feed-infinite-scroll.spec.ts
+++ b/packages/web/e2e/activity-feed-infinite-scroll.spec.ts
@@ -9,7 +9,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Sessions Feed - Unauthenticated', () => {
   test('renders Sessions tab as default', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // The Sessions tab should be active by default
     const sessionsTab = page.getByRole('tab', { name: 'Sessions' });
@@ -18,7 +18,7 @@ test.describe('Sessions Feed - Unauthenticated', () => {
   });
 
   test('renders initial feed items', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // Wait for feed items to render
     const feedItems = page.locator('[data-testid="activity-feed-item"]');
@@ -30,7 +30,7 @@ test.describe('Sessions Feed - Unauthenticated', () => {
   });
 
   test('infinite scroll loads more items', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // Wait for initial items to render
     const feedItems = page.locator('[data-testid="activity-feed-item"]');
@@ -53,7 +53,7 @@ test.describe('Sessions Feed - Unauthenticated', () => {
 
 test.describe('Proposals Feed', () => {
   test('renders proposals when tab is clicked', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // Click the Proposals tab
     const proposalsTab = page.getByRole('tab', { name: 'Proposals' });
@@ -69,7 +69,7 @@ test.describe('Proposals Feed', () => {
   });
 
   test('can navigate directly to proposals tab', async ({ page }) => {
-    await page.goto('/?tab=proposals');
+    await page.goto('/feed?tab=proposals');
 
     const proposalsTab = page.getByRole('tab', { name: 'Proposals' });
     await expect(proposalsTab).toHaveAttribute('aria-selected', 'true', { timeout: 15000 });
@@ -81,7 +81,7 @@ test.describe('Proposals Feed', () => {
 
 test.describe('Comments Feed', () => {
   test('renders comments when tab is clicked', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // Click the Comments tab
     const commentsTab = page.getByRole('tab', { name: 'Comments' });
@@ -97,7 +97,7 @@ test.describe('Comments Feed', () => {
   });
 
   test('can navigate directly to comments tab', async ({ page }) => {
-    await page.goto('/?tab=comments');
+    await page.goto('/feed?tab=comments');
 
     const commentsTab = page.getByRole('tab', { name: 'Comments' });
     await expect(commentsTab).toHaveAttribute('aria-selected', 'true', { timeout: 15000 });
@@ -109,7 +109,7 @@ test.describe('Comments Feed', () => {
 
 test.describe('Tab Navigation', () => {
   test('all three tabs are visible', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     await expect(page.getByRole('tab', { name: 'Sessions' })).toBeVisible({ timeout: 15000 });
     await expect(page.getByRole('tab', { name: 'Proposals' })).toBeVisible();
@@ -118,7 +118,7 @@ test.describe('Tab Navigation', () => {
 
   test('tab switching preserves board filter in URL', async ({ page }) => {
     // Start with a board filter
-    await page.goto('/?board=test-board-uuid');
+    await page.goto('/feed?board=test-board-uuid');
 
     // Switch to Proposals tab
     const proposalsTab = page.getByRole('tab', { name: 'Proposals' });
@@ -139,7 +139,7 @@ test.describe('Tab Navigation', () => {
   });
 
   test('sessions tab does not have sort buttons', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/feed');
 
     // Wait for the page to load
     const sessionsTab = page.getByRole('tab', { name: 'Sessions' });
@@ -154,14 +154,15 @@ test.describe('Tab Navigation', () => {
 
 test.describe('Sessions Feed - Authenticated', () => {
   test.beforeEach(async ({ page }) => {
-    // Log in via the auth login form
-    await page.goto('/auth/login');
+    // Log in via the auth login form. The login page honors callbackUrl,
+    // so we land directly on /feed after auth succeeds.
+    await page.goto('/auth/login?callbackUrl=/feed');
     await page.getByLabel('Email').fill('test@boardsesh.com');
     await page.getByLabel('Password').fill('test');
     await page.getByRole('button', { name: 'Login' }).click();
 
-    // Wait for redirect to home page after login
-    await page.waitForURL('/', { timeout: 15000 });
+    // Wait for redirect to the feed page after login
+    await page.waitForURL('/feed', { timeout: 15000 });
   });
 
   test('renders personalized feed without sign-in alert', async ({ page }) => {


### PR DESCRIPTION
The e2e workflow was disabled in 42adf2e because the feed tabs (Sessions /
Proposals / Comments) moved from `/` to a dedicated `/feed` route, so every
`page.goto('/')` in `activity-feed-infinite-scroll.spec.ts` landed on the
new home landing page and failed to find the Sessions tab.

- Rewrite `activity-feed-infinite-scroll.spec.ts` to target `/feed` (and
  use `callbackUrl=/feed` for the authenticated login flow) so tests hit
  the feed page directly.
- Re-enable the workflow trigger, add a fail-fast `typecheck` job, a
  4-way `e2e` shard matrix (`1/4..4/4`), parallel backend/web server
  startup with a single `wait-on`, `.next/cache` caching, and a concurrency
  group that cancels superseded runs.
- Run screenshot specs in CI using the seeded test user
  (`test@boardsesh.com` / `test`) from the pre-built dev DB, upload
  rendered PNGs as `screenshots-shard-N` artifacts, and add a
  `report-screenshots` job that upserts a single sticky PR comment
  (`marocchino/sticky-pull-request-comment@v2`, header `e2e-screenshots`)
  summarizing which scenes rendered per shard.
- Add root `test:e2e` / `test:e2e:setup` scripts so `bun run test:e2e`
  is a one-liner for local runs (brings up the dev DB, exports the test
  user creds, lets Playwright's webServer auto-start backend+web).
- Document the new scripts in CLAUDE.md.