### PR TITLE
Make search form input fields white

### DIFF
--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -76,13 +76,13 @@
 
 /* Scoped MUI input overrides for modern filled-background look */
 .panelContent :global(.MuiOutlinedInput-root) {
-  background-color: var(--neutral-50, #F9FAFB);
+  background-color: var(--semantic-surface, #FFFFFF);
   border-radius: 12px;
   transition: background-color 200ms ease, box-shadow 200ms ease;
 }
 
 .panelContent :global(.MuiOutlinedInput-root:hover) {
-  background-color: var(--neutral-100, #F3F4F6);
+  background-color: var(--neutral-50, #F9FAFB);
 }
 
 .panelContent :global(.MuiOutlinedInput-root.Mui-focused) {

--- a/packages/web/app/components/search-drawer/search-form.module.css
+++ b/packages/web/app/components/search-drawer/search-form.module.css
@@ -100,13 +100,13 @@
 
 /* Scoped MUI overrides for hold search select */
 .holdSearchHeaderCompact :global(.MuiOutlinedInput-root) {
-  background-color: var(--neutral-50, #F9FAFB);
+  background-color: var(--semantic-surface, #FFFFFF);
   border-radius: 12px;
   transition: background-color 200ms ease, box-shadow 200ms ease;
 }
 
 .holdSearchHeaderCompact :global(.MuiOutlinedInput-root:hover) {
-  background-color: var(--neutral-100, #F3F4F6);
+  background-color: var(--neutral-50, #F9FAFB);
 }
 
 .holdSearchHeaderCompact :global(.MuiOutlinedInput-root.Mui-focused) {


### PR DESCRIPTION
Change default background of MUI outlined inputs in the search form
from neutral-50 gray to white, with a subtler neutral-50 hover state.

https://claude.ai/code/session_01SGUy3x51buoztkVZfx6Jkg