### PR TITLE
feat: zoomable climb setter with drawer-style layout

### DIFF
--- a/packages/web/app/components/board-renderer/zoomable-board.tsx
+++ b/packages/web/app/components/board-renderer/zoomable-board.tsx
@@ -8,7 +8,7 @@ import styles from './swipe-board-carousel.module.css';
 
 interface ZoomableBoardProps {
   children: React.ReactNode;
-  onZoomChange: (isZoomed: boolean) => void;
+  onZoomChange?: (isZoomed: boolean) => void;
   resetKey: string;
 }
 
@@ -18,7 +18,7 @@ const ZoomableBoard = memo(function ZoomableBoard({ children, onZoomChange, rese
 
   // Notify parent of zoom state changes
   useEffect(() => {
-    onZoomChange(isZoomed);
+    onZoomChange?.(isZoomed);
   }, [isZoomed, onZoomChange]);
 
   // Reset zoom when climb changes

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -7,46 +7,36 @@
   background-color: var(--semantic-background);
   border: 1px solid var(--neutral-200);
   border-radius: 20px;
+  min-height: 0;
 }
 
-/* Alert banner styling */
+/* Header section (PlayViewDrawer-style) */
+.headerSection {
+  flex-shrink: 0;
+  background-color: var(--semantic-surface);
+  border-bottom: 1px solid var(--neutral-100);
+}
+
 .alertBanner {
   margin: 8px 12px;
   flex-shrink: 0;
 }
 
-/* Validation bar at bottom */
-.validationBar {
-  padding: 8px 12px;
-  text-align: center;
-  background-color: var(--semantic-surface);
-  border-top: 1px solid var(--border-subtle);
-  flex-shrink: 0;
-}
-
-/* Content wrapper - scrollable for mobile */
-.contentWrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  position: relative;
-  min-height: 0;
-}
-
-.climbTitleContainer {
-  width: 100%;
-  flex-shrink: 0;
-  padding: 10px 12px;
-  background-color: var(--semantic-surface);
-  border-bottom: 1px solid var(--neutral-200);
-}
-
-.controlBarContent {
+.headerRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  padding: 10px 12px;
+  flex-wrap: wrap;
+}
+
+.headerControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 /* Draft label */
@@ -79,49 +69,76 @@
   margin: 0;
 }
 
