### PR TITLE
Render playlist climbs on the user's session board

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -640,8 +640,8 @@ const ClimbsList = ({
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert severity="warning" onClose={handleCloseBiggerBoard} variant="filled">
-          <AlertTitle>Bigger board needed</AlertTitle>
-          This climb needs a bigger board than your current setup.
+          <AlertTitle>Won&apos;t fit your board</AlertTitle>
+          This one runs off the edge of your wall. You&apos;ll need a bigger size to send it.
         </Alert>
       </Snackbar>
     </Box>

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -2,6 +2,9 @@
 import React, { useEffect, useCallback, useState, useMemo, useRef, useImperativeHandle, forwardRef } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import { usePathname } from 'next/navigation';
@@ -148,8 +151,9 @@ SharedDrawers.displayName = 'SharedDrawers';
 
 export type ClimbsListProps = {
   boardDetails: BoardDetails;
-  boardDetailsMap?: Record<string, BoardDetails>;
+  boardDetailsByClimb?: Record<string, BoardDetails>;
   unsupportedClimbs?: Set<string>;
+  upsizedClimbs?: Set<string>;
   initialImageCount?: number;
   climbs: Climb[];
   selectedClimbUuid?: string | null;
@@ -184,7 +188,9 @@ type GridClimbItemProps = {
   boardDetails: BoardDetails;
   preferImageLayers: boolean;
   unsupported?: boolean;
+  needsBiggerBoard?: boolean;
   onClimbClickByIndex: (index: number) => void;
+  onNeedsBiggerBoard?: () => void;
   renderItemExtra?: (climb: Climb) => React.ReactNode;
 };
 
@@ -194,10 +200,18 @@ const GridClimbItem = React.memo(function GridClimbItem({
   boardDetails,
   preferImageLayers,
   unsupported,
+  needsBiggerBoard,
   onClimbClickByIndex,
+  onNeedsBiggerBoard,
   renderItemExtra,
 }: GridClimbItemProps) {
-  const handleCoverClick = useCallback(() => onClimbClickByIndex(index), [onClimbClickByIndex, index]);
+  const handleCoverClick = useCallback(() => {
+    if (needsBiggerBoard) {
+      onNeedsBiggerBoard?.();
+      return;
+    }
+    onClimbClickByIndex(index);
+  }, [onClimbClickByIndex, index, needsBiggerBoard, onNeedsBiggerBoard]);
   return (
     <>
       <div {...(index === 0 ? { id: 'onboarding-climb-card' } : {})}>
@@ -206,7 +220,7 @@ const GridClimbItem = React.memo(function GridClimbItem({
           boardDetails={boardDetails}
           preferImageLayers={preferImageLayers}
           onCoverClick={handleCoverClick}
-          unsupported={unsupported}
+          unsupported={unsupported || needsBiggerBoard}
         />
       </div>
       {renderItemExtra?.(climb)}
@@ -216,8 +230,9 @@ const GridClimbItem = React.memo(function GridClimbItem({
 
 const ClimbsList = ({
   boardDetails,
-  boardDetailsMap,
+  boardDetailsByClimb,
   unsupportedClimbs,
+  upsizedClimbs,
   initialImageCount = 0,
   climbs,
   selectedClimbUuid,
@@ -359,17 +374,21 @@ const ClimbsList = ({
 
   const resolveBoardDetails = useCallback(
     (climb: Climb): BoardDetails => {
-      if (boardDetailsMap && climb.boardType && climb.layoutId != null) {
-        const key = `${climb.boardType}:${climb.layoutId}`;
-        return boardDetailsMap[key] || boardDetails;
+      if (boardDetailsByClimb) {
+        const resolved = boardDetailsByClimb[climb.uuid];
+        if (resolved) return resolved;
       }
       return boardDetails;
     },
-    [boardDetails, boardDetailsMap],
+    [boardDetails, boardDetailsByClimb],
   );
 
   // --- Shared drawers via imperative handle (state lives in SharedDrawers, not here) ---
   const drawerRef = useRef<SharedDrawerHandle>(null);
+
+  const [biggerBoardOpen, setBiggerBoardOpen] = useState(false);
+  const handleNeedsBiggerBoard = useCallback(() => setBiggerBoardOpen(true), []);
+  const handleCloseBiggerBoard = useCallback(() => setBiggerBoardOpen(false), []);
 
   const handleOpenActions = useCallback((climb: Climb) => {
     if (process.env.NODE_ENV !== 'production' && !drawerRef.current) {
@@ -532,7 +551,9 @@ const ClimbsList = ({
                 boardDetails={resolveBoardDetails(climb)}
                 preferImageLayers={index < initialImageCount}
                 unsupported={unsupportedClimbs?.has(climb.uuid)}
+                needsBiggerBoard={upsizedClimbs?.has(climb.uuid)}
                 onClimbClickByIndex={handleClimbThumbnailClickByIndex}
+                onNeedsBiggerBoard={handleNeedsBiggerBoard}
                 renderItemExtra={renderItemExtra}
               />
             </Box>
@@ -577,6 +598,8 @@ const ClimbsList = ({
                       onThumbnailClick={() => handleClimbThumbnailClickByIndex(index)}
                       disableSwipe={!hydrated}
                       unsupported={unsupportedClimbs?.has(climb.uuid)}
+                      needsBiggerBoard={upsizedClimbs?.has(climb.uuid)}
+                      onNeedsBiggerBoard={handleNeedsBiggerBoard}
                       onOpenActions={handleOpenActions}
                       onOpenPlaylistSelector={handleOpenPlaylistSelector}
                       addToQueue={addToQueue}
@@ -609,6 +632,18 @@ const ClimbsList = ({
 
       {/* Shared drawers — owns its own state so open/close doesn't re-render the list */}
       <SharedDrawers ref={drawerRef} boardDetails={boardDetails} resolveBoardDetails={resolveBoardDetails} />
+
+      <Snackbar
+        open={biggerBoardOpen}
+        autoHideDuration={4000}
+        onClose={handleCloseBiggerBoard}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="warning" onClose={handleCloseBiggerBoard} variant="filled">
+          <AlertTitle>Bigger board needed</AlertTitle>
+          This climb needs a bigger board than your current setup.
+        </Alert>
+      </Snackbar>
     </Box>
     </SelectionStoreContext.Provider>
   );

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -151,6 +151,10 @@ type ClimbListItemProps = {
   selected?: boolean;
   /** When true, the item is visually dimmed (greyed out) but still interactive */
   unsupported?: boolean;
+  /** When true, the climb fits only on a bigger board than the user's current session — render dimmed and route clicks to `onNeedsBiggerBoard` instead of selecting. */
+  needsBiggerBoard?: boolean;
+  /** Fired when the user taps a `needsBiggerBoard` item, so the parent can show a warning. */
+  onNeedsBiggerBoard?: () => void;
   /** When true, swipe gestures (favorite/queue) are disabled */
   disableSwipe?: boolean;
   onSelect?: () => void;
@@ -186,6 +190,8 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     isDark,
     selected: selectedOverride,
     unsupported,
+    needsBiggerBoard,
+    onNeedsBiggerBoard,
     disableSwipe,
     onSelect,
     swipeRightAction,
@@ -322,13 +328,36 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       }
     }, [disableSwipe, swipeHandlers, contentRef]);
 
+    // Stable refs so the memoized handlers below stay stable across renders
+    // even when the bigger-board callback identity changes.
+    const onNeedsBiggerBoardRef = useRef(onNeedsBiggerBoard);
+    onNeedsBiggerBoardRef.current = onNeedsBiggerBoard;
+    const needsBiggerBoardRef = useRef(needsBiggerBoard);
+    needsBiggerBoardRef.current = needsBiggerBoard;
+    const onSelectRef = useRef(onSelect);
+    onSelectRef.current = onSelect;
+
     // Thumbnail click handler — uses ref to avoid stale closure.
     // Always attached (not conditional) because onThumbnailClick is excluded from
     // the memo comparator; a render-time conditional would go stale.
     const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
+      if (needsBiggerBoardRef.current) {
+        e.stopPropagation();
+        onNeedsBiggerBoardRef.current?.();
+        return;
+      }
       if (!onThumbnailClickRef.current) return;
       e.stopPropagation();
       onThumbnailClickRef.current();
+    }, []);
+
+    // Row click — same interception for the bigger-board case.
+    const handleRowClick = useCallback(() => {
+      if (needsBiggerBoardRef.current) {
+        onNeedsBiggerBoardRef.current?.();
+        return;
+      }
+      onSelectRef.current?.();
     }, []);
 
     // Drawer state callbacks — extracted from inline to avoid per-render allocation
@@ -360,9 +389,9 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       () => ({
         position: 'relative' as const,
         overflow: 'hidden' as const,
-        ...(unsupported ? { opacity: 0.5, filter: 'grayscale(80%)' } : {}),
+        ...(unsupported || needsBiggerBoard ? { opacity: 0.5, filter: 'grayscale(80%)' } : {}),
       }),
-      [unsupported],
+      [unsupported, needsBiggerBoard],
     );
 
 
@@ -471,7 +500,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
           <div
             {...(disableSwipe ? {} : swipeHandlers)}
             ref={contentCombinedRef}
-            onClick={onSelect}
+            onClick={handleRowClick}
             style={swipeableContentStyle}
           >
             {/* Thumbnail */}
@@ -561,6 +590,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       prev.isDark === next.isDark &&
       prev.selected === next.selected &&
       prev.unsupported === next.unsupported &&
+      prev.needsBiggerBoard === next.needsBiggerBoard &&
       prev.disableSwipe === next.disableSwipe &&
       prev.boardDetails === next.boardDetails &&
       prev.swipeRightAction === next.swipeRightAction &&

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -13,8 +13,9 @@ import BoardFilterStrip from '@/app/components/board-scroll/board-filter-strip';
 import ClimbsList from '@/app/components/board-page/climbs-list';
 import { FavoritesProvider } from '@/app/components/climb-actions/favorites-batch-context';
 import { PlaylistsProvider } from '@/app/components/climb-actions/playlists-batch-context';
-import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import { getDefaultAngleForBoard, type SessionBoardConfig } from '@/app/lib/board-config-for-playlist';
 import { useOptionalQueueActions } from '@/app/components/graphql-queue';
+import { usePersistentSessionState } from '@/app/components/persistent-session/persistent-session-context';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { Climb } from '@/app/lib/types';
 
@@ -71,10 +72,26 @@ export default function MultiboardClimbList({
 }: MultiboardClimbListProps) {
   const { boards: myBoards, isLoading: isLoadingBoards } = useMyBoards(true);
 
-  const { boardDetailsMap, defaultBoardDetails, unsupportedClimbs } = useBoardDetailsMap(
+  // Prefer the user's active session (the board they are actually climbing on)
+  // so playlist previews match the physical wall. Falls back to the list's
+  // selected board when there is no session.
+  const { activeSession } = usePersistentSessionState();
+  const sessionBoard: SessionBoardConfig | null = useMemo(() => {
+    if (!activeSession?.parsedParams) return null;
+    const { board_name, layout_id, size_id, set_ids } = activeSession.parsedParams;
+    return {
+      boardType: board_name,
+      layoutId: layout_id,
+      sizeId: size_id,
+      setIds: set_ids,
+    };
+  }, [activeSession]);
+
+  const { boardDetailsByClimb, defaultBoardDetails, unsupportedClimbs, upsizedClimbs } = useBoardDetailsMap(
     climbs,
     myBoards,
     selectedBoard,
+    sessionBoard,
     fallbackBoardTypes,
   );
 
@@ -182,8 +199,9 @@ export default function MultiboardClimbList({
           <PlaylistsProvider {...playlistsProviderProps}>
             <ClimbsList
               boardDetails={defaultBoardDetails}
-              boardDetailsMap={boardDetailsMap}
+              boardDetailsByClimb={boardDetailsByClimb}
               unsupportedClimbs={unsupportedClimbs}
+              upsizedClimbs={upsizedClimbs}
               climbs={climbs}
               selectedClimbUuid={effectiveSelectedUuid}
               isFetching={isFetching}

--- a/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
@@ -203,4 +203,47 @@ describe('useBoardDetailsMap', () => {
 
     expect(Object.keys(result.current.boardDetailsByClimb)).toHaveLength(0);
   });
+
+  it('should synthesize session config from selectedBoard when no sessionBoard provided', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const selectedBoard = makeUserBoard({
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      // Includes an invalid entry to exercise the Number.isFinite filter.
+      setIds: '1,2,abc',
+    });
+    const details = makeBoardDetails('kilter-selected');
+    mockGetUserBoardDetails.mockReturnValue(details);
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'exact' });
+
+    renderHook(() => useBoardDetailsMap([climb], [selectedBoard], selectedBoard));
+
+    // The resolver should be invoked with the synthesized session config —
+    // boardType/layoutId/sizeId from the selected board and numeric set IDs
+    // parsed from its comma-separated setIds string.
+    expect(mockResolveBoardDetailsForClimb).toHaveBeenCalledWith(climb, {
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [1, 2],
+    });
+  });
+
+  it('should prefer sessionBoard over selectedBoard when both are provided', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const selectedBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sessionBoard = {
+      boardType: 'kilter' as const,
+      layoutId: 1,
+      sizeId: 27,
+      setIds: [1, 20],
+    };
+    const details = makeBoardDetails('kilter');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'exact' });
+
+    renderHook(() => useBoardDetailsMap([climb], [selectedBoard], selectedBoard, sessionBoard));
+
+    expect(mockResolveBoardDetailsForClimb).toHaveBeenCalledWith(climb, sessionBoard);
+  });
 });

--- a/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
@@ -210,8 +210,8 @@ describe('useBoardDetailsMap', () => {
       boardType: 'kilter',
       layoutId: 1,
       sizeId: 10,
-      // Includes an invalid entry to exercise the Number.isFinite filter.
-      setIds: '1,2,abc',
+      // Includes an invalid entry and a zero to exercise the numeric filter.
+      setIds: '1,2,abc,0',
     });
     const details = makeBoardDetails('kilter-selected');
     mockGetUserBoardDetails.mockReturnValue(details);
@@ -227,6 +227,27 @@ describe('useBoardDetailsMap', () => {
       layoutId: 1,
       sizeId: 10,
       setIds: [1, 2],
+    });
+  });
+
+  it('should synthesize an empty setIds array when selectedBoard.setIds is empty', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const selectedBoard = makeUserBoard({
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '',
+    });
+    const details = makeBoardDetails('kilter-selected');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'exact' });
+
+    renderHook(() => useBoardDetailsMap([climb], [selectedBoard], selectedBoard));
+
+    expect(mockResolveBoardDetailsForClimb).toHaveBeenCalledWith(climb, {
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [],
     });
   });
 

--- a/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-board-details-map.test.ts
@@ -5,15 +5,21 @@ import { renderHook } from '@testing-library/react';
 vi.mock('@/app/lib/board-config-for-playlist', () => ({
   getUserBoardDetails: vi.fn(),
   getBoardDetailsForPlaylist: vi.fn(),
+  resolveBoardDetailsForClimb: vi.fn(),
 }));
 
 import { useBoardDetailsMap } from '../use-board-details-map';
-import { getUserBoardDetails, getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
+import {
+  getUserBoardDetails,
+  getBoardDetailsForPlaylist,
+  resolveBoardDetailsForClimb,
+} from '@/app/lib/board-config-for-playlist';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 
 const mockGetUserBoardDetails = vi.mocked(getUserBoardDetails);
 const mockGetBoardDetailsForPlaylist = vi.mocked(getBoardDetailsForPlaylist);
+const mockResolveBoardDetailsForClimb = vi.mocked(resolveBoardDetailsForClimb);
 
 function makeClimb(overrides: Partial<Climb> = {}): Climb {
   return {
@@ -70,76 +76,57 @@ describe('useBoardDetailsMap', () => {
   });
 
   it('should return empty map when no climbs provided', () => {
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([], []),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([], []));
 
-    expect(Object.keys(result.current.boardDetailsMap)).toHaveLength(0);
+    expect(Object.keys(result.current.boardDetailsByClimb)).toHaveLength(0);
     expect(result.current.unsupportedClimbs.size).toBe(0);
+    expect(result.current.upsizedClimbs.size).toBe(0);
   });
 
-  it('should build boardDetailsMap keyed by "boardType:layoutId"', () => {
-    const climb = makeClimb({ boardType: 'kilter', layoutId: 1 });
-    const genericDetails = makeBoardDetails('kilter');
-    mockGetBoardDetailsForPlaylist.mockReturnValue(genericDetails);
+  it('should key boardDetailsByClimb by climb uuid', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const details = makeBoardDetails('kilter');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'exact' });
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb], []),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([climb], []));
 
-    expect(result.current.boardDetailsMap['kilter:1']).toBe(genericDetails);
+    expect(result.current.boardDetailsByClimb['c1']).toBe(details);
   });
 
-  it('should prefer user board details over generic details', () => {
-    const climb = makeClimb({ boardType: 'kilter', layoutId: 1 });
-    const userBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1 });
-    const userDetails = makeBoardDetails('kilter-user');
-    const genericDetails = makeBoardDetails('kilter-generic');
+  it('should populate upsizedClimbs for climbs that only fit on a bigger size', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const userBoard = makeUserBoard({ boardType: 'kilter' });
+    const details = makeBoardDetails('kilter-bigger');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'upsized' });
 
-    mockGetUserBoardDetails.mockReturnValue(userDetails);
-    mockGetBoardDetailsForPlaylist.mockReturnValue(genericDetails);
+    const { result } = renderHook(() => useBoardDetailsMap([climb], [userBoard]));
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb], [userBoard]),
-    );
-
-    expect(result.current.boardDetailsMap['kilter:1']).toBe(userDetails);
-    // Generic should NOT be called because user board took precedence
-    expect(mockGetBoardDetailsForPlaylist).not.toHaveBeenCalled();
-  });
-
-  it('should fall back to generic details when user does not own that board', () => {
-    const climb = makeClimb({ boardType: 'tension', layoutId: 2 });
-    const genericDetails = makeBoardDetails('tension');
-
-    mockGetBoardDetailsForPlaylist.mockReturnValue(genericDetails);
-
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb], []),
-    );
-
-    expect(result.current.boardDetailsMap['tension:2']).toBe(genericDetails);
-    expect(mockGetBoardDetailsForPlaylist).toHaveBeenCalledWith('tension', 2);
-  });
-
-  it('should populate unsupportedClimbs set for board types user does not own', () => {
-    const climb1 = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
-    const climb2 = makeClimb({ uuid: 'c2', boardType: 'tension', layoutId: 2 });
-    const userBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1 });
-
-    const kilterDetails = makeBoardDetails('kilter');
-    const tensionDetails = makeBoardDetails('tension');
-    mockGetUserBoardDetails.mockReturnValue(kilterDetails);
-    mockGetBoardDetailsForPlaylist.mockReturnValue(tensionDetails);
-
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb1, climb2], [userBoard]),
-    );
-
-    // Kilter climb is supported (user owns kilter board)
+    expect(result.current.upsizedClimbs.has('c1')).toBe(true);
     expect(result.current.unsupportedClimbs.has('c1')).toBe(false);
