### PR TITLE
Improve list route mobile performance (LCP, DOM size)

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { PropsWithChildren } from 'react';
 import { BoardRouteParameters } from '@/app/lib/types';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
@@ -12,7 +12,6 @@ import { WebSocketConnectionProvider } from '@/app/components/connection-manager
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import { BoardSessionBridge } from '@/app/components/persistent-session';
 import { Metadata } from 'next';
-import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
 import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
@@ -116,9 +115,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                       }}
                     >
                       <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
-                      <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
-                        {children}
-                      </Suspense>
+                      {children}
                     </main>
                   </UISearchParamsProvider>
                 </BluetoothProvider>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -15,6 +15,7 @@ import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
+import { buildOverlayUrl } from '@/app/components/board-renderer/util';
 
 export default async function DynamicResultsPage(props: {
   params: Promise<BoardRouteParametersWithUuid>;
@@ -121,5 +122,19 @@ export default async function DynamicResultsPage(props: {
 
   scheduleOverlayWarming({ boardDetails, climbs: searchResponse.climbs, variant: 'thumbnail' });
 
-  return <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />;
+  // Preload the first climb's thumbnail so the browser can fetch it before JS hydration.
+  // The climb list is virtualized (client-only), so the LCP image isn't in the initial HTML.
+  const firstClimb = searchResponse.climbs[0];
+  const preloadUrl = firstClimb?.frames
+    ? buildOverlayUrl(boardDetails, firstClimb.frames, true)
+    : null;
+
+  return (
+    <>
+      {preloadUrl && (
+        <link rel="preload" as="image" href={preloadUrl} fetchPriority="high" />
+      )}
+      <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />
+    </>
+  );
 }

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { PropsWithChildren } from 'react';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
@@ -10,7 +10,6 @@ import { ConnectionSettingsProvider } from '@/app/components/connection-manager/
 import { WebSocketConnectionProvider } from '@/app/components/connection-manager/websocket-connection-provider';
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import { BoardSessionBridge } from '@/app/components/persistent-session';
-import BoardPageSkeleton from '@/app/components/board-page/board-page-skeleton';
 import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
 import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { BoardProvider } from '@/app/components/board-provider/board-provider-context';
@@ -91,9 +90,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                       }}
                     >
                       <BoardSeshHeader boardDetails={boardDetails} angle={angle} isAngleAdjustable={board.isAngleAdjustable} />
-                      <Suspense fallback={<BoardPageSkeleton aspectRatio={boardDetails.boardWidth / boardDetails.boardHeight} />}>
-                        {children}
-                      </Suspense>
+                      {children}
                     </main>
                   </UISearchParamsProvider>
                 </BluetoothProvider>

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -11,6 +11,7 @@ import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
+import { buildOverlayUrl } from '@/app/components/board-renderer/util';
 
 interface BoardSlugListPageProps {
   params: Promise<{ board_slug: string; angle: string }>;
@@ -79,5 +80,17 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
 
   scheduleOverlayWarming({ boardDetails, climbs: searchResponse.climbs, variant: 'thumbnail' });
 
-  return <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />;
+  const firstClimb = searchResponse.climbs[0];
+  const preloadUrl = firstClimb?.frames
+    ? buildOverlayUrl(boardDetails, firstClimb.frames, true)
+    : null;
+
+  return (
+    <>
+      {preloadUrl && (
+        <link rel="preload" as="image" href={preloadUrl} fetchPriority="high" />
+      )}
+      <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />
+    </>
+  );
 }

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -533,6 +533,10 @@ const ClimbsList = ({
     estimateSize: () => 102,
     overscan: 25,
     getItemKey: (index) => visibleClimbs[index]?.uuid ?? index,
+    // Provide a fake viewport so the virtualizer renders items during SSR.
+    // Without this, getVirtualItems() returns [] on the server and the
+    // climb list is entirely client-rendered (hurts LCP).
+    initialRect: { width: 375, height: 812 },
   });
 
   const virtualItems = virtualizer.getVirtualItems();

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -633,6 +633,7 @@ const ClimbsList = ({
                       pathname={pathname}
                       isDark={isDark}
                       preferImageLayers={index < initialImageCount}
+                      fetchPriority={index === 0 ? 'high' : undefined}
                       onSelect={() => handleClimbClickByIndex(index)}
                       onThumbnailClick={() => handleClimbThumbnailClickByIndex(index)}
                       disableSwipe={!hydrated}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -530,7 +530,7 @@ const ClimbsList = ({
   // never outpaces the render cycle and causes a blank screen.
   const virtualizer = useWindowVirtualizer({
     count: visibleClimbs.length,
-    estimateSize: () => 102,
+    estimateSize: () => 107,
     overscan: 25,
     getItemKey: (index) => visibleClimbs[index]?.uuid ?? index,
     // Provide a fake viewport so the virtualizer renders items during SSR.

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -16,11 +16,7 @@ import drawerCss from '../swipeable-drawer/swipeable-drawer.module.css';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import ErrorBoundary from '../error-boundary';
-import ClimbCard from '../climb-card/climb-card';
 import ClimbListItem from '../climb-card/climb-list-item';
-import DrawerClimbHeader from '../climb-card/drawer-climb-header';
-import { ClimbActions } from '../climb-actions';
-import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
 import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
@@ -34,6 +30,10 @@ import listStyles from './climbs-list.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), { ssr: false });
 const QueueDrawer = dynamic(() => import('../play-view/queue-drawer'), { ssr: false });
+const DrawerClimbHeader = dynamic(() => import('../climb-card/drawer-climb-header'), { ssr: false });
+const ClimbActions = dynamic(() => import('../climb-actions/climb-actions'), { ssr: false });
+const PlaylistSelectionContent = dynamic(() => import('../climb-actions/playlist-selection-content'), { ssr: false });
+const ClimbCard = dynamic(() => import('../climb-card/climb-card'), { ssr: false });
 
 type ViewMode = 'grid' | 'list';
 

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -28,6 +28,8 @@ export interface BoardImageLayersProps {
   contain?: boolean;
   /** Additional styles for the container div */
   style?: React.CSSProperties;
+  /** Set fetchpriority="high" for LCP-critical images */
+  fetchPriority?: 'high' | 'low' | 'auto';
 }
 
 /**
@@ -43,6 +45,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
   thumbnail,
   contain,
   style,
+  fetchPriority,
 }: BoardImageLayersProps) {
   const overlayUrl = frames ? buildOverlayUrl(boardDetails, frames, thumbnail) : null;
   const backgroundUrls = useMemo(
@@ -95,6 +98,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
           width={imgWidth}
           height={imgHeight}
           style={imgStyle}
+          fetchPriority={fetchPriority}
           onLoad={handleOverlayLoad}
           onError={handleOverlayError}
         />

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -181,6 +181,8 @@ type ClimbListItemProps = {
   contentOpacity?: number;
   /** When true, prefer SSR image layers over the canvas renderer for this item. */
   preferImageLayers?: boolean;
+  /** Set fetchpriority="high" for LCP-critical images */
+  fetchPriority?: 'high' | 'low' | 'auto';
   /** Handler for thumbnail clicks. When set, stops propagation so the row onClick doesn't also fire. */
   onThumbnailClick?: () => void;
   /** When provided, the item delegates opening the actions drawer to the parent instead of rendering its own. */
@@ -210,6 +212,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     backgroundColor,
     contentOpacity,
     preferImageLayers,
+    fetchPriority,
     onThumbnailClick,
     onOpenActions,
     onOpenPlaylistSelector,
@@ -561,6 +564,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
                 currentClimb={climb}
                 pathname={pathname}
                 preferImageLayers={preferImageLayers}
+                fetchPriority={fetchPriority}
               />
               <HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} size={32} />
               <AscentStatus climbUuid={climb.uuid} fontSize={12} className={styles.thumbnailBadge} mirroredClassName={styles.thumbnailBadgeMirrored} />

--- a/packages/web/app/components/climb-card/climb-thumbnail.tsx
+++ b/packages/web/app/components/climb-card/climb-thumbnail.tsx
@@ -14,6 +14,8 @@ type ClimbThumbnailProps = {
   onClick?: () => void;
   maxHeight?: string;
   preferImageLayers?: boolean;
+  /** Set fetchpriority="high" for LCP-critical images */
+  fetchPriority?: 'high' | 'low' | 'auto';
 };
 
 const ClimbThumbnail: React.FC<ClimbThumbnailProps> = React.memo(({
@@ -23,6 +25,7 @@ const ClimbThumbnail: React.FC<ClimbThumbnailProps> = React.memo(({
   onClick,
   maxHeight,
   preferImageLayers = false,
+  fetchPriority,
 }) => {
   const canvasReady = useCanvasRendererReady();
 
@@ -52,6 +55,7 @@ const ClimbThumbnail: React.FC<ClimbThumbnailProps> = React.memo(({
           mirrored={!!currentClimb.mirrored}
           thumbnail
           style={boardStyle}
+          fetchPriority={fetchPriority}
         />
       );
     }
@@ -100,7 +104,8 @@ const ClimbThumbnail: React.FC<ClimbThumbnailProps> = React.memo(({
     prev.pathname === next.pathname &&
     prev.onClick === next.onClick &&
     prev.maxHeight === next.maxHeight &&
-    prev.preferImageLayers === next.preferImageLayers
+    prev.preferImageLayers === next.preferImageLayers &&
+    prev.fetchPriority === next.fetchPriority
   );
 });
 

--- a/packages/web/app/components/queue-control/queue-control-bar-shell.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar-shell.tsx
@@ -27,7 +27,7 @@ export default function QueueControlBarShell({
             <div
               className={styles.swipeContainer}
               style={{
-                padding: `6px ${themeTokens.spacing[3]}px 6px ${themeTokens.spacing[3]}px`,
+                padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
                 backgroundColor: 'var(--semantic-surface)',
               }}
             >

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -316,6 +316,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
       title: 'Search by Hold',
       defaultSummary: 'Any',
       getSummary: () => getHoldsPanelSummary(uiSearchParams),
+      lazy: true,
       content: (
         <div className={styles.holdSearchContainer}>
           <ClimbHoldSearchForm boardDetails={boardDetails} />


### PR DESCRIPTION
- Lazy-load holds search section to remove ~500 hidden SVG elements from initial DOM
- Preload first climb thumbnail from server component for earlier LCP fetch
- Thread fetchPriority="high" through to first list item's thumbnail image