### PR TITLE
fix: improve hold set selector clarity in custom board form

### DIFF
--- a/packages/web/app/components/board-entity/board-form.tsx
+++ b/packages/web/app/components/board-entity/board-form.tsx
@@ -10,8 +10,8 @@ import CircularProgress from '@mui/material/CircularProgress';
 import MuiTypography from '@mui/material/Typography';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
-import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';
+import Check from '@mui/icons-material/Check';
 import MuiSelect from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import FormControl from '@mui/material/FormControl';
@@ -214,9 +214,16 @@ export default function BoardForm({
                 }
               >
                 {availableSets.map(({ id, name: setName }) => (
-                  <MenuItem key={id} value={id}>
-                    <Checkbox checked={selectedSets.includes(id)} />
-                    <ListItemText primary={setName} />
+                  <MenuItem key={id} value={id} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                    <ListItemText
+                      primary={setName}
+                      primaryTypographyProps={{
+                        color: selectedSets.includes(id) ? 'text.primary' : 'text.secondary',
+                      }}
+                    />
+                    {selectedSets.includes(id) && (
+                      <Check fontSize="small" sx={{ color: 'primary.main', flexShrink: 0 }} />
+                    )}
                   </MenuItem>
                 ))}
               </MuiSelect>

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -39,7 +39,7 @@ export const themeTokens = {
 
   // Semantic colors
   semantic: {
-    selected: '#F7F2F3', // Very light warm grey with subtle rose tint
+    selected: 'rgba(140, 74, 82, 0.18)', // Visible rose tint for selected state
     selectedHover: '#EFE6E8', // Darker rose tint for hover feedback
     selectedLight: 'rgba(140, 74, 82, 0.06)', // Very subtle rose highlight
     selectedBorder: '#8C4A52', // Matches primary


### PR DESCRIPTION
- Replace left-side checkbox with right-side tick icon on selected items
- Grey out text of unselected items so selection state is immediately obvious
- Brighten the selected background token from near-invisible #F7F2F3 to a visible rose tint

Fixes #1412

https://claude.ai/code/session_01MuAU2EGN3XroBNtCCvZEuT