### PR TITLE
fix: prevent unhandled promise rejections from WebSocket DOM Events

### DIFF
--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -168,7 +168,12 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
           if (!hasResolved) {
             hasResolved = true;
             unsubscribe();
-            reject(err);
+            // graphql-ws can pass a raw DOM Event (ErrorEvent/CloseEvent) when the
+            // WebSocket connection fails. Rejecting with a DOM Event causes Sentry to
+            // report "Event `Event` (type=error) captured as promise rejection" and
+            // prevents catch blocks from seeing a useful message. Always reject with
+            // a proper Error so callers receive a catchable, inspectable value.
+            reject(err instanceof Error ? err : new Error(String(err)));
           }
         },
         complete: () => {

--- a/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
@@ -148,10 +148,14 @@ export function useOfflineReconciliation({
         unsubscribe();
 
         if (shouldClientWin(event.sequence)) {
-          reconcileClientWins();
+          reconcileClientWins().catch((err) =>
+            console.error('[OfflineReconciliation] reconcileClientWins failed:', err),
+          );
         } else {
           const serverQueue = (event.state?.queue ?? []) as ClimbQueueItem[];
-          reconcileAdditionsOnly(serverQueue);
+          reconcileAdditionsOnly(serverQueue).catch((err) =>
+            console.error('[OfflineReconciliation] reconcileAdditionsOnly failed:', err),
+          );
         }
       }
     });
@@ -162,7 +166,9 @@ export function useOfflineReconciliation({
     // items are skipped. This is a best-effort fallback.
     timeoutId = setTimeout(() => {
       unsubscribe();
-      reconcileAdditionsOnly(currentQueueRef.current);
+      reconcileAdditionsOnly(currentQueueRef.current).catch((err) =>
+        console.error('[OfflineReconciliation] timeout reconcileAdditionsOnly failed:', err),
+      );
     }, RECONCILIATION_TIMEOUT_MS);
 
     return () => {


### PR DESCRIPTION
graphql-ws passes raw DOM ErrorEvent/CloseEvent objects to subscription
error sinks when a WebSocket connection fails. In execute(), this value
was passed directly to reject(), producing Sentry's "Event `Event`
(type=error) captured as promise rejection" report — especially visible
on Mobile Safari (WKWebView) where the WebSocket error fires before
hydration settles.

Fix 1: Normalize the rejection in execute()'s error sink to always be a
proper Error object (following the existing pattern in the codebase),
so catch blocks and Sentry always see an inspectable Error.

Fix 2: Add .catch() handlers to the three unawaited calls to
reconcileClientWins() and reconcileAdditionsOnly() in
use-offline-reconciliation.ts. These async functions have internal
try-catch blocks covering the persistentSession.* calls, but any
exception escaping those blocks (e.g. from offlineBuffer.clearBuffer())
would otherwise become an unhandled rejection.

https://claude.ai/code/session_01AkYn7QRzjogGe1nTHDgvGi