### PR TITLE
Add dynamic OG images and share buttons for climbs, profiles, sessions, playlists

### DIFF
--- a/docs/og-smartlinks-roadmap.md
+++ b/docs/og-smartlinks-roadmap.md
@@ -1,0 +1,89 @@
+# OG Smart Links & Share Buttons Roadmap
+
+Status of Open Graph metadata, dynamic OG images, and share buttons across all routes.
+
+## Current Status
+
+### Routes with Dynamic OG Images + Share Buttons (Complete)
+
+| Route | OG Image API | Share Button | Notes |
+|-------|-------------|--------------|-------|
+| `[board_name]/.../view/[climb_uuid]` | `/api/og/climb` | Yes (climb actions drawer) | Board render + hold overlay + climb info |
+| `[board_name]/.../play/[climb_uuid]` | `/api/og/climb` | Yes (climb actions drawer) | Same as view, canonical to view URL |
+| `/b/[board_slug]/[angle]/view/[climb_uuid]` | `/api/og/climb` | Yes (inherited) | Slug route, same OG as legacy |
+| `/b/[board_slug]/[angle]/play/[climb_uuid]` | `/api/og/climb` | Yes (inherited) | Slug route, same OG as legacy |
+| `/crusher/[user_id]` | `/api/og/profile` | Yes (header) | Avatar + grade distribution chart |
+| `/setter/[setter_username]` | `/api/og/setter` | Yes (header) | Avatar + ascents-per-grade chart for created climbs |
+| `/session/[sessionId]` | `/api/og/session` | Yes (header) | Session name + participants + grade chart |
+| `/join/[sessionId]` | `/api/og/session?variant=join` | N/A (redirect page) | Same as session but with "Get on the wall" CTA |
+| `/playlists/[playlist_uuid]` | `/api/og/playlist` | Yes (hero) | Playlist color/icon + name + climb count |
+
+### Routes with Static Metadata (Default OG Image)
+
+| Route | Title Pattern | Notes |
+|-------|--------------|-------|
+| `/` | `Boardsesh - ...` | Homepage with brand image |
+| `/about` | `About | Boardsesh` | |
+| `/help` | `Help | Boardsesh` | |
+| `/docs` | `Docs | Boardsesh` | |
+| `/legal` | `Legal | Boardsesh` | |
+| `/privacy` | `Privacy | Boardsesh` | |
+| `/aurora-migration` | `Migration | Boardsesh` | |
+| `/playlists` | `Playlists | Boardsesh` | List page |
+| `/logbook` | `Logbook | Boardsesh` | |
+| `/b/[board_slug]/[angle]/list` | `{Board} Climbs at {angle}° | Boardsesh` | Dynamic title, default image |
+| `/b/[board_slug]/[angle]/create` | `Create a Climb | Boardsesh` | |
+| `/b/[board_slug]/[angle]/import` | `Import Climbs | Boardsesh` | |
+| `/b/[board_slug]/[angle]/playlists` | `Playlists | Boardsesh` | |
+| `/b/[board_slug]/[angle]/playlists/[uuid]` | `{Playlist Name} | Boardsesh` | Dynamic title |
+
+### Routes with noindex
+
+| Route | Reason |
+|-------|--------|
+| `/auth/login` | Auth flow |
+| `/auth/error` | Auth flow |
+| `/auth/native-start` | Auth flow |
+| `/auth/verify-request` | Auth flow |
+| `/feed` | Authenticated feed |
+| `/settings` | User settings |
+| `/b/[board_slug]/[angle]/liked` | User-specific |
+| `/b/[board_slug]/[angle]/logbook` | User-specific |
+| `/join/[sessionId]` | Redirect/utility |
+
+## OG Image API Routes
+
+| Endpoint | Params | Renders |
+|----------|--------|---------|
+| `/api/og/climb` | board_name, layout_id, size_id, set_ids, angle, climb_uuid | Board background + lit holds + climb name/grade/setter |
+| `/api/og/profile` | user_id | Avatar + name + grade distribution bar chart |
+| `/api/og/setter` | username | Avatar + name + ascents-per-grade bar chart for created climbs |
+| `/api/og/session` | sessionId, variant? | Session name + participants + grade chart. variant=join adds CTA |
+| `/api/og/playlist` | uuid | Playlist color/icon + name + description + climb count |
+
+## Future Improvements
+
+### Custom OG Images for Static Pages
+
+These pages currently use the default brand OG image. Custom images could improve click-through:
+
+- `/aurora-migration` - Could show a visual comparison or migration flow
+- `/about` - Could show board photos or app screenshots
+
+### Board List Page OG
+
+The `/b/[board_slug]/[angle]/list` page could potentially have a custom OG image showing a sample of popular climbs on that board, but the value is low since these pages are primarily navigational.
+
+### Sitemap Updates
+
+When adding new public page types, update `packages/web/app/sitemap.ts` to include:
+- Popular setter profiles
+- Popular climb view URLs (slug-based)
+- Public playlists
+
+### Structured Data
+
+Consider adding JSON-LD structured data to:
+- Profile pages (`ProfilePage` type)
+- Session pages (event-like structured data)
+- Homepage (`Organization` + `WebSite` types)

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page.tsx
@@ -38,13 +38,14 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
         : `/${parsedParams.board_name}/${parsedParams.layout_id}/${parsedParams.size_id}/${parsedParams.set_ids.join(',')}/${parsedParams.angle}/play/${parsedParams.climb_uuid}`;
 
     // Generate OG image URL - use parsed numeric IDs for better performance
-    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
-    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
-    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
-    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
-    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
-    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogParams = new URLSearchParams();
+    ogParams.set('board_name', parsedParams.board_name);
+    ogParams.set('layout_id', parsedParams.layout_id.toString());
+    ogParams.set('size_id', parsedParams.size_id.toString());
+    ogParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogParams.set('angle', parsedParams.angle.toString());
+    ogParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogImagePath = `/api/og/climb?${ogParams.toString()}`;
 
     return {
       title: `${climbName} - ${climbGrade} | Play Mode | Boardsesh`,
@@ -56,7 +57,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
         url: playUrl,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
@@ -67,7 +68,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
         card: 'summary_large_image',
         title: `${climbName} - ${climbGrade}`,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -32,13 +32,14 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
       parsedParams.set_ids, parsedParams.angle, parsedParams.climb_uuid, climbName,
     ) ?? constructClimbViewUrl(parsedParams, parsedParams.climb_uuid, climbName);
 
