### PR TITLE
fix: remove nested focusable elements in create-climb-form links

### DIFF
--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -911,11 +911,9 @@ export default function CreateClimbForm({
     if (boardType === 'moonboard' && !hasMoonBoardSessionUser) {
       return (
         <MuiTooltip title="Log in to save your climb">
-          <Link href="/api/auth/signin" aria-label="Log in to save">
-            <IconButton size="small" color="primary" component="span">
-              <LoginOutlined fontSize="small" />
-            </IconButton>
-          </Link>
+          <IconButton size="small" color="primary" component={Link} href="/api/auth/signin" aria-label="Log in to save">
+            <LoginOutlined fontSize="small" />
+          </IconButton>
         </MuiTooltip>
       );
     }
@@ -1176,11 +1174,9 @@ export default function CreateClimbForm({
               </span>
             </MuiTooltip>
             <MuiTooltip title="Bulk import">
-              <Link href={bulkImportUrl} aria-label="Bulk import">
-                <IconButton size="small" component="span">
-                  <GetAppOutlined fontSize="small" />
-                </IconButton>
-              </Link>
+              <IconButton size="small" component={Link} href={bulkImportUrl} aria-label="Bulk import">
+                <GetAppOutlined fontSize="small" />
+              </IconButton>
             </MuiTooltip>
           </>
         )}


### PR DESCRIPTION
<Link><IconButton component="span"> rendered <a><span role="button" tabIndex="0">,
putting two focusable elements inside each other. Pass component={Link} and href
directly to IconButton so each renders as a single <a> element.

Fixes both the bulk-import link and the MoonBoard sign-in link.

https://claude.ai/code/session_01AXZihEydyEGt7PqAe57tq1