### PR TITLE
feat: hold type picker for climb setter

### DIFF
--- a/packages/web/app/components/board-renderer/board-litup-holds.tsx
+++ b/packages/web/app/components/board-renderer/board-litup-holds.tsx
@@ -6,7 +6,7 @@ interface BoardLitupHoldsProps {
   litUpHoldsMap: LitUpHoldsMap;
   mirrored: boolean;
   thumbnail?: boolean;
-  onHoldClick?: (holdId: number) => void;
+  onHoldClick?: (holdId: number, anchor: Element) => void;
 }
 
 const areLitUpHoldsMapsEqual = (prev: LitUpHoldsMap, next: LitUpHoldsMap): boolean => {
@@ -71,7 +71,7 @@ const BoardLitupHolds = React.memo(
               fillOpacity={thumbnail ? 0.3 : 0}
               fill={thumbnail ? color : undefined}
               style={{ cursor: onHoldClick ? 'pointer' : 'default' }}
-              onClick={onHoldClick ? () => onHoldClick(renderHold.id) : undefined}
+              onClick={onHoldClick ? (event) => onHoldClick(renderHold.id, event.currentTarget) : undefined}
             />
           );
         })}

--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -16,7 +16,7 @@ export type BoardProps = {
   fillHeight?: boolean;
   /** Custom max-height for the board SVG. Defaults to '55vh', or '10vh' for thumbnails. Ignored when fillHeight is true. */
   maxHeight?: string;
-  onHoldClick?: (holdId: number) => void;
+  onHoldClick?: (holdId: number, anchor: Element) => void;
 };
 
 const BoardRenderer = React.memo(

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../../board-bluetooth-control/use-board-bluetooth', () => ({
 vi.mock('../use-create-climb', () => ({
   useCreateClimb: () => ({
     litUpHoldsMap: {},
-    handleHoldClick: vi.fn(),
+    setHoldState: vi.fn(),
     startingCount: 0,
     finishCount: 0,
     totalHolds: 0,
@@ -48,7 +48,7 @@ vi.mock('../use-moonboard-create-climb', () => ({
       25: { state: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
     },
     setLitUpHoldsMap: vi.fn(),
-    handleHoldClick: vi.fn(),
+    setHoldState: vi.fn(),
     startingCount: 1,
     finishCount: 1,
     handCount: 1,

--- a/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
@@ -1,0 +1,209 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import React, { useRef, useEffect } from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import HoldTypePicker, { buildOptions } from '../hold-type-picker';
+
+// Note: MUI Popover prints "anchorEl is invalid" warnings during the brief
+// window between `cleanup()` and the Popover exit transition. They're benign
+// noise specific to the test harness — the component itself is verified
+// correct by the assertions below.
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Render the picker with the anchor element as a sibling inside the RTL
+ * container so it gets unmounted by `cleanup()` rather than left dangling
+ * in document.body across tests.
+ */
+function PickerHarness(
+  props: Omit<React.ComponentProps<typeof HoldTypePicker>, 'anchorEl'> & {
+    withAnchor: boolean;
+  },
+) {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [anchor, setAnchor] = React.useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (props.withAnchor) {
+      setAnchor(anchorRef.current);
+    }
+  }, [props.withAnchor]);
+
+  return (
+    <>
+      <div ref={anchorRef} data-testid="anchor" />
+      <HoldTypePicker {...props} anchorEl={anchor} />
+    </>
+  );
+}
+
+function renderPicker(
+  overrides: Partial<React.ComponentProps<typeof HoldTypePicker>> & {
+    withAnchor?: boolean;
+  } = {},
+) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const { withAnchor = true, ...pickerProps } = overrides;
+
+  const utils = render(
+    <PickerHarness
+      boardName="kilter"
+      currentState="OFF"
+      startingCount={0}
+      finishCount={0}
+      onSelect={onSelect}
+      onClose={onClose}
+      withAnchor={withAnchor}
+      {...pickerProps}
+    />,
+  );
+
+  return { ...utils, onSelect, onClose };
+}
+
+describe('buildOptions', () => {
+  it('returns Start, Mid, Finish, Foot for Kilter', () => {
+    const options = buildOptions('kilter');
+    expect(options.map((o) => o.state)).toEqual(['STARTING', 'HAND', 'FINISH', 'FOOT']);
+  });
+
+  it('returns Start, Mid, Finish, Foot for Tension', () => {
+    const options = buildOptions('tension');
+    expect(options.map((o) => o.state)).toEqual(['STARTING', 'HAND', 'FINISH', 'FOOT']);
+  });
+
+  it('skips Foot for MoonBoard', () => {
+    const options = buildOptions('moonboard');
+    expect(options.map((o) => o.state)).toEqual(['STARTING', 'HAND', 'FINISH']);
+    expect(options.map((o) => o.state)).not.toContain('FOOT');
+  });
+
+  it('uses board-specific colors', () => {
+    const kilter = buildOptions('kilter');
+    const moonboard = buildOptions('moonboard');
+
+    // Kilter STARTING color from HOLD_STATE_MAP
+    expect(kilter.find((o) => o.state === 'STARTING')?.color).toBe('#00FF00');
+    // Kilter FOOT color
+    expect(kilter.find((o) => o.state === 'FOOT')?.color).toBe('#FFAA00');
+    // MoonBoard STARTING uses displayColor
+    expect(moonboard.find((o) => o.state === 'STARTING')?.color).toBe('#44FF44');
+  });
+});
+
+describe('HoldTypePicker', () => {
+  it('renders all four hold types and Clear for Aurora boards', () => {
+    renderPicker({ boardName: 'kilter' });
+
+    expect(screen.getByLabelText('Start')).toBeTruthy();
+    expect(screen.getByLabelText('Mid')).toBeTruthy();
+    expect(screen.getByLabelText('Finish')).toBeTruthy();
+    expect(screen.getByLabelText('Foot')).toBeTruthy();
+    expect(screen.getByLabelText('Clear')).toBeTruthy();
+  });
+
+  it('omits Foot for MoonBoard', () => {
+    renderPicker({ boardName: 'moonboard' });
+
+    expect(screen.getByLabelText('Start')).toBeTruthy();
+    expect(screen.getByLabelText('Mid')).toBeTruthy();
+    expect(screen.getByLabelText('Finish')).toBeTruthy();
+    expect(screen.queryByLabelText('Foot')).toBeNull();
+    expect(screen.getByLabelText('Clear')).toBeTruthy();
+  });
+
+  it('does not render when anchorEl is null', () => {
+    renderPicker({ withAnchor: false });
+
+    // Popover is closed → no swatches should be in the DOM.
+    expect(screen.queryByLabelText('Start')).toBeNull();
+  });
+
+  it('calls onSelect when a swatch is clicked', () => {
+    const { onSelect } = renderPicker({ boardName: 'kilter' });
+
+    fireEvent.click(screen.getByLabelText('Start'));
+    expect(onSelect).toHaveBeenCalledWith('STARTING');
+
+    fireEvent.click(screen.getByLabelText('Foot'));
+    expect(onSelect).toHaveBeenCalledWith('FOOT');
+  });
+
+  it('calls onSelect with OFF when Clear is clicked', () => {
+    const { onSelect } = renderPicker({
+      boardName: 'kilter',
+      currentState: 'STARTING',
+    });
+
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(onSelect).toHaveBeenCalledWith('OFF');
+  });
+
+  it('disables STARTING when startingCount is at the max of 2', () => {
+    const { onSelect } = renderPicker({
+      boardName: 'kilter',
+      startingCount: 2,
+      currentState: 'OFF',
+    });
+
+    const startButton = screen.getByLabelText('Start') as HTMLButtonElement;
+    expect(startButton.disabled).toBe(true);
+
+    fireEvent.click(startButton);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('disables FINISH when finishCount is at the max of 2', () => {
+    const { onSelect } = renderPicker({
+      boardName: 'kilter',
+      finishCount: 2,
+      currentState: 'OFF',
+    });
+
+    const finishButton = screen.getByLabelText('Finish') as HTMLButtonElement;
+    expect(finishButton.disabled).toBe(true);
+
+    fireEvent.click(finishButton);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('keeps STARTING enabled when this hold is already STARTING and at the cap', () => {
+    // The user is editing a hold that already counts toward the cap; allowing
+    // re-selection lets them confirm the same state without surprising no-ops.
+    const { onSelect } = renderPicker({
+      boardName: 'kilter',
+      startingCount: 2,
+      currentState: 'STARTING',
+    });
+
+    const startButton = screen.getByLabelText('Start') as HTMLButtonElement;
+    expect(startButton.disabled).toBe(false);
+
+    fireEvent.click(startButton);
+    expect(onSelect).toHaveBeenCalledWith('STARTING');
+  });
+
+  it('marks the active swatch with aria-pressed', () => {
+    renderPicker({ boardName: 'kilter', currentState: 'FINISH' });
+
+    expect(screen.getByLabelText('Finish').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByLabelText('Start').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('keeps FOOT enabled even when starting/finish are capped', () => {
+    const { onSelect } = renderPicker({
+      boardName: 'kilter',
+      startingCount: 2,
+      finishCount: 2,
+    });
+
+    const footButton = screen.getByLabelText('Foot') as HTMLButtonElement;
+    expect(footButton.disabled).toBe(false);
+
+    fireEvent.click(footButton);
+    expect(onSelect).toHaveBeenCalledWith('FOOT');
+  });
+});

--- a/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
@@ -1,6 +1,53 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import React, { useRef, useEffect } from 'react';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+// Mock HOLD_STATE_MAP so picker color assertions don't depend on the real LED
+// colors — if production LED hex values change, these tests should keep passing
+// because the picker logic is what's under test, not the colors themselves.
+vi.mock('../../board-renderer/types', () => ({
+  HOLD_STATE_MAP: {
+    kilter: {
+      42: { name: 'STARTING', color: '#11AA11' },
+      43: { name: 'HAND', color: '#11AAAA' },
+      44: { name: 'FINISH', color: '#AA11AA' },
+      45: { name: 'FOOT', color: '#AA8800' },
+    },
+    tension: {
+      1: { name: 'STARTING', displayColor: '#22BB22', color: '#11AA11' },
+      2: { name: 'HAND', displayColor: '#2222BB', color: '#1111AA' },
+      3: { name: 'FINISH', color: '#AA1111' },
+      4: { name: 'FOOT', color: '#AA11AA' },
+    },
+    moonboard: {
+      42: { name: 'STARTING', color: '#11AA11', displayColor: '#33CC33' },
+      43: { name: 'HAND', color: '#1111AA', displayColor: '#3333CC' },
+      44: { name: 'FINISH', color: '#AA1111', displayColor: '#CC2222' },
+      // BLE-preview-only entries that should NOT show up in the picker.
+      45: { name: 'FOOT', color: '#11AAAA' },
+      46: { name: 'AUX', color: '#FFE066' },
+    },
+    decoy: {
+      1: { name: 'STARTING', color: '#11AA11' },
+      2: { name: 'HAND', color: '#1111AA' },
+      3: { name: 'FINISH', color: '#AA1111' },
+      4: { name: 'FOOT', color: '#AA11AA' },
+    },
+    touchstone: {
+      1: { name: 'STARTING', color: '#11AA11' },
+      2: { name: 'HAND', color: '#1111AA' },
+      3: { name: 'FINISH', color: '#AA1111' },
+      4: { name: 'FOOT', color: '#AA11AA' },
+    },
+    grasshopper: {
+      1: { name: 'STARTING', color: '#11AA11' },
+      2: { name: 'HAND', color: '#1111AA' },
+      3: { name: 'FINISH', color: '#AA1111' },
+      4: { name: 'FOOT', color: '#AA11AA' },
+    },
+  },
+}));
+
 import HoldTypePicker, { buildOptions } from '../hold-type-picker';
 
 // Note: MUI Popover prints "anchorEl is invalid" warnings during the brief
@@ -83,14 +130,16 @@ describe('buildOptions', () => {
 
   it('uses board-specific colors', () => {
     const kilter = buildOptions('kilter');
+    const tension = buildOptions('tension');
     const moonboard = buildOptions('moonboard');
 
-    // Kilter STARTING color from HOLD_STATE_MAP
-    expect(kilter.find((o) => o.state === 'STARTING')?.color).toBe('#00FF00');
-    // Kilter FOOT color
-    expect(kilter.find((o) => o.state === 'FOOT')?.color).toBe('#FFAA00');
-    // MoonBoard STARTING uses displayColor
-    expect(moonboard.find((o) => o.state === 'STARTING')?.color).toBe('#44FF44');
+    // Kilter has no displayColor, so the picker uses the raw color.
+    expect(kilter.find((o) => o.state === 'STARTING')?.color).toBe('#11AA11');
+    expect(kilter.find((o) => o.state === 'FOOT')?.color).toBe('#AA8800');
+    // Tension prefers displayColor over color when present.
+    expect(tension.find((o) => o.state === 'STARTING')?.color).toBe('#22BB22');
+    // MoonBoard also has a displayColor that should win over color.
+    expect(moonboard.find((o) => o.state === 'STARTING')?.color).toBe('#33CC33');
   });
 });
 

--- a/packages/web/app/components/create-climb/__tests__/use-create-climb.test.ts
+++ b/packages/web/app/components/create-climb/__tests__/use-create-climb.test.ts
@@ -4,21 +4,21 @@ import { renderHook, act } from '@testing-library/react';
 vi.mock('../../board-renderer/types', () => ({
   HOLD_STATE_MAP: {
     kilter: {
-      42: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      43: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      44: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
-      45: { state: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+      42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+      43: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+      44: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+      45: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
     },
     tension: {
-      1: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      2: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      3: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
-      4: { state: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+      1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+      2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+      3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+      4: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
     },
     moonboard: {
-      1: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      2: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      3: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+      1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+      2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+      3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
     },
   },
 }));
@@ -38,12 +38,12 @@ describe('useCreateClimb', () => {
     });
   });
 
-  describe('hold state cycling', () => {
-    it('first click cycles hold to STARTING', () => {
+  describe('setHoldState', () => {
+    it('sets a hold to STARTING', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
 
       expect(result.current.litUpHoldsMap[100]).toEqual({
@@ -53,74 +53,62 @@ describe('useCreateClimb', () => {
       });
     });
 
-    it('second click cycles hold from STARTING to HAND', () => {
+    it('sets a hold to HAND', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'HAND');
       });
 
       expect(result.current.litUpHoldsMap[100].state).toBe('HAND');
       expect(result.current.litUpHoldsMap[100].color).toBe('#00FFFF');
     });
 
-    it('third click cycles hold from HAND to FOOT', () => {
+    it('sets a hold to FOOT', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'FOOT');
       });
 
       expect(result.current.litUpHoldsMap[100].state).toBe('FOOT');
       expect(result.current.litUpHoldsMap[100].color).toBe('#FFA500');
     });
 
-    it('fourth click cycles hold from FOOT to FINISH', () => {
+    it('sets a hold to FINISH', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'FINISH');
       });
 
       expect(result.current.litUpHoldsMap[100].state).toBe('FINISH');
       expect(result.current.litUpHoldsMap[100].color).toBe('#FF00FF');
     });
 
-    it('fifth click cycles hold from FINISH to OFF (removed)', () => {
+    it('changes a hold from one state to another', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'FOOT');
       });
+
+      expect(result.current.litUpHoldsMap[100].state).toBe('FOOT');
+    });
+
+    it('OFF removes the hold from the map', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
+      expect(result.current.totalHolds).toBe(1);
+
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'OFF');
       });
 
       expect(result.current.litUpHoldsMap[100]).toBeUndefined();
@@ -129,60 +117,59 @@ describe('useCreateClimb', () => {
   });
 
   describe('max state limits', () => {
-    it('skips STARTING when 2 starting holds already exist', () => {
+    it('refuses to add a third STARTING hold when 2 already exist', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
-      // Add 2 starting holds
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(200, 'STARTING');
       });
-
       expect(result.current.startingCount).toBe(2);
 
-      // Third hold should skip STARTING and go to HAND
       act(() => {
-        result.current.handleHoldClick(300);
-      });
-
-      expect(result.current.litUpHoldsMap[300].state).toBe('HAND');
-    });
-
-    it('skips FINISH when 2 finish holds already exist', () => {
-      const { result } = renderHook(() => useCreateClimb('kilter'));
-
-      // Add 2 finish holds (cycle each through STARTING -> HAND -> FOOT -> FINISH)
-      for (let i = 0; i < 4; i++) {
-        act(() => {
-          result.current.handleHoldClick(100);
-        });
-      }
-      for (let i = 0; i < 4; i++) {
-        act(() => {
-          result.current.handleHoldClick(200);
-        });
-      }
-
-      expect(result.current.finishCount).toBe(2);
-
-      // Now add a hold and cycle to where FINISH would be
-      // It should skip FINISH and go to OFF
-      act(() => {
-        result.current.handleHoldClick(300); // STARTING
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // HAND
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // FOOT
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // Should skip FINISH -> OFF
+        result.current.setHoldState(300, 'STARTING');
       });
 
       expect(result.current.litUpHoldsMap[300]).toBeUndefined();
+      expect(result.current.startingCount).toBe(2);
+    });
+
+    it('refuses to add a third FINISH hold when 2 already exist', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'FINISH');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FINISH');
+      });
+      expect(result.current.finishCount).toBe(2);
+
+      act(() => {
+        result.current.setHoldState(300, 'FINISH');
+      });
+
+      expect(result.current.litUpHoldsMap[300]).toBeUndefined();
+    });
+
+    it('allows re-selecting the same state on a hold already at the limit', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'STARTING');
+      });
+      // Re-set hold 100 to STARTING — should not no-op since it's already there.
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+
+      expect(result.current.litUpHoldsMap[100].state).toBe('STARTING');
+      expect(result.current.startingCount).toBe(2);
     });
   });
 
@@ -190,9 +177,8 @@ describe('useCreateClimb', () => {
     it('produces correct format for kilter holds', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
-      // Add a STARTING hold (holdId=100, stateCode=42)
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
 
       const frames = result.current.generateFramesString();
@@ -202,17 +188,11 @@ describe('useCreateClimb', () => {
     it('produces correct format for multiple holds', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
-      // Add a STARTING hold
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
-      // Add another STARTING hold
       act(() => {
-        result.current.handleHoldClick(200);
-      });
-      // Cycle second hold to HAND
-      act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(200, 'HAND');
       });
 
       const frames = result.current.generateFramesString();
@@ -233,10 +213,10 @@ describe('useCreateClimb', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(200, 'HAND');
       });
       expect(result.current.totalHolds).toBe(2);
 
@@ -257,13 +237,13 @@ describe('useCreateClimb', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(200, 'HAND');
       });
       act(() => {
-        result.current.handleHoldClick(300);
+        result.current.setHoldState(300, 'FOOT');
       });
 
       expect(result.current.totalHolds).toBe(3);
@@ -273,10 +253,10 @@ describe('useCreateClimb', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
-        result.current.handleHoldClick(100); // STARTING
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(200); // STARTING
+        result.current.setHoldState(200, 'STARTING');
       });
 
       expect(result.current.startingCount).toBe(2);
@@ -285,12 +265,9 @@ describe('useCreateClimb', () => {
     it('finishCount is correct', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
-      // Cycle hold to FINISH
-      for (let i = 0; i < 4; i++) {
-        act(() => {
-          result.current.handleHoldClick(100);
-        });
-      }
+      act(() => {
+        result.current.setHoldState(100, 'FINISH');
+      });
 
       expect(result.current.finishCount).toBe(1);
     });
@@ -301,7 +278,7 @@ describe('useCreateClimb', () => {
       expect(result.current.isValid).toBe(false);
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
 
       expect(result.current.isValid).toBe(true);
@@ -331,7 +308,7 @@ describe('useCreateClimb', () => {
       const { result } = renderHook(() => useCreateClimb('tension'));
 
       act(() => {
-        result.current.handleHoldClick(100); // STARTING
+        result.current.setHoldState(100, 'STARTING');
       });
 
       const frames = result.current.generateFramesString();

--- a/packages/web/app/components/create-climb/__tests__/use-hold-type-picker.test.ts
+++ b/packages/web/app/components/create-climb/__tests__/use-hold-type-picker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHoldTypePicker } from '../use-hold-type-picker';
+import type { LitUpHoldsMap } from '../../board-renderer/types';
+
+const makeAnchor = () => document.createElement('div');
+
+describe('useHoldTypePicker', () => {
+  it('starts closed', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    expect(result.current.anchorEl).toBeNull();
+    expect(result.current.currentState).toBe('OFF');
+  });
+
+  it('handleHoldClick anchors the picker against the tapped element', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    const anchor = makeAnchor();
+    act(() => {
+      result.current.handleHoldClick(42, anchor);
+    });
+
+    expect(result.current.anchorEl).toBe(anchor);
+  });
+
+  it('exposes the current state from litUpHoldsMap when a hold is tapped', () => {
+    const setHoldState = vi.fn();
+    const litUpHoldsMap: LitUpHoldsMap = {
+      42: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ map }: { map: LitUpHoldsMap }) =>
+        useHoldTypePicker({ litUpHoldsMap: map, setHoldState }),
+      { initialProps: { map: litUpHoldsMap } },
+    );
+
+    expect(result.current.currentState).toBe('OFF');
+
+    act(() => {
+      result.current.handleHoldClick(42, makeAnchor());
+    });
+
+    rerender({ map: litUpHoldsMap });
+    expect(result.current.currentState).toBe('FINISH');
+  });
+
+  it('falls back to OFF when the tapped hold is not in the map', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    act(() => {
+      result.current.handleHoldClick(99, makeAnchor());
+    });
+
+    expect(result.current.currentState).toBe('OFF');
+  });
+
+  it('handleSelect calls setHoldState with the tapped hold id and clears the picker', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    act(() => {
+      result.current.handleHoldClick(7, makeAnchor());
+    });
+    act(() => {
+      result.current.handleSelect('STARTING');
+    });
+
+    expect(setHoldState).toHaveBeenCalledWith(7, 'STARTING');
+    expect(result.current.anchorEl).toBeNull();
+  });
+
+  it('handleSelect is a no-op when nothing is open', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    act(() => {
+      result.current.handleSelect('STARTING');
+    });
+
+    expect(setHoldState).not.toHaveBeenCalled();
+  });
+
+  it('handleClose clears the picker without calling setHoldState', () => {
+    const setHoldState = vi.fn();
+    const { result } = renderHook(() =>
+      useHoldTypePicker({ litUpHoldsMap: {}, setHoldState }),
+    );
+
+    act(() => {
+      result.current.handleHoldClick(7, makeAnchor());
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(result.current.anchorEl).toBeNull();
+    expect(setHoldState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/create-climb/__tests__/use-moonboard-create-climb.test.ts
+++ b/packages/web/app/components/create-climb/__tests__/use-moonboard-create-climb.test.ts
@@ -125,6 +125,25 @@ describe('useMoonBoardCreateClimb', () => {
 
       expect(result.current.litUpHoldsMap[300]).toBeUndefined();
     });
+
+    it('allows re-selecting the same state on a hold already at the limit', () => {
+      const { result } = renderHook(() => useMoonBoardCreateClimb());
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'STARTING');
+      });
+      // Re-set hold 100 to STARTING — should still apply because the hold is
+      // already counted toward the cap (no new hold is being added).
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+
+      expect(result.current.litUpHoldsMap[100].state).toBe('STARTING');
+      expect(result.current.startingCount).toBe(2);
+    });
   });
 
   describe('isValid', () => {

--- a/packages/web/app/components/create-climb/__tests__/use-moonboard-create-climb.test.ts
+++ b/packages/web/app/components/create-climb/__tests__/use-moonboard-create-climb.test.ts
@@ -25,12 +25,12 @@ describe('useMoonBoardCreateClimb', () => {
     });
   });
 
-  describe('hold state cycling (no FOOT state)', () => {
-    it('first click cycles to STARTING', () => {
+  describe('setHoldState', () => {
+    it('sets a hold to STARTING', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
 
       expect(result.current.litUpHoldsMap[100]).toEqual({
@@ -40,108 +40,87 @@ describe('useMoonBoardCreateClimb', () => {
       });
     });
 
-    it('second click cycles from STARTING to HAND', () => {
+    it('sets a hold to HAND', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'HAND');
       });
 
       expect(result.current.litUpHoldsMap[100].state).toBe('HAND');
       expect(result.current.litUpHoldsMap[100].color).toBe('#00FFFF');
     });
 
-    it('third click cycles from HAND to FINISH', () => {
+    it('sets a hold to FINISH', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'FINISH');
       });
 
       expect(result.current.litUpHoldsMap[100].state).toBe('FINISH');
       expect(result.current.litUpHoldsMap[100].color).toBe('#FF00FF');
     });
 
-    it('fourth click cycles from FINISH to OFF (removed)', () => {
+    it('OFF removes the hold from the map', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
+      expect(result.current.totalHolds).toBe(1);
+
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'OFF');
       });
 
       expect(result.current.litUpHoldsMap[100]).toBeUndefined();
       expect(result.current.totalHolds).toBe(0);
     });
-  });
 
