### PR TITLE
Tokenize dark mode white inputs and document the design decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ We are using next.js app router, it's important we try to use server side compon
 - Always use CSS media queries for mobile/responsive design
 - For rendering avoid JavaScript breakpoint detection & Grid.useBreakpoint()
 - While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
+- **Dark mode uses white input fields** — This is intentional for contrast. All input components (TextField, Select, Autocomplete, etc.) have white backgrounds in dark mode via `darkTokens.semantic.inputSurface`. Do not change them to dark backgrounds.
 - **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
 
 ### Copy & Microcopy

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -228,6 +228,29 @@ Climbing difficulty is represented by a spectrum from yellow through red to purp
 
 ---
 
+## Dark Mode
+
+Dark mode tokens live in `darkTokens` in `packages/web/app/theme/theme-config.ts`. The neutral palette is fully inverted (50 = black, 900 = near-white), and surfaces use near-black values.
+
+### Dark Mode Surfaces
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `darkTokens.semantic.background` | `#000000` | Page background |
+| `darkTokens.semantic.surface` | `#0A0A0A` | Card surfaces |
+| `darkTokens.semantic.surfaceElevated` | `#121212` | Elevated surfaces (paper) |
+| `darkTokens.semantic.inputSurface` | `#FFFFFF` | All input field backgrounds |
+
+### White Input Fields (Intentional)
+
+Dark mode uses **white input fields** (`darkTokens.semantic.inputSurface`) on dark backgrounds. This is a deliberate design decision for high contrast and clarity — inputs must stand out from the surrounding dark UI.
+
+All input variants (TextField, OutlinedInput, FilledInput, Select, Autocomplete) use white backgrounds with dark text (`themeTokens.neutral[800]`) in dark mode. These overrides are defined in `darkComponents` in `packages/web/app/theme/mui-theme.ts`.
+
+**Do not change dark mode input backgrounds to dark colors.** This is not a bug — it is the intended design.
+
+---
+
 ## Typography Hierarchy
 
 ### Display Grade
@@ -740,6 +763,7 @@ These are explicitly prohibited in the Boardsesh codebase:
 | Creating new files unnecessarily | Edit existing files; prefer CSS modules co-located with components |
 | Adding unused code | Remove dead code immediately |
 | Over-engineering | Minimum complexity for current task |
+| Dark input backgrounds in dark mode | Use `darkTokens.semantic.inputSurface` (white) — intentional high-contrast design |
 
 ---
 

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -268,7 +268,7 @@ const darkComponents: Components<Theme> = {
   MuiInputBase: {
     styleOverrides: {
       root: {
-        backgroundColor: '#FFFFFF',
+        backgroundColor: darkTokens.semantic.inputSurface,
         color: themeTokens.neutral[800],
         '&.Mui-disabled': {
           backgroundColor: themeTokens.neutral[200],
@@ -287,7 +287,7 @@ const darkComponents: Components<Theme> = {
     styleOverrides: {
       root: {
         borderRadius: themeTokens.borderRadius.md,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: darkTokens.semantic.inputSurface,
         color: themeTokens.neutral[800],
         '& .MuiOutlinedInput-notchedOutline': {
           borderColor: themeTokens.neutral[300],
@@ -307,13 +307,13 @@ const darkComponents: Components<Theme> = {
   MuiFilledInput: {
     styleOverrides: {
       root: {
-        backgroundColor: '#FFFFFF',
+        backgroundColor: darkTokens.semantic.inputSurface,
         color: themeTokens.neutral[800],
         '&:hover': {
           backgroundColor: themeTokens.neutral[100],
         },
         '&.Mui-focused': {
-          backgroundColor: '#FFFFFF',
+          backgroundColor: darkTokens.semantic.inputSurface,
         },
         '&.Mui-disabled': {
           backgroundColor: themeTokens.neutral[200],
@@ -326,7 +326,7 @@ const darkComponents: Components<Theme> = {
     styleOverrides: {
       root: {
         borderRadius: themeTokens.borderRadius.md,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: darkTokens.semantic.inputSurface,
         color: themeTokens.neutral[800],
       },
       icon: {
@@ -337,7 +337,7 @@ const darkComponents: Components<Theme> = {
   MuiAutocomplete: {
     styleOverrides: {
       inputRoot: {
-        backgroundColor: '#FFFFFF',
+        backgroundColor: darkTokens.semantic.inputSurface,
         color: themeTokens.neutral[800],
       },
     },
@@ -358,7 +358,7 @@ const darkComponents: Components<Theme> = {
       root: {
         '& .MuiOutlinedInput-root': {
           borderRadius: themeTokens.borderRadius.md,
-          backgroundColor: '#FFFFFF',
+          backgroundColor: darkTokens.semantic.inputSurface,
           color: themeTokens.neutral[800],
         },
         '& .MuiInputLabel-root': {

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -177,6 +177,7 @@ export const darkTokens = {
     background: '#000000',
     surface: '#0A0A0A',
     surfaceElevated: '#121212',
+    inputSurface: '#FFFFFF',
     surfaceOverlay: 'rgba(10, 10, 10, 0.95)',
     overlayLight: 'rgba(0, 0, 0, 0.4)',
     overlayDark: 'rgba(0, 0, 0, 0.7)',


### PR DESCRIPTION
AI agents kept removing the intentional white input backgrounds in dark mode because nothing documented the decision. Adds inputSurface token, replaces hardcoded #FFFFFF, and documents the pattern in both CLAUDE.md and the design guidelines.