### PR TITLE
fix: publish test reports via workflow_run to support forked PRs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,11 +18,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-
     services:
       postgres:
         image: ghcr.io/boardsesh/boardsesh-postgres-postgis:latest
@@ -97,11 +92,3 @@ jobs:
           path: packages/backend/test-results/junit.xml
           retention-days: 7
 
-      - name: Publish test report
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: Backend Integration Tests
-          path: packages/backend/test-results/junit.xml
-          reporter: java-junit
-          fail-on-error: false

--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -1,0 +1,41 @@
+name: Publish Test Reports
+
+# Runs after the CI workflows complete — including PRs from forks.
+# The workflow_run trigger executes in the base repo context, so
+# GITHUB_TOKEN has checks:write permission even for forked PRs.
+on:
+  workflow_run:
+    workflows: ["Web Tests", "Backend Integration Tests"]
+    types:
+      - completed
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  publish-web-tests:
+    if: github.event.workflow.name == 'Web Tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Web Unit Tests report
+        uses: dorny/test-reporter@v1
+        with:
+          artifact: web-test-results
+          name: Web Unit Tests
+          path: '*.xml'
+          reporter: java-junit
+          fail-on-error: false
+
+  publish-backend-tests:
+    if: github.event.workflow.name == 'Backend Integration Tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Backend Integration Tests report
+        uses: dorny/test-reporter@v1
+        with:
+          artifact: backend-test-results
+          name: Backend Integration Tests
+          path: '*.xml'
+          reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,6 @@ jobs:
   test:
     needs: setup
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
     steps:
     - uses: actions/checkout@v6
       with:
@@ -147,11 +143,3 @@ jobs:
         path: packages/web/test-results/junit.xml
         retention-days: 7
 
-    - name: Publish test report
-      uses: dorny/test-reporter@v1
-      if: always()
-      with:
-        name: Web Unit Tests
-        path: packages/web/test-results/junit.xml
-        reporter: java-junit
-        fail-on-error: false


### PR DESCRIPTION
The dorny/test-reporter step was failing with "Resource not accessible
by integration" on fork PRs because pull_request workflows run with a
read-only GITHUB_TOKEN that cannot write to the Checks API.

Split into two parts:
- CI workflows (test.yml, backend-tests.yml) upload JUnit XML as an
  artifact and drop the publish step + now-unneeded checks/PR write
  permissions.
- New publish-test-reports.yml triggers on workflow_run (runs in the
  base repo context) and uses dorny/test-reporter with the artifact
  input to download and publish reports with checks:write permission.

https://claude.ai/code/session_01JZsVR4G92UhBi5C7KVELmc