### PR TITLE
fix: add contents:read permission to fix dorny/test-reporter git access

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      contents: read
       pull-requests: write
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      contents: read
       pull-requests: write
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
When permissions are explicitly set in a GitHub Actions job, all
unspecified permissions are implicitly denied. The dorny/test-reporter
action runs `git ls-files` internally, which requires read access to the
repository contents. Without `contents: read`, git fails with
"not a git repository" even though the checkout step ran successfully.

https://claude.ai/code/session_01U8aoJLhvKYAXi5hRDGpeWK