### PR TITLE
feat: auto-default blank holds to HAND and shrink picker swatches

### DIFF
--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -80,7 +80,7 @@ export function buildOptions(boardName: BoardName): PickerOption[] {
   return options;
 }
 
-const SWATCH_SIZE = 36;
+const SWATCH_SIZE = 25;
 
 export default function HoldTypePicker({
   boardName,
@@ -192,7 +192,7 @@ function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: Swatch
           width: SWATCH_SIZE,
           height: SWATCH_SIZE,
           borderRadius: '50%',
-          border: `3px solid ${ring}`,
+          border: `2px solid ${ring}`,
           backgroundColor: isActive && !isClear ? ring : 'transparent',
           display: 'flex',
           alignItems: 'center',
@@ -201,12 +201,12 @@ function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: Swatch
           boxSizing: 'border-box',
         }}
       >
-        {isClear && <CloseIcon sx={{ fontSize: 18 }} />}
+        {isClear && <CloseIcon sx={{ fontSize: 13 }} />}
       </Box>
       <Typography
         variant="caption"
         sx={{
-          fontSize: 11,
+          fontSize: 8,
           fontWeight: themeTokens.typography.fontWeight.medium,
           lineHeight: 1,
           color: 'text.primary',

--- a/packages/web/app/components/create-climb/use-hold-type-picker.ts
+++ b/packages/web/app/components/create-climb/use-hold-type-picker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { HoldState, LitUpHoldsMap } from '../board-renderer/types';
 
 export type PickerSelection = HoldState | 'OFF';
@@ -22,9 +22,19 @@ interface UseHoldTypePickerOptions {
 export function useHoldTypePicker({ litUpHoldsMap, setHoldState }: UseHoldTypePickerOptions) {
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
 
+  // Ref so handleHoldClick can read the latest map without being recreated on every hold change.
+  const litUpHoldsMapRef = useRef(litUpHoldsMap);
+  litUpHoldsMapRef.current = litUpHoldsMap;
+
   const handleHoldClick = useCallback((holdId: number, anchor: Element) => {
+    // Auto-assign HAND to blank holds so the user gets immediate visual
+    // confirmation that the hold has been selected.
+    const currentState = litUpHoldsMapRef.current[holdId]?.state ?? 'OFF';
+    if (currentState === 'OFF') {
+      setHoldState(holdId, 'HAND');
+    }
     setPickerState({ holdId, anchor });
-  }, []);
+  }, [setHoldState]);
 
   const handleSelect = useCallback(
     (state: PickerSelection) => {


### PR DESCRIPTION
Tapping an unset hold now immediately lights it up in HAND (the most-used
type), giving instant visual confirmation before the picker even appears.
Already-assigned holds keep their current color.

Carousel swatches reduced ~30% (36→25px) to reduce clutter on small screens.

https://claude.ai/code/session_01YaD99M6QzUKUQ4NsUASxCd