### PR TITLE
Fix grade selector showing v4 twice instead of v4/v4+

### DIFF
--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -358,7 +358,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
                   setGradeAnchorEl(null);
                 }}
               >
-                {grade.v_grade}
+                {formatVGrade(grade.difficulty_name) ?? grade.v_grade}
               </MenuItem>
             );
           })}


### PR DESCRIPTION
Use formatVGrade(difficulty_name) in the grade menu items so grades like
V4/V4+, V5/V5+, V8/V8+ are properly disambiguated instead of showing
the same v_grade label twice.

https://claude.ai/code/session_014t59xdeQ8umyQa2SbERHWw