### PR TITLE
fix: show draft climbs with NULL denormalized columns in search

### DIFF
--- a/packages/backend/src/db/queries/climbs/count-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/count-climbs.ts
@@ -25,7 +25,9 @@ export const countClimbs = async (
 
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
-    ...filters.getSizeConditions(),
+    // Draft climbs may have NULL compatible_size_ids (denormalized columns not yet populated),
+    // so skip the size filter entirely — users must be able to find their freshly saved drafts.
+    ...(isDraftsQuery ? [] : filters.getSizeConditions()),
     // Draft climbs never have stats rows — skip stats filters to avoid rejecting all drafts
     ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),
   ];

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -165,8 +165,13 @@ export const createClimbFilters = (
   // Uses denormalized required_set_ids array (pre-computed from climb_holds -> placements).
   // The <@ operator checks that all required sets are in the user's selected sets.
   // MoonBoard has no set data, so skip.
+  //
+  // For draft queries, allow NULL required_set_ids — denormalized columns are populated
+  // asynchronously and may be NULL for freshly saved drafts, so we must not exclude them.
   const setIdsConditions: SQL[] = params.board_name === 'moonboard' || params.set_ids.length === 0 ? [] : [
-    sql`${boardClimbs.requiredSetIds} <@ ARRAY[${sql.join(params.set_ids.map(id => sql`${id}`), sql`, `)}]::int[]`,
+    isOnlyDrafts
+      ? sql`(${boardClimbs.requiredSetIds} IS NULL OR ${boardClimbs.requiredSetIds} <@ ARRAY[${sql.join(params.set_ids.map(id => sql`${id}`), sql`, `)}]::int[])`
+      : sql`${boardClimbs.requiredSetIds} <@ ARRAY[${sql.join(params.set_ids.map(id => sql`${id}`), sql`, `)}]::int[]`,
   ];
 
   // Personal progress filter conditions

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -211,7 +211,9 @@ async function standardSearch(
 
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
-    ...filters.getSizeConditions(),
+    // Draft climbs may have NULL compatible_size_ids (denormalized columns not yet populated),
+    // so skip the size filter entirely — users must be able to find their freshly saved drafts.
+    ...(isDraftsQuery ? [] : filters.getSizeConditions()),
     // Draft climbs never have board_climb_stats rows, so stats-based filters
     // (grade range, min ascents, quality, accuracy) would reject every draft.
     ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),


### PR DESCRIPTION
Newly saved Aurora draft climbs have NULL required_set_ids and
compatible_size_ids because populateDenormalizedColumns couldn't
find matching hold placements yet. The draft search was silently
excluding these rows, making users think their saves failed.

- Skip sizeConditions for onlyDrafts queries in searchClimbs and
  countClimbs, mirroring the existing skip for stats conditions
- Make setIdsConditions null-safe for draft queries so climbs with
  NULL required_set_ids still appear in the drafts drawer

https://claude.ai/code/session_01LpkjHJUUNob7oCfNoALYXT