### PR TITLE
Add 4 more test shards (8 total) to speed up E2E test execution

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
 
@@ -168,8 +168,8 @@ jobs:
           NEXTAUTH_URL: http://localhost:3000
           NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
-      - name: Run Playwright shard ${{ matrix.shard }}/4
-        run: bunx playwright test --shard=${{ matrix.shard }}/4
+      - name: Run Playwright shard ${{ matrix.shard }}/8
+        run: bunx playwright test --shard=${{ matrix.shard }}/8
         working-directory: packages/web
         env:
           PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000


### PR DESCRIPTION
- Increases total shards from 4 to 8 to better distribute test load
- Shards 3 and 4 were slower, splitting into more shards helps balance execution time
- Updates matrix to include shards 1-8 and shard command from /4 to /8

https://claude.ai/code/session_01VW6NBsMhF2Q5LTiYPLZ89b