### PR TITLE
Centralize drawer height transition to theme tokens

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -48,7 +48,7 @@ const sharedDrawerStyles = {
   wrapper: {
     width: '100%',
     touchAction: 'pan-y' as const,
-    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transition: themeTokens.transitions.drawerHeight,
   },
   body: { padding: `${themeTokens.spacing[2]}px 0` },
   header: {

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -140,7 +140,7 @@ const actionsDrawerStyles = {
   wrapper: {
     width: '100%',
     touchAction: 'pan-y' as const,
-    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transition: themeTokens.transitions.drawerHeight,
   },
   body: { padding: `${themeTokens.spacing[2]}px 0` },
   header: {

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -25,7 +25,7 @@ import drawerStyles from '../swipeable-drawer/swipeable-drawer.module.css';
 const DRAFTS_DRAWER_STYLES = {
   wrapper: {
     touchAction: 'pan-y' as const,
-    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transition: themeTokens.transitions.drawerHeight,
   },
   body: { padding: 0, overflow: 'hidden' as const, touchAction: 'pan-y' as const },
 } as const;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -916,7 +916,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
                 styles={{
                   wrapper: {
                     touchAction: 'pan-y' as const,
-                    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+                    transition: themeTokens.transitions.drawerHeight,
                   },
                   body: { padding: `${themeTokens.spacing[2]}px 0` },
                 }}

--- a/packages/web/app/components/play-view/queue-drawer.tsx
+++ b/packages/web/app/components/play-view/queue-drawer.tsx
@@ -23,7 +23,7 @@ import drawerStyles from '../swipeable-drawer/swipeable-drawer.module.css';
 const QUEUE_DRAWER_STYLES = {
   wrapper: {
     touchAction: 'pan-y' as const,
-    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transition: themeTokens.transitions.drawerHeight,
   },
   body: { padding: 0, overflow: 'hidden' as const, touchAction: 'pan-y' as const },
 } as const;

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -596,7 +596,7 @@ const actionsDrawerStyles = {
   wrapper: {
     width: '100%',
     touchAction: 'pan-y' as const,
-    transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    transition: themeTokens.transitions.drawerHeight,
   },
   body: { padding: `${themeTokens.spacing[2]}px 0` },
 } as const;

--- a/packages/web/app/hooks/use-drawer-drag-resize.ts
+++ b/packages/web/app/hooks/use-drawer-drag-resize.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
+import { themeTokens } from '@/app/theme/theme-config';
 
 export const DRAG_MOVE_THRESHOLD = 10;
 /** Minimum velocity (px/ms) for a flick to close the drawer. */
@@ -184,7 +185,7 @@ export function useDrawerDragResize({
 
     // Re-enable transition for the snap animation
     if (paper) {
-      paper.style.transition = 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
+      paper.style.transition = themeTokens.transitions.drawerHeight;
     }
 
     if (!isDragGesture.current) return;

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -129,6 +129,7 @@ export const themeTokens = {
     fast: '150ms ease',
     normal: '200ms ease',
     slow: '300ms ease',
+    drawerHeight: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
   },
 
   // Z-index scale


### PR DESCRIPTION
## Summary
Extracted the hardcoded drawer height transition value into a centralized theme token to improve maintainability and consistency across the codebase.

## Key Changes
- Added `drawerHeight: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)'` to `themeTokens.transitions` in `theme-config.ts`
- Replaced 6 instances of the hardcoded transition string with `themeTokens.transitions.drawerHeight` across multiple components:
  - `use-drawer-drag-resize.ts` (hook)
  - `climbs-list.tsx`
  - `climb-list-item.tsx`
  - `drafts-drawer.tsx`
  - `play-view-drawer.tsx`
  - `queue-drawer.tsx`
  - `queue-list.tsx`

## Benefits
- **Single source of truth**: Drawer transition timing is now defined in one place
- **Easier maintenance**: Future changes to the transition timing only require updating the theme token
- **Consistency**: Ensures all drawer components use the exact same transition value
- **Theme alignment**: Follows the existing pattern of storing design tokens in the theme configuration

https://claude.ai/code/session_01Aapu4C4eq5diNnG3HYcSyq