### PR TITLE
fix: prevent unhandled rejections when favorite toggle fails on iOS

### DIFF
--- a/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
+++ b/packages/web/app/components/climb-actions/use-double-tap-favorite.ts
@@ -51,7 +51,9 @@ export function useDoubleTapFavorite({ climbUuid }: UseDoubleTapFavoriteOptions)
 
     // Only toggle if not already favorited (Instagram behavior)
     if (!isFavoritedRef.current) {
-      toggleFavorite();
+      void toggleFavorite().catch(() => {
+        // Errors are handled by the mutation's onError handler (snackbar + rollback)
+      });
     }
   }, [isAuthenticated, toggleFavorite, openAuthModal]);
 

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -603,6 +603,12 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     boardPull.onTouchEnd();
   }, [boardPull]);
 
+  const handleToggleFavorite = useCallback(() => {
+    void toggleFavorite().catch(() => {
+      // Errors are handled by the mutation's onError handler (snackbar + rollback)
+    });
+  }, [toggleFavorite]);
+
   const aboveFold = useMemo(() => {
     if (!currentClimb) return null;
     return (
@@ -677,7 +683,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           onPrevClick={handlePrevNavClick}
           onNextClick={handleNextNavClick}
           onMirror={mirrorClimb}
-          onToggleFavorite={toggleFavorite}
+          onToggleFavorite={handleToggleFavorite}
           onOpenActions={handleOpenActionsMenu}
           onOpenQueue={handleOpenQueueDrawer}
           angleSelector={
@@ -717,7 +723,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     handlePrevNavClick,
     handleNextNavClick,
     mirrorClimb,
-    toggleFavorite,
+    handleToggleFavorite,
     handleOpenActionsMenu,
     handleOpenQueueDrawer,
     angle,


### PR DESCRIPTION
When the GraphQL mutation fails (e.g. "TypeError: Load failed" on Mobile Safari), the error was propagating as an unhandled promise rejection because two call sites fired toggleFavorite() without catching the result:

1. useDoubleTapFavorite.handleDoubleTap called toggleFavorite() with no await and no .catch(), making any network failure an unhandled rejection.

2. PlayViewActionBar received toggleFavorite (async) directly as its onToggleFavorite prop, which called it via onClick without awaiting — same result on failure.

The mutation's onError handler already shows the error snackbar and rolls back the optimistic update, so callers don't need to act on the error. Adding void …catch(() => {}) at both call sites absorbs the rejection and lets the existing handler do its job.

https://claude.ai/code/session_014HS7ASF98yQBbVWxWzqtuA