### PR TITLE
Move periodic DB cleanup to Vercel crons so Neon can spin down

### DIFF
--- a/docs/inferred-sessions.md
+++ b/docs/inferred-sessions.md
@@ -23,7 +23,7 @@ There are no "ungrouped" ticks — the backfill migration (0060) ensures every h
 
 1. **Real-time** (`assignInferredSession`): Called from `saveTick` when a user logs a new tick. Looks at the user's most recent tick — if it's within 4 hours, the new tick joins that session. Otherwise, a new inferred session is created.
 
-2. **Batched** (`runInferredSessionBuilderBatched`): Runs on a 30-minute interval in the backend. Processes all users who have unassigned ticks, grouping them using the same 4-hour gap heuristic.
+2. **Batched** (`buildInferredSessionsForUser`): Runs as a daily Vercel cron (`/api/internal/inferred-sessions-backfill`) as a safety net for ticks that failed real-time assignment. Processes users with unassigned ticks in paginated batches, grouping them using the same 4-hour gap heuristic.
 
 3. **Post-sync** (`buildInferredSessionsForUser`): Runs after Aurora data sync completes, assigning sessions to newly imported ticks.
 

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -180,7 +180,7 @@ export const tickMutations = {
     };
 
     // Assign inferred session for ticks not in party mode (fire-and-forget).
