### PR TITLE
Open grade selector upward and deepen selected color token

### DIFF
--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -335,6 +335,8 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           anchorEl={gradeAnchorEl}
           open={Boolean(gradeAnchorEl)}
           onClose={() => setGradeAnchorEl(null)}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           slotProps={{ paper: { sx: { maxHeight: 240 } } }}
         >
           <MenuItem
@@ -351,7 +353,6 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
               <MenuItem
                 key={grade.difficulty_id}
                 selected={isCurrent}
-                autoFocus={isCurrent}
                 onClick={() => {
                   setDifficulty(grade.difficulty_id);
                   setGradeAnchorEl(null);

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -39,9 +39,9 @@ export const themeTokens = {
 
   // Semantic colors
   semantic: {
-    selected: 'rgba(140, 74, 82, 0.18)', // Visible rose tint for selected state
-    selectedHover: '#EFE6E8', // Darker rose tint for hover feedback
-    selectedLight: 'rgba(140, 74, 82, 0.06)', // Very subtle rose highlight
+    selected: 'rgba(175, 45, 60, 0.28)', // Visible rose tint for selected state
+    selectedHover: '#E8C8CC', // Darker rose tint for hover feedback
+    selectedLight: 'rgba(175, 45, 60, 0.10)', // Very subtle rose highlight
     selectedBorder: '#8C4A52', // Matches primary
     background: '#F9FAFB',
     surface: '#FFFFFF',
@@ -170,9 +170,9 @@ export const darkTokens = {
   },
 
   semantic: {
-    selected: 'rgba(140, 74, 82, 0.12)',
-    selectedHover: 'rgba(140, 74, 82, 0.18)',
-    selectedLight: 'rgba(140, 74, 82, 0.08)',
+    selected: 'rgba(175, 45, 60, 0.25)',
+    selectedHover: 'rgba(175, 45, 60, 0.32)',
+    selectedLight: 'rgba(175, 45, 60, 0.12)',
     selectedBorder: '#8C4A52',
     background: '#000000',
     surface: '#0A0A0A',


### PR DESCRIPTION
- Grade menu now opens upward (same anchorOrigin/transformOrigin as the
  tries selector) so it doesn't overlap the queue bar content below
- Removed autoFocus on the current grade so it stays at its natural
  position in the list rather than being scrolled to the bottom edge
- Selected state highlight uses rgba(175,45,60) at higher opacity for a
  noticeably redder, more prominent selection indicator in both light and
  dark mode

https://claude.ai/code/session_01PMoVmYHzn8baY3dZ2KxAqv