### PR TITLE
Improve playlists page CWV: fix SSR/client mismatch, lazy-load Logboo…

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
@@ -6,8 +6,7 @@ import { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from '@/app/playlists/library-page-content';
-import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
-import { getImageUrl } from '@/app/components/board-renderer/util';
+import { getPlaylistLcpPreloadUrl } from '@/app/lib/lcp-preload-url';
 import styles from '@/app/components/library/library.module.css';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -35,18 +34,9 @@ export default async function PlaylistsPage(props: { params: Promise<BoardRouteP
       cachedDiscoverPlaylists(playlistFilter),
     ]);
 
-    // Compute LCP preload: first playlist's board thumbnail image
-    const firstPlaylist = initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0];
-    let lcpPreloadUrl: string | null = null;
-    if (firstPlaylist) {
-      const boardDetails = getBoardDetailsForPlaylist(firstPlaylist.boardType, firstPlaylist.layoutId);
-      if (boardDetails) {
-        const firstImage = Object.keys(boardDetails.images_to_holds)[0];
-        if (firstImage) {
-          lcpPreloadUrl = getImageUrl(firstImage, boardDetails.board_name, true);
-        }
-      }
-    }
+    const lcpPreloadUrl = getPlaylistLcpPreloadUrl(
+      initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0],
+    );
 
     return (
       <>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/page.tsx
@@ -6,6 +6,8 @@ import { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from '@/app/playlists/library-page-content';
+import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
+import { getImageUrl } from '@/app/components/board-renderer/util';
 import styles from '@/app/components/library/library.module.css';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -33,15 +35,33 @@ export default async function PlaylistsPage(props: { params: Promise<BoardRouteP
       cachedDiscoverPlaylists(playlistFilter),
     ]);
 
+    // Compute LCP preload: first playlist's board thumbnail image
+    const firstPlaylist = initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0];
+    let lcpPreloadUrl: string | null = null;
+    if (firstPlaylist) {
+      const boardDetails = getBoardDetailsForPlaylist(firstPlaylist.boardType, firstPlaylist.layoutId);
+      if (boardDetails) {
+        const firstImage = Object.keys(boardDetails.images_to_holds)[0];
+        if (firstImage) {
+          lcpPreloadUrl = getImageUrl(firstImage, boardDetails.board_name, true);
+        }
+      }
+    }
+
     return (
-      <div className={styles.pageContainer}>
-        <LibraryPageContent
-          playlistsBasePath={playlistsBasePath}
-          initialMyBoards={initialMyBoards}
-          initialPlaylists={initialPlaylists}
-          initialDiscoverPlaylists={initialDiscoverPlaylists}
-        />
-      </div>
+      <>
+        {lcpPreloadUrl && (
+          <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />
+        )}
+        <div className={styles.pageContainer}>
+          <LibraryPageContent
+            playlistsBasePath={playlistsBasePath}
+            initialMyBoards={initialMyBoards}
+            initialPlaylists={initialPlaylists}
+            initialDiscoverPlaylists={initialDiscoverPlaylists}
+          />
+        </div>
+      </>
     );
   } catch (error) {
     console.error('Error loading playlists page:', error);

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -104,7 +104,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
         />
       ) : (
         // No climb selected: just show background layers
-        backgroundUrls.map((url) => (
+        backgroundUrls.map((url, i) => (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             key={url}
@@ -113,6 +113,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
             width={imgWidth}
             height={imgHeight}
             style={imgStyle}
+            fetchPriority={i === 0 ? fetchPriority : undefined}
           />
         ))
       )}

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -237,6 +237,12 @@
               linear-gradient(135deg, var(--color-error), #D87F7A);
 }
 
+/* Placeholder to prevent CLS while auth status resolves */
+.signInBannerPlaceholder {
+  height: 72px;
+  margin-bottom: 20px;
+}
+
 /* Sign-in Banner (compact, non-blocking) */
 .signInBanner {
   display: flex;

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -237,22 +237,23 @@
               linear-gradient(135deg, var(--color-error), #D87F7A);
 }
 
-/* Placeholder to prevent CLS while auth status resolves */
+/* Placeholder to prevent CLS while auth status resolves.
+   Height matches .signInBanner: padding-top + content + padding-bottom. */
 .signInBannerPlaceholder {
-  height: 72px;
-  margin-bottom: 20px;
+  height: calc(var(--spacing-4) * 2 + var(--spacing-10));
+  margin-bottom: var(--spacing-5);
 }
 
 /* Sign-in Banner (compact, non-blocking) */
 .signInBanner {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background-color: var(--semantic-surface);
   border-radius: 12px;
   box-shadow: var(--shadow-sm);
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .signInBannerText {
@@ -332,6 +333,11 @@
 
 .skeletonText {
   border-radius: 4px;
+}
+
+/* Loading skeleton for lazy-loaded tab content */
+.tabSkeletonContainer {
+  padding: var(--spacing-4) 0;
 }
 
 /* Mobile */

--- a/packages/web/app/components/library/playlist-card-grid.tsx
+++ b/packages/web/app/components/library/playlist-card-grid.tsx
@@ -54,6 +54,7 @@ export default function PlaylistCardGrid({
           href={getPlaylistUrl(playlist.uuid)}
           variant="grid"
           index={index}
+          fetchPriority={index === 0 ? 'high' : undefined}
         />
       ))}
     </div>

--- a/packages/web/app/components/library/playlist-card.tsx
+++ b/packages/web/app/components/library/playlist-card.tsx
@@ -16,6 +16,7 @@ export type PlaylistCardProps = {
   variant: 'grid' | 'scroll';
   index?: number;
   isLikedClimbs?: boolean;
+  fetchPriority?: 'high' | 'low' | 'auto';
 };
 
 export default function PlaylistCard({
@@ -29,6 +30,7 @@ export default function PlaylistCard({
   variant,
   index = 0,
   isLikedClimbs,
+  fetchPriority,
 }: PlaylistCardProps) {
   if (variant === 'grid') {
     return (
@@ -42,6 +44,7 @@ export default function PlaylistCard({
             isLikedClimbs={isLikedClimbs}
             index={index}
             className={styles.previewCompact}
+            fetchPriority={fetchPriority}
           />
         </div>
         <div className={styles.cardCompactInfo}>
@@ -67,6 +70,7 @@ export default function PlaylistCard({
           icon={icon}
           isLikedClimbs={isLikedClimbs}
           index={index}
+          fetchPriority={fetchPriority}
         />
       </div>
       <div className={styles.cardName}>{name}</div>

--- a/packages/web/app/components/library/playlist-preview-square.tsx
+++ b/packages/web/app/components/library/playlist-preview-square.tsx
@@ -42,6 +42,7 @@ export type PlaylistPreviewSquareProps = {
   isLikedClimbs?: boolean;
   index?: number;
   className?: string;
+  fetchPriority?: 'high' | 'low' | 'auto';
 };
 
 export default function PlaylistPreviewSquare({
@@ -52,6 +53,7 @@ export default function PlaylistPreviewSquare({
   isLikedClimbs,
   index = 0,
   className,
+  fetchPriority,
 }: PlaylistPreviewSquareProps) {
   const boardDetails = useMemo(
     () => getBoardDetailsForPlaylist(boardType, layoutId),
@@ -106,6 +108,7 @@ export default function PlaylistPreviewSquare({
           mirrored={false}
           thumbnail
           style={{ width: '100%', height: '100%' }}
+          fetchPriority={fetchPriority}
         />
       </div>
       <div

--- a/packages/web/app/lib/__tests__/derive-auth-status.test.ts
+++ b/packages/web/app/lib/__tests__/derive-auth-status.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { deriveIsAuthenticated } from '../derive-auth-status';
+
+describe('deriveIsAuthenticated', () => {
+  it('returns true when session is authenticated', () => {
+    expect(deriveIsAuthenticated('authenticated', false)).toBe(true);
+    expect(deriveIsAuthenticated('authenticated', true)).toBe(true);
+  });
+
+  it('returns true during loading when SSR provided user data', () => {
+    expect(deriveIsAuthenticated('loading', true)).toBe(true);
+  });
+
+  it('returns false during loading when no SSR user data', () => {
+    expect(deriveIsAuthenticated('loading', false)).toBe(false);
+  });
+
+  it('returns false when session resolves to unauthenticated even with SSR data', () => {
+    // Session expired or user logged out in another tab between SSR and hydration
+    expect(deriveIsAuthenticated('unauthenticated', true)).toBe(false);
+  });
+
+  it('returns false when unauthenticated and no SSR data', () => {
+    expect(deriveIsAuthenticated('unauthenticated', false)).toBe(false);
+  });
+});

--- a/packages/web/app/lib/derive-auth-status.ts
+++ b/packages/web/app/lib/derive-auth-status.ts
@@ -1,0 +1,19 @@
+/**
+ * Derive effective authentication status for the library page.
+ *
+ * During SSR, `useSession()` starts in `'loading'` state. If the server already
+ * fetched user data (playlists, boards), we treat the user as authenticated while
+ * the session is loading to prevent SSR content from flashing away during hydration.
+ *
+ * Once `useSession()` settles (to `'authenticated'` or `'unauthenticated'`), we
+ * defer to its verdict so session expiry or logout in another tab correctly
+ * reverts the UI.
+ */
+export function deriveIsAuthenticated(
+  sessionStatus: 'loading' | 'authenticated' | 'unauthenticated',
+  hasServerUserData: boolean,
+): boolean {
+  return (
+    sessionStatus === 'authenticated' || (sessionStatus === 'loading' && hasServerUserData)
+  );
+}

--- a/packages/web/app/lib/lcp-preload-url.ts
+++ b/packages/web/app/lib/lcp-preload-url.ts
@@ -1,0 +1,20 @@
+import { getBoardDetailsForPlaylist } from './board-config-for-playlist';
+import { getImageUrl } from '@/app/components/board-renderer/util';
+
+/**
+ * Compute the thumbnail URL for the first playlist's board image.
+ * Used in server components to emit a `<link rel="preload">` for the LCP image.
+ */
+export function getPlaylistLcpPreloadUrl(
+  playlist: { boardType: string; layoutId?: number | null } | undefined | null,
+): string | null {
+  if (!playlist) return null;
+
+  const boardDetails = getBoardDetailsForPlaylist(playlist.boardType, playlist.layoutId);
+  if (!boardDetails) return null;
+
+  const firstImage = Object.keys(boardDetails.images_to_holds)[0];
+  if (!firstImage) return null;
+
+  return getImageUrl(firstImage, boardDetails.board_name, true);
+}

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -28,6 +28,7 @@ import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { findMatchingBoard } from '@/app/lib/find-matching-board';
+import { deriveIsAuthenticated } from '@/app/lib/derive-auth-status';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import PlaylistCardGrid from '@/app/components/library/playlist-card-grid';
@@ -44,7 +45,7 @@ const LogbookFeed = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div style={{ padding: '16px 0' }}>
+      <div className={styles.tabSkeletonContainer}>
         <Skeleton variant="rounded" height={80} sx={{ mb: 1 }} />
         <Skeleton variant="rounded" height={80} sx={{ mb: 1 }} />
         <Skeleton variant="rounded" height={80} />
@@ -81,10 +82,8 @@ export default function LibraryPageContent({
   const hasInitialPlaylistData = initialPlaylists != null;
   const hasInitialDiscoverData = initialDiscoverPlaylists != null;
 
-  // Trust SSR data: if the server fetched user data, treat as authenticated even while
-  // useSession() is still loading. This prevents SSR content from flashing away during hydration.
   const hasServerUserData = hasInitialPlaylistData || hasInitialBoardData;
-  const isAuthenticated = sessionStatus === 'authenticated' || hasServerUserData;
+  const isAuthenticated = deriveIsAuthenticated(sessionStatus, hasServerUserData);
   const [activeTab, setActiveTab] = useState<'playlists' | 'logbook'>('playlists');
   // Initialize selectedBoard from SSR data immediately when boardSlug is provided
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
@@ -424,7 +423,7 @@ export default function LibraryPageContent({
                   href={getPlaylistUrl(p.uuid)}
                   variant="scroll"
                   index={i}
-                  fetchPriority={i === 0 && !isAuthenticated ? 'high' : undefined}
+                  fetchPriority={i === 0 ? 'high' : undefined}
                 />
               ))}
             </PlaylistScrollSection>

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -33,10 +33,25 @@ import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import PlaylistCardGrid from '@/app/components/library/playlist-card-grid';
 import PlaylistScrollSection from '@/app/components/library/playlist-scroll-section';
 import PlaylistCard from '@/app/components/library/playlist-card';
-import LogbookFeed from '@/app/components/library/logbook-feed';
+import dynamic from 'next/dynamic';
+import Skeleton from '@mui/material/Skeleton';
 import BoardFilterStrip from '@/app/components/board-scroll/board-filter-strip';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import styles from '@/app/components/library/library.module.css';
+
+const LogbookFeed = dynamic(
+  () => import('@/app/components/library/logbook-feed'),
+  {
+    ssr: false,
+    loading: () => (
+      <div style={{ padding: '16px 0' }}>
+        <Skeleton variant="rounded" height={80} sx={{ mb: 1 }} />
+        <Skeleton variant="rounded" height={80} sx={{ mb: 1 }} />
+        <Skeleton variant="rounded" height={80} />
+      </div>
+    ),
+  },
+);
 
 type LibraryPageContentProps = {
   /** When set, the page was rendered from a board route and this board is pre-selected. */
@@ -61,13 +76,15 @@ export default function LibraryPageContent({
   const { data: session, status: sessionStatus } = useSession();
   const { token, isLoading: tokenLoading } = useWsAuthToken();
   const router = useRouter();
-  const isAuthenticated = sessionStatus === 'authenticated';
 
   const hasInitialBoardData = initialMyBoards != null && initialMyBoards.length > 0;
   const hasInitialPlaylistData = initialPlaylists != null;
   const hasInitialDiscoverData = initialDiscoverPlaylists != null;
 
-  const [hasMounted, setHasMounted] = useState(false);
+  // Trust SSR data: if the server fetched user data, treat as authenticated even while
+  // useSession() is still loading. This prevents SSR content from flashing away during hydration.
+  const hasServerUserData = hasInitialPlaylistData || hasInitialBoardData;
+  const isAuthenticated = sessionStatus === 'authenticated' || hasServerUserData;
   const [activeTab, setActiveTab] = useState<'playlists' | 'logbook'>('playlists');
   // Initialize selectedBoard from SSR data immediately when boardSlug is provided
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(
@@ -78,7 +95,7 @@ export default function LibraryPageContent({
 
   // Fetch user's boards for the board selector (with SSR initial data)
   const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(
-    hasMounted || hasInitialBoardData,
+    hasInitialBoardData || sessionStatus === 'authenticated',
     50,
     initialMyBoards,
   );
@@ -87,7 +104,6 @@ export default function LibraryPageContent({
   const { boardDetails: currentBoardDetails, hasActiveQueue } = useQueueBridgeBoardInfo();
 
   useEffect(() => {
-    setHasMounted(true);
     getPreference<'playlists' | 'logbook'>('libraryTab').then((saved) => {
       if (saved) setActiveTab(saved);
     });
@@ -294,7 +310,7 @@ export default function LibraryPageContent({
     );
   }
 
-  const isLoading = (!hasMounted && !hasInitialPlaylistData) || playlistsLoading || tokenLoading || sessionStatus === 'loading';
+  const isLoading = playlistsLoading || tokenLoading || (!hasServerUserData && sessionStatus === 'loading');
   const discoverItems = getDiscoverPlaylists();
 
   // Server query already filters by boardType + layoutId; no client-side filter needed
@@ -320,8 +336,13 @@ export default function LibraryPageContent({
         onBoardSelect={handleBoardSelect}
       />
 
+      {/* Placeholder to reserve space while auth status resolves (prevents CLS) */}
+      {!hasServerUserData && sessionStatus === 'loading' && (
+        <div className={styles.signInBannerPlaceholder} aria-hidden="true" />
+      )}
+
       {/* Sign-in banner for non-authenticated users */}
-      {hasMounted && !isAuthenticated && sessionStatus !== 'loading' && (
+      {!hasServerUserData && !isAuthenticated && sessionStatus !== 'loading' && (
         <div className={styles.signInBanner}>
           <LoginOutlined sx={{ color: 'text.secondary', fontSize: 28 }} />
           <div className={styles.signInBannerText}>
@@ -403,6 +424,7 @@ export default function LibraryPageContent({
                   href={getPlaylistUrl(p.uuid)}
                   variant="scroll"
                   index={i}
+                  fetchPriority={i === 0 && !isAuthenticated ? 'high' : undefined}
                 />
               ))}
             </PlaylistScrollSection>

--- a/packages/web/app/playlists/page.tsx
+++ b/packages/web/app/playlists/page.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from './library-page-content';
+import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
+import { getImageUrl } from '@/app/components/board-renderer/util';
 import styles from '@/app/components/library/library.module.css';
 import { createPageMetadata } from '@/app/lib/seo/metadata';
 
@@ -21,13 +23,31 @@ export default async function PlaylistsPage() {
     cachedDiscoverPlaylists(),
   ]);
 
+  // Compute LCP preload: first playlist's board thumbnail image
+  const firstPlaylist = initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0];
+  let lcpPreloadUrl: string | null = null;
+  if (firstPlaylist) {
+    const boardDetails = getBoardDetailsForPlaylist(firstPlaylist.boardType, firstPlaylist.layoutId);
+    if (boardDetails) {
+      const firstImage = Object.keys(boardDetails.images_to_holds)[0];
+      if (firstImage) {
+        lcpPreloadUrl = getImageUrl(firstImage, boardDetails.board_name, true);
+      }
+    }
+  }
+
   return (
-    <div className={styles.pageContainer}>
-      <LibraryPageContent
-        initialMyBoards={initialMyBoards}
-        initialPlaylists={initialPlaylists}
-        initialDiscoverPlaylists={initialDiscoverPlaylists}
-      />
-    </div>
+    <>
+      {lcpPreloadUrl && (
+        <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />
+      )}
+      <div className={styles.pageContainer}>
+        <LibraryPageContent
+          initialMyBoards={initialMyBoards}
+          initialPlaylists={initialPlaylists}
+          initialDiscoverPlaylists={initialDiscoverPlaylists}
+        />
+      </div>
+    </>
   );
 }

--- a/packages/web/app/playlists/page.tsx
+++ b/packages/web/app/playlists/page.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { serverMyBoards, serverUserPlaylists, cachedDiscoverPlaylists } from '@/app/lib/graphql/server-cached-client';
 import LibraryPageContent from './library-page-content';
-import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
-import { getImageUrl } from '@/app/components/board-renderer/util';
+import { getPlaylistLcpPreloadUrl } from '@/app/lib/lcp-preload-url';
 import styles from '@/app/components/library/library.module.css';
 import { createPageMetadata } from '@/app/lib/seo/metadata';
 
@@ -23,18 +22,9 @@ export default async function PlaylistsPage() {
     cachedDiscoverPlaylists(),
   ]);
 
-  // Compute LCP preload: first playlist's board thumbnail image
-  const firstPlaylist = initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0];
-  let lcpPreloadUrl: string | null = null;
-  if (firstPlaylist) {
-    const boardDetails = getBoardDetailsForPlaylist(firstPlaylist.boardType, firstPlaylist.layoutId);
-    if (boardDetails) {
-      const firstImage = Object.keys(boardDetails.images_to_holds)[0];
-      if (firstImage) {
-        lcpPreloadUrl = getImageUrl(firstImage, boardDetails.board_name, true);
-      }
-    }
-  }
+  const lcpPreloadUrl = getPlaylistLcpPreloadUrl(
+    initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0],
+  );
 
   return (
     <>


### PR DESCRIPTION
…kFeed, boost LCP

- Trust SSR-provided auth data during hydration to prevent content flash (CLS fix)
- Remove hasMounted gate that caused sign-in banner layout shift
- Add CLS placeholder while auth status resolves
- Lazy-load LogbookFeed (1005 lines + 15 MUI imports) via next/dynamic
- Pass fetchPriority="high" through PlaylistPreviewSquare -> BoardImageLayers
- Fix fetchPriority not applied to background-only images in BoardImageLayers
- Add <link rel="preload"> for first playlist thumbnail in server components