### PR TITLE
Add Kilter data request email button

### DIFF
--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -57,13 +57,18 @@
 
 .buttonRow {
   display: flex;
-  flex-wrap: wrap;
   gap: 8px;
 }
 
 .buttonRow > * {
   flex: 1;
-  min-width: fit-content;
+  min-width: 0;
+}
+
+.buttonColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -57,12 +57,13 @@
 
 .buttonRow {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
 .buttonRow > * {
   flex: 1;
-  min-width: 0;
+  min-width: fit-content;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -69,6 +69,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  margin-top: 8px;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -20,7 +20,7 @@
 
 .notConnectedText {
   display: block;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 .credentialInfo {
@@ -69,7 +69,6 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-top: 8px;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -156,7 +156,7 @@ export function BoardCredentialCard({
           {isKilter ? (
             <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
               The Kilter backend has been shut down. You can import your data using an Aurora JSON export file, or
-              email Peter from Aurora Climbing to request a data export.
+              email Aurora Climbing to request a data export.
             </Typography>
           ) : (
             <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -163,7 +163,7 @@ export function BoardCredentialCard({
               Not connected. Link your {boardName} account to import your Aurora data, or import from a JSON export file.
             </Typography>
           )}
-          <div className={styles.buttonRow}>
+          <div className={isKilter ? styles.buttonColumn : styles.buttonRow}>
             {!isKilter && (
               <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
                 Link

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -30,8 +30,10 @@ import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import SyncOutlined from '@mui/icons-material/SyncOutlined';
 import WarningOutlined from '@mui/icons-material/WarningOutlined';
+import EmailOutlined from '@mui/icons-material/EmailOutlined';
 import FileUploadOutlined from '@mui/icons-material/FileUploadOutlined';
 import RadioButtonUncheckedOutlined from '@mui/icons-material/RadioButtonUncheckedOutlined';
+import { useSession } from 'next-auth/react';
 import type { AuroraCredentialStatus } from '@/app/api/internal/aurora-credentials/route';
 import type { UnsyncedCounts } from '@/app/api/internal/aurora-credentials/unsynced/route';
 import type { ImportResult } from '@/app/lib/data-sync/aurora/json-import';
@@ -67,6 +69,23 @@ export const STEP_LABELS: Record<ImportStep, string> = {
   sessions: 'Building sessions',
 };
 
+function buildKilterDataRequestMailto(userName?: string | null, userEmail?: string | null): string {
+  const name = userName || '[YOUR NAME]';
+  const email = userEmail || '[YOUR EMAIL]';
+  const subject = 'Kilterboard data';
+  const body = `Hey there!
+
+Ex-app user here. I was wondering if I could get a copy of my data so I can save my logbooks and other data for personal tracking records.
+
+My username is ${name}, and this should be under this email (${email}).
+
+Thanks!
+
+${name}`;
+
+  return `mailto:peter@auroraclimbing.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
 export interface BoardCredentialCardProps {
   boardType: 'kilter' | 'tension';
   credential: AuroraCredentialStatus | null;
@@ -76,6 +95,8 @@ export interface BoardCredentialCardProps {
   onImportJson: () => void;
   isRemoving: boolean;
   isImporting: boolean;
+  userName?: string | null;
+  userEmail?: string | null;
 }
 
 export function BoardCredentialCard({
@@ -87,6 +108,8 @@ export function BoardCredentialCard({
   onImportJson,
   isRemoving,
   isImporting,
+  userName,
+  userEmail,
 }: BoardCredentialCardProps) {
   const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
   const totalUnsynced = unsyncedCounts.ascents + unsyncedCounts.climbs;
@@ -132,7 +155,8 @@ export function BoardCredentialCard({
           </div>
           {isKilter ? (
             <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
-              The Kilter backend has been shut down. You can import your data using an Aurora JSON export file.
+              The Kilter backend has been shut down. You can import your data using an Aurora JSON export file, or
+              email Peter from Aurora Climbing to request a data export.
             </Typography>
           ) : (
             <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
@@ -153,6 +177,15 @@ export function BoardCredentialCard({
             >
               Import
             </Button>
+            {isKilter && (
+              <Button
+                variant="outlined"
+                startIcon={<EmailOutlined />}
+                href={buildKilterDataRequestMailto(userName, userEmail)}
+              >
+                Request your data
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -272,6 +305,7 @@ export function ImportProgressSteps({ progress }: { progress: ImportProgress | n
 }
 
 export default function AuroraCredentialsSection() {
+  const { data: session } = useSession();
   const { showMessage } = useSnackbar();
   const [credentials, setCredentials] = useState<AuroraCredentialStatus[]>([]);
   const [unsyncedCounts, setUnsyncedCounts] = useState<UnsyncedCounts | null>(null);
@@ -564,6 +598,8 @@ export default function AuroraCredentialsSection() {
               onImportJson={() => handleImportClick('kilter')}
               isRemoving={removingBoard === 'kilter'}
               isImporting={isImporting && importingBoard === 'kilter'}
+              userName={session?.user?.name}
+              userEmail={session?.user?.email}
             />
             <BoardCredentialCard
               boardType="tension"


### PR DESCRIPTION
## Summary
- Adds a "Request your data" button to the Kilter Board settings card that opens the user's email client with a pre-filled message to `peter@auroraclimbing.com`
- Pre-fills the email with the user's Boardsesh name and email (likely the same credentials they used for Kilter)
- Casual, friendly template based on a real successful data request exchange

## Test plan
- [ ] Go to Settings > Board Accounts > Kilter Board section
- [ ] Verify "Request your data" button appears next to "Import"
- [ ] Click the button and confirm the email client opens with pre-filled subject, body, and recipient
- [ ] Verify user name and email are correctly populated from the session