### PR TITLE
fix(drafts-drawer): remove redundant inline style, add component tests

### DIFF
--- a/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockPush = vi.fn();
+const mockRequest = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/app/hooks/use-color-mode', () => ({
+  useColorMode: () => ({ mode: 'light' }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'auth-token' }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('../../swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="swipeable-drawer">{children}</div> : null,
+}));
+
+vi.mock('../../climb-card/climb-list-item', () => ({
+  default: ({ climb, onSelect }: { climb: { uuid: string; name: string }; onSelect: () => void }) => (
+    <div data-testid={`climb-item-${climb.uuid}`} onClick={onSelect}>
+      {climb.name}
+    </div>
+  ),
+}));
+
+import DraftsDrawer from '../drafts-drawer';
+
+const boardDetails = {
+  board_name: 'kilter' as const,
+  layout_id: 1,
+  size_id: 2,
+  set_ids: [3, 4],
+  angle: 40,
+};
+
+function renderDrawer(open = true) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const onClose = vi.fn();
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <DraftsDrawer open={open} onClose={onClose} boardDetails={boardDetails} angle={40} />
+    </QueryClientProvider>,
+  );
+  return { ...result, onClose, queryClient };
+}
+
+describe('DraftsDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when closed', () => {
+    renderDrawer(false);
+    expect(screen.queryByTestId('swipeable-drawer')).toBeNull();
+  });
+
+  it('shows loading spinner while fetching drafts', async () => {
+    // Never resolve so we stay in loading state
+    mockRequest.mockReturnValue(new Promise(() => {}));
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar')).toBeTruthy();
+    });
+  });
+
+  it('shows error message when query fails', async () => {
+    mockRequest.mockRejectedValue(new Error('network error'));
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load your drafts/)).toBeTruthy();
+    });
+  });
+
+  it('shows empty state when no drafts are returned', async () => {
+    mockRequest.mockResolvedValue({ searchClimbs: { climbs: [], hasMore: false } });
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByText('No drafts yet')).toBeTruthy();
+    });
+  });
+
+  it('renders draft climbs when query returns results', async () => {
+    mockRequest.mockResolvedValue({
+      searchClimbs: {
+        climbs: [
+          { uuid: 'draft-1', name: 'Draft Alpha', frames: '', angle: 40 },
+          { uuid: 'draft-2', name: 'Draft Beta', frames: '', angle: 40 },
+        ],
+        hasMore: false,
+      },
+    });
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByTestId('climb-item-draft-1')).toBeTruthy();
+      expect(screen.getByTestId('climb-item-draft-2')).toBeTruthy();
+    });
+  });
+
+  it('shows singular "draft" label for a single result', async () => {
+    mockRequest.mockResolvedValue({
+      searchClimbs: {
+        climbs: [{ uuid: 'draft-1', name: 'Solo Draft', frames: '', angle: 40 }],
+        hasMore: false,
+      },
+    });
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByText('1 draft')).toBeTruthy();
+    });
+  });
+
+  it('shows plural "drafts" label for multiple results', async () => {
+    mockRequest.mockResolvedValue({
+      searchClimbs: {
+        climbs: [
+          { uuid: 'draft-1', name: 'A', frames: '', angle: 40 },
+          { uuid: 'draft-2', name: 'B', frames: '', angle: 40 },
+        ],
+        hasMore: false,
+      },
+    });
+    renderDrawer();
+    await waitFor(() => {
+      expect(screen.getByText('2 drafts')).toBeTruthy();
+    });
+  });
+
+  it('navigates to the climb view and closes when a draft is selected', async () => {
+    const onClose = vi.fn();
+    mockRequest.mockResolvedValue({
+      searchClimbs: {
+        climbs: [{ uuid: 'draft-1', name: 'My Draft', frames: '', angle: 40 }],
+        hasMore: false,
+      },
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsDrawer open onClose={onClose} boardDetails={boardDetails} angle={40} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => screen.getByTestId('climb-item-draft-1'));
+    fireEvent.click(screen.getByTestId('climb-item-draft-1'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    // URL should include the board name, layout, size, sets, angle and climb uuid/name
+    const pushedUrl: string = mockPush.mock.calls[0][0];
+    expect(pushedUrl).toContain('kilter');
+    expect(pushedUrl).toContain('draft-1');
+  });
+
+  it('passes onlyDrafts: true in the query variables', async () => {
+    mockRequest.mockResolvedValue({ searchClimbs: { climbs: [], hasMore: false } });
+    renderDrawer();
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+    const [, variables] = mockRequest.mock.calls[0] as [unknown, { input: Record<string, unknown> }];
+    expect(variables.input.onlyDrafts).toBe(true);
+  });
+
+  it('does not fetch when drawer is closed', () => {
+    mockRequest.mockResolvedValue({ searchClimbs: { climbs: [], hasMore: false } });
+    renderDrawer(false);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
@@ -36,13 +36,21 @@ vi.mock('../../climb-card/climb-list-item', () => ({
 }));
 
 import DraftsDrawer from '../drafts-drawer';
+import type { BoardDetails } from '@/app/lib/types';
 
-const boardDetails = {
-  board_name: 'kilter' as const,
+const boardDetails: BoardDetails = {
+  board_name: 'kilter',
   layout_id: 1,
   size_id: 2,
   set_ids: [3, 4],
-  angle: 40,
+  images_to_holds: {},
+  holdsData: [],
+  edge_left: 0,
+  edge_right: 100,
+  edge_bottom: 0,
+  edge_top: 100,
+  boardHeight: 100,
+  boardWidth: 100,
 };
 
 function renderDrawer(open = true) {

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -209,7 +209,7 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
       </div>
 
       <div className={queueStyles.queueBodyLayout}>
-        <div className={queueStyles.queueScrollContainer} style={{ touchAction: 'pan-y' }}>
+        <div className={queueStyles.queueScrollContainer}>
           {isLoading ? (
             <Box
               sx={{


### PR DESCRIPTION
- Remove `style={{ touchAction: 'pan-y' }}` inline prop from line 212;
  `.queueScrollContainer` already declares `touch-action: pan-y` in CSS,
  making the inline style redundant and violating the project guideline
  against inline styles.
- Add 10 Vitest tests covering: closed state (no render), loading spinner,
  error message, empty state, draft list rendering, singular/plural count
  label, draft selection navigation, onlyDrafts query variable, and
  query disabled when drawer is closed.

https://claude.ai/code/session_01XM5jAm82x6QpPeh9LyyugU