### PR TITLE
Fix Kilter data request button layout and spacing

### DIFF
--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -57,13 +57,17 @@
 
 .buttonRow {
   display: flex;
-  flex-wrap: wrap;
   gap: 8px;
 }
 
 .buttonRow > * {
   flex: 1;
-  min-width: 160px;
+  min-width: 0;
+}
+
+.buttonRowStacked {
+  composes: buttonRow;
+  flex-direction: column;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -58,6 +58,7 @@
 .buttonRow {
   display: flex;
   gap: 8px;
+  margin-top: 16px;
 }
 
 .buttonRow > * {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -71,6 +71,10 @@
   flex-direction: column;
 }
 
+.buttonRowStacked > * {
+  flex: none;
+}
+
 .unresolvedList {
   max-height: 200px;
   overflow-y: auto;

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -57,18 +57,13 @@
 
 .buttonRow {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
 .buttonRow > * {
   flex: 1;
-  min-width: 0;
-}
-
-.buttonColumn {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  min-width: 120px;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -63,7 +63,7 @@
 
 .buttonRow > * {
   flex: 1;
-  min-width: 120px;
+  min-width: 160px;
 }
 
 .unresolvedList {

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -163,7 +163,7 @@ export function BoardCredentialCard({
               Not connected. Link your {boardName} account to import your Aurora data, or import from a JSON export file.
             </Typography>
           )}
-          <div className={styles.buttonRow}>
+          <div className={isKilter ? styles.buttonRowStacked : styles.buttonRow}>
             {!isKilter && (
               <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
                 Link

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -163,7 +163,7 @@ export function BoardCredentialCard({
               Not connected. Link your {boardName} account to import your Aurora data, or import from a JSON export file.
             </Typography>
           )}
-          <div className={isKilter ? styles.buttonColumn : styles.buttonRow}>
+          <div className={styles.buttonRow}>
             {!isKilter && (
               <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
                 Link


### PR DESCRIPTION
## Summary
- Stack Kilter card buttons vertically using a composable `buttonRowStacked` CSS class
- Add consistent spacing between paragraph text and button groups for both board cards
- Keep Tension card buttons horizontal (short labels fit side-by-side)

<img width="986" height="1626" alt="image" src="https://github.com/user-attachments/assets/58c4d3e1-0bac-4e58-bbbd-1c315a59ab42" />


## Test plan
- [ ] Kilter Board card: buttons stack vertically with good spacing from the description text
- [ ] Tension Board card: buttons stay side-by-side with matching spacing
- [ ] Both cards look good on narrow phone screens