-  describe('max starting holds', () => {
-    it('skips STARTING when 2 starting holds already exist', () => {
+    it('refuses FOOT (MoonBoard has no foot holds)', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
-      // Add 2 starting holds
       act(() => {
-        result.current.handleHoldClick(100);
-      });
-      act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(100, 'FOOT');
       });
 
-      expect(result.current.startingCount).toBe(2);
-
-      // Third hold should skip STARTING and go to HAND
-      act(() => {
-        result.current.handleHoldClick(300);
-      });
-
-      expect(result.current.litUpHoldsMap[300].state).toBe('HAND');
+      expect(result.current.litUpHoldsMap[100]).toBeUndefined();
     });
   });
 
-  describe('max finish holds', () => {
-    it('skips FINISH when 2 finish holds already exist', () => {
+  describe('max state limits', () => {
+    it('refuses to add a third STARTING hold when 2 already exist', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
-      // Add 2 finish holds (cycle each through STARTING -> HAND -> FINISH)
-      for (let i = 0; i < 3; i++) {
-        act(() => {
-          result.current.handleHoldClick(100);
-        });
-      }
-      for (let i = 0; i < 3; i++) {
-        act(() => {
-          result.current.handleHoldClick(200);
-        });
-      }
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'STARTING');
+      });
+      expect(result.current.startingCount).toBe(2);
 
+      act(() => {
+        result.current.setHoldState(300, 'STARTING');
+      });
+
+      expect(result.current.litUpHoldsMap[300]).toBeUndefined();
+    });
+
+    it('refuses to add a third FINISH hold when 2 already exist', () => {
+      const { result } = renderHook(() => useMoonBoardCreateClimb());
+
+      act(() => {
+        result.current.setHoldState(100, 'FINISH');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FINISH');
+      });
       expect(result.current.finishCount).toBe(2);
 
-      // Now add a hold and cycle to where FINISH would be
       act(() => {
-        result.current.handleHoldClick(300); // STARTING
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // HAND
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // Should skip FINISH -> OFF
+        result.current.setHoldState(300, 'FINISH');
       });
 
       expect(result.current.litUpHoldsMap[300]).toBeUndefined();
@@ -154,32 +133,19 @@ describe('useMoonBoardCreateClimb', () => {
 
       expect(result.current.isValid).toBe(false);
 
-      // Add starting hold
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       expect(result.current.isValid).toBe(false);
 
-      // Add hand hold
       act(() => {
-        result.current.handleHoldClick(200);
-      });
-      act(() => {
-        result.current.handleHoldClick(200); // HAND
+        result.current.setHoldState(200, 'HAND');
       });
       expect(result.current.isValid).toBe(false);
 
-      // Add finish hold
       act(() => {
-        result.current.handleHoldClick(300);
+        result.current.setHoldState(300, 'FINISH');
       });
-      act(() => {
-        result.current.handleHoldClick(300); // HAND
-      });
-      act(() => {
-        result.current.handleHoldClick(300); // FINISH
-      });
-
       expect(result.current.isValid).toBe(true);
     });
   });
@@ -189,10 +155,10 @@ describe('useMoonBoardCreateClimb', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
       act(() => {
-        result.current.handleHoldClick(100);
+        result.current.setHoldState(100, 'STARTING');
       });
       act(() => {
-        result.current.handleHoldClick(200);
+        result.current.setHoldState(200, 'HAND');
       });
       expect(result.current.totalHolds).toBe(2);
 
@@ -213,24 +179,14 @@ describe('useMoonBoardCreateClimb', () => {
     it('tracks hand holds correctly', () => {
       const { result } = renderHook(() => useMoonBoardCreateClimb());
 
-      // Add hold and cycle to HAND
       act(() => {
-        result.current.handleHoldClick(100); // STARTING
+        result.current.setHoldState(100, 'HAND');
       });
-      act(() => {
-        result.current.handleHoldClick(100); // HAND
-      });
-
       expect(result.current.handCount).toBe(1);
 
-      // Add another HAND hold
       act(() => {
-        result.current.handleHoldClick(200); // STARTING
+        result.current.setHoldState(200, 'HAND');
       });
-      act(() => {
-        result.current.handleHoldClick(200); // HAND
-      });
-
       expect(result.current.handCount).toBe(2);
     });
   });

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -47,6 +47,8 @@ import { refreshClimbSearchAfterSave } from '@/app/lib/climb-search-cache';
 import CreateClimbHeatmapOverlay from './create-climb-heatmap-overlay';
 import HoldStatusChip from './hold-status-chip';
 import DraftsDrawer from './drafts-drawer';
+import HoldTypePicker from './hold-type-picker';
+import type { HoldState } from '../board-renderer/types';
 import { useCreateHeaderBridgeSetters } from './create-header-bridge-context';
 import {
   SEARCH_CLIMBS_COUNT,
@@ -138,7 +140,7 @@ export default function CreateClimbForm({
   // Use the appropriate hook values based on board type
   const {
     litUpHoldsMap,
-    handleHoldClick: baseHandleHoldClick,
+    setHoldState,
     startingCount,
     finishCount,
     totalHolds,
@@ -213,13 +215,28 @@ export default function CreateClimbForm({
     }
   }, [boardType, litUpHoldsMap, isConnected, generateFramesString, sendFramesToBoard]);
 
-  // Wrap handleHoldClick
-  const handleHoldClick = useCallback(
-    (holdId: number) => {
-      baseHandleHoldClick(holdId);
+  // Hold-type picker state: which hold the user just tapped, and the DOM
+  // anchor (the SVG circle / MoonBoard cell) to position the popover against.
+  const [pickerState, setPickerState] = useState<{ holdId: number; anchor: Element } | null>(null);
+
+  const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
+    setPickerState({ holdId, anchor });
+  }, []);
+
+  const handlePickerSelect = useCallback(
+    (state: HoldState | 'OFF') => {
+      if (!pickerState) return;
+      setHoldState(pickerState.holdId, state);
+      setPickerState(null);
     },
-    [baseHandleHoldClick],
+    [pickerState, setHoldState],
   );
+
+  const handlePickerClose = useCallback(() => {
+    setPickerState(null);
+  }, []);
+
+  const pickerBoardName = boardType === 'aurora' ? boardDetails?.board_name ?? 'kilter' : 'moonboard';
 
   // Wrap resetHolds to also clear the board
   const resetHolds = useCallback(() => {
@@ -817,6 +834,16 @@ export default function CreateClimbForm({
           ) : null}
         </ZoomableBoard>
       </div>
+
+      <HoldTypePicker
+        boardName={pickerBoardName}
+        anchorEl={pickerState?.anchor ?? null}
+        currentState={pickerState ? litUpHoldsMap[pickerState.holdId]?.state ?? 'OFF' : 'OFF'}
+        startingCount={startingCount}
+        finishCount={finishCount}
+        onSelect={handlePickerSelect}
+        onClose={handlePickerClose}
+      />
 
       {/* MoonBoard validation hint band */}
       {boardType === 'moonboard' && !isValid && totalHolds > 0 && (

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -48,7 +48,7 @@ import CreateClimbHeatmapOverlay from './create-climb-heatmap-overlay';
 import HoldStatusChip from './hold-status-chip';
 import DraftsDrawer from './drafts-drawer';
 import HoldTypePicker from './hold-type-picker';
-import type { HoldState } from '../board-renderer/types';
+import { useHoldTypePicker } from './use-hold-type-picker';
 import { useCreateHeaderBridgeSetters } from './create-header-bridge-context';
 import {
   SEARCH_CLIMBS_COUNT,
@@ -215,27 +215,9 @@ export default function CreateClimbForm({
     }
   }, [boardType, litUpHoldsMap, isConnected, generateFramesString, sendFramesToBoard]);
 
-  // Hold-type picker state: which hold the user just tapped, and the DOM
-  // anchor (the SVG circle / MoonBoard cell) to position the popover against.
-  const [pickerState, setPickerState] = useState<{ holdId: number; anchor: Element } | null>(null);
-
-  const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
-    setPickerState({ holdId, anchor });
-  }, []);
-
-  const handlePickerSelect = useCallback(
-    (state: HoldState | 'OFF') => {
-      if (!pickerState) return;
-      setHoldState(pickerState.holdId, state);
-      setPickerState(null);
-    },
-    [pickerState, setHoldState],
-  );
-
-  const handlePickerClose = useCallback(() => {
-    setPickerState(null);
-  }, []);
-
+  // Hold-type picker: tracks which hold the user just tapped, anchors the
+  // popover against its DOM element, and routes selections back to setHoldState.
+  const picker = useHoldTypePicker({ litUpHoldsMap, setHoldState });
   const pickerBoardName = boardType === 'aurora' ? boardDetails?.board_name ?? 'kilter' : 'moonboard';
 
   // Wrap resetHolds to also clear the board
@@ -811,7 +793,7 @@ export default function CreateClimbForm({
                 boardDetails={boardDetails}
                 litUpHoldsMap={litUpHoldsMap}
                 mirrored={false}
-                onHoldClick={handleHoldClick}
+                onHoldClick={picker.handleHoldClick}
                 fillHeight
               />
               <CreateClimbHeatmapOverlay
@@ -828,7 +810,7 @@ export default function CreateClimbForm({
                 layoutFolder={layoutFolder}
                 holdSetImages={holdSetImages}
                 litUpHoldsMap={litUpHoldsMap}
-                onHoldClick={handleHoldClick}
+                onHoldClick={picker.handleHoldClick}
               />
             </div>
           ) : null}
@@ -837,12 +819,12 @@ export default function CreateClimbForm({
 
       <HoldTypePicker
         boardName={pickerBoardName}
-        anchorEl={pickerState?.anchor ?? null}
-        currentState={pickerState ? litUpHoldsMap[pickerState.holdId]?.state ?? 'OFF' : 'OFF'}
+        anchorEl={picker.anchorEl}
+        currentState={picker.currentState}
         startingCount={startingCount}
         finishCount={finishCount}
-        onSelect={handlePickerSelect}
-        onClose={handlePickerClose}
+        onSelect={picker.handleSelect}
+        onClose={picker.handleClose}
       />
 
       {/* MoonBoard validation hint band */}

--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -22,33 +22,46 @@ interface HoldTypePickerProps {
   onClose: () => void;
 }
 
-// Order in which hold types should appear in the picker.
-const STATE_ORDER: HoldState[] = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+// Hold types the picker can show, in display order. Search-only states like
+// ANY/NOT and the MoonBoard above-marker AUX state are intentionally excluded
+// — the picker is for setting climbs, not searching them.
+type PickerHoldState = 'STARTING' | 'HAND' | 'FINISH' | 'FOOT';
 
-const STATE_LABELS: Record<HoldState, string> = {
+const STATE_ORDER: readonly PickerHoldState[] = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+
+const STATE_LABELS: Record<PickerHoldState, string> = {
   STARTING: 'Start',
   HAND: 'Mid',
   FINISH: 'Finish',
   FOOT: 'Foot',
-  OFF: 'Clear',
-  ANY: 'Any',
-  NOT: 'Not',
-  AUX: 'Aux',
+};
+
+// Per-board allowlist of selectable states. MoonBoard climbs are STARTING /
+// HAND / FINISH only — its HOLD_STATE_MAP entries 45-48 exist to render live
+// BLE preview frames from the dev firmware, not to set climbs, so we filter
+// them out here so they never appear in the picker.
+const PICKER_STATES_BY_BOARD: Record<BoardName, readonly PickerHoldState[]> = {
+  kilter: STATE_ORDER,
+  tension: STATE_ORDER,
+  decoy: STATE_ORDER,
+  touchstone: STATE_ORDER,
+  grasshopper: STATE_ORDER,
+  moonboard: ['STARTING', 'HAND', 'FINISH'],
 };
 
 interface PickerOption {
-  state: SelectableState;
+  state: PickerHoldState;
   label: string;
   color: string;
 }
 
 /**
- * Build the picker's options from HOLD_STATE_MAP. Each board exposes a different
- * set of role codes — MoonBoard has no FOOT, etc. We dedupe by HoldState name
- * and use the first occurrence's displayColor (or color) so the swatch matches
- * what the LED actually shows on that board.
+ * Build the picker's options for a given board. The list of states comes from
+ * PICKER_STATES_BY_BOARD (so we don't surface preview-only roles like the
+ * MoonBoard FOOT/AUX BLE codes), and the colors come from HOLD_STATE_MAP so
+ * each swatch matches the actual LED color the board uses.
  */
-function buildOptions(boardName: BoardName): PickerOption[] {
+export function buildOptions(boardName: BoardName): PickerOption[] {
   const boardMap = HOLD_STATE_MAP[boardName];
   const colorByState = new Map<HoldState, string>();
 
@@ -59,7 +72,7 @@ function buildOptions(boardName: BoardName): PickerOption[] {
   }
 
   const options: PickerOption[] = [];
-  for (const state of STATE_ORDER) {
+  for (const state of PICKER_STATES_BY_BOARD[boardName]) {
     const color = colorByState.get(state);
     if (!color) continue;
     options.push({ state, label: STATE_LABELS[state], color });

--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import Popover from '@mui/material/Popover';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Typography from '@mui/material/Typography';
+import CloseIcon from '@mui/icons-material/Close';
+import { HOLD_STATE_MAP, type HoldState } from '../board-renderer/types';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { BoardName } from '@/app/lib/types';
+
+type SelectableState = HoldState | 'OFF';
+
+interface HoldTypePickerProps {
+  boardName: BoardName;
+  anchorEl: Element | null;
+  currentState: SelectableState;
+  startingCount: number;
+  finishCount: number;
+  onSelect: (state: SelectableState) => void;
+  onClose: () => void;
+}
+
+// Order in which hold types should appear in the picker.
+const STATE_ORDER: HoldState[] = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+
+const STATE_LABELS: Record<HoldState, string> = {
+  STARTING: 'Start',
+  HAND: 'Mid',
+  FINISH: 'Finish',
+  FOOT: 'Foot',
+  OFF: 'Clear',
+  ANY: 'Any',
+  NOT: 'Not',
+  AUX: 'Aux',
+};
+
+interface PickerOption {
+  state: SelectableState;
+  label: string;
+  color: string;
+}
+
+/**
+ * Build the picker's options from HOLD_STATE_MAP. Each board exposes a different
+ * set of role codes — MoonBoard has no FOOT, etc. We dedupe by HoldState name
+ * and use the first occurrence's displayColor (or color) so the swatch matches
+ * what the LED actually shows on that board.
+ */
+function buildOptions(boardName: BoardName): PickerOption[] {
+  const boardMap = HOLD_STATE_MAP[boardName];
+  const colorByState = new Map<HoldState, string>();
+
+  for (const entry of Object.values(boardMap)) {
+    if (!colorByState.has(entry.name)) {
+      colorByState.set(entry.name, entry.displayColor ?? entry.color);
+    }
+  }
+
+  const options: PickerOption[] = [];
+  for (const state of STATE_ORDER) {
+    const color = colorByState.get(state);
+    if (!color) continue;
+    options.push({ state, label: STATE_LABELS[state], color });
+  }
+  return options;
+}
+
+const SWATCH_SIZE = 36;
+
+export default function HoldTypePicker({
+  boardName,
+  anchorEl,
+  currentState,
+  startingCount,
+  finishCount,
+  onSelect,
+  onClose,
+}: HoldTypePickerProps) {
+  const options = useMemo(() => buildOptions(boardName), [boardName]);
+
+  const handleSelect = (state: SelectableState, disabled: boolean) => {
+    if (disabled) return;
+    onSelect(state);
+  };
+
+  return (
+    <Popover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: `${themeTokens.borderRadius.lg}px`,
+            boxShadow: themeTokens.shadows.lg,
+            overflow: 'visible',
+          },
+        },
+      }}
+    >
+      <Box
+        role="menu"
+        aria-label="Hold type"
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: `${themeTokens.spacing[1]}px`,
+          padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
+        }}
+      >
+        {options.map((option) => {
+          const isActive = option.state === currentState;
+          const isDisabled =
+            (option.state === 'STARTING' && startingCount >= 2 && !isActive) ||
+            (option.state === 'FINISH' && finishCount >= 2 && !isActive);
+
+          return (
+            <Swatch
+              key={option.state}
+              label={option.label}
+              color={option.color}
+              isActive={isActive}
+              isDisabled={isDisabled}
+              onClick={() => handleSelect(option.state, isDisabled)}
+            />
+          );
+        })}
+        <Swatch
+          key="clear"
+          label="Clear"
+          isClear
+          isActive={currentState === 'OFF'}
+          isDisabled={currentState === 'OFF'}
+          onClick={() => handleSelect('OFF', currentState === 'OFF')}
+        />
+      </Box>
+    </Popover>
+  );
+}
+
+interface SwatchProps {
+  label: string;
+  color?: string;
+  isActive: boolean;
+  isDisabled: boolean;
+  isClear?: boolean;
+  onClick: () => void;
+}
+
+function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: SwatchProps) {
+  const ring = isClear ? themeTokens.neutral[400] : color ?? themeTokens.neutral[400];
+
+  return (
+    <ButtonBase
+      onClick={onClick}
+      disabled={isDisabled}
+      aria-label={label}
+      aria-pressed={isActive}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: `${themeTokens.spacing[1]}px`,
+        padding: `${themeTokens.spacing[1]}px`,
+        borderRadius: `${themeTokens.borderRadius.md}px`,
+        opacity: isDisabled ? 0.35 : 1,
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        transition: themeTokens.transitions.fast,
+        '&:hover': isDisabled
+          ? undefined
+          : { backgroundColor: themeTokens.semantic.selectedLight },
+      }}
+    >
+      <Box
+        sx={{
+          width: SWATCH_SIZE,
+          height: SWATCH_SIZE,
+          borderRadius: '50%',
+          border: `3px solid ${ring}`,
+          backgroundColor: isActive && !isClear ? ring : 'transparent',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: isClear ? ring : isActive ? '#FFFFFF' : 'transparent',
+          boxSizing: 'border-box',
+        }}
+      >
+        {isClear && <CloseIcon sx={{ fontSize: 18 }} />}
+      </Box>
+      <Typography
+        variant="caption"
+        sx={{
+          fontSize: 11,
+          fontWeight: themeTokens.typography.fontWeight.medium,
+          lineHeight: 1,
+          color: 'text.primary',
+        }}
+      >
+        {label}
+      </Typography>
+    </ButtonBase>
+  );
+}

--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -116,7 +116,7 @@ export default function HoldTypePicker({
       }}
     >
       <Box
-        role="menu"
+        role="toolbar"
         aria-label="Hold type"
         sx={{
           display: 'flex',
@@ -181,7 +181,6 @@ function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: Swatch
         padding: `${themeTokens.spacing[1]}px`,
         borderRadius: `${themeTokens.borderRadius.md}px`,
         opacity: isDisabled ? 0.35 : 1,
-        cursor: isDisabled ? 'not-allowed' : 'pointer',
         transition: themeTokens.transitions.fast,
         '&:hover': isDisabled
           ? undefined

--- a/packages/web/app/components/create-climb/use-create-climb.ts
+++ b/packages/web/app/components/create-climb/use-create-climb.ts
@@ -4,9 +4,6 @@ import { useState, useCallback, useMemo } from 'react';
 import { LitUpHoldsMap, HoldState, HOLD_STATE_MAP, HoldCode } from '../board-renderer/types';
 import { BoardName } from '@/app/lib/types';
 
-// Hold state cycle order: Starting -> Hand -> Foot -> Finish -> OFF
-const STATE_CYCLE: HoldState[] = ['STARTING', 'HAND', 'FOOT', 'FINISH', 'OFF'];
-
 // Map from state name to the primary hold code for each board
 const STATE_TO_CODE: Record<BoardName, Partial<Record<HoldState, HoldCode>>> = {
   kilter: {
@@ -74,50 +71,32 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
 
   const isValid = totalHolds > 0;
 
-  const handleHoldClick = useCallback(
-    (holdId: number) => {
+  const setHoldState = useCallback(
+    (holdId: number, nextState: HoldState | 'OFF') => {
       setLitUpHoldsMap((prev) => {
-        const currentHold = prev[holdId];
-        const currentState: HoldState = currentHold?.state || 'OFF';
-
-        // Find current position in cycle
-        const currentIndex = STATE_CYCLE.indexOf(currentState);
-
-        // Count current states (excluding this hold if it has that state)
-        const currentStartingCount = Object.entries(prev).filter(
-          ([id, h]) => h.state === 'STARTING' && Number(id) !== holdId,
-        ).length;
-        const currentFinishCount = Object.entries(prev).filter(
-          ([id, h]) => h.state === 'FINISH' && Number(id) !== holdId,
-        ).length;
-
-        // Find next valid state in cycle
-        let nextState: HoldState = 'OFF';
-        for (let i = 1; i <= STATE_CYCLE.length; i++) {
-          const candidateIndex = (currentIndex + i) % STATE_CYCLE.length;
-          const candidateState = STATE_CYCLE[candidateIndex];
-
-          // Skip STARTING if already at max (2)
-          if (candidateState === 'STARTING' && currentStartingCount >= 2) {
-            continue;
-          }
-          // Skip FINISH if already at max (2)
-          if (candidateState === 'FINISH' && currentFinishCount >= 2) {
-            continue;
-          }
-
-          nextState = candidateState;
-          break;
-        }
-
-        // If next state is OFF, remove the hold from the map
+        // Clearing a hold removes it from the map.
         if (nextState === 'OFF') {
+          if (!(holdId in prev)) return prev;
           const { [holdId]: _removed, ...rest } = prev;
-          void _removed; // Explicitly mark as intentionally unused
+          void _removed;
           return rest;
         }
 
-        // Get the color info for this state
+        // Enforce max-2 STARTING / FINISH limits as a safety net — the picker
+        // already disables these options when at the cap.
+        const currentHold = prev[holdId];
+        const isAlreadyThisState = currentHold?.state === nextState;
+        if (!isAlreadyThisState) {
+          if (nextState === 'STARTING') {
+            const startingCount = Object.values(prev).filter((h) => h.state === 'STARTING').length;
+            if (startingCount >= 2) return prev;
+          }
+          if (nextState === 'FINISH') {
+            const finishCount = Object.values(prev).filter((h) => h.state === 'FINISH').length;
+            if (finishCount >= 2) return prev;
+          }
+        }
+
         const stateCode = STATE_TO_CODE[boardName][nextState];
         if (stateCode === undefined) {
           return prev;
@@ -160,7 +139,7 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
 
   return {
     litUpHoldsMap,
-    handleHoldClick,
+    setHoldState,
     generateFramesString,
     startingCount,
     finishCount,

--- a/packages/web/app/components/create-climb/use-hold-type-picker.ts
+++ b/packages/web/app/components/create-climb/use-hold-type-picker.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { HoldState, LitUpHoldsMap } from '../board-renderer/types';
+
+export type PickerSelection = HoldState | 'OFF';
+
+interface PickerState {
+  holdId: number;
+  anchor: Element;
+}
+
+interface UseHoldTypePickerOptions {
+  litUpHoldsMap: LitUpHoldsMap;
+  setHoldState: (holdId: number, state: PickerSelection) => void;
+}
+
+/**
+ * Shared state plumbing for the HoldTypePicker. Tracks which hold the user
+ * just tapped (and the DOM element to anchor the popover against), and wires
+ * the picker's `onSelect` / `onClose` callbacks back to the create-climb hook
+ * so they don't have to be re-implemented per consumer.
+ */
+export function useHoldTypePicker({ litUpHoldsMap, setHoldState }: UseHoldTypePickerOptions) {
+  const [pickerState, setPickerState] = useState<PickerState | null>(null);
+
+  const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
+    setPickerState({ holdId, anchor });
+  }, []);
+
+  const handleSelect = useCallback(
+    (state: PickerSelection) => {
+      if (!pickerState) return;
+      setHoldState(pickerState.holdId, state);
+      setPickerState(null);
+    },
+    [pickerState, setHoldState],
+  );
+
+  const handleClose = useCallback(() => {
+    setPickerState(null);
+  }, []);
+
+  const currentState: PickerSelection = pickerState
+    ? litUpHoldsMap[pickerState.holdId]?.state ?? 'OFF'
+    : 'OFF';
+
+  return {
+    anchorEl: pickerState?.anchor ?? null,
+    currentState,
+    handleHoldClick,
+    handleSelect,
+    handleClose,
+  };
+}

--- a/packages/web/app/components/create-climb/use-hold-type-picker.ts
+++ b/packages/web/app/components/create-climb/use-hold-type-picker.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useCallback, useState } from 'react';
 import type { HoldState, LitUpHoldsMap } from '../board-renderer/types';
 

--- a/packages/web/app/components/create-climb/use-moonboard-create-climb.ts
+++ b/packages/web/app/components/create-climb/use-moonboard-create-climb.ts
@@ -4,9 +4,6 @@ import { useState, useCallback, useMemo } from 'react';
 import { LitUpHoldsMap, HoldState } from '../board-renderer/types';
 import { MOONBOARD_HOLD_STATES } from '@/app/lib/moonboard-config';
 
-// MoonBoard hold state cycle: STARTING -> HAND -> FINISH -> OFF
-const STATE_CYCLE: (HoldState | 'OFF')[] = ['STARTING', 'HAND', 'FINISH', 'OFF'];
-
 interface UseMoonBoardCreateClimbOptions {
   initialHoldsMap?: LitUpHoldsMap;
 }
@@ -37,56 +34,42 @@ export function useMoonBoardCreateClimb(options?: UseMoonBoardCreateClimbOptions
   // MoonBoard climbs need at least 1 start hold and 1 finish hold
   const isValid = totalHolds > 0 && startingCount >= 1 && finishCount >= 1;
 
-  const handleHoldClick = useCallback((holdId: number) => {
+  const setHoldState = useCallback((holdId: number, nextState: HoldState | 'OFF') => {
     setLitUpHoldsMap((prev) => {
-      const currentHold = prev[holdId];
-      const currentState: HoldState | 'OFF' = currentHold?.state || 'OFF';
-
-      // Find current position in cycle
-      const currentIndex = STATE_CYCLE.indexOf(currentState);
-
-      // Count current states (excluding this hold if it has that state)
-      const currentStartCount = Object.entries(prev).filter(
-        ([id, h]) => h.state === 'STARTING' && Number(id) !== holdId,
-      ).length;
-      const currentFinishCount = Object.entries(prev).filter(
-        ([id, h]) => h.state === 'FINISH' && Number(id) !== holdId,
-      ).length;
-
-      // Find next valid state in cycle
-      let nextState: HoldState | 'OFF' = 'OFF';
-      for (let i = 1; i <= STATE_CYCLE.length; i++) {
-        const candidateIndex = (currentIndex + i) % STATE_CYCLE.length;
-        const candidateState = STATE_CYCLE[candidateIndex];
-
-        // Skip STARTING if already at max (2)
-        if (candidateState === 'STARTING' && currentStartCount >= 2) {
-          continue;
-        }
-        // Skip FINISH if already at max (2)
-        if (candidateState === 'FINISH' && currentFinishCount >= 2) {
-          continue;
-        }
-
-        nextState = candidateState;
-        break;
-      }
-
-      // If next state is OFF, remove the hold from the map
+      // Clearing a hold removes it from the map.
       if (nextState === 'OFF') {
+        if (!(holdId in prev)) return prev;
         const { [holdId]: _removed, ...rest } = prev;
-        void _removed; // Explicitly mark as intentionally unused
+        void _removed;
         return rest;
       }
 
-      // Map state to Moonboard hold states for colors
+      // MoonBoard has no FOOT state — silently no-op if asked.
+      if (nextState !== 'STARTING' && nextState !== 'HAND' && nextState !== 'FINISH') {
+        return prev;
+      }
+
+      // Enforce max-2 STARTING / FINISH limits as a safety net.
+      const currentHold = prev[holdId];
+      const isAlreadyThisState = currentHold?.state === nextState;
+      if (!isAlreadyThisState) {
+        if (nextState === 'STARTING') {
+          const startingCount = Object.values(prev).filter((h) => h.state === 'STARTING').length;
+          if (startingCount >= 2) return prev;
+        }
+        if (nextState === 'FINISH') {
+          const finishCount = Object.values(prev).filter((h) => h.state === 'FINISH').length;
+          if (finishCount >= 2) return prev;
+        }
+      }
+
       const stateToMoonboard = {
         STARTING: MOONBOARD_HOLD_STATES.start,
         HAND: MOONBOARD_HOLD_STATES.hand,
         FINISH: MOONBOARD_HOLD_STATES.finish,
       } as const;
 
-      const stateInfo = stateToMoonboard[nextState as keyof typeof stateToMoonboard];
+      const stateInfo = stateToMoonboard[nextState];
 
       return {
         ...prev,
@@ -107,7 +90,7 @@ export function useMoonBoardCreateClimb(options?: UseMoonBoardCreateClimbOptions
   return {
     litUpHoldsMap,
     setLitUpHoldsMap,
-    handleHoldClick,
+    setHoldState,
     startingCount,
     finishCount,
     handCount,

--- a/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
@@ -12,10 +12,11 @@ import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
 import { useMoonBoardCreateClimb } from '../create-climb/use-moonboard-create-climb';
 import HoldStatusChip from '../create-climb/hold-status-chip';
 import HoldTypePicker from '../create-climb/hold-type-picker';
+import { useHoldTypePicker } from '../create-climb/use-hold-type-picker';
 import { coordinateToHoldId, MOONBOARD_HOLD_STATES } from '@/app/lib/moonboard-config';
 import { convertLitUpHoldsMapToMoonBoardHolds } from '@/app/lib/moonboard-climb-helpers';
 import type { MoonBoardClimb, GridCoordinate } from '@boardsesh/moonboard-ocr/browser';
-import type { HoldState, LitUpHoldsMap } from '../board-renderer/types';
+import type { LitUpHoldsMap } from '../board-renderer/types';
 import styles from './moonboard-edit-modal.module.css';
 
 
@@ -99,24 +100,7 @@ export default function MoonBoardEditModal({
     isValid,
   } = useMoonBoardCreateClimb({ initialHoldsMap });
 
-  const [pickerState, setPickerState] = useState<{ holdId: number; anchor: Element } | null>(null);
-
-  const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
-    setPickerState({ holdId, anchor });
-  }, []);
-
-  const handlePickerSelect = useCallback(
-    (state: HoldState | 'OFF') => {
-      if (!pickerState) return;
-      setHoldState(pickerState.holdId, state);
-      setPickerState(null);
-    },
-    [pickerState, setHoldState],
-  );
-
-  const handlePickerClose = useCallback(() => {
-    setPickerState(null);
-  }, []);
+  const picker = useHoldTypePicker({ litUpHoldsMap, setHoldState });
 
   // Reset to initial state when climb changes
   useEffect(() => {
@@ -153,17 +137,17 @@ export default function MoonBoardEditModal({
               layoutFolder={layoutFolder}
               holdSetImages={holdSetImages}
               litUpHoldsMap={litUpHoldsMap}
-              onHoldClick={handleHoldClick}
+              onHoldClick={picker.handleHoldClick}
             />
 
             <HoldTypePicker
               boardName="moonboard"
-              anchorEl={pickerState?.anchor ?? null}
-              currentState={pickerState ? litUpHoldsMap[pickerState.holdId]?.state ?? 'OFF' : 'OFF'}
+              anchorEl={picker.anchorEl}
+              currentState={picker.currentState}
               startingCount={startingCount}
               finishCount={finishCount}
-              onSelect={handlePickerSelect}
-              onClose={handlePickerClose}
+              onSelect={picker.handleSelect}
+              onClose={picker.handleClose}
             />
 
             <div className={styles.holdCounts}>

--- a/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
@@ -11,10 +11,11 @@ import Button from '@mui/material/Button';
 import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
 import { useMoonBoardCreateClimb } from '../create-climb/use-moonboard-create-climb';
 import HoldStatusChip from '../create-climb/hold-status-chip';
+import HoldTypePicker from '../create-climb/hold-type-picker';
 import { coordinateToHoldId, MOONBOARD_HOLD_STATES } from '@/app/lib/moonboard-config';
 import { convertLitUpHoldsMapToMoonBoardHolds } from '@/app/lib/moonboard-climb-helpers';
 import type { MoonBoardClimb, GridCoordinate } from '@boardsesh/moonboard-ocr/browser';
-import type { LitUpHoldsMap } from '../board-renderer/types';
+import type { HoldState, LitUpHoldsMap } from '../board-renderer/types';
 import styles from './moonboard-edit-modal.module.css';
 
 
@@ -90,13 +91,32 @@ export default function MoonBoardEditModal({
   const {
     litUpHoldsMap,
     setLitUpHoldsMap,
-    handleHoldClick,
+    setHoldState,
     startingCount,
     finishCount,
     handCount,
     totalHolds,
     isValid,
   } = useMoonBoardCreateClimb({ initialHoldsMap });
+
+  const [pickerState, setPickerState] = useState<{ holdId: number; anchor: Element } | null>(null);
+
+  const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
+    setPickerState({ holdId, anchor });
+  }, []);
+
+  const handlePickerSelect = useCallback(
+    (state: HoldState | 'OFF') => {
+      if (!pickerState) return;
+      setHoldState(pickerState.holdId, state);
+      setPickerState(null);
+    },
+    [pickerState, setHoldState],
+  );
+
+  const handlePickerClose = useCallback(() => {
+    setPickerState(null);
+  }, []);
 
   // Reset to initial state when climb changes
   useEffect(() => {
@@ -134,6 +154,16 @@ export default function MoonBoardEditModal({
               holdSetImages={holdSetImages}
               litUpHoldsMap={litUpHoldsMap}
               onHoldClick={handleHoldClick}
+            />
+
+            <HoldTypePicker
+              boardName="moonboard"
+              anchorEl={pickerState?.anchor ?? null}
+              currentState={pickerState ? litUpHoldsMap[pickerState.holdId]?.state ?? 'OFF' : 'OFF'}
+              startingCount={startingCount}
+              finishCount={finishCount}
+              onSelect={handlePickerSelect}
+              onClose={handlePickerClose}
             />
 
             <div className={styles.holdCounts}>

--- a/packages/web/app/components/moonboard-renderer/moonboard-renderer.tsx
+++ b/packages/web/app/components/moonboard-renderer/moonboard-renderer.tsx
@@ -113,7 +113,7 @@ const MoonBoardRenderer: React.FC<MoonBoardRendererProps> = ({
             fillOpacity={thumbnail && isLitUp ? 1 : 0}
             fill={thumbnail && isLitUp ? color : 'transparent'}
             style={{ cursor: onHoldClick ? 'pointer' : 'default' }}
-            onClick={onHoldClick ? () => onHoldClick(hold.id) : undefined}
+            onClick={onHoldClick ? (event) => onHoldClick(hold.id, event.currentTarget) : undefined}
           />
         );
       })}

--- a/packages/web/app/components/moonboard-renderer/types.ts
+++ b/packages/web/app/components/moonboard-renderer/types.ts
@@ -29,5 +29,5 @@ export interface MoonBoardRendererProps {
   litUpHoldsMap?: LitUpHoldsMap;
   mirrored?: boolean;
   thumbnail?: boolean;
-  onHoldClick?: (holdId: number) => void;
+  onHoldClick?: (holdId: number, anchor: Element) => void;
 }


### PR DESCRIPTION
Tapping a hold while setting a climb now opens a compact floating picker
with Start / Mid / Finish / Foot / Clear swatches in the board's native
LED colors, instead of silently cycling through hold states.

Picker options are derived from HOLD_STATE_MAP so each board (Kilter,
Tension, MoonBoard, Decoy, Touchstone, Grasshopper) shows the right set
of types — MoonBoard skips Foot, every Aurora-family board includes it.
Start and Finish swatches are disabled at the 2-hold cap.

useCreateClimb / useMoonBoardCreateClimb now expose setHoldState
directly instead of the cycling handleHoldClick. Board renderers pass
the clicked SVG element up so the popover anchors to the actual hold
even while the board is zoomed/panned.

https://claude.ai/code/session_01DKkeqDbarUMRDtGUmEmbi1