### PR TITLE
Default playlist board filter to current queue's board

### DIFF
--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -46,6 +46,8 @@ interface MultiboardClimbListProps {
   showBottomSpacer?: boolean;
   /** Fallback board types for default board details resolution */
   fallbackBoardTypes?: string[];
+  /** SSR-fetched user boards, forwarded to useMyBoards so the filter strip renders without a flash. */
+  initialBoards?: UserBoard[] | null;
 }
 
 export default function MultiboardClimbList({
@@ -68,8 +70,9 @@ export default function MultiboardClimbList({
   hideEndMessage = true,
   showBottomSpacer = true,
   fallbackBoardTypes,
+  initialBoards,
 }: MultiboardClimbListProps) {
-  const { boards: myBoards, isLoading: isLoadingBoards } = useMyBoards(true);
+  const { boards: myBoards, isLoading: isLoadingBoards } = useMyBoards(true, 50, initialBoards);
 
   const { boardDetailsMap, defaultBoardDetails, unsupportedClimbs } = useBoardDetailsMap(
     climbs,

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -48,6 +48,14 @@ interface MultiboardClimbListProps {
   fallbackBoardTypes?: string[];
   /** SSR-fetched user boards, forwarded to useMyBoards so the filter strip renders without a flash. */
   initialBoards?: UserBoard[] | null;
+  /**
+   * Pre-fetched boards to use instead of the internal `useMyBoards` call.
+   * When provided, skips the internal GraphQL request entirely — used by
+   * callers that already hold the list (e.g. playlist detail view).
+   */
+  boards?: UserBoard[];
+  /** Loading flag matching `boards` when it's passed in externally. */
+  boardsLoading?: boolean;
 }
 
 export default function MultiboardClimbList({
@@ -71,8 +79,21 @@ export default function MultiboardClimbList({
   showBottomSpacer = true,
   fallbackBoardTypes,
   initialBoards,
+  boards: externalBoards,
+  boardsLoading: externalBoardsLoading,
 }: MultiboardClimbListProps) {
-  const { boards: myBoards, isLoading: isLoadingBoards } = useMyBoards(true, 50, initialBoards);
+  // Only fetch boards internally when the caller hasn't supplied them.
+  // Passing `enabled={false}` short-circuits useMyBoards so we don't fire a
+  // duplicate GraphQL request against the same endpoint.
+  const { boards: fetchedBoards, isLoading: fetchedBoardsLoading } = useMyBoards(
+    externalBoards === undefined,
+    50,
+    initialBoards,
+  );
+  const myBoards = externalBoards ?? fetchedBoards;
+  const isLoadingBoards = externalBoards !== undefined
+    ? (externalBoardsLoading ?? false)
+    : fetchedBoardsLoading;
 
   const { boardDetailsMap, defaultBoardDetails, unsupportedClimbs } = useBoardDetailsMap(
     climbs,

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -32,12 +32,20 @@ interface QueueBridgeBoardInfo {
   boardDetails: BoardDetails | null;
   angle: Angle;
   hasActiveQueue: boolean;
+  /**
+   * True once the persistent session has finished restoring from IndexedDB
+   * (or immediately when a board-route injector is active). Consumers that
+   * want to read `hasActiveQueue`/`boardDetails` on mount must wait for this
+   * flag — otherwise they race the async restore and see stale defaults.
+   */
+  isHydrated: boolean;
 }
 
 const QueueBridgeBoardInfoContext = createContext<QueueBridgeBoardInfo>({
   boardDetails: null,
   angle: 0,
   hasActiveQueue: false,
+  isHydrated: false,
 });
 
 export function useQueueBridgeBoardInfo() {
@@ -83,6 +91,7 @@ function usePersistentSessionQueueAdapter(): {
   boardDetails: BoardDetails | null;
   angle: Angle;
   hasActiveQueue: boolean;
+  isHydrated: boolean;
   syncFromInjected: (q: ClimbQueueItem[], current: ClimbQueueItem | null, boardPath: string, bd: BoardDetails) => void;
 } {
   const ps = usePersistentSession();
@@ -351,7 +360,16 @@ function usePersistentSessionQueueAdapter(): {
     [],
   );
 
-  return { context, actionsValue, dataValue, boardDetails, angle, hasActiveQueue, syncFromInjected };
+  return {
+    context,
+    actionsValue,
+    dataValue,
+    boardDetails,
+    angle,
+    hasActiveQueue,
+    isHydrated: ps.isLocalQueueLoaded,
+    syncFromInjected,
+  };
 }
 
 // -------------------------------------------------------------------
@@ -414,14 +432,18 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
   const effectiveHasActiveQueue = isInjected
     ? true // If injected, a board route is active — always show bar
     : adapter.hasActiveQueue;
+  // When a board route injector is active we already know board state
+  // synchronously; otherwise mirror the persistent session's restore flag.
+  const effectiveIsHydrated = isInjected ? true : adapter.isHydrated;
 
   const boardInfo = useMemo<QueueBridgeBoardInfo>(
     () => ({
       boardDetails: effectiveBoardDetails,
       angle: effectiveAngle,
       hasActiveQueue: effectiveHasActiveQueue,
+      isHydrated: effectiveIsHydrated,
     }),
-    [effectiveBoardDetails, effectiveAngle, effectiveHasActiveQueue],
+    [effectiveBoardDetails, effectiveAngle, effectiveHasActiveQueue, effectiveIsHydrated],
   );
 
   const inject = useCallback((

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
 import PlaylistDetailContent from './playlist-detail-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -15,9 +17,14 @@ export default async function PlaylistDetailPage({
 }) {
   const { playlist_uuid } = await params;
 
+  // Fetch user's boards server-side so the filter strip renders populated on first paint
+  // and the current-queue fallback can seed the selection without flashing "All Boards".
+  const authToken = await getServerAuthToken();
+  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+
   return (
     <div className={styles.pageContainer}>
-      <PlaylistDetailContent playlistUuid={playlist_uuid} />
+      <PlaylistDetailContent playlistUuid={playlist_uuid} initialMyBoards={initialMyBoards} />
     </div>
   );
 }

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -55,6 +55,7 @@ import PlaylistEditDrawer from '@/app/components/library/playlist-edit-drawer';
 import CommentSection from '@/app/components/social/comment-section';
 import MultiboardClimbList from '@/app/components/climb-list/multiboard-climb-list';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
+import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { findMatchingBoard, type BoardConfig } from '@/app/lib/find-matching-board';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
@@ -114,17 +115,42 @@ export default function PlaylistDetailContent({
   // Fetch user's boards (with SSR initial data to avoid loading skeleton)
   const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(true, 50, initialMyBoards);
 
-  // Auto-select the matching board when boards load (fallback for non-SSR paths)
+  // Current queue/session board info — used to default the filter to whatever the user is
+  // currently sessioning on when no explicit board context came from the route.
+  const { boardDetails: currentBoardDetails, hasActiveQueue } = useQueueBridgeBoardInfo();
+
+  // Auto-select the matching board once boards finish loading.
+  // - Route-provided boardSlug/boardConfig always wins.
+  // - Otherwise fall back to the current queue's board so the filter opens on
+  //   whatever the user is actively climbing, mirroring the playlists library page.
   useEffect(() => {
     if (defaultBoardAppliedRef.current || boardsLoading || myBoards.length === 0) return;
-    if (!boardSlug && !boardConfig) return;
 
-    const match = findMatchingBoard(myBoards, boardSlug, boardConfig);
+    if (boardSlug || boardConfig) {
+      const match = findMatchingBoard(myBoards, boardSlug, boardConfig);
+      if (match) {
+        setSelectedBoard(match);
+      }
+      defaultBoardAppliedRef.current = true;
+      return;
+    }
+
+    // Wait for queue bridge board details if there's an active queue but details
+    // haven't hydrated yet — otherwise we'd prematurely commit to "All Boards".
+    if (!currentBoardDetails && hasActiveQueue) return;
+
+    const match = currentBoardDetails
+      ? findMatchingBoard(myBoards, undefined, {
+          boardType: currentBoardDetails.board_name,
+          layoutId: currentBoardDetails.layout_id,
+          sizeId: currentBoardDetails.size_id,
+        })
+      : null;
     if (match) {
       setSelectedBoard(match);
     }
     defaultBoardAppliedRef.current = true;
-  }, [myBoards, boardsLoading, boardSlug, boardConfig]);
+  }, [myBoards, boardsLoading, boardSlug, boardConfig, currentBoardDetails, hasActiveQueue]);
 
   const fetchPlaylist = useCallback(async () => {
     if (tokenLoading) return;
@@ -440,6 +466,7 @@ export default function PlaylistDetailContent({
               selectedBoard={selectedBoard}
               onBoardSelect={handleBoardSelect}
               fallbackBoardTypes={[playlist.boardType]}
+              initialBoards={initialMyBoards}
             />
           )}
         </div>

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -112,12 +112,17 @@ export default function PlaylistDetailContent({
   const defaultBoardAppliedRef = useRef(!!selectedBoard);
   const { token, isLoading: tokenLoading } = useWsAuthToken();
 
-  // Fetch user's boards (with SSR initial data to avoid loading skeleton)
+  // Fetch user's boards (with SSR initial data to avoid loading skeleton).
+  // These boards are forwarded to MultiboardClimbList via the `boards` prop so
+  // we avoid duplicate GraphQL requests from MultiboardClimbList's internal hook.
   const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(true, 50, initialMyBoards);
 
   // Current queue/session board info — used to default the filter to whatever the user is
   // currently sessioning on when no explicit board context came from the route.
-  const { boardDetails: currentBoardDetails, hasActiveQueue } = useQueueBridgeBoardInfo();
+  const {
+    boardDetails: currentBoardDetails,
+    isHydrated: isQueueHydrated,
+  } = useQueueBridgeBoardInfo();
 
   // Auto-select the matching board once boards finish loading.
   // - Route-provided boardSlug/boardConfig always wins.
@@ -135,9 +140,11 @@ export default function PlaylistDetailContent({
       return;
     }
 
-    // Wait for queue bridge board details if there's an active queue but details
-    // haven't hydrated yet — otherwise we'd prematurely commit to "All Boards".
-    if (!currentBoardDetails && hasActiveQueue) return;
+    // Wait until the persistent session has finished restoring from IndexedDB.
+    // On a fresh direct load both `currentBoardDetails` and `hasActiveQueue` start
+    // as null/false, so without this guard we'd commit to "All Boards" before the
+    // real queue board is available and then never re-apply because of the ref.
+    if (!isQueueHydrated) return;
 
     const match = currentBoardDetails
       ? findMatchingBoard(myBoards, undefined, {
@@ -150,7 +157,7 @@ export default function PlaylistDetailContent({
       setSelectedBoard(match);
     }
     defaultBoardAppliedRef.current = true;
-  }, [myBoards, boardsLoading, boardSlug, boardConfig, currentBoardDetails, hasActiveQueue]);
+  }, [myBoards, boardsLoading, boardSlug, boardConfig, currentBoardDetails, isQueueHydrated]);
 
   const fetchPlaylist = useCallback(async () => {
     if (tokenLoading) return;
@@ -466,7 +473,8 @@ export default function PlaylistDetailContent({
               selectedBoard={selectedBoard}
               onBoardSelect={handleBoardSelect}
               fallbackBoardTypes={[playlist.boardType]}
-              initialBoards={initialMyBoards}
+              boards={myBoards}
+              boardsLoading={boardsLoading}
             />
           )}
         </div>


### PR DESCRIPTION
The playlist detail view now defaults the horizontal board filter to
whichever board the user is actively sessioning on, matching the behavior
of the /playlists library page. Also threads SSR-fetched user boards
through MultiboardClimbList so owned/custom boards render immediately
instead of flashing in after a client-side refetch, and fetches initial
boards on the generic /playlists/[uuid] route.