-    // On failure, the tick stays unassigned until the background builder picks it up (~30 min).
+    // On failure, the tick stays unassigned until the daily safety-net cron picks it up.
     if (!validatedInput.sessionId) {
       assignInferredSession(uuid, userId, climbedAt, validatedInput.status).catch((err) => {
         console.error(`[saveTick] Failed to assign inferred session for tick ${uuid} (user ${userId}):`, err);

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -4,8 +4,6 @@ import { pubsub } from './pubsub/index';
 import { roomManager } from './services/room-manager';
 import { redisClientManager } from './redis/client';
 import { eventBroker, NotificationWorker } from './events/index';
-import { sql } from 'drizzle-orm';
-import { db } from './db/client';
 import { initCors, applyCorsHeaders } from './handlers/cors';
 import { handleHealthCheck } from './handlers/health';
 import { handleSessionJoin } from './handlers/join';
@@ -15,7 +13,6 @@ import { handleSyncCron } from './handlers/sync';
 import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
 import { createYogaInstance } from './graphql/yoga';
 import { setupWebSocketServer } from './websocket/setup';
-import { runInferredSessionBuilderBatched } from './jobs/inferred-session-builder';
 import { warmPopularConfigsCache } from './graphql/resolvers/social/boards';
 
 /**
@@ -203,30 +200,6 @@ export async function startServer(): Promise<ServerResources> {
   }, 60000);
   intervals.push(flushInterval);
 
-  // Periodic notification cleanup (once per day)
-  const notificationCleanupInterval = setInterval(async () => {
-    try {
-      await db.execute(sql`DELETE FROM notifications WHERE created_at < NOW() - INTERVAL '90 days'`);
-    } catch (error) {
-      console.error('[Server] Notification cleanup error:', error);
-    }
-  }, 24 * 60 * 60 * 1000);
-  intervals.push(notificationCleanupInterval);
-
-  // Periodic feed items cleanup (hourly, retains 180 days)
-  const feedCleanupInterval = setInterval(async () => {
-    try {
-      const result = await db.execute(sql`DELETE FROM feed_items WHERE created_at < NOW() - INTERVAL '180 days'`);
-      const deleted = (result as unknown as { rowCount?: number }).rowCount ?? 0;
-      if (deleted > 0) {
-        console.log(`[Server] Feed cleanup: deleted ${deleted} old feed items`);
-      }
-    } catch (error) {
-      console.error('[Server] Feed cleanup error:', error);
-    }
-  }, 60 * 60 * 1000);
-  intervals.push(feedCleanupInterval);
-
   // Periodic TTL refresh for active sessions (every 2 minutes)
   const ttlRefreshInterval = setInterval(async () => {
     try {
@@ -255,19 +228,6 @@ export async function startServer(): Promise<ServerResources> {
     }
   }, 120000); // 2 minutes
   intervals.push(ttlRefreshInterval);
-
-  // Periodic inferred session builder (every 30 minutes)
-  const inferredSessionInterval = setInterval(async () => {
-    try {
-      const result = await runInferredSessionBuilderBatched();
-      if (result.ticksAssigned > 0) {
-        console.log(`[Server] Inferred session builder: assigned ${result.ticksAssigned} ticks for ${result.usersProcessed} users`);
-      }
-    } catch (error) {
-      console.error('[Server] Inferred session builder error:', error);
-    }
-  }, 30 * 60 * 1000);
-  intervals.push(inferredSessionInterval);
 
   return { wss, httpServer, cleanupIntervals, shutdownServices };
 }

--- a/packages/web/app/api/internal/cleanup/route.ts
+++ b/packages/web/app/api/internal/cleanup/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { lt, sql } from 'drizzle-orm';
+import { lt, inArray, sql } from 'drizzle-orm';
 import { dbz as db } from '@/app/lib/db/db';
 import { feedItems, notifications } from '@boardsesh/db/schema';
 
@@ -7,6 +7,10 @@ export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 const CRON_SECRET = process.env.CRON_SECRET;
+const BATCH_SIZE = 5000;
+
+// Leave 10s buffer before timeout
+const DEADLINE_MS = (maxDuration - 10) * 1000;
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
@@ -15,15 +19,56 @@ export async function GET(request: Request) {
   }
 
   try {
-    await db
-      .delete(feedItems)
-      .where(lt(feedItems.createdAt, sql`NOW() - INTERVAL '180 days'`));
+    const deadline = Date.now() + DEADLINE_MS;
+    let feedDeleted = 0;
+    let notifDeleted = 0;
 
-    await db
-      .delete(notifications)
-      .where(lt(notifications.createdAt, sql`NOW() - INTERVAL '90 days'`));
+    // Batched feed item cleanup (180-day retention)
+    while (Date.now() < deadline) {
+      const batch = await db
+        .select({ id: feedItems.id })
+        .from(feedItems)
+        .where(lt(feedItems.createdAt, sql`NOW() - INTERVAL '180 days'`))
+        .limit(BATCH_SIZE);
 
-    return NextResponse.json({ success: true });
+      if (batch.length === 0) break;
+
+      await db
+        .delete(feedItems)
+        .where(inArray(feedItems.id, batch.map((r) => r.id)));
+
+      feedDeleted += batch.length;
+      if (batch.length < BATCH_SIZE) break;
+    }
+
+    // Batched notification cleanup (90-day retention)
+    while (Date.now() < deadline) {
+      const batch = await db
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(lt(notifications.createdAt, sql`NOW() - INTERVAL '90 days'`))
+        .limit(BATCH_SIZE);
+
+      if (batch.length === 0) break;
+
+      await db
+        .delete(notifications)
+        .where(inArray(notifications.id, batch.map((r) => r.id)));
+
+      notifDeleted += batch.length;
+      if (batch.length < BATCH_SIZE) break;
+    }
+
+    if (feedDeleted > 0 || notifDeleted > 0) {
+      console.log(
+        `[Cleanup cron] Deleted ${feedDeleted} feed items, ${notifDeleted} notifications`,
+      );
+    }
+
+    return NextResponse.json({
+      feedItemsDeleted: feedDeleted,
+      notificationsDeleted: notifDeleted,
+    });
   } catch (error) {
     console.error('[Cleanup cron] Error:', error);
     return NextResponse.json(

--- a/packages/web/app/api/internal/cleanup/route.ts
+++ b/packages/web/app/api/internal/cleanup/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { sql } from 'drizzle-orm';
+import { lt, sql } from 'drizzle-orm';
 import { dbz as db } from '@/app/lib/db/db';
+import { feedItems, notifications } from '@boardsesh/db/schema';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -14,22 +15,15 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Delete feed items older than 180 days
-    const feedResult = await db.execute<{ count: string }>(
-      sql`DELETE FROM feed_items WHERE created_at < NOW() - INTERVAL '180 days'`,
-    );
-    const feedDeleted = (feedResult as unknown as { rowCount?: number }).rowCount ?? 0;
+    await db
+      .delete(feedItems)
+      .where(lt(feedItems.createdAt, sql`NOW() - INTERVAL '180 days'`));
 
-    // Delete notifications older than 90 days
-    const notifResult = await db.execute<{ count: string }>(
-      sql`DELETE FROM notifications WHERE created_at < NOW() - INTERVAL '90 days'`,
-    );
-    const notifDeleted = (notifResult as unknown as { rowCount?: number }).rowCount ?? 0;
+    await db
+      .delete(notifications)
+      .where(lt(notifications.createdAt, sql`NOW() - INTERVAL '90 days'`));
 
-    return NextResponse.json({
-      feedItemsDeleted: feedDeleted,
-      notificationsDeleted: notifDeleted,
-    });
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error('[Cleanup cron] Error:', error);
     return NextResponse.json(

--- a/packages/web/app/api/internal/cleanup/route.ts
+++ b/packages/web/app/api/internal/cleanup/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { dbz as db } from '@/app/lib/db/db';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Delete feed items older than 180 days
+    const feedResult = await db.execute<{ count: string }>(
+      sql`DELETE FROM feed_items WHERE created_at < NOW() - INTERVAL '180 days'`,
+    );
+    const feedDeleted = (feedResult as unknown as { rowCount?: number }).rowCount ?? 0;
+
+    // Delete notifications older than 90 days
+    const notifResult = await db.execute<{ count: string }>(
+      sql`DELETE FROM notifications WHERE created_at < NOW() - INTERVAL '90 days'`,
+    );
+    const notifDeleted = (notifResult as unknown as { rowCount?: number }).rowCount ?? 0;
+
+    return NextResponse.json({
+      feedItemsDeleted: feedDeleted,
+      notificationsDeleted: notifDeleted,
+    });
+  } catch (error) {
+    console.error('[Cleanup cron] Error:', error);
+    return NextResponse.json(
+      { error: 'Cleanup failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
+++ b/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
@@ -9,6 +9,9 @@ export const maxDuration = 300;
 
 const CRON_SECRET = process.env.CRON_SECRET;
 
+// Leave a 30s buffer before the Vercel timeout to return a partial result
+const DEADLINE_MS = (maxDuration - 30) * 1000;
+
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
@@ -17,6 +20,7 @@ export async function GET(request: Request) {
 
   try {
     const db = getDb();
+    const startedAt = Date.now();
 
     // Find users with orphaned ticks (failed immediate assignment)
     const usersWithUnassigned = await db
@@ -37,14 +41,34 @@ export async function GET(request: Request) {
     }
 
     let totalAssigned = 0;
+    let usersProcessed = 0;
+    const errors: Array<{ userId: string; error: string }> = [];
+
     for (const { userId } of usersWithUnassigned) {
-      const assigned = await buildInferredSessionsForUser(userId);
-      totalAssigned += assigned;
+      // Stop processing before we hit the Vercel timeout
+      if (Date.now() - startedAt > DEADLINE_MS) {
+        console.log(
+          `[Inferred sessions backfill] Deadline reached after ${usersProcessed}/${usersWithUnassigned.length} users`,
+        );
+        break;
+      }
+
+      try {
+        const assigned = await buildInferredSessionsForUser(userId);
+        totalAssigned += assigned;
+        usersProcessed++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[Inferred sessions backfill] Failed for user ${userId}:`, message);
+        errors.push({ userId, error: message });
+      }
     }
 
     return NextResponse.json({
-      usersProcessed: usersWithUnassigned.length,
+      usersProcessed,
+      usersTotal: usersWithUnassigned.length,
       ticksAssigned: totalAssigned,
+      errors: errors.length > 0 ? errors : undefined,
     });
   } catch (error) {
     console.error('[Inferred sessions backfill] Error:', error);

--- a/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
+++ b/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
@@ -12,6 +12,9 @@ const CRON_SECRET = process.env.CRON_SECRET;
 // Leave a 30s buffer before the Vercel timeout to return a partial result
 const DEADLINE_MS = (maxDuration - 30) * 1000;
 
+// Process at most this many users per invocation to guarantee forward progress
+const MAX_USERS_PER_RUN = 50;
+
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
@@ -22,7 +25,7 @@ export async function GET(request: Request) {
     const db = getDb();
     const startedAt = Date.now();
 
-    // Find users with orphaned ticks (failed immediate assignment)
+    // Paginated: fetch a bounded batch of users, ordered by userId for deterministic progress
     const usersWithUnassigned = await db
       .selectDistinct({ userId: boardseshTicks.userId })
       .from(boardseshTicks)
@@ -31,24 +34,27 @@ export async function GET(request: Request) {
           isNull(boardseshTicks.sessionId),
           isNull(boardseshTicks.inferredSessionId),
         ),
-      );
+      )
+      .orderBy(boardseshTicks.userId)
+      .limit(MAX_USERS_PER_RUN);
 
     if (usersWithUnassigned.length === 0) {
       return NextResponse.json({
-        usersProcessed: 0,
+        usersSucceeded: 0,
         ticksAssigned: 0,
+        hasMore: false,
       });
     }
 
     let totalAssigned = 0;
-    let usersProcessed = 0;
+    let usersSucceeded = 0;
     const errors: Array<{ userId: string; error: string }> = [];
 
     for (const { userId } of usersWithUnassigned) {
       // Stop processing before we hit the Vercel timeout
       if (Date.now() - startedAt > DEADLINE_MS) {
         console.log(
-          `[Inferred sessions backfill] Deadline reached after ${usersProcessed}/${usersWithUnassigned.length} users`,
+          `[Inferred sessions backfill] Deadline reached after ${usersSucceeded}/${usersWithUnassigned.length} users`,
         );
         break;
       }
@@ -56,7 +62,7 @@ export async function GET(request: Request) {
       try {
         const assigned = await buildInferredSessionsForUser(userId);
         totalAssigned += assigned;
-        usersProcessed++;
+        usersSucceeded++;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`[Inferred sessions backfill] Failed for user ${userId}:`, message);
@@ -64,10 +70,14 @@ export async function GET(request: Request) {
       }
     }
 
+    // If we fetched a full page, there may be more users to process
+    const hasMore = usersWithUnassigned.length === MAX_USERS_PER_RUN;
+
     return NextResponse.json({
-      usersProcessed,
-      usersTotal: usersWithUnassigned.length,
+      usersSucceeded,
+      usersFailed: errors.length,
       ticksAssigned: totalAssigned,
+      hasMore,
       errors: errors.length > 0 ? errors : undefined,
     });
   } catch (error) {

--- a/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
+++ b/packages/web/app/api/internal/inferred-sessions-backfill/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/app/lib/db/db';
+import { boardseshTicks } from '@/app/lib/db/schema';
+import { and, isNull } from 'drizzle-orm';
+import { buildInferredSessionsForUser } from '@/app/lib/data-sync/aurora/inferred-session-builder';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const db = getDb();
+
+    // Find users with orphaned ticks (failed immediate assignment)
+    const usersWithUnassigned = await db
+      .selectDistinct({ userId: boardseshTicks.userId })
+      .from(boardseshTicks)
+      .where(
+        and(
+          isNull(boardseshTicks.sessionId),
+          isNull(boardseshTicks.inferredSessionId),
+        ),
+      );
+
+    if (usersWithUnassigned.length === 0) {
+      return NextResponse.json({
+        usersProcessed: 0,
+        ticksAssigned: 0,
+      });
+    }
+
+    let totalAssigned = 0;
+    for (const { userId } of usersWithUnassigned) {
+      const assigned = await buildInferredSessionsForUser(userId);
+      totalAssigned += assigned;
+    }
+
+    return NextResponse.json({
+      usersProcessed: usersWithUnassigned.length,
+      ticksAssigned: totalAssigned,
+    });
+  } catch (error) {
+    console.error('[Inferred sessions backfill] Error:', error);
+    return NextResponse.json(
+      { error: 'Backfill failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,14 @@
     {
       "path": "/api/internal/prewarm-heatmap/grasshopper",
       "schedule": "0 5 * * 0"
+    },
+    {
+      "path": "/api/internal/cleanup",
+      "schedule": "0 5 * * *"
+    },
+    {
+      "path": "/api/internal/inferred-sessions-backfill",
+      "schedule": "30 5 * * *"
     }
   ]
 }


### PR DESCRIPTION
The backend ran 3 setInterval jobs that unconditionally queried the
database, preventing Neon from ever reaching its 5-minute idle
threshold to spin down. With 2 Railway replicas, this doubled the
wake-ups.

- Remove notification cleanup (24h), feed cleanup (1h), and inferred
  session builder (30m) intervals from backend server.ts
- Add /api/internal/cleanup Vercel cron (daily) for feed + notification
  retention deletes
- Add /api/internal/inferred-sessions-backfill Vercel cron (daily) as
  safety net for failed fire-and-forget session assignments
- Remaining backend intervals (flush, TTL refresh) only touch DB/Redis
  when active sessions exist

https://claude.ai/code/session_01TAxPrp5DyZM4cTaXdwzSrU