### PR TITLE
Add spacing CSS variables and replace hardcoded padding with design tokens

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -49,6 +49,18 @@
   --overlay-dark: rgba(0, 0, 0, 0.6);
   --overlay-text: rgba(255, 255, 255, 0.9);
 
+  /* Spacing scale (matches themeTokens.spacing in theme-config.ts) */
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-8: 32px;
+  --spacing-10: 40px;
+  --spacing-12: 48px;
+  --spacing-16: 64px;
+
   /* Layout */
   --global-header-height: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
 }

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -98,8 +98,9 @@
 .cardCompactInfo {
   flex: 1;
   min-width: 0;
-  padding-left: 10px;
-  padding-right: 8px;
+  /* Slightly more left padding to create visual separation from the thumbnail */
+  padding-left: var(--spacing-3);
+  padding-right: var(--spacing-2);
 }
 
 .cardCompactName {
@@ -249,11 +250,11 @@
 .skeletonCompact {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2);
   background-color: var(--semantic-surface);
   border-radius: 8px;
   overflow: hidden;
-  padding-right: 8px;
+  padding-right: var(--spacing-2);
 }
 
 .skeletonCompactText {


### PR DESCRIPTION
- Adds --spacing-{1..16} CSS custom properties to index.css, mirroring
  themeTokens.spacing from theme-config.ts
- Replaces hardcoded padding-left: 10px / padding-right: 8px in
  .cardCompactInfo with var(--spacing-3) / var(--spacing-2); adds a
  comment explaining the asymmetry (thumbnail clearance)
- Fixes matching hardcoded values in .skeletonCompact (gap, padding-right)

https://claude.ai/code/session_01Mu8NnuqPuKdZwCA68kHorQ