-    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
-    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
-    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
-    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
-    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
-    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogParams = new URLSearchParams();
+    ogParams.set('board_name', parsedParams.board_name);
+    ogParams.set('layout_id', parsedParams.layout_id.toString());
+    ogParams.set('size_id', parsedParams.size_id.toString());
+    ogParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogParams.set('angle', parsedParams.angle.toString());
+    ogParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogImagePath = `/api/og/climb?${ogParams.toString()}`;
 
     return {
       title: `${climbName} - ${climbGrade} | Boardsesh`,
@@ -50,7 +51,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
         url: climbUrl,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
@@ -61,7 +62,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
         card: 'summary_large_image',
         title: `${climbName} - ${climbGrade}`,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/api/internal/join/[sessionId]/route.ts
+++ b/packages/web/app/api/internal/join/[sessionId]/route.ts
@@ -5,37 +5,18 @@ import { eq } from 'drizzle-orm';
 import { SessionIdSchema } from '@/app/lib/validation/session';
 import { CLIMB_SESSION_COOKIE } from '@/app/lib/climb-session-cookie';
 
-// Default angle to use when boardPath doesn't include one (for backward compatibility)
 const DEFAULT_ANGLE = 40;
 
-/**
- * Ensures the board path ends with a view segment (/list, /play/uuid, /view/slug, /create)
- * If not, appends /list to provide a good landing page for joined users.
- *
- * Handles three cases:
- * 1. Path already has view segment: /board/.../40/list → use as-is
- * 2. Path has angle but no view: /board/.../40 → append /list
- * 3. Old format without angle: /board/.../sets → append default angle and /list
- */
 function ensureViewSegment(path: string): string {
-  // Check if path already ends with a view segment
   if (/\/(list|create)$/.test(path) || /\/(play|view)\/[^/]+$/.test(path)) {
     return path;
   }
-
-  // Check if path ends with an angle (a number)
   if (/\/\d+$/.test(path)) {
-    // Has angle, just append /list
     return `${path}/list`;
   }
-
-  // Old format without angle - append default angle and /list
   return `${path}/${DEFAULT_ANGLE}/list`;
 }
 
-// Derives the base URL for redirects. In development, trusts x-forwarded-host
-// to support reverse proxies (e.g. Tailscale). In production, Vercel sets the
-// correct host header directly so forwarded headers aren't needed.
 function getBaseUrl(request: Request): string {
   const headers = request.headers;
   const host = headers.get('host');
@@ -62,17 +43,14 @@ export async function GET(request: Request, { params }: { params: Promise<{ sess
   const { sessionId } = await params;
   const baseUrl = getBaseUrl(request);
 
-  // Validate session ID format using Zod
   const validationResult = SessionIdSchema.safeParse(sessionId);
 
   if (!validationResult.success) {
-    // Redirect to an error page or return a simple error response
     return new NextResponse('Invalid session ID format', { status: 400 });
   }
 
   const validatedSessionId = validationResult.data;
 
-  // Look up the session in the database
   const session = await dbz
     .select({
       id: boardSessions.id,
@@ -87,12 +65,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ sess
   }
 
   const { boardPath } = session[0];
-
-  // boardPath format: {board_name}/{layout_id}/{size_id}/{set_ids}[/{angle}][/list|/play/uuid]
-  // Strip leading slashes to avoid creating protocol-relative URLs (//kilter/... → kilter as host)
   const cleanPath = boardPath.replace(/^\/+/, '');
-
-  // Ensure the path ends with a view segment (/list) for a good user experience
   const redirectPath = ensureViewSegment(cleanPath);
 
   const response = NextResponse.redirect(`${baseUrl}/${redirectPath}`, 307);

--- a/packages/web/app/api/og/climb/route.tsx
+++ b/packages/web/app/api/og/climb/route.tsx
@@ -7,6 +7,7 @@ import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { convertLitUpHoldsStringToMap, getImageUrl } from '@/app/components/board-renderer/util';
 import { HoldRenderData } from '@/app/components/board-renderer/types';
 import { darkTokens } from '@/app/theme/theme-config';
+import { formatBoardDisplayName } from '@/app/lib/string-utils';
 
 export const runtime = 'edge';
 
@@ -61,11 +62,7 @@ export async function GET(request: NextRequest) {
       return `${origin}${relativeUrl}`;
     });
 
-    // Render proper trademark-safe board name ("MoonBoard", not "Moonboard").
-    const boardDisplayName =
-      board_name === 'moonboard'
-        ? 'MoonBoard'
-        : board_name.charAt(0).toUpperCase() + board_name.slice(1);
+    const boardDisplayName = formatBoardDisplayName(board_name);
 
     return new ImageResponse(
       (

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export const runtime = 'edge';
@@ -20,25 +21,39 @@ export async function GET(request: NextRequest) {
       return new Response('Missing uuid parameter', { status: 400 });
     }
 
-    const rows = await sql`
+    const result = await dbz.execute<{
+      name: string | null;
+      description: string | null;
+      color: string | null;
+      icon: string | null;
+      is_public: boolean;
+      board_type: string;
+      climb_count: number;
+    }>(sql`
       SELECT p.name, p.description, p.color, p.icon, p.is_public,
              p.board_type,
              (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
       FROM playlists p
       WHERE p.uuid = ${uuid}
       LIMIT 1
-    `;
+    `);
+    const rows = result.rows;
 
     if (rows.length === 0) {
       return new Response('Playlist not found', { status: 404 });
     }
 
     const playlist = rows[0];
-    const name = (playlist.name as string) || 'Playlist';
-    const description = playlist.description as string | null;
-    const color = (playlist.color as string) || themeTokens.colors.primary;
-    const icon = (playlist.icon as string) || null;
-    const boardType = playlist.board_type as string;
+
+    if (!playlist.is_public) {
+      return new Response('Playlist is private', { status: 404 });
+    }
+
+    const name = playlist.name || 'Playlist';
+    const description = playlist.description;
+    const color = playlist.color || themeTokens.colors.primary;
+    const icon = playlist.icon || null;
+    const boardType = playlist.board_type;
     const climbCount = Number(playlist.climb_count);
     const boardLabel = capitalizeBoardType(boardType);
 

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+import { sql } from '@/app/lib/db/db';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export const runtime = 'edge';
+
+function capitalizeBoardType(boardType: string): string {
+  if (boardType === 'moonboard') return 'MoonBoard';
+  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const uuid = searchParams.get('uuid');
+
+    if (!uuid) {
+      return new Response('Missing uuid parameter', { status: 400 });
+    }
+
+    const rows = await sql`
+      SELECT p.name, p.description, p.color, p.icon, p.is_public,
+             p.board_type,
+             (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
+      FROM playlists p
+      WHERE p.uuid = ${uuid}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return new Response('Playlist not found', { status: 404 });
+    }
+
+    const playlist = rows[0];
+    const name = (playlist.name as string) || 'Playlist';
+    const description = playlist.description as string | null;
+    const color = (playlist.color as string) || themeTokens.colors.primary;
+    const icon = (playlist.icon as string) || null;
+    const boardType = playlist.board_type as string;
+    const climbCount = Number(playlist.climb_count);
+    const boardLabel = capitalizeBoardType(boardType);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            background: '#FFFFFF',
+            padding: '60px 80px',
+            gap: '48px',
+          }}
+        >
+          {/* Left: Colored square with icon */}
+          <div
+            style={{
+              width: '280px',
+              height: '280px',
+              borderRadius: '32px',
+              backgroundColor: color,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <div
+              style={{
+                fontSize: '120px',
+                lineHeight: 1,
+                color: '#FFFFFF',
+              }}
+            >
+              {icon || '\u{1F3B5}'}
+            </div>
+          </div>
+
+          {/* Right: Info */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '16px',
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
+            <div
+              style={{
+                fontSize: '48px',
+                fontWeight: 'bold',
+                color: themeTokens.neutral[900],
+                lineHeight: 1.2,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {name}
+            </div>
+
+            {description && (
+              <div
+                style={{
+                  fontSize: '24px',
+                  color: themeTokens.neutral[500],
+                  lineHeight: 1.4,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {description.length > 120 ? `${description.slice(0, 120)}...` : description}
+              </div>
+            )}
+
+            <div
+              style={{
+                display: 'flex',
+                gap: '24px',
+                marginTop: '8px',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '28px',
+                  color: themeTokens.neutral[600],
+                  fontWeight: 600,
+                }}
+              >
+                {climbCount} {climbCount === 1 ? 'climb' : 'climbs'}
+              </div>
+              <div
+                style={{
+                  fontSize: '28px',
+                  color: themeTokens.neutral[400],
+                }}
+              >
+                {boardLabel}
+              </div>
+            </div>
+          </div>
+
+          {/* Branding */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '24px',
+              right: '40px',
+              fontSize: '20px',
+              color: themeTokens.neutral[300],
+              fontWeight: 600,
+            }}
+          >
+            boardsesh.com
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (error) {
+    console.error('Error generating playlist OG image:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Error generating image: ${message}`, { status: 500 });
+  }
+}

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -4,13 +4,9 @@ import { NextRequest } from 'next/server';
 import { dbz } from '@/app/lib/db/db';
 import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
+import { formatBoardDisplayName } from '@/app/lib/string-utils';
 
 export const runtime = 'edge';
-
-function capitalizeBoardType(boardType: string): string {
-  if (boardType === 'moonboard') return 'MoonBoard';
-  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
-}
 
 export async function GET(request: NextRequest) {
   try {
@@ -55,7 +51,7 @@ export async function GET(request: NextRequest) {
     const icon = playlist.icon || null;
     const boardType = playlist.board_type;
     const climbCount = Number(playlist.climb_count);
-    const boardLabel = capitalizeBoardType(boardType);
+    const boardLabel = formatBoardDisplayName(boardType);
 
     return new ImageResponse(
       (

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
 import { BOULDER_GRADES } from '@/app/lib/board-data';
@@ -25,14 +26,20 @@ export async function GET(request: NextRequest) {
     }
 
     // Fetch session info, participants, and grade distribution in parallel
-    const [sessionRows, participantRows, gradeRows] = await Promise.all([
-      sql`
+    const [sessionResult, participantResult, gradeResult] = await Promise.all([
+      dbz.execute<{
+        id: string;
+        session_name: string | null;
+        board_path: string | null;
+      }>(sql`
         SELECT bs.id, bs.session_name, bs.board_path
         FROM board_sessions bs
         WHERE bs.id = ${sessionId}
         LIMIT 1
-      `,
-      sql`
+      `),
+      dbz.execute<{
+        display_name: string;
+      }>(sql`
         SELECT DISTINCT
           COALESCE(up.display_name, u.name, 'Climber') as display_name
         FROM boardsesh_ticks bt
@@ -40,8 +47,11 @@ export async function GET(request: NextRequest) {
         LEFT JOIN user_profiles up ON up.user_id = bt.user_id
         WHERE bt.session_id = ${sessionId}
         LIMIT 6
-      `,
-      sql`
+      `),
+      dbz.execute<{
+        difficulty: number;
+        cnt: number;
+      }>(sql`
         SELECT bt.difficulty, COUNT(*) as cnt
         FROM boardsesh_ticks bt
         WHERE bt.session_id = ${sessionId}
@@ -49,8 +59,11 @@ export async function GET(request: NextRequest) {
           AND bt.difficulty IS NOT NULL
         GROUP BY bt.difficulty
         ORDER BY bt.difficulty
-      `,
+      `),
     ]);
+    const sessionRows = sessionResult.rows;
+    const participantRows = participantResult.rows;
+    const gradeRows = gradeResult.rows;
 
     if (sessionRows.length === 0) {
       return new Response('Session not found', { status: 404 });

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+import { sql } from '@/app/lib/db/db';
+import { themeTokens } from '@/app/theme/theme-config';
+import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
+
+export const runtime = 'edge';
+
+const DIFFICULTY_TO_GRADE: Record<number, string> = Object.fromEntries(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.font_grade]),
+);
+
+const GRADE_ORDER: string[] = BOULDER_GRADES.map((g) => g.font_grade);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get('sessionId');
+    const variant = searchParams.get('variant');
+
+    if (!sessionId) {
+      return new Response('Missing sessionId parameter', { status: 400 });
+    }
+
+    // Fetch session info, participants, and grade distribution in parallel
+    const [sessionRows, participantRows, gradeRows] = await Promise.all([
+      sql`
+        SELECT bs.id, bs.session_name, bs.board_path
+        FROM board_sessions bs
+        WHERE bs.id = ${sessionId}
+        LIMIT 1
+      `,
+      sql`
+        SELECT DISTINCT
+          COALESCE(up.display_name, u.name, 'Climber') as display_name
+        FROM boardsesh_ticks bt
+        JOIN users u ON u.id = bt.user_id
+        LEFT JOIN user_profiles up ON up.user_id = bt.user_id
+        WHERE bt.session_id = ${sessionId}
+        LIMIT 6
+      `,
+      sql`
+        SELECT bt.difficulty, COUNT(*) as cnt
+        FROM boardsesh_ticks bt
+        WHERE bt.session_id = ${sessionId}
+          AND bt.status IN ('flash', 'send')
+          AND bt.difficulty IS NOT NULL
+        GROUP BY bt.difficulty
+        ORDER BY bt.difficulty
+      `,
+    ]);
+
+    if (sessionRows.length === 0) {
+      return new Response('Session not found', { status: 404 });
+    }
+
+    const session = sessionRows[0];
+    const sessionName = (session.session_name as string) || 'Climbing Session';
+    const participantNames = participantRows
+      .map((r) => r.display_name as string)
+      .join(', ');
+
+    // Build grade bars
+    const gradeBars: Array<{ grade: string; count: number; color: string }> = [];
+    let totalSends = 0;
+
+    for (const row of gradeRows) {
+      const difficulty = Number(row.difficulty);
+      const count = Number(row.cnt);
+      const grade = DIFFICULTY_TO_GRADE[difficulty];
+      if (!grade) continue;
+
+      totalSends += count;
+      const hex = FONT_GRADE_COLORS[grade.toLowerCase()];
+      const color = hex ? getGradeColorWithOpacity(hex, 0.5) : 'rgba(200, 200, 200, 0.5)';
+      gradeBars.push({ grade, count, color });
+    }
+
+    // Sort by grade order
+    gradeBars.sort((a, b) => GRADE_ORDER.indexOf(a.grade) - GRADE_ORDER.indexOf(b.grade));
+
+    const maxCount = Math.max(...gradeBars.map((b) => b.count), 1);
+    const isJoinVariant = variant === 'join';
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            background: '#FFFFFF',
+            padding: '60px 80px',
+            gap: '32px',
+          }}
+        >
+          {/* Top section: Session name + participants */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '12px',
+              width: '100%',
+            }}
+          >
+            <div
+              style={{
+                fontSize: '48px',
+                fontWeight: 'bold',
+                color: themeTokens.neutral[900],
+                lineHeight: 1.2,
+              }}
+            >
+              {sessionName}
+            </div>
+            {participantNames && (
+              <div
+                style={{
+                  fontSize: '24px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {participantNames}
+              </div>
+            )}
+            <div
+              style={{
+                fontSize: '20px',
+                color: themeTokens.neutral[400],
+              }}
+            >
+              {totalSends > 0
+                ? `${totalSends} send${totalSends !== 1 ? 's' : ''}`
+                : 'No sends yet'}
+            </div>
+          </div>
+
+          {/* Grade chart */}
+          {gradeBars.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                gap: '8px',
+              }}
+            >
+              {/* Bars */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  gap: '4px',
+                  height: '180px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      height: `${Math.max((bar.count / maxCount) * 100, 5)}%`,
+                      backgroundColor: bar.color,
+                      borderRadius: '3px 3px 0 0',
+                    }}
+                  />
+                ))}
+              </div>
+              {/* Labels */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '4px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      fontSize: '14px',
+                      textAlign: 'center',
+                      color: themeTokens.neutral[400],
+                    }}
+                  >
+                    {bar.grade}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Join CTA */}
+          {isJoinVariant && (
+            <div
+              style={{
+                fontSize: '36px',
+                fontWeight: 'bold',
+                color: themeTokens.colors.primary,
+                marginTop: '8px',
+              }}
+            >
+              Get on the wall
+            </div>
+          )}
+
+          {/* Branding */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '24px',
+              right: '40px',
+              fontSize: '20px',
+              color: themeTokens.neutral[300],
+              fontWeight: 600,
+            }}
+          >
+            boardsesh.com
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (error) {
+    console.error('Error generating session OG image:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Error generating image: ${message}`, { status: 500 });
+  }
+}

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
 import { BOULDER_GRADES } from '@/app/lib/board-data';
@@ -27,25 +28,36 @@ export async function GET(request: NextRequest) {
     }
 
     // Fetch setter profile info and grade distribution in parallel
-    const [setterRows, gradeRows] = await Promise.all([
-      sql`
-        SELECT uc.user_id, u.name, p.display_name, p.avatar_url
-        FROM user_credentials uc
-        JOIN users u ON u.id = uc.user_id
-        LEFT JOIN user_profiles p ON p.user_id = uc.user_id
-        WHERE uc.aurora_username = ${username}
+    const [setterResult, gradeResult] = await Promise.all([
+      dbz.execute<{
+        user_id: string;
+        name: string | null;
+        display_name: string | null;
+        avatar_url: string | null;
+      }>(sql`
+        SELECT ubm.user_id, u.name, p.display_name, p.avatar_url
+        FROM user_board_mappings ubm
+        JOIN users u ON u.id = ubm.user_id
+        LEFT JOIN user_profiles p ON p.user_id = ubm.user_id
+        WHERE ubm.board_username = ${username}
         LIMIT 1
-      `,
-      sql`
+      `),
+      dbz.execute<{
+        difficulty: number;
+        cnt: number;
+      }>(sql`
         SELECT bt.difficulty, COUNT(*) as cnt
         FROM boardsesh_ticks bt
-        WHERE bt.setter_username = ${username}
+        JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
+        WHERE bc.setter_username = ${username}
           AND bt.status IN ('flash', 'send')
           AND bt.difficulty IS NOT NULL
         GROUP BY bt.difficulty
         ORDER BY bt.difficulty
-      `,
+      `),
     ]);
