### PR TITLE
Add visibility assertion for reset button before pinch zoom

### DIFF
--- a/packages/web/e2e/climb-setter-zoom.spec.ts
+++ b/packages/web/e2e/climb-setter-zoom.spec.ts
@@ -87,8 +87,9 @@ test.describe('Climb Setter - Zoomable Board', () => {
     await page.screenshot({ path: beforePath, fullPage: false });
     await testInfo.attach('create-screen-initial', { path: beforePath, contentType: 'image/png' });
 
-    // Reset button should NOT have the visible class before zooming.
+    // Reset button should NOT be visible before zooming.
     const resetButton = page.getByRole('button', { name: 'Reset zoom' });
+    await expect(resetButton).not.toBeVisible();
 
     // Pinch out from the center of the board.
     const box = await boardSection.boundingBox();


### PR DESCRIPTION
The test now asserts that the reset button is not visible before the
pinch zoom action, confirming it's hidden initially. This fulfills the
intent of the comment and ensures the resetButton variable is used
meaningfully in the test.

https://claude.ai/code/session_018dX3FRJgRKT3JJGBX3dEQb