### PR TITLE
Ask for confirmation when switching layout or size with active session/BT

### DIFF
--- a/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
+++ b/packages/web/app/components/board-lock/__tests__/use-board-switch-guard.test.tsx
@@ -93,6 +93,57 @@ describe('useBoardSwitchGuard', () => {
     expect(mockConfirmBoardSwitch).not.toHaveBeenCalled();
   });
 
+  it('does not open dialog when only set_ids differ', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1, size_id: 1, set_ids: [1, 2] }),
+      reason: 'session',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(
+        makeTarget({ board_name: 'kilter', layout_id: 1, size_id: 1, set_ids: [3, 4] }),
+        onConfirmed,
+      );
+    });
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(mockConfirmBoardSwitch).not.toHaveBeenCalled();
+  });
+
+  it('opens confirmation dialog when layout changes within the same board', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1, size_id: 1 }),
+      reason: 'session',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'kilter', layout_id: 2, size_id: 1 }), onConfirmed);
+    });
+
+    expect(mockConfirmBoardSwitch).toHaveBeenCalledOnce();
+    expect(onConfirmed).not.toHaveBeenCalled();
+  });
+
+  it('opens confirmation dialog when size changes within the same board and layout', () => {
+    mockLock = {
+      lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1, size_id: 1 }),
+      reason: 'bluetooth',
+    };
+    const { result } = renderHook(() => useBoardSwitchGuard());
+    const onConfirmed = vi.fn();
+
+    act(() => {
+      result.current(makeTarget({ board_name: 'kilter', layout_id: 1, size_id: 2 }), onConfirmed);
+    });
+
+    expect(mockConfirmBoardSwitch).toHaveBeenCalledOnce();
+    expect(onConfirmed).not.toHaveBeenCalled();
+  });
+
   it('opens confirmation dialog when switching to a different board', () => {
     mockLock = {
       lockedBoard: makeBoard({ board_name: 'kilter', layout_id: 1 }),

--- a/packages/web/app/components/board-lock/use-board-switch-guard.ts
+++ b/packages/web/app/components/board-lock/use-board-switch-guard.ts
@@ -6,25 +6,16 @@ import { useActiveBoardLock } from './use-active-board-lock';
 import { useBoardSwitchConfirm } from './board-switch-confirm-provider';
 import { disconnectAllBluetooth } from '../board-bluetooth-control/bluetooth-status-store';
 
-function sameSetIds(a: readonly number[], b: readonly number[]): boolean {
-  if (a.length !== b.length) return false;
-  const sa = [...a].sort((x, y) => x - y);
-  const sb = [...b].sort((x, y) => x - y);
-  for (let i = 0; i < sa.length; i++) {
-    if (sa[i] !== sb[i]) return false;
-  }
-  return true;
-}
-
 function isSameBoard(
   a: BoardDetails | BoardRouteIdentity,
   b: BoardDetails | BoardRouteIdentity,
 ): boolean {
+  // set_ids intentionally excluded: changing hold sets is a minor config
+  // change that does not warrant a board-switch confirmation.
   return (
     a.board_name === b.board_name &&
     a.layout_id === b.layout_id &&
-    a.size_id === b.size_id &&
-    sameSetIds(a.set_ids, b.set_ids)
+    a.size_id === b.size_id
   );
 }
 

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -35,8 +35,10 @@ import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
-import { BoardDetails } from '@/app/lib/types';
+import { BoardDetails, BoardName } from '@/app/lib/types';
+import type { BoardRouteIdentity } from '@/app/lib/types';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
+import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
 import {
   type StoredSession,
   getRecentSessions,
@@ -69,6 +71,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
 
   const { mode, toggleMode } = useColorMode();
   const isMoonboard = boardDetails?.board_name === 'moonboard';
+  const guardBoardSwitch = useBoardSwitchGuard();
 
   // Load recent sessions when drawer opens
   useEffect(() => {
@@ -98,11 +101,18 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   }, []);
 
   const handleChangeBoardClick = useCallback((board: UserBoard) => {
-    if (board.slug) {
-      router.push(constructBoardSlugListUrl(board.slug, board.angle));
-    }
-    setShowBoardSelector(false);
-  }, [router]);
+    if (!board.slug) return;
+    const target: BoardRouteIdentity = {
+      board_name: board.boardType as BoardName,
+      layout_id: board.layoutId,
+      size_id: board.sizeId,
+      set_ids: board.setIds.split(',').map(Number),
+    };
+    guardBoardSwitch(target, () => {
+      router.push(constructBoardSlugListUrl(board.slug!, board.angle));
+      setShowBoardSelector(false);
+    });
+  }, [router, guardBoardSwitch]);
 
   const handleChangeConfigClick = useCallback((config: PopularBoardConfig) => {
     const angle = getDefaultAngleForBoard(config.boardType);
@@ -117,9 +127,17 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
       url = tryConstructSlugListUrl(config.boardType, config.layoutId, config.sizeId, config.setIds, angle)
         ?? `/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`;
     }
-    router.push(url);
-    setShowBoardSelector(false);
-  }, [router]);
+    const target: BoardRouteIdentity = {
+      board_name: config.boardType as BoardName,
+      layout_id: config.layoutId,
+      size_id: config.sizeId,
+      set_ids: config.setIds,
+    };
+    guardBoardSwitch(target, () => {
+      router.push(url);
+      setShowBoardSelector(false);
+    });
+  }, [router, guardBoardSwitch]);
 
   const handleSignOut = () => {
     signOut();

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -37,6 +37,7 @@ import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
 import { BoardDetails, BoardName } from '@/app/lib/types';
 import type { BoardRouteIdentity } from '@/app/lib/types';
+import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
 import {
@@ -46,6 +47,10 @@ import {
   extractBoardName,
 } from '@/app/lib/session-history-db';
 import styles from './user-drawer.module.css';
+
+function asBoardName(value: string): BoardName | null {
+  return (SUPPORTED_BOARDS as readonly string[]).includes(value) ? (value as BoardName) : null;
+}
 
 interface UserDrawerProps {
   boardDetails?: BoardDetails | null;
@@ -102,16 +107,22 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
 
   const handleChangeBoardClick = useCallback((board: UserBoard) => {
     if (!board.slug) return;
-    const target: BoardRouteIdentity = {
-      board_name: board.boardType as BoardName,
-      layout_id: board.layoutId,
-      size_id: board.sizeId,
-      set_ids: board.setIds.split(',').map(Number),
-    };
-    guardBoardSwitch(target, () => {
+    const boardName = asBoardName(board.boardType);
+    const navigate = () => {
       router.push(constructBoardSlugListUrl(board.slug!, board.angle));
       setShowBoardSelector(false);
-    });
+    };
+    if (!boardName) {
+      navigate();
+      return;
+    }
+    const target: BoardRouteIdentity = {
+      board_name: boardName,
+      layout_id: board.layoutId,
+      size_id: board.sizeId,
+      set_ids: board.setIds ? board.setIds.split(',').map(Number).filter(Number.isFinite) : [],
+    };
+    guardBoardSwitch(target, navigate);
   }, [router, guardBoardSwitch]);
 
   const handleChangeConfigClick = useCallback((config: PopularBoardConfig) => {
@@ -127,16 +138,22 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
       url = tryConstructSlugListUrl(config.boardType, config.layoutId, config.sizeId, config.setIds, angle)
         ?? `/${config.boardType}/${config.layoutId}/${config.sizeId}/${setIds}/${angle}/list`;
     }
+    const navigate = () => {
+      router.push(url);
+      setShowBoardSelector(false);
+    };
+    const boardName = asBoardName(config.boardType);
+    if (!boardName) {
+      navigate();
+      return;
+    }
     const target: BoardRouteIdentity = {
-      board_name: config.boardType as BoardName,
+      board_name: boardName,
       layout_id: config.layoutId,
       size_id: config.sizeId,
       set_ids: config.setIds,
     };
-    guardBoardSwitch(target, () => {
-      router.push(url);
-      setShowBoardSelector(false);
-    });
+    guardBoardSwitch(target, navigate);
   }, [router, guardBoardSwitch]);
 
   const handleSignOut = () => {


### PR DESCRIPTION
The board-switch guard was bypassed in the UserDrawer: handleChangeBoardClick
and handleChangeConfigClick called router.push directly without going through
useBoardSwitchGuard, so tapping a different layout (e.g. Kilter OG) from the
avatar menu skipped the confirmation dialog entirely.

- Wire useBoardSwitchGuard into both UserDrawer board-pick handlers
- Drop set_ids from isSameBoard(): changing hold sets is a minor config tweak
  that doesn't need a board-switch confirmation; only board_name, layout_id,
  and size_id matter
- Add three new guard tests: layout-only change → dialog, size-only change →
  dialog, set_ids-only change → no dialog

https://claude.ai/code/session_0139PznwueZpHKVdV8iAwYLs