### PR TITLE
Fix draft preview not updating in drafts drawer

### DIFF
--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -586,6 +586,9 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
   (prev, next) => {
     return (
       prev.climb.uuid === next.climb.uuid &&
+      prev.climb.frames === next.climb.frames &&
+      prev.climb.name === next.climb.name &&
+      prev.climb.mirrored === next.climb.mirrored &&
       prev.pathname === next.pathname &&
       prev.isDark === next.isDark &&
       prev.selected === next.selected &&

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -133,7 +133,6 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
       const result = await client.request<ClimbSearchResponse>(SEARCH_DRAFT_CLIMBS, { input });
       return result.searchClimbs.climbs;
     },
-    staleTime: 30 * 1000,
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
Two bugs prevented the draft thumbnail and title from refreshing after an edit:

1. ClimbListItem's React.memo comparator only checked climb.uuid, so when a
   draft was updated (same UUID, new frames/name), the component skipped
   re-rendering even when the query returned fresh data. Added frames, name,
   and mirrored to the comparator so content changes trigger a re-render.

2. DraftsDrawer used staleTime: 30s, which could serve cached data when the
   drawer was reopened within the stale window. Removing it reverts to the
   React Query default (0), ensuring fresh data is always fetched on open.

https://claude.ai/code/session_01LNSfB9pg3j9twRY6hAkT2N