+    const setterRows = setterResult.rows;
+    const gradeRows = gradeResult.rows;
 
     // Setter may not be linked to a user account — that's okay
     const setter = setterRows.length > 0 ? setterRows[0] : null;

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+import { sql } from '@/app/lib/db/db';
+import { themeTokens } from '@/app/theme/theme-config';
+import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
+
+export const runtime = 'edge';
+
+// Maps difficulty ID to Font grade name for OG image labels.
+// OG images are static server-rendered PNGs — they always use Font grades
+// since we can't access the user's display preference here.
+const DIFFICULTY_TO_GRADE: Record<number, string> = Object.fromEntries(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.font_grade]),
+);
+
+const GRADE_ORDER: string[] = BOULDER_GRADES.map((g) => g.font_grade);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const username = searchParams.get('username');
+
+    if (!username) {
+      return new Response('Missing username parameter', { status: 400 });
+    }
+
+    // Fetch setter profile info and grade distribution in parallel
+    const [setterRows, gradeRows] = await Promise.all([
+      sql`
+        SELECT uc.user_id, u.name, p.display_name, p.avatar_url
+        FROM user_credentials uc
+        JOIN users u ON u.id = uc.user_id
+        LEFT JOIN user_profiles p ON p.user_id = uc.user_id
+        WHERE uc.aurora_username = ${username}
+        LIMIT 1
+      `,
+      sql`
+        SELECT bt.difficulty, COUNT(*) as cnt
+        FROM boardsesh_ticks bt
+        WHERE bt.setter_username = ${username}
+          AND bt.status IN ('flash', 'send')
+          AND bt.difficulty IS NOT NULL
+        GROUP BY bt.difficulty
+        ORDER BY bt.difficulty
+      `,
+    ]);
+
+    // Setter may not be linked to a user account — that's okay
+    const setter = setterRows.length > 0 ? setterRows[0] : null;
+    const displayName = setter?.display_name || setter?.name || username;
+    const avatarUrl = setter?.avatar_url || null;
+
+    // Build grade bars from ascents of climbs this setter created
+    const gradeBars: Array<{ grade: string; count: number; color: string }> = [];
+    let totalAscents = 0;
+
+    for (const row of gradeRows) {
+      const difficulty = Number(row.difficulty);
+      const count = Number(row.cnt);
+      const grade = DIFFICULTY_TO_GRADE[difficulty];
+      if (!grade) continue;
+
+      totalAscents += count;
+      const hex = FONT_GRADE_COLORS[grade.toLowerCase()];
+      const color = hex ? getGradeColorWithOpacity(hex, 0.5) : 'rgba(200, 200, 200, 0.5)';
+      gradeBars.push({ grade, count, color });
+    }
+
+    // Sort by grade order
+    gradeBars.sort((a, b) => GRADE_ORDER.indexOf(a.grade) - GRADE_ORDER.indexOf(b.grade));
+
+    const maxCount = Math.max(...gradeBars.map((b) => b.count), 1);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            background: '#FFFFFF',
+            padding: '60px 80px',
+            gap: '40px',
+          }}
+        >
+          {/* Top section: Avatar + Name */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '32px',
+              width: '100%',
+            }}
+          >
+            {avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={avatarUrl}
+                alt=""
+                width={120}
+                height={120}
+                style={{
+                  borderRadius: '60px',
+                  objectFit: 'cover',
+                }}
+              />
+            ) : (
+              <div
+                style={{
+                  width: '120px',
+                  height: '120px',
+                  borderRadius: '60px',
+                  background: themeTokens.neutral[200],
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '48px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {displayName.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '48px',
+                  fontWeight: 'bold',
+                  color: themeTokens.neutral[900],
+                  lineHeight: 1.2,
+                }}
+              >
+                {displayName}
+              </div>
+              <div
+                style={{
+                  fontSize: '24px',
+                  color: themeTokens.neutral[500],
+                }}
+              >
+                {totalAscents > 0
+                  ? `${totalAscents} ascent${totalAscents !== 1 ? 's' : ''} on created climbs`
+                  : 'Boardsesh setter'}
+              </div>
+            </div>
+          </div>
+
+          {/* Grade chart */}
+          {gradeBars.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                gap: '8px',
+              }}
+            >
+              {/* Bars */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  gap: '4px',
+                  height: '160px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      height: `${Math.max((bar.count / maxCount) * 100, 5)}%`,
+                      backgroundColor: bar.color,
+                      borderRadius: '3px 3px 0 0',
+                    }}
+                  />
+                ))}
+              </div>
+              {/* Labels */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '4px',
+                  width: '100%',
+                }}
+              >
+                {gradeBars.map((bar) => (
+                  <div
+                    key={bar.grade}
+                    style={{
+                      flex: 1,
+                      fontSize: '14px',
+                      textAlign: 'center',
+                      color: themeTokens.neutral[400],
+                    }}
+                  >
+                    {bar.grade}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Branding */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '24px',
+              right: '40px',
+              fontSize: '20px',
+              color: themeTokens.neutral[300],
+              fontWeight: 600,
+            }}
+          >
+            boardsesh.com
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (error) {
+    console.error('Error generating setter OG image:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Error generating image: ${message}`, { status: 500 });
+  }
+}

--- a/packages/web/app/b/[board_slug]/[angle]/liked/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/liked/page.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { notFound } from 'next/navigation';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { Metadata } from 'next';
 import LikedClimbsViewContent from '@/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-view-content';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import styles from '@/app/components/library/playlist-view.module.css';
 
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: 'Liked Climbs | Boardsesh',
-    description: 'View your liked climbs',
-  };
-}
+export const metadata = createNoIndexMetadata({
+  title: 'Liked Climbs',
+  description: 'Your liked climbs',
+});
 
 interface LikedPageProps {
   params: Promise<{ board_slug: string; angle: string }>;

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
 import { SearchRequestPagination } from '@/app/lib/types';
 import { parsedRouteSearchParamsToSearchParams } from '@/app/lib/url-utils';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
@@ -16,6 +17,47 @@ import { buildOverlayUrl } from '@/app/components/board-renderer/util';
 interface BoardSlugListPageProps {
   params: Promise<{ board_slug: string; angle: string }>;
   searchParams: Promise<SearchRequestPagination>;
+}
+
+function capitalizeBoardName(boardType: string): string {
+  if (boardType === 'moonboard') return 'MoonBoard';
+  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+}
+
+export async function generateMetadata(props: BoardSlugListPageProps): Promise<Metadata> {
+  const params = await props.params;
+
+  try {
+    const board = await resolveBoardBySlug(params.board_slug);
+    if (!board) {
+      return { title: 'Climbs | Boardsesh', description: 'Browse climbing routes' };
+    }
+
+    const boardName = capitalizeBoardName(board.boardType);
+    const angle = params.angle;
+    const title = `${boardName} Climbs at ${angle}\u00B0 | Boardsesh`;
+    const description = `Browse climbing routes on ${boardName} at ${angle}\u00B0`;
+    const canonicalUrl = `/b/${params.board_slug}/${angle}/list`;
+
+    return {
+      title,
+      description,
+      alternates: { canonical: canonicalUrl },
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: canonicalUrl,
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+      },
+    };
+  } catch {
+    return { title: 'Climbs | Boardsesh', description: 'Browse climbing routes' };
+  }
 }
 
 export default async function BoardSlugListPage(props: BoardSlugListPageProps) {

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -13,15 +13,11 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
 import { buildOverlayUrl } from '@/app/components/board-renderer/util';
+import { formatBoardDisplayName } from '@/app/lib/string-utils';
 
 interface BoardSlugListPageProps {
   params: Promise<{ board_slug: string; angle: string }>;
   searchParams: Promise<SearchRequestPagination>;
-}
-
-function capitalizeBoardName(boardType: string): string {
-  if (boardType === 'moonboard') return 'MoonBoard';
-  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
 }
 
 export async function generateMetadata(props: BoardSlugListPageProps): Promise<Metadata> {
@@ -33,7 +29,7 @@ export async function generateMetadata(props: BoardSlugListPageProps): Promise<M
       return { title: 'Climbs | Boardsesh', description: 'Browse climbing routes' };
     }
 
-    const boardName = capitalizeBoardName(board.boardType);
+    const boardName = formatBoardDisplayName(board.boardType);
     const angle = params.angle;
     const title = `${boardName} Climbs at ${angle}\u00B0 | Boardsesh`;
     const description = `Browse climbing routes on ${boardName} at ${angle}\u00B0`;

--- a/packages/web/app/b/[board_slug]/[angle]/logbook/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/logbook/page.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
-import { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from '@/app/playlists/library-page-content';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import styles from '@/app/components/library/library.module.css';
 
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: 'Logbook | Boardsesh',
-    description: 'Track your climbing history for this board',
-  };
-}
+export const metadata = createNoIndexMetadata({
+  title: 'Logbook',
+  description: 'Your climbing history',
+});
 
 interface BoardSlugLogbookPageProps {
   params: Promise<{ board_slug: string; angle: string }>;

--- a/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
@@ -39,13 +39,14 @@ export async function generateMetadata(props: BoardSlugPlayPageProps): Promise<M
     const title = `${climbName} - ${climbGrade} | Boardsesh`;
     const canonicalUrl = `/b/${params.board_slug}/${params.angle}/play/${params.climb_uuid}`;
 
-    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
-    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
-    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
-    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
-    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
-    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogParams = new URLSearchParams();
+    ogParams.set('board_name', parsedParams.board_name);
+    ogParams.set('layout_id', parsedParams.layout_id.toString());
+    ogParams.set('size_id', parsedParams.size_id.toString());
+    ogParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogParams.set('angle', parsedParams.angle.toString());
+    ogParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogImagePath = `/api/og/climb?${ogParams.toString()}`;
 
     return {
       title,
@@ -59,7 +60,7 @@ export async function generateMetadata(props: BoardSlugPlayPageProps): Promise<M
         url: canonicalUrl,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
@@ -70,7 +71,7 @@ export async function generateMetadata(props: BoardSlugPlayPageProps): Promise<M
         card: 'summary_large_image',
         title: `${climbName} - ${climbGrade}`,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/play/[climb_uuid]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getClimb } from '@/app/lib/data/queries';
@@ -10,6 +11,74 @@ import { extractUuidFromSlug } from '@/app/lib/url-utils';
 
 interface BoardSlugPlayPageProps {
   params: Promise<{ board_slug: string; angle: string; climb_uuid: string }>;
+}
+
+export async function generateMetadata(props: BoardSlugPlayPageProps): Promise<Metadata> {
+  const params = await props.params;
+
+  try {
+    const board = await resolveBoardBySlug(params.board_slug);
+    if (!board) {
+      return { title: 'Play Climb | Boardsesh', description: 'Play a climb on your board' };
+    }
+
+    const parsedParams = {
+      ...boardToRouteParams(board, Number(params.angle)),
+      climb_uuid: extractUuidFromSlug(params.climb_uuid),
+    };
+
+    const [boardDetails, currentClimb] = await Promise.all([
+      getBoardDetailsForBoard(parsedParams),
+      getClimb(parsedParams),
+    ]);
+
+    const climbName = currentClimb.name || `${boardDetails.board_name} Climb`;
+    const climbGrade = currentClimb.difficulty || 'Unknown Grade';
+    const setter = currentClimb.setter_username || 'Unknown Setter';
+    const description = `${climbName} - ${climbGrade} by ${setter}. Quality: ${currentClimb.quality_average || 0}/5. Ascents: ${currentClimb.ascensionist_count || 0}`;
+    const title = `${climbName} - ${climbGrade} | Boardsesh`;
+    const canonicalUrl = `/b/${params.board_slug}/${params.angle}/play/${params.climb_uuid}`;
+
+    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
+    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
+    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
+    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
+    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
+    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+
+    return {
+      title,
+      description,
+      alternates: { canonical: canonicalUrl },
+      robots: { index: false, follow: true },
+      openGraph: {
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        type: 'website',
+        url: canonicalUrl,
+        images: [
+          {
+            url: ogImageUrl.toString(),
+            width: 1200,
+            height: 630,
+            alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        images: [ogImageUrl.toString()],
+      },
+    };
+  } catch {
+    return {
+      title: 'Play Climb | Boardsesh',
+      description: 'Play a climb on your board',
+    };
+  }
 }
 
 export default async function BoardSlugPlayPage(props: BoardSlugPlayPageProps) {

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -6,7 +6,9 @@ import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import styles from '@/app/components/library/playlist-view.module.css';
 
 interface PlaylistDetailPageProps {
@@ -17,44 +19,57 @@ export async function generateMetadata(props: PlaylistDetailPageProps): Promise<
   const params = await props.params;
 
   try {
-    const rows = await sql`
+    const result = await dbz.execute<{
+      name: string;
+      description: string | null;
+      is_public: boolean;
+      climb_count: number;
+    }>(sql`
       SELECT p.name, p.description, p.is_public,
              (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
       FROM playlists p
       WHERE p.uuid = ${params.playlist_uuid}
       LIMIT 1
-    `;
+    `);
 
-    if (rows.length === 0) {
+    if (result.rows.length === 0) {
       return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
     }
 
-    const playlist = rows[0];
-    const name = playlist.name as string;
+    const playlist = result.rows[0];
+
+    if (!playlist.is_public) {
+      return createNoIndexMetadata({
+        title: 'Private Playlist',
+        description: 'This playlist is private',
+        imagePath: null,
+      });
+    }
+
+    const name = playlist.name;
     const climbCount = Number(playlist.climb_count);
-    const description = (playlist.description as string) || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
+    const description = playlist.description || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
     const title = `${name} | Boardsesh`;
 
-    const ogImageUrl = `https://boardsesh.com/api/og/playlist?uuid=${params.playlist_uuid}`;
+    const ogImagePath = `/api/og/playlist?uuid=${params.playlist_uuid}`;
     const canonicalUrl = `/playlists/${params.playlist_uuid}`;
 
     return {
       title,
       description,
       alternates: { canonical: canonicalUrl },
-      ...(!playlist.is_public && { robots: { index: false, follow: true } }),
       openGraph: {
         title,
         description,
         type: 'website',
         url: canonicalUrl,
-        images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} playlist` }],
+        images: [{ url: ogImagePath, width: 1200, height: 630, alt: `${name} playlist` }],
       },
       twitter: {
         card: 'summary_large_image',
         title,
         description,
-        images: [ogImageUrl],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -6,15 +6,60 @@ import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
+import { sql } from '@/app/lib/db/db';
 import styles from '@/app/components/library/playlist-view.module.css';
-
-export const metadata: Metadata = {
-  title: 'Playlist | Boardsesh',
-  description: 'View playlist details and climbs',
-};
 
 interface PlaylistDetailPageProps {
   params: Promise<{ board_slug: string; angle: string; playlist_uuid: string }>;
+}
+
+export async function generateMetadata(props: PlaylistDetailPageProps): Promise<Metadata> {
+  const params = await props.params;
+
+  try {
+    const rows = await sql`
+      SELECT p.name, p.description, p.is_public,
+             (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
+      FROM playlists p
+      WHERE p.uuid = ${params.playlist_uuid}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
+    }
+
+    const playlist = rows[0];
+    const name = playlist.name as string;
+    const climbCount = Number(playlist.climb_count);
+    const description = (playlist.description as string) || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
+    const title = `${name} | Boardsesh`;
+
+    const ogImageUrl = `https://boardsesh.com/api/og/playlist?uuid=${params.playlist_uuid}`;
+    const canonicalUrl = `/playlists/${params.playlist_uuid}`;
+
+    return {
+      title,
+      description,
+      alternates: { canonical: canonicalUrl },
+      ...(!playlist.is_public && { robots: { index: false, follow: true } }),
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: canonicalUrl,
+        images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} playlist` }],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: [ogImageUrl],
+      },
+    };
+  } catch {
+    return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
+  }
 }
 
 export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailPageProps) {

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -40,13 +40,14 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
     const title = `${climbName} - ${climbGrade} | Boardsesh`;
     const climbUrl = `/b/${params.board_slug}/${params.angle}/view/${params.climb_uuid}`;
 
-    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
-    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
-    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
-    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
-    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
-    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogParams = new URLSearchParams();
+    ogParams.set('board_name', parsedParams.board_name);
+    ogParams.set('layout_id', parsedParams.layout_id.toString());
+    ogParams.set('size_id', parsedParams.size_id.toString());
+    ogParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogParams.set('angle', parsedParams.angle.toString());
+    ogParams.set('climb_uuid', parsedParams.climb_uuid);
+    const ogImagePath = `/api/og/climb?${ogParams.toString()}`;
 
     return {
       title,
@@ -59,7 +60,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
         url: climbUrl,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
@@ -70,7 +71,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
         card: 'summary_large_image',
         title: `${climbName} - ${climbGrade}`,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
 import { resolveBoardBySlug, boardToRouteParams } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getClimb } from '@/app/lib/data/queries';
@@ -11,6 +12,73 @@ import { extractUuidFromSlug } from '@/app/lib/url-utils';
 
 interface BoardSlugViewPageProps {
   params: Promise<{ board_slug: string; angle: string; climb_uuid: string }>;
+}
+
+export async function generateMetadata(props: BoardSlugViewPageProps): Promise<Metadata> {
+  const params = await props.params;
+
+  try {
+    const board = await resolveBoardBySlug(params.board_slug);
+    if (!board) {
+      return { title: 'Climb View | Boardsesh', description: 'View climb details and beta videos' };
+    }
+
+    const parsedParams = {
+      ...boardToRouteParams(board, Number(params.angle)),
+      climb_uuid: extractUuidFromSlug(params.climb_uuid),
+    };
+
+    const [boardDetails, currentClimb] = await Promise.all([
+      getBoardDetailsForBoard(parsedParams),
+      getClimb(parsedParams),
+    ]);
+
+    const climbName = currentClimb.name || `${boardDetails.board_name} Climb`;
+    const climbGrade = currentClimb.difficulty || 'Unknown Grade';
+    const setter = currentClimb.setter_username || 'Unknown Setter';
+    const description = `${climbName} - ${climbGrade} by ${setter}. Quality: ${currentClimb.quality_average || 0}/5. Ascents: ${currentClimb.ascensionist_count || 0}`;
+    const title = `${climbName} - ${climbGrade} | Boardsesh`;
+    const climbUrl = `/b/${params.board_slug}/${params.angle}/view/${params.climb_uuid}`;
+
+    const ogImageUrl = new URL('/api/og/climb', 'https://boardsesh.com');
+    ogImageUrl.searchParams.set('board_name', parsedParams.board_name);
+    ogImageUrl.searchParams.set('layout_id', parsedParams.layout_id.toString());
+    ogImageUrl.searchParams.set('size_id', parsedParams.size_id.toString());
+    ogImageUrl.searchParams.set('set_ids', parsedParams.set_ids.join(','));
+    ogImageUrl.searchParams.set('angle', parsedParams.angle.toString());
+    ogImageUrl.searchParams.set('climb_uuid', parsedParams.climb_uuid);
+
+    return {
+      title,
+      description,
+      alternates: { canonical: climbUrl },
+      openGraph: {
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        type: 'website',
+        url: climbUrl,
+        images: [
+          {
+            url: ogImageUrl.toString(),
+            width: 1200,
+            height: 630,
+            alt: `${climbName} - ${climbGrade} on ${boardDetails.board_name} board`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${climbName} - ${climbGrade}`,
+        description,
+        images: [ogImageUrl.toString()],
+      },
+    };
+  } catch {
+    return {
+      title: 'Climb View | Boardsesh',
+      description: 'View climb details and beta videos',
+    };
+  }
 }
 
 export default async function BoardSlugViewPage(props: BoardSlugViewPageProps) {

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -41,7 +41,7 @@ export function ShareAction({
       ? `${window.location.origin}${viewUrl}`
       : viewUrl;
 
-    await shareWithFallback({
+    const shared = await shareWithFallback({
       url: shareUrl,
       title: climb.name,
       text: `Check out "${climb.name}" (${climb.difficulty}) on Boardsesh`,
@@ -50,7 +50,9 @@ export function ShareAction({
       onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
       onError: () => showMessage('Failed to share', 'error'),
     });
-    onComplete?.();
+    if (shared) {
+      onComplete?.();
+    }
   }, [climb, viewUrl, boardDetails.board_name, onComplete, showMessage]);
 
   const icon = <ShareOutlined sx={{ fontSize: iconSize }} />;

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -3,12 +3,12 @@
 import React, { useCallback } from 'react';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import ShareOutlined from '@mui/icons-material/ShareOutlined';
-import { track } from '@vercel/analytics';
 import { ClimbActionProps, ClimbActionResult } from '../types';
 import {
   getContextAwareClimbViewUrl,
 } from '@/app/lib/url-utils';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
+import { shareWithFallback } from '@/app/lib/share-utils';
 
 export function ShareAction({
   climb,
@@ -41,43 +41,17 @@ export function ShareAction({
       ? `${window.location.origin}${viewUrl}`
       : viewUrl;
 
-    const shareData = {
+    await shareWithFallback({
+      url: shareUrl,
       title: climb.name,
       text: `Check out "${climb.name}" (${climb.difficulty}) on Boardsesh`,
-      url: shareUrl,
-    };
-
-    try {
-      if (navigator.share && navigator.canShare?.(shareData)) {
-        await navigator.share(shareData);
-        track('Climb Shared', {
-          boardName: boardDetails.board_name,
-          climbUuid: climb.uuid,
-          method: 'native',
-        });
-      } else {
-        await navigator.clipboard.writeText(shareUrl);
-        showMessage('Link copied to clipboard!', 'success');
-        track('Climb Shared', {
-          boardName: boardDetails.board_name,
-          climbUuid: climb.uuid,
-          method: 'clipboard',
-        });
-      }
-      onComplete?.();
-    } catch (error) {
-      // User cancelled share or error occurred
-      if ((error as Error).name !== 'AbortError') {
-        // Fallback to clipboard
-        try {
-          await navigator.clipboard.writeText(shareUrl);
-          showMessage('Link copied to clipboard!', 'success');
-        } catch {
-          showMessage('Failed to share', 'error');
-        }
-      }
-    }
-  }, [climb, viewUrl, boardDetails.board_name, onComplete]);
+      trackingEvent: 'Climb Shared',
+      trackingProps: { boardName: boardDetails.board_name, climbUuid: climb.uuid },
+      onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
+      onError: () => showMessage('Failed to share', 'error'),
+    });
+    onComplete?.();
+  }, [climb, viewUrl, boardDetails.board_name, onComplete, showMessage]);
 
   const icon = <ShareOutlined sx={{ fontSize: iconSize }} />;
 

--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -10,6 +10,9 @@
 
 /* Actions section - white card container */
 .actionsSection {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   background-color: var(--semantic-surface);
   border-radius: 12px;
   padding: 16px;

--- a/packages/web/app/crusher/[user_id]/page.tsx
+++ b/packages/web/app/crusher/[user_id]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Metadata } from 'next';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import ProfilePageContent from './profile-page-content';
 
 type PageProps = {
@@ -11,27 +12,32 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { user_id } = await params;
 
   try {
-    const rows = await sql`
+    const result = await dbz.execute<{
+      name: string | null;
+      display_name: string | null;
+      avatar_url: string | null;
+    }>(sql`
       SELECT u.name, p.display_name, p.avatar_url
       FROM users u
       LEFT JOIN user_profiles p ON p.user_id = u.id
       WHERE u.id = ${user_id}
       LIMIT 1
-    `;
+    `);
 
-    if (rows.length === 0) {
+    if (result.rows.length === 0) {
       return {
         title: 'Profile | Boardsesh',
         description: 'View climbing profile and stats',
       };
     }
 
-    const row = rows[0];
-    const displayName = (row.display_name as string) || (row.name as string) || 'Crusher';
+    const row = result.rows[0];
+    const displayName = row.display_name || row.name || 'Crusher';
     const description = `${displayName}'s climbing profile on Boardsesh`;
 
-    const ogImageUrl = new URL('/api/og/profile', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('user_id', user_id);
+    const ogParams = new URLSearchParams();
+    ogParams.set('user_id', user_id);
+    const ogImagePath = `/api/og/profile?${ogParams.toString()}`;
 
     return {
       title: `${displayName} | Boardsesh`,
@@ -43,7 +49,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         url: `/crusher/${user_id}`,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `${displayName}'s climbing profile`,
@@ -54,7 +60,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         card: 'summary_large_image',
         title: `${displayName} | Boardsesh`,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
@@ -9,11 +9,14 @@ import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import MuiButton from '@mui/material/Button';
-import { HistoryOutlined } from '@mui/icons-material';
+import IconButton from '@mui/material/IconButton';
+import { HistoryOutlined, ShareOutlined } from '@mui/icons-material';
 import Link from 'next/link';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { shareWithFallback } from '@/app/lib/share-utils';
 import AscentsFeed from '@/app/components/activity-feed';
 import SetterClimbList from '@/app/components/climb-list/setter-climb-list';
 import styles from './profile-page.module.css';
@@ -22,6 +25,7 @@ import ProfileHeader from './components/profile-header';
 import BoardStatsSection from './components/board-stats-section';
 
 export default function ProfilePageContent({ userId }: { userId: string }) {
+  const { showMessage } = useSnackbar();
   const {
     loading,
     notFound,
@@ -56,6 +60,21 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
     activeTab,
     setActiveTab,
   } = useProfileData(userId);
+
+  const handleShare = useCallback(async () => {
+    const displayName = profile?.profile?.displayName || profile?.name || 'Crusher';
+    const shareUrl = `${window.location.origin}/crusher/${userId}`;
+
+    await shareWithFallback({
+      url: shareUrl,
+      title: `${displayName}'s climbing profile`,
+      text: `Check out ${displayName}'s climbing profile on Boardsesh`,
+      trackingEvent: 'Profile Shared',
+      trackingProps: { userId },
+      onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
+      onError: () => showMessage('Failed to share', 'error'),
+    });
+  }, [profile, userId, showMessage]);
 
   if (loading) {
     return (
@@ -92,6 +111,11 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
         <Typography variant="h6" component="h4" className={styles.headerTitle}>
           Profile
         </Typography>
+        {profile && (
+          <IconButton onClick={handleShare} aria-label="Share profile">
+            <ShareOutlined />
+          </IconButton>
+        )}
       </Box>
 
       <Box component="main" className={styles.content}>

--- a/packages/web/app/join/[sessionId]/join-redirect.tsx
+++ b/packages/web/app/join/[sessionId]/join-redirect.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+
+export default function JoinRedirect({ sessionId }: { sessionId: string }) {
+  useEffect(() => {
+    window.location.href = `/api/internal/join/${encodeURIComponent(sessionId)}`;
+  }, [sessionId]);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        gap: 2,
+      }}
+    >
+      <CircularProgress size={48} />
+      <Typography variant="body1" color="text.secondary">
+        Joining session...
+      </Typography>
+    </Box>
+  );
+}

--- a/packages/web/app/join/[sessionId]/page.tsx
+++ b/packages/web/app/join/[sessionId]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import JoinRedirect from './join-redirect';
 
@@ -17,14 +18,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const sessionId = decodeURIComponent(rawSessionId);
 
   try {
-    const [sessionRows, participantRows, gradeRows] = await Promise.all([
-      sql`
+    const [sessionResult, participantResult, gradeResult] = await Promise.all([
+      dbz.execute<{ session_name: string | null }>(sql`
         SELECT bs.session_name
         FROM board_sessions bs
         WHERE bs.id = ${sessionId}
         LIMIT 1
-      `,
-      sql`
+      `),
+      dbz.execute<{ display_name: string }>(sql`
         SELECT DISTINCT
           COALESCE(up.display_name, u.name, 'Climber') as display_name
         FROM boardsesh_ticks bt
@@ -32,24 +33,29 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         LEFT JOIN user_profiles up ON up.user_id = bt.user_id
         WHERE bt.session_id = ${sessionId}
         LIMIT 6
-      `,
-      sql`
+      `),
+      dbz.execute<{ difficulty: number; cnt: number }>(sql`
         SELECT bt.difficulty, COUNT(*) as cnt
         FROM boardsesh_ticks bt
         WHERE bt.session_id = ${sessionId}
           AND bt.status IN ('flash', 'send')
           AND bt.difficulty IS NOT NULL
         GROUP BY bt.difficulty
-      `,
+        ORDER BY bt.difficulty
+      `),
     ]);
+
+    const sessionRows = sessionResult.rows;
+    const participantRows = participantResult.rows;
+    const gradeRows = gradeResult.rows;
 
     if (sessionRows.length === 0) {
       return { title: 'Session Not Found | Boardsesh' };
     }
 
-    const sessionName = (sessionRows[0].session_name as string) || 'Climbing Session';
+    const sessionName = sessionRows[0].session_name || 'Climbing Session';
     const participantNames = participantRows
-      .map((r) => r.display_name as string)
+      .map((r) => r.display_name)
       .join(', ');
 
     const totalSends = gradeRows.reduce((sum, r) => sum + Number(r.cnt), 0);
@@ -63,9 +69,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       ? `${participantNames} sent ${totalSends} climbs${gradeRange ? ` (${gradeRange})` : ''}. Get on the wall!`
       : `Join this climbing session on Boardsesh`;
 
-    const ogImageUrl = new URL('/api/og/session', 'https://boardsesh.com');
-    ogImageUrl.searchParams.set('sessionId', sessionId);
-    ogImageUrl.searchParams.set('variant', 'join');
+    const ogParams = new URLSearchParams();
+    ogParams.set('sessionId', sessionId);
+    ogParams.set('variant', 'join');
+    const ogImagePath = `/api/og/session?${ogParams.toString()}`;
 
     return {
       title,
@@ -78,7 +85,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `/join/${sessionId}`,
         images: [
           {
-            url: ogImageUrl.toString(),
+            url: ogImagePath,
             width: 1200,
             height: 630,
             alt: `Join ${sessionName}`,
@@ -89,7 +96,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         card: 'summary_large_image',
         title,
         description,
-        images: [ogImageUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/join/[sessionId]/page.tsx
+++ b/packages/web/app/join/[sessionId]/page.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import { sql } from '@/app/lib/db/db';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
+import JoinRedirect from './join-redirect';
+
+type Props = {
+  params: Promise<{ sessionId: string }>;
+};
+
+const DIFFICULTY_TO_GRADE: Record<number, string> = Object.fromEntries(
+  BOULDER_GRADES.map((g) => [g.difficulty_id, g.font_grade]),
+);
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { sessionId: rawSessionId } = await params;
+  const sessionId = decodeURIComponent(rawSessionId);
+
+  try {
+    const [sessionRows, participantRows, gradeRows] = await Promise.all([
+      sql`
+        SELECT bs.session_name
+        FROM board_sessions bs
+        WHERE bs.id = ${sessionId}
+        LIMIT 1
+      `,
+      sql`
+        SELECT DISTINCT
+          COALESCE(up.display_name, u.name, 'Climber') as display_name
+        FROM boardsesh_ticks bt
+        JOIN users u ON u.id = bt.user_id
+        LEFT JOIN user_profiles up ON up.user_id = bt.user_id
+        WHERE bt.session_id = ${sessionId}
+        LIMIT 6
+      `,
+      sql`
+        SELECT bt.difficulty, COUNT(*) as cnt
+        FROM boardsesh_ticks bt
+        WHERE bt.session_id = ${sessionId}
+          AND bt.status IN ('flash', 'send')
+          AND bt.difficulty IS NOT NULL
+        GROUP BY bt.difficulty
+      `,
+    ]);
+
+    if (sessionRows.length === 0) {
+      return { title: 'Session Not Found | Boardsesh' };
+    }
+
+    const sessionName = (sessionRows[0].session_name as string) || 'Climbing Session';
+    const participantNames = participantRows
+      .map((r) => r.display_name as string)
+      .join(', ');
+
+    const totalSends = gradeRows.reduce((sum, r) => sum + Number(r.cnt), 0);
+    const grades = gradeRows
+      .map((r) => DIFFICULTY_TO_GRADE[Number(r.difficulty)])
+      .filter(Boolean);
+    const gradeRange = grades.length > 0 ? `${grades[0]} - ${grades[grades.length - 1]}` : '';
+
+    const title = `Join ${sessionName} | Boardsesh`;
+    const description = participantNames
+      ? `${participantNames} sent ${totalSends} climbs${gradeRange ? ` (${gradeRange})` : ''}. Get on the wall!`
+      : `Join this climbing session on Boardsesh`;
+
+    const ogImageUrl = new URL('/api/og/session', 'https://boardsesh.com');
+    ogImageUrl.searchParams.set('sessionId', sessionId);
+    ogImageUrl.searchParams.set('variant', 'join');
+
+    return {
+      title,
+      description,
+      robots: { index: false, follow: true },
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: `/join/${sessionId}`,
+        images: [
+          {
+            url: ogImageUrl.toString(),
+            width: 1200,
+            height: 630,
+            alt: `Join ${sessionName}`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: [ogImageUrl.toString()],
+      },
+    };
+  } catch {
+    return {
+      title: 'Join Session | Boardsesh',
+      description: 'Join a climbing session on Boardsesh',
+      robots: { index: false, follow: true },
+    };
+  }
+}
+
+export default async function JoinSessionPage({ params }: Props) {
+  const { sessionId: rawSessionId } = await params;
+  const sessionId = decodeURIComponent(rawSessionId);
+
+  return <JoinRedirect sessionId={sessionId} />;
+}

--- a/packages/web/app/lib/__tests__/share-utils.test.ts
+++ b/packages/web/app/lib/__tests__/share-utils.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shareWithFallback } from '../share-utils';
+
+// Mock @vercel/analytics
+vi.mock('@vercel/analytics', () => ({
+  track: vi.fn(),
+}));
+
+const baseOptions = {
+  url: 'https://boardsesh.com/test',
+  title: 'Test Share',
+  text: 'Check this out',
+  trackingEvent: 'Test Shared',
+  trackingProps: { source: 'unit-test' },
+};
+
+describe('shareWithFallback', () => {
+  let originalNavigator: Navigator;
+
+  beforeEach(() => {
+    originalNavigator = globalThis.navigator;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function mockNavigator(overrides: Partial<Navigator>) {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNavigator, ...overrides },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  describe('native share path', () => {
+    it('uses navigator.share when available and canShare returns true', async () => {
+      const share = vi.fn().mockResolvedValue(undefined);
+      const canShare = vi.fn().mockReturnValue(true);
+      mockNavigator({ share, canShare } as unknown as Partial<Navigator>);
+
+      const result = await shareWithFallback(baseOptions);
+
+      expect(result).toBe(true);
+      expect(share).toHaveBeenCalledWith({
+        title: baseOptions.title,
+        text: baseOptions.text,
+        url: baseOptions.url,
+      });
+    });
+
+    it('returns false when native share is cancelled (AbortError)', async () => {
+      const abortError = new DOMException('Share cancelled', 'AbortError');
+      const share = vi.fn().mockRejectedValue(abortError);
+      const canShare = vi.fn().mockReturnValue(true);
+      mockNavigator({ share, canShare } as unknown as Partial<Navigator>);
+
+      const onError = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onError });
+
+      expect(result).toBe(false);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('falls back to clipboard when native share fails with non-AbortError', async () => {
+      const share = vi.fn().mockRejectedValue(new Error('Share failed'));
+      const canShare = vi.fn().mockReturnValue(true);
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      mockNavigator({
+        share,
+        canShare,
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      const onClipboardSuccess = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onClipboardSuccess });
+
+      expect(result).toBe(true);
+      expect(writeText).toHaveBeenCalledWith(baseOptions.url);
+      expect(onClipboardSuccess).toHaveBeenCalled();
+    });
+  });
+
+  describe('clipboard fallback path', () => {
+    it('copies to clipboard when navigator.share is unavailable', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      mockNavigator({
+        share: undefined,
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      const onClipboardSuccess = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onClipboardSuccess });
+
+      expect(result).toBe(true);
+      expect(writeText).toHaveBeenCalledWith(baseOptions.url);
+      expect(onClipboardSuccess).toHaveBeenCalled();
+    });
+
+    it('copies to clipboard when canShare returns false', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      mockNavigator({
+        share: vi.fn(),
+        canShare: vi.fn().mockReturnValue(false),
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      const onClipboardSuccess = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onClipboardSuccess });
+
+      expect(result).toBe(true);
+      expect(writeText).toHaveBeenCalledWith(baseOptions.url);
+    });
+
+    it('copies to clipboard when canShare is undefined', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      mockNavigator({
+        share: vi.fn(),
+        canShare: undefined,
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      const onClipboardSuccess = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onClipboardSuccess });
+
+      expect(result).toBe(true);
+      expect(writeText).toHaveBeenCalledWith(baseOptions.url);
+    });
+  });
+
+  describe('error handling', () => {
+    it('calls onError when both share and clipboard fail', async () => {
+      const share = vi.fn().mockRejectedValue(new Error('Share failed'));
+      const canShare = vi.fn().mockReturnValue(true);
+      const writeText = vi.fn().mockRejectedValue(new Error('Clipboard failed'));
+      mockNavigator({
+        share,
+        canShare,
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      const onError = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onError });
+
+      expect(result).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('returns false without calling onError when AbortError and clipboard not attempted', async () => {
+      const abortError = new DOMException('Aborted', 'AbortError');
+      const share = vi.fn().mockRejectedValue(abortError);
+      const canShare = vi.fn().mockReturnValue(true);
+      mockNavigator({ share, canShare } as unknown as Partial<Navigator>);
+
+      const onError = vi.fn();
+      const onClipboardSuccess = vi.fn();
+      const result = await shareWithFallback({ ...baseOptions, onError, onClipboardSuccess });
+
+      expect(result).toBe(false);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onClipboardSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('analytics tracking', () => {
+    it('tracks native share method', async () => {
+      const { track } = await import('@vercel/analytics');
+      const share = vi.fn().mockResolvedValue(undefined);
+      const canShare = vi.fn().mockReturnValue(true);
+      mockNavigator({ share, canShare } as unknown as Partial<Navigator>);
+
+      await shareWithFallback(baseOptions);
+
+      expect(track).toHaveBeenCalledWith('Test Shared', {
+        source: 'unit-test',
+        method: 'native',
+      });
+    });
+
+    it('tracks clipboard method', async () => {
+      const { track } = await import('@vercel/analytics');
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      mockNavigator({
+        share: undefined,
+        clipboard: { writeText } as unknown as Clipboard,
+      } as unknown as Partial<Navigator>);
+
+      await shareWithFallback(baseOptions);
+
+      expect(track).toHaveBeenCalledWith('Test Shared', {
+        source: 'unit-test',
+        method: 'clipboard',
+      });
+    });
+  });
+});

--- a/packages/web/app/lib/share-utils.ts
+++ b/packages/web/app/lib/share-utils.ts
@@ -25,26 +25,31 @@ export async function shareWithFallback({
   trackingProps = {},
   onClipboardSuccess,
   onError,
-}: ShareOptions): Promise<void> {
+}: ShareOptions): Promise<boolean> {
   const shareData = { title, text, url };
 
   try {
     if (navigator.share && navigator.canShare?.(shareData)) {
       await navigator.share(shareData);
       track(trackingEvent, { ...trackingProps, method: 'native' });
+      return true;
     } else {
       await navigator.clipboard.writeText(url);
       onClipboardSuccess?.();
       track(trackingEvent, { ...trackingProps, method: 'clipboard' });
+      return true;
     }
   } catch (error) {
     if ((error as Error).name !== 'AbortError') {
       try {
         await navigator.clipboard.writeText(url);
         onClipboardSuccess?.();
+        return true;
       } catch {
         onError?.();
+        return false;
       }
     }
+    return false;
   }
 }

--- a/packages/web/app/lib/share-utils.ts
+++ b/packages/web/app/lib/share-utils.ts
@@ -1,0 +1,50 @@
+import { track } from '@vercel/analytics';
+
+type ShareOptions = {
+  /** The full URL to share */
+  url: string;
+  /** Title for the native share sheet */
+  title: string;
+  /** Description text for the native share sheet */
+  text: string;
+  /** Vercel Analytics event name, e.g. 'Profile Shared' */
+  trackingEvent: string;
+  /** Additional properties for the analytics event */
+  trackingProps?: Record<string, string>;
+  /** Called after successful clipboard copy */
+  onClipboardSuccess?: () => void;
+  /** Called when sharing fails entirely */
+  onError?: () => void;
+};
+
+export async function shareWithFallback({
+  url,
+  title,
+  text,
+  trackingEvent,
+  trackingProps = {},
+  onClipboardSuccess,
+  onError,
+}: ShareOptions): Promise<void> {
+  const shareData = { title, text, url };
+
+  try {
+    if (navigator.share && navigator.canShare?.(shareData)) {
+      await navigator.share(shareData);
+      track(trackingEvent, { ...trackingProps, method: 'native' });
+    } else {
+      await navigator.clipboard.writeText(url);
+      onClipboardSuccess?.();
+      track(trackingEvent, { ...trackingProps, method: 'clipboard' });
+    }
+  } catch (error) {
+    if ((error as Error).name !== 'AbortError') {
+      try {
+        await navigator.clipboard.writeText(url);
+        onClipboardSuccess?.();
+      } catch {
+        onError?.();
+      }
+    }
+  }
+}

--- a/packages/web/app/lib/string-utils.ts
+++ b/packages/web/app/lib/string-utils.ts
@@ -1,3 +1,9 @@
 export function capitalizeFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
+
+/** Trademark-safe display name for a board type (e.g. "kilter" → "Kilter", "moonboard" → "MoonBoard"). */
+export function formatBoardDisplayName(boardType: string): string {
+  if (boardType === 'moonboard') return 'MoonBoard';
+  return capitalizeFirst(boardType);
+}

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import PlaylistDetailContent from './playlist-detail-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -14,44 +16,57 @@ export async function generateMetadata({
   const { playlist_uuid } = await params;
 
   try {
-    const rows = await sql`
+    const result = await dbz.execute<{
+      name: string;
+      description: string | null;
+      is_public: boolean;
+      climb_count: number;
+    }>(sql`
       SELECT p.name, p.description, p.is_public,
              (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
       FROM playlists p
       WHERE p.uuid = ${playlist_uuid}
       LIMIT 1
-    `;
+    `);
 
-    if (rows.length === 0) {
+    if (result.rows.length === 0) {
       return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
     }
 
-    const playlist = rows[0];
-    const name = playlist.name as string;
+    const playlist = result.rows[0];
+
+    if (!playlist.is_public) {
+      return createNoIndexMetadata({
+        title: 'Private Playlist',
+        description: 'This playlist is private',
+        imagePath: null,
+      });
+    }
+
+    const name = playlist.name;
     const climbCount = Number(playlist.climb_count);
-    const description = (playlist.description as string) || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
+    const description = playlist.description || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
     const title = `${name} | Boardsesh`;
 
-    const ogImageUrl = `https://boardsesh.com/api/og/playlist?uuid=${playlist_uuid}`;
+    const ogImagePath = `/api/og/playlist?uuid=${playlist_uuid}`;
     const canonicalUrl = `/playlists/${playlist_uuid}`;
 
     return {
       title,
       description,
       alternates: { canonical: canonicalUrl },
-      ...(!playlist.is_public && { robots: { index: false, follow: true } }),
       openGraph: {
         title,
         description,
         type: 'website',
         url: canonicalUrl,
-        images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} playlist` }],
+        images: [{ url: ogImagePath, width: 1200, height: 630, alt: `${name} playlist` }],
       },
       twitter: {
         card: 'summary_large_image',
         title,
         description,
-        images: [ogImageUrl],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -2,13 +2,62 @@ import React from 'react';
 import { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { sql } from '@/app/lib/db/db';
 import PlaylistDetailContent from './playlist-detail-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
-export const metadata: Metadata = {
-  title: 'Playlist | Boardsesh',
-  description: 'View playlist details and climbs',
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ playlist_uuid: string }>;
+}): Promise<Metadata> {
+  const { playlist_uuid } = await params;
+
+  try {
+    const rows = await sql`
+      SELECT p.name, p.description, p.is_public,
+             (SELECT COUNT(*) FROM playlist_climbs pc WHERE pc.playlist_id = p.id) as climb_count
+      FROM playlists p
+      WHERE p.uuid = ${playlist_uuid}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
+    }
+
+    const playlist = rows[0];
+    const name = playlist.name as string;
+    const climbCount = Number(playlist.climb_count);
+    const description = (playlist.description as string) || `A climbing playlist on Boardsesh with ${climbCount} climb${climbCount === 1 ? '' : 's'}`;
+    const title = `${name} | Boardsesh`;
+
+    const ogImageUrl = `https://boardsesh.com/api/og/playlist?uuid=${playlist_uuid}`;
+    const canonicalUrl = `/playlists/${playlist_uuid}`;
+
+    return {
+      title,
+      description,
+      alternates: { canonical: canonicalUrl },
+      ...(!playlist.is_public && { robots: { index: false, follow: true } }),
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+        url: canonicalUrl,
+        images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} playlist` }],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: [ogImageUrl],
+      },
+    };
+  } catch {
+    return { title: 'Playlist | Boardsesh', description: 'View playlist details and climbs' };
+  }
+}
 
 export default async function PlaylistDetailPage({
   params,

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -18,6 +18,7 @@ import {
   EditOutlined,
   DeleteOutlined,
   PeopleOutlined,
+  ShareOutlined,
 } from '@mui/icons-material';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Climb } from '@/app/lib/types';
@@ -41,6 +42,7 @@ import {
   DeletePlaylistMutationResponse,
 } from '@/app/lib/graphql/operations/playlists';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { shareWithFallback } from '@/app/lib/share-utils';
 import { LoadingSpinner } from '@/app/components/ui/loading-spinner';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import FollowButton from '@/app/components/ui/follow-button';
@@ -280,6 +282,19 @@ export default function PlaylistDetailContent({
     setSelectedBoard(board);
   }, []);
 
+  const handleShare = useCallback(async () => {
+    const shareUrl = `${window.location.origin}/playlists/${playlistUuid}`;
+    await shareWithFallback({
+      url: shareUrl,
+      title: playlist?.name || 'Playlist',
+      text: 'Check out this climbing playlist on Boardsesh',
+      trackingEvent: 'Playlist Shared',
+      trackingProps: { playlistUuid },
+      onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
+      onError: () => showMessage('Failed to share', 'error'),
+    });
+  }, [playlistUuid, playlist, showMessage]);
+
   const isOwner = playlist?.userRole === 'owner';
 
   const getPlaylistColor = () => {
@@ -394,14 +409,24 @@ export default function PlaylistDetailContent({
             </div>
           </div>
 
-          {/* Ellipsis Menu */}
-          <IconButton
-            className={styles.heroMenuButton}
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => setMenuAnchor(e.currentTarget)}
-            aria-label="Playlist actions"
-          >
-            <MoreVertOutlined />
-          </IconButton>
+          {/* Share + Ellipsis Menu */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {playlist.isPublic && (
+              <IconButton
+                onClick={handleShare}
+                aria-label="Share playlist"
+              >
+                <ShareOutlined />
+              </IconButton>
+            )}
+            <IconButton
+              className={styles.heroMenuButton}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => setMenuAnchor(e.currentTarget)}
+              aria-label="Playlist actions"
+            >
+              <MoreVertOutlined />
+            </IconButton>
+          </Box>
 
           <Menu
             anchorEl={menuAnchor}

--- a/packages/web/app/session/[sessionId]/page.tsx
+++ b/packages/web/app/session/[sessionId]/page.tsx
@@ -40,9 +40,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = `${session.sessionName || 'Climbing Session'} | Boardsesh`;
   const description = `${participantNames} - ${session.totalSends} sends, ${session.totalFlashes} flashes`;
 
-  const ogImageUrl = new URL('/api/og/session', 'https://boardsesh.com');
-  ogImageUrl.searchParams.set('sessionId', sessionId);
-  const ogImage = ogImageUrl.toString();
+  const ogParams = new URLSearchParams();
+  ogParams.set('sessionId', sessionId);
+  const ogImage = `/api/og/session?${ogParams.toString()}`;
 
   return {
     title,

--- a/packages/web/app/session/[sessionId]/page.tsx
+++ b/packages/web/app/session/[sessionId]/page.tsx
@@ -37,16 +37,28 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     .map((p) => p.displayName || 'Climber')
     .join(', ');
 
-  const title = `${session.sessionName || 'Climbing Session'} | Boardsesh`;
-  const description = `${participantNames} - ${session.totalSends} sends, ${session.totalFlashes} flashes`;
+  const sessionName = session.sessionName || 'Climbing Session';
+  const title = `${sessionName} | Boardsesh`;
+
+  let description: string;
+  if (session.totalSends > 0 || session.totalFlashes > 0) {
+    const stats = `${session.totalSends} send${session.totalSends !== 1 ? 's' : ''}, ${session.totalFlashes} flash${session.totalFlashes !== 1 ? 'es' : ''}`;
+    description = participantNames ? `${participantNames} — ${stats}` : stats;
+  } else {
+    description = participantNames
+      ? `${participantNames} climbing on Boardsesh`
+      : `${sessionName} on Boardsesh`;
+  }
 
   const ogParams = new URLSearchParams();
   ogParams.set('sessionId', sessionId);
   const ogImage = `/api/og/session?${ogParams.toString()}`;
+  const canonicalUrl = `/session/${sessionId}`;
 
   return {
     title,
     description,
+    alternates: { canonical: canonicalUrl },
     openGraph: {
       title,
       description,

--- a/packages/web/app/session/[sessionId]/page.tsx
+++ b/packages/web/app/session/[sessionId]/page.tsx
@@ -37,9 +37,29 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     .map((p) => p.displayName || 'Climber')
     .join(', ');
 
+  const title = `${session.sessionName || 'Climbing Session'} | Boardsesh`;
+  const description = `${participantNames} - ${session.totalSends} sends, ${session.totalFlashes} flashes`;
+
+  const ogImageUrl = new URL('/api/og/session', 'https://boardsesh.com');
+  ogImageUrl.searchParams.set('sessionId', sessionId);
+  const ogImage = ogImageUrl.toString();
+
   return {
-    title: `${session.sessionName || 'Climbing Session'} | Boardsesh`,
-    description: `${participantNames} - ${session.totalSends} sends, ${session.totalFlashes} flashes`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      url: `/session/${sessionId}`,
+      images: [{ url: ogImage, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
   };
 }
 

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import React, { useState, useCallback, useMemo } from 'react';
+import ShareOutlined from '@mui/icons-material/ShareOutlined';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { shareWithFallback } from '@/app/lib/share-utils';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';
@@ -272,6 +275,7 @@ export default function SessionDetailContent({
   const { data: authSession } = useSession();
   const router = useRouter();
   const deleteTick = useDeleteTick();
+  const { showMessage } = useSnackbar();
 
   const {
     session: hookSession,
@@ -403,6 +407,20 @@ export default function SessionDetailContent({
       console.error('Failed to navigate to climb:', error);
     }
   }, [router]);
+
+  const handleShare = useCallback(async () => {
+    const shareUrl = `${window.location.origin}/session/${sessionId}`;
+    const name = sessionName || 'Climbing Session';
+    await shareWithFallback({
+      url: shareUrl,
+      title: name,
+      text: 'Check out this climbing session on Boardsesh',
+      trackingEvent: 'Session Shared',
+      trackingProps: { sessionId },
+      onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
+      onError: () => showMessage('Failed to share', 'error'),
+    });
+  }, [sessionId, sessionName, showMessage]);
 
   const handleDeleteTick = useCallback((uuid: string) => {
     deleteTick.mutate(uuid);
@@ -616,6 +634,11 @@ export default function SessionDetailContent({
               {formatDate(firstTickAt)}
             </Typography>
           </Box>
+          {!isEditing && (
+            <IconButton size="small" onClick={handleShare} aria-label="Share session">
+              <ShareOutlined fontSize="small" />
+            </IconButton>
+          )}
           {canEdit && !isEditing && (
             <IconButton size="small" onClick={handleStartEdit}>
               <EditOutlined fontSize="small" />

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { sql } from '@/app/lib/db/db';
+import { dbz } from '@/app/lib/db/db';
+import { sql } from 'drizzle-orm';
 import SetterProfileContent from './setter-profile-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -13,18 +14,20 @@ export async function generateMetadata({
   const username = decodeURIComponent(setter_username);
 
   try {
-    const rows = await sql`
+    const result = await dbz.execute<{
+      display_name: string | null;
+      name: string | null;
+    }>(sql`
       SELECT p.display_name, u.name
-      FROM user_credentials uc
-      JOIN users u ON u.id = uc.user_id
-      LEFT JOIN user_profiles p ON p.user_id = uc.user_id
-      WHERE uc.aurora_username = ${username}
+      FROM user_board_mappings ubm
+      JOIN users u ON u.id = ubm.user_id
+      LEFT JOIN user_profiles p ON p.user_id = ubm.user_id
+      WHERE ubm.board_username = ${username}
       LIMIT 1
-    `;
+    `);
 
-    const displayName = rows[0]?.display_name || rows[0]?.name || username;
-    const ogUrl = new URL('/api/og/setter', 'https://boardsesh.com');
-    ogUrl.searchParams.set('username', setter_username);
+    const displayName = result.rows[0]?.display_name || result.rows[0]?.name || username;
+    const ogImagePath = `/api/og/setter?username=${encodeURIComponent(setter_username)}`;
 
     return {
       title: `${displayName} - Setter | Boardsesh`,
@@ -32,13 +35,13 @@ export async function generateMetadata({
       openGraph: {
         title: `${displayName} - Setter | Boardsesh`,
         description: `Climbs created by ${displayName} on Boardsesh`,
-        images: [{ url: ogUrl.toString(), width: 1200, height: 630 }],
+        images: [{ url: ogImagePath, width: 1200, height: 630 }],
       },
       twitter: {
         card: 'summary_large_image',
         title: `${displayName} - Setter | Boardsesh`,
         description: `Climbs created by ${displayName} on Boardsesh`,
-        images: [ogUrl.toString()],
+        images: [ogImagePath],
       },
     };
   } catch {

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -28,19 +28,24 @@ export async function generateMetadata({
 
     const displayName = result.rows[0]?.display_name || result.rows[0]?.name || username;
     const ogImagePath = `/api/og/setter?username=${encodeURIComponent(setter_username)}`;
+    const title = `${displayName} - Setter | Boardsesh`;
+    const description = `Climbs created by ${displayName} on Boardsesh`;
+    const canonicalUrl = `/setter/${encodeURIComponent(setter_username)}`;
 
     return {
-      title: `${displayName} - Setter | Boardsesh`,
-      description: `Climbs created by ${displayName} on Boardsesh`,
+      title,
+      description,
+      alternates: { canonical: canonicalUrl },
       openGraph: {
-        title: `${displayName} - Setter | Boardsesh`,
-        description: `Climbs created by ${displayName} on Boardsesh`,
+        title,
+        description,
+        url: canonicalUrl,
         images: [{ url: ogImagePath, width: 1200, height: 630 }],
       },
       twitter: {
         card: 'summary_large_image',
-        title: `${displayName} - Setter | Boardsesh`,
-        description: `Climbs created by ${displayName} on Boardsesh`,
+        title,
+        description,
         images: [ogImagePath],
       },
     };

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -1,12 +1,53 @@
 import React from 'react';
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
+import { sql } from '@/app/lib/db/db';
 import SetterProfileContent from './setter-profile-content';
 import styles from '@/app/components/library/playlist-view.module.css';
 
-export const metadata: Metadata = {
-  title: 'Setter Profile | Boardsesh',
-  description: 'View setter profile and climbs',
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ setter_username: string }>;
+}): Promise<Metadata> {
+  const { setter_username } = await params;
+  const username = decodeURIComponent(setter_username);
+
+  try {
+    const rows = await sql`
+      SELECT p.display_name, u.name
+      FROM user_credentials uc
+      JOIN users u ON u.id = uc.user_id
+      LEFT JOIN user_profiles p ON p.user_id = uc.user_id
+      WHERE uc.aurora_username = ${username}
+      LIMIT 1
+    `;
+
+    const displayName = rows[0]?.display_name || rows[0]?.name || username;
+    const ogUrl = new URL('/api/og/setter', 'https://boardsesh.com');
+    ogUrl.searchParams.set('username', setter_username);
+
+    return {
+      title: `${displayName} - Setter | Boardsesh`,
+      description: `Climbs created by ${displayName} on Boardsesh`,
+      openGraph: {
+        title: `${displayName} - Setter | Boardsesh`,
+        description: `Climbs created by ${displayName} on Boardsesh`,
+        images: [{ url: ogUrl.toString(), width: 1200, height: 630 }],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${displayName} - Setter | Boardsesh`,
+        description: `Climbs created by ${displayName} on Boardsesh`,
+        images: [ogUrl.toString()],
+      },
+    };
+  } catch {
+    return {
+      title: 'Setter Profile | Boardsesh',
+      description: 'View setter profile and climbs on Boardsesh',
+    };
+  }
+}
 
 export default async function SetterProfilePage({
   params,

--- a/packages/web/app/setter/[setter_username]/setter-profile-content.tsx
+++ b/packages/web/app/setter/[setter_username]/setter-profile-content.tsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
-import { PersonOutlined, SentimentDissatisfiedOutlined } from '@mui/icons-material';
+import IconButton from '@mui/material/IconButton';
+import { PersonOutlined, SentimentDissatisfiedOutlined, ShareOutlined } from '@mui/icons-material';
 import { useSession } from 'next-auth/react';
 import BackButton from '@/app/components/back-button';
 import FollowButton from '@/app/components/ui/follow-button';
@@ -19,6 +20,8 @@ import {
   type GetSetterProfileQueryResponse,
 } from '@/app/lib/graphql/operations';
 import { themeTokens } from '@/app/theme/theme-config';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { shareWithFallback } from '@/app/lib/share-utils';
 import type { SetterProfile } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -28,6 +31,7 @@ interface SetterProfileContentProps {
 
 export default function SetterProfileContent({ username }: SetterProfileContentProps) {
   const { data: session } = useSession();
+  const { showMessage } = useSnackbar();
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<SetterProfile | null>(null);
 
@@ -75,11 +79,27 @@ export default function SetterProfileContent({ username }: SetterProfileContentP
   const avatarUrl = profile.linkedUserAvatarUrl;
   const authToken = (session as { authToken?: string } | null)?.authToken ?? null;
 
+  const handleShare = useCallback(async () => {
+    const shareUrl = `${window.location.origin}/setter/${encodeURIComponent(username)}`;
+    await shareWithFallback({
+      url: shareUrl,
+      title: `${displayName} - Setter`,
+      text: `Check out ${displayName}'s climbs on Boardsesh`,
+      trackingEvent: 'Setter Shared',
+      trackingProps: { username },
+      onClipboardSuccess: () => showMessage('Link copied to clipboard!', 'success'),
+      onError: () => showMessage('Failed to share', 'error'),
+    });
+  }, [username, displayName, showMessage]);
+
   return (
     <>
-      {/* Back Button */}
+      {/* Back Button & Share */}
       <div className={styles.actionsSection}>
         <BackButton fallbackUrl="/" />
+        <IconButton onClick={handleShare} aria-label="Share setter profile">
+          <ShareOutlined />
+        </IconButton>
       </div>
 
       {/* Main Content */}


### PR DESCRIPTION
## Summary

This PR adds dynamic Open Graph image generation and share functionality across multiple routes in Boardsesh. Users can now share climbs, profiles, sessions, and playlists with rich preview images that display relevant data like grade distributions, participant names, and climb details.

## Key Changes

### Dynamic OG Image APIs
- **`/api/og/climb`** - Renders climb board visualization with hold overlay and climb metadata
- **`/api/og/setter`** - Displays setter avatar, name, and grade distribution chart of created climbs
- **`/api/og/session`** - Shows session name, participants, grade chart, and optional "Get on the wall" CTA
- **`/api/og/playlist`** - Renders playlist icon/color, name, description, and climb count

### Metadata Generation
- Updated climb view/play pages (`/b/[board_slug]/[angle]/view|play/[climb_uuid]`) with dynamic metadata and OG images
- Updated playlist pages (`/playlists/[uuid]` and board-specific variants) with dynamic titles, descriptions, and OG images
- Updated setter profile page (`/setter/[username]`) with dynamic metadata and OG image
- Updated session page (`/session/[sessionId]`) with OG image
- Added new `/join/[sessionId]` page with redirect logic and dynamic metadata for session join links
- Updated climb list page (`/b/[board_slug]/[angle]/list`) with dynamic metadata

### Share Functionality
- Created `shareWithFallback()` utility in `lib/share-utils.ts` that handles native Web Share API with clipboard fallback and analytics tracking
- Added share buttons to:
  - Climb actions drawer (existing, now uses shared utility)
  - Playlist detail header (new)
  - Setter profile header (new)
  - Session detail header (new)
  - Crusher/user profile header (new)
- All share actions track analytics events with method (native vs clipboard)

### Supporting Changes
- Added `docs/og-smartlinks-roadmap.md` documenting OG image coverage across all routes
- Updated CSS for playlist actions section to support flex layout for share button placement
- All OG image endpoints run on edge runtime for performance

## Implementation Details

- OG images use Vercel's `@vercel/og` library with 1200x630px dimensions
- Grade distribution charts normalize to max count and use theme colors with 50% opacity
- Setter and session OG images fetch data in parallel for performance
- Share utility supports custom success/error callbacks and analytics properties
- Join page uses client-side redirect to internal API endpoint for session joining
- All metadata generation handles missing data gracefully with fallback values

https://claude.ai/code/session_01Jia9xqSCvt38RECbZTt87t