### PR TITLE
Save ticks optimistically with IndexedDB draft backup

### DIFF
--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -92,6 +92,11 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     }
   }, [currentClimb, angle, boardDetails, logbook]);
 
+  const [quality, setQuality] = useState<number | null>(null);
+  const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
+  const [attemptCount, setAttemptCount] = useState<number>(1);
+  const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
+
   // Restore draft values from a previous failed save for this climb.
   const draftLoaded = useRef(false);
   useEffect(() => {
@@ -107,11 +112,6 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
       }
     });
   }, [tickTarget, onDraftRestored]);
-
-  const [quality, setQuality] = useState<number | null>(null);
-  const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
-  const [attemptCount, setAttemptCount] = useState<number>(1);
-  const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
   // Track which picker was last open so we can keep it mounted during collapse.
   const [lastExpandedControl, setLastExpandedControl] = useState<ExpandedControl>(null);
   const [pickerVisible, setPickerVisible] = useState(false);

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -97,7 +97,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   useEffect(() => {
     if (!tickTarget || draftLoaded.current) return;
     draftLoaded.current = true;
-    loadTickDraft(tickTarget.climb.uuid).then((draft) => {
+    loadTickDraft(tickTarget.climb.uuid, Number(tickTarget.angle)).then((draft) => {
       if (!draft) return;
       setQuality(draft.quality);
       setDifficulty(draft.difficulty);
@@ -174,7 +174,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
       }
 
       // Capture values for the draft in case the save fails.
-      const draftValues = { climbUuid: climb.uuid, quality, difficulty, attemptCount, comment, status };
+      const draftValues = { climbUuid: climb.uuid, angle: Number(targetAngle), quality, difficulty, attemptCount, comment, status };
 
       // Fire confetti and close the bar immediately — don't wait for the network.
       fireConfetti(confettiOrigin ?? document.getElementById('button-tick'));
@@ -206,7 +206,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
           hasDifficulty: difficulty !== undefined,
           hasComment: comment.length > 0,
         });
-        clearTickDraft(climb.uuid);
+        clearTickDraft(climb.uuid, Number(targetAngle));
       }).catch(() => {
         track('Quick Tick Failed', {
           boardLayout: targetBoard.layout_name || '',

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -8,6 +8,7 @@ import { useBoardProvider } from '../board-provider/board-provider-context';
 import type { LogbookEntry, TickStatus } from '@/app/hooks/use-logbook';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { useConfetti } from '@/app/hooks/use-confetti';
+import { saveTickDraft, loadTickDraft, clearTickDraft } from '@/app/lib/tick-draft-db';
 import {
   TickControls,
   TickGradeButton,
@@ -34,6 +35,8 @@ export interface QuickTickBarProps {
   onSave: () => void;
   /** Called when a save fails so the parent can show feedback. */
   onError?: () => void;
+  /** Called when a draft is restored from a previous failed save. */
+  onDraftRestored?: (comment: string) => void;
   /** Current comment text. Owned by the parent so the comment field can live
    *  outside this bar (above the queue control bar) without causing reflow. */
   comment: string;
@@ -62,6 +65,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   boardDetails,
   onSave,
   onError,
+  onDraftRestored,
   comment,
   commentSlot,
 }, ref) => {
@@ -88,9 +92,24 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     }
   }, [currentClimb, angle, boardDetails, logbook]);
 
+  // Restore draft values from a previous failed save for this climb.
+  const draftLoaded = useRef(false);
+  useEffect(() => {
+    if (!tickTarget || draftLoaded.current) return;
+    draftLoaded.current = true;
+    loadTickDraft(tickTarget.climb.uuid).then((draft) => {
+      if (!draft) return;
+      setQuality(draft.quality);
+      setDifficulty(draft.difficulty);
+      setAttemptCount(draft.attemptCount);
+      if (draft.comment) {
+        onDraftRestored?.(draft.comment);
+      }
+    });
+  }, [tickTarget, onDraftRestored]);
+
   const [quality, setQuality] = useState<number | null>(null);
   const [difficulty, setDifficulty] = useState<number | undefined>(undefined);
-  const [isSaving, setIsSaving] = useState(false);
   const [attemptCount, setAttemptCount] = useState<number>(1);
   const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
   // Track which picker was last open so we can keep it mounted during collapse.
@@ -142,8 +161,8 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   }, []);
 
   const handleSave = useCallback(
-    async (isAscent: boolean, confettiOrigin?: HTMLElement | null) => {
-      if (!tickTarget || isSaving) return;
+    (isAscent: boolean, confettiOrigin?: HTMLElement | null) => {
+      if (!tickTarget) return;
 
       const { climb, angle: targetAngle, boardDetails: targetBoard, hasPriorHistory } = tickTarget;
 
@@ -154,26 +173,31 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
         status = 'attempt';
       }
 
-      setIsSaving(true);
-      try {
-        await saveTick({
-          climbUuid: climb.uuid,
-          angle: Number(targetAngle),
-          isMirror: !!climb.mirrored,
-          status,
-          attemptCount,
-          quality: quality ?? undefined,
-          difficulty,
-          isBenchmark: false,
-          comment: comment || '',
-          climbedAt: new Date().toISOString(),
-          layoutId: targetBoard.layout_id,
-          sizeId: targetBoard.size_id,
-          setIds: Array.isArray(targetBoard.set_ids)
-            ? targetBoard.set_ids.join(',')
-            : String(targetBoard.set_ids),
-        });
+      // Capture values for the draft in case the save fails.
+      const draftValues = { climbUuid: climb.uuid, quality, difficulty, attemptCount, comment, status };
 
+      // Fire confetti and close the bar immediately — don't wait for the network.
+      fireConfetti(confettiOrigin ?? document.getElementById('button-tick'));
+      onSave();
+
+      // Fire-and-forget: the logbook cache updates optimistically via useSaveTick's onMutate.
+      saveTick({
+        climbUuid: climb.uuid,
+        angle: Number(targetAngle),
+        isMirror: !!climb.mirrored,
+        status,
+        attemptCount,
+        quality: quality ?? undefined,
+        difficulty,
+        isBenchmark: false,
+        comment: comment || '',
+        climbedAt: new Date().toISOString(),
+        layoutId: targetBoard.layout_id,
+        sizeId: targetBoard.size_id,
+        setIds: Array.isArray(targetBoard.set_ids)
+          ? targetBoard.set_ids.join(',')
+          : String(targetBoard.set_ids),
+      }).then(() => {
         track('Quick Tick Saved', {
           boardLayout: targetBoard.layout_name || '',
           status,
@@ -182,20 +206,16 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
           hasDifficulty: difficulty !== undefined,
           hasComment: comment.length > 0,
         });
-
-        fireConfetti(confettiOrigin ?? document.getElementById('button-tick'));
-
-        onSave();
-      } catch {
+        clearTickDraft(climb.uuid);
+      }).catch(() => {
         track('Quick Tick Failed', {
           boardLayout: targetBoard.layout_name || '',
         });
+        saveTickDraft(draftValues);
         onError?.();
-      } finally {
-        setIsSaving(false);
-      }
+      });
     },
-    [tickTarget, quality, difficulty, comment, isSaving, saveTick, onSave, attemptCount, fireConfetti, onError],
+    [tickTarget, quality, difficulty, comment, saveTick, onSave, attemptCount, fireConfetti, onError],
   );
 
   const handleConfirm = useCallback(() => handleSave(true), [handleSave]);

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -600,6 +600,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   boardDetails={boardDetails}
                   onSave={() => setActiveDrawer('none')}
                   onError={() => showMessage('Couldn\u2019t save your tick. Give it another go.', 'error')}
+                  onDraftRestored={(draftComment) => setTickComment(draftComment)}
                   comment={tickComment}
                   commentSlot={
                     <div className={`${styles.tickComment} ${tickCommentFocused ? styles.tickCommentExpanded : ''}`}>

--- a/packages/web/app/hooks/__tests__/use-save-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-save-tick.test.ts
@@ -244,10 +244,12 @@ describe('useSaveTick', () => {
     expect(data?.length).toBe(0);
   });
 
-  it('shows error snackbar on failure', async () => {
+  it('rolls back optimistic entry on failure without showing snackbar', async () => {
     mockRequest.mockRejectedValue(new Error('Save failed'));
 
-    const { wrapper } = createTestWrapper();
+    const { wrapper, queryClient } = createTestWrapper();
+
+    queryClient.setQueryData(['logbook', 'kilter', 'accumulated'], []);
 
     const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
 
@@ -259,7 +261,12 @@ describe('useSaveTick', () => {
       expect(result.current.isError).toBe(true);
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith('Save failed', 'error');
+    // Optimistic entry should be rolled back
+    const data = queryClient.getQueryData(['logbook', 'kilter', 'accumulated']) as LogbookEntry[];
+    expect(data).toEqual([]);
+
+    // Snackbar is NOT called — callers handle their own error feedback
+    expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
   it('optimistic entry has correct is_ascent for flash/send', async () => {
@@ -321,7 +328,7 @@ describe('useSaveTick', () => {
     });
   });
 
-  it('extracts GraphQL error message from response', async () => {
+  it('propagates GraphQL errors to the caller', async () => {
     const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
     graphqlError.response = {
       errors: [{ message: 'Climb not found' }],
@@ -340,6 +347,9 @@ describe('useSaveTick', () => {
       expect(result.current.isError).toBe(true);
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith('Climb not found', 'error');
+    // Error is propagated so callers can handle their own feedback
+    expect(result.current.error).toBe(graphqlError);
+    // No snackbar from the hook itself
+    expect(mockShowMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -3,7 +3,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useWsAuthToken } from './use-ws-auth-token';
 import { useSession } from 'next-auth/react';
-import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   SAVE_TICK,
@@ -39,7 +38,6 @@ export interface SaveTickOptions {
 export function useSaveTick(boardName: BoardName) {
   const { token } = useWsAuthToken();
   const { status: sessionStatus } = useSession();
-  const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -119,27 +117,16 @@ export function useSaveTick(boardName: BoardName) {
       // Clear any IndexedDB draft for this climb (belt-and-suspenders with QuickTickBar's .then)
       clearTickDraft(options.climbUuid, options.angle);
     },
-    onError: (err, _options, context) => {
-      // Rollback optimistic update
+    onError: (_err, _options, context) => {
+      // Rollback optimistic update. User-facing error feedback is handled by
+      // the caller (e.g. QuickTickBar's .catch → onError callback) to avoid
+      // duplicate snackbars.
       if (context?.tempUuid) {
         queryClient.setQueriesData<LogbookEntry[]>(
           { queryKey: ['logbook', boardName] },
           (old) => old?.filter((entry) => entry.uuid !== context.tempUuid),
         );
       }
-
-      let errorMessage = 'Failed to save tick';
-      if (err instanceof Error) {
-        if ('response' in err && typeof err.response === 'object' && err.response !== null) {
-          const response = err.response as { errors?: Array<{ message: string }> };
-          if (response.errors && response.errors.length > 0) {
-            errorMessage = response.errors[0].message;
-          }
-        } else {
-          errorMessage = err.message;
-        }
-      }
-      showMessage(errorMessage, 'error');
     },
   });
 }

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -117,7 +117,7 @@ export function useSaveTick(boardName: BoardName) {
         );
       }
       // Clear any IndexedDB draft for this climb (belt-and-suspenders with QuickTickBar's .then)
-      clearTickDraft(options.climbUuid);
+      clearTickDraft(options.climbUuid, options.angle);
     },
     onError: (err, _options, context) => {
       // Rollback optimistic update

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -12,6 +12,7 @@ import {
 } from '@/app/lib/graphql/operations';
 import type { BoardName } from '@/app/lib/types';
 import type { TickStatus, LogbookEntry } from './use-logbook';
+import { clearTickDraft } from '@/app/lib/tick-draft-db';
 
 // Options for saving a tick (local storage, no Aurora required)
 export interface SaveTickOptions {
@@ -102,7 +103,7 @@ export function useSaveTick(boardName: BoardName) {
 
       return { tempUuid };
     },
-    onSuccess: (savedTick, _options, context) => {
+    onSuccess: (savedTick, options, context) => {
       // Replace temp entry with real data
       if (context?.tempUuid) {
         queryClient.setQueriesData<LogbookEntry[]>(
@@ -115,6 +116,8 @@ export function useSaveTick(boardName: BoardName) {
             ),
         );
       }
+      // Clear any IndexedDB draft for this climb (belt-and-suspenders with QuickTickBar's .then)
+      clearTickDraft(options.climbUuid);
     },
     onError: (err, _options, context) => {
       // Rollback optimistic update

--- a/packages/web/app/lib/tick-draft-db.ts
+++ b/packages/web/app/lib/tick-draft-db.ts
@@ -5,11 +5,16 @@ const STORE_NAME = 'tick-drafts';
 
 export interface TickDraft {
   climbUuid: string;
+  angle: number;
   quality: number | null;
   difficulty: number | undefined;
   attemptCount: number;
   comment: string;
   status: TickStatus;
+}
+
+function draftKey(climbUuid: string, angle: number): string {
+  return `${climbUuid}:${angle}`;
 }
 
 const getDB = createIndexedDBStore('boardsesh-tick-drafts', STORE_NAME);
@@ -18,28 +23,28 @@ export async function saveTickDraft(draft: TickDraft): Promise<void> {
   try {
     const db = await getDB();
     if (!db) return;
-    await db.put(STORE_NAME, draft, draft.climbUuid);
+    await db.put(STORE_NAME, draft, draftKey(draft.climbUuid, draft.angle));
   } catch {
     // Best-effort — don't block the UI
   }
 }
 
-export async function loadTickDraft(climbUuid: string): Promise<TickDraft | null> {
+export async function loadTickDraft(climbUuid: string, angle: number): Promise<TickDraft | null> {
   try {
     const db = await getDB();
     if (!db) return null;
-    const data = (await db.get(STORE_NAME, climbUuid)) as TickDraft | undefined;
+    const data = (await db.get(STORE_NAME, draftKey(climbUuid, angle))) as TickDraft | undefined;
     return data ?? null;
   } catch {
     return null;
   }
 }
 
-export async function clearTickDraft(climbUuid: string): Promise<void> {
+export async function clearTickDraft(climbUuid: string, angle: number): Promise<void> {
   try {
     const db = await getDB();
     if (!db) return;
-    await db.delete(STORE_NAME, climbUuid);
+    await db.delete(STORE_NAME, draftKey(climbUuid, angle));
   } catch {
     // Silently ignore
   }

--- a/packages/web/app/lib/tick-draft-db.ts
+++ b/packages/web/app/lib/tick-draft-db.ts
@@ -1,0 +1,46 @@
+import { createIndexedDBStore } from './idb-helper';
+import type { TickStatus } from '@/app/hooks/use-logbook';
+
+const STORE_NAME = 'tick-drafts';
+
+export interface TickDraft {
+  climbUuid: string;
+  quality: number | null;
+  difficulty: number | undefined;
+  attemptCount: number;
+  comment: string;
+  status: TickStatus;
+}
+
+const getDB = createIndexedDBStore('boardsesh-tick-drafts', STORE_NAME);
+
+export async function saveTickDraft(draft: TickDraft): Promise<void> {
+  try {
+    const db = await getDB();
+    if (!db) return;
+    await db.put(STORE_NAME, draft, draft.climbUuid);
+  } catch {
+    // Best-effort — don't block the UI
+  }
+}
+
+export async function loadTickDraft(climbUuid: string): Promise<TickDraft | null> {
+  try {
+    const db = await getDB();
+    if (!db) return null;
+    const data = (await db.get(STORE_NAME, climbUuid)) as TickDraft | undefined;
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearTickDraft(climbUuid: string): Promise<void> {
+  try {
+    const db = await getDB();
+    if (!db) return;
+    await db.delete(STORE_NAME, climbUuid);
+  } catch {
+    // Silently ignore
+  }
+}


### PR DESCRIPTION
## Summary
- Fire confetti and close the tick bar immediately instead of waiting for the GraphQL response — the logbook cache already updates optimistically via `useSaveTick`'s `onMutate`
- If the network save fails, persist form values (quality, difficulty, tries, comment, status) to IndexedDB keyed by climb UUID
- Next time the user opens the tick bar for the same climb, restore the saved draft values so they don't have to re-enter everything

## Test plan
- [ ] Open tick bar, fill in values, save → confetti fires instantly, bar closes instantly
- [ ] Simulate network failure (DevTools throttle / offline) → error snackbar appears
- [ ] Re-open tick bar for the same climb → form pre-populated with saved draft values
- [ ] Save successfully → draft cleared from IndexedDB (check Application tab)
- [ ] Open tick bar for a different climb → no draft values restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)