### PR TITLE
Auto-activate board when selecting a climb from a playlist

### DIFF
--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -69,6 +69,38 @@ vi.mock('@/app/lib/url-utils', () => ({
   },
 }));
 
+// Mock playlist board-config helper so cold-start seeding tests don't pull in
+// the real board constants data. Returns a simple, deterministic BoardDetails
+// shape per board type that the seed helper can stringify into baseBoardPath.
+vi.mock('@/app/lib/board-config-for-playlist', () => ({
+  getBoardDetailsForPlaylist: (boardType: string, layoutId: number | null | undefined) => {
+    if (!layoutId) return null;
+    if (boardType === 'moonboard') {
+      return {
+        board_name: 'moonboard',
+        layout_id: layoutId,
+        size_id: 0,
+        set_ids: [17, 18],
+        layout_name: 'MoonBoard 2024',
+        size_name: 'Full',
+        size_description: 'Full',
+        set_names: ['A', 'B'],
+      };
+    }
+    return {
+      board_name: boardType,
+      layout_id: layoutId,
+      size_id: 10,
+      set_ids: [1, 2],
+      layout_name: 'Original',
+      size_name: '12x12',
+      size_description: 'Full Size',
+      set_names: ['Standard', 'Extended'],
+    };
+  },
+  getDefaultAngleForBoard: () => 40,
+}));
+
 // Now import the SUT — after all vi.mock calls
 import {
   QueueBridgeProvider,
@@ -525,6 +557,87 @@ describe('queue-bridge-context', () => {
         expect(newQueue[1].climb.uuid).toBe('c2');
         // New item becomes current
         expect(newCurrent.climb.uuid).toBe('c2');
+      });
+    });
+
+    // -------------------------------------------------------------------
+    // Cold-start seeding: selecting a climb from a surface with no active
+    // board (e.g. a playlist view) must auto-activate the climb's board.
+    // -------------------------------------------------------------------
+    describe('adapter cold-start seeding', () => {
+      function renderWithoutLocalBoard() {
+        mockPersistentSession = createDefaultPersistentSession({
+          localQueue: [],
+          localCurrentClimbQueueItem: null,
+          localBoardDetails: null,
+          localBoardPath: null,
+          isLocalQueueLoaded: true,
+        });
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+          <QueueBridgeProvider>{children}</QueueBridgeProvider>
+        );
+        return renderHook(() => useTestQueueContext(), { wrapper });
+      }
+
+      it('setCurrentClimb seeds local state from a Kilter climb when no board is active', () => {
+        const climb = createTestClimb({ uuid: 'c-cold', boardType: 'kilter', layoutId: 1 });
+        const { result } = renderWithoutLocalBoard();
+        act(() => {
+          result.current!.setCurrentClimb(climb);
+        });
+        expect(mockSetLocalQueueState).toHaveBeenCalledTimes(1);
+        const [newQueue, newCurrent, boardPath, boardDetails] =
+          mockSetLocalQueueState.mock.calls[0];
+        expect(newQueue).toHaveLength(1);
+        expect(newQueue[0].climb.uuid).toBe('c-cold');
+        expect(newCurrent.climb.uuid).toBe('c-cold');
+        expect(boardPath).toBe('/kilter/1/10/1,2');
+        expect(boardDetails.board_name).toBe('kilter');
+        expect(boardDetails.layout_id).toBe(1);
+      });
+
+      it('setCurrentClimb seeds with moonboard path shape (no size segment)', () => {
+        const climb = createTestClimb({ uuid: 'mb-1', boardType: 'moonboard', layoutId: 99 });
+        const { result } = renderWithoutLocalBoard();
+        act(() => {
+          result.current!.setCurrentClimb(climb);
+        });
+        expect(mockSetLocalQueueState).toHaveBeenCalledTimes(1);
+        const [, , boardPath, boardDetails] = mockSetLocalQueueState.mock.calls[0];
+        expect(boardPath).toBe('/moonboard/99/17,18');
+        expect(boardDetails.board_name).toBe('moonboard');
+      });
+
+      it('addToQueue seeds local state from the climb when no board is active', () => {
+        const climb = createTestClimb({ uuid: 'c-add', boardType: 'tension', layoutId: 2 });
+        const { result } = renderWithoutLocalBoard();
+        act(() => {
+          result.current!.addToQueue(climb);
+        });
+        expect(mockSetLocalQueueState).toHaveBeenCalledTimes(1);
+        const [newQueue, newCurrent, boardPath] = mockSetLocalQueueState.mock.calls[0];
+        expect(newQueue).toHaveLength(1);
+        expect(newQueue[0].climb.uuid).toBe('c-add');
+        expect(newCurrent.climb.uuid).toBe('c-add');
+        expect(boardPath).toBe('/tension/2/10/1,2');
+      });
+
+      it('setCurrentClimb is a no-op when the climb has no layoutId to seed from', () => {
+        const climb = createTestClimb({ uuid: 'orphan', boardType: 'kilter', layoutId: null });
+        const { result } = renderWithoutLocalBoard();
+        act(() => {
+          result.current!.setCurrentClimb(climb);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+
+      it('setCurrentClimb is a no-op when the climb has no boardType to seed from', () => {
+        const climb = createTestClimb({ uuid: 'orphan', boardType: undefined, layoutId: 1 });
+        const { result } = renderWithoutLocalBoard();
+        act(() => {
+          result.current!.setCurrentClimb(climb);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -16,6 +16,7 @@ import type { ClimbQueueItem } from './types';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
+import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
 import { useSnackbar } from '../providers/snackbar-provider';
 import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
 
@@ -23,6 +24,29 @@ const LiveActivityBridge = dynamic(
   () => import('@/app/lib/live-activity/live-activity-bridge'),
   { ssr: false },
 );
+
+/**
+ * Derive BoardDetails + baseBoardPath from a climb's own boardType/layoutId.
+ *
+ * Used to seed `ps.localBoardDetails` when a user selects a climb from a
+ * surface that has no active board context (e.g. a playlist view when the
+ * user has never been on a board route). The resulting `baseBoardPath` must
+ * match `getBaseBoardPath` output so queue restoration (`use-queue-restoration`)
+ * and party-session transfer (`start-sesh-drawer`) keep working.
+ */
+function deriveSeedStateFromClimb(
+  climb: Climb,
+): { boardDetails: BoardDetails; baseBoardPath: string } | null {
+  if (!climb.boardType || climb.layoutId == null) return null;
+  const details = getBoardDetailsForPlaylist(climb.boardType, climb.layoutId);
+  if (!details) return null;
+  const setIds = details.set_ids.join(',');
+  const baseBoardPath =
+    details.board_name === 'moonboard'
+      ? `/moonboard/${details.layout_id}/${setIds}`
+      : `/${details.board_name}/${details.layout_id}/${details.size_id}/${setIds}`;
+  return { boardDetails: details, baseBoardPath };
+}
 
 // -------------------------------------------------------------------
 // Board info context (for the root-level bottom bar to know what board is active)
@@ -163,7 +187,6 @@ function usePersistentSessionQueueAdapter(): {
   const addToQueue = useCallback(
     (climb: Climb) => {
       const r = latestRef.current;
-      if (!r.boardDetails) return;
       if (!validateClimbForQueue(climb)) return;
       const newItem: ClimbQueueItem = {
         climb,
@@ -171,6 +194,14 @@ function usePersistentSessionQueueAdapter(): {
         uuid: uuidv4(),
         suggested: false,
       };
+      if (!r.boardDetails) {
+        // Cold-start path: no active board yet. Seed local state from the
+        // climb's own board config so the queue bar begins showing.
+        const seed = deriveSeedStateFromClimb(climb);
+        if (!seed) return;
+        r.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        return;
+      }
       const newQueue = [...r.queue, newItem];
       const current = r.currentClimbQueueItem ?? newItem;
       r.ps.setLocalQueueState(newQueue, current, r.baseBoardPath, r.boardDetails);
@@ -220,7 +251,6 @@ function usePersistentSessionQueueAdapter(): {
   const setCurrentClimb = useCallback(
     (climb: Climb) => {
       const r = latestRef.current;
-      if (!r.boardDetails) return;
       if (!validateClimbForQueue(climb)) return;
       const newItem: ClimbQueueItem = {
         climb,
@@ -228,6 +258,14 @@ function usePersistentSessionQueueAdapter(): {
         uuid: uuidv4(),
         suggested: false,
       };
+      if (!r.boardDetails) {
+        // Cold-start path: no active board yet. Seed local state from the
+        // climb's own board config so the queue bar begins showing.
+        const seed = deriveSeedStateFromClimb(climb);
+        if (!seed) return;
+        r.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        return;
+      }
       const currentIdx = r.currentClimbQueueItem
         ? r.queue.findIndex(q => q.uuid === r.currentClimbQueueItem!.uuid)
         : -1;

--- a/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
@@ -142,6 +142,20 @@ describe('useBoardDetailsMap', () => {
     expect(result.current.unsupportedClimbs.has('c2')).toBe(true);
   });
 
+  it('should not mark any climbs as unsupported when the user owns zero boards', () => {
+    // Users without any registered boards shouldn't see climbs greyed out —
+    // selection auto-activates the climb's own board config downstream.
+    const climb1 = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const climb2 = makeClimb({ uuid: 'c2', boardType: 'tension', layoutId: 2 });
+    mockGetBoardDetailsForPlaylist.mockReturnValue(makeBoardDetails('kilter'));
+
+    const { result } = renderHook(() =>
+      useBoardDetailsMap([climb1, climb2], []),
+    );
+
+    expect(result.current.unsupportedClimbs.size).toBe(0);
+  });
+
   it('should return defaultBoardDetails from selectedBoard when provided', () => {
     const selectedBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1 });
     const selectedDetails = makeBoardDetails('kilter-selected');

--- a/packages/web/app/hooks/use-board-details-map.ts
+++ b/packages/web/app/hooks/use-board-details-map.ts
@@ -59,11 +59,16 @@ export function useBoardDetailsMap(
       }
     }
 
-    // Mark unsupported climbs (board types the user doesn't have)
-    const userBoardTypes = new Set(myBoards.map((b) => b.boardType));
-    for (const climb of climbs) {
-      if (climb.boardType && !userBoardTypes.has(climb.boardType)) {
-        unsupported.add(climb.uuid);
+    // Mark unsupported climbs (board types the user doesn't have).
+    // Only meaningful when the user actually owns at least one board — when
+    // myBoards is empty we can't filter by ownership, so we render every climb
+    // normally and let selection auto-activate the climb's own board config.
+    if (myBoards.length > 0) {
+      const userBoardTypes = new Set(myBoards.map((b) => b.boardType));
+      for (const climb of climbs) {
+        if (climb.boardType && !userBoardTypes.has(climb.boardType)) {
+          unsupported.add(climb.uuid);
+        }
       }
     }
 


### PR DESCRIPTION
When a user with no active board visited a playlist, every climb rendered
greyed out and clicking did nothing. The root bridge adapter's
setCurrentClimb/addToQueue bailed out on null boardDetails, and
useBoardDetailsMap marked every climb as unsupported when the user owned
zero boards.

Seed local board state from the climb's own boardType/layoutId inside
the bridge adapter so selection activates the queue bar. Suppress the
unsupported marking when the user has no boards to compare against.

https://claude.ai/code/session_011UytPRnTtwyMX2tadQ9tfS