-    // Tension climb is unsupported (user doesn't own tension board)
-    expect(result.current.unsupportedClimbs.has('c2')).toBe(true);
+    expect(result.current.boardDetailsByClimb['c1']).toBe(details);
+  });
+
+  it('should mark climbs as unsupported when the resolver reports incompatible', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
+    const userBoard = makeUserBoard({ boardType: 'kilter' });
+    const details = makeBoardDetails('fallback');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'incompatible' });
+
+    const { result } = renderHook(() => useBoardDetailsMap([climb], [userBoard]));
+
+    expect(result.current.unsupportedClimbs.has('c1')).toBe(true);
+    expect(result.current.boardDetailsByClimb['c1']).toBe(details);
+  });
+
+  it('should mark climbs unsupported when the user owns none of that board type', () => {
+    const climb = makeClimb({ uuid: 'c1', boardType: 'tension', layoutId: 2 });
+    const kilterBoard = makeUserBoard({ boardType: 'kilter' });
+    const details = makeBoardDetails('tension');
+    mockResolveBoardDetailsForClimb.mockReturnValue({ details, status: 'exact' });
+
+    const { result } = renderHook(() => useBoardDetailsMap([climb], [kilterBoard]));
+
+    expect(result.current.unsupportedClimbs.has('c1')).toBe(true);
   });
 
   it('should not mark any climbs as unsupported when the user owns zero boards', () => {
@@ -147,7 +134,10 @@ describe('useBoardDetailsMap', () => {
     // selection auto-activates the climb's own board config downstream.
     const climb1 = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
     const climb2 = makeClimb({ uuid: 'c2', boardType: 'tension', layoutId: 2 });
-    mockGetBoardDetailsForPlaylist.mockReturnValue(makeBoardDetails('kilter'));
+    mockResolveBoardDetailsForClimb.mockReturnValue({
+      details: makeBoardDetails('kilter'),
+      status: 'exact',
+    });
 
     const { result } = renderHook(() =>
       useBoardDetailsMap([climb1, climb2], []),
@@ -159,12 +149,9 @@ describe('useBoardDetailsMap', () => {
   it('should return defaultBoardDetails from selectedBoard when provided', () => {
     const selectedBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1 });
     const selectedDetails = makeBoardDetails('kilter-selected');
-
     mockGetUserBoardDetails.mockReturnValue(selectedDetails);
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([], [], selectedBoard),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([], [], selectedBoard));
 
     expect(result.current.defaultBoardDetails).toBe(selectedDetails);
   });
@@ -172,12 +159,9 @@ describe('useBoardDetailsMap', () => {
   it('should return defaultBoardDetails from first myBoard as fallback', () => {
     const myBoard = makeUserBoard({ boardType: 'kilter', layoutId: 1 });
     const myBoardDetails = makeBoardDetails('kilter-mine');
-
     mockGetUserBoardDetails.mockReturnValue(myBoardDetails);
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([], [myBoard]),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([], [myBoard]));
 
     expect(result.current.defaultBoardDetails).toBe(myBoardDetails);
   });
@@ -187,7 +171,7 @@ describe('useBoardDetailsMap', () => {
     mockGetBoardDetailsForPlaylist.mockReturnValue(genericDetails);
 
     const { result } = renderHook(() =>
-      useBoardDetailsMap([], [], null, ['tension']),
+      useBoardDetailsMap([], [], null, null, ['tension']),
     );
 
     expect(result.current.defaultBoardDetails).toBe(genericDetails);
@@ -197,33 +181,26 @@ describe('useBoardDetailsMap', () => {
   it('should handle multiple climbs from different board types', () => {
     const climb1 = makeClimb({ uuid: 'c1', boardType: 'kilter', layoutId: 1 });
     const climb2 = makeClimb({ uuid: 'c2', boardType: 'tension', layoutId: 2 });
-    const climb3 = makeClimb({ uuid: 'c3', boardType: 'kilter', layoutId: 1 }); // duplicate key
-
     const kilterDetails = makeBoardDetails('kilter');
     const tensionDetails = makeBoardDetails('tension');
 
-    mockGetBoardDetailsForPlaylist
-      .mockReturnValueOnce(kilterDetails)
-      .mockReturnValueOnce(tensionDetails);
+    mockResolveBoardDetailsForClimb.mockImplementation((climb) => {
+      if (climb.uuid === 'c1') return { details: kilterDetails, status: 'exact' };
+      return { details: tensionDetails, status: 'exact' };
+    });
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb1, climb2, climb3], []),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([climb1, climb2], []));
 
-    // Only 2 unique keys in the boardDetailsMap
-    expect(Object.keys(result.current.boardDetailsMap)).toHaveLength(2);
-    expect(result.current.boardDetailsMap['kilter:1']).toBe(kilterDetails);
-    expect(result.current.boardDetailsMap['tension:2']).toBe(tensionDetails);
+    expect(result.current.boardDetailsByClimb['c1']).toBe(kilterDetails);
+    expect(result.current.boardDetailsByClimb['c2']).toBe(tensionDetails);
   });
 
-  it('should skip climbs without boardType or layoutId', () => {
+  it('should skip climbs when the resolver returns null', () => {
     const climb1 = makeClimb({ uuid: 'c1', boardType: undefined, layoutId: 1 });
-    const climb2 = makeClimb({ uuid: 'c2', boardType: 'kilter', layoutId: null });
+    mockResolveBoardDetailsForClimb.mockReturnValue(null);
 
-    const { result } = renderHook(() =>
-      useBoardDetailsMap([climb1, climb2], []),
-    );
+    const { result } = renderHook(() => useBoardDetailsMap([climb1], []));
 
-    expect(Object.keys(result.current.boardDetailsMap)).toHaveLength(0);
+    expect(Object.keys(result.current.boardDetailsByClimb)).toHaveLength(0);
   });
 });

--- a/packages/web/app/hooks/use-board-details-map.ts
+++ b/packages/web/app/hooks/use-board-details-map.ts
@@ -51,7 +51,10 @@ export function useBoardDetailsMap(
             boardType: selectedBoard.boardType as BoardName,
             layoutId: selectedBoard.layoutId,
             sizeId: selectedBoard.sizeId,
-            setIds: selectedBoard.setIds.split(',').map(Number).filter((n) => Number.isFinite(n)),
+            setIds: selectedBoard.setIds
+              .split(',')
+              .map(Number)
+              .filter((n) => Number.isFinite(n) && n > 0),
           }
         : null;
 

--- a/packages/web/app/hooks/use-board-details-map.ts
+++ b/packages/web/app/hooks/use-board-details-map.ts
@@ -1,18 +1,32 @@
 import { useMemo } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import type { Climb, BoardDetails } from '@/app/lib/types';
-import { getUserBoardDetails, getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
+import type { Climb, BoardDetails, BoardName } from '@/app/lib/types';
+import {
+  getUserBoardDetails,
+  getBoardDetailsForPlaylist,
+  resolveBoardDetailsForClimb,
+  type SessionBoardConfig,
+} from '@/app/lib/board-config-for-playlist';
 
 interface UseBoardDetailsMapResult {
-  boardDetailsMap: Record<string, BoardDetails>;
+  /** BoardDetails keyed by climb uuid — resolved per climb. */
+  boardDetailsByClimb: Record<string, BoardDetails>;
+  /** Fallback BoardDetails for the list as a whole (hydration fallback). */
   defaultBoardDetails: BoardDetails | null;
+  /** Climbs that the user doesn't own a matching board type/layout for. */
   unsupportedClimbs: Set<string>;
+  /** Climbs that fit only on a larger size than the user's current session board. */
+  upsizedClimbs: Set<string>;
 }
 
 /**
- * Shared hook that builds a boardDetailsMap for multi-board climb rendering.
- * Maps "boardType:layoutId" keys to BoardDetails objects, preferring user's
- * own board details over generic fallbacks.
+ * Builds per-climb BoardDetails for multi-board climb rendering. When the
+ * caller passes a `sessionBoard`, each climb is resolved against it:
+ *  - Climbs that fit exactly render at the session's size/sets.
+ *  - Climbs that don't fit render on the smallest larger size that does
+ *    (same layout), and are marked as upsized so the UI can grey them out.
+ *  - Climbs from a different board/layout fall back to the generic preview
+ *    and are marked as unsupported (existing behavior).
  *
  * Used by: SetterClimbList, PlaylistDetailContent, SessionDetailContent
  */
@@ -20,59 +34,49 @@ export function useBoardDetailsMap(
   climbs: Climb[],
   myBoards: UserBoard[],
   selectedBoard?: UserBoard | null,
+  sessionBoard?: SessionBoardConfig | null,
   fallbackBoardTypes?: string[],
 ): UseBoardDetailsMapResult {
   return useMemo(() => {
-    const map: Record<string, BoardDetails> = {};
+    const byClimb: Record<string, BoardDetails> = {};
     const unsupported = new Set<string>();
+    const upsized = new Set<string>();
 
-    // Build user boards keyed by "boardType:layoutId"
-    const userBoardsByKey = new Map<string, UserBoard>();
-    for (const board of myBoards) {
-      const key = `${board.boardType}:${board.layoutId}`;
-      if (!userBoardsByKey.has(key)) {
-        userBoardsByKey.set(key, board);
-      }
-    }
+    // Use the active session when provided; otherwise synthesize one from the
+    // selected board so the playlist board filter still drives the preview.
+    const effectiveSession: SessionBoardConfig | null = sessionBoard
+      ? sessionBoard
+      : selectedBoard
+        ? {
+            boardType: selectedBoard.boardType as BoardName,
+            layoutId: selectedBoard.layoutId,
+            sizeId: selectedBoard.sizeId,
+            setIds: selectedBoard.setIds.split(',').map(Number).filter((n) => Number.isFinite(n)),
+          }
+        : null;
 
-    // Resolve BoardDetails for each unique boardType:layoutId
+    // Only filter by ownership when the user actually owns at least one board.
+    // When myBoards is empty we render every climb normally and let selection
+    // auto-activate the climb's own board config downstream.
+    const userBoardTypes = myBoards.length > 0 ? new Set(myBoards.map((b) => b.boardType)) : null;
+
     for (const climb of climbs) {
-      const bt = climb.boardType;
-      const layoutId = climb.layoutId;
-      if (!bt || layoutId == null) continue;
-
-      const key = `${bt}:${layoutId}`;
-      if (map[key]) continue;
-
-      const userBoard = userBoardsByKey.get(key);
-      if (userBoard) {
-        const details = getUserBoardDetails(userBoard);
-        if (details) {
-          map[key] = details;
-          continue;
-        }
+      // Mark climbs whose board type the user simply doesn't own at all.
+      if (userBoardTypes && climb.boardType && !userBoardTypes.has(climb.boardType)) {
+        unsupported.add(climb.uuid);
       }
 
-      const genericDetails = getBoardDetailsForPlaylist(bt, layoutId);
-      if (genericDetails) {
-        map[key] = genericDetails;
+      const resolved = resolveBoardDetailsForClimb(climb, effectiveSession);
+      if (!resolved) continue;
+      byClimb[climb.uuid] = resolved.details;
+      if (resolved.status === 'upsized') {
+        upsized.add(climb.uuid);
+      } else if (resolved.status === 'incompatible' && userBoardTypes) {
+        unsupported.add(climb.uuid);
       }
     }
 
-    // Mark unsupported climbs (board types the user doesn't have).
-    // Only meaningful when the user actually owns at least one board — when
-    // myBoards is empty we can't filter by ownership, so we render every climb
-    // normally and let selection auto-activate the climb's own board config.
-    if (myBoards.length > 0) {
-      const userBoardTypes = new Set(myBoards.map((b) => b.boardType));
-      for (const climb of climbs) {
-        if (climb.boardType && !userBoardTypes.has(climb.boardType)) {
-          unsupported.add(climb.uuid);
-        }
-      }
-    }
-
-    // Determine default board details
+    // Determine default board details (used as a hydration fallback by ClimbsList).
     let defaultDetails: BoardDetails | null = null;
     if (selectedBoard) {
       defaultDetails = getUserBoardDetails(selectedBoard);
@@ -86,6 +90,11 @@ export function useBoardDetailsMap(
       defaultDetails = getBoardDetailsForPlaylist(fallbackBoardType, fallbackLayoutId);
     }
 
-    return { boardDetailsMap: map, defaultBoardDetails: defaultDetails, unsupportedClimbs: unsupported };
-  }, [climbs, myBoards, selectedBoard, fallbackBoardTypes]);
+    return {
+      boardDetailsByClimb: byClimb,
+      defaultBoardDetails: defaultDetails,
+      unsupportedClimbs: unsupported,
+      upsizedClimbs: upsized,
+    };
+  }, [climbs, myBoards, selectedBoard, sessionBoard, fallbackBoardTypes]);
 }

--- a/packages/web/app/lib/__tests__/board-config-for-playlist.test.ts
+++ b/packages/web/app/lib/__tests__/board-config-for-playlist.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/board-constants', () => ({
+  getBoardDetails: vi.fn(),
+  getSizesForLayoutId: vi.fn(),
+  getSetsForLayoutAndSize: vi.fn(),
+  LAYOUTS: { kilter: { 1: {} }, tension: { 2: {} } },
+}));
+
+vi.mock('@/app/lib/moonboard-config', () => ({
+  getMoonBoardDetails: vi.fn(),
+  MOONBOARD_LAYOUTS: { 'moonboard-2024': { id: 100 } },
+  MOONBOARD_SETS: { 'moonboard-2024': [{ id: 1, name: 's1', imageFile: '' }] },
+}));
+
+vi.mock('@/app/lib/board-compatibility', () => ({
+  canAddClimbToBoard: vi.fn(),
+}));
+
+import { resolveBoardDetailsForClimb, type SessionBoardConfig } from '../board-config-for-playlist';
+import {
+  getBoardDetails,
+  getSizesForLayoutId,
+  getSetsForLayoutAndSize,
+} from '@/app/lib/board-constants';
+import { getMoonBoardDetails } from '@/app/lib/moonboard-config';
+import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
+import type { Climb, BoardDetails } from '@/app/lib/types';
+
+const mockGetBoardDetails = vi.mocked(getBoardDetails);
+const mockGetSizes = vi.mocked(getSizesForLayoutId);
+const mockGetSets = vi.mocked(getSetsForLayoutAndSize);
+const mockGetMoonBoardDetails = vi.mocked(getMoonBoardDetails);
+const mockCanAdd = vi.mocked(canAddClimbToBoard);
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'c1',
+    name: 'Test Climb',
+    frames: '',
+    angle: 40,
+    difficulty: 'V5',
+    quality_average: '3',
+    setter_username: 'setter',
+    description: '',
+    ascensionist_count: 0,
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+    boardType: 'kilter',
+    layoutId: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a BoardDetails stub. Edges default to a 100x100 box so callers
+ * can adjust the area by overriding edge_right/edge_top.
+ */
+function makeDetails(overrides: Partial<BoardDetails> = {}): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 2],
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    holdsData: [],
+    images_to_holds: {},
+    boardHeight: 1000,
+    boardWidth: 1000,
+    ...overrides,
+  } as unknown as BoardDetails;
+}
+
+/** Stub a `{ edgeLeft, edgeRight, edgeBottom, edgeTop }` size entry. */
+function makeSize(id: number, width: number, height: number) {
+  return {
+    id,
+    name: `size-${id}`,
+    description: '',
+    productId: 1,
+    edgeLeft: 0,
+    edgeRight: width,
+    edgeBottom: 0,
+    edgeTop: height,
+  };
+}
+
+function makeSet(id: number) {
+  return { id, name: `set-${id}`, imageFile: '' };
+}
+
+const KILTER_SESSION: SessionBoardConfig = {
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: [1, 2],
+};
+
+describe('resolveBoardDetailsForClimb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('no session board', () => {
+    it('returns the generic playlist details with exact status when one is available', () => {
+      const playlistDetails = makeDetails({ size_id: 20 });
+      // getBoardDetailsForPlaylist chain: sizes → sets → getBoardDetails.
+      mockGetSizes.mockReturnValue([makeSize(20, 120, 100)]);
+      mockGetSets.mockReturnValue([makeSet(1), makeSet(2)]);
+      mockGetBoardDetails.mockReturnValue(playlistDetails);
+
+      const climb = makeClimb({ boardType: 'kilter', layoutId: 1 });
+      const result = resolveBoardDetailsForClimb(climb, null);
+
+      expect(result).toEqual({ details: playlistDetails, status: 'exact' });
+      expect(mockCanAdd).not.toHaveBeenCalled();
+    });
+
+    it('returns null when no generic details can be built', () => {
+      mockGetSizes.mockReturnValue([]);
+
+      const climb = makeClimb({ boardType: 'kilter', layoutId: 1 });
+      const result = resolveBoardDetailsForClimb(climb, null);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('layout / board-type mismatches', () => {
+    it('falls back to generic playlist details with incompatible status when the board types differ', () => {
+      const playlistDetails = makeDetails({ board_name: 'tension' });
+      mockGetSizes.mockReturnValue([makeSize(50, 140, 120)]);
+      mockGetSets.mockReturnValue([makeSet(1)]);
+      mockGetBoardDetails.mockReturnValue(playlistDetails);
+
+      const climb = makeClimb({ boardType: 'tension', layoutId: 2 });
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result).toEqual({ details: playlistDetails, status: 'incompatible' });
+      expect(mockCanAdd).not.toHaveBeenCalled();
+    });
+
+    it('marks incompatible when the layout differs but board type matches', () => {
+      const playlistDetails = makeDetails({ layout_id: 2 });
+      mockGetSizes.mockReturnValue([makeSize(30, 120, 120)]);
+      mockGetSets.mockReturnValue([makeSet(1)]);
+      mockGetBoardDetails.mockReturnValue(playlistDetails);
+
+      const climb = makeClimb({ boardType: 'kilter', layoutId: 2 });
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result?.status).toBe('incompatible');
+      expect(mockCanAdd).not.toHaveBeenCalled();
+    });
+
+    it('treats a climb without a boardType as incompatible', () => {
+      const playlistDetails = makeDetails();
+      mockGetSizes.mockReturnValue([makeSize(10, 100, 100)]);
+      mockGetSets.mockReturnValue([makeSet(1)]);
+      mockGetBoardDetails.mockReturnValue(playlistDetails);
+
+      const climb = makeClimb({ boardType: undefined, layoutId: 1 });
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result?.status).toBe('incompatible');
+    });
+  });
+
+  describe('session fit (same layout + board type)', () => {
+    it('returns the session details with exact status when the climb fits', () => {
+      const sessionDetails = makeDetails({ size_id: 10, edge_right: 100, edge_top: 100 });
+      mockGetBoardDetails.mockReturnValue(sessionDetails);
+      mockCanAdd.mockReturnValue({ ok: true });
+
+      const climb = makeClimb();
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result).toEqual({ details: sessionDetails, status: 'exact' });
+      expect(mockGetBoardDetails).toHaveBeenCalledWith({
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+      });
+    });
+
+    it('walks larger sizes and returns the smallest one that fits as upsized', () => {
+      const sessionDetails = makeDetails({ size_id: 10, edge_right: 100, edge_top: 100 });
+      const smallerDetails = makeDetails({ size_id: 11, edge_right: 90, edge_top: 90 });
+      const midDetails = makeDetails({ size_id: 12, edge_right: 110, edge_top: 110 });
+      const largeDetails = makeDetails({ size_id: 13, edge_right: 140, edge_top: 140 });
+
+      // Exact session → fails fit. Smaller size is filtered out by area.
+      // Mid-size is the first larger candidate and wins.
+      mockGetBoardDetails.mockImplementation(({ size_id }) => {
+        if (size_id === 10) return sessionDetails;
+        if (size_id === 11) return smallerDetails;
+        if (size_id === 12) return midDetails;
+        return largeDetails;
+      });
+
+      mockGetSizes.mockReturnValue([
+        makeSize(10, 100, 100),
+        makeSize(11, 90, 90),
+        makeSize(12, 110, 110),
+        makeSize(13, 140, 140),
+      ]);
+      // Mid-size publishes the session sets, so the resolver should prefer them.
+      mockGetSets.mockImplementation((_board, _layout, sizeId) => {
+        if (sizeId === 12) return [makeSet(1), makeSet(2)];
+        if (sizeId === 13) return [makeSet(1), makeSet(2), makeSet(3)];
+        return [makeSet(1)];
+      });
+
+      // Session board fails, mid-size board passes.
+      mockCanAdd.mockImplementation((_climb, target) => {
+        if (target === midDetails) return { ok: true };
+        return { ok: false, reason: 'holds_out_of_range' };
+      });
+
+      const climb = makeClimb();
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result).toEqual({ details: midDetails, status: 'upsized' });
+      // Never attempts the smaller size.
+      expect(mockGetBoardDetails).not.toHaveBeenCalledWith(
+        expect.objectContaining({ size_id: 11 }),
+      );
+      // Mid-size was built with the preferred (session) set IDs.
+      expect(mockGetBoardDetails).toHaveBeenCalledWith({
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 12,
+        set_ids: [1, 2],
+      });
+    });
+
+    it('falls back to all published sets when the larger size lacks the session sets', () => {
+      const sessionDetails = makeDetails({ size_id: 10, edge_right: 100, edge_top: 100 });
+      const biggerDetails = makeDetails({ size_id: 20, edge_right: 140, edge_top: 140 });
+
+      mockGetBoardDetails.mockImplementation(({ size_id, set_ids }) => {
+        if (size_id === 10) return sessionDetails;
+        // Expect all published sets on the bigger size, not the session ones.
+        expect(set_ids).toEqual([9, 10, 11]);
+        return biggerDetails;
+      });
+
+      mockGetSizes.mockReturnValue([makeSize(10, 100, 100), makeSize(20, 140, 140)]);
+      mockGetSets.mockImplementation((_board, _layout, sizeId) => {
+        if (sizeId === 20) return [makeSet(9), makeSet(10), makeSet(11)];
+        return [makeSet(1), makeSet(2)];
+      });
+
+      mockCanAdd.mockImplementation((_climb, target) => {
+        if (target === biggerDetails) return { ok: true };
+        return { ok: false, reason: 'holds_out_of_range' };
+      });
+
+      const climb = makeClimb();
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result).toEqual({ details: biggerDetails, status: 'upsized' });
+    });
+
+    it('returns incompatible fallback (skipping the upsize walk) when the session details fail to build', () => {
+      // First call is the session build — throw. Second call is the fallback
+      // via getBoardDetailsForPlaylist — succeed.
+      const fallbackDetails = makeDetails({ size_id: 99 });
+      let callCount = 0;
+      mockGetBoardDetails.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          throw new Error('boom');
+        }
+        return fallbackDetails;
+      });
+
+      // For the playlist fallback chain we still need sizes/sets.
+      mockGetSizes.mockReturnValue([makeSize(99, 200, 200)]);
+      mockGetSets.mockReturnValue([makeSet(1), makeSet(2)]);
+
+      const climb = makeClimb();
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      expect(result).toEqual({ details: fallbackDetails, status: 'incompatible' });
+      // canAddClimbToBoard should never run — no usable session board to compare against.
+      expect(mockCanAdd).not.toHaveBeenCalled();
+      // Only two getBoardDetails calls: session (threw) + fallback.
+      expect(mockGetBoardDetails).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns incompatible fallback when no larger size fits', () => {
+      const sessionDetails = makeDetails({ size_id: 10, edge_right: 100, edge_top: 100 });
+      const biggerDetails = makeDetails({ size_id: 11, edge_right: 140, edge_top: 140 });
+
+      mockGetBoardDetails.mockImplementation(({ size_id }) => {
+        if (size_id === 10) return sessionDetails;
+        return biggerDetails;
+      });
+
+      mockGetSizes.mockReturnValue([makeSize(10, 100, 100), makeSize(11, 140, 140)]);
+      mockGetSets.mockReturnValue([makeSet(1), makeSet(2)]);
+      mockCanAdd.mockReturnValue({ ok: false, reason: 'holds_out_of_range' });
+
+      const climb = makeClimb();
+      const result = resolveBoardDetailsForClimb(climb, KILTER_SESSION);
+
+      // Nothing fit → final call is getBoardDetailsForPlaylist, which picks
+      // the largest size on the layout (size 11) and returns those details.
+      expect(result).toEqual({ details: biggerDetails, status: 'incompatible' });
+      // canAddClimbToBoard was invoked twice: session + the one larger candidate.
+      expect(mockCanAdd).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('moonboard session', () => {
+    const MOONBOARD_SESSION: SessionBoardConfig = {
+      boardType: 'moonboard',
+      layoutId: 100,
+      sizeId: 1,
+      setIds: [1],
+    };
+
+    it('returns exact when the climb fits the moonboard session', () => {
+      const details = makeDetails({ board_name: 'moonboard', layout_id: 100 });
+      mockGetMoonBoardDetails.mockReturnValue(
+        details as unknown as ReturnType<typeof getMoonBoardDetails>,
+      );
+      mockCanAdd.mockReturnValue({ ok: true });
+
+      const climb = makeClimb({ boardType: 'moonboard', layoutId: 100 });
+      const result = resolveBoardDetailsForClimb(climb, MOONBOARD_SESSION);
+
+      expect(result).toEqual({ details, status: 'exact' });
+    });
+
+    it('skips the upsize walk and falls back to incompatible when the climb does not fit moonboard', () => {
+      const sessionDetails = makeDetails({ board_name: 'moonboard', layout_id: 100 });
+      const fallbackDetails = makeDetails({ board_name: 'moonboard', layout_id: 100, size_id: 999 });
+
+      let moonCalls = 0;
+      mockGetMoonBoardDetails.mockImplementation(() => {
+        moonCalls += 1;
+        // First call is the session build, second is the playlist fallback.
+        return (moonCalls === 1 ? sessionDetails : fallbackDetails) as unknown as ReturnType<
+          typeof getMoonBoardDetails
+        >;
+      });
+      mockCanAdd.mockReturnValue({ ok: false, reason: 'holds_out_of_range' });
+
+      const climb = makeClimb({ boardType: 'moonboard', layoutId: 100 });
+      const result = resolveBoardDetailsForClimb(climb, MOONBOARD_SESSION);
+
+      expect(result).toEqual({ details: fallbackDetails, status: 'incompatible' });
+      // getSizesForLayoutId should never be consulted for moonboard — no upsize walk.
+      expect(mockGetSizes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/app/lib/board-config-for-playlist.ts
+++ b/packages/web/app/lib/board-config-for-playlist.ts
@@ -211,20 +211,14 @@ export function resolveBoardDetailsForClimb(
   }
 
   // Otherwise walk larger sizes on the same layout and pick the smallest that fits.
-  // Moonboard doesn't have multiple sizes — skip the search.
-  if (sessionBoard.boardType !== 'moonboard') {
-    const sessionSizeData = exactDetails
-      ? {
-          edgeLeft: exactDetails.edge_left,
-          edgeRight: exactDetails.edge_right,
-          edgeBottom: exactDetails.edge_bottom,
-          edgeTop: exactDetails.edge_top,
-        }
-      : null;
-    const sessionArea = sessionSizeData
-      ? (sessionSizeData.edgeRight - sessionSizeData.edgeLeft) *
-        (sessionSizeData.edgeTop - sessionSizeData.edgeBottom)
-      : 0;
+  // Moonboard doesn't have multiple sizes — skip the search. We also bail out
+  // when the exact session details couldn't be built: without them we don't
+  // know the session's area, and defaulting to 0 would let smaller sizes slip
+  // through as "upsized" candidates.
+  if (sessionBoard.boardType !== 'moonboard' && exactDetails) {
+    const sessionArea =
+      (exactDetails.edge_right - exactDetails.edge_left) *
+      (exactDetails.edge_top - exactDetails.edge_bottom);
 
     const candidates = getSizesForLayoutId(sessionBoard.boardType, sessionBoard.layoutId)
       .filter((size) => size.id !== sessionBoard.sizeId)

--- a/packages/web/app/lib/board-config-for-playlist.ts
+++ b/packages/web/app/lib/board-config-for-playlist.ts
@@ -1,5 +1,5 @@
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { BoardName, BoardDetails } from './types';
+import { BoardName, BoardDetails, Climb } from './types';
 import {
   getSizesForLayoutId,
   getSetsForLayoutAndSize,
@@ -7,6 +7,7 @@ import {
   LAYOUTS,
 } from './board-constants';
 import { getMoonBoardDetails, MOONBOARD_LAYOUTS, MOONBOARD_SETS, MoonBoardLayoutKey } from './moonboard-config';
+import { canAddClimbToBoard } from './board-compatibility';
 
 /**
  * Derive BoardDetails for a playlist using the largest available size and all sets.
@@ -123,4 +124,143 @@ export function getUserBoardDetails(board: UserBoard): BoardDetails | null {
   } catch {
     return null;
   }
+}
+
+export type SessionBoardConfig = {
+  boardType: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+};
+
+export type ClimbFitStatus = 'exact' | 'upsized' | 'incompatible';
+
+export type ClimbFitResult = {
+  details: BoardDetails;
+  status: ClimbFitStatus;
+};
+
+function buildDetailsSafely(
+  boardName: BoardName,
+  layoutId: number,
+  sizeId: number,
+  setIds: number[],
+): BoardDetails | null {
+  if (boardName === 'moonboard') {
+    try {
+      return getMoonBoardDetails({ layout_id: layoutId, set_ids: setIds }) as BoardDetails;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return getBoardDetails({
+      board_name: boardName,
+      layout_id: layoutId,
+      size_id: sizeId,
+      set_ids: setIds,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a BoardDetails for rendering a playlist climb preview, preferring
+ * the user's current session board. If the climb fits the session's size/sets,
+ * render at that size. If not, find the smallest larger size on the same
+ * layout that fits. If nothing fits (or the layout/board type don't match),
+ * fall back to the generic largest-size playlist details.
+ */
+export function resolveBoardDetailsForClimb(
+  climb: Climb,
+  sessionBoard: SessionBoardConfig | null,
+): ClimbFitResult | null {
+  const climbBoardType = climb.boardType as BoardName | undefined;
+  const climbLayoutId = climb.layoutId ?? null;
+
+  // No session at all — behave like before: pick the generic (largest) preview.
+  if (!sessionBoard) {
+    const details = getBoardDetailsForPlaylist(climbBoardType ?? '', climbLayoutId);
+    return details ? { details, status: 'exact' } : null;
+  }
+
+  // Layout or board type mismatch — fully incompatible, render on generic preview.
+  if (
+    !climbBoardType ||
+    climbBoardType !== sessionBoard.boardType ||
+    climbLayoutId == null ||
+    climbLayoutId !== sessionBoard.layoutId
+  ) {
+    const details = getBoardDetailsForPlaylist(climbBoardType ?? sessionBoard.boardType, climbLayoutId);
+    return details ? { details, status: 'incompatible' } : null;
+  }
+
+  // Try the exact session config first.
+  const exactDetails = buildDetailsSafely(
+    sessionBoard.boardType,
+    sessionBoard.layoutId,
+    sessionBoard.sizeId,
+    sessionBoard.setIds,
+  );
+  if (exactDetails) {
+    const fit = canAddClimbToBoard(climb, exactDetails);
+    if (fit.ok) {
+      return { details: exactDetails, status: 'exact' };
+    }
+  }
+
+  // Otherwise walk larger sizes on the same layout and pick the smallest that fits.
+  // Moonboard doesn't have multiple sizes — skip the search.
+  if (sessionBoard.boardType !== 'moonboard') {
+    const sessionSizeData = exactDetails
+      ? {
+          edgeLeft: exactDetails.edge_left,
+          edgeRight: exactDetails.edge_right,
+          edgeBottom: exactDetails.edge_bottom,
+          edgeTop: exactDetails.edge_top,
+        }
+      : null;
+    const sessionArea = sessionSizeData
+      ? (sessionSizeData.edgeRight - sessionSizeData.edgeLeft) *
+        (sessionSizeData.edgeTop - sessionSizeData.edgeBottom)
+      : 0;
+
+    const candidates = getSizesForLayoutId(sessionBoard.boardType, sessionBoard.layoutId)
+      .filter((size) => size.id !== sessionBoard.sizeId)
+      .map((size) => ({
+        size,
+        area: (size.edgeRight - size.edgeLeft) * (size.edgeTop - size.edgeBottom),
+      }))
+      .filter(({ area }) => area > sessionArea)
+      .sort((a, b) => a.area - b.area);
+
+    for (const { size } of candidates) {
+      const availableSets = getSetsForLayoutAndSize(sessionBoard.boardType, sessionBoard.layoutId, size.id);
+      if (availableSets.length === 0) continue;
+
+      const availableSetIds = new Set(availableSets.map((s) => s.id));
+      const preferredSetIds = sessionBoard.setIds.filter((id) => availableSetIds.has(id));
+      // If the user's session sets don't exist on this size, use every set the
+      // size publishes so the climb's holds stand a chance of rendering.
+      const setIdsToTry = preferredSetIds.length > 0 ? preferredSetIds : availableSets.map((s) => s.id);
+
+      const candidateDetails = buildDetailsSafely(
+        sessionBoard.boardType,
+        sessionBoard.layoutId,
+        size.id,
+        setIdsToTry,
+      );
+      if (!candidateDetails) continue;
+
+      const fit = canAddClimbToBoard(climb, candidateDetails);
+      if (fit.ok) {
+        return { details: candidateDetails, status: 'upsized' };
+      }
+    }
+  }
+
+  // Nothing fit — fall back to the generic (largest) preview and mark incompatible.
+  const fallback = getBoardDetailsForPlaylist(climbBoardType, climbLayoutId);
+  return fallback ? { details: fallback, status: 'incompatible' } : null;
 }

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -357,10 +357,11 @@ export default function SessionDetailContent({
   // Collect tick UUIDs for batch vote summary fetching
   const tickUuids = useMemo(() => ticks.map((t) => t.uuid), [ticks]);
 
-  // Build boardDetailsMap for multi-board support
-  const { boardDetailsMap, defaultBoardDetails, unsupportedClimbs } = useBoardDetailsMap(
+  // Build per-climb BoardDetails for multi-board support
+  const { boardDetailsByClimb, defaultBoardDetails, unsupportedClimbs, upsizedClimbs } = useBoardDetailsMap(
     sessionClimbs,
     myBoards,
+    null,
     null,
     boardTypes,
   );
@@ -593,8 +594,9 @@ export default function SessionDetailContent({
             <PlaylistsProvider {...playlistsProviderProps}>
               <ClimbsList
                 boardDetails={effectiveBoardDetails}
-                boardDetailsMap={boardDetailsMap}
+                boardDetailsByClimb={boardDetailsByClimb}
                 unsupportedClimbs={unsupportedClimbs}
+                upsizedClimbs={upsizedClimbs}
                 climbs={sessionClimbs}
                 isFetching={false}
                 hasMore={false}


### PR DESCRIPTION
Playlist previews now use the user's active session size and sets so
climbers see what the climb actually looks like on the wall in front of
them. When a climb's holds don't fit, the preview upsizes to the
smallest larger size on the same layout and renders greyed out; tapping
it shows a warning instead of loading the climb.

https://claude.ai/code/session_0182opStxzY1R5Mwt5DJmMcR