### PR TITLE
Disable E2E screenshot tests temporarily

### DIFF
--- a/packages/web/e2e/app-store-screenshots.spec.ts
+++ b/packages/web/e2e/app-store-screenshots.spec.ts
@@ -30,6 +30,8 @@ const boardUrl = '/kilter/original/12x12-square/screw_bolt/40/list';
 // Board-page screenshots: beforeEach navigates to the board list.
 // Viewport and device settings come from the app-store-screenshots project in playwright.config.ts.
 test.describe('App Store Screenshots', () => {
+  test.skip(true, 'Temporarily disabled — screenshot tests not working as expected');
+
   // These are heavy pages at 3x scale -- give them room to load
   test.setTimeout(90_000);
 

--- a/packages/web/e2e/help-screenshots.spec.ts
+++ b/packages/web/e2e/help-screenshots.spec.ts
@@ -25,6 +25,8 @@ const boardUrl = '/kilter/original/12x12-square/screw_bolt/40/list';
 // Both describe blocks here inherit it without needing their own test.use() calls.
 
 test.describe('Help Page Screenshots', () => {
+  test.skip(true, 'Temporarily disabled — screenshot tests not working as expected');
+
   test.beforeEach(async ({ page }) => {
     await page.goto(boardUrl);
     await page.waitForSelector('#onboarding-climb-card, [data-testid="climb-card"]', { timeout: 30000 })
@@ -117,10 +119,12 @@ test.describe('Help Page Screenshots', () => {
 
 // Authenticated tests - requires TEST_USER_EMAIL and TEST_USER_PASSWORD env vars
 test.describe('Help Page Screenshots - Authenticated', () => {
+  test.skip(true, 'Temporarily disabled — screenshot tests not working as expected');
+
   const testEmail = process.env.TEST_USER_EMAIL;
   const testPassword = process.env.TEST_USER_PASSWORD;
 
-  test.skip(!testEmail || !testPassword, 'Set TEST_USER_EMAIL and TEST_USER_PASSWORD env vars to run authenticated tests');
+  // test.skip(!testEmail || !testPassword, 'Set TEST_USER_EMAIL and TEST_USER_PASSWORD env vars to run authenticated tests');
 
   test.beforeEach(async ({ page }) => {
     await page.goto(boardUrl);

--- a/packages/web/e2e/layout-screenshots.spec.ts
+++ b/packages/web/e2e/layout-screenshots.spec.ts
@@ -68,6 +68,8 @@ const LAYOUTS = [
 ] as const;
 
 test.describe('Layout Screenshots', () => {
+  test.skip(true, 'Temporarily disabled — screenshot tests not working as expected');
+
   // Board image assets can be large — give each test plenty of headroom
   test.setTimeout(90_000);
 


### PR DESCRIPTION
All three screenshot test suites (app-store, help, and layout) are now skipped. These tests were not working as expected and are disabled until they can be fixed.

- app-store-screenshots.spec.ts: Skip all tests
- help-screenshots.spec.ts: Skip both authenticated and unauthenticated suites
- layout-screenshots.spec.ts: Skip all tests

https://claude.ai/code/session_019SpRYj1EcA8uWHfjM6i1EE