-/* Board container - fills remaining space like play view */
-.boardContainer {
+/* Board section (flex:1, holds ZoomableBoard + heatmap) */
+.boardSectionWrapper {
   flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px 12px;
-  min-height: 300px;
-  width: 100%;
+  min-height: 0;
   position: relative;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-.boardWrapper {
-  position: relative;
-  height: 100%;
-  width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.settingsPanel {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
   padding: 12px;
-  background-color: var(--semantic-surface-overlay);
-  overflow: auto;
-  z-index: 10;
+  overflow: hidden;
 }
 
-.settingsPanelHeader {
-  margin-bottom: 12px;
+.zoomFill {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.settingsPanelContent {
+.moonboardFill {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Validation hint band (MoonBoard) */
+.validationHintBar {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  text-align: center;
+  background-color: var(--semantic-surface);
+  border-top: 1px solid var(--neutral-100);
+}
+
+/* Bottom action bar (PlayViewDrawer-style) */
+.actionBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  flex-shrink: 0;
+  background-color: var(--semantic-surface);
+  border-top: 1px solid var(--neutral-100);
+  flex-wrap: wrap;
+}
+
+.actionBarChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.actionBarButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Settings nested drawer content */
+.settingsDrawerContent {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding: 12px 16px 24px;
 }
 
 .settingsField {
@@ -134,21 +151,8 @@
   font-size: 12px;
 }
 
-/* MoonBoard-specific grade field */
 .settingsGradeField {
   width: 100%;
-}
-
-.holdCountsBar {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px;
-  flex-shrink: 0;
-  background-color: var(--semantic-surface);
-  border-top: 1px solid var(--neutral-200);
 }
 
 /* Mobile adjustments */
@@ -157,36 +161,31 @@
     border-radius: 16px;
   }
 
-  .holdCountsBar {
-    padding: 6px 8px;
+  .headerRow {
+    padding: 8px 10px;
+    gap: 8px;
+  }
+
+  .actionBar {
+    padding: 8px 10px;
     gap: 6px;
     justify-content: center;
-  }
-
-  .climbTitleContainer {
-    padding: 8px;
-  }
-
-  .controlBarContent {
-    flex-direction: column;
-    align-items: stretch;
   }
 
   .opacitySlider {
     width: 60px;
   }
-}
 
-/* Validation hint text */
-.validationHint {
-  margin-top: 8px;
-  display: block;
+  .boardSectionWrapper {
+    padding: 8px;
+  }
 }
 
 /* Desktop adjustments */
 @media (min-width: 768px) {
-  .boardContainer {
-    max-width: 600px;
+  .pageContainer {
+    max-width: 720px;
     margin: 0 auto;
+    width: 100%;
   }
 }

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -15,13 +15,15 @@ import MuiSwitch from '@mui/material/Switch';
 import MuiSlider from '@mui/material/Slider';
 import MuiSelect from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import { SettingsOutlined, CloseOutlined, LocalFireDepartmentOutlined, SaveOutlined, LoginOutlined, CloudUploadOutlined, GetAppOutlined } from '@mui/icons-material';
+import { SettingsOutlined, LocalFireDepartmentOutlined, SaveOutlined, LoginOutlined, CloudUploadOutlined, GetAppOutlined } from '@mui/icons-material';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { track } from '@vercel/analytics';
 import { useSession } from 'next-auth/react';
 import BoardRenderer from '../board-renderer/board-renderer';
 import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
+import ZoomableBoard from '../board-renderer/zoomable-board';
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useCreateClimb } from './use-create-climb';
 import { useMoonBoardCreateClimb } from './use-moonboard-create-climb';
@@ -59,6 +61,11 @@ import {
 } from '@/app/lib/graphql/operations/new-climb-feed';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 
+
+const SETTINGS_DRAWER_STYLES = {
+  wrapper: { height: 'auto', maxHeight: '70vh' },
+  body: { padding: 0 },
+};
 
 interface CreateClimbFormValues {
   name: string;
@@ -169,6 +176,8 @@ export default function CreateClimbForm({
   const [climbName, setClimbName] = useState(forkName ? `${forkName} fork` : '');
   const [description, setDescription] = useState('');
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
+  const handleBoardZoomChange = useCallback(() => {}, []);
+  const zoomResetKey = boardType === 'moonboard' ? `moonboard-${selectedAngle}` : `aurora-${angle}`;
   const climbNameRef = useRef(climbName);
   const setClimbNameRef = useRef(setClimbName);
   const headerActionRef = useRef<React.ReactNode | null>(null);
@@ -597,276 +606,276 @@ export default function CreateClimbForm({
 
   return (
     <div className={styles.pageContainer}>
-      {/* MoonBoard OCR errors */}
-      {boardType === 'moonboard' && ocrError && (
-        <MuiAlert
-          severity="error"
-          onClose={() => setOcrError(null)}
-          className={styles.alertBanner}
-        >
-          Import Failed: {ocrError}
-        </MuiAlert>
-      )}
+      {/* Header section: alerts + control row */}
+      <div className={styles.headerSection}>
+        {/* MoonBoard OCR errors */}
+        {boardType === 'moonboard' && ocrError && (
+          <MuiAlert
+            severity="error"
+            onClose={() => setOcrError(null)}
+            className={styles.alertBanner}
+          >
+            Import Failed: {ocrError}
+          </MuiAlert>
+        )}
 
-      {boardType === 'moonboard' && ocrWarnings.length > 0 && (
-        <MuiAlert
-          severity="warning"
-          onClose={() => setOcrWarnings([])}
-          className={styles.alertBanner}
-        >
-          Import Warnings: {ocrWarnings.map((w, i) => <div key={i}>{w}</div>)}
-        </MuiAlert>
-      )}
+        {boardType === 'moonboard' && ocrWarnings.length > 0 && (
+          <MuiAlert
+            severity="warning"
+            onClose={() => setOcrWarnings([])}
+            className={styles.alertBanner}
+          >
+            Import Warnings: {ocrWarnings.map((w, i) => <div key={i}>{w}</div>)}
+          </MuiAlert>
+        )}
 
-      {boardType === 'moonboard' && moonBoardDuplicateError && (
-        <MuiAlert severity="error" className={styles.alertBanner}>
-          {moonBoardDuplicateError}
-        </MuiAlert>
-      )}
+        {boardType === 'moonboard' && moonBoardDuplicateError && (
+          <MuiAlert severity="error" className={styles.alertBanner}>
+            {moonBoardDuplicateError}
+          </MuiAlert>
+        )}
 
-      {boardType === 'moonboard' && !moonBoardDuplicateError && isCheckingMoonBoardDuplicate && isValid && (
-        <MuiAlert severity="info" className={styles.alertBanner}>
-          Checking whether this MoonBoard climb already exists...
-        </MuiAlert>
-      )}
+        {boardType === 'moonboard' && !moonBoardDuplicateError && isCheckingMoonBoardDuplicate && isValid && (
+          <MuiAlert severity="info" className={styles.alertBanner}>
+            Checking whether this MoonBoard climb already exists...
+          </MuiAlert>
+        )}
 
-      <div className={styles.contentWrapper}>
-        {/* Controls bar with draft toggle (all boards) and heatmap (Aurora only) */}
-        <div className={styles.climbTitleContainer}>
-          <div className={styles.controlBarContent}>
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <Typography variant="body2" component="span" color="text.secondary" className={styles.draftLabel}>
-                Draft
-              </Typography>
-              <MuiSwitch
-                size="small"
-                checked={isDraft}
-                onChange={(_, checked) => setIsDraft(checked)}
-              />
-              {/* Aurora-only: Heatmap toggle */}
-              {boardType === 'aurora' && (
-                <>
-                  <MuiTooltip title={showHeatmap ? 'Hide heatmap' : 'Show hold popularity heatmap'}>
-                    <IconButton
-                      color={showHeatmap ? 'error' : 'default'}
-                      size="small"
-                      onClick={handleToggleHeatmap}
-                      className={styles.heatmapButton}
-                    >
-                      <LocalFireDepartmentOutlined />
-                    </IconButton>
-                  </MuiTooltip>
-                  {showHeatmap && (
-                    <>
-                      <Typography variant="body2" component="span" color="text.secondary" className={styles.draftLabel}>
-                        Opacity
-                      </Typography>
-                      <MuiSlider
-                        min={0.1}
-                        max={1}
-                        step={0.1}
-                        value={heatmapOpacity}
-                        onChange={(_, value) => setHeatmapOpacity(value as number)}
-                        className={styles.opacitySlider}
-                      />
-                    </>
-                  )}
-                </>
-              )}
-              {boardType === 'moonboard' && userGrade && (
-                <Typography
-                  variant="body2"
-                  component="span"
-                  className={styles.gradeBadge}
-                  style={{
-                    color: getSoftFontGradeColor(userGrade, isDark) ?? 'var(--neutral-500)',
-                  }}
-                >
-                  {userGrade}
-                </Typography>
-              )}
-            </Box>
-
-            <MuiButton
+        <div className={styles.headerRow}>
+          <div className={styles.headerControls}>
+            <Typography variant="body2" component="span" color="text.secondary" className={styles.draftLabel}>
+              Draft
+            </Typography>
+            <MuiSwitch
               size="small"
-              variant={showSettingsPanel ? 'contained' : 'outlined'}
-              startIcon={showSettingsPanel ? <CloseOutlined /> : <SettingsOutlined />}
-              onClick={handleToggleSettings}
-            >
-              Settings
-            </MuiButton>
-          </div>
-        </div>
-
-        {/* Board Section */}
-        <div className={styles.boardContainer}>
-          <div className={styles.boardWrapper}>
-            {boardType === 'aurora' && boardDetails ? (
+              checked={isDraft}
+              onChange={(_, checked) => setIsDraft(checked)}
+            />
+            {/* Aurora-only: Heatmap toggle */}
+            {boardType === 'aurora' && (
               <>
-                <BoardRenderer
-                  boardDetails={boardDetails}
-                  litUpHoldsMap={litUpHoldsMap}
-                  mirrored={false}
-                  onHoldClick={handleHoldClick}
-                  fillHeight
-                />
-                <CreateClimbHeatmapOverlay
-                  boardDetails={boardDetails}
-                  angle={angle}
-                  litUpHoldsMap={litUpHoldsMap}
-                  opacity={heatmapOpacity}
-                  enabled={showHeatmap}
-                />
+                <MuiTooltip title={showHeatmap ? 'Hide heatmap' : 'Show hold popularity heatmap'}>
+                  <IconButton
+                    color={showHeatmap ? 'error' : 'default'}
+                    size="small"
+                    onClick={handleToggleHeatmap}
+                    className={styles.heatmapButton}
+                  >
+                    <LocalFireDepartmentOutlined />
+                  </IconButton>
+                </MuiTooltip>
+                {showHeatmap && (
+                  <>
+                    <Typography variant="body2" component="span" color="text.secondary" className={styles.draftLabel}>
+                      Opacity
+                    </Typography>
+                    <MuiSlider
+                      min={0.1}
+                      max={1}
+                      step={0.1}
+                      value={heatmapOpacity}
+                      onChange={(_, value) => setHeatmapOpacity(value as number)}
+                      className={styles.opacitySlider}
+                    />
+                  </>
+                )}
               </>
-            ) : boardType === 'moonboard' && layoutFolder && holdSetImages ? (
+            )}
+            {boardType === 'moonboard' && userGrade && (
+              <Typography
+                variant="body2"
+                component="span"
+                className={styles.gradeBadge}
+                style={{
+                  color: getSoftFontGradeColor(userGrade, isDark) ?? 'var(--neutral-500)',
+                }}
+              >
+                {userGrade}
+              </Typography>
+            )}
+          </div>
+
+          <MuiButton
+            size="small"
+            variant="outlined"
+            startIcon={<SettingsOutlined />}
+            onClick={handleToggleSettings}
+          >
+            Settings
+          </MuiButton>
+        </div>
+      </div>
+
+      {/* Board section: zoomable SVG renderer */}
+      <div className={styles.boardSectionWrapper}>
+        <ZoomableBoard resetKey={zoomResetKey} onZoomChange={handleBoardZoomChange}>
+          {boardType === 'aurora' && boardDetails ? (
+            <div className={styles.zoomFill}>
+              <BoardRenderer
+                boardDetails={boardDetails}
+                litUpHoldsMap={litUpHoldsMap}
+                mirrored={false}
+                onHoldClick={handleHoldClick}
+                fillHeight
+              />
+              <CreateClimbHeatmapOverlay
+                boardDetails={boardDetails}
+                angle={angle}
+                litUpHoldsMap={litUpHoldsMap}
+                opacity={heatmapOpacity}
+                enabled={showHeatmap}
+              />
+            </div>
+          ) : boardType === 'moonboard' && layoutFolder && holdSetImages ? (
+            <div className={styles.moonboardFill}>
               <MoonBoardRenderer
                 layoutFolder={layoutFolder}
                 holdSetImages={holdSetImages}
                 litUpHoldsMap={litUpHoldsMap}
                 onHoldClick={handleHoldClick}
               />
-            ) : null}
-          </div>
-
-          {/* Settings overlay panel */}
-          {showSettingsPanel && (
-            <div
-              className={styles.settingsPanel}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className={styles.settingsPanelHeader}>
-                <Typography variant="body2" component="span" fontWeight={600}>Climb Settings</Typography>
-              </div>
-              <div className={styles.settingsPanelContent}>
-                {/* MoonBoard-specific: Angle, Grade and Benchmark */}
-                {boardType === 'moonboard' && (
-                  <>
-                    <div className={styles.settingsField}>
-                      <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-                        Angle
-                      </Typography>
-                      <MuiSelect
-                        value={selectedAngle}
-                        onChange={(e) => setSelectedAngle(e.target.value as number)}
-                        className={styles.settingsGradeField}
-                        size="small"
-                      >
-                        {MOONBOARD_ANGLES.map(a => (
-                          <MenuItem key={a} value={a}>{a}&deg;</MenuItem>
-                        ))}
-                      </MuiSelect>
-                    </div>
-                    <div className={styles.settingsField}>
-                      <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-                        Grade
-                      </Typography>
-                      <MuiSelect
-                        displayEmpty
-                        value={userGrade ?? ''}
-                        onChange={(e) => setUserGrade(e.target.value === '' ? undefined : (e.target.value as string))}
-                        className={styles.settingsGradeField}
-                        size="small"
-                      >
-                        <MenuItem value=""><em>None</em></MenuItem>
-                        {MOONBOARD_GRADES.map(g => (
-                          <MenuItem key={g.value} value={g.value}>{g.label}</MenuItem>
-                        ))}
-                      </MuiSelect>
-                    </div>
-                    <div className={styles.settingsField}>
-                      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                        <MuiSwitch
-                          size="small"
-                          checked={isBenchmark}
-                          onChange={(_, checked) => setIsBenchmark(checked)}
-                        />
-                        <Typography variant="body2" component="span">Benchmark</Typography>
-                      </Box>
-                    </div>
-                  </>
-                )}
-                {/* Common: Description */}
-                <div className={styles.settingsField}>
-                  <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-                    Description (optional)
-                  </Typography>
-                  <TextField
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Add beta or notes about your climb..."
-                    multiline
-                    rows={3}
-                    inputProps={{ maxLength: 500 }}
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                  />
-                </div>
-              </div>
             </div>
-          )}
-        </div>
-
-        {/* Hold counts bar at bottom */}
-        <div className={styles.holdCountsBar}>
-          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-            {boardType === 'aurora' ? (
-              <>
-                <HoldStatusChip label={`Starting: ${startingCount}/2`} active={startingCount > 0} tone="success" />
-                <HoldStatusChip label={`Finish: ${finishCount}/2`} active={finishCount > 0} tone="pink" />
-                <HoldStatusChip label={`Total: ${totalHolds}`} active={totalHolds > 0} tone="primary" />
-              </>
-            ) : (
-              <>
-                <HoldStatusChip label={`Start: ${startingCount}/2`} active={startingCount > 0} tone="error" />
-                <HoldStatusChip label={`Hand: ${handCount}`} active={handCount > 0} tone="primary" />
-                <HoldStatusChip label={`Finish: ${finishCount}/2`} active={finishCount > 0} tone="success" />
-                <HoldStatusChip label={`Total: ${totalHolds}`} active={totalHolds > 0} tone="secondary" />
-              </>
-            )}
-          </Stack>
-          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-            {totalHolds > 0 && (
-              <MuiButton size="small" variant="outlined" onClick={resetHolds}>
-                Clear
-              </MuiButton>
-            )}
-            {/* MoonBoard-only: Import buttons */}
-            {boardType === 'moonboard' && (
-              <>
-                <input
-                  type="file"
-                  ref={fileInputRef}
-                  accept="image/png,image/jpeg,image/webp"
-                  style={{ display: 'none' }}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) handleOcrImport(file);
-                    e.target.value = '';
-                  }}
-                  disabled={isOcrProcessing}
-                />
-                <MuiButton size="small" variant="outlined" startIcon={isOcrProcessing ? <CircularProgress size={16} /> : <CloudUploadOutlined />} disabled={isOcrProcessing} onClick={() => fileInputRef.current?.click()}>
-                  {isOcrProcessing ? 'Processing...' : 'Import'}
-                </MuiButton>
-                <Link href={bulkImportUrl}>
-                  <MuiButton size="small" variant="outlined" startIcon={<GetAppOutlined />}>Bulk</MuiButton>
-                </Link>
-              </>
-            )}
-          </Stack>
-        </div>
+          ) : null}
+        </ZoomableBoard>
       </div>
 
-      {/* MoonBoard validation hint */}
+      {/* MoonBoard validation hint band */}
       {boardType === 'moonboard' && !isValid && totalHolds > 0 && (
-        <div className={styles.validationBar}>
+        <div className={styles.validationHintBar}>
           <Typography variant="body2" component="span" color="text.secondary">
             A valid climb needs at least 1 start hold and 1 finish hold
           </Typography>
         </div>
       )}
 
+      {/* Bottom action bar: hold counts + clear/import */}
+      <div className={styles.actionBar}>
+        <Stack direction="row" className={styles.actionBarChips}>
+          {boardType === 'aurora' ? (
+            <>
+              <HoldStatusChip label={`Starting: ${startingCount}/2`} active={startingCount > 0} tone="success" />
+              <HoldStatusChip label={`Finish: ${finishCount}/2`} active={finishCount > 0} tone="pink" />
+              <HoldStatusChip label={`Total: ${totalHolds}`} active={totalHolds > 0} tone="primary" />
+            </>
+          ) : (
+            <>
+              <HoldStatusChip label={`Start: ${startingCount}/2`} active={startingCount > 0} tone="error" />
+              <HoldStatusChip label={`Hand: ${handCount}`} active={handCount > 0} tone="primary" />
+              <HoldStatusChip label={`Finish: ${finishCount}/2`} active={finishCount > 0} tone="success" />
+              <HoldStatusChip label={`Total: ${totalHolds}`} active={totalHolds > 0} tone="secondary" />
+            </>
+          )}
+        </Stack>
+        <Stack direction="row" className={styles.actionBarButtons}>
+          {totalHolds > 0 && (
+            <MuiButton size="small" variant="outlined" onClick={resetHolds}>
+              Clear
+            </MuiButton>
+          )}
+          {/* MoonBoard-only: Import buttons */}
+          {boardType === 'moonboard' && (
+            <>
+              <input
+                type="file"
+                ref={fileInputRef}
+                accept="image/png,image/jpeg,image/webp"
+                style={{ display: 'none' }}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleOcrImport(file);
+                  e.target.value = '';
+                }}
+                disabled={isOcrProcessing}
+              />
+              <MuiButton size="small" variant="outlined" startIcon={isOcrProcessing ? <CircularProgress size={16} /> : <CloudUploadOutlined />} disabled={isOcrProcessing} onClick={() => fileInputRef.current?.click()}>
+                {isOcrProcessing ? 'Processing...' : 'Import'}
+              </MuiButton>
+              <Link href={bulkImportUrl}>
+                <MuiButton size="small" variant="outlined" startIcon={<GetAppOutlined />}>Bulk</MuiButton>
+              </Link>
+            </>
+          )}
+        </Stack>
+      </div>
+
+      {/* Settings nested drawer — lazy-mounted */}
+      {showSettingsPanel && (
+        <SwipeableDrawer
+          title="Climb Settings"
+          placement="bottom"
+          open={showSettingsPanel}
+          onClose={() => setShowSettingsPanel(false)}
+          swipeEnabled={false}
+          styles={SETTINGS_DRAWER_STYLES}
+        >
+          <div className={styles.settingsDrawerContent}>
+            {/* MoonBoard-specific: Angle, Grade and Benchmark */}
+            {boardType === 'moonboard' && (
+              <>
+                <div className={styles.settingsField}>
+                  <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
+                    Angle
+                  </Typography>
+                  <MuiSelect
+                    value={selectedAngle}
+                    onChange={(e) => setSelectedAngle(e.target.value as number)}
+                    className={styles.settingsGradeField}
+                    size="small"
+                  >
+                    {MOONBOARD_ANGLES.map(a => (
+                      <MenuItem key={a} value={a}>{a}&deg;</MenuItem>
+                    ))}
+                  </MuiSelect>
+                </div>
+                <div className={styles.settingsField}>
+                  <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
+                    Grade
+                  </Typography>
+                  <MuiSelect
+                    displayEmpty
+                    value={userGrade ?? ''}
+                    onChange={(e) => setUserGrade(e.target.value === '' ? undefined : (e.target.value as string))}
+                    className={styles.settingsGradeField}
+                    size="small"
+                  >
+                    <MenuItem value=""><em>None</em></MenuItem>
+                    {MOONBOARD_GRADES.map(g => (
+                      <MenuItem key={g.value} value={g.value}>{g.label}</MenuItem>
+                    ))}
+                  </MuiSelect>
+                </div>
+                <div className={styles.settingsField}>
+                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                    <MuiSwitch
+                      size="small"
+                      checked={isBenchmark}
+                      onChange={(_, checked) => setIsBenchmark(checked)}
+                    />
+                    <Typography variant="body2" component="span">Benchmark</Typography>
+                  </Box>
+                </div>
+              </>
+            )}
+            {/* Common: Description */}
+            <div className={styles.settingsField}>
+              <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
+                Description (optional)
+              </Typography>
+              <TextField
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Add beta or notes about your climb..."
+                multiline
+                rows={3}
+                inputProps={{ maxLength: 500 }}
+                variant="outlined"
+                size="small"
+                fullWidth
+              />
+            </div>
+          </div>
+        </SwipeableDrawer>
+      )}
     </div>
   );
 }

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -176,7 +176,6 @@ export default function CreateClimbForm({
   const [climbName, setClimbName] = useState(forkName ? `${forkName} fork` : '');
   const [description, setDescription] = useState('');
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
-  const handleBoardZoomChange = useCallback(() => {}, []);
   const zoomResetKey = boardType === 'moonboard' ? `moonboard-${selectedAngle}` : `aurora-${angle}`;
   const climbNameRef = useRef(climbName);
   const setClimbNameRef = useRef(setClimbName);
@@ -605,7 +604,7 @@ export default function CreateClimbForm({
   }, [climbName, headerAction, setClimbName, update]);
 
   return (
-    <div className={styles.pageContainer}>
+    <div className={styles.pageContainer} data-testid="climb-setter">
       {/* Header section: alerts + control row */}
       <div className={styles.headerSection}>
         {/* MoonBoard OCR errors */}
@@ -707,8 +706,8 @@ export default function CreateClimbForm({
       </div>
 
       {/* Board section: zoomable SVG renderer */}
-      <div className={styles.boardSectionWrapper}>
-        <ZoomableBoard resetKey={zoomResetKey} onZoomChange={handleBoardZoomChange}>
+      <div className={styles.boardSectionWrapper} data-testid="climb-setter-board">
+        <ZoomableBoard resetKey={zoomResetKey}>
           {boardType === 'aurora' && boardDetails ? (
             <div className={styles.zoomFill}>
               <BoardRenderer

--- a/packages/web/e2e/climb-setter-zoom.spec.ts
+++ b/packages/web/e2e/climb-setter-zoom.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * E2E tests for the zoomable climb setter.
+ *
+ * Renders the create-climb screen, captures a baseline screenshot,
+ * performs a pinch-zoom on the board via the Chrome DevTools Protocol,
+ * then captures a second screenshot showing the zoomed-in state.
+ *
+ * Screenshots are saved as per-test attachments (test-results/<test>/*.png)
+ * and embedded in the Playwright HTML report.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+// Touch emulation is required so @use-gesture/react's pinch handler fires
+// from CDP-dispatched touch events. Override the chromium project defaults.
+test.use({
+  viewport: { width: 430, height: 932 },
+  hasTouch: true,
+  isMobile: true,
+});
+
+const createUrl = '/kilter/original/12x12-square/screw_bolt/40/create';
+
+/**
+ * Dispatch a two-finger pinch gesture via CDP. Playwright has no native pinch
+ * helper, so we synthesize touch events directly. The touchpoints share stable
+ * `id`s across the Start/Move/End phases so Chromium tracks them as a single
+ * continuous gesture.
+ */
+async function pinchZoom(
+  page: Page,
+  center: { x: number; y: number },
+  fromDistance: number,
+  toDistance: number,
+  steps = 12,
+) {
+  const client = await page.context().newCDPSession(page);
+
+  const pointsAt = (offset: number) => [
+    { x: center.x - offset / 2, y: center.y, id: 0, radiusX: 2, radiusY: 2, force: 1 },
+    { x: center.x + offset / 2, y: center.y, id: 1, radiusX: 2, radiusY: 2, force: 1 },
+  ];
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: pointsAt(fromDistance),
+  });
+
+  for (let i = 1; i <= steps; i++) {
+    const progress = i / steps;
+    const offset = fromDistance + (toDistance - fromDistance) * progress;
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: pointsAt(offset),
+    });
+    await page.waitForTimeout(16);
+  }
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  });
+
+  await client.detach();
+}
+
+test.describe('Climb Setter - Zoomable Board', () => {
+  test.setTimeout(90_000);
+
+  test('renders create screen and pinch-zooms the board', async ({ page }, testInfo) => {
+    await page.goto(createUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+    const setter = page.getByTestId('climb-setter');
+    await expect(setter).toBeVisible({ timeout: 30_000 });
+
+    const boardSection = page.getByTestId('climb-setter-board');
+    await expect(boardSection).toBeVisible();
+
+    // Wait for the board SVG (BoardRenderer) to mount inside the zoom container.
+    const boardSvg = boardSection.locator('svg').first();
+    await expect(boardSvg).toBeVisible({ timeout: 30_000 });
+
+    // Give images a moment to finish decoding before capturing the baseline.
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // Baseline screenshot: zoomed-out board with header + action bar visible.
+    const beforePath = testInfo.outputPath('create-screen-initial.png');
+    await page.screenshot({ path: beforePath, fullPage: false });
+    await testInfo.attach('create-screen-initial', { path: beforePath, contentType: 'image/png' });
+
+    // Reset button should NOT have the visible class before zooming.
+    const resetButton = page.getByRole('button', { name: 'Reset zoom' });
+
+    // Pinch out from the center of the board.
+    const box = await boardSection.boundingBox();
+    if (!box) throw new Error('climb-setter-board has no bounding box');
+    const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    await pinchZoom(page, center, 80, 260);
+
+    // Once the pinch ends, useZoomPan flips isZoomed=true, which causes
+    // ZoomableBoard to set data-swipe-blocked on the container and tabIndex=0
+    // on the reset button. We assert both as a sanity check.
+    await expect(boardSection.locator('[data-swipe-blocked]')).toHaveCount(1, { timeout: 5_000 });
+    await expect(resetButton).toHaveAttribute('tabindex', '0', { timeout: 5_000 });
+
+    // Zoomed screenshot: board should appear magnified compared to baseline.
+    const afterPath = testInfo.outputPath('create-screen-zoomed.png');
+    await page.screenshot({ path: afterPath, fullPage: false });
+    await testInfo.attach('create-screen-zoomed', { path: afterPath, contentType: 'image/png' });
+  });
+});


### PR DESCRIPTION
Wraps the SVG BoardRenderer/MoonBoardRenderer in ZoomableBoard so setters
can pinch-zoom and pan the board to tap small holds accurately, while
keeping the SVG path intact for transparent click targets. Restructures
CreateClimbForm into PlayViewDrawer-style header / board / action bar
sections and moves climb settings into a nested SwipeableDrawer.