### PR TITLE
Sync hero card frosted glass with library card fix

### DIFF
--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -47,7 +47,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255,255,255,0.25), inset 0 -1px 0 rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255,255,255,0.5), inset 0 -1px 0 rgba(0,0,0,0.15), inset 1px 0 0 rgba(255,255,255,0.2);
 }
 
 .heroSquareIcon {

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -362,7 +362,7 @@ export default function PlaylistDetailContent({
           <div className={styles.heroContent}>
             <div
               className={styles.heroSquare}
-              style={{ background: `linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.03) 100%), ${getPlaylistColor()}` }}
+              style={{ background: `linear-gradient(135deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.08) 100%), ${getPlaylistColor()}` }}
             >
               {playlist.icon ? (
                 <span className={styles.heroSquareEmoji}>{playlist.icon}</span>


### PR DESCRIPTION
The previous fix (ca3b0b0) bumped the gradient overlay from 0.18→0.03
to 0.4→0.08 and strengthened the inset highlights on the library list
cards but missed the hero square on the playlist detail page. Both
files now use the same values.

https://claude.ai/code/session_01Hm44WWyvVboj2sEExFUZmn