### PR TITLE
fix: re-throw Next.js internal errors on view page and silence overla…

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -141,6 +141,11 @@ export default async function DynamicResultsPage(props: { params: Promise<BoardR
       />
     );
   } catch (error) {
+    // Re-throw Next.js internal errors (permanentRedirect, notFound, etc.) so they
+    // are handled correctly instead of being replaced by a 404.
+    if (error !== null && typeof error === 'object' && 'digest' in error) {
+      throw error;
+    }
     console.error('Error fetching results or climb:', error);
     notFound();
   }

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -35,7 +35,9 @@ async function warmOverlays(options: {
     await Promise.allSettled(
       toWarm.map((climb) => {
         const path = buildOverlayUrl(boardDetails, climb.frames, isThumbnail);
-        return fetch(`${BASE_URL}${path}`).then((r) => r.body?.cancel());
+        return fetch(`${BASE_URL}${path}`)
+          .then((r) => r.body?.cancel())
+          .catch(() => {});
       }),
     );
   } catch {


### PR DESCRIPTION
…y warming socket errors

Two bugs fixed:

1. The climb view page wrapped `permanentRedirect()` inside a try/catch. Since Next.js redirect/notFound calls work by throwing objects with a `digest` property, they were being caught and replaced with a `notFound()` call, so numeric-format URLs that should have 301-redirected were showing 404s instead. The catch block now re-throws any error with a `digest` property before falling back to notFound().

2. `warmOverlays` makes fire-and-forget fetches to warm the CDN overlay cache. These fetches occasionally fail with `UND_ERR_SOCKET` (other side closed) because the request goes through Cloudflare from a serverless context. `Promise.allSettled` captures the rejections, but Node.js/undici can emit socket errors before allSettled has a chance to handle them. Adding `.catch(() => {})` directly on each fetch promise closes that gap.

https://claude.ai/code/session_01AcP5vP56r1nzfxWGYHoPCi