### PR TITLE
Reuse titleCase from queue-add-error-messages; test onConfirmed throw after disconnect

### DIFF
--- a/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
+++ b/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
@@ -133,6 +133,31 @@ describe('useBoardSwitchGuard', () => {
     expect(onConfirmed).toHaveBeenCalledOnce();
   });
 
+  it('still disconnects bluetooth even when onConfirmed throws', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1 }),
+      reason: 'bluetooth',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn().mockImplementation(() => {
+      throw new Error('navigation failed');
+    });
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'tension', layout_id: 2 }), onConfirmed);
+    });
+
+    const args = mockConfirmBoardSwitch.mock.calls[0][0];
+    expect(() => {
+      act(() => {
+        args.onConfirmed();
+      });
+    }).toThrow('navigation failed');
+
+    expect(mockDisconnectAll).toHaveBeenCalledOnce();
+    expect(onConfirmed).toHaveBeenCalledOnce();
+  });
+
   it('falls back to immediate call-through when the confirm provider is missing', () => {
     mockLock = {
       lockedBoard: makeBoard({ board_name: 'kilter' }),

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -9,7 +9,7 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import type { BoardLockReason } from './use-active-board-lock';
-import { titleCase } from './queue-add-error-messages';
+import { titleCase } from '@/app/lib/string-utils';
 
 interface ConfirmArgs {
   reason: BoardLockReason;

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -9,6 +9,7 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import type { BoardLockReason } from './use-active-board-lock';
+import { titleCase } from './queue-add-error-messages';
 
 interface ConfirmArgs {
   reason: BoardLockReason;
@@ -35,8 +36,7 @@ export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue | null {
 }
 
 function formatBoardLabel(board: BoardDetails | BoardRouteIdentity): string {
-  const name = board.board_name.charAt(0).toUpperCase() + board.board_name.slice(1);
-  const parts = [name];
+  const parts = [titleCase(board.board_name)];
   if (board.layout_name) parts.push(board.layout_name);
   if (board.size_name) parts.push(board.size_name);
   return parts.join(' · ');

--- a/packages/web/app/components/board-lock/queue-add-error-messages.ts
+++ b/packages/web/app/components/board-lock/queue-add-error-messages.ts
@@ -1,11 +1,8 @@
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import type { BoardCompatibilityResult } from '@/app/lib/board-compatibility';
+import { titleCase } from '@/app/lib/string-utils';
 
 type QueueAddFailure = Extract<BoardCompatibilityResult, { ok: false }>;
-
-export function titleCase(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
 
 function climbBoardLabel(climb: Climb): string {
   if (climb.boardType) return titleCase(climb.boardType);

--- a/packages/web/app/components/board-lock/queue-add-error-messages.ts
+++ b/packages/web/app/components/board-lock/queue-add-error-messages.ts
@@ -3,7 +3,7 @@ import type { BoardCompatibilityResult } from '@/app/lib/board-compatibility';
 
 type QueueAddFailure = Extract<BoardCompatibilityResult, { ok: false }>;
 
-function titleCase(value: string): string {
+export function titleCase(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 

--- a/packages/web/app/lib/string-utils.ts
+++ b/packages/web/app/lib/string-utils.ts
@@ -1,0 +1,3 @@
+export function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
- Export titleCase from queue-add-error-messages.ts and import it in
  board-switch-confirm-provider.tsx, removing the duplicate
  charAt(0).toUpperCase() logic from formatBoardLabel.
- Add test covering the case where onConfirmed throws after
  disconnectAllBluetooth() has already been called, confirming
  Bluetooth is still disconnected and the error propagates.

https://claude.ai/code/session_016usTcTAx1kPkwZXbS42KzU