### PR TITLE
Add grade display format setting (V-Grade vs Font)

### DIFF
--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -4,20 +4,18 @@ import { NextRequest } from 'next/server';
 import { sql } from '@/app/lib/db/db';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
 
 export const runtime = 'edge';
 
-// Maps difficulty ID to font grade name (same as profile-constants.ts)
-const DIFFICULTY_TO_GRADE: Record<number, string> = {
-  10: '4a', 11: '4b', 12: '4c',
-  13: '5a', 14: '5b', 15: '5c',
-  16: '6a', 17: '6a+', 18: '6b', 19: '6b+',
-  20: '6c', 21: '6c+',
-  22: '7a', 23: '7a+', 24: '7b', 25: '7b+', 26: '7c', 27: '7c+',
-  28: '8a', 29: '8a+', 30: '8b', 31: '8b+', 32: '8c', 33: '8c+',
-};
+// Maps difficulty ID to Font grade name for OG image labels.
+// OG images are static server-rendered PNGs — they always use Font grades
+// since we can't access the user's display preference here.
+const DIFFICULTY_TO_GRADE: Record<number, string> = Object.fromEntries(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.font_grade]),
+);
 
-const GRADE_ORDER = Object.values(DIFFICULTY_TO_GRADE);
+const GRADE_ORDER: string[] = BOULDER_GRADES.map((g) => g.font_grade);
 
 export async function GET(request: NextRequest) {
   try {

--- a/packages/web/app/components/activity-feed/__tests__/session-feed-card.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/session-feed-card.test.tsx
@@ -59,7 +59,16 @@ vi.mock('@/app/theme/theme-config', () => ({
 vi.mock('@/app/lib/grade-colors', () => ({
   getGradeColor: () => '#F44336',
   getGradeTextColor: () => '#FFFFFF',
-  formatVGrade: (g: string | null | undefined) => g ?? null,
+}));
+
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (g: string | null | undefined) => g ?? null,
+    getGradeColor: vi.fn(),
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 import SessionFeedCard from '../session-feed-card';

--- a/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
@@ -31,11 +31,12 @@ vi.mock('@/app/lib/grade-colors', () => ({
   getGradeColor: (d: string | null | undefined) => (d ? '#vivid' : undefined),
 }));
 
+import type { ActivityFeedItem } from '@boardsesh/shared-schema';
 import SessionSummaryFeedItem from '../session-summary-feed-item';
 
 // --- Helpers ---
 
-const makeItem = (overrides = {}) =>
+const makeItem = (overrides: Partial<ActivityFeedItem> = {}): ActivityFeedItem =>
   ({
     id: '1',
     type: 'session_summary',
@@ -49,8 +50,7 @@ const makeItem = (overrides = {}) =>
     }),
     createdAt: new Date().toISOString(),
     ...overrides,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }) as any;
+  }) as unknown as ActivityFeedItem;
 
 describe('SessionSummaryFeedItem grade format integration', () => {
   beforeEach(() => {

--- a/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// --- Mocks ---
+
+const defaultGradeFormat = {
+  gradeFormat: 'v-grade' as const,
+  formatGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+  getGradeColor: () => '#888',
+  loaded: true,
+  setGradeFormat: vi.fn(),
+};
+const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  getGradeColor: (d: string | null | undefined) => (d ? '#vivid' : undefined),
+}));
+
+import SessionSummaryFeedItem from '../session-summary-feed-item';
+
+// --- Helpers ---
+
+const makeItem = (overrides = {}) =>
+  ({
+    id: '1',
+    type: 'session_summary',
+    actorUserId: 'user1',
+    actorDisplayName: 'Tester',
+    actorAvatarUrl: null,
+    metadata: JSON.stringify({
+      totalSends: 5,
+      totalAttempts: 3,
+      gradeDistribution: [{ grade: '6a/V3', count: 3 }],
+    }),
+    createdAt: new Date().toISOString(),
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+describe('SessionSummaryFeedItem grade format integration', () => {
+  beforeEach(() => {
+    mockUseGradeFormat.mockReturnValue({ ...defaultGradeFormat });
+  });
+
+  it('renders grade labels with V-grade format', () => {
+    render(<SessionSummaryFeedItem item={makeItem()} />);
+    expect(screen.getByText('V3')).toBeTruthy();
+  });
+
+  it('shows Skeleton for grade labels when loading', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+    const { container } = render(<SessionSummaryFeedItem item={makeItem()} />);
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders Font grade labels', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      gradeFormat: 'font' as const,
+      formatGrade: (d: string | null | undefined) => {
+        if (!d) return null;
+        const slashIndex = d.indexOf('/');
+        if (slashIndex > 0) return d.substring(0, slashIndex).toUpperCase();
+        const match = d.match(/\d[abc]\+?/i);
+        return match ? match[0].toUpperCase() : null;
+      },
+    });
+    render(<SessionSummaryFeedItem item={makeItem()} />);
+    expect(screen.getByText('6A')).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/session-summary-feed-item-grade-format.test.tsx
@@ -4,8 +4,15 @@ import React from 'react';
 
 // --- Mocks ---
 
-const defaultGradeFormat = {
-  gradeFormat: 'v-grade' as const,
+interface GradeFormatMock {
+  gradeFormat: 'v-grade' | 'font';
+  formatGrade: (d: string | null | undefined) => string | null;
+  getGradeColor: (d?: string | null, dk?: boolean) => string | undefined;
+  loaded: boolean;
+  setGradeFormat: ReturnType<typeof vi.fn>;
+}
+const defaultGradeFormat: GradeFormatMock = {
+  gradeFormat: 'v-grade',
   formatGrade: (d: string | null | undefined) => {
     if (!d) return null;
     const match = d.match(/V\d+\+?/i);
@@ -15,9 +22,9 @@ const defaultGradeFormat = {
   loaded: true,
   setGradeFormat: vi.fn(),
 };
-const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+const mockUseGradeFormat = vi.fn<() => GradeFormatMock>(() => defaultGradeFormat);
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+  useGradeFormat: () => mockUseGradeFormat(),
 }));
 
 vi.mock('@/app/lib/grade-colors', () => ({
@@ -68,7 +75,7 @@ describe('SessionSummaryFeedItem grade format integration', () => {
   it('renders Font grade labels', () => {
     mockUseGradeFormat.mockReturnValue({
       ...defaultGradeFormat,
-      gradeFormat: 'font' as const,
+      gradeFormat: 'font',
       formatGrade: (d: string | null | undefined) => {
         if (!d) return null;
         const slashIndex = d.indexOf('/');

--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
 import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import FlashOnOutlined from '@mui/icons-material/FlashOnOutlined';
@@ -65,7 +66,7 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export default function SessionFeedCard({ session }: SessionFeedCardProps) {
-  const { formatGrade } = useGradeFormat();
+  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
 
   const {
     sessionId,
@@ -232,16 +233,20 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
               />
             )}
             {hardestGrade && (
-              <Chip
-                label={formatGrade(hardestGrade) ?? hardestGrade}
-                size="small"
-                sx={{
-                  borderRadius: themeTokens.borderRadius.full,
-                  bgcolor: hardestGradeColor || 'var(--neutral-200)',
-                  color: hardestGradeTextColor,
-                  fontWeight: 600,
-                }}
-              />
+              gradeFormatLoaded ? (
+                <Chip
+                  label={formatGrade(hardestGrade) ?? hardestGrade}
+                  size="small"
+                  sx={{
+                    borderRadius: themeTokens.borderRadius.full,
+                    bgcolor: hardestGradeColor || 'var(--neutral-200)',
+                    color: hardestGradeTextColor,
+                    fontWeight: 600,
+                  }}
+                />
+              ) : (
+                <Skeleton variant="rounded" width={40} height={24} sx={{ borderRadius: themeTokens.borderRadius.full }} />
+              )
             )}
           </Box>
 

--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -22,7 +22,8 @@ import OutcomeDoughnut from '@/app/components/charts/outcome-doughnut';
 import VoteButton from '@/app/components/social/vote-button';
 import FeedCommentButton from '@/app/components/social/feed-comment-button';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeColor, getGradeTextColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor, getGradeTextColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionFeedCardProps {
   session: SessionFeedItem;
@@ -64,6 +65,8 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export default function SessionFeedCard({ session }: SessionFeedCardProps) {
+  const { formatGrade } = useGradeFormat();
+
   const {
     sessionId,
     sessionName,
@@ -230,7 +233,7 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
             )}
             {hardestGrade && (
               <Chip
-                label={formatVGrade(hardestGrade) ?? hardestGrade}
+                label={formatGrade(hardestGrade) ?? hardestGrade}
                 size="small"
                 sx={{
                   borderRadius: themeTokens.borderRadius.full,

--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -96,8 +96,8 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
   const hardestGradeTextColor = getGradeTextColor(hardestGradeColor);
 
   const gradeBars = React.useMemo(
-    () => buildSessionGradeBars(gradeDistribution),
-    [gradeDistribution],
+    () => buildSessionGradeBars(gradeDistribution, formatGrade),
+    [gradeDistribution, formatGrade],
   );
 
   return (

--- a/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
@@ -31,7 +31,7 @@ interface SessionSummaryFeedItemProps {
 }
 
 export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemProps) {
-  const { formatGrade } = useGradeFormat();
+  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
 
   let metadata: SessionSummaryMetadata = {};
   try {
@@ -99,7 +99,7 @@ export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemP
           <Box sx={{ display: 'flex', gap: 0.5, mb: 1, flexWrap: 'wrap' }}>
             {gradeDistribution.slice(0, 6).map((g) => (
               <Box key={g.grade} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24 }}>
+                <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24, visibility: gradeFormatLoaded ? 'visible' : 'hidden' }}>
                   {formatGrade(g.grade) ?? g.grade}
                 </Typography>
                 <LinearProgress

--- a/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
@@ -14,7 +14,8 @@ import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import GroupsOutlined from '@mui/icons-material/GroupsOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { ActivityFeedItem } from '@boardsesh/shared-schema';
-import { getGradeColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryMetadata {
   totalSends?: number;
@@ -30,6 +31,8 @@ interface SessionSummaryFeedItemProps {
 }
 
 export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemProps) {
+  const { formatGrade } = useGradeFormat();
+
   let metadata: SessionSummaryMetadata = {};
   try {
     if (typeof item.metadata === 'string') {
@@ -97,7 +100,7 @@ export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemP
             {gradeDistribution.slice(0, 6).map((g) => (
               <Box key={g.grade} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                 <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24 }}>
-                  {formatVGrade(g.grade) ?? g.grade}
+                  {formatGrade(g.grade) ?? g.grade}
                 </Typography>
                 <LinearProgress
                   variant="determinate"

--- a/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
@@ -9,6 +9,7 @@ import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Chip from '@mui/material/Chip';
 import LinearProgress from '@mui/material/LinearProgress';
+import Skeleton from '@mui/material/Skeleton';
 import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import GroupsOutlined from '@mui/icons-material/GroupsOutlined';
@@ -99,9 +100,13 @@ export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemP
           <Box sx={{ display: 'flex', gap: 0.5, mb: 1, flexWrap: 'wrap' }}>
             {gradeDistribution.slice(0, 6).map((g) => (
               <Box key={g.grade} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24, visibility: gradeFormatLoaded ? 'visible' : 'hidden' }}>
-                  {formatGrade(g.grade) ?? g.grade}
-                </Typography>
+                {gradeFormatLoaded ? (
+                  <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 24 }}>
+                    {formatGrade(g.grade) ?? g.grade}
+                  </Typography>
+                ) : (
+                  <Skeleton variant="text" width={24} sx={{ fontSize: '0.75rem' }} />
+                )}
                 <LinearProgress
                   variant="determinate"
                   value={(g.count / maxGradeCount) * 100}

--- a/packages/web/app/components/charts/__tests__/session-grade-bars.test.ts
+++ b/packages/web/app/components/charts/__tests__/session-grade-bars.test.ts
@@ -104,6 +104,38 @@ describe('buildSessionGradeBars', () => {
   });
 });
 
+describe('buildSessionGradeBars with custom formatGradeFn', () => {
+  it('uses custom formatGradeFn for labels when provided', () => {
+    const input: SessionGradeDistributionItem[] = [
+      { grade: '7a/V6', flash: 0, send: 1, attempt: 0 },
+      { grade: '6a/V3', flash: 1, send: 0, attempt: 0 },
+    ];
+    const fontFormatter = (grade: string) => {
+      const slash = grade.indexOf('/');
+      return slash > 0 ? grade.substring(0, slash).toUpperCase() : grade;
+    };
+    const bars = buildSessionGradeBars(input, fontFormatter);
+    expect(bars[0].label).toBe('6A');
+    expect(bars[1].label).toBe('7A');
+  });
+
+  it('falls back to raw grade when custom formatGradeFn returns null', () => {
+    const input: SessionGradeDistributionItem[] = [
+      { grade: 'unknown', flash: 1, send: 0, attempt: 0 },
+    ];
+    const bars = buildSessionGradeBars(input, () => null);
+    expect(bars[0].label).toBe('unknown');
+  });
+
+  it('uses formatVGrade as default when no formatGradeFn provided', () => {
+    const input: SessionGradeDistributionItem[] = [
+      { grade: '6a/V3', flash: 1, send: 0, attempt: 0 },
+    ];
+    const bars = buildSessionGradeBars(input);
+    expect(bars[0].label).toBe('V3');
+  });
+});
+
 describe('SESSION_GRADE_LEGEND', () => {
   it('has 3 entries: Flash, Send, Attempt', () => {
     expect(SESSION_GRADE_LEGEND).toHaveLength(3);

--- a/packages/web/app/components/charts/session-grade-bars.ts
+++ b/packages/web/app/components/charts/session-grade-bars.ts
@@ -17,15 +17,21 @@ export const SESSION_GRADE_LEGEND = [
 /**
  * Convert session grade distribution data into CssBarChart bars.
  * Data arrives hardest-first from the backend; this reverses to easiest-first for display.
+ *
+ * @param formatGradeFn - Optional formatter for grade labels. When omitted, falls back to
+ *   formatVGrade. Components that have access to the useGradeFormat hook should pass
+ *   their `formatGrade` function here so labels respect the user's display preference.
  */
 export function buildSessionGradeBars(
   gradeDistribution: SessionGradeDistributionItem[],
+  formatGradeFn?: (grade: string) => string | null,
 ): CssBarChartBar[] {
   const sorted = [...gradeDistribution].reverse();
+  const fmt = formatGradeFn ?? ((g: string) => formatVGrade(g));
 
   return sorted.map((item) => ({
     key: item.grade,
-    label: formatVGrade(item.grade) ?? item.grade,
+    label: fmt(item.grade) ?? item.grade,
     segments: [
       { value: item.flash, color: FLASH_COLOR, label: 'Flash' },
       { value: item.send, color: SEND_COLOR, label: 'Send' },

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -8,22 +8,26 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
+const defaultGradeFormatReturn = {
+  gradeFormat: 'v-grade' as const,
+  formatGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+  getGradeColor: (d: string | null | undefined) => {
+    if (!d) return undefined;
+    const match = d.match(/V\d+\+?/i);
+    return match ? `#color-${match[0].toUpperCase()}` : undefined;
+  },
+  loaded: true,
+  setGradeFormat: vi.fn(),
+};
+
+const mockUseGradeFormat = vi.fn(() => defaultGradeFormatReturn);
+
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: () => ({
-    gradeFormat: 'v-grade',
-    formatGrade: (d: string | null | undefined) => {
-      if (!d) return null;
-      const match = d.match(/V\d+\+?/i);
-      return match ? match[0].toUpperCase() : null;
-    },
-    getGradeColor: (d: string | null | undefined) => {
-      if (!d) return undefined;
-      const match = d.match(/V\d+\+?/i);
-      return match ? `#color-${match[0].toUpperCase()}` : undefined;
-    },
-    loaded: true,
-    setGradeFormat: vi.fn(),
-  }),
+  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -311,6 +315,90 @@ describe('ClimbTitle', () => {
       render(<ClimbTitle climb={makeClimb()} />);
       expect(screen.getByText('Test Boulder')).toBeTruthy();
       expect(screen.getByText('6a/V3 3.5★')).toBeTruthy();
+    });
+  });
+
+  // --- Font grade format ---
+
+  describe('Font grade format', () => {
+    beforeEach(() => {
+      mockUseGradeFormat.mockReturnValue({
+        gradeFormat: 'font' as const,
+        formatGrade: (d: string | null | undefined) => {
+          if (!d) return null;
+          const slash = d.indexOf('/');
+          return slash > 0 ? d.substring(0, slash).toUpperCase() : null;
+        },
+        getGradeColor: () => '#color-font',
+        loaded: true,
+        setGradeFormat: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      mockUseGradeFormat.mockReturnValue(defaultGradeFormatReturn);
+    });
+
+    it('renders Font grade in horizontal layout', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3' })} layout="horizontal" />);
+      expect(screen.getByText('6A')).toBeTruthy();
+    });
+
+    it('renders Font grade in gradePosition="right" layout', () => {
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3' })} gradePosition="right" />);
+      expect(screen.getByText('6A')).toBeTruthy();
+    });
+
+    it('calls getGradeColor with the difficulty string', () => {
+      const getGradeColorSpy = vi.fn(() => '#color-font');
+      mockUseGradeFormat.mockReturnValue({
+        gradeFormat: 'font' as const,
+        formatGrade: (d: string | null | undefined) => {
+          if (!d) return null;
+          const slash = d.indexOf('/');
+          return slash > 0 ? d.substring(0, slash).toUpperCase() : null;
+        },
+        getGradeColor: getGradeColorSpy,
+        loaded: true,
+        setGradeFormat: vi.fn(),
+      });
+      render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3' })} gradePosition="right" />);
+      expect(getGradeColorSpy).toHaveBeenCalledWith('6a/V3', false);
+    });
+  });
+
+  // --- Loading state ---
+
+  describe('loading state', () => {
+    beforeEach(() => {
+      mockUseGradeFormat.mockReturnValue({
+        gradeFormat: 'v-grade' as const,
+        formatGrade: () => null,
+        getGradeColor: () => undefined,
+        loaded: false,
+        setGradeFormat: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      mockUseGradeFormat.mockReturnValue(defaultGradeFormatReturn);
+    });
+
+    it('renders a Skeleton instead of grade text in gradePosition="right" layout', () => {
+      const { container } = render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3' })} gradePosition="right" />);
+      expect(container.querySelector('.MuiSkeleton-root')).toBeTruthy();
+      expect(screen.queryByText('V3')).toBeNull();
+    });
+
+    it('renders a Skeleton instead of grade text in horizontal layout', () => {
+      const { container } = render(<ClimbTitle climb={makeClimb({ difficulty: '6a/V3' })} layout="horizontal" />);
+      expect(container.querySelector('.MuiSkeleton-root')).toBeTruthy();
+      expect(screen.queryByText('V3')).toBeNull();
+    });
+
+    it('does not render a Skeleton when difficulty is null', () => {
+      const { container } = render(<ClimbTitle climb={makeClimb({ difficulty: null })} gradePosition="right" />);
+      expect(container.querySelector('.MuiSkeleton-root')).toBeNull();
     });
   });
 });

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -8,8 +8,14 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-const defaultGradeFormatReturn = {
-  gradeFormat: 'v-grade' as const,
+const defaultGradeFormatReturn: {
+  gradeFormat: 'v-grade' | 'font';
+  formatGrade: (d: string | null | undefined) => string | null;
+  getGradeColor: (d: string | null | undefined, darkMode?: boolean) => string | undefined;
+  loaded: boolean;
+  setGradeFormat: ReturnType<typeof vi.fn>;
+} = {
+  gradeFormat: 'v-grade',
   formatGrade: (d: string | null | undefined) => {
     if (!d) return null;
     const match = d.match(/V\d+\+?/i);
@@ -24,10 +30,10 @@ const defaultGradeFormatReturn = {
   setGradeFormat: vi.fn(),
 };
 
-const mockUseGradeFormat = vi.fn(() => defaultGradeFormatReturn);
+const mockUseGradeFormat = vi.fn<() => typeof defaultGradeFormatReturn>(() => defaultGradeFormatReturn);
 
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+  useGradeFormat: () => mockUseGradeFormat(),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -323,7 +329,7 @@ describe('ClimbTitle', () => {
   describe('Font grade format', () => {
     beforeEach(() => {
       mockUseGradeFormat.mockReturnValue({
-        gradeFormat: 'font' as const,
+        gradeFormat: 'font',
         formatGrade: (d: string | null | undefined) => {
           if (!d) return null;
           const slash = d.indexOf('/');
@@ -352,7 +358,7 @@ describe('ClimbTitle', () => {
     it('calls getGradeColor with the difficulty string', () => {
       const getGradeColorSpy = vi.fn(() => '#color-font');
       mockUseGradeFormat.mockReturnValue({
-        gradeFormat: 'font' as const,
+        gradeFormat: 'font',
         formatGrade: (d: string | null | undefined) => {
           if (!d) return null;
           const slash = d.indexOf('/');
@@ -372,7 +378,7 @@ describe('ClimbTitle', () => {
   describe('loading state', () => {
     beforeEach(() => {
       mockUseGradeFormat.mockReturnValue({
-        gradeFormat: 'v-grade' as const,
+        gradeFormat: 'v-grade',
         formatGrade: () => null,
         getGradeColor: () => undefined,
         loaded: false,

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -8,13 +8,22 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-vi.mock('@/app/lib/grade-colors', () => ({
-  getSoftVGradeColor: (vGrade: string) => `#color-${vGrade}`,
-  formatVGrade: (d: string | null | undefined) => {
-    if (!d) return null;
-    const match = d.match(/V\d+\+?/i);
-    return match ? match[0].toUpperCase() : null;
-  },
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (d: string | null | undefined) => {
+      if (!d) return null;
+      const match = d.match(/V\d+\+?/i);
+      return match ? match[0].toUpperCase() : null;
+    },
+    getGradeColor: (d: string | null | undefined) => {
+      if (!d) return undefined;
+      const match = d.match(/V\d+\+?/i);
+      return match ? `#color-${match[0].toUpperCase()}` : undefined;
+    },
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -5,9 +5,9 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import ClimbIcons from './climb-icons';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getSoftVGradeColor, formatVGrade } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { formatSends, formatQuality } from '@/app/lib/format-climb-stats';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 export type ClimbTitleData = {
   name?: string;
@@ -179,14 +179,15 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
   isNoMatch = false,
 }) => {
   const isDark = useIsDarkMode();
+  const { formatGrade, getGradeColor } = useGradeFormat();
 
   const resolvedSubtitleSx = ellipsis ? subtitleEllipsisSx : subtitleSx;
 
   // Derived values — safe to compute even when climb is null (used after the guard below)
   const displayDifficulty = climb?.communityGrade || climb?.difficulty;
-  const vGrade = formatVGrade(displayDifficulty);
+  const formattedGrade = formatGrade(displayDifficulty);
   const nameFontSize = titleFontSize ?? themeTokens.typography.fontSize.sm;
-  const gradeColor = vGrade ? getSoftVGradeColor(vGrade, isDark) : undefined;
+  const gradeColor = formattedGrade ? getGradeColor(displayDifficulty, isDark) : undefined;
 
   // ALL useMemo hooks must be called unconditionally (before any early return)
   const nameSx = useMemo(() => ({
@@ -246,9 +247,9 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
     </Typography>
   );
 
-  const largeGradeElement = vGrade && (
+  const largeGradeElement = formattedGrade && (
     <Typography variant="body2" component="span" sx={largeGradeSx}>
-      {vGrade}
+      {formattedGrade}
     </Typography>
   );
 
@@ -303,7 +304,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
         <Box sx={rightRightColumnSx}>
           {rightAddon}
           {largeGradeElement}
-          {!vGrade && displayDifficulty && (
+          {!formattedGrade && displayDifficulty && (
             <Typography variant="body2" component="span" color="text.secondary" sx={fallbackGradeSx}>
               {displayDifficulty}
             </Typography>
@@ -330,7 +331,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
 
     return (
       <Box sx={centered ? horizontalCenteredSx : horizontalDefaultSx} className={className}>
-        {/* Colorized V grade - absolutely positioned left when centered */}
+        {/* Colorized grade - absolutely positioned left when centered */}
         {largeGradeElement && (
           <Box sx={centered ? absoluteLeftSx : undefined}>
             {largeGradeElement}

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
 import ClimbIcons from './climb-icons';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
@@ -179,7 +180,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
   isNoMatch = false,
 }) => {
   const isDark = useIsDarkMode();
-  const { formatGrade, getGradeColor } = useGradeFormat();
+  const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
   const resolvedSubtitleSx = ellipsis ? subtitleEllipsisSx : subtitleSx;
 
@@ -247,10 +248,14 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(({
     </Typography>
   );
 
-  const largeGradeElement = formattedGrade && (
-    <Typography variant="body2" component="span" sx={largeGradeSx}>
-      {formattedGrade}
-    </Typography>
+  const largeGradeElement = displayDifficulty && (
+    !gradeFormatLoaded ? (
+      <Skeleton variant="rounded" width={nameFontSize * 2.2} height={nameFontSize} sx={{ flexShrink: 0 }} />
+    ) : formattedGrade ? (
+      <Typography variant="body2" component="span" sx={largeGradeSx}>
+        {formattedGrade}
+      </Typography>
+    ) : null
   );
 
   const setterText = climb.is_draft

--- a/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
+
+const defaultGradeFormat = {
+  gradeFormat: 'v-grade' as const,
+  formatGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+  getGradeColor: () => '#888',
+  loaded: true,
+  setGradeFormat: vi.fn(),
+};
+const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+    colors: { primary: '#8C4A52' },
+    typography: {
+      fontSize: { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 },
+      fontWeight: { normal: 400, medium: 500, semibold: 600, bold: 700 },
+    },
+  },
+}));
+
+vi.mock('@/app/lib/format-climb-stats', () => ({
+  formatSends: (n: number) => `${n} send${n !== 1 ? 's' : ''}`,
+}));
+
+// Import component after mocks
+import ClimbDetailHeader from '../climb-detail-header';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const makeClimb = (overrides = {}) =>
+  ({
+    name: 'Test Climb',
+    difficulty: '6a/V3',
+    quality_average: '3.5',
+    benchmark_difficulty: null,
+    setter_username: 'setter',
+    ascensionist_count: 10,
+    ...overrides,
+  }) as unknown as Parameters<typeof ClimbDetailHeader>[0]['climb'];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  mockUseGradeFormat.mockReset();
+  mockUseGradeFormat.mockReturnValue(defaultGradeFormat);
+});
+
+describe('V-grade format (default)', () => {
+  it('renders V-grade when loaded', () => {
+    render(<ClimbDetailHeader climb={makeClimb()} />);
+    expect(screen.getByText('V3')).toBeTruthy();
+  });
+
+  it('renders "project" when difficulty is null', () => {
+    render(<ClimbDetailHeader climb={makeClimb({ difficulty: null })} />);
+    expect(screen.getByText('project')).toBeTruthy();
+  });
+});
+
+describe('Font grade format', () => {
+  it('renders Font grade when format is font', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      gradeFormat: 'font' as const,
+      formatGrade: (d: string | null | undefined) => {
+        if (!d) return null;
+        const before = d.split('/')[0];
+        return before ? before.toUpperCase() : null;
+      },
+    });
+
+    render(<ClimbDetailHeader climb={makeClimb()} />);
+    expect(screen.getByText('6A')).toBeTruthy();
+  });
+});
+
+describe('loading state', () => {
+  it('shows Skeleton when loaded=false and difficulty exists', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+
+    const { container } = render(<ClimbDetailHeader climb={makeClimb()} />);
+    expect(container.querySelector('.MuiSkeleton-root')).toBeTruthy();
+    expect(screen.queryByText('V3')).toBeNull();
+  });
+
+  it('does not show Skeleton when loaded=false and difficulty is null', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+
+    const { container } = render(
+      <ClimbDetailHeader climb={makeClimb({ difficulty: null })} />,
+    );
+    expect(container.querySelector('.MuiSkeleton-root')).toBeNull();
+    expect(screen.getByText('project')).toBeTruthy();
+  });
+
+  it('shows grade after loading completes', () => {
+    // Default mock already has loaded: true
+    render(<ClimbDetailHeader climb={makeClimb()} />);
+    expect(screen.getByText('V3')).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
@@ -9,8 +9,15 @@ import React from 'react';
 
 vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
 
-const defaultGradeFormat = {
-  gradeFormat: 'v-grade' as const,
+interface GradeFormatMock {
+  gradeFormat: 'v-grade' | 'font';
+  formatGrade: (d: string | null | undefined) => string | null;
+  getGradeColor: (d?: string | null, dk?: boolean) => string | undefined;
+  loaded: boolean;
+  setGradeFormat: ReturnType<typeof vi.fn>;
+}
+const defaultGradeFormat: GradeFormatMock = {
+  gradeFormat: 'v-grade',
   formatGrade: (d: string | null | undefined) => {
     if (!d) return null;
     const match = d.match(/V\d+\+?/i);
@@ -20,9 +27,9 @@ const defaultGradeFormat = {
   loaded: true,
   setGradeFormat: vi.fn(),
 };
-const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+const mockUseGradeFormat = vi.fn<() => GradeFormatMock>(() => defaultGradeFormat);
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+  useGradeFormat: () => mockUseGradeFormat(),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -83,7 +90,7 @@ describe('Font grade format', () => {
   it('renders Font grade when format is font', () => {
     mockUseGradeFormat.mockReturnValue({
       ...defaultGradeFormat,
-      gradeFormat: 'font' as const,
+      gradeFormat: 'font',
       formatGrade: (d: string | null | undefined) => {
         if (!d) return null;
         const before = d.split('/')[0];

--- a/packages/web/app/components/climb-detail/climb-detail-header.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-header.tsx
@@ -3,9 +3,10 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
 import CopyrightOutlined from '@mui/icons-material/CopyrightOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getSoftVGradeColor, formatVGrade } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { formatSends } from '@/app/lib/format-climb-stats';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import type { Climb } from '@/app/lib/types';
@@ -25,11 +26,12 @@ export default function ClimbDetailHeader({
   communityGrade,
 }: ClimbDetailHeaderProps) {
   const isDark = useIsDarkMode();
+  const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
   // Use community grade when available, otherwise fall back to original difficulty
   const displayDifficulty = communityGrade || climb.difficulty;
-  const vGrade = formatVGrade(displayDifficulty);
-  const gradeColor = vGrade ? getSoftVGradeColor(vGrade, isDark) : undefined;
+  const formattedGrade = formatGrade(displayDifficulty);
+  const gradeColor = formattedGrade ? getGradeColor(displayDifficulty, isDark) : undefined;
 
   // Check if climb is a benchmark/classic
   const benchmarkValue = climb.benchmark_difficulty != null ? Number(climb.benchmark_difficulty) : null;
@@ -49,7 +51,9 @@ export default function ClimbDetailHeader({
     >
       {/* Left: Grade */}
       <Box sx={{ flexShrink: 0, minWidth: 48 }}>
-        {vGrade ? (
+        {!gradeFormatLoaded && displayDifficulty ? (
+          <Skeleton variant="rounded" width={48} height={themeTokens.typography.fontSize['2xl']} />
+        ) : formattedGrade ? (
           <Typography
             variant="h5"
             component="span"
@@ -60,7 +64,7 @@ export default function ClimbDetailHeader({
               color: gradeColor ?? 'text.primary',
             }}
           >
-            {vGrade}
+            {formattedGrade}
           </Typography>
         ) : displayDifficulty ? (
           <Typography

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// --- Mocks (must be hoisted before imports of the component under test) ---
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
+
+const defaultGradeFormat = {
+  gradeFormat: 'v-grade' as const,
+  formatGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+  getGradeColor: () => '#888',
+  loaded: true,
+  setGradeFormat: vi.fn(),
+};
+const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+    colors: { primary: '#8C4A52', error: '#f44336', success: '#4caf50', successHover: '#388e3c' },
+    opacity: { subtle: 0.6 },
+    typography: {
+      fontSize: { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 },
+      fontWeight: { normal: 400, medium: 500, semibold: 600, bold: 700 },
+    },
+  },
+}));
+
+vi.mock('../../board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({
+    saveTick: vi.fn(),
+    logbook: [],
+  }),
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  TENSION_KILTER_GRADES: [
+    { difficulty_id: 16, difficulty_name: '6a/V3', v_grade: 'V3', font_grade: '6a' },
+    { difficulty_id: 22, difficulty_name: '7a/V6', v_grade: 'V6', font_grade: '7a' },
+  ],
+}));
+
+vi.mock('react-swipeable', () => ({
+  useSwipeable: () => ({}),
+}));
+
+vi.mock('@vercel/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('../quick-tick-bar.module.css', () => ({
+  default: {
+    tickBar: 'tickBar',
+    controls: 'controls',
+    rating: 'rating',
+    gradeLabel: 'gradeLabel',
+    attemptButton: 'attemptButton',
+    attemptNumber: 'attemptNumber',
+    attemptLabel: 'attemptLabel',
+  },
+}));
+
+// Import after mocks.
+import { QuickTickBar } from '../quick-tick-bar';
+
+// --- Fixtures ---
+
+const defaultProps = {
+  currentClimb: {
+    uuid: 'test-uuid',
+    name: 'Test Climb',
+    difficulty: '6a/V3',
+    quality_average: '3.0',
+    setter_username: 'tester',
+    ascensionist_count: 5,
+    benchmark_difficulty: null,
+    mirrored: false,
+  } as unknown as Parameters<typeof QuickTickBar>[0]['currentClimb'],
+  angle: 40 as unknown as Parameters<typeof QuickTickBar>[0]['angle'],
+  boardDetails: { layout_id: 1, size_id: 1, set_ids: '1', layout_name: 'Test' } as unknown as Parameters<typeof QuickTickBar>[0]['boardDetails'],
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+  comment: '',
+  commentOpen: false,
+  onCommentToggle: vi.fn(),
+  commentFocused: false,
+};
+
+describe('QuickTickBar grade format integration', () => {
+  afterEach(() => {
+    mockUseGradeFormat.mockReturnValue(defaultGradeFormat);
+  });
+
+  it('shows Skeleton when grade format not loaded', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+
+    const { container } = render(<QuickTickBar {...defaultProps} />);
+
+    // A MUI Skeleton should be rendered in place of the grade label.
+    const skeleton = container.querySelector('.MuiSkeleton-root');
+    expect(skeleton).not.toBeNull();
+
+    // The grade text element should not be present.
+    expect(screen.queryByTestId('quick-tick-grade')).toBeNull();
+  });
+
+  it('shows formatted grade when loaded', () => {
+    // Default mock has loaded: true and v-grade formatter.
+    render(<QuickTickBar {...defaultProps} />);
+
+    const gradeEl = screen.getByTestId('quick-tick-grade');
+    expect(gradeEl.textContent).toBe('V3');
+  });
+
+  it('shows Font grade when format is font', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      gradeFormat: 'font' as const,
+      formatGrade: (d: string | null | undefined) => {
+        if (!d) return null;
+        // Extract the Font portion before the slash and uppercase it.
+        const slashIndex = d.indexOf('/');
+        if (slashIndex > 0) {
+          return d.substring(0, slashIndex).toUpperCase();
+        }
+        const match = d.match(/\d[abc]\+?/i);
+        return match ? match[0].toUpperCase() : null;
+      },
+    });
+
+    render(<QuickTickBar {...defaultProps} />);
+
+    const gradeEl = screen.getByTestId('quick-tick-grade');
+    expect(gradeEl.textContent).toBe('6A');
+  });
+});

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
@@ -6,8 +6,15 @@ import React from 'react';
 
 vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
 
-const defaultGradeFormat = {
-  gradeFormat: 'v-grade' as const,
+interface GradeFormatMock {
+  gradeFormat: 'v-grade' | 'font';
+  formatGrade: (d: string | null | undefined) => string | null;
+  getGradeColor: (d?: string | null, dk?: boolean) => string | undefined;
+  loaded: boolean;
+  setGradeFormat: ReturnType<typeof vi.fn>;
+}
+const defaultGradeFormat: GradeFormatMock = {
+  gradeFormat: 'v-grade',
   formatGrade: (d: string | null | undefined) => {
     if (!d) return null;
     const match = d.match(/V\d+\+?/i);
@@ -17,9 +24,9 @@ const defaultGradeFormat = {
   loaded: true,
   setGradeFormat: vi.fn(),
 };
-const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+const mockUseGradeFormat = vi.fn<() => GradeFormatMock>(() => defaultGradeFormat);
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+  useGradeFormat: () => mockUseGradeFormat(),
 }));
 
 vi.mock('@/app/theme/theme-config', () => ({
@@ -126,7 +133,7 @@ describe('QuickTickBar grade format integration', () => {
   it('shows Font grade when format is font', () => {
     mockUseGradeFormat.mockReturnValue({
       ...defaultGradeFormat,
-      gradeFormat: 'font' as const,
+      gradeFormat: 'font',
       formatGrade: (d: string | null | undefined) => {
         if (!d) return null;
         // Extract the Font portion before the slash and uppercase it.

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 // NOTE: the "swipe left to dismiss" hint is intentionally NOT rendered here —
 // it lives above the queue control bar as a transient toast so it doesn't
 // push the stars out of alignment with the action buttons.
+import Skeleton from '@mui/material/Skeleton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
@@ -86,7 +87,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
 }) => {
   const { saveTick, logbook } = useBoardProvider();
   const isDark = useIsDarkMode();
-  const { formatGrade, getGradeColor } = useGradeFormat();
+  const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
   // Snapshot the target climb the first time we get a non-null climb.
   // All subsequent saves use this snapshot, not the live props.
@@ -310,28 +311,37 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
           <ChatBubbleOutlineOutlined fontSize="small" />
         </IconButton>
 
-        {/* Colourised V-grade, matching the styling used by ClimbTitle's
+        {/* Colourised grade, matching the styling used by ClimbTitle's
             right-aligned large grade. Click opens the override menu. */}
-        <Typography
-          variant="body2"
-          component="span"
-          onClick={(e) => setGradeAnchorEl(e.currentTarget)}
-          role="button"
-          aria-label="Select logged grade"
-          data-testid="quick-tick-grade"
-          className={styles.gradeLabel}
-          sx={{
-            fontSize: themeTokens.typography.fontSize.sm,
-            fontWeight: themeTokens.typography.fontWeight.bold,
-            lineHeight: 1,
-            color: gradeColor ?? 'text.secondary',
-            cursor: 'pointer',
-            flexShrink: 0,
-            px: '4px',
-          }}
-        >
-          {gradeLabel}
-        </Typography>
+        {!gradeFormatLoaded ? (
+          <Skeleton
+            variant="rounded"
+            width={themeTokens.typography.fontSize.sm * 2.5}
+            height={themeTokens.typography.fontSize.sm}
+            sx={{ flexShrink: 0, mx: '4px' }}
+          />
+        ) : (
+          <Typography
+            variant="body2"
+            component="span"
+            onClick={(e) => setGradeAnchorEl(e.currentTarget)}
+            role="button"
+            aria-label="Select logged grade"
+            data-testid="quick-tick-grade"
+            className={styles.gradeLabel}
+            sx={{
+              fontSize: themeTokens.typography.fontSize.sm,
+              fontWeight: themeTokens.typography.fontWeight.bold,
+              lineHeight: 1,
+              color: gradeColor ?? 'text.secondary',
+              cursor: 'pointer',
+              flexShrink: 0,
+              px: '4px',
+            }}
+          >
+            {gradeLabel}
+          </Typography>
+        )}
         <Menu
           anchorEl={gradeAnchorEl}
           open={Boolean(gradeAnchorEl)}

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -20,7 +20,7 @@ import { useBoardProvider } from '../board-provider/board-provider-context';
 import type { LogbookEntry, TickStatus } from '@/app/hooks/use-logbook';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { themeTokens } from '@/app/theme/theme-config';
-import { formatVGrade, getSoftVGradeColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import styles from './quick-tick-bar.module.css';
 
@@ -86,6 +86,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
 }) => {
   const { saveTick, logbook } = useBoardProvider();
   const isDark = useIsDarkMode();
+  const { formatGrade, getGradeColor } = useGradeFormat();
 
   // Snapshot the target climb the first time we get a non-null climb.
   // All subsequent saves use this snapshot, not the live props.
@@ -126,13 +127,13 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
     : undefined;
 
   // Prefer the user's override (which carries the full "font/v" difficulty
-  // name so formatVGrade can disambiguate V5 vs V5+), otherwise fall back
+  // name so formatGrade can disambiguate V5 vs V5+), otherwise fall back
   // to the snapshot climb's own difficulty string.
   const displayDifficulty =
     selectedGrade?.difficulty_name ?? tickTarget?.climb.difficulty ?? currentClimb?.difficulty ?? '';
-  const vGrade = formatVGrade(displayDifficulty);
-  const gradeLabel = vGrade ?? (displayDifficulty || '—');
-  const gradeColor = getSoftVGradeColor(vGrade, isDark);
+  const formattedGrade = formatGrade(displayDifficulty);
+  const gradeLabel = formattedGrade ?? (displayDifficulty || '—');
+  const gradeColor = getGradeColor(displayDifficulty, isDark);
 
   // Fall back to matching the climb's own difficulty string against the
   // grade list so the menu can highlight the "current" grade even before
@@ -358,7 +359,7 @@ export const QuickTickBar: React.FC<QuickTickBarProps> = ({
                   setGradeAnchorEl(null);
                 }}
               >
-                {formatVGrade(grade.difficulty_name) ?? grade.v_grade}
+                {formatGrade(grade.difficulty_name) ?? grade.v_grade}
               </MenuItem>
             );
           })}

--- a/packages/web/app/components/session-details/__tests__/session-overview-panel.test.tsx
+++ b/packages/web/app/components/session-details/__tests__/session-overview-panel.test.tsx
@@ -18,8 +18,14 @@ vi.mock('@/app/components/charts/session-grade-bars', () => ({
   ],
 }));
 
-vi.mock('@/app/lib/grade-colors', () => ({
-  formatVGrade: (g: string | null | undefined) => g ?? null,
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade',
+    formatGrade: (g: string | null | undefined) => g ?? null,
+    getGradeColor: vi.fn(),
+    loaded: true,
+    setGradeFormat: vi.fn(),
+  }),
 }));
 
 import SessionOverviewPanel from '../session-overview-panel';

--- a/packages/web/app/components/session-details/session-overview-panel.tsx
+++ b/packages/web/app/components/session-details/session-overview-panel.tsx
@@ -10,6 +10,7 @@ import AvatarGroup from '@mui/material/AvatarGroup';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import CircularProgress from '@mui/material/CircularProgress';
+import Skeleton from '@mui/material/Skeleton';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlashOnOutlined from '@mui/icons-material/FlashOnOutlined';
@@ -91,7 +92,7 @@ export default function SessionOverviewPanel({
   getParticipantHref,
   afterParticipants,
 }: SessionOverviewPanelProps) {
-  const { formatGrade } = useGradeFormat();
+  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
 
   // Defensive dedup: during WebSocket reconnection race conditions the server
   // may briefly report the same participant twice. Deduplicating by userId
@@ -226,7 +227,9 @@ export default function SessionOverviewPanel({
         )}
         <Chip label={`${tickCount} climb${tickCount !== 1 ? 's' : ''}`} variant="outlined" />
         {hardestGrade && (
-          <Chip label={`Hardest: ${formatGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
+          gradeFormatLoaded
+            ? <Chip label={`Hardest: ${formatGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
+            : <Skeleton variant="rounded" width={80} height={32} />
         )}
       </Box>
 

--- a/packages/web/app/components/session-details/session-overview-panel.tsx
+++ b/packages/web/app/components/session-details/session-overview-panel.tsx
@@ -104,8 +104,8 @@ export default function SessionOverviewPanel({
   const isMultiUser = uniqueParticipants.length > 1;
 
   const gradeBars = React.useMemo(
-    () => buildSessionGradeBars(gradeDistribution),
-    [gradeDistribution],
+    () => buildSessionGradeBars(gradeDistribution, formatGrade),
+    [gradeDistribution, formatGrade],
   );
 
   return (

--- a/packages/web/app/components/session-details/session-overview-panel.tsx
+++ b/packages/web/app/components/session-details/session-overview-panel.tsx
@@ -22,7 +22,7 @@ import type { SessionFeedParticipant, SessionGradeDistributionItem } from '@boar
 import { deduplicateBy } from '@/app/utils/deduplicate';
 import { CssBarChart } from '@/app/components/charts/css-bar-chart';
 import { buildSessionGradeBars, SESSION_GRADE_LEGEND } from '@/app/components/charts/session-grade-bars';
-import { formatVGrade } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionOverviewPanelProps {
   participants: SessionFeedParticipant[];
@@ -91,6 +91,8 @@ export default function SessionOverviewPanel({
   getParticipantHref,
   afterParticipants,
 }: SessionOverviewPanelProps) {
+  const { formatGrade } = useGradeFormat();
+
   // Defensive dedup: during WebSocket reconnection race conditions the server
   // may briefly report the same participant twice. Deduplicating by userId
   // keeps the UI stable until the next authoritative state sync arrives.
@@ -224,7 +226,7 @@ export default function SessionOverviewPanel({
         )}
         <Chip label={`${tickCount} climb${tickCount !== 1 ? 's' : ''}`} variant="outlined" />
         {hardestGrade && (
-          <Chip label={`Hardest: ${formatVGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
+          <Chip label={`Hardest: ${formatGrade(hardestGrade) ?? hardestGrade}`} variant="outlined" />
         )}
       </Box>
 

--- a/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
+++ b/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// --- Mocks ---
+
+const defaultGradeFormat = {
+  gradeFormat: 'v-grade' as const,
+  formatGrade: (d: string | null | undefined) => {
+    if (!d) return null;
+    const match = d.match(/V\d+\+?/i);
+    return match ? match[0].toUpperCase() : null;
+  },
+  getGradeColor: () => '#888',
+  loaded: true,
+  setGradeFormat: vi.fn(),
+};
+const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  getGradeColor: (d: string | null | undefined) => (d ? '#vivid' : undefined),
+}));
+
+import SessionSummaryView from '../session-summary-view';
+
+// --- Helpers ---
+
+const makeSummary = (overrides = {}) =>
+  ({
+    totalSends: 5,
+    totalAttempts: 3,
+    totalFlashes: 2,
+    durationMinutes: 60,
+    goal: null,
+    hardestClimb: { climbName: 'Hard One', grade: '7a/V6' },
+    gradeDistribution: [
+      { grade: '6a/V3', count: 3 },
+      { grade: '7a/V6', count: 1 },
+    ],
+    participants: [],
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+describe('SessionSummaryView grade format integration', () => {
+  beforeEach(() => {
+    mockUseGradeFormat.mockReturnValue({ ...defaultGradeFormat });
+  });
+
+  it('renders V-grade in hardest climb chip when loaded', () => {
+    const { container } = render(<SessionSummaryView summary={makeSummary()} />);
+    // The Chip label is rendered inside a span with MuiChip-label class
+    const chipLabel = container.querySelector('.MuiChip-label');
+    expect(chipLabel).toBeTruthy();
+    expect(chipLabel!.textContent).toBe('V6');
+  });
+
+  it('renders Font grade in hardest climb chip', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      gradeFormat: 'font' as const,
+      formatGrade: (d: string | null | undefined) => {
+        if (!d) return null;
+        const slashIndex = d.indexOf('/');
+        if (slashIndex > 0) return d.substring(0, slashIndex).toUpperCase();
+        const match = d.match(/\d[abc]\+?/i);
+        return match ? match[0].toUpperCase() : null;
+      },
+    });
+    const { container } = render(<SessionSummaryView summary={makeSummary()} />);
+    const chipLabel = container.querySelector('.MuiChip-label');
+    expect(chipLabel).toBeTruthy();
+    expect(chipLabel!.textContent).toBe('7A');
+  });
+
+  it('renders grade distribution labels with format', () => {
+    render(<SessionSummaryView summary={makeSummary()} />);
+    expect(screen.getByText('V3')).toBeTruthy();
+    // V6 appears in both chip and distribution; verify at least 2 occurrences
+    expect(screen.getAllByText('V6').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows Skeleton for hardest climb chip when loading', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+    const { container } = render(<SessionSummaryView summary={makeSummary()} />);
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows Skeleton for distribution labels when loading', () => {
+    mockUseGradeFormat.mockReturnValue({
+      ...defaultGradeFormat,
+      loaded: false,
+    });
+    const { container } = render(<SessionSummaryView summary={makeSummary()} />);
+    // One skeleton for the hardest climb chip + one per grade distribution entry (2)
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
+++ b/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
@@ -31,11 +31,12 @@ vi.mock('@/app/lib/grade-colors', () => ({
   getGradeColor: (d: string | null | undefined) => (d ? '#vivid' : undefined),
 }));
 
+import type { SessionSummary } from '@boardsesh/shared-schema';
 import SessionSummaryView from '../session-summary-view';
 
 // --- Helpers ---
 
-const makeSummary = (overrides = {}) =>
+const makeSummary = (overrides: Partial<SessionSummary> = {}): SessionSummary =>
   ({
     totalSends: 5,
     totalAttempts: 3,
@@ -49,8 +50,7 @@ const makeSummary = (overrides = {}) =>
     ],
     participants: [],
     ...overrides,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }) as any;
+  }) as unknown as SessionSummary;
 
 describe('SessionSummaryView grade format integration', () => {
   beforeEach(() => {

--- a/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
+++ b/packages/web/app/components/session-summary/__tests__/session-summary-view-grade-format.test.tsx
@@ -4,8 +4,15 @@ import React from 'react';
 
 // --- Mocks ---
 
-const defaultGradeFormat = {
-  gradeFormat: 'v-grade' as const,
+interface GradeFormatMock {
+  gradeFormat: 'v-grade' | 'font';
+  formatGrade: (d: string | null | undefined) => string | null;
+  getGradeColor: (d?: string | null, dk?: boolean) => string | undefined;
+  loaded: boolean;
+  setGradeFormat: ReturnType<typeof vi.fn>;
+}
+const defaultGradeFormat: GradeFormatMock = {
+  gradeFormat: 'v-grade',
   formatGrade: (d: string | null | undefined) => {
     if (!d) return null;
     const match = d.match(/V\d+\+?/i);
@@ -15,9 +22,9 @@ const defaultGradeFormat = {
   loaded: true,
   setGradeFormat: vi.fn(),
 };
-const mockUseGradeFormat = vi.fn(() => defaultGradeFormat);
+const mockUseGradeFormat = vi.fn<() => GradeFormatMock>(() => defaultGradeFormat);
 vi.mock('@/app/hooks/use-grade-format', () => ({
-  useGradeFormat: (...args: unknown[]) => mockUseGradeFormat(...args),
+  useGradeFormat: () => mockUseGradeFormat(),
 }));
 
 vi.mock('@/app/lib/grade-colors', () => ({
@@ -61,7 +68,7 @@ describe('SessionSummaryView grade format integration', () => {
   it('renders Font grade in hardest climb chip', () => {
     mockUseGradeFormat.mockReturnValue({
       ...defaultGradeFormat,
-      gradeFormat: 'font' as const,
+      gradeFormat: 'font',
       formatGrade: (d: string | null | undefined) => {
         if (!d) return null;
         const slashIndex = d.indexOf('/');

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -19,6 +19,7 @@ import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { SessionSummary } from '@boardsesh/shared-schema';
+import { getGradeColor as getVividGradeColor } from '@/app/lib/grade-colors';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryViewProps {
@@ -26,7 +27,7 @@ interface SessionSummaryViewProps {
 }
 
 export default function SessionSummaryView({ summary }: SessionSummaryViewProps) {
-  const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
+  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((g) => g.count), 1);
 
   const formatDuration = (minutes: number | null | undefined) => {
@@ -112,7 +113,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                   label={formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
                   size="small"
                   sx={{
-                    bgcolor: getGradeColor(summary.hardestClimb.grade),
+                    bgcolor: getVividGradeColor(summary.hardestClimb.grade),
                     color: '#fff',
                     fontWeight: 600,
                   }}
@@ -154,7 +155,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                       borderRadius: 1,
                       bgcolor: 'action.hover',
                       '& .MuiLinearProgress-bar': {
-                        bgcolor: getGradeColor(g.grade) ?? 'action.selected',
+                        bgcolor: getVividGradeColor(g.grade) ?? 'action.selected',
                         borderRadius: 1,
                       },
                     }}

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -26,7 +26,7 @@ interface SessionSummaryViewProps {
 }
 
 export default function SessionSummaryView({ summary }: SessionSummaryViewProps) {
-  const { formatGrade } = useGradeFormat();
+  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((g) => g.count), 1);
 
   const formatDuration = (minutes: number | null | undefined) => {
@@ -108,7 +108,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                 {summary.hardestClimb.climbName}
               </Typography>
               <Chip
-                label={formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
+                label={gradeFormatLoaded ? (formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade) : '\u00A0'}
                 size="small"
                 sx={{
                   bgcolor: getGradeColor(summary.hardestClimb.grade),
@@ -135,7 +135,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                     variant="body2"
                     sx={{ minWidth: 40, fontWeight: 600, textAlign: 'right' }}
                   >
-                    {formatGrade(g.grade) ?? g.grade}
+                    {gradeFormatLoaded ? (formatGrade(g.grade) ?? g.grade) : '\u00A0'}
                   </Typography>
                   <LinearProgress
                     variant="determinate"

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -11,6 +11,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import ListItemText from '@mui/material/ListItemText';
 import LinearProgress from '@mui/material/LinearProgress';
+import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Chip from '@mui/material/Chip';
 import EmojiEventsOutlined from '@mui/icons-material/EmojiEventsOutlined';
@@ -18,7 +19,6 @@ import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { SessionSummary } from '@boardsesh/shared-schema';
-import { getGradeColor } from '@/app/lib/grade-colors';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryViewProps {
@@ -26,7 +26,7 @@ interface SessionSummaryViewProps {
 }
 
 export default function SessionSummaryView({ summary }: SessionSummaryViewProps) {
-  const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
+  const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((g) => g.count), 1);
 
   const formatDuration = (minutes: number | null | undefined) => {
@@ -107,15 +107,19 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
               <Typography variant="body2" fontWeight={600}>
                 {summary.hardestClimb.climbName}
               </Typography>
-              <Chip
-                label={gradeFormatLoaded ? (formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade) : '\u00A0'}
-                size="small"
-                sx={{
-                  bgcolor: getGradeColor(summary.hardestClimb.grade),
-                  color: '#fff',
-                  fontWeight: 600,
-                }}
-              />
+              {gradeFormatLoaded ? (
+                <Chip
+                  label={formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
+                  size="small"
+                  sx={{
+                    bgcolor: getGradeColor(summary.hardestClimb.grade),
+                    color: '#fff',
+                    fontWeight: 600,
+                  }}
+                />
+              ) : (
+                <Skeleton variant="rounded" width={40} height={24} />
+              )}
             </Box>
           </CardContent>
         </Card>
@@ -131,12 +135,16 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
             <Stack spacing={0.75}>
               {summary.gradeDistribution.map((g) => (
                 <Box key={g.grade} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography
-                    variant="body2"
-                    sx={{ minWidth: 40, fontWeight: 600, textAlign: 'right' }}
-                  >
-                    {gradeFormatLoaded ? (formatGrade(g.grade) ?? g.grade) : '\u00A0'}
-                  </Typography>
+                  {gradeFormatLoaded ? (
+                    <Typography
+                      variant="body2"
+                      sx={{ minWidth: 40, fontWeight: 600, textAlign: 'right' }}
+                    >
+                      {formatGrade(g.grade) ?? g.grade}
+                    </Typography>
+                  ) : (
+                    <Skeleton variant="text" width={40} sx={{ fontSize: '0.875rem' }} />
+                  )}
                   <LinearProgress
                     variant="determinate"
                     value={(g.count / maxGradeCount) * 100}
@@ -146,7 +154,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                       borderRadius: 1,
                       bgcolor: 'action.hover',
                       '& .MuiLinearProgress-bar': {
-                        bgcolor: getGradeColor(g.grade),
+                        bgcolor: getGradeColor(g.grade) ?? 'action.selected',
                         borderRadius: 1,
                       },
                     }}

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -18,13 +18,15 @@ import TimerOutlined from '@mui/icons-material/TimerOutlined';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { SessionSummary } from '@boardsesh/shared-schema';
-import { getGradeColor, formatVGrade } from '@/app/lib/grade-colors';
+import { getGradeColor } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 
 interface SessionSummaryViewProps {
   summary: SessionSummary;
 }
 
 export default function SessionSummaryView({ summary }: SessionSummaryViewProps) {
+  const { formatGrade } = useGradeFormat();
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((g) => g.count), 1);
 
   const formatDuration = (minutes: number | null | undefined) => {
@@ -106,7 +108,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                 {summary.hardestClimb.climbName}
               </Typography>
               <Chip
-                label={formatVGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
+                label={formatGrade(summary.hardestClimb.grade) ?? summary.hardestClimb.grade}
                 size="small"
                 sx={{
                   bgcolor: getGradeColor(summary.hardestClimb.grade),
@@ -133,7 +135,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                     variant="body2"
                     sx={{ minWidth: 40, fontWeight: 600, textAlign: 'right' }}
                   >
-                    {formatVGrade(g.grade) ?? g.grade}
+                    {formatGrade(g.grade) ?? g.grade}
                   </Typography>
                   <LinearProgress
                     variant="determinate"

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -56,7 +56,7 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
   const { gradeFormat } = useGradeFormat();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [totalClimbs, setTotalClimbs] = useState(0);
-  const [gradeBars, setGradeBars] = useState<GradeBar[]>([]);
+  const [rawStats, setRawStats] = useState<GetUserProfileStatsQueryResponse['userProfileStats'] | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
@@ -84,41 +84,40 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
 
       if (statsData) {
         setTotalClimbs(statsData.totalDistinctClimbs);
-
-        // Aggregate grade counts across all layouts, grouped by display grade
-        const mapping = getDifficultyMapping(gradeFormat);
-        const gradeAgg: Record<string, number> = {};
-        for (const layout of statsData.layoutStats) {
-          for (const gc of layout.gradeCounts) {
-            const num = parseInt(gc.grade, 10);
-            if (isNaN(num)) continue;
-            const grade = mapping[num];
-            if (!grade) continue;
-            gradeAgg[grade] = (gradeAgg[grade] || 0) + gc.count;
-          }
-        }
-
-        // Convert to sorted bars
-        const sortedGradeKeys = sortGrades(Object.keys(gradeAgg), gradeFormat);
-        const bars: GradeBar[] = sortedGradeKeys.map((grade) => {
-          const count = gradeAgg[grade];
-          const hex = V_GRADE_COLORS[grade] ?? FONT_GRADE_COLORS[grade.toLowerCase()];
-          const color = hex ? getGradeColorWithOpacity(hex, 0.4) : 'rgba(200, 200, 200, 0.4)';
-          return { grade, count, color };
-        });
-
-        setGradeBars(bars);
+        setRawStats(statsData);
       }
     } catch {
       // Silently fail — card is a nice-to-have
     } finally {
       setLoading(false);
     }
-  }, [userId, gradeFormat]);
+  }, [userId]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData, refreshKey]);
+
+  const gradeBars = useMemo(() => {
+    if (!rawStats) return [];
+    const mapping = getDifficultyMapping(gradeFormat);
+    const gradeAgg: Record<string, number> = {};
+    for (const layout of rawStats.layoutStats) {
+      for (const gc of layout.gradeCounts) {
+        const num = parseInt(gc.grade, 10);
+        if (isNaN(num)) continue;
+        const grade = mapping[num];
+        if (!grade) continue;
+        gradeAgg[grade] = (gradeAgg[grade] || 0) + gc.count;
+      }
+    }
+    const sortedGradeKeys = sortGrades(Object.keys(gradeAgg), gradeFormat);
+    return sortedGradeKeys.map((grade) => {
+      const count = gradeAgg[grade];
+      const hex = V_GRADE_COLORS[grade] ?? FONT_GRADE_COLORS[grade.toLowerCase()];
+      const color = hex ? getGradeColorWithOpacity(hex, 0.4) : 'rgba(200, 200, 200, 0.4)';
+      return { grade, count, color };
+    });
+  }, [rawStats, gradeFormat]);
 
   const maxCount = useMemo(() => Math.max(...gradeBars.map((b: GradeBar) => b.count), 1), [gradeBars]);
 

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -17,8 +17,9 @@ import {
   type GetUserProfileStatsQueryVariables,
   type GetUserProfileStatsQueryResponse,
 } from '@/app/lib/graphql/operations';
-import { difficultyMapping } from '@/app/crusher/[user_id]/utils/profile-constants';
-import { V_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import { getDifficultyMapping, sortGrades } from '@/app/crusher/[user_id]/utils/profile-constants';
+import { V_GRADE_COLORS, FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import styles from './user-smart-card.module.css';
 
 interface UserSmartCardProps {
@@ -48,11 +49,11 @@ interface GradeBar {
   color: string;
 }
 
-const GRADE_ORDER = [...new Set(Object.values(difficultyMapping))];
 const CHIP_SX = { height: 20, fontSize: '0.7rem' } as const;
 
 export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardProps) {
   const router = useRouter();
+  const { gradeFormat } = useGradeFormat();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [totalClimbs, setTotalClimbs] = useState(0);
   const [gradeBars, setGradeBars] = useState<GradeBar[]>([]);
@@ -84,26 +85,27 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
       if (statsData) {
         setTotalClimbs(statsData.totalDistinctClimbs);
 
-        // Aggregate grade counts across all layouts, grouped by V-grade
+        // Aggregate grade counts across all layouts, grouped by display grade
+        const mapping = getDifficultyMapping(gradeFormat);
         const gradeAgg: Record<string, number> = {};
         for (const layout of statsData.layoutStats) {
           for (const gc of layout.gradeCounts) {
             const num = parseInt(gc.grade, 10);
             if (isNaN(num)) continue;
-            const grade = difficultyMapping[num];
+            const grade = mapping[num];
             if (!grade) continue;
             gradeAgg[grade] = (gradeAgg[grade] || 0) + gc.count;
           }
         }
 
         // Convert to sorted bars
-        const bars: GradeBar[] = Object.entries(gradeAgg)
-          .map(([grade, count]) => {
-            const hex = V_GRADE_COLORS[grade];
-            const color = hex ? getGradeColorWithOpacity(hex, 0.4) : 'rgba(200, 200, 200, 0.4)';
-            return { grade, count, color };
-          })
-          .sort((a: GradeBar, b: GradeBar) => GRADE_ORDER.indexOf(a.grade) - GRADE_ORDER.indexOf(b.grade));
+        const sortedGradeKeys = sortGrades(Object.keys(gradeAgg), gradeFormat);
+        const bars: GradeBar[] = sortedGradeKeys.map((grade) => {
+          const count = gradeAgg[grade];
+          const hex = V_GRADE_COLORS[grade] ?? FONT_GRADE_COLORS[grade.toLowerCase()];
+          const color = hex ? getGradeColorWithOpacity(hex, 0.4) : 'rgba(200, 200, 200, 0.4)';
+          return { grade, count, color };
+        });
 
         setGradeBars(bars);
       }
@@ -112,7 +114,7 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, gradeFormat]);
 
   useEffect(() => {
     fetchData();

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -53,7 +53,7 @@ const CHIP_SX = { height: 20, fontSize: '0.7rem' } as const;
 
 export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardProps) {
   const router = useRouter();
-  const { gradeFormat } = useGradeFormat();
+  const { gradeFormat, loaded: gradeFormatLoaded } = useGradeFormat();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [totalClimbs, setTotalClimbs] = useState(0);
   const [rawStats, setRawStats] = useState<GetUserProfileStatsQueryResponse['userProfileStats'] | null>(null);
@@ -205,7 +205,7 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
               <div className={styles.gradeLegend}>
                 {gradeBars.map((bar: GradeBar) => (
                   <span key={bar.grade} className={styles.gradeLegendLabel}>
-                    {bar.grade}
+                    {gradeFormatLoaded ? bar.grade : <Skeleton variant="text" width={20} sx={{ display: 'inline-block', fontSize: 'inherit' }} />}
                   </span>
                 ))}
               </div>

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -12,6 +12,7 @@ import {
   type GetUserProfileStatsQueryResponse,
 } from '@/app/lib/graphql/operations';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import {
   type UserProfile,
   type LogbookEntry,
@@ -31,6 +32,7 @@ import {
 export function useProfileData(userId: string) {
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
+  const { gradeFormat } = useGradeFormat();
 
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
@@ -162,23 +164,23 @@ export function useProfileData(userId: string) {
   );
 
   const aggregatedStackedBars = useMemo(
-    () => buildAggregatedStackedBars(allBoardsTicks, aggregatedTimeframe),
-    [allBoardsTicks, aggregatedTimeframe],
+    () => buildAggregatedStackedBars(allBoardsTicks, aggregatedTimeframe, gradeFormat),
+    [allBoardsTicks, aggregatedTimeframe, gradeFormat],
   );
 
   const weeklyBars = useMemo(
-    () => buildWeeklyBars(filteredLogbook, weeklyFromDate || undefined, weeklyToDate || undefined),
-    [filteredLogbook, weeklyFromDate, weeklyToDate],
+    () => buildWeeklyBars(filteredLogbook, weeklyFromDate || undefined, weeklyToDate || undefined, gradeFormat),
+    [filteredLogbook, weeklyFromDate, weeklyToDate, gradeFormat],
   );
 
   const aggregatedFlashRedpointBars = useMemo(
-    () => buildAggregatedFlashRedpointBars(allBoardsTicks, aggregatedTimeframe),
-    [allBoardsTicks, aggregatedTimeframe],
+    () => buildAggregatedFlashRedpointBars(allBoardsTicks, aggregatedTimeframe, gradeFormat),
+    [allBoardsTicks, aggregatedTimeframe, gradeFormat],
   );
 
   const statisticsSummary = useMemo(
-    () => buildStatisticsSummary(profileStats),
-    [profileStats],
+    () => buildStatisticsSummary(profileStats, gradeFormat),
+    [profileStats, gradeFormat],
   );
 
   const vPointsTimeline = useMemo(

--- a/packages/web/app/crusher/[user_id]/utils/__tests__/chart-data-builders-grade-format.test.ts
+++ b/packages/web/app/crusher/[user_id]/utils/__tests__/chart-data-builders-grade-format.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/app/lib/board-data', () => ({
+  SUPPORTED_BOARDS: ['kilter', 'tension'],
+  BOULDER_GRADES: [
+    { difficulty_id: 16, font_grade: '6a', v_grade: 'V3', difficulty_name: '6a/V3' },
+    { difficulty_id: 17, font_grade: '6a+', v_grade: 'V3', difficulty_name: '6a+/V3' },
+    { difficulty_id: 22, font_grade: '7a', v_grade: 'V6', difficulty_name: '7a/V6' },
+  ],
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  V_GRADE_COLORS: { V3: '#FF7043', V6: '#E53935' } as Record<string, string>,
+  FONT_GRADE_COLORS: { '6a': '#FF7043', '6a+': '#FF7043', '7a': '#E53935' } as Record<string, string>,
+  GradeDisplayFormat: {},
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    colors: { success: '#4caf50', error: '#f44336' },
+    neutral: { 300: '#e0e0e0' },
+  },
+}));
+
+import {
+  buildAggregatedStackedBars,
+  buildWeeklyBars,
+  buildFlashRedpointBars,
+  buildStatisticsSummary,
+} from '../chart-data-builders';
+import type { LogbookEntry } from '../profile-constants';
+
+// ── Shared test data ───────────────────────────────────────────────────────
+
+const entries: LogbookEntry[] = [
+  { climbed_at: '2025-01-15T10:00:00Z', difficulty: 16, tries: 1, angle: 40, status: 'flash', climbUuid: 'a' },
+  { climbed_at: '2025-01-15T11:00:00Z', difficulty: 22, tries: 3, angle: 40, status: 'send', climbUuid: 'b' },
+  { climbed_at: '2025-01-15T12:00:00Z', difficulty: 17, tries: 1, angle: 40, status: 'flash', climbUuid: 'c' },
+];
+
+// ── buildAggregatedStackedBars with Font format ────────────────────────────
+
+describe('buildAggregatedStackedBars with font format', () => {
+  const ticks: Record<string, LogbookEntry[]> = {
+    kilter: entries.map((e) => ({ ...e, layoutId: 1, boardType: 'kilter' })),
+  };
+
+  it('uses Font grade labels (6A, 6A+, 7A) instead of V-grade labels', () => {
+    const result = buildAggregatedStackedBars(ticks, 'all', 'font');
+    expect(result).not.toBeNull();
+
+    const labels = result!.bars.map((b) => b.label);
+    expect(labels).toContain('6A');
+    expect(labels).toContain('6A+');
+    expect(labels).toContain('7A');
+    // V-grade labels must not appear
+    expect(labels).not.toContain('V3');
+    expect(labels).not.toContain('V6');
+  });
+
+  it('sorts bars by Font grade order (6A before 6A+ before 7A)', () => {
+    const result = buildAggregatedStackedBars(ticks, 'all', 'font');
+    expect(result).not.toBeNull();
+
+    const labels = result!.bars.map((b) => b.label);
+    expect(labels).toEqual(['6A', '6A+', '7A']);
+  });
+});
+
+// ── buildWeeklyBars with Font format ───────────────────────────────────────
+
+describe('buildWeeklyBars with font format', () => {
+  it('uses Font grade labels in segment labels', () => {
+    const result = buildWeeklyBars(entries, undefined, undefined, 'font');
+    expect(result).not.toBeNull();
+
+    // All segments across all bars should use Font labels
+    const segmentLabels = new Set(result!.flatMap((bar) => bar.segments.map((s) => s.label)));
+    expect(segmentLabels.has('6A')).toBe(true);
+    expect(segmentLabels.has('7A')).toBe(true);
+    // V-grade labels must not appear
+    expect(segmentLabels.has('V3')).toBe(false);
+    expect(segmentLabels.has('V6')).toBe(false);
+  });
+
+  it('sorts active grades by Font order', () => {
+    const result = buildWeeklyBars(entries, undefined, undefined, 'font');
+    expect(result).not.toBeNull();
+
+    // Pick the first bar and verify its segment labels are in Font order
+    const bar = result![0];
+    const segmentLabels = bar.segments.map((s) => s.label);
+    // 6A should come before 6A+ which should come before 7A
+    const idx6A = segmentLabels.indexOf('6A');
+    const idx6APlus = segmentLabels.indexOf('6A+');
+    const idx7A = segmentLabels.indexOf('7A');
+    expect(idx6A).toBeLessThan(idx6APlus);
+    expect(idx6APlus).toBeLessThan(idx7A);
+  });
+});
+
+// ── buildFlashRedpointBars with Font format ────────────────────────────────
+
+describe('buildFlashRedpointBars with font format', () => {
+  it('uses Font grade labels for bar keys and labels', () => {
+    const result = buildFlashRedpointBars(entries, 'font');
+    expect(result).not.toBeNull();
+
+    const labels = result!.map((b) => b.label);
+    expect(labels).toContain('6A');
+    expect(labels).toContain('6A+');
+    expect(labels).toContain('7A');
+    expect(labels).not.toContain('V3');
+    expect(labels).not.toContain('V6');
+  });
+
+  it('sorts bars by Font grade order', () => {
+    const result = buildFlashRedpointBars(entries, 'font');
+    expect(result).not.toBeNull();
+
+    const labels = result!.map((b) => b.label);
+    expect(labels).toEqual(['6A', '6A+', '7A']);
+  });
+});
+
+// ── buildStatisticsSummary with Font format ────────────────────────────────
+
+describe('buildStatisticsSummary with font format', () => {
+  it('maps numeric grade keys to Font labels in layout grades', () => {
+    const profileStats = {
+      totalDistinctClimbs: 10,
+      layoutStats: [
+        {
+          layoutKey: 'kilter-1',
+          boardType: 'kilter',
+          layoutId: 1,
+          distinctClimbCount: 10,
+          gradeCounts: [
+            { grade: '16', count: 3 }, // 6A
+            { grade: '17', count: 2 }, // 6A+
+            { grade: '22', count: 5 }, // 7A
+          ],
+        },
+      ],
+    };
+
+    const { layoutPercentages } = buildStatisticsSummary(profileStats, 'font');
+    const grades = layoutPercentages[0].grades;
+    expect(grades).toEqual({ '6A': 3, '6A+': 2, '7A': 5 });
+    // V-grade keys must not appear
+    expect(grades).not.toHaveProperty('V3');
+    expect(grades).not.toHaveProperty('V6');
+  });
+});
+
+// ── Comparison: same data with v-grade format still produces V-grade labels ──
+
+describe('v-grade format comparison (default behavior)', () => {
+  it('buildAggregatedStackedBars with v-grade uses V3, V6 labels', () => {
+    const ticks: Record<string, LogbookEntry[]> = {
+      kilter: entries.map((e) => ({ ...e, layoutId: 1, boardType: 'kilter' })),
+    };
+    const result = buildAggregatedStackedBars(ticks, 'all', 'v-grade');
+    expect(result).not.toBeNull();
+
+    const labels = result!.bars.map((b) => b.label);
+    // difficulty 16 and 17 both map to V3, so there are only two distinct bars
+    expect(labels).toContain('V3');
+    expect(labels).toContain('V6');
+    expect(labels).not.toContain('6A');
+    expect(labels).not.toContain('7A');
+  });
+
+  it('buildFlashRedpointBars with v-grade uses V-grade labels', () => {
+    const result = buildFlashRedpointBars(entries, 'v-grade');
+    expect(result).not.toBeNull();
+
+    const labels = result!.map((b) => b.label);
+    expect(labels).toContain('V3');
+    expect(labels).toContain('V6');
+    expect(labels).not.toContain('6A');
+    expect(labels).not.toContain('7A');
+  });
+});

--- a/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/crusher/[user_id]/utils/chart-data-builders.ts
@@ -6,11 +6,14 @@ import type { GetUserProfileStatsQueryResponse } from '@/app/lib/graphql/operati
 import type { CssBarChartBar } from '@/app/components/charts/css-bar-chart';
 import type { GroupedBar } from '@/app/components/charts/css-bar-chart';
 import { themeTokens } from '@/app/theme/theme-config';
+import { type GradeDisplayFormat } from '@/app/lib/grade-colors';
 import {
   type LogbookEntry,
   type TimeframeType,
   type AggregatedTimeframeType,
   difficultyMapping,
+  getDifficultyMapping,
+  sortGrades,
   getGradeChartColor,
   getLayoutKey,
   getLayoutDisplayName,
@@ -95,7 +98,9 @@ export interface LayoutLegendEntry {
 export function buildAggregatedStackedBars(
   allBoardsTicks: Record<string, LogbookEntry[]>,
   aggregatedTimeframe: AggregatedTimeframeType,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): { bars: CssBarChartBar[]; legendEntries: LayoutLegendEntry[] } | null {
+  const mapping = getDifficultyMapping(gradeFormat);
   const layoutGradeClimbs: Record<string, Record<string, Set<string>>> = {};
   const allGrades = new Set<string>();
   const allLayouts = new Set<string>();
@@ -106,7 +111,7 @@ export function buildAggregatedStackedBars(
 
     filteredTicks.forEach((entry) => {
       if (entry.difficulty === null || entry.status === 'attempt' || !entry.climbUuid) return;
-      const grade = difficultyMapping[entry.difficulty];
+      const grade = mapping[entry.difficulty];
       if (grade) {
         const layoutKey = getLayoutKey(boardType, entry.layoutId);
         if (!layoutGradeClimbs[layoutKey]) layoutGradeClimbs[layoutKey] = {};
@@ -120,7 +125,7 @@ export function buildAggregatedStackedBars(
 
   if (allGrades.size === 0) return null;
 
-  const sortedGrades = GRADE_ORDER.filter((g) => allGrades.has(g));
+  const sortedGrades = sortGrades(Array.from(allGrades), gradeFormat);
 
   const layoutOrder = [
     'kilter-1', 'kilter-8', 'tension-9', 'tension-10', 'tension-11',
@@ -167,8 +172,11 @@ export function buildWeeklyBars(
   filteredLogbook: LogbookEntry[],
   weeklyFromDate?: string,
   weeklyToDate?: string,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): CssBarChartBar[] | null {
   if (filteredLogbook.length === 0) return null;
+
+  const mapping = getDifficultyMapping(gradeFormat);
 
   // Apply weekly date filter if provided
   const entries = (weeklyFromDate || weeklyToDate)
@@ -200,7 +208,7 @@ export function buildWeeklyBars(
     if (entry.difficulty === null) return;
     const d = dayjs(entry.climbed_at);
     const weekKey = `${d.isoWeekYear()}-W${d.isoWeek()}`;
-    const difficulty = difficultyMapping[entry.difficulty];
+    const difficulty = mapping[entry.difficulty];
     if (difficulty) {
       if (!weeklyData[weekKey]) weeklyData[weekKey] = {};
       weeklyData[weekKey][difficulty] = (weeklyData[weekKey][difficulty] || 0) + 1;
@@ -208,8 +216,15 @@ export function buildWeeklyBars(
   });
 
   // Find which grades actually appear
-  const activeGrades = GRADE_ORDER.filter((grade) =>
-    weekKeys.some((wk) => (weeklyData[wk]?.[grade] || 0) > 0),
+  const usedGrades = new Set<string>();
+  Object.values(weeklyData).forEach((weekGrades) => {
+    Object.keys(weekGrades).forEach((grade) => usedGrades.add(grade));
+  });
+  const activeGrades = sortGrades(
+    Array.from(usedGrades).filter((grade) =>
+      weekKeys.some((wk) => (weeklyData[wk]?.[grade] || 0) > 0),
+    ),
+    gradeFormat,
   );
 
   if (activeGrades.length === 0) return null;
@@ -235,15 +250,19 @@ export function buildWeeklyBars(
 
 // ── Flash vs Redpoint grouped bars ──────────────────────────────────
 
-export function buildFlashRedpointBars(filteredLogbook: LogbookEntry[]): GroupedBar[] | null {
+export function buildFlashRedpointBars(
+  filteredLogbook: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): GroupedBar[] | null {
   if (filteredLogbook.length === 0) return null;
 
+  const mapping = getDifficultyMapping(gradeFormat);
   const flash: Record<string, number> = {};
   const redpoint: Record<string, number> = {};
 
   filteredLogbook.forEach((entry) => {
     if (entry.difficulty === null) return;
-    const difficulty = difficultyMapping[entry.difficulty];
+    const difficulty = mapping[entry.difficulty];
     if (!difficulty) return;
     // Prefer the canonical status field when available. Fall back to the old
     // tries-based heuristic for legacy rows that don't have status set.
@@ -257,7 +276,7 @@ export function buildFlashRedpointBars(filteredLogbook: LogbookEntry[]): Grouped
   });
 
   const allGrades = new Set([...Object.keys(flash), ...Object.keys(redpoint)]);
-  const sortedGrades = GRADE_ORDER.filter((g) => allGrades.has(g));
+  const sortedGrades = sortGrades(Array.from(allGrades), gradeFormat);
 
   if (sortedGrades.length === 0) return null;
 
@@ -276,12 +295,13 @@ export function buildFlashRedpointBars(filteredLogbook: LogbookEntry[]): Grouped
 export function buildAggregatedFlashRedpointBars(
   allBoardsTicks: Record<string, LogbookEntry[]>,
   aggregatedTimeframe: AggregatedTimeframeType,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): GroupedBar[] | null {
   const allEntries = BOARD_TYPES.flatMap((boardType) =>
     filterByAggregatedTimeframe(allBoardsTicks[boardType] || [], aggregatedTimeframe),
   );
 
-  return buildFlashRedpointBars(allEntries);
+  return buildFlashRedpointBars(allEntries, gradeFormat);
 }
 
 // ── V-Points stacked area timeline ──────────────────────────────────
@@ -361,6 +381,7 @@ export function buildVPointsTimeline(
   const skippedKeys = allWeekKeys.length > 104 ? allWeekKeys.slice(0, -104) : [];
 
   // Per-layout: sum points per week
+  // V-Points always use V-grade mapping regardless of display format
   const layoutWeeklyPoints: Record<string, Record<string, number>> = {};
   for (const layoutKey of activeLayouts) {
     const weekPoints: Record<string, number> = {};
@@ -445,11 +466,13 @@ export interface LayoutPercentage {
 
 export function buildStatisticsSummary(
   profileStats: GetUserProfileStatsQueryResponse['userProfileStats'] | null,
+  gradeFormat: GradeDisplayFormat = 'v-grade',
 ): { totalAscents: number; layoutPercentages: LayoutPercentage[] } {
   if (!profileStats) {
     return { totalAscents: 0, layoutPercentages: [] };
   }
 
+  const mapping = getDifficultyMapping(gradeFormat);
   const totalAscents = profileStats.totalDistinctClimbs;
 
   const layoutsWithExactPercentages = profileStats.layoutStats
@@ -459,7 +482,7 @@ export function buildStatisticsSummary(
       stats.gradeCounts.forEach(({ grade, count }) => {
         const difficultyNum = parseInt(grade, 10);
         if (!isNaN(difficultyNum)) {
-          const gradeName = difficultyMapping[difficultyNum];
+          const gradeName = mapping[difficultyNum];
           if (gradeName) {
             grades[gradeName] = (grades[gradeName] || 0) + count;
           }

--- a/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
+++ b/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
@@ -1,4 +1,4 @@
-import { V_GRADE_COLORS, type GradeDisplayFormat } from '@/app/lib/grade-colors';
+import { V_GRADE_COLORS, FONT_GRADE_COLORS, type GradeDisplayFormat } from '@/app/lib/grade-colors';
 import { SUPPORTED_BOARDS, BOULDER_GRADES } from '@/app/lib/board-data';
 
 export interface UserProfile {
@@ -129,9 +129,9 @@ export const getLayoutColor = (boardType: string, layoutId: number | null | unde
  * and raises lightness for a cohesive, muted look.
  */
 export const getGradeChartColor = (grade: string): string => {
-  // Strip trailing "+" so "V5+" looks up the same color as "V5"
+  // Try V-grade first (strip trailing "+"), then Font grade (lowercase)
   const normalized = grade.replace(/\+$/, '');
-  const hexColor = V_GRADE_COLORS[normalized];
+  const hexColor = V_GRADE_COLORS[normalized] ?? FONT_GRADE_COLORS[grade.toLowerCase()];
   if (!hexColor) return 'hsla(0, 0%, 78%, 0.7)';
 
   // Convert hex to HSL for smoother control

--- a/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
+++ b/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
@@ -1,4 +1,4 @@
-import { V_GRADE_COLORS } from '@/app/lib/grade-colors';
+import { V_GRADE_COLORS, type GradeDisplayFormat } from '@/app/lib/grade-colors';
 import { SUPPORTED_BOARDS, BOULDER_GRADES } from '@/app/lib/board-data';
 
 export interface UserProfile {
@@ -42,6 +42,42 @@ export const BOARD_TYPES = SUPPORTED_BOARDS;
 export const difficultyMapping: Record<number, string> = Object.fromEntries(
   BOULDER_GRADES.map((g) => [g.difficulty_id, g.v_grade]),
 );
+
+// Font grade mapping: difficulty_id → uppercase Font grade (e.g., 16 → "6A")
+const fontGradeDifficultyMapping: Record<number, string> = Object.fromEntries(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.font_grade.toUpperCase()]),
+);
+
+// Get difficulty mapping based on format preference
+export const getDifficultyMapping = (format: GradeDisplayFormat): Record<number, string> => {
+  return format === 'font' ? fontGradeDifficultyMapping : difficultyMapping;
+};
+
+// Build reverse mapping from grade string to numeric difficulty for sorting
+const buildGradeOrder = (mapping: Record<number, string>): Map<string, number> => {
+  const order = new Map<string, number>();
+  for (const [numStr, grade] of Object.entries(mapping)) {
+    const num = parseInt(numStr, 10);
+    // For grades that map to the same string (e.g., V0 from 10, 11, 12), keep the lowest number
+    if (!order.has(grade) || num < (order.get(grade) ?? Infinity)) {
+      order.set(grade, num);
+    }
+  }
+  return order;
+};
+
+const vGradeOrder = buildGradeOrder(difficultyMapping);
+const fontGradeOrderMap = buildGradeOrder(fontGradeDifficultyMapping);
+
+// Sort grades by their numeric difficulty value
+export const sortGrades = (grades: string[], format: GradeDisplayFormat): string[] => {
+  const gradeOrder = format === 'font' ? fontGradeOrderMap : vGradeOrder;
+  return [...grades].sort((a, b) => {
+    const orderA = gradeOrder.get(a) ?? 999;
+    const orderB = gradeOrder.get(b) ?? 999;
+    return orderA - orderB;
+  });
+};
 
 // Layout name mapping: boardType-layoutId -> display name
 const layoutNames: Record<string, string> = {

--- a/packages/web/app/hooks/__tests__/use-grade-format.test.ts
+++ b/packages/web/app/hooks/__tests__/use-grade-format.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const mockGetFormat = vi.fn<() => Promise<'v-grade' | 'font'>>().mockResolvedValue('v-grade');
+const mockSetFormat = vi.fn<(f: 'v-grade' | 'font') => Promise<void>>().mockResolvedValue(undefined);
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getGradeDisplayFormat: (...args: unknown[]) => mockGetFormat(...args as []),
+  setGradeDisplayFormat: (...args: unknown[]) => mockSetFormat(...args as []),
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  formatGrade: (d: string | null | undefined, format: string) =>
+    d ? `${format}:${d}` : null,
+  getSoftGradeColorByFormat: (d: string | null | undefined, format: string) =>
+    d ? `color:${format}:${d}` : undefined,
+}));
+
+import { useGradeFormat } from '../use-grade-format';
+
+describe('useGradeFormat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFormat.mockResolvedValue('v-grade');
+    mockSetFormat.mockResolvedValue(undefined);
+  });
+
+  it('defaults to v-grade and loaded=false before IndexedDB resolves', () => {
+    mockGetFormat.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    expect(result.current.gradeFormat).toBe('v-grade');
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('sets loaded=true after IndexedDB resolves', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.gradeFormat).toBe('v-grade');
+  });
+
+  it('loads font format from IndexedDB when stored', async () => {
+    mockGetFormat.mockResolvedValue('font');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.gradeFormat).toBe('font');
+  });
+
+  it('formatGrade delegates with current format', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.formatGrade('6a/V3')).toBe('v-grade:6a/V3');
+    expect(result.current.formatGrade(null)).toBeNull();
+  });
+
+  it('getGradeColor delegates with current format', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.getGradeColor('6a/V3')).toBe('color:v-grade:6a/V3');
+    expect(result.current.getGradeColor(null)).toBeUndefined();
+  });
+
+  it('setGradeFormat persists and updates state', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.gradeFormat).toBe('v-grade');
+
+    await act(async () => {
+      await result.current.setGradeFormat('font');
+    });
+
+    expect(mockSetFormat).toHaveBeenCalledWith('font');
+    expect(result.current.gradeFormat).toBe('font');
+  });
+
+  it('setGradeFormat dispatches CustomEvent for cross-component sync', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    const events: CustomEvent[] = [];
+    const listener = (e: Event) => {
+      events.push(e as CustomEvent);
+    };
+    window.addEventListener('boardsesh:gradeFormatChange', listener);
+
+    await act(async () => {
+      await result.current.setGradeFormat('font');
+    });
+
+    window.removeEventListener('boardsesh:gradeFormatChange', listener);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toBe('font');
+  });
+
+  it('CustomEvent from another source updates state', async () => {
+    mockGetFormat.mockResolvedValue('v-grade');
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.gradeFormat).toBe('v-grade');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('boardsesh:gradeFormatChange', { detail: 'font' }),
+      );
+    });
+
+    expect(result.current.gradeFormat).toBe('font');
+  });
+});

--- a/packages/web/app/hooks/__tests__/use-grade-format.test.ts
+++ b/packages/web/app/hooks/__tests__/use-grade-format.test.ts
@@ -147,4 +147,17 @@ describe('useGradeFormat', () => {
 
     expect(result.current.gradeFormat).toBe('font');
   });
+
+  it('sets loaded=true even when IndexedDB rejects', async () => {
+    mockGetFormat.mockRejectedValue(new Error('IndexedDB unavailable'));
+
+    const { result } = renderHook(() => useGradeFormat());
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    // Falls back to default v-grade
+    expect(result.current.gradeFormat).toBe('v-grade');
+  });
 });

--- a/packages/web/app/hooks/__tests__/use-grade-format.test.ts
+++ b/packages/web/app/hooks/__tests__/use-grade-format.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const mockGetFormat = vi.fn<() => Promise<'v-grade' | 'font'>>().mockResolvedValue('v-grade');
-const mockSetFormat = vi.fn<(f: 'v-grade' | 'font') => Promise<void>>().mockResolvedValue(undefined);
+const mockGetFormat = vi.fn().mockResolvedValue('v-grade' as 'v-grade' | 'font');
+const mockSetFormat = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/app/lib/user-preferences-db', () => ({
-  getGradeDisplayFormat: (...args: unknown[]) => mockGetFormat(...args as []),
-  setGradeDisplayFormat: (...args: unknown[]) => mockSetFormat(...args as []),
+  getGradeDisplayFormat: () => mockGetFormat(),
+  setGradeDisplayFormat: (f: string) => mockSetFormat(f),
 }));
 
 vi.mock('@/app/lib/grade-colors', () => ({

--- a/packages/web/app/hooks/use-grade-format.ts
+++ b/packages/web/app/hooks/use-grade-format.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   getGradeDisplayFormat,
   setGradeDisplayFormat,
@@ -12,6 +12,9 @@ const GRADE_FORMAT_CHANGE_EVENT = 'boardsesh:gradeFormatChange';
 export function useGradeFormat() {
   const [gradeFormat, setGradeFormatState] = useState<GradeDisplayFormat>('v-grade');
   const [loaded, setLoaded] = useState(false);
+  // Track whether this instance originated the current change so the event
+  // listener can skip the redundant setState.
+  const isLocalChangeRef = useRef(false);
 
   useEffect(() => {
     getGradeDisplayFormat().then((value) => {
@@ -23,6 +26,10 @@ export function useGradeFormat() {
   // Listen for changes from other components that call setGradeFormat
   useEffect(() => {
     const handler = (e: Event) => {
+      if (isLocalChangeRef.current) {
+        isLocalChangeRef.current = false;
+        return;
+      }
       const format = (e as CustomEvent<GradeDisplayFormat>).detail;
       setGradeFormatState(format);
     };
@@ -33,7 +40,8 @@ export function useGradeFormat() {
   const setGradeFormat = useCallback(async (format: GradeDisplayFormat) => {
     await setGradeDisplayFormat(format);
     setGradeFormatState(format);
-    // Notify all other mounted instances of the hook
+    // Notify other mounted instances of the hook
+    isLocalChangeRef.current = true;
     window.dispatchEvent(
       new CustomEvent(GRADE_FORMAT_CHANGE_EVENT, { detail: format }),
     );

--- a/packages/web/app/hooks/use-grade-format.ts
+++ b/packages/web/app/hooks/use-grade-format.ts
@@ -2,9 +2,12 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   getGradeDisplayFormat,
   setGradeDisplayFormat,
-  type GradeDisplayFormat,
 } from '@/app/lib/user-preferences-db';
+import type { GradeDisplayFormat } from '@/app/lib/grade-colors';
 import { formatGrade, getSoftGradeColorByFormat } from '@/app/lib/grade-colors';
+
+/** Custom event name used to sync grade format across mounted components. */
+const GRADE_FORMAT_CHANGE_EVENT = 'boardsesh:gradeFormatChange';
 
 export function useGradeFormat() {
   const [gradeFormat, setGradeFormatState] = useState<GradeDisplayFormat>('v-grade');
@@ -17,9 +20,23 @@ export function useGradeFormat() {
     });
   }, []);
 
+  // Listen for changes from other components that call setGradeFormat
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const format = (e as CustomEvent<GradeDisplayFormat>).detail;
+      setGradeFormatState(format);
+    };
+    window.addEventListener(GRADE_FORMAT_CHANGE_EVENT, handler);
+    return () => window.removeEventListener(GRADE_FORMAT_CHANGE_EVENT, handler);
+  }, []);
+
   const setGradeFormat = useCallback(async (format: GradeDisplayFormat) => {
     await setGradeDisplayFormat(format);
     setGradeFormatState(format);
+    // Notify all other mounted instances of the hook
+    window.dispatchEvent(
+      new CustomEvent(GRADE_FORMAT_CHANGE_EVENT, { detail: format }),
+    );
   }, []);
 
   const formatGradeWithPreference = useCallback(

--- a/packages/web/app/hooks/use-grade-format.ts
+++ b/packages/web/app/hooks/use-grade-format.ts
@@ -17,10 +17,17 @@ export function useGradeFormat() {
   const isLocalChangeRef = useRef(false);
 
   useEffect(() => {
-    getGradeDisplayFormat().then((value) => {
-      setGradeFormatState(value);
-      setLoaded(true);
-    });
+    getGradeDisplayFormat()
+      .then((value) => {
+        setGradeFormatState(value);
+      })
+      .catch(() => {
+        // IndexedDB unavailable (private browsing, quota exceeded, etc.)
+        // Fall back to default v-grade so Skeletons don't stay forever.
+      })
+      .finally(() => {
+        setLoaded(true);
+      });
   }, []);
 
   // Listen for changes from other components that call setGradeFormat

--- a/packages/web/app/hooks/use-grade-format.ts
+++ b/packages/web/app/hooks/use-grade-format.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  getGradeDisplayFormat,
+  setGradeDisplayFormat,
+  type GradeDisplayFormat,
+} from '@/app/lib/user-preferences-db';
+import { formatGrade, getSoftGradeColorByFormat } from '@/app/lib/grade-colors';
+
+export function useGradeFormat() {
+  const [gradeFormat, setGradeFormatState] = useState<GradeDisplayFormat>('v-grade');
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    getGradeDisplayFormat().then((value) => {
+      setGradeFormatState(value);
+      setLoaded(true);
+    });
+  }, []);
+
+  const setGradeFormat = useCallback(async (format: GradeDisplayFormat) => {
+    await setGradeDisplayFormat(format);
+    setGradeFormatState(format);
+  }, []);
+
+  const formatGradeWithPreference = useCallback(
+    (difficulty: string | null | undefined): string | null => {
+      return formatGrade(difficulty, gradeFormat);
+    },
+    [gradeFormat],
+  );
+
+  const getGradeColor = useCallback(
+    (difficulty: string | null | undefined, darkMode?: boolean): string | undefined => {
+      return getSoftGradeColorByFormat(difficulty, gradeFormat, darkMode);
+    },
+    [gradeFormat],
+  );
+
+  return useMemo(
+    () => ({
+      gradeFormat,
+      setGradeFormat,
+      loaded,
+      formatGrade: formatGradeWithPreference,
+      getGradeColor,
+    }),
+    [gradeFormat, setGradeFormat, loaded, formatGradeWithPreference, getGradeColor],
+  );
+}

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -162,6 +162,67 @@ export function formatVGrade(difficulty: string | null | undefined): string | nu
 }
 
 /**
+ * Extract Font grade from a difficulty string (e.g., "6a/V3" -> "6A")
+ * @param difficulty - Difficulty string that may contain Font grade
+ * @returns Uppercase Font grade string for display (e.g., "6A", "7B+") or null if not found
+ */
+function extractFontGrade(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  // Try to extract from "6a/V3" format first
+  const slashIndex = difficulty.indexOf('/');
+  if (slashIndex > 0) {
+    return difficulty.substring(0, slashIndex).toUpperCase();
+  }
+  // Fall back to regex match for standalone Font grade
+  const fontGradeMatch = difficulty.match(/\d[abc]\+?/i);
+  return fontGradeMatch ? fontGradeMatch[0].toUpperCase() : null;
+}
+
+/**
+ * Format a difficulty string to a Font grade display label.
+ * @param difficulty - Difficulty string (e.g., "6a/V3", "7b+/V8")
+ * @returns Font grade string (e.g., "6a", "7b+") or null if not found
+ */
+export function formatFontGrade(difficulty: string | null | undefined): string | null {
+  return extractFontGrade(difficulty);
+}
+
+export type GradeDisplayFormat = 'v-grade' | 'font';
+
+/**
+ * Format a difficulty string based on the specified format preference.
+ * @param difficulty - Difficulty string (e.g., "6a/V3")
+ * @param format - Display format: 'v-grade' or 'font'
+ * @returns Formatted grade string based on the format, or null if not found
+ */
+export function formatGrade(difficulty: string | null | undefined, format: GradeDisplayFormat): string | null {
+  if (format === 'font') {
+    return formatFontGrade(difficulty);
+  }
+  return formatVGrade(difficulty);
+}
+
+/**
+ * Get a softened grade color based on the display format.
+ * @param difficulty - Difficulty string (e.g., "6a/V3")
+ * @param format - Display format: 'v-grade' or 'font'
+ * @param darkMode - Whether dark mode is active
+ * @returns Softened color string suitable for text display
+ */
+export function getSoftGradeColorByFormat(
+  difficulty: string | null | undefined,
+  format: GradeDisplayFormat,
+  darkMode?: boolean
+): string | undefined {
+  if (format === 'font') {
+    const fontGrade = extractFontGrade(difficulty);
+    return getSoftFontGradeColor(fontGrade, darkMode);
+  }
+  const vGrade = extractVGrade(difficulty);
+  return getSoftVGradeColor(vGrade, darkMode);
+}
+
+/**
  * Get a semi-transparent version of a grade color for backgrounds
  * @param color - Hex color string
  * @param opacity - Opacity value between 0 and 1

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -92,7 +92,10 @@ export const setAlwaysTickInApp = async (enabled: boolean): Promise<void> => {
   await setPreference('alwaysTickInApp', enabled);
 };
 
-export type GradeDisplayFormat = 'v-grade' | 'font';
+export type { GradeDisplayFormat } from './grade-colors';
+// Re-export so existing consumers don't break.
+// The canonical definition lives in grade-colors.ts.
+import type { GradeDisplayFormat } from './grade-colors';
 
 /**
  * Get the grade display format preference.

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -91,3 +91,21 @@ export const getAlwaysTickInApp = async (): Promise<boolean> => {
 export const setAlwaysTickInApp = async (enabled: boolean): Promise<void> => {
   await setPreference('alwaysTickInApp', enabled);
 };
+
+export type GradeDisplayFormat = 'v-grade' | 'font';
+
+/**
+ * Get the grade display format preference.
+ * Defaults to 'v-grade' if not set.
+ */
+export const getGradeDisplayFormat = async (): Promise<GradeDisplayFormat> => {
+  const value = await getPreference<GradeDisplayFormat>('gradeDisplayFormat');
+  return value === 'font' ? 'font' : 'v-grade';
+};
+
+/**
+ * Set the grade display format preference.
+ */
+export const setGradeDisplayFormat = async (format: GradeDisplayFormat): Promise<void> => {
+  await setPreference('gradeDisplayFormat', format);
+};

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -30,6 +30,9 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { usePartyProfile } from '@/app/components/party-manager/party-profile-context';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 
 const MAX_INPUT_SIZE = 10 * 1024 * 1024; // 10MB input ceiling before compression
 const MAX_DIMENSION = 1024; // resize longest side to ≤ 1024 px
@@ -120,6 +123,7 @@ export default function SettingsPageContent() {
   const { refreshProfile: refreshPartyProfile } = usePartyProfile();
   const { showMessage } = useSnackbar();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { gradeFormat, setGradeFormat, loaded: gradeFormatLoaded } = useGradeFormat();
 
   // Redirect unauthenticated users to login with a return URL
   useEffect(() => {
@@ -458,6 +462,40 @@ export default function SettingsPageContent() {
                   Save Changes
                 </Button>
               </Box>
+            </Box>
+          </CardContent>
+        </Card>
+
+        <MuiDivider sx={{ my: 2 }} />
+
+        <Card>
+          <CardContent>
+            <Typography variant="h5">Display Preferences</Typography>
+            <Typography variant="body2" component="span" color="text.secondary" sx={{ display: 'block', marginBottom: 3 }}>
+              Customize how grades and other data are displayed
+            </Typography>
+
+            <Box>
+              <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>Grade Display Format</Typography>
+              <ToggleButtonGroup
+                value={gradeFormat}
+                exclusive
+                onChange={(_e, newFormat) => {
+                  if (newFormat !== null) {
+                    setGradeFormat(newFormat);
+                  }
+                }}
+                disabled={!gradeFormatLoaded}
+                size="small"
+                fullWidth
+              >
+                <ToggleButton value="v-grade">
+                  V-Grade (V3, V6, ...)
+                </ToggleButton>
+                <ToggleButton value="font">
+                  Font (6A, 7C+, ...)
+                </ToggleButton>
+              </ToggleButtonGroup>
             </Box>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

- Adds a user preference to toggle grade display between V-grade (V3, V5+) and Font grade (6A, 7B+) across the entire app
- Based on gardaholm's original work, rebased onto latest main and extended to cover all grade display locations added since the original PR
- Shows Skeleton placeholders while the format preference loads from IndexedDB to prevent flash

## Changes

**Core infrastructure** (gardaholm's original, rebased):
- `useGradeFormat` hook backed by IndexedDB preference
- `getDifficultyMapping(format)` and `sortGrades()` in profile-constants
- `gradeFormat` threaded through all profile chart builders
- Settings UI toggle (V-Grade / Font)

**Additional integration** (new locations on main since original PR):
- `ClimbTitle` — uses hook + Skeleton while loading
- `ClimbDetailHeader` — uses hook + Skeleton while loading
- `QuickTickBar` — grade label and color from hook
- `SessionGradeBars` — accepts optional `formatGradeFn` param
- `SessionFeedCard` / `SessionOverviewPanel` — passes `formatGrade` to chart builders
- `UserSmartCard` — format-aware grade aggregation and sorting
- `OG profile route` — replaced hardcoded mapping with `BOULDER_GRADES` import

## Test plan

- [ ] Toggle grade format in Settings between V-Grade and Font
- [ ] Verify ClimbTitle shows correct format in queue list, climb cards, and play view
- [ ] Verify ClimbDetailHeader shows correct format on climb detail page
- [ ] Verify QuickTickBar grade label and menu items respect format
- [ ] Verify profile page charts (grade distribution, weekly, flash/redpoint) use correct labels
- [ ] Verify session feed cards show correct grade format
- [ ] Verify UserSmartCard grade bars use correct labels
- [ ] Verify no flash from V-grade to Font on initial page load (Skeleton shown instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)