### PR TITLE
Add frosted glass effect to playlist card color squares

### DIFF
--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -77,6 +77,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 8px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
 }
 
 .cardCompactIcon {
@@ -149,7 +150,7 @@
   justify-content: center;
   margin-bottom: 8px;
   transition: box-shadow 150ms ease;
-  box-shadow: var(--shadow-xs);
+  box-shadow: var(--shadow-xs), inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
 }
 
 .cardIcon {
@@ -174,7 +175,8 @@
 
 /* Liked Climbs Card */
 .likedGradient {
-  background: linear-gradient(135deg, var(--color-error), #D87F7A);
+  background: linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%),
+              linear-gradient(135deg, var(--color-error), #D87F7A);
 }
 
 /* Sign-in Banner (compact, non-blocking) */

--- a/packages/web/app/components/library/playlist-card.tsx
+++ b/packages/web/app/components/library/playlist-card.tsx
@@ -66,7 +66,7 @@ export default function PlaylistCard({
       <Link href={href} className={styles.cardCompact}>
         <div
           className={`${styles.cardCompactSquare} ${isLikedClimbs ? styles.likedGradient : ''}`}
-          style={!isLikedClimbs ? { backgroundColor } : undefined}
+          style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${backgroundColor}` } : undefined}
         >
           {renderIcon(styles.cardCompactIcon)}
         </div>
@@ -87,7 +87,7 @@ export default function PlaylistCard({
     >
       <div
         className={`${styles.cardSquare} ${isLikedClimbs ? styles.likedGradient : ''}`}
-        style={!isLikedClimbs ? { backgroundColor } : undefined}
+        style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${backgroundColor}` } : undefined}
       >
         {renderIcon(styles.cardIcon)}
       </div>

--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -47,7 +47,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
 }
 
 .heroSquareIcon {

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -329,7 +329,7 @@ export default function PlaylistDetailContent({
           <div className={styles.heroContent}>
             <div
               className={styles.heroSquare}
-              style={{ backgroundColor: getPlaylistColor() }}
+              style={{ background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${getPlaylistColor()}` }}
             >
               {playlist.icon ? (
                 <span className={styles.heroSquareEmoji}>{playlist.icon}</span>


### PR DESCRIPTION
Layers a white-to-transparent gradient (18%→3%) over the base color
on all card variants (grid compact, scroll, hero) to soften the harsh
solid fills. Adds inset box-shadows to simulate the glass edge — a
light highlight at the top and a subtle shadow at the bottom.

https://claude.ai/code/session_01C3YtyDpLBjzJ3MPhAPe9kp