### PR TITLE
Prewarm heatmap cache so the fire icon feels instant

### DIFF
--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { AURORA_BOARD_NAMES, getBoardSelectorOptions, isAuroraBoardName } from '@/app/lib/board-constants';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { dbz as db } from '@/app/lib/db/db';
+import { cachedGetHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap-cache';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import type { ParsedBoardRouteParameters } from '@/app/lib/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+// Max concurrent warm-up queries per run. Keeps DB load reasonable while still
+// finishing well inside maxDuration for the largest boards.
+const CONCURRENCY = 4;
+
+type PrewarmRouteParams = {
+  board_name: string;
+};
+
+type WarmTarget = {
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+  angle: number;
+};
+
+async function getAnglesForLayout(boardName: AuroraBoardName, layoutId: number): Promise<number[]> {
+  // Same query used by packages/backend/src/graphql/resolvers/board/queries.ts:44-50
+  const result = await db.execute<{ angle: number }>(sql`
+    SELECT DISTINCT pa.angle
+    FROM board_products_angles pa
+    JOIN board_layouts l
+      ON l.board_type = pa.board_type AND l.product_id = pa.product_id
+    WHERE l.board_type = ${boardName} AND l.id = ${layoutId}
+    ORDER BY pa.angle ASC
+  `);
+  return result.rows.map((row) => Number(row.angle));
+}
+
+function buildTargetsForBoard(
+  boardName: AuroraBoardName,
+  anglesByLayout: Map<number, number[]>,
+): WarmTarget[] {
+  const selectorOptions = getBoardSelectorOptions();
+  const layouts = selectorOptions.layouts[boardName] ?? [];
+  const targets: WarmTarget[] = [];
+
+  for (const layout of layouts) {
+    const angles = anglesByLayout.get(layout.id) ?? [];
+    if (angles.length === 0) continue;
+
+    const sizeKey = `${boardName}-${layout.id}`;
+    const sizes = selectorOptions.sizes[sizeKey] ?? [];
+
+    for (const size of sizes) {
+      const setKey = `${boardName}-${layout.id}-${size.id}`;
+      const sets = selectorOptions.sets[setKey] ?? [];
+      if (sets.length === 0) continue;
+
+      // Warm the cache for the "all sets" combination the board-selector UI
+      // lands on by default — that matches what first-visit anonymous requests hit.
+      const setIds = sets.map((s) => s.id);
+
+      for (const angle of angles) {
+        targets.push({
+          layoutId: layout.id,
+          sizeId: size.id,
+          setIds,
+          angle,
+        });
+      }
+    }
+  }
+
+  return targets;
+}
+
+async function warmTarget(boardName: AuroraBoardName, target: WarmTarget): Promise<void> {
+  const parsedParams: ParsedBoardRouteParameters = {
+    board_name: boardName,
+    layout_id: target.layoutId,
+    size_id: target.sizeId,
+    set_ids: target.setIds,
+    angle: target.angle,
+  };
+
+  // DEFAULT_SEARCH_PARAMS is exactly what urlParamsToSearchParams returns for an
+  // empty querystring, so the warmed cache key matches a real first-visit request
+  // byte-for-byte. Don't substitute anything here or the keys will drift.
+  await cachedGetHoldHeatmapData(parsedParams, DEFAULT_SEARCH_PARAMS);
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<{ warmed: number; failed: number }> {
+  let warmed = 0;
+  let failed = 0;
+  let cursor = 0;
+
+  async function runOne() {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      const item = items[idx];
+      try {
+        await worker(item);
+        warmed++;
+      } catch (error) {
+        failed++;
+        console.error('[prewarm-heatmap] warm failed:', error);
+      }
+    }
+  }
+
+  const runners = Array.from({ length: Math.min(limit, items.length) }, runOne);
+  await Promise.all(runners);
+
+  return { warmed, failed };
+}
+
+export async function GET(request: Request, props: { params: Promise<PrewarmRouteParams> }) {
+  const startedAt = Date.now();
+  const params = await props.params;
+  const { board_name: boardNameParam } = params;
+
+  // Auth check — always require valid CRON_SECRET.
+  const authHeader = request.headers.get('authorization');
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!isAuroraBoardName(boardNameParam)) {
+    return NextResponse.json(
+      {
+        error: `Invalid board name: ${boardNameParam}. Expected one of: ${AURORA_BOARD_NAMES.join(', ')}`,
+      },
+      { status: 400 },
+    );
+  }
+  const boardName = boardNameParam;
+
+  try {
+    console.log(`[prewarm-heatmap] starting for ${boardName}`);
+
+    const selectorOptions = getBoardSelectorOptions();
+    const layouts = selectorOptions.layouts[boardName] ?? [];
+
+    // Fetch angles per layout once (they're the same across all sizes/sets).
+    const anglesByLayout = new Map<number, number[]>();
+    await Promise.all(
+      layouts.map(async (layout) => {
+        try {
+          const angles = await getAnglesForLayout(boardName, layout.id);
+          anglesByLayout.set(layout.id, angles);
+        } catch (error) {
+          console.error(
+            `[prewarm-heatmap] failed to load angles for ${boardName} layout ${layout.id}:`,
+            error,
+          );
+          anglesByLayout.set(layout.id, []);
+        }
+      }),
+    );
+
+    const targets = buildTargetsForBoard(boardName, anglesByLayout);
+    console.log(`[prewarm-heatmap] ${boardName}: ${targets.length} combinations to warm`);
+
+    const { warmed, failed } = await runWithConcurrency(targets, CONCURRENCY, (target) =>
+      warmTarget(boardName, target),
+    );
+
+    const durationMs = Date.now() - startedAt;
+    console.log(
+      `[prewarm-heatmap] ${boardName} done in ${durationMs}ms — warmed=${warmed} failed=${failed}`,
+    );
+
+    return NextResponse.json({
+      board: boardName,
+      total: targets.length,
+      warmed,
+      failed,
+      durationMs,
+    });
+  } catch (error) {
+    console.error(`[prewarm-heatmap] ${boardName} failed:`, error);
+    return NextResponse.json({ success: false, error: 'Prewarm failed' }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
+++ b/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/heatmap/route.ts
@@ -1,64 +1,11 @@
-import { getHoldHeatmapData, HoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap';
-import { BoardRouteParameters, ErrorResponse, ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+import { getHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap';
+import { cachedGetHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap-cache';
+import { BoardRouteParameters, ErrorResponse, SearchRequestPagination } from '@/app/lib/types';
 import { urlParamsToSearchParams } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
-import { sortObjectKeys } from '@/app/lib/cache-utils';
-import { unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
-
-/**
- * Cache duration for heatmap queries (in seconds)
- * Anonymous heatmap queries are cached for 30 days since aggregate data doesn't change meaningfully
- */
-const CACHE_DURATION_HEATMAP = 30 * 24 * 60 * 60; // 30 days
-
-/**
- * Cached version of getHoldHeatmapData
- * Only used for anonymous requests - user-specific data is not cached
- */
-async function cachedGetHoldHeatmapData(
-  params: ParsedBoardRouteParameters,
-  searchParams: SearchRequestPagination,
-): Promise<HoldHeatmapData[]> {
-  // Build explicit cache key with board identifiers as separate segments
-  // This ensures cache hits/misses are correctly differentiated by board configuration
-  const cacheKey = [
-    'heatmap',
-    params.board_name,
-    String(params.layout_id),
-    String(params.size_id),
-    params.set_ids.join(','),
-    String(params.angle),
-    // Include filter params as a sorted JSON string
-    JSON.stringify(sortObjectKeys({
-      gradeAccuracy: searchParams.gradeAccuracy,
-      minGrade: searchParams.minGrade,
-      maxGrade: searchParams.maxGrade,
-      minAscents: searchParams.minAscents,
-      minRating: searchParams.minRating,
-      sortBy: searchParams.sortBy,
-      sortOrder: searchParams.sortOrder,
-      name: searchParams.name,
-      settername: searchParams.settername,
-      onlyClassics: searchParams.onlyClassics,
-      onlyTallClimbs: searchParams.onlyTallClimbs,
-      holdsFilter: searchParams.holdsFilter,
-    })),
-  ];
-
-  const cachedFn = unstable_cache(
-    async () => getHoldHeatmapData(params, searchParams, undefined),
-    cacheKey,
-    {
-      revalidate: CACHE_DURATION_HEATMAP,
-      tags: ['heatmap'],
-    }
-  );
-
-  return cachedFn();
-}
 
 export interface HoldHeatmapResponse {
   holdStats: Array<{
@@ -99,8 +46,8 @@ export async function GET(
     const session = await getServerSession(authOptions);
     const userId = session?.user?.id;
 
-    // Get the heatmap data - use cached version for anonymous requests only
-    // User-specific data is not cached to ensure fresh personal progress data
+    // Get the heatmap data - use cached version for anonymous requests only.
+    // User-specific data is not cached to ensure fresh personal progress data.
     const holdStats = userId
       ? await getHoldHeatmapData(parsedParams, searchParams, userId)
       : await cachedGetHoldHeatmapData(parsedParams, searchParams);

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -713,12 +713,16 @@ export default function CreateClimbForm({
             {/* Aurora-only: Heatmap toggle */}
             {boardType === 'aurora' && (
               <>
-                <MuiTooltip title={showHeatmap ? 'Hide heatmap' : 'Show hold popularity heatmap'}>
+                <Typography variant="body2" component="span" color="text.secondary" className={styles.draftLabel}>
+                  Heatmap
+                </Typography>
+                <MuiTooltip title={showHeatmap ? 'Hide heatmap' : 'Show which holds get used most'}>
                   <IconButton
                     color={showHeatmap ? 'error' : 'default'}
                     size="small"
                     onClick={handleToggleHeatmap}
                     className={styles.heatmapButton}
+                    aria-label={showHeatmap ? 'Hide heatmap' : 'Show heatmap'}
                   >
                     <LocalFireDepartmentOutlined />
                   </IconButton>

--- a/packages/web/app/lib/db/queries/climbs/holds-heatmap-cache.ts
+++ b/packages/web/app/lib/db/queries/climbs/holds-heatmap-cache.ts
@@ -1,0 +1,61 @@
+import { unstable_cache } from 'next/cache';
+import { sortObjectKeys } from '@/app/lib/cache-utils';
+import { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+import { getHoldHeatmapData, HoldHeatmapData } from './holds-heatmap';
+
+/**
+ * Cache duration for heatmap queries (in seconds).
+ * Anonymous heatmap queries are cached for 30 days since aggregate data doesn't change
+ * meaningfully. A weekly cron (see /api/internal/prewarm-heatmap/[board_name]) refreshes
+ * the default zero-holds state for every board configuration so first-visit users always
+ * hit a warm cache.
+ */
+export const CACHE_DURATION_HEATMAP = 30 * 24 * 60 * 60; // 30 days
+
+/**
+ * Cached version of getHoldHeatmapData — only used for anonymous requests.
+ * User-specific data is not cached to ensure fresh personal progress data.
+ *
+ * IMPORTANT: The cache key shape here must exactly match what the heatmap GET route
+ * builds, and what the prewarm endpoint passes in. Any drift means cache misses on
+ * first-visit anonymous requests. All callers should go through this helper.
+ */
+export async function cachedGetHoldHeatmapData(
+  params: ParsedBoardRouteParameters,
+  searchParams: SearchRequestPagination,
+): Promise<HoldHeatmapData[]> {
+  // Build explicit cache key with board identifiers as separate segments
+  // so cache hits/misses are correctly differentiated by board configuration.
+  const cacheKey = [
+    'heatmap',
+    params.board_name,
+    String(params.layout_id),
+    String(params.size_id),
+    params.set_ids.join(','),
+    String(params.angle),
+    // Sorted JSON of the filter subset that affects the query result.
+    JSON.stringify(
+      sortObjectKeys({
+        gradeAccuracy: searchParams.gradeAccuracy,
+        minGrade: searchParams.minGrade,
+        maxGrade: searchParams.maxGrade,
+        minAscents: searchParams.minAscents,
+        minRating: searchParams.minRating,
+        sortBy: searchParams.sortBy,
+        sortOrder: searchParams.sortOrder,
+        name: searchParams.name,
+        settername: searchParams.settername,
+        onlyClassics: searchParams.onlyClassics,
+        onlyTallClimbs: searchParams.onlyTallClimbs,
+        holdsFilter: searchParams.holdsFilter,
+      }),
+    ),
+  ];
+
+  const cachedFn = unstable_cache(async () => getHoldHeatmapData(params, searchParams, undefined), cacheKey, {
+    revalidate: CACHE_DURATION_HEATMAP,
+    tags: ['heatmap'],
+  });
+
+  return cachedFn();
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,26 @@
     {
       "path": "/api/internal/shared-sync/tension",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/internal/prewarm-heatmap/kilter",
+      "schedule": "0 4 * * 0"
+    },
+    {
+      "path": "/api/internal/prewarm-heatmap/tension",
+      "schedule": "15 4 * * 0"
+    },
+    {
+      "path": "/api/internal/prewarm-heatmap/decoy",
+      "schedule": "30 4 * * 0"
+    },
+    {
+      "path": "/api/internal/prewarm-heatmap/touchstone",
+      "schedule": "45 4 * * 0"
+    },
+    {
+      "path": "/api/internal/prewarm-heatmap/grasshopper",
+      "schedule": "0 5 * * 0"
     }
   ]
 }


### PR DESCRIPTION
Issue #1430: the hold-popularity heatmap takes several seconds on first
view, which reads as broken. The route already cached anonymous results
for 30 days, but every (board, layout, size, sets, angle) combo was its
own cache key and nothing warmed them, so first-visit users always paid
the slow path.

Extract the existing cachedGetHoldHeatmapData into a shared module so
the route and a new /api/internal/prewarm-heatmap/[board_name] cron
endpoint build the exact same cache key. The cron iterates every Aurora
layout/size/sets/angle and warms the default (no holds, default filters)
state using DEFAULT_SEARCH_PARAMS — the byte-for-byte key real anonymous
first-visit requests hit. vercel.json runs one cron per board weekly,
staggered Sunday morning so they don't pile up. The existing 30-day TTL
covers the gap.

Also label the fire icon "Heatmap" so new users know what it does.