### PR TITLE
Fix duplicate Bluetooth devices in iOS device picker (#1511)

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -205,7 +205,7 @@ describe('useBoardBluetooth', () => {
       await result.current.connect();
     });
 
-    expect(mockCreateBluetoothAdapter).toHaveBeenCalledWith('moonboard');
+    expect(mockCreateBluetoothAdapter).toHaveBeenCalledWith('moonboard', undefined);
   });
 
   it('handles connect failure', async () => {

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '@vercel/analytics';
 import { useBoardBluetooth } from './use-board-bluetooth';
+import { DevicePickerDialog } from './device-picker-dialog';
 import { useCurrentClimb } from '../graphql-queue';
 import type { BoardDetails } from '@/app/lib/types';
 import { isCapacitor, isCapacitorWebView, waitForCapacitor, CAPACITOR_BRIDGE_TIMEOUT_MS } from '@/app/lib/ble/capacitor-utils';
@@ -92,7 +93,7 @@ export function BluetoothProvider({
   boardDetails: BoardDetails;
   children: React.ReactNode;
 }) {
-  const { isConnected, loading, connect, disconnect, sendFramesToBoard } =
+  const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } =
     useBoardBluetooth({ boardDetails });
 
   const [isBluetoothSupported, setIsBluetoothSupported] = useState(false);
@@ -167,6 +168,13 @@ export function BluetoothProvider({
         <BluetoothAutoSender
           sendFramesToBoard={sendFramesToBoard}
           layoutName={boardDetails.layout_name ?? ''}
+        />
+      )}
+      {pickerState && (
+        <DevicePickerDialog
+          devices={pickerState.devices}
+          onSelect={pickerState.onSelect}
+          onCancel={pickerState.onCancel}
         />
       )}
       {children}

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
@@ -15,13 +15,16 @@ const MOONBOARD_ROLE_MAP = {
 } as const;
 
 export const MOONBOARD_SCAN_SERVICE_UUIDS = [UART_SERVICE_UUID] as const;
-export const MOONBOARD_OPTIONAL_SERVICE_UUIDS = [UART_SERVICE_UUID] as const;
+// UART service is already in the scan filter — no additional services needed
+export const MOONBOARD_OPTIONAL_SERVICE_UUIDS = [] as const;
 
+// Each filter AND's service UUID + name prefix. Two filters are OR'd so we
+// match both capitalization variants without showing the same device twice.
 export const MOONBOARD_REQUEST_DEVICE_OPTIONS: RequestDeviceOptions = {
-  filters: [
-    { services: [...MOONBOARD_SCAN_SERVICE_UUIDS] },
-    ...MOONBOARD_DEVICE_NAME_PREFIXES.map((namePrefix) => ({ namePrefix })),
-  ],
+  filters: MOONBOARD_DEVICE_NAME_PREFIXES.map((namePrefix) => ({
+    services: [...MOONBOARD_SCAN_SERVICE_UUIDS],
+    namePrefix,
+  })),
   optionalServices: [...MOONBOARD_OPTIONAL_SERVICE_UUIDS],
 };
 

--- a/packages/web/app/components/board-bluetooth-control/device-picker-dialog.tsx
+++ b/packages/web/app/components/board-bluetooth-control/device-picker-dialog.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import BluetoothSearching from '@mui/icons-material/BluetoothSearching';
+import Bluetooth from '@mui/icons-material/Bluetooth';
+import SignalCellularAlt from '@mui/icons-material/SignalCellularAlt';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { DiscoveredDevice } from '@/app/lib/ble/types';
+
+interface DevicePickerDialogProps {
+  devices: DiscoveredDevice[];
+  onSelect: (deviceId: string) => void;
+  onCancel: () => void;
+}
+
+function signalLabel(rssi: number): string {
+  if (rssi >= -50) return 'Strong';
+  if (rssi >= -70) return 'Good';
+  if (rssi >= -85) return 'Weak';
+  return 'Very weak';
+}
+
+export function DevicePickerDialog({ devices, onSelect, onCancel }: DevicePickerDialogProps) {
+  // Sort by signal strength (strongest first)
+  const sorted = [...devices].sort((a, b) => b.rssi - a.rssi);
+
+  return (
+    <Dialog open onClose={onCancel} fullWidth maxWidth="xs">
+      <DialogTitle>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <BluetoothSearching />
+          <span>Select your board</span>
+        </Stack>
+      </DialogTitle>
+      <DialogContent sx={{ minHeight: 120 }}>
+        {sorted.length === 0 ? (
+          <Stack direction="row" alignItems="center" spacing={2} sx={{ py: 3, justifyContent: 'center' }}>
+            <CircularProgress size={20} />
+            <Typography variant="body2" color="text.secondary">
+              Scanning for boards nearby&hellip;
+            </Typography>
+          </Stack>
+        ) : (
+          <List disablePadding>
+            {sorted.map((device) => (
+              <ListItemButton key={device.deviceId} onClick={() => onSelect(device.deviceId)}>
+                <ListItemIcon sx={{ minWidth: 40 }}>
+                  <Bluetooth />
+                </ListItemIcon>
+                <ListItemText
+                  primary={device.name || 'Unknown device'}
+                  secondary={
+                    <Stack direction="row" alignItems="center" spacing={0.5} component="span">
+                      <SignalCellularAlt sx={{ fontSize: 14 }} />
+                      <span>{signalLabel(device.rssi)}</span>
+                    </Stack>
+                  }
+                />
+              </ListItemButton>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel}>Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -9,8 +9,15 @@ import { getAuroraBluetoothPacket, parseApiLevel } from './bluetooth-aurora';
 import { getMoonboardBluetoothPacket } from './bluetooth-moonboard';
 import { HoldRenderData } from '../board-renderer/types';
 import { useWakeLock } from './use-wake-lock';
-import type { BluetoothAdapter } from '@/app/lib/ble/types';
+import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from '@/app/lib/ble/types';
 import { createBluetoothAdapter } from '@/app/lib/ble/adapter-factory';
+import { isCapacitor } from '@/app/lib/ble/capacitor-utils';
+
+export interface PickerState {
+  devices: DiscoveredDevice[];
+  onSelect: (deviceId: string) => void;
+  onCancel: () => void;
+}
 
 // Module-level cache for Aurora LED placements loader to avoid repeated dynamic import overhead
 type GetLedPlacementsFn = (boardName: string, layoutId: number, sizeId: number) => Record<number, number>;
@@ -59,6 +66,41 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
   const adapterRef = useRef<BluetoothAdapter | null>(null);
   const apiLevelRef = useRef<number>(3);
   const unsubDisconnectRef = useRef<(() => void) | null>(null);
+
+  // Device picker state for custom Capacitor scanning
+  const [pickerState, setPickerState] = useState<PickerState | null>(null);
+  const pickerResolveRef = useRef<((deviceId: string) => void) | null>(null);
+  const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
+
+  // Stable device picker function for the Capacitor adapter
+  const devicePicker = useCallback<DevicePickerFn>((subscribe) => {
+    return new Promise<string>((resolve, reject) => {
+      pickerResolveRef.current = resolve;
+      pickerRejectRef.current = reject;
+
+      const handleSelect = (deviceId: string) => {
+        pickerResolveRef.current = null;
+        pickerRejectRef.current = null;
+        setPickerState(null);
+        resolve(deviceId);
+      };
+
+      const handleCancel = () => {
+        pickerResolveRef.current = null;
+        pickerRejectRef.current = null;
+        setPickerState(null);
+        reject(new Error('Device selection cancelled'));
+      };
+
+      setPickerState({ devices: [], onSelect: handleSelect, onCancel: handleCancel });
+
+      subscribe((devices) => {
+        setPickerState((prev) =>
+          prev ? { ...prev, devices } : null,
+        );
+      });
+    });
+  }, []);
 
   // Handler for device disconnection
   const handleDisconnection = useCallback(() => {
@@ -152,8 +194,13 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
       setLoading(true);
 
       try {
-        // Create a fresh adapter for each connection attempt
-        const adapter = await createBluetoothAdapter(boardDetails.board_name);
+        // Create a fresh adapter for each connection attempt.
+        // On Capacitor, inject our custom device picker so we control
+        // the scan UI and can deduplicate discovered devices.
+        const adapter = await createBluetoothAdapter(
+          boardDetails.board_name,
+          isCapacitor() ? devicePicker : undefined,
+        );
 
         const available = await adapter.isAvailable();
         if (!available) {
@@ -199,7 +246,7 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
 
       return false;
     },
-    [handleDisconnection, boardDetails, onConnectionChange, sendFramesToBoard, showMessage],
+    [handleDisconnection, boardDetails, onConnectionChange, sendFramesToBoard, showMessage, devicePicker],
   );
 
   // Disconnect from the board
@@ -226,5 +273,6 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
     connect,
     disconnect,
     sendFramesToBoard,
+    pickerState,
   };
 }

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -67,28 +67,29 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
   const apiLevelRef = useRef<number>(3);
   const unsubDisconnectRef = useRef<(() => void) | null>(null);
 
-  // Device picker state for custom Capacitor scanning
+  // Device picker state for custom Capacitor scanning.
+  // pickerRejectRef holds the pending promise's reject so unmount cleanup
+  // can drain it, which causes the adapter's finally block to call stopLEScan.
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
-  const pickerResolveRef = useRef<((deviceId: string) => void) | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
 
   // Stable device picker function for the Capacitor adapter
   const devicePicker = useCallback<DevicePickerFn>((subscribe) => {
     return new Promise<string>((resolve, reject) => {
-      pickerResolveRef.current = resolve;
       pickerRejectRef.current = reject;
 
-      const handleSelect = (deviceId: string) => {
-        pickerResolveRef.current = null;
+      const cleanup = () => {
         pickerRejectRef.current = null;
         setPickerState(null);
+      };
+
+      const handleSelect = (deviceId: string) => {
+        cleanup();
         resolve(deviceId);
       };
 
       const handleCancel = () => {
-        pickerResolveRef.current = null;
-        pickerRejectRef.current = null;
-        setPickerState(null);
+        cleanup();
         reject(new Error('Device selection cancelled'));
       };
 
@@ -259,9 +260,12 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
     onConnectionChange?.(false);
   }, [onConnectionChange]);
 
-  // Clean up on unmount
+  // Clean up on unmount — reject any pending picker promise so the adapter's
+  // finally block calls stopLEScan, then tear down the BLE connection.
   useEffect(() => {
     return () => {
+      pickerRejectRef.current?.(new Error('Component unmounted'));
+      pickerRejectRef.current = null;
       unsubDisconnectRef.current?.();
       adapterRef.current?.disconnect();
     };

--- a/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
@@ -12,10 +12,18 @@ import {
 const mockListenerRemove = vi.fn().mockResolvedValue(undefined);
 let disconnectListenerCallback: ((data: { deviceId: string }) => void) | null = null;
 
+// Capture the scan callback so tests can simulate device discovery
+let scanCallback: ((result: { device: { deviceId: string; name?: string }; localName?: string; rssi: number }) => void) | null = null;
+
 const mockBlePlugin = {
   initialize: vi.fn().mockResolvedValue(undefined),
   isEnabled: vi.fn().mockResolvedValue({ value: true }),
   requestDevice: vi.fn().mockResolvedValue({ deviceId: 'dev-1', name: 'Kilter Board' }),
+  requestLEScan: vi.fn().mockImplementation((_options: unknown, callback: typeof scanCallback) => {
+    scanCallback = callback;
+    return Promise.resolve();
+  }),
+  stopLEScan: vi.fn().mockResolvedValue(undefined),
   connect: vi.fn().mockResolvedValue(undefined),
   disconnect: vi.fn().mockResolvedValue(undefined),
   write: vi.fn().mockResolvedValue(undefined),
@@ -57,6 +65,7 @@ describe('CapacitorBleAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     disconnectListenerCallback = null;
+    scanCallback = null;
     _resetInitCache();
     adapter = new CapacitorBleAdapter();
   });
@@ -315,6 +324,95 @@ describe('CapacitorBleAdapter', () => {
       await adapter.disconnect();
 
       expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestAndConnect with devicePicker', () => {
+    it('uses manual scan and custom picker when devicePicker is provided', async () => {
+      const pickerAdapter = new CapacitorBleAdapter('kilter', (subscribe) => {
+        // Subscribe to device updates
+        subscribe(() => {});
+        // Simulate immediate user selection
+        return Promise.resolve('scan-dev-1');
+      });
+
+      // Simulate device discovery after requestLEScan starts
+      mockBlePlugin.requestLEScan.mockImplementation((_opts: unknown, cb: typeof scanCallback) => {
+        cb?.({ device: { deviceId: 'scan-dev-1', name: 'My Kilter' }, rssi: -60 });
+        return Promise.resolve();
+      });
+
+      const connection = await pickerAdapter.requestAndConnect();
+
+      expect(connection.deviceId).toBe('scan-dev-1');
+      expect(connection.deviceName).toBe('My Kilter');
+      expect(mockBlePlugin.requestLEScan).toHaveBeenCalledWith(
+        { services: [...AURORA_SCAN_SERVICE_UUIDS] },
+        expect.any(Function),
+      );
+      expect(mockBlePlugin.stopLEScan).toHaveBeenCalled();
+      expect(mockBlePlugin.requestDevice).not.toHaveBeenCalled();
+      expect(mockBlePlugin.connect).toHaveBeenCalledWith({ deviceId: 'scan-dev-1' });
+    });
+
+    it('deduplicates devices by deviceId', async () => {
+      let receivedDevices: Array<{ deviceId: string; name?: string; rssi: number }> = [];
+
+      const pickerAdapter = new CapacitorBleAdapter('kilter', (subscribe) => {
+        subscribe((devices) => {
+          receivedDevices = devices;
+        });
+        // Wait a tick for devices to arrive, then select
+        return new Promise<string>((resolve) => {
+          setTimeout(() => resolve('dev-A'), 10);
+        });
+      });
+
+      // Emit the same device twice with updated RSSI
+      mockBlePlugin.requestLEScan.mockImplementation((_opts: unknown, cb: typeof scanCallback) => {
+        cb?.({ device: { deviceId: 'dev-A', name: 'Board A' }, rssi: -80 });
+        cb?.({ device: { deviceId: 'dev-A', name: 'Board A' }, rssi: -55 });
+        return Promise.resolve();
+      });
+
+      await pickerAdapter.requestAndConnect();
+
+      // Should have exactly 1 device (deduplicated), with updated RSSI
+      expect(receivedDevices).toHaveLength(1);
+      expect(receivedDevices[0].rssi).toBe(-55);
+    });
+
+    it('stops scanning even when picker rejects', async () => {
+      const pickerAdapter = new CapacitorBleAdapter('kilter', () => {
+        return Promise.reject(new Error('User cancelled'));
+      });
+
+      await expect(pickerAdapter.requestAndConnect()).rejects.toThrow('User cancelled');
+
+      expect(mockBlePlugin.stopLEScan).toHaveBeenCalled();
+    });
+
+    it('falls back to requestDevice when no devicePicker is provided', async () => {
+      const fallbackAdapter = new CapacitorBleAdapter('kilter');
+      await fallbackAdapter.requestAndConnect();
+
+      expect(mockBlePlugin.requestDevice).toHaveBeenCalled();
+      expect(mockBlePlugin.requestLEScan).not.toHaveBeenCalled();
+    });
+
+    it('uses localName from scan result when device.name is missing', async () => {
+      const pickerAdapter = new CapacitorBleAdapter('kilter', (subscribe) => {
+        subscribe(() => {});
+        return Promise.resolve('dev-local');
+      });
+
+      mockBlePlugin.requestLEScan.mockImplementation((_opts: unknown, cb: typeof scanCallback) => {
+        cb?.({ device: { deviceId: 'dev-local' }, localName: 'Local Name', rssi: -70 });
+        return Promise.resolve();
+      });
+
+      const connection = await pickerAdapter.requestAndConnect();
+      expect(connection.deviceName).toBe('Local Name');
     });
   });
 });

--- a/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
@@ -362,10 +362,8 @@ describe('CapacitorBleAdapter', () => {
         subscribe((devices) => {
           receivedDevices = devices;
         });
-        // Wait a tick for devices to arrive, then select
-        return new Promise<string>((resolve) => {
-          setTimeout(() => resolve('dev-A'), 10);
-        });
+        // Yield to the microtask queue so scan callbacks fire first, then select
+        return Promise.resolve().then(() => 'dev-A');
       });
 
       // Emit the same device twice with updated RSSI

--- a/packages/web/app/lib/ble/adapter-factory.ts
+++ b/packages/web/app/lib/ble/adapter-factory.ts
@@ -1,10 +1,10 @@
 import type { BoardName } from '@/app/lib/types';
 import { isCapacitor, isCapacitorWebView, waitForCapacitor, CAPACITOR_BRIDGE_TIMEOUT_MS } from './capacitor-utils';
-import type { BluetoothAdapter } from './types';
+import type { BluetoothAdapter, DevicePickerFn } from './types';
 
 // Cache the detected adapter class after the first call so subsequent
 // connection attempts skip platform detection and bridge polling entirely.
-type AdapterFactory = (boardName: BoardName) => Promise<BluetoothAdapter>;
+type AdapterFactory = (boardName: BoardName, devicePicker?: DevicePickerFn) => Promise<BluetoothAdapter>;
 let cachedFactory: AdapterFactory | null = null;
 
 /** @internal Reset cached factory — only for tests */
@@ -12,9 +12,12 @@ export function _resetFactoryCache(): void {
   cachedFactory = null;
 }
 
-export async function createBluetoothAdapter(boardName: BoardName): Promise<BluetoothAdapter> {
+export async function createBluetoothAdapter(
+  boardName: BoardName,
+  devicePicker?: DevicePickerFn,
+): Promise<BluetoothAdapter> {
   if (cachedFactory) {
-    return cachedFactory(boardName);
+    return cachedFactory(boardName, devicePicker);
   }
 
   // If we detect a WebView but the Capacitor bridge isn't ready yet, wait briefly
@@ -24,8 +27,8 @@ export async function createBluetoothAdapter(boardName: BoardName): Promise<Blue
 
   if (isCapacitor()) {
     const { CapacitorBleAdapter } = await import('./capacitor-adapter');
-    cachedFactory = async (nextBoardName) => new CapacitorBleAdapter(nextBoardName);
-    return new CapacitorBleAdapter(boardName);
+    cachedFactory = async (nextBoardName, picker) => new CapacitorBleAdapter(nextBoardName, picker);
+    return new CapacitorBleAdapter(boardName, devicePicker);
   }
 
   const { WebBluetoothAdapter } = await import('./web-adapter');

--- a/packages/web/app/lib/ble/capacitor-adapter.ts
+++ b/packages/web/app/lib/ble/capacitor-adapter.ts
@@ -1,5 +1,5 @@
 import type { BoardName } from '@/app/lib/types';
-import type { BleConnection, BluetoothAdapter } from './types';
+import type { BleConnection, BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import {
   AURORA_OPTIONAL_SERVICE_UUIDS,
   AURORA_SCAN_SERVICE_UUIDS,
@@ -20,6 +20,13 @@ const DEFAULT_MTU = MAX_BLUETOOTH_MESSAGE_SIZE;
 // Gives CoreBluetooth breathing room when sending many small chunks.
 const INTER_CHUNK_DELAY_MS = 5;
 
+/** Scan result from the Capacitor BLE plugin's requestLEScan callback. */
+interface CapacitorScanResult {
+  device: { deviceId: string; name?: string };
+  localName?: string;
+  rssi: number;
+}
+
 // Raw Capacitor plugin interface as exposed via window.Capacitor.Plugins.BluetoothLe.
 // The plugin JS is injected by the native shell. We type only the methods we use.
 // IMPORTANT: The raw plugin's write() expects `value` as a continuous hex string (no spaces), not DataView.
@@ -36,6 +43,11 @@ interface CapacitorBlePlugin {
     services: string[];
     optionalServices?: string[];
   }): Promise<{ deviceId: string; name?: string }>;
+  requestLEScan(
+    options: { services?: string[] },
+    callback: (result: CapacitorScanResult) => void,
+  ): Promise<void>;
+  stopLEScan(): Promise<void>;
   connect(options: {
     deviceId: string;
   }): Promise<void>;
@@ -92,7 +104,10 @@ function toHexString(data: Uint8Array): string {
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export class CapacitorBleAdapter implements BluetoothAdapter {
-  constructor(private readonly boardName: BoardName = 'kilter') {}
+  constructor(
+    private readonly boardName: BoardName = 'kilter',
+    private readonly devicePicker?: DevicePickerFn,
+  ) {}
 
   private deviceId: string | null = null;
   private disconnectCallback: (() => void) | null = null;
@@ -117,31 +132,66 @@ export class CapacitorBleAdapter implements BluetoothAdapter {
     const services = this.boardName === 'moonboard'
       ? [...MOONBOARD_SCAN_SERVICE_UUIDS]
       : [...AURORA_SCAN_SERVICE_UUIDS];
-    const optionalServices = this.boardName === 'moonboard'
-      ? [...MOONBOARD_OPTIONAL_SERVICE_UUIDS]
-      : [...AURORA_OPTIONAL_SERVICE_UUIDS];
 
-    // Request device — shows native scan dialog on iOS.
-    // MoonBoard controllers advertise Nordic UART directly; Aurora boards use
-    // their own advertised service and expose UART after connection.
-    const device = await ble.requestDevice({
-      services,
-      optionalServices,
-    });
+    let selectedDeviceId: string;
+    let selectedDeviceName: string | undefined;
+
+    if (this.devicePicker) {
+      // Manual scan with custom picker — deduplicates devices ourselves
+      const devices = new Map<string, DiscoveredDevice>();
+      let updateListener: ((devices: DiscoveredDevice[]) => void) | null = null;
+
+      // Start the picker promise (resolves when user selects a device)
+      const selectionPromise = this.devicePicker((onUpdate) => {
+        updateListener = onUpdate;
+      });
+
+      // Start scanning — each callback adds/updates the device map
+      await ble.requestLEScan({ services }, (result) => {
+        const device: DiscoveredDevice = {
+          deviceId: result.device.deviceId,
+          name: result.localName || result.device.name,
+          rssi: result.rssi,
+        };
+        devices.set(device.deviceId, device);
+        updateListener?.([...devices.values()]);
+      });
+
+      try {
+        selectedDeviceId = await selectionPromise;
+      } finally {
+        await ble.stopLEScan();
+      }
+
+      selectedDeviceName = devices.get(selectedDeviceId)?.name;
+    } else {
+      // Fallback: use the plugin's built-in device picker
+      const optionalServices = this.boardName === 'moonboard'
+        ? [...MOONBOARD_OPTIONAL_SERVICE_UUIDS]
+        : [...AURORA_OPTIONAL_SERVICE_UUIDS];
+
+      const device = await ble.requestDevice({
+        services,
+        optionalServices,
+      });
+
+      selectedDeviceId = device.deviceId;
+      selectedDeviceName = device.name;
+    }
 
     // Connect to the device
-    await ble.connect({ deviceId: device.deviceId });
+    await ble.connect({ deviceId: selectedDeviceId });
 
     // Negotiate larger MTU (iOS negotiates automatically, but requesting
     // explicitly ensures we know the actual value for chunking)
     try {
-      const mtuResult = await ble.requestMtu({ deviceId: device.deviceId, mtu: 512 });
+      const mtuResult = await ble.requestMtu({ deviceId: selectedDeviceId, mtu: 512 });
       this.mtu = mtuResult.value - 3; // MTU minus ATT header overhead
     } catch {
       // MTU negotiation not supported or failed — keep default 20
     }
 
-    this.deviceId = device.deviceId;
+    this.deviceId = selectedDeviceId;
 
     // Listen for unexpected disconnections from the native CoreBluetooth layer
     this.disconnectListenerHandle = await ble.addListener('disconnected', (data) => {
@@ -153,8 +203,8 @@ export class CapacitorBleAdapter implements BluetoothAdapter {
     });
 
     return {
-      deviceId: device.deviceId,
-      deviceName: device.name,
+      deviceId: selectedDeviceId,
+      deviceName: selectedDeviceName,
     };
   }
 

--- a/packages/web/app/lib/ble/types.ts
+++ b/packages/web/app/lib/ble/types.ts
@@ -3,6 +3,23 @@ export interface BleConnection {
   deviceName?: string;
 }
 
+/** A BLE device discovered during scanning. */
+export interface DiscoveredDevice {
+  deviceId: string;
+  name?: string;
+  rssi: number;
+}
+
+/**
+ * Function provided by the React layer to display a custom device picker.
+ * Called with a `subscribe` function that the picker uses to receive
+ * live device list updates. Must resolve with a deviceId when the user
+ * selects a device, or reject/throw to cancel.
+ */
+export type DevicePickerFn = (
+  subscribe: (onUpdate: (devices: DiscoveredDevice[]) => void) => void,
+) => Promise<string>;
+
 export interface BluetoothAdapter {
   /** Check if BLE is available and enabled */
   isAvailable(): Promise<boolean>;


### PR DESCRIPTION
Replace the Capacitor BLE plugin's built-in device picker with a custom scan flow that deduplicates discovered devices. The plugin's requestDevice() on iOS was showing the same physical board multiple times.

- Add requestLEScan/stopLEScan to the Capacitor adapter with a DevicePickerFn callback for custom device selection UI
- Create DevicePickerDialog component (MUI) showing deduplicated devices sorted by signal strength with live scan updates
- Wire picker through adapter-factory → use-board-bluetooth → bluetooth-context
- Web Bluetooth path (browser) is unaffected — continues using browser picker

Also fix MoonBoard Web Bluetooth filters: combine 3 OR'd filters (service UUID
+ two name prefixes) into 2 AND'd filters to prevent the same device matching multiple filters. Clean up redundant MOONBOARD_OPTIONAL_SERVICE_UUIDS.

https://claude.ai/code/session_01NJe5GKNbVc6qj517pbMPZS