### PR TITLE
Rename titleCase to capitalizeFirst for accuracy

### DIFF
--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -9,7 +9,7 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import type { BoardLockReason } from './use-active-board-lock';
-import { titleCase } from '@/app/lib/string-utils';
+import { capitalizeFirst } from '@/app/lib/string-utils';
 
 interface ConfirmArgs {
   reason: BoardLockReason;
@@ -36,7 +36,7 @@ export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue | null {
 }
 
 function formatBoardLabel(board: BoardDetails | BoardRouteIdentity): string {
-  const parts = [titleCase(board.board_name)];
+  const parts = [capitalizeFirst(board.board_name)];
   if (board.layout_name) parts.push(board.layout_name);
   if (board.size_name) parts.push(board.size_name);
   return parts.join(' · ');

--- a/packages/web/app/components/board-lock/queue-add-error-messages.ts
+++ b/packages/web/app/components/board-lock/queue-add-error-messages.ts
@@ -1,16 +1,16 @@
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import type { BoardCompatibilityResult } from '@/app/lib/board-compatibility';
-import { titleCase } from '@/app/lib/string-utils';
+import { capitalizeFirst } from '@/app/lib/string-utils';
 
 type QueueAddFailure = Extract<BoardCompatibilityResult, { ok: false }>;
 
 function climbBoardLabel(climb: Climb): string {
-  if (climb.boardType) return titleCase(climb.boardType);
+  if (climb.boardType) return capitalizeFirst(climb.boardType);
   return 'a different board';
 }
 
 function targetBoardLabel(target: BoardDetails): string {
-  return titleCase(target.board_name);
+  return capitalizeFirst(target.board_name);
 }
 
 function targetSizeLabel(target: BoardDetails): string {

--- a/packages/web/app/lib/string-utils.ts
+++ b/packages/web/app/lib/string-utils.ts
@@ -1,3 +1,3 @@
-export function titleCase(value: string): string {
+export function capitalizeFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }


### PR DESCRIPTION
The titleCase function only capitalizes the first character of a string
('kilter' → 'Kilter'), not each word. Rename to capitalizeFirst to clearly
convey its actual behavior and prevent misuse by future callers expecting
true title-casing (e.g. 'kilter board' → 'Kilter Board').

Updates all usages in:
- packages/web/app/lib/string-utils.ts (function definition)
- packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
- packages/web/app/components/board-lock/queue-add-error-messages.ts

https://claude.ai/code/session_01K9AuRKmZ2Li532YaMstCS8