### PR TITLE
fix: restore hold type picker caption font size to 11px

### DIFF
--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -206,7 +206,7 @@ function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: Swatch
       <Typography
         variant="caption"
         sx={{
-          fontSize: 8,
+          fontSize: 11,
           fontWeight: themeTokens.typography.fontWeight.medium,
           lineHeight: 1,
           color: 'text.primary',


### PR DESCRIPTION
8px is below the readable threshold and fails WCAG SC 1.4.4. Restores
the label font size to 11px, the previous value before the regression.

https://claude.ai/code/session_012kvBtLojgt1ZzA34MxdwkH