### PR TITLE
fix: use commit SHA in screenshot URLs to prevent CDN caching stale images

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -271,16 +271,22 @@ jobs:
             || echo "nothing to commit"
           git push origin "$BRANCH"
 
+          SCREENSHOTS_SHA=$(git rev-parse HEAD)
+          echo "SCREENSHOTS_SHA=$SCREENSHOTS_SHA" >> "$GITHUB_ENV"
+
       - name: Build screenshot gallery
         run: |
           python3 << 'PYEOF'
           import os, glob
 
-          pr   = "${{ github.event.pull_request.number }}"
-          repo = "${{ github.repository }}"
-          sha  = "${{ github.event.pull_request.head.sha }}"
-          run  = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          base = f"https://raw.githubusercontent.com/{repo}/test-screenshots/pr-{pr}"
+          pr            = "${{ github.event.pull_request.number }}"
+          repo          = "${{ github.repository }}"
+          sha           = "${{ github.event.pull_request.head.sha }}"
+          run           = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          screenshots_sha = "${{ env.SCREENSHOTS_SHA }}"
+          # Use the exact commit SHA so GitHub CDN serves fresh images each run
+          # instead of returning a cached response for the branch-name URL.
+          base = f"https://raw.githubusercontent.com/{repo}/{screenshots_sha}/pr-{pr}"
 
           app = sorted(glob.glob(f"/tmp/ss-branch/pr-{pr}/app-store/*.png"))
           hlp = sorted(glob.glob(f"/tmp/ss-branch/pr-{pr}/help/*.png"))


### PR DESCRIPTION
PR comment screenshots were stale because the image URLs pointed to the
branch name (`test-screenshots`) rather than a specific commit SHA.
GitHub's CDN caches raw.githubusercontent.com responses by URL path, so
updating the files on the branch didn't invalidate the cached images in
PR comments.

Now the workflow captures the commit SHA after pushing to test-screenshots
and uses it as the git ref in all image URLs. Each CI run produces a new
commit (new SHA), so the URLs change and fresh images are served.

https://claude.ai/code/session_014LyKvCLAQemtygXokUdEKD