### PR TITLE
Persist logbook preferences and polish filter controls

### DIFF
--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -24,9 +24,25 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Checkbox from '@mui/material/Checkbox';
 import FormGroup from '@mui/material/FormGroup';
-import { HistoryOutlined, SearchOutlined, FilterListOutlined, SwapVertOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import IconButton from '@mui/material/IconButton';
+import { HistoryOutlined, SearchOutlined, FilterListOutlined, SwapVertOutlined, ExpandMoreOutlined, CloseOutlined } from '@mui/icons-material';
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { getAllLayouts } from '@/app/lib/board-constants';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import {
+  ALL_LAYOUT_SELECTIONS,
+  DEFAULT_ANGLE_RANGE,
+  DEFAULT_FILTERS,
+  DEFAULT_SORT,
+  sanitizeLogbookPreferences,
+  type BoardFilter,
+  type LogbookPreferences,
+  type LogbookFilterState as FilterState,
+  type LogbookSortState as SortState,
+  type SortDirection,
+  type SortField,
+  type SortPreset,
+} from '@/app/lib/logbook-preferences';
 import { useSession } from 'next-auth/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -47,55 +63,7 @@ import styles from './library.module.css';
 import feedStyles from '@/app/components/activity-feed/ascents-feed.module.css';
 
 const PAGE_SIZE = 20;
-const DEFAULT_ANGLE_RANGE: [number, number] = [0, 70];
-
-type BoardFilter = 'all' | 'kilter' | 'tension' | 'moonboard';
 type StatusMode = 'both' | 'send' | 'attempt';
-type SortPreset = 'recent' | 'hardest';
-type SortField = 'climbName' | 'loggedGrade' | 'consensusGrade' | 'date' | 'attemptCount';
-type SortDirection = 'asc' | 'desc';
-
-type FilterState = {
-  includeSends: boolean;
-  includeAttempts: boolean;
-  flashOnly: boolean;
-  minGrade: number | '';
-  maxGrade: number | '';
-  fromDate: string;
-  toDate: string;
-  angleRange: [number, number];
-  benchmarkOnly: boolean;
-};
-
-type SortState = {
-  mode: 'preset' | 'custom';
-  preset: SortPreset;
-  primaryField: SortField;
-  primaryDirection: SortDirection;
-  secondaryField: '' | SortField;
-  secondaryDirection: SortDirection;
-};
-
-const DEFAULT_FILTERS: FilterState = {
-  includeSends: true,
-  includeAttempts: false,
-  flashOnly: false,
-  minGrade: '',
-  maxGrade: '',
-  fromDate: '',
-  toDate: '',
-  angleRange: DEFAULT_ANGLE_RANGE,
-  benchmarkOnly: false,
-};
-
-const DEFAULT_SORT: SortState = {
-  mode: 'preset',
-  preset: 'recent',
-  primaryField: 'date',
-  primaryDirection: 'desc',
-  secondaryField: '',
-  secondaryDirection: 'desc',
-};
 
 const BOARD_OPTIONS: { value: BoardFilter; label: string }[] = [
   { value: 'all', label: 'All boards' },
@@ -210,10 +178,9 @@ export default function LogbookFeed() {
   const [sortAnchorEl, setSortAnchorEl] = useState<HTMLElement | null>(null);
   const [boardAnchorEl, setBoardAnchorEl] = useState<HTMLElement | null>(null);
   const [layoutSelections, setLayoutSelections] = useState<Record<Exclude<BoardFilter, 'all'>, number[]>>({
-    kilter: BOARD_LAYOUT_OPTIONS.kilter.map((layout) => layout.id),
-    tension: BOARD_LAYOUT_OPTIONS.tension.map((layout) => layout.id),
-    moonboard: BOARD_LAYOUT_OPTIONS.moonboard.map((layout) => layout.id),
+    ...ALL_LAYOUT_SELECTIONS,
   });
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -226,6 +193,31 @@ export default function LogbookFeed() {
   }, []);
 
   useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    getPreference('logbookPreferences').then((saved) => {
+      if (isCancelled) return;
+
+      if (saved) {
+        const sanitized = sanitizeLogbookPreferences(saved);
+        setBoardFilter(sanitized.boardFilter);
+        setLayoutSelections(sanitized.layoutSelections);
+        setFilters(sanitized.filters);
+        setDraftFilters(sanitized.filters);
+        setSortState(sanitized.sort);
+        setDraftSortState(sanitized.sort);
+        setIsAdvancedSortOpen(Boolean(sanitized.sort.secondaryField));
+      }
+
+      setPreferencesLoaded(true);
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
 
   const openFilterMenu = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     setDraftFilters(filters);
@@ -271,6 +263,48 @@ export default function LogbookFeed() {
     });
     closeSortMenu();
   }, [closeSortMenu, draftSortState, isAdvancedSortOpen]);
+
+  const applyPresetSort = useCallback((preset: SortPreset) => {
+    const nextSortState: SortState = {
+      ...sortState,
+      mode: 'preset',
+      preset,
+    };
+    setDraftSortState(nextSortState);
+    setSortState(nextSortState);
+  }, [sortState]);
+
+  const persistedPreferences = useMemo<LogbookPreferences>(() => ({
+    version: 1,
+    boardFilter,
+    layoutSelections,
+    filters,
+    sort: sortState,
+  }), [boardFilter, layoutSelections, filters, sortState]);
+
+  const boardChipLabels = useMemo(() => {
+    return BOARD_OPTIONS.reduce<Record<BoardFilter, string>>((labels, option) => {
+      if (option.value === 'all') {
+        labels.all = option.label;
+        return labels;
+      }
+
+      const totalVariants = BOARD_LAYOUT_OPTIONS[option.value].length;
+      if (totalVariants <= 1) {
+        labels[option.value] = option.label;
+        return labels;
+      }
+
+      const selectedVariants = layoutSelections[option.value].length;
+      labels[option.value] = `${option.label} (${selectedVariants}/${totalVariants})`;
+      return labels;
+    }, { all: 'All boards', kilter: 'Kilter', tension: 'Tension', moonboard: 'MoonBoard' });
+  }, [layoutSelections]);
+
+  useEffect(() => {
+    if (!preferencesLoaded) return;
+    void setPreference('logbookPreferences', persistedPreferences);
+  }, [persistedPreferences, preferencesLoaded]);
 
   const boardTypeParam = boardFilter === 'all' ? undefined : boardFilter;
   const selectedLayoutIds = boardFilter === 'all' ? undefined : layoutSelections[boardFilter];
@@ -410,7 +444,7 @@ export default function LogbookFeed() {
           {BOARD_OPTIONS.map((opt) => (
             <Chip
               key={opt.value}
-              label={opt.label}
+              label={boardChipLabels[opt.value]}
               size="small"
               variant={boardFilter === opt.value ? 'filled' : 'outlined'}
               color={boardFilter === opt.value ? 'primary' : 'default'}
@@ -487,6 +521,7 @@ export default function LogbookFeed() {
           setIsAdvancedSortOpen={setIsAdvancedSortOpen}
           onClose={closeSortMenu}
           onApply={applySort}
+          onPresetChange={applyPresetSort}
         />
         {boardFilter !== 'all' && (
           <BoardLayoutsPopover
@@ -531,6 +566,7 @@ export default function LogbookFeed() {
         setIsAdvancedSortOpen={setIsAdvancedSortOpen}
         onClose={closeSortMenu}
         onApply={applySort}
+        onPresetChange={applyPresetSort}
       />
       {boardFilter !== 'all' && (
         <BoardLayoutsPopover
@@ -730,6 +766,7 @@ function SortPopover({
   setIsAdvancedSortOpen,
   onClose,
   onApply,
+  onPresetChange,
 }: {
   anchorEl: HTMLElement | null;
   draftSortState: SortState;
@@ -738,6 +775,7 @@ function SortPopover({
   setIsAdvancedSortOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onClose: () => void;
   onApply: () => void;
+  onPresetChange: (preset: SortPreset) => void;
 }) {
   const open = Boolean(anchorEl);
   const primaryDirectionOptions = getDirectionOptions(draftSortState.primaryField);
@@ -753,9 +791,14 @@ function SortPopover({
       slotProps={{ paper: { sx: { width: 420, maxWidth: 'calc(100vw - 24px)', borderRadius: '16px', mt: 1 } } }}
     >
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <Box>
-          <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>Sort Logbook</Typography>
-          <Typography variant="body2" color="text.secondary">Choose how your entries are ordered.</Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>Sort Logbook</Typography>
+            <Typography variant="body2" color="text.secondary">Choose how your entries are ordered.</Typography>
+          </Box>
+          <IconButton size="small" onClick={onClose} sx={{ mt: -0.5, mr: -0.5 }}>
+            <CloseOutlined fontSize="small" />
+          </IconButton>
         </Box>
 
         <Box sx={{ display: 'flex', gap: 1 }}>
@@ -779,7 +822,11 @@ function SortPopover({
           <FormControl size="small" fullWidth>
             <Select
               value={draftSortState.preset}
-              onChange={(e) => setDraftSortState((current) => ({ ...current, preset: e.target.value as SortPreset }))}
+              onChange={(e) => {
+                const nextPreset = e.target.value as SortPreset;
+                setDraftSortState((current) => ({ ...current, mode: 'preset', preset: nextPreset }));
+                onPresetChange(nextPreset);
+              }}
               sx={{ borderRadius: '10px' }}
             >
               {SORT_PRESET_OPTIONS.map((option) => (
@@ -789,7 +836,7 @@ function SortPopover({
           </FormControl>
         ) : (
           <>
-            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.25 }}>
+            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.25, mb: 0.5 }}>
               <FormControl size="small" fullWidth>
                 <Select
                   value={draftSortState.primaryField}
@@ -820,6 +867,7 @@ function SortPopover({
               disableGutters
               elevation={0}
               sx={{
+                mt: 0.5,
                 bgcolor: 'transparent',
                 border: '1px solid',
                 borderColor: 'divider',
@@ -862,12 +910,16 @@ function SortPopover({
           </>
         )}
 
-        <Divider />
+        {draftSortState.mode === 'custom' && (
+          <>
+            <Divider />
 
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-          <Button variant="outlined" color="inherit" onClick={onClose} sx={{ textTransform: 'none' }}>Cancel</Button>
-          <Button variant="contained" onClick={onApply} sx={{ textTransform: 'none' }}>Apply</Button>
-        </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+              <Button variant="outlined" color="inherit" onClick={onClose} sx={{ textTransform: 'none' }}>Cancel</Button>
+              <Button variant="contained" onClick={onApply} sx={{ textTransform: 'none' }}>Apply</Button>
+            </Box>
+          </>
+        )}
       </Box>
     </Popover>
   );

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -256,6 +256,10 @@ export default function LogbookFeed() {
     closeFilterMenu();
   }, [closeFilterMenu, draftFilters]);
 
+  const clearFilters = useCallback(() => {
+    setDraftFilters(DEFAULT_FILTERS);
+  }, []);
+
   const applySort = useCallback(() => {
     setSortState({
       ...draftSortState,
@@ -510,8 +514,10 @@ export default function LogbookFeed() {
           anchorEl={filterAnchorEl}
           draftFilters={draftFilters}
           setDraftFilters={setDraftFilters}
+          appliedFilters={filters}
           onClose={closeFilterMenu}
           onApply={applyFilters}
+          onClear={clearFilters}
         />
         <SortPopover
           anchorEl={sortAnchorEl}
@@ -555,8 +561,10 @@ export default function LogbookFeed() {
         anchorEl={filterAnchorEl}
         draftFilters={draftFilters}
         setDraftFilters={setDraftFilters}
+        appliedFilters={filters}
         onClose={closeFilterMenu}
         onApply={applyFilters}
+        onClear={clearFilters}
       />
       <SortPopover
         anchorEl={sortAnchorEl}
@@ -585,16 +593,21 @@ function FilterPopover({
   anchorEl,
   draftFilters,
   setDraftFilters,
+  appliedFilters,
   onClose,
   onApply,
+  onClear,
 }: {
   anchorEl: HTMLElement | null;
   draftFilters: FilterState;
   setDraftFilters: React.Dispatch<React.SetStateAction<FilterState>>;
+  appliedFilters: FilterState;
   onClose: () => void;
   onApply: () => void;
+  onClear: () => void;
 }) {
   const open = Boolean(anchorEl);
+  const clearDisabled = isDefaultFilters(appliedFilters) && isDefaultFilters(draftFilters);
 
   return (
     <Popover
@@ -606,9 +619,14 @@ function FilterPopover({
       slotProps={{ paper: { sx: { width: 420, maxWidth: 'calc(100vw - 24px)', borderRadius: '16px', mt: 1 } } }}
     >
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <Box>
-          <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>Filter Logbook</Typography>
-          <Typography variant="body2" color="text.secondary">Narrow down your climbing history.</Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>Filter Logbook</Typography>
+            <Typography variant="body2" color="text.secondary">Narrow down your climbing history.</Typography>
+          </Box>
+          <IconButton size="small" onClick={onClose} sx={{ mt: -0.5, mr: -0.5 }}>
+            <CloseOutlined fontSize="small" />
+          </IconButton>
         </Box>
 
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -658,6 +676,17 @@ function FilterPopover({
             />
           }
           label="Flash only"
+          sx={{ m: 0 }}
+        />
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={draftFilters.benchmarkOnly}
+              onChange={(_, checked) => setDraftFilters((current) => ({ ...current, benchmarkOnly: checked }))}
+            />
+          }
+          label="Benchmark climbs only"
           sx={{ m: 0 }}
         />
 
@@ -736,21 +765,10 @@ function FilterPopover({
           />
         </Box>
 
-        <FormControlLabel
-          control={
-            <Switch
-              checked={draftFilters.benchmarkOnly}
-              onChange={(_, checked) => setDraftFilters((current) => ({ ...current, benchmarkOnly: checked }))}
-            />
-          }
-          label="Benchmark climbs only"
-          sx={{ m: 0 }}
-        />
-
         <Divider />
 
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-          <Button variant="outlined" color="inherit" onClick={onClose} sx={{ textTransform: 'none' }}>Cancel</Button>
+          <Button variant="outlined" color="inherit" onClick={onClear} disabled={clearDisabled} sx={{ textTransform: 'none' }}>Clear</Button>
           <Button variant="contained" onClick={onApply} sx={{ textTransform: 'none' }}>Apply</Button>
         </Box>
       </Box>

--- a/packages/web/app/lib/__tests__/logbook-preferences.test.ts
+++ b/packages/web/app/lib/__tests__/logbook-preferences.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_LAYOUT_SELECTIONS,
+  DEFAULT_LOGBOOK_PREFERENCES,
+  sanitizeLogbookPreferences,
+} from '../logbook-preferences';
+
+describe('sanitizeLogbookPreferences', () => {
+  it('returns defaults for non-object values', () => {
+    expect(sanitizeLogbookPreferences(null)).toEqual(DEFAULT_LOGBOOK_PREFERENCES);
+  });
+
+  it('drops invalid board filters and layout ids', () => {
+    const result = sanitizeLogbookPreferences({
+      version: 1,
+      boardFilter: 'spraywall',
+      layoutSelections: {
+        kilter: [999999],
+        tension: [ALL_LAYOUT_SELECTIONS.tension[0]],
+        moonboard: [],
+      },
+      filters: {},
+      sort: {},
+    });
+
+    expect(result.boardFilter).toBe('all');
+    expect(result.layoutSelections.kilter).toEqual(ALL_LAYOUT_SELECTIONS.kilter);
+    expect(result.layoutSelections.tension).toEqual([ALL_LAYOUT_SELECTIONS.tension[0]]);
+    expect(result.layoutSelections.moonboard).toEqual(ALL_LAYOUT_SELECTIONS.moonboard);
+  });
+
+  it('forces at least one result type and clears flashOnly when sends are off', () => {
+    const result = sanitizeLogbookPreferences({
+      version: 1,
+      boardFilter: 'all',
+      layoutSelections: ALL_LAYOUT_SELECTIONS,
+      filters: {
+        includeSends: false,
+        includeAttempts: false,
+        flashOnly: true,
+        minGrade: '',
+        maxGrade: '',
+        fromDate: '',
+        toDate: '',
+        angleRange: [0, 70],
+        benchmarkOnly: false,
+      },
+      sort: DEFAULT_LOGBOOK_PREFERENCES.sort,
+    });
+
+    expect(result.filters.includeSends).toBe(true);
+    expect(result.filters.includeAttempts).toBe(false);
+    expect(result.filters.flashOnly).toBe(true);
+  });
+});

--- a/packages/web/app/lib/__tests__/user-preferences-db.test.ts
+++ b/packages/web/app/lib/__tests__/user-preferences-db.test.ts
@@ -2,12 +2,36 @@ import 'fake-indexeddb/auto';
 import { openDB } from 'idb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPreference, setPreference, removePreference } from '../user-preferences-db';
+import { DEFAULT_LOGBOOK_PREFERENCES } from '../logbook-preferences';
 
 const DB_NAME = 'boardsesh-user-preferences';
 const STORE_NAME = 'preferences';
+const createStorageShim = () => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+const storage = createStorageShim();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: storage,
+});
 
 beforeEach(async () => {
-  localStorage.clear();
+  storage.clear();
   // Clear the store contents using a separate short-lived connection
   const db = await openDB(DB_NAME, 1, {
     upgrade(db) {
@@ -33,6 +57,12 @@ describe('user-preferences-db', () => {
       await setPreference('objKey', obj);
       const result = await getPreference<typeof obj>('objKey');
       expect(result).toEqual(obj);
+    });
+
+    it('should store and retrieve logbookPreferences', async () => {
+      await setPreference('logbookPreferences', DEFAULT_LOGBOOK_PREFERENCES);
+      const result = await getPreference('logbookPreferences');
+      expect(result).toEqual(DEFAULT_LOGBOOK_PREFERENCES);
     });
 
     it('should return null for a non-existent key', async () => {
@@ -63,22 +93,22 @@ describe('user-preferences-db', () => {
 
   describe('localStorage migration', () => {
     it('should migrate climbListViewMode from localStorage on first read', async () => {
-      localStorage.setItem('climbListViewMode', 'grid');
+      storage.setItem('climbListViewMode', 'grid');
 
       const result = await getPreference<string>('climbListViewMode');
       expect(result).toBe('grid');
 
       // localStorage key should be cleaned up
-      expect(localStorage.getItem('climbListViewMode')).toBeNull();
+      expect(storage.getItem('climbListViewMode')).toBeNull();
     });
 
     it('should migrate boardsesh:partyMode from localStorage on first read', async () => {
-      localStorage.setItem('boardsesh:partyMode', 'backend');
+      storage.setItem('boardsesh:partyMode', 'backend');
 
       const result = await getPreference<string>('boardsesh:partyMode');
       expect(result).toBe('backend');
 
-      expect(localStorage.getItem('boardsesh:partyMode')).toBeNull();
+      expect(storage.getItem('boardsesh:partyMode')).toBeNull();
     });
 
     it('should not re-migrate if IndexedDB already has the value', async () => {
@@ -86,13 +116,13 @@ describe('user-preferences-db', () => {
       await setPreference('climbListViewMode', 'list');
 
       // Set a different value in localStorage (simulating stale data)
-      localStorage.setItem('climbListViewMode', 'grid');
+      storage.setItem('climbListViewMode', 'grid');
 
       const result = await getPreference<string>('climbListViewMode');
       expect(result).toBe('list');
 
       // localStorage should remain untouched since migration was skipped
-      expect(localStorage.getItem('climbListViewMode')).toBe('grid');
+      expect(storage.getItem('climbListViewMode')).toBe('grid');
     });
 
     it('should return null when neither IndexedDB nor localStorage has the value', async () => {
@@ -101,26 +131,26 @@ describe('user-preferences-db', () => {
     });
 
     it('should not attempt migration for keys without a legacy mapping', async () => {
-      localStorage.setItem('someOtherKey', 'value');
+      storage.setItem('someOtherKey', 'value');
 
       const result = await getPreference<string>('someOtherKey');
       expect(result).toBeNull();
 
       // localStorage should be untouched
-      expect(localStorage.getItem('someOtherKey')).toBe('value');
+      expect(storage.getItem('someOtherKey')).toBe('value');
     });
 
     it('should parse JSON values during migration', async () => {
-      localStorage.setItem('climbListViewMode', JSON.stringify({ mode: 'grid' }));
+      storage.setItem('climbListViewMode', JSON.stringify({ mode: 'grid' }));
 
       const result = await getPreference<{ mode: string }>('climbListViewMode');
       expect(result).toEqual({ mode: 'grid' });
 
-      expect(localStorage.getItem('climbListViewMode')).toBeNull();
+      expect(storage.getItem('climbListViewMode')).toBeNull();
     });
 
     it('should persist migrated value so subsequent reads come from IndexedDB', async () => {
-      localStorage.setItem('climbListViewMode', 'grid');
+      storage.setItem('climbListViewMode', 'grid');
 
       // First read triggers migration
       await getPreference<string>('climbListViewMode');

--- a/packages/web/app/lib/logbook-preferences.ts
+++ b/packages/web/app/lib/logbook-preferences.ts
@@ -1,0 +1,180 @@
+import { getAllLayouts } from '@/app/lib/board-constants';
+
+export type BoardFilter = 'all' | 'kilter' | 'tension' | 'moonboard';
+export type SortPreset = 'recent' | 'hardest';
+export type SortField = 'climbName' | 'loggedGrade' | 'consensusGrade' | 'date' | 'attemptCount';
+export type SortDirection = 'asc' | 'desc';
+
+export type LogbookFilterState = {
+  includeSends: boolean;
+  includeAttempts: boolean;
+  flashOnly: boolean;
+  minGrade: number | '';
+  maxGrade: number | '';
+  fromDate: string;
+  toDate: string;
+  angleRange: [number, number];
+  benchmarkOnly: boolean;
+};
+
+export type LogbookSortState = {
+  mode: 'preset' | 'custom';
+  preset: SortPreset;
+  primaryField: SortField;
+  primaryDirection: SortDirection;
+  secondaryField: '' | SortField;
+  secondaryDirection: SortDirection;
+};
+
+export type LogbookPreferences = {
+  version: 1;
+  boardFilter: BoardFilter;
+  layoutSelections: Record<Exclude<BoardFilter, 'all'>, number[]>;
+  filters: LogbookFilterState;
+  sort: LogbookSortState;
+};
+
+export const DEFAULT_ANGLE_RANGE: [number, number] = [0, 70];
+
+export const DEFAULT_FILTERS: LogbookFilterState = {
+  includeSends: true,
+  includeAttempts: false,
+  flashOnly: false,
+  minGrade: '',
+  maxGrade: '',
+  fromDate: '',
+  toDate: '',
+  angleRange: DEFAULT_ANGLE_RANGE,
+  benchmarkOnly: false,
+};
+
+export const DEFAULT_SORT: LogbookSortState = {
+  mode: 'preset',
+  preset: 'recent',
+  primaryField: 'date',
+  primaryDirection: 'desc',
+  secondaryField: '',
+  secondaryDirection: 'desc',
+};
+
+export const ALL_LAYOUT_SELECTIONS: Record<Exclude<BoardFilter, 'all'>, number[]> = {
+  kilter: getAllLayouts('kilter').map((layout) => layout.id),
+  tension: getAllLayouts('tension').map((layout) => layout.id),
+  moonboard: getAllLayouts('moonboard').map((layout) => layout.id),
+};
+
+export const DEFAULT_LOGBOOK_PREFERENCES: LogbookPreferences = {
+  version: 1,
+  boardFilter: 'all',
+  layoutSelections: ALL_LAYOUT_SELECTIONS,
+  filters: DEFAULT_FILTERS,
+  sort: DEFAULT_SORT,
+};
+
+const VALID_BOARD_FILTERS: BoardFilter[] = ['all', 'kilter', 'tension', 'moonboard'];
+const VALID_SORT_FIELDS: Array<SortField | ''> = ['', 'climbName', 'loggedGrade', 'consensusGrade', 'date', 'attemptCount'];
+const VALID_SORT_DIRECTIONS: SortDirection[] = ['asc', 'desc'];
+const VALID_SORT_PRESETS: SortPreset[] = ['recent', 'hardest'];
+
+function sanitizeDifficulty(value: unknown): number | '' {
+  return typeof value === 'number' && Number.isFinite(value) ? value : '';
+}
+
+function sanitizeDate(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function sanitizeAngleRange(value: unknown): [number, number] {
+  if (!Array.isArray(value) || value.length !== 2) {
+    return DEFAULT_ANGLE_RANGE;
+  }
+
+  const rawMin = typeof value[0] === 'number' ? value[0] : DEFAULT_ANGLE_RANGE[0];
+  const rawMax = typeof value[1] === 'number' ? value[1] : DEFAULT_ANGLE_RANGE[1];
+  const min = Math.max(0, Math.min(70, rawMin));
+  const max = Math.max(min, Math.min(70, rawMax));
+  return [min, max];
+}
+
+function sanitizeLayoutSelections(value: unknown): Record<Exclude<BoardFilter, 'all'>, number[]> {
+  const source = value && typeof value === 'object' ? value as Partial<Record<Exclude<BoardFilter, 'all'>, unknown>> : {};
+
+  return {
+    kilter: sanitizeBoardLayouts(source.kilter, 'kilter'),
+    tension: sanitizeBoardLayouts(source.tension, 'tension'),
+    moonboard: sanitizeBoardLayouts(source.moonboard, 'moonboard'),
+  };
+}
+
+function sanitizeBoardLayouts(value: unknown, board: Exclude<BoardFilter, 'all'>): number[] {
+  const validIds = new Set(ALL_LAYOUT_SELECTIONS[board]);
+  const ids = Array.isArray(value)
+    ? value.filter((candidate): candidate is number => typeof candidate === 'number' && validIds.has(candidate))
+    : [];
+
+  return ids.length > 0 ? Array.from(new Set(ids)).sort((a, b) => a - b) : ALL_LAYOUT_SELECTIONS[board];
+}
+
+export function sanitizeLogbookPreferences(value: unknown): LogbookPreferences {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_LOGBOOK_PREFERENCES;
+  }
+
+  const source = value as Partial<LogbookPreferences>;
+  const filters = source.filters && typeof source.filters === 'object' ? source.filters : {};
+  const sort = source.sort && typeof source.sort === 'object' ? source.sort : {};
+
+  const sanitizedFilters: LogbookFilterState = {
+    includeSends: sanitizeBoolean((filters as Partial<LogbookFilterState>).includeSends, DEFAULT_FILTERS.includeSends),
+    includeAttempts: sanitizeBoolean((filters as Partial<LogbookFilterState>).includeAttempts, DEFAULT_FILTERS.includeAttempts),
+    flashOnly: sanitizeBoolean((filters as Partial<LogbookFilterState>).flashOnly, DEFAULT_FILTERS.flashOnly),
+    minGrade: sanitizeDifficulty((filters as Partial<LogbookFilterState>).minGrade),
+    maxGrade: sanitizeDifficulty((filters as Partial<LogbookFilterState>).maxGrade),
+    fromDate: sanitizeDate((filters as Partial<LogbookFilterState>).fromDate),
+    toDate: sanitizeDate((filters as Partial<LogbookFilterState>).toDate),
+    angleRange: sanitizeAngleRange((filters as Partial<LogbookFilterState>).angleRange),
+    benchmarkOnly: sanitizeBoolean((filters as Partial<LogbookFilterState>).benchmarkOnly, DEFAULT_FILTERS.benchmarkOnly),
+  };
+
+  if (!sanitizedFilters.includeSends && !sanitizedFilters.includeAttempts) {
+    sanitizedFilters.includeSends = true;
+  }
+  if (!sanitizedFilters.includeSends) {
+    sanitizedFilters.flashOnly = false;
+  }
+
+  const sanitizedSort: LogbookSortState = {
+    mode: sort && (sort as Partial<LogbookSortState>).mode === 'custom' ? 'custom' : 'preset',
+    preset: VALID_SORT_PRESETS.includes((sort as Partial<LogbookSortState>).preset ?? 'recent')
+      ? ((sort as Partial<LogbookSortState>).preset as SortPreset)
+      : DEFAULT_SORT.preset,
+    primaryField: VALID_SORT_FIELDS.includes((sort as Partial<LogbookSortState>).primaryField ?? 'date')
+      ? (((sort as Partial<LogbookSortState>).primaryField || 'date') as SortField)
+      : DEFAULT_SORT.primaryField,
+    primaryDirection: VALID_SORT_DIRECTIONS.includes((sort as Partial<LogbookSortState>).primaryDirection ?? 'desc')
+      ? ((sort as Partial<LogbookSortState>).primaryDirection as SortDirection)
+      : DEFAULT_SORT.primaryDirection,
+    secondaryField: VALID_SORT_FIELDS.includes((sort as Partial<LogbookSortState>).secondaryField ?? '')
+      ? (((sort as Partial<LogbookSortState>).secondaryField ?? '') as '' | SortField)
+      : DEFAULT_SORT.secondaryField,
+    secondaryDirection: VALID_SORT_DIRECTIONS.includes((sort as Partial<LogbookSortState>).secondaryDirection ?? 'desc')
+      ? ((sort as Partial<LogbookSortState>).secondaryDirection as SortDirection)
+      : DEFAULT_SORT.secondaryDirection,
+  };
+
+  const boardFilter = VALID_BOARD_FILTERS.includes(source.boardFilter ?? 'all')
+    ? (source.boardFilter as BoardFilter)
+    : DEFAULT_LOGBOOK_PREFERENCES.boardFilter;
+
+  return {
+    version: 1,
+    boardFilter,
+    layoutSelections: sanitizeLayoutSelections(source.layoutSelections),
+    filters: sanitizedFilters,
+    sort: sanitizedSort,
+  };
+}

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -1,6 +1,12 @@
 import { createIndexedDBStore, migrateFromLocalStorage } from './idb-helper';
+import type { LogbookPreferences } from './logbook-preferences';
 
 const STORE_NAME = 'preferences';
+
+export type UserPreferenceKeyMap = {
+  libraryTab: 'playlists' | 'logbook';
+  logbookPreferences: LogbookPreferences;
+};
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration
 const LEGACY_LOCALSTORAGE_KEYS: Record<string, string> = {
@@ -13,12 +19,14 @@ const getDB = createIndexedDBStore('boardsesh-user-preferences', STORE_NAME);
 /**
  * Get a preference value from IndexedDB.
  */
-export const getPreference = async <T>(key: string): Promise<T | null> => {
+export const getPreference = async <T = unknown, K extends string = string>(
+  key: K,
+): Promise<(K extends keyof UserPreferenceKeyMap ? UserPreferenceKeyMap[K] : T) | null> => {
   try {
     const db = await getDB();
     if (!db) return null;
     const value = await db.get(STORE_NAME, key);
-    if (value !== undefined) return value as T;
+    if (value !== undefined) return value as (K extends keyof UserPreferenceKeyMap ? UserPreferenceKeyMap[K] : T);
 
     // Attempt one-time migration from localStorage
     const legacyKey = LEGACY_LOCALSTORAGE_KEYS[key];
@@ -30,7 +38,7 @@ export const getPreference = async <T>(key: string): Promise<T | null> => {
         migratedValue = val;
         migrated = true;
       });
-      if (migrated) return migratedValue;
+      if (migrated) return migratedValue as (K extends keyof UserPreferenceKeyMap ? UserPreferenceKeyMap[K] : T);
     }
 
     return null;
@@ -43,7 +51,10 @@ export const getPreference = async <T>(key: string): Promise<T | null> => {
 /**
  * Save a preference value to IndexedDB.
  */
-export const setPreference = async <T>(key: string, value: T): Promise<void> => {
+export const setPreference = async <K extends string>(
+  key: K,
+  value: K extends keyof UserPreferenceKeyMap ? UserPreferenceKeyMap[K] : unknown,
+): Promise<void> => {
   try {
     const db = await getDB();
     if (!db) return;


### PR DESCRIPTION
## Summary
- persist committed logbook board, layout, filter, and sort preferences in the existing browser preference store
- restore saved logbook state on refresh and future visits
- polish the filter and sort popovers for a smoother logbook workflow

## What changed
- add a versioned logbook preference shape and validation for saved browser state
- save only committed logbook choices, not temporary draft edits inside open popovers
- restore board selection, layout variants, applied filters, and applied sort on logbook mount
- make sort presets apply immediately while custom sort still uses Apply
- refine filter UX with a top-right close action, a clear action, and better control ordering
- show board variant counts directly on board chips, e.g. Kilter (1/2)

## Testing
- manual refresh and revisit testing for persisted board, layout, filter, and sort state
- bun run typecheck:web
- bun run test -- app/lib/__tests__/user-preferences-db.test.ts app/lib/__tests__/logbook-preferences.test.ts

## Notes
- browser-local persistence only
- search text is still intentionally not persisted in this pass