### PR TITLE
Fix playlist card frosted glass effect visibility

### DIFF
--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -77,7 +77,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 8px;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), inset 0 -1px 0 rgba(0,0,0,0.15), inset 1px 0 0 rgba(255,255,255,0.2);
 }
 
 .cardCompactIcon {
@@ -150,7 +150,7 @@
   justify-content: center;
   margin-bottom: 8px;
   transition: box-shadow 150ms ease;
-  box-shadow: var(--shadow-xs), inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-xs), inset 0 1px 0 rgba(255,255,255,0.5), inset 0 -1px 0 rgba(0,0,0,0.15), inset 1px 0 0 rgba(255,255,255,0.2);
 }
 
 .cardIcon {
@@ -175,7 +175,7 @@
 
 /* Liked Climbs Card */
 .likedGradient {
-  background: linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%),
+  background: linear-gradient(135deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.08) 100%),
               linear-gradient(135deg, var(--color-error), #D87F7A);
 }
 

--- a/packages/web/app/components/library/playlist-card.tsx
+++ b/packages/web/app/components/library/playlist-card.tsx
@@ -66,7 +66,7 @@ export default function PlaylistCard({
       <Link href={href} className={styles.cardCompact}>
         <div
           className={`${styles.cardCompactSquare} ${isLikedClimbs ? styles.likedGradient : ''}`}
-          style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${backgroundColor}` } : undefined}
+          style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.08) 100%), ${backgroundColor}` } : undefined}
         >
           {renderIcon(styles.cardCompactIcon)}
         </div>
@@ -87,7 +87,7 @@ export default function PlaylistCard({
     >
       <div
         className={`${styles.cardSquare} ${isLikedClimbs ? styles.likedGradient : ''}`}
-        style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${backgroundColor}` } : undefined}
+        style={!isLikedClimbs ? { background: `linear-gradient(135deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.08) 100%), ${backgroundColor}` } : undefined}
       >
         {renderIcon(styles.cardIcon)}
       </div>


### PR DESCRIPTION
The white gradient overlay was too faint (0.18→0.03 opacity) to be
visible on solid color backgrounds. Bumped to 0.4→0.08 so the glass
sheen is clearly visible. Also strengthened the inset box-shadow
highlights on both card variants (0.25→0.5 top, 0.08→0.15 bottom,
added 0.2 left edge).

https://claude.ai/code/session_01FhhaVLUwkeVzwvLgj9kKk7