### PR TITLE
Reverse tries selector order and move label above number in tick bar

### DIFF
--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -70,10 +70,10 @@
 
 .attemptLabel {
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 1px;
+  margin-bottom: 1px;
   font-size: 8px;
   font-weight: 500;
   line-height: 1;

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -70,10 +70,10 @@
 
 .attemptLabel {
   position: absolute;
-  bottom: 100%;
+  top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-bottom: 1px;
+  margin-top: 1px;
   font-size: 8px;
   font-weight: 500;
   line-height: 1;

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -58,6 +58,7 @@ const SNAP_BACK_DURATION_MS = 180;
 
 /** Options shown in the attempts picker. 10 displays as "9+" in the UI. */
 const ATTEMPT_OPTIONS: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const REVERSED_ATTEMPT_OPTIONS: readonly number[] = [...ATTEMPT_OPTIONS].reverse();
 
 /**
  * Inline tick entry bar. Designed to be embedded in a parent row (e.g. the queue
@@ -389,7 +390,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           slotProps={{ paper: { sx: { minWidth: 64 } } }}
         >
-          {[...ATTEMPT_OPTIONS].reverse().map((n) => (
+          {REVERSED_ATTEMPT_OPTIONS.map((n) => (
             <MenuItem
               key={n}
               selected={n === attemptCount}

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -389,7 +389,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           slotProps={{ paper: { sx: { minWidth: 64 } } }}
         >
-          {ATTEMPT_OPTIONS.map((n) => (
+          {[...ATTEMPT_OPTIONS].reverse().map((n) => (
             <MenuItem
               key={n}
               selected={n === attemptCount}


### PR DESCRIPTION
- Menu now shows 9+ at top descending to 1 at bottom so the most common
  multi-try selections are at the top where the menu opens
- "tries" label repositioned above the number (bottom: 100%) so the count
  reads as a labelled value with the descriptor above

https://claude.ai/code/session_01N4CH8NFeKTUDoPu5eUkZaA