### PR TITLE
fix: stop filtering playlist climbs to active queue board

### DIFF
--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -55,7 +55,6 @@ import PlaylistEditDrawer from '@/app/components/library/playlist-edit-drawer';
 import CommentSection from '@/app/components/social/comment-section';
 import MultiboardClimbList from '@/app/components/climb-list/multiboard-climb-list';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
-import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { findMatchingBoard, type BoardConfig } from '@/app/lib/find-matching-board';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
@@ -117,47 +116,22 @@ export default function PlaylistDetailContent({
   // we avoid duplicate GraphQL requests from MultiboardClimbList's internal hook.
   const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(true, 50, initialMyBoards);
 
-  // Current queue/session board info — used to default the filter to whatever the user is
-  // currently sessioning on when no explicit board context came from the route.
-  const {
-    boardDetails: currentBoardDetails,
-    isHydrated: isQueueHydrated,
-  } = useQueueBridgeBoardInfo();
-
-  // Auto-select the matching board once boards finish loading.
-  // - Route-provided boardSlug/boardConfig always wins.
-  // - Otherwise fall back to the current queue's board so the filter opens on
-  //   whatever the user is actively climbing, mirroring the playlists library page.
+  // Auto-select the matching board once boards finish loading, but only when the
+  // route explicitly provides a board context. Without a route-provided board,
+  // default to "All Boards" so multi-board playlists show all their climbs.
+  // Incompatible climbs are blocked at add-time by useQueueAddValidator.
   useEffect(() => {
     if (defaultBoardAppliedRef.current || boardsLoading || myBoards.length === 0) return;
-
-    if (boardSlug || boardConfig) {
-      const match = findMatchingBoard(myBoards, boardSlug, boardConfig);
-      if (match) {
-        setSelectedBoard(match);
-      }
+    if (!(boardSlug || boardConfig)) {
       defaultBoardAppliedRef.current = true;
       return;
     }
-
-    // Wait until the persistent session has finished restoring from IndexedDB.
-    // On a fresh direct load both `currentBoardDetails` and `hasActiveQueue` start
-    // as null/false, so without this guard we'd commit to "All Boards" before the
-    // real queue board is available and then never re-apply because of the ref.
-    if (!isQueueHydrated) return;
-
-    const match = currentBoardDetails
-      ? findMatchingBoard(myBoards, undefined, {
-          boardType: currentBoardDetails.board_name,
-          layoutId: currentBoardDetails.layout_id,
-          sizeId: currentBoardDetails.size_id,
-        })
-      : null;
+    const match = findMatchingBoard(myBoards, boardSlug, boardConfig);
     if (match) {
       setSelectedBoard(match);
     }
     defaultBoardAppliedRef.current = true;
-  }, [myBoards, boardsLoading, boardSlug, boardConfig, currentBoardDetails, isQueueHydrated]);
+  }, [myBoards, boardsLoading, boardSlug, boardConfig]);
 
   const fetchPlaylist = useCallback(async () => {
     if (tokenLoading) return;


### PR DESCRIPTION
Playlist detail was auto-selecting the current queue's board and
querying only that board's climbs — hiding climbs from other boards
even when the user selected "All Boards". The protection against
adding incompatible climbs already exists in useQueueAddValidator
(blocks the add and shows a snackbar), so the view-side filtering
was unnecessary.

Now the filter defaults to "All Boards" unless the route itself
supplies an explicit boardSlug or boardConfig.

https://claude.ai/code/session_01VQ1rSZAWy9sJcvYsYFNAur