### PR TITLE
feat: drafts drawer on create climb screen

### DIFF
--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import MuiAlert from '@mui/material/Alert';
 import MuiTooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
@@ -15,7 +15,8 @@ import MuiSwitch from '@mui/material/Switch';
 import MuiSlider from '@mui/material/Slider';
 import MuiSelect from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import { SettingsOutlined, LocalFireDepartmentOutlined, SaveOutlined, LoginOutlined, CloudUploadOutlined, GetAppOutlined } from '@mui/icons-material';
+import Badge from '@mui/material/Badge';
+import { SettingsOutlined, LocalFireDepartmentOutlined, SaveOutlined, LoginOutlined, CloudUploadOutlined, GetAppOutlined, DraftsOutlined } from '@mui/icons-material';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { track } from '@vercel/analytics';
@@ -45,7 +46,13 @@ import { useSnackbar } from '../providers/snackbar-provider';
 import { refreshClimbSearchAfterSave } from '@/app/lib/climb-search-cache';
 import CreateClimbHeatmapOverlay from './create-climb-heatmap-overlay';
 import HoldStatusChip from './hold-status-chip';
+import DraftsDrawer from './drafts-drawer';
 import { useCreateHeaderBridgeSetters } from './create-header-bridge-context';
+import {
+  SEARCH_CLIMBS_COUNT,
+  type ClimbSearchCountResponse,
+  type ClimbSearchInputVariables,
+} from '@/app/lib/graphql/operations/climb-search';
 import {
   convertLitUpHoldsMapToMoonBoardHolds,
   isMoonBoardDuplicateError,
@@ -176,6 +183,7 @@ export default function CreateClimbForm({
   const [climbName, setClimbName] = useState(forkName ? `${forkName} fork` : '');
   const [description, setDescription] = useState('');
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
+  const [showDraftsDrawer, setShowDraftsDrawer] = useState(false);
   const zoomResetKey = boardType === 'moonboard' ? `moonboard-${selectedAngle}` : `aurora-${angle}`;
   const climbNameRef = useRef(climbName);
   const setClimbNameRef = useRef(setClimbName);
@@ -350,6 +358,12 @@ export default function CreateClimbForm({
 
       if (!isDraft) {
         await refreshClimbSearchAfterSave(queryClient, boardDetails.board_name, boardDetails.layout_id);
+      } else {
+        // Refresh drafts list/count so the new draft shows up immediately.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['climbDrafts', boardDetails.board_name, boardDetails.layout_id] }),
+          queryClient.invalidateQueries({ queryKey: ['climbDraftsCount', boardDetails.board_name, boardDetails.layout_id] }),
+        ]);
       }
 
       track('Climb Created', {
@@ -517,6 +531,52 @@ export default function CreateClimbForm({
 
   const handleToggleSettings = useCallback(() => {
     setShowSettingsPanel((prev) => !prev);
+  }, []);
+
+  // Drafts: count query for the badge (Aurora only — MoonBoard has its own flow).
+  // Scoped to the current layout/size/sets/angle so users see drafts for the wall in front of them.
+  const canShowDrafts = boardType === 'aurora' && !!boardDetails && isLoggedIn;
+  const draftsCountQueryKey = useMemo(() => {
+    if (!boardDetails) return ['climbDraftsCount', 'disabled'] as const;
+    return [
+      'climbDraftsCount',
+      boardDetails.board_name,
+      boardDetails.layout_id,
+      boardDetails.size_id,
+      boardDetails.set_ids.join(','),
+      angle,
+    ] as const;
+  }, [boardDetails, angle]);
+
+  const { data: draftsCount } = useQuery({
+    queryKey: draftsCountQueryKey,
+    enabled: canShowDrafts && !!wsAuthToken,
+    queryFn: async (): Promise<number> => {
+      if (!boardDetails) return 0;
+      const input: ClimbSearchInputVariables['input'] = {
+        boardName: boardDetails.board_name,
+        layoutId: boardDetails.layout_id,
+        sizeId: boardDetails.size_id,
+        setIds: boardDetails.set_ids.join(','),
+        angle,
+        page: 0,
+        pageSize: 1,
+        onlyDrafts: true,
+      };
+      const client = createGraphQLHttpClient(wsAuthToken);
+      const result = await client.request<ClimbSearchCountResponse>(SEARCH_CLIMBS_COUNT, { input });
+      return result.searchClimbs.totalCount ?? 0;
+    },
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const handleOpenDrafts = useCallback(() => {
+    setShowDraftsDrawer(true);
+  }, []);
+
+  const handleCloseDrafts = useCallback(() => {
+    setShowDraftsDrawer(false);
   }, []);
 
   const handleToggleHeatmap = useCallback(() => {
@@ -694,14 +754,34 @@ export default function CreateClimbForm({
             )}
           </div>
 
-          <MuiButton
-            size="small"
-            variant="outlined"
-            startIcon={<SettingsOutlined />}
-            onClick={handleToggleSettings}
-          >
-            Settings
-          </MuiButton>
+          <Stack direction="row" spacing={1} alignItems="center">
+            {canShowDrafts && (
+              <Badge
+                color="primary"
+                badgeContent={draftsCount ?? 0}
+                max={99}
+                invisible={!draftsCount}
+                overlap="rectangular"
+              >
+                <MuiButton
+                  size="small"
+                  variant="outlined"
+                  startIcon={<DraftsOutlined />}
+                  onClick={handleOpenDrafts}
+                >
+                  Drafts
+                </MuiButton>
+              </Badge>
+            )}
+            <MuiButton
+              size="small"
+              variant="outlined"
+              startIcon={<SettingsOutlined />}
+              onClick={handleToggleSettings}
+            >
+              Settings
+            </MuiButton>
+          </Stack>
         </div>
       </div>
 
@@ -796,6 +876,16 @@ export default function CreateClimbForm({
           )}
         </Stack>
       </div>
+
+      {/* Drafts drawer — only for Aurora boards where boardDetails is loaded */}
+      {canShowDrafts && boardDetails && (
+        <DraftsDrawer
+          open={showDraftsDrawer}
+          onClose={handleCloseDrafts}
+          boardDetails={boardDetails}
+          angle={angle}
+        />
+      )}
 
       {/* Settings nested drawer — lazy-mounted */}
       {showSettingsPanel && (

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import ClimbListItem from '../climb-card/climb-list-item';
+import { useColorMode } from '@/app/hooks/use-color-mode';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  SEARCH_CLIMBS,
+  type ClimbSearchInputVariables,
+  type ClimbSearchResponse,
+} from '@/app/lib/graphql/operations/climb-search';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { themeTokens } from '@/app/theme/theme-config';
+import { constructClimbViewUrl } from '@/app/lib/url-utils';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+import queueStyles from '../play-view/play-view-drawer.module.css';
+import drawerStyles from '../swipeable-drawer/swipeable-drawer.module.css';
+
+const DRAFTS_DRAWER_STYLES = {
+  wrapper: {
+    touchAction: 'pan-y' as const,
+    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  },
+  body: { padding: 0, overflow: 'hidden' as const, touchAction: 'pan-y' as const },
+} as const;
+
+export interface DraftsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  boardDetails: BoardDetails;
+  angle: number;
+}
+
+const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails, angle }) => {
+  const router = useRouter();
+  const { mode } = useColorMode();
+  const isDark = mode === 'dark';
+  const { token: wsAuthToken } = useWsAuthToken();
+
+  const draftsDrawerHeightRef = useRef('60%');
+  const draftsPaperRef = useRef<HTMLDivElement>(null);
+
+  const updateDraftsDrawerHeight = useCallback((height: string) => {
+    draftsDrawerHeightRef.current = height;
+    if (draftsPaperRef.current) {
+      draftsPaperRef.current.style.height = height;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      updateDraftsDrawerHeight('60%');
+    }
+  }, [open, updateDraftsDrawerHeight]);
+
+  // Drag-to-resize handlers on the header
+  const dragStartY = useRef<number>(0);
+  const dragStartHeightRef = useRef<string>('60%');
+  const isDragGestureRef = useRef(false);
+
+  const handleDragStart = useCallback((e: React.TouchEvent) => {
+    dragStartY.current = e.touches[0].clientY;
+    dragStartHeightRef.current = draftsDrawerHeightRef.current;
+    isDragGestureRef.current = false;
+  }, []);
+
+  const handleDragMove = useCallback((e: React.TouchEvent) => {
+    const delta = Math.abs(e.touches[0].clientY - dragStartY.current);
+    if (delta > 10) {
+      isDragGestureRef.current = true;
+    }
+  }, []);
+
+  const handleDragEnd = useCallback((e: React.TouchEvent) => {
+    if (!isDragGestureRef.current) return;
+    const deltaY = e.changedTouches[0].clientY - dragStartY.current;
+    const THRESHOLD = 30;
+
+    if (deltaY < -THRESHOLD) {
+      updateDraftsDrawerHeight('100%');
+    } else if (deltaY > THRESHOLD) {
+      if (dragStartHeightRef.current === '100%') {
+        updateDraftsDrawerHeight('60%');
+      } else {
+        onClose();
+      }
+    }
+  }, [onClose, updateDraftsDrawerHeight]);
+
+  // Query: only run when drawer is open and user has a token
+  const queryKey = useMemo(
+    () => [
+      'climbDrafts',
+      boardDetails.board_name,
+      boardDetails.layout_id,
+      boardDetails.size_id,
+      boardDetails.set_ids.join(','),
+      angle,
+    ] as const,
+    [boardDetails.board_name, boardDetails.layout_id, boardDetails.size_id, boardDetails.set_ids, angle],
+  );
+
+  const { data, isLoading, error } = useQuery({
+    queryKey,
+    enabled: open && !!wsAuthToken,
+    queryFn: async (): Promise<Climb[]> => {
+      const input: ClimbSearchInputVariables['input'] = {
+        boardName: boardDetails.board_name,
+        layoutId: boardDetails.layout_id,
+        sizeId: boardDetails.size_id,
+        setIds: boardDetails.set_ids.join(','),
+        angle,
+        page: 0,
+        pageSize: 100,
+        sortBy: 'ascents',
+        sortOrder: 'desc',
+        onlyDrafts: true,
+      };
+      const client = createGraphQLHttpClient(wsAuthToken);
+      const result = await client.request<ClimbSearchResponse>(SEARCH_CLIMBS, { input });
+      return result.searchClimbs.climbs;
+    },
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const drafts = data ?? [];
+
+  const handleSelectDraft = useCallback(
+    (climb: Climb) => {
+      const url = constructClimbViewUrl(
+        {
+          board_name: boardDetails.board_name,
+          layout_id: boardDetails.layout_id,
+          size_id: boardDetails.size_id,
+          set_ids: boardDetails.set_ids,
+          angle,
+        },
+        climb.uuid,
+        climb.name,
+      );
+      onClose();
+      router.push(url);
+    },
+    [router, onClose, boardDetails, angle],
+  );
+
+  // Current page pathname for ClimbListItem (used for thumbnail prefetch hints)
+  const pathname = useMemo(
+    () =>
+      `/${boardDetails.board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/create`,
+    [boardDetails, angle],
+  );
+
+  return (
+    <SwipeableDrawer
+      placement="bottom"
+      height="60%"
+      paperRef={draftsPaperRef}
+      open={open}
+      showCloseButton={false}
+      swipeEnabled={false}
+      showDragHandle={false}
+      onClose={onClose}
+      styles={DRAFTS_DRAWER_STYLES}
+    >
+      {/* Drag header */}
+      <div
+        className={queueStyles.queueDragHeader}
+        data-swipe-blocked=""
+        onTouchStart={handleDragStart}
+        onTouchMove={handleDragMove}
+        onTouchEnd={handleDragEnd}
+      >
+        <div className={drawerStyles.dragHandleZoneHorizontal}>
+          <div className={drawerStyles.dragHandleBarHorizontal} />
+        </div>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: `${themeTokens.spacing[4]}px ${themeTokens.spacing[6]}px`,
+            borderBottom: '1px solid var(--neutral-200)',
+          }}
+        >
+          <Typography
+            variant="h6"
+            component="div"
+            sx={{
+              fontWeight: themeTokens.typography.fontWeight.semibold,
+              fontSize: themeTokens.typography.fontSize.base,
+            }}
+          >
+            Drafts
+          </Typography>
+          {drafts.length > 0 && (
+            <Typography variant="body2" color="text.secondary">
+              {drafts.length} draft{drafts.length === 1 ? '' : 's'}
+            </Typography>
+          )}
+        </Box>
+      </div>
+
+      <div className={queueStyles.queueBodyLayout}>
+        <div className={queueStyles.queueScrollContainer} style={{ touchAction: 'pan-y' }}>
+          {isLoading ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: themeTokens.spacing[8],
+              }}
+            >
+              <CircularProgress size={24} />
+            </Box>
+          ) : error ? (
+            <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                Couldn&apos;t load your drafts. Try again.
+              </Typography>
+            </Box>
+          ) : drafts.length === 0 ? (
+            <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
+              <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                No drafts yet
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
+                Save a climb as a draft to pick it up later.
+              </Typography>
+            </Box>
+          ) : (
+            drafts.map((climb) => (
+              <ClimbListItem
+                key={climb.uuid}
+                climb={climb}
+                boardDetails={boardDetails}
+                pathname={pathname}
+                isDark={isDark}
+                disableSwipe
+                onSelect={() => handleSelectDraft(climb)}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </SwipeableDrawer>
+  );
+};
+
+export default React.memo(DraftsDrawer);


### PR DESCRIPTION
Adds a Drafts button with a badge count to the create-climb header and a
bottom drawer (mirrors the queue drawer: opens at 60%, swipe up to 100%,
swipe down to close) that lists the current user's drafts for the active
layout/size/sets/angle. Tapping a draft navigates to its view page.
Saving a draft invalidates the drafts query so the count and list refresh.

https://claude.ai/code/session_01T8vYw5QBgrjTwwJ3ehMTG2