### PR TITLE
Fix hold-indicator test, dark mode dot opacity, and CSS spacing tokens

### DIFF
--- a/packages/web/app/components/create-climb/__tests__/hold-indicator.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/hold-indicator.test.tsx
@@ -18,9 +18,9 @@ describe('HoldIndicator', () => {
     expect(screen.getByText('0/2')).toBeTruthy();
   });
 
-  it('shows the label as tooltip text', () => {
+  it('associates the label via aria-label for accessibility', () => {
     render(<HoldIndicator count={2} max={2} color="#ec4899" label="Finish" />);
-    expect(screen.getByTitle('Finish')).toBeTruthy();
+    expect(screen.getByRole('generic', { name: 'Finish' })).toBeTruthy();
   });
 
   it('renders string count when max is undefined', () => {

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -143,7 +143,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 10px 12px;
+  padding: 8px 12px;
   background-color: var(--semantic-surface);
   border-top: 1px solid var(--neutral-100);
   flex-wrap: wrap;
@@ -201,7 +201,7 @@
   }
 
   .bottomControls {
-    padding: 8px 10px;
+    padding: 8px;
     gap: 8px;
   }
 

--- a/packages/web/app/components/create-climb/hold-indicator.tsx
+++ b/packages/web/app/components/create-climb/hold-indicator.tsx
@@ -17,16 +17,22 @@ export default function HoldIndicator({ count, max, color, label }: HoldIndicato
   const active = count > 0;
   return (
     <MuiTooltip title={label}>
-      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ cursor: 'default' }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={0.5}
+        aria-label={label}
+        sx={{ cursor: 'default' }}
+      >
         <Box
-          sx={{
+          sx={(theme) => ({
             width: 10,
             height: 10,
             borderRadius: '50%',
             backgroundColor: color,
-            opacity: active ? 1 : 0.25,
+            opacity: active ? 1 : theme.palette.mode === 'dark' ? 0.4 : 0.25,
             flexShrink: 0,
-          }}
+          })}
         />
         <Typography
           variant="caption"


### PR DESCRIPTION
- Replace getByTitle('Finish') with getByRole('generic', { name }) —
  MUI Tooltip uses aria-describedby, not a title attribute; add
  aria-label to the Stack so the label is reliably queryable
- Adjust inactive dot opacity in dark mode (0.4) vs light (0.25) so
  the indicator remains visible on near-black surfaces
- Replace non-token 10px padding with 8px (spacing[2]) in the new
  .bottomControls CSS so spacing aligns with the design token scale

https://claude.ai/code/session_0164ufdAUwixezAUq2WkLS6M