### PR TITLE
SSR crusher profile page: fetch all data server-side to eliminate loa…

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, asc, inArray, sql, count, ilike, gte, lte } from 'drizzle-orm';
+import { eq, and, desc, inArray, sql, count, ilike, gte, lte } from 'drizzle-orm';
 import type { ConnectionContext, BoardName } from '@boardsesh/shared-schema';
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';

--- a/packages/web/app/api/internal/profile/[userId]/route.ts
+++ b/packages/web/app/api/internal/profile/[userId]/route.ts
@@ -19,10 +19,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    return NextResponse.json({
-      ...profileData,
-      isOwnProfile: viewerUserId === userId,
-    });
+    return NextResponse.json(profileData);
   } catch (error) {
     console.error("Failed to get profile:", error);
     return NextResponse.json({ error: "Failed to get profile" }, { status: 500 });

--- a/packages/web/app/api/internal/profile/[userId]/route.ts
+++ b/packages/web/app/api/internal/profile/[userId]/route.ts
@@ -1,10 +1,7 @@
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/app/lib/db/db";
-import * as schema from "@/app/lib/db/schema";
-import { eq, and, count } from "drizzle-orm";
 import { authOptions } from "@/app/lib/auth/auth-options";
-import { getUserBoardMappings } from "@/app/lib/auth/user-board-mappings";
+import { getProfileData } from "@/app/crusher/[user_id]/server-profile-data";
 
 type RouteParams = {
   params: Promise<{ userId: string }>;
@@ -14,88 +11,17 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { userId } = await params;
     const session = await getServerSession(authOptions);
-    const isOwnProfile = session?.user?.id === userId;
+    const viewerUserId = session?.user?.id;
 
-    const db = getDb();
+    const profileData = await getProfileData(userId, viewerUserId);
 
-    // Get user profile
-    const profiles = await db
-      .select()
-      .from(schema.userProfiles)
-      .where(eq(schema.userProfiles.userId, userId))
-      .limit(1);
-
-    // Get base user data
-    const users = await db
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.id, userId))
-      .limit(1);
-
-    if (users.length === 0) {
+    if (!profileData) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    const user = users[0];
-    const profile = profiles.length > 0 ? profiles[0] : null;
-
-    // Get board mappings for this user
-    const mappings = await getUserBoardMappings(userId);
-
-    // Transform mappings to credential format
-    const credentials = mappings.map((m) => ({
-      boardType: m.boardType,
-      auroraUsername: m.boardUsername || '',
-      auroraUserId: m.boardUserId,
-    }));
-
-    // Get follower/following counts
-    const [followerCountResult] = await db
-      .select({ count: count() })
-      .from(schema.userFollows)
-      .where(eq(schema.userFollows.followingId, userId));
-
-    const [followingCountResult] = await db
-      .select({ count: count() })
-      .from(schema.userFollows)
-      .where(eq(schema.userFollows.followerId, userId));
-
-    const followerCount = Number(followerCountResult?.count || 0);
-    const followingCount = Number(followingCountResult?.count || 0);
-
-    // Check if current user follows this profile
-    let isFollowedByMe = false;
-    if (session?.user?.id && session.user.id !== userId) {
-      const [followCheck] = await db
-        .select({ count: count() })
-        .from(schema.userFollows)
-        .where(
-          and(
-            eq(schema.userFollows.followerId, session.user.id),
-            eq(schema.userFollows.followingId, userId)
-          )
-        );
-      isFollowedByMe = Number(followCheck?.count || 0) > 0;
-    }
-
     return NextResponse.json({
-      id: user.id,
-      // Only include email if viewing own profile
-      email: isOwnProfile ? user.email : undefined,
-      name: user.name,
-      image: user.image,
-      profile: profile
-        ? {
-            displayName: profile.displayName,
-            avatarUrl: profile.avatarUrl,
-            instagramUrl: profile.instagramUrl,
-          }
-        : null,
-      credentials,
-      isOwnProfile,
-      followerCount,
-      followingCount,
-      isFollowedByMe,
+      ...profileData,
+      isOwnProfile: viewerUserId === userId,
     });
   } catch (error) {
     console.error("Failed to get profile:", error);

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -13,7 +13,7 @@ import { BoardDetails } from '@/app/lib/types';
 import { constructClimbListWithSlugs, generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib/url-utils';
 import { useCurrentClimb, useSearchData } from '../graphql-queue';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
-import { hasActiveFilters, getSearchPillSummary } from '../search-drawer/search-summary-utils';
+import { hasActiveFilters, hasActiveNonNameFilters as computeNonNameFilters, getSearchPillSummary } from '../search-drawer/search-summary-utils';
 import { addRecentSearch } from '../search-drawer/recent-searches-storage';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import ChevronLeftOutlined from '@mui/icons-material/ChevronLeftOutlined';
@@ -31,7 +31,7 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
   const pathname = usePathname();
   const { currentClimb } = useCurrentClimb();
   const { totalSearchResultCount, isFetchingClimbs } = useSearchData();
-  const { uiSearchParams, clearClimbSearchParams } = useUISearchParams();
+  const { uiSearchParams, clearClimbSearchParams, updateFilters } = useUISearchParams();
   const searchParams = useSearchParams();
   const router = useRouter();
   const [searchDropdownOpen, setSearchDropdownOpen] = useState(false);
@@ -48,6 +48,12 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
   // Compute filter summary for the bridge
   const summary = getSearchPillSummary(uiSearchParams);
   const filtersActive = hasActiveFilters(uiSearchParams);
+  const nonNameFiltersActive = computeNonNameFilters(uiSearchParams);
+
+  // Name filter callbacks for the bridge
+  const handleNameFilterChange = useCallback((name: string) => {
+    updateFilters({ name });
+  }, [updateFilters]);
 
   // Create mode has its own header in the form — hide the board toolbar
   if (isCreatePage) {
@@ -92,6 +98,9 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
         summary={summary}
         hasActiveFilters={filtersActive}
         isOnListPage={isListPage}
+        nameFilter={uiSearchParams.name}
+        onNameFilterChange={handleNameFilterChange}
+        hasActiveNonNameFilters={nonNameFiltersActive}
       />
 
       {(hasBackButton || hasAngleSelector || hasCreateButton) && (

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -111,6 +111,8 @@ interface CreateClimbFormProps {
   holdSetImages?: string[];
 }
 
+const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 export default function CreateClimbForm({
   boardType,
   angle,
@@ -257,7 +259,6 @@ export default function CreateClimbForm({
   // Published climbs remain editable for 24 hours after their first publish.
   // Drafts are editable indefinitely. We re-check on every render so the lock
   // naturally engages while the form is open past the window.
-  const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
   const [nowTick, setNowTick] = useState(() => Date.now());
   useEffect(() => {
     if (!savedClimb?.publishedAt) return;
@@ -271,7 +272,7 @@ export default function CreateClimbForm({
     // Tick once when the edit window expires so the button flips to locked.
     const timeoutId = window.setTimeout(() => setNowTick(Date.now()), remaining + 50);
     return () => window.clearTimeout(timeoutId);
-  }, [savedClimb?.publishedAt, EDIT_WINDOW_MS]);
+  }, [savedClimb?.publishedAt]);
 
   const editLocked = useMemo(() => {
     if (!savedClimb) return false;
@@ -280,7 +281,7 @@ export default function CreateClimbForm({
     const publishedMs = Date.parse(savedClimb.publishedAt);
     if (!Number.isFinite(publishedMs)) return false;
     return nowTick - publishedMs > EDIT_WINDOW_MS;
-  }, [savedClimb, nowTick, EDIT_WINDOW_MS]);
+  }, [savedClimb, nowTick]);
 
   // Aurora-specific state
   const [showHeatmap, setShowHeatmap] = useState(false);
@@ -805,7 +806,7 @@ export default function CreateClimbForm({
     } finally {
       setIsSaving(false);
     }
-  }, [boardDetails, generateFramesString, saveClimb, updateClimb, climbName, description, isDraft, angle, totalHolds, queryClient, markJustSaved, savedClimb, showMessage, EDIT_WINDOW_MS, syncSavedClimbToQueue]);
+  }, [boardDetails, generateFramesString, saveClimb, updateClimb, climbName, description, isDraft, angle, totalHolds, queryClient, markJustSaved, savedClimb, showMessage, syncSavedClimbToQueue]);
 
   // Save climb - MoonBoard
   //
@@ -969,7 +970,6 @@ export default function CreateClimbForm({
     markJustSaved,
     savedClimb,
     updateClimb,
-    EDIT_WINDOW_MS,
     syncSavedClimbToQueue,
   ]);
 

--- a/packages/web/app/components/global-header/__tests__/global-header.test.tsx
+++ b/packages/web/app/components/global-header/__tests__/global-header.test.tsx
@@ -17,10 +17,21 @@ vi.mock('@/app/components/persistent-session/persistent-session-context', () => 
 }));
 
 const mockOpenClimbSearchDrawer = vi.fn();
-let mockBridgeState = {
-  openClimbSearchDrawer: null as (() => void) | null,
-  searchPillSummary: null as string | null,
+const mockSetNameFilter = vi.fn();
+let mockBridgeState: {
+  openClimbSearchDrawer: (() => void) | null;
+  searchPillSummary: string | null;
+  hasActiveFilters: boolean;
+  nameFilter: string;
+  setNameFilter: ((name: string) => void) | null;
+  hasActiveNonNameFilters: boolean;
+} = {
+  openClimbSearchDrawer: null,
+  searchPillSummary: null,
   hasActiveFilters: false,
+  nameFilter: '',
+  setNameFilter: null,
+  hasActiveNonNameFilters: false,
 };
 
 vi.mock('@/app/components/search-drawer/search-drawer-bridge-context', () => ({
@@ -40,6 +51,10 @@ vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
 vi.mock('@/app/components/sesh-settings/sesh-settings-drawer', () => ({
   default: ({ open }: { open: boolean; onClose: () => void }) =>
     open ? <div data-testid="sesh-settings-drawer" /> : null,
+}));
+
+vi.mock('@/app/components/sesh-settings/sesh-settings-drawer-event', () => ({
+  SESH_SETTINGS_DRAWER_EVENT: 'boardsesh:open-sesh-settings-drawer',
 }));
 
 vi.mock('@/app/components/user-drawer/user-drawer', () => ({
@@ -69,23 +84,31 @@ describe('GlobalHeader', () => {
       openClimbSearchDrawer: null,
       searchPillSummary: null,
       hasActiveFilters: false,
+      nameFilter: '',
+      setNameFilter: null,
+      hasActiveNonNameFilters: false,
     };
   });
 
-  it('renders user drawer, search pill, and Sesh button', () => {
+  it('renders user drawer and search input', () => {
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
     expect(screen.getByTestId('user-drawer')).toBeTruthy();
-    expect(screen.getByText('Search')).toBeTruthy();
-    expect(screen.getByText('Sesh')).toBeTruthy();
+    // Search input renders as a TextField with placeholder
+    expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
   });
 
-  it('opens UnifiedSearchDrawer when search pill is clicked', () => {
+  it('does not render a Sesh button', () => {
+    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+    expect(screen.queryByText('Sesh')).toBeNull();
+  });
+
+  it('opens UnifiedSearchDrawer when search input is focused (non-list page)', () => {
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
     expect(screen.queryByTestId('unified-search-drawer')).toBeNull();
 
-    fireEvent.click(screen.getByText('Search'));
+    fireEvent.focus(screen.getByPlaceholderText('What do you want to climb?'));
     expect(screen.getByTestId('unified-search-drawer')).toBeTruthy();
   });
 
@@ -93,7 +116,7 @@ describe('GlobalHeader', () => {
     mockIsOnBoardRoute = false;
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    fireEvent.click(screen.getByText('Search'));
+    fireEvent.focus(screen.getByPlaceholderText('What do you want to climb?'));
     expect(screen.getByTestId('unified-search-drawer').getAttribute('data-category')).toBe('boards');
   });
 
@@ -101,50 +124,29 @@ describe('GlobalHeader', () => {
     mockIsOnBoardRoute = true;
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    fireEvent.click(screen.getByText('Search'));
+    fireEvent.focus(screen.getByPlaceholderText('What do you want to climb?'));
     expect(screen.getByTestId('unified-search-drawer').getAttribute('data-category')).toBe('climbs');
   });
 
-  it('opens StartSeshDrawer when clicking Sesh with no active session', () => {
-    mockActiveSession = null;
-    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-
-    fireEvent.click(screen.getByText('Sesh'));
-    expect(screen.getByTestId('start-sesh-drawer')).toBeTruthy();
-    expect(screen.queryByTestId('sesh-settings-drawer')).toBeNull();
-  });
-
-  it('opens SeshSettingsDrawer when clicking Sesh with active session', () => {
-    mockActiveSession = { sessionId: 'session-123', boardPath: '/b/test/40/list' };
-    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-
-    fireEvent.click(screen.getByText('Sesh'));
-    expect(screen.getByTestId('sesh-settings-drawer')).toBeTruthy();
-    expect(screen.queryByTestId('start-sesh-drawer')).toBeNull();
-  });
-
-  it('renders only the avatar in a transparent bar on board create routes', () => {
+  it('renders nothing on board create routes', () => {
     mockPathname = '/b/test-board/40/create';
 
-    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+    const { container } = render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    expect(screen.getByTestId('user-drawer')).toBeTruthy();
-    expect(screen.queryByText('Search')).toBeNull();
-    expect(screen.queryByText('Sesh')).toBeNull();
+    // The header should be completely hidden (returns null)
+    expect(container.innerHTML).toBe('');
   });
 
-  it('renders only the avatar on MoonBoard create routes', () => {
+  it('renders nothing on MoonBoard create routes', () => {
     mockPathname = '/moonboard/moonboard-2024/standard-11x18-grid/wooden-holds/40/create';
 
-    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+    const { container } = render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    expect(screen.getByTestId('user-drawer')).toBeTruthy();
-    expect(screen.queryByText('Search')).toBeNull();
-    expect(screen.queryByText('Sesh')).toBeNull();
+    expect(container.innerHTML).toBe('');
   });
 
   // -----------------------------------------------------------------------
-  // Bridge integration tests
+  // Bridge integration tests (list page behavior)
   // -----------------------------------------------------------------------
   describe('with search drawer bridge active (on board list page)', () => {
     beforeEach(() => {
@@ -152,108 +154,124 @@ describe('GlobalHeader', () => {
         openClimbSearchDrawer: mockOpenClimbSearchDrawer,
         searchPillSummary: 'V5-V7 · Tall',
         hasActiveFilters: true,
+        nameFilter: '',
+        setNameFilter: mockSetNameFilter,
+        hasActiveNonNameFilters: true,
       };
     });
 
-    it('shows filter summary text instead of "Search" when bridge is active', () => {
+    it('shows "Search climbs..." placeholder when bridge is active', () => {
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      expect(screen.getByText('V5-V7 · Tall')).toBeTruthy();
-      expect(screen.queryByText('Search')).toBeNull();
+      expect(screen.getByPlaceholderText('Search climbs...')).toBeTruthy();
     });
 
-    it('calls openClimbSearchDrawer instead of opening its own drawer', () => {
+    it('renders the filter button when bridge is active', () => {
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      fireEvent.click(screen.getByText('V5-V7 · Tall'));
+      expect(screen.getByLabelText('Open filters')).toBeTruthy();
+    });
 
+    it('calls openClimbSearchDrawer when filter button is clicked', () => {
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+
+      fireEvent.click(screen.getByLabelText('Open filters'));
       expect(mockOpenClimbSearchDrawer).toHaveBeenCalledTimes(1);
-      // Should NOT open its own UnifiedSearchDrawer
-      expect(screen.queryByTestId('unified-search-drawer')).toBeNull();
     });
 
-    it('shows active indicator dot when filters are active', () => {
+    it('shows filter active indicator when non-name filters are active', () => {
       const { container } = render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      const activeIndicator = container.querySelector('[class*="searchPillActiveIndicator"]');
+      const activeIndicator = container.querySelector('[class*="filterActiveIndicator"]');
       expect(activeIndicator).toBeTruthy();
     });
 
-    it('does not show active indicator dot when filters are not active', () => {
+    it('does not show filter active indicator when non-name filters are not active', () => {
       mockBridgeState = {
-        openClimbSearchDrawer: mockOpenClimbSearchDrawer,
-        searchPillSummary: 'Search climbs...',
-        hasActiveFilters: false,
+        ...mockBridgeState,
+        hasActiveNonNameFilters: false,
       };
 
       const { container } = render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      const activeIndicator = container.querySelector('[class*="searchPillActiveIndicator"]');
+      const activeIndicator = container.querySelector('[class*="filterActiveIndicator"]');
       expect(activeIndicator).toBeNull();
     });
 
     it('adds onboarding-search-button id when bridge is active', () => {
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      const searchButton = screen.getByText('V5-V7 · Tall').closest('button');
-      expect(searchButton?.id).toBe('onboarding-search-button');
+      const searchWrapper = screen.getByPlaceholderText('Search climbs...').closest('[id="onboarding-search-button"]');
+      expect(searchWrapper).toBeTruthy();
     });
 
-    it('does not add onboarding-search-button id when bridge is inactive', () => {
+    it('does not show filter button when bridge is inactive', () => {
       mockBridgeState = {
         openClimbSearchDrawer: null,
         searchPillSummary: null,
         hasActiveFilters: false,
+        nameFilter: '',
+        setNameFilter: null,
+        hasActiveNonNameFilters: false,
       };
 
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      const searchButton = screen.getByText('Search').closest('button');
-      expect(searchButton?.id).toBe('');
+      expect(screen.queryByLabelText('Open filters')).toBeNull();
     });
 
-    it('shows "Search" when bridge has null summary', () => {
+    it('shows clear button when nameFilter has a value', () => {
       mockBridgeState = {
-        openClimbSearchDrawer: mockOpenClimbSearchDrawer,
-        searchPillSummary: null,
-        hasActiveFilters: false,
+        ...mockBridgeState,
+        nameFilter: 'some search',
       };
 
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      expect(screen.getByText('Search')).toBeTruthy();
+      expect(screen.getByLabelText('Clear search')).toBeTruthy();
+    });
+
+    it('does not show clear button when nameFilter is empty', () => {
+      mockBridgeState = {
+        ...mockBridgeState,
+        nameFilter: '',
+      };
+
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+
+      expect(screen.queryByLabelText('Clear search')).toBeNull();
+    });
+
+    it('calls setNameFilter with empty string when clear button is clicked', () => {
+      mockBridgeState = {
+        ...mockBridgeState,
+        nameFilter: 'some search',
+      };
+
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+
+      fireEvent.click(screen.getByLabelText('Clear search'));
+      expect(mockSetNameFilter).toHaveBeenCalledWith('');
     });
   });
 
-  it('shows "Search climbs..." on board list routes before the bridge registers', () => {
+  it('shows "Search climbs..." placeholder on board list routes before the bridge registers', () => {
     mockPathname = '/b/test-board/40/list';
 
+    // Bridge not registered yet — openClimbSearchDrawer is null
+    // but the pathname check in the component might not suffice;
+    // the real behavior is driven by the bridge state.
+    // With no bridge, non-list placeholder is shown
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    expect(screen.getByText('Search climbs...')).toBeTruthy();
-    expect(screen.queryByText('Search')).toBeNull();
+    expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
   });
 
-  it('keeps "Search" on non-list routes when the bridge is inactive', () => {
+  it('shows generic placeholder on non-list routes when the bridge is inactive', () => {
     mockPathname = '/b/test-board/40/view/some-climb';
 
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    expect(screen.getByText('Search')).toBeTruthy();
-    expect(screen.queryByText('Search climbs...')).toBeNull();
-  });
-
-  it('falls back to "Search climbs..." when the bridge is active on a list route but summary is null', () => {
-    mockPathname = '/b/test-board/40/list';
-    mockBridgeState = {
-      openClimbSearchDrawer: mockOpenClimbSearchDrawer,
-      searchPillSummary: null,
-      hasActiveFilters: false,
-    };
-
-    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-
-    expect(screen.getByText('Search climbs...')).toBeTruthy();
-    expect(screen.queryByText('Search')).toBeNull();
+    expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
   });
 });

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -23,49 +23,33 @@
   touch-action: manipulation;
 }
 
-.searchPillButton {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.searchInput {
   flex: 1;
-  padding: 6px 14px;
-  border-radius: 8px;
-  background: var(--neutral-50);
-  border: 1px solid var(--neutral-200);
-  cursor: pointer;
-  transition: box-shadow 200ms ease;
+  min-width: 0;
+}
+
+.searchInput input {
   font-size: 14px;
-  color: var(--neutral-500);
-  line-height: 1.4;
+  padding: 6px 0;
 }
 
-.searchPillButton:hover {
-  box-shadow: var(--shadow-sm);
-}
-
-.searchPillButton:active {
-  background: var(--neutral-100);
-}
-
-.searchPillIcon {
+.filterButton {
+  position: relative;
   flex-shrink: 0;
-  font-size: 14px;
-  color: var(--neutral-400);
 }
 
-.searchPillText {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-}
-
-.searchPillActiveIndicator {
-  width: 6px;
-  height: 6px;
+.filterActiveIndicator {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background-color: var(--color-primary);
+  pointer-events: none;
+}
+
+.seshIconButton {
   flex-shrink: 0;
 }
 
@@ -98,21 +82,16 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-:global(html[data-theme="dark"]) .searchPillButton {
+:global(html[data-theme="dark"]) .searchInput :global(.MuiOutlinedInput-root) {
   background: #FFFFFF;
-  border-color: #FFFFFF;
   color: #000000;
 }
 
-:global(html[data-theme="dark"]) .searchPillButton:hover {
-  background: #F3F4F6;
+:global(html[data-theme="dark"]) .searchInput :global(.MuiOutlinedInput-root) fieldset {
+  border-color: #FFFFFF;
 }
 
-:global(html[data-theme="dark"]) .searchPillButton:active {
-  background: #E5E7EB;
-}
-
-:global(html[data-theme="dark"]) .searchPillIcon {
+:global(html[data-theme="dark"]) .searchInput :global(.MuiSvgIcon-root) {
   color: #6B7280;
 }
 

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -49,9 +49,6 @@
   pointer-events: none;
 }
 
-.seshIconButton {
-  flex-shrink: 0;
-}
 
 .headerTransparent {
   position: fixed;

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -10,7 +10,6 @@ import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-drawer-bridge-context';
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
-import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
 import { SESH_SETTINGS_DRAWER_EVENT } from '@/app/components/sesh-settings/sesh-settings-drawer-event';
 import { useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
@@ -37,8 +36,6 @@ interface GlobalHeaderProps {
 export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchRendered, setSearchRendered] = useState(false);
-  const [startSeshOpen, setStartSeshOpen] = useState(false);
-  const [startSeshRendered, setStartSeshRendered] = useState(false);
   const [seshSettingsOpen, setSeshSettingsOpen] = useState(false);
   const [seshSettingsRendered, setSeshSettingsRendered] = useState(false);
 
@@ -53,9 +50,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   // MUI Modal/Portal/FocusTrap infrastructure on every parent re-render.
   const handleSearchTransitionEnd = useCallback((open: boolean) => {
     if (!open) setSearchRendered(false);
-  }, []);
-  const handleStartSeshTransitionEnd = useCallback((open: boolean) => {
-    if (!open) setStartSeshRendered(false);
   }, []);
   const handleSeshSettingsTransitionEnd = useCallback((open: boolean) => {
     if (!open) setSeshSettingsRendered(false);
@@ -187,15 +181,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
           onClose={() => setSearchOpen(false)}
           onTransitionEnd={handleSearchTransitionEnd}
           defaultCategory={isOnBoardRoute ? 'climbs' : 'boards'}
-        />
-      )}
-
-      {startSeshRendered && (
-        <StartSeshDrawer
-          open={startSeshOpen}
-          onClose={() => setStartSeshOpen(false)}
-          onTransitionEnd={handleStartSeshTransitionEnd}
-          boardConfigs={boardConfigs}
         />
       )}
 

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import ClearOutlined from '@mui/icons-material/ClearOutlined';
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
@@ -13,6 +14,7 @@ import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-dra
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
 import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
+import { SESH_SETTINGS_DRAWER_EVENT } from '@/app/components/sesh-settings/sesh-settings-drawer-event';
 import { usePersistentSessionState, useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
 import { isBoardCreatePath } from '@/app/lib/board-route-paths';
@@ -59,6 +61,16 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   }, []);
   const handleSeshSettingsTransitionEnd = useCallback((open: boolean) => {
     if (!open) setSeshSettingsRendered(false);
+  }, []);
+
+  // Listen for session mini-bar events to open the sesh settings drawer
+  useEffect(() => {
+    const handleOpenSeshSettings = () => {
+      setSeshSettingsRendered(true);
+      setSeshSettingsOpen(true);
+    };
+    window.addEventListener(SESH_SETTINGS_DRAWER_EVENT, handleOpenSeshSettings);
+    return () => window.removeEventListener(SESH_SETTINGS_DRAWER_EVENT, handleOpenSeshSettings);
   }, []);
 
   // On board create routes, hide the header entirely
@@ -147,6 +159,19 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
                     <SearchOutlined sx={{ fontSize: 18 }} />
                   </InputAdornment>
                 ),
+                endAdornment: useClimbSearchBridge && nameFilter ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => setNameFilter?.('')}
+                      aria-label="Clear search"
+                      edge="end"
+                      sx={{ padding: '2px' }}
+                    >
+                      <ClearOutlined sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
               },
             }}
           />

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -7,18 +7,16 @@ import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import ClearOutlined from '@mui/icons-material/ClearOutlined';
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
-import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
-import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-drawer-bridge-context';
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
 import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
 import { SESH_SETTINGS_DRAWER_EVENT } from '@/app/components/sesh-settings/sesh-settings-drawer-event';
-import { usePersistentSessionState, useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
+import { useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
 import { isBoardCreatePath } from '@/app/lib/board-route-paths';
-import { themeTokens } from '@/app/theme/theme-config';
+
 import { usePathname } from 'next/navigation';
 import BackButton from '@/app/components/back-button';
 import Typography from '@mui/material/Typography';
@@ -43,13 +41,13 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const [startSeshRendered, setStartSeshRendered] = useState(false);
   const [seshSettingsOpen, setSeshSettingsOpen] = useState(false);
   const [seshSettingsRendered, setSeshSettingsRendered] = useState(false);
-  const { activeSession } = usePersistentSessionState();
+
   const isOnBoardRoute = useIsOnBoardRoute();
   const { openClimbSearchDrawer, nameFilter, setNameFilter, hasActiveNonNameFilters: nonNameFiltersActive } = useSearchDrawerBridge();
   const pathname = usePathname();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const hasActiveSession = !!activeSession;
+
 
   // Unmount drawer trees after close animation finishes to avoid rendering
   // MUI Modal/Portal/FocusTrap infrastructure on every parent re-render.
@@ -108,15 +106,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
     }
   };
 
-  const handleSeshClick = () => {
-    if (hasActiveSession) {
-      setSeshSettingsRendered(true);
-      setSeshSettingsOpen(true);
-    } else {
-      setStartSeshRendered(true);
-      setStartSeshOpen(true);
-    }
-  };
 
   const searchPlaceholder = useClimbSearchBridge ? 'Search climbs...' : 'What do you want to climb?';
 
@@ -190,18 +179,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
           </div>
         )}
 
-        <IconButton
-          className={styles.seshIconButton}
-          onClick={handleSeshClick}
-          aria-label={hasActiveSession ? 'Session settings' : 'Start session'}
-          sx={hasActiveSession ? {
-            backgroundColor: themeTokens.colors.success,
-            color: '#fff',
-            '&:hover': { backgroundColor: themeTokens.colors.successHover },
-          } : undefined}
-        >
-          {hasActiveSession ? <StopCircleOutlined /> : <PlayCircleOutlineOutlined />}
-        </IconButton>
       </header>
 
       {searchRendered && (

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
-import Button from '@mui/material/Button';
+import React, { useState, useCallback, useRef } from 'react';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
 import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-drawer-bridge-context';
-import { DEFAULT_CLIMB_SEARCH_SUMMARY } from '@/app/components/search-drawer/search-summary-utils';
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
 import StartSeshDrawer from '@/app/components/session-creation/start-sesh-drawer';
 import SeshSettingsDrawer from '@/app/components/sesh-settings/sesh-settings-drawer';
 import { usePersistentSessionState, useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
-import { useSessionTimer } from '@/app/hooks/use-session-timer';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
-import { isBoardCreatePath, isBoardListPath } from '@/app/lib/board-route-paths';
+import { isBoardCreatePath } from '@/app/lib/board-route-paths';
 import { themeTokens } from '@/app/theme/theme-config';
 import { usePathname } from 'next/navigation';
 import BackButton from '@/app/components/back-button';
@@ -40,13 +41,13 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const [startSeshRendered, setStartSeshRendered] = useState(false);
   const [seshSettingsOpen, setSeshSettingsOpen] = useState(false);
   const [seshSettingsRendered, setSeshSettingsRendered] = useState(false);
-  const { activeSession, session } = usePersistentSessionState();
+  const { activeSession } = usePersistentSessionState();
   const isOnBoardRoute = useIsOnBoardRoute();
-  const { openClimbSearchDrawer, searchPillSummary, hasActiveFilters: filtersActive } = useSearchDrawerBridge();
+  const { openClimbSearchDrawer, nameFilter, setNameFilter, hasActiveNonNameFilters: nonNameFiltersActive } = useSearchDrawerBridge();
   const pathname = usePathname();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const hasActiveSession = !!activeSession;
-  const timerText = useSessionTimer(hasActiveSession ? session?.startedAt : null, { short: true });
 
   // Unmount drawer trees after close animation finishes to avoid rendering
   // MUI Modal/Portal/FocusTrap infrastructure on every parent re-render.
@@ -79,14 +80,19 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
 
   // When the bridge is active (on a board list page), delegate to the board route's drawer
   const useClimbSearchBridge = openClimbSearchDrawer !== null;
-  const defaultSearchPillText = isBoardListPath(pathname) ? DEFAULT_CLIMB_SEARCH_SUMMARY : 'What do you want to climb?';
 
-  const handleSearchClick = () => {
-    if (useClimbSearchBridge) {
-      openClimbSearchDrawer();
-    } else {
+  const handleSearchFocus = () => {
+    // On non-list pages, the input acts as a fake search trigger
+    if (!useClimbSearchBridge) {
+      inputRef.current?.blur();
       setSearchRendered(true);
       setSearchOpen(true);
+    }
+  };
+
+  const handleFilterClick = () => {
+    if (useClimbSearchBridge) {
+      openClimbSearchDrawer();
     }
   };
 
@@ -100,7 +106,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
     }
   };
 
-  const pillText = useClimbSearchBridge ? (searchPillSummary ?? defaultSearchPillText) : defaultSearchPillText;
+  const searchPlaceholder = useClimbSearchBridge ? 'Search climbs...' : 'What do you want to climb?';
 
   // Simple title header for specific pages (back button + title, no search/sesh)
   if (titleHeaderPage) {
@@ -119,30 +125,58 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
       <header className={styles.header}>
         <UserDrawer boardConfigs={boardConfigs} />
 
-        <button
+        <div
           id={useClimbSearchBridge ? 'onboarding-search-button' : undefined}
-          className={styles.searchPillButton}
-          onClick={handleSearchClick}
-          type="button"
+          className={styles.searchInput}
         >
-          <SearchOutlined className={styles.searchPillIcon} />
-          <span className={styles.searchPillText}>{pillText}</span>
-          {useClimbSearchBridge && filtersActive && <span className={styles.searchPillActiveIndicator} />}
-        </button>
+          <TextField
+            inputRef={inputRef}
+            placeholder={searchPlaceholder}
+            variant="outlined"
+            size="small"
+            fullWidth
+            value={useClimbSearchBridge ? nameFilter : ''}
+            onChange={(e) => setNameFilter?.(e.target.value)}
+            onFocus={handleSearchFocus}
+            aria-label="Search climbs by name"
+            slotProps={{
+              input: {
+                readOnly: !useClimbSearchBridge,
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchOutlined sx={{ fontSize: 18 }} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </div>
 
-        <Button
-          variant="contained"
-          size="small"
-          startIcon={hasActiveSession ? <StopCircleOutlined /> : <PlayCircleOutlineOutlined />}
+        {useClimbSearchBridge && (
+          <div className={styles.filterButton}>
+            <IconButton
+              onClick={handleFilterClick}
+              aria-label="Open filters"
+              size="small"
+            >
+              <FilterListOutlined />
+            </IconButton>
+            {nonNameFiltersActive && <span className={styles.filterActiveIndicator} />}
+          </div>
+        )}
+
+        <IconButton
+          className={styles.seshIconButton}
           onClick={handleSeshClick}
+          aria-label={hasActiveSession ? 'Session settings' : 'Start session'}
           sx={hasActiveSession ? {
             backgroundColor: themeTokens.colors.success,
+            color: '#fff',
             '&:hover': { backgroundColor: themeTokens.colors.successHover },
-            ...(timerText ? { fontFamily: 'monospace', fontVariantNumeric: 'tabular-nums' } : {}),
           } : undefined}
         >
-          {hasActiveSession && timerText ? timerText : 'Sesh'}
-        </Button>
+          {hasActiveSession ? <StopCircleOutlined /> : <PlayCircleOutlineOutlined />}
+        </IconButton>
       </header>
 
       {searchRendered && (

--- a/packages/web/app/components/logbook/inline-list-tick-bar.tsx
+++ b/packages/web/app/components/logbook/inline-list-tick-bar.tsx
@@ -191,6 +191,9 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
             >
               <CheckOutlined sx={{ fontSize: 18 }} />
             </IconButton>
+            {/* Intentional: both the attempt and cancel buttons use CloseOutlined.
+                The red "X" (attempt/fail) vs small muted "X" (cancel) distinction is
+                a deliberate design choice — do not change these icons. */}
             <IconButton
               ref={attemptButtonRef}
               size="small"

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -90,8 +90,9 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   useEffect(() => {
     if (!tickTarget || draftLoaded.current) return;
     draftLoaded.current = true;
+    let cancelled = false;
     loadTickDraft(tickTarget.climb.uuid, Number(tickTarget.angle)).then((draft) => {
-      if (!draft) return;
+      if (cancelled || !draft) return;
       setQuality(draft.quality);
       setDifficulty(draft.difficulty);
       setAttemptCount(draft.attemptCount);
@@ -99,6 +100,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
         onDraftRestored?.(draft.comment);
       }
     });
+    return () => { cancelled = true; };
   }, [tickTarget, onDraftRestored]);
   // Track which picker was last open so we can keep it mounted during collapse.
   const [lastExpandedControl, setLastExpandedControl] = useState<ExpandedControl>(null);

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -124,6 +124,39 @@
   }
 }
 
+/* Session header strip — sits above the swipe container inside the card */
+@keyframes sessionHeaderFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 12px;
+  cursor: pointer;
+  touch-action: manipulation;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  animation: sessionHeaderFadeIn 400ms ease-out;
+}
+
+:global(html[data-theme="dark"]) .sessionHeader {
+  border-bottom-color: rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.sessionName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .swipeWrapper {
   position: relative;
   overflow: hidden;
@@ -236,6 +269,11 @@
 .tickRowExpanded {
   grid-template-rows: 1fr;
   opacity: 1;
+}
+
+/* Closing state: keep visible briefly so the collapse transition plays */
+.tickRow:not(.tickRowExpanded) {
+  pointer-events: none;
 }
 
 .tickRowInner {

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -125,11 +125,6 @@
 }
 
 /* Session header strip — sits above the swipe container inside the card */
-@keyframes sessionHeaderFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
 .sessionHeader {
   display: flex;
   align-items: center;
@@ -139,7 +134,6 @@
   touch-action: manipulation;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
-  animation: sessionHeaderFadeIn 400ms ease-out;
 }
 
 :global(html[data-theme="dark"]) .sessionHeader {

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -133,7 +133,7 @@
 .sessionHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 6px;
   padding: 4px 12px;
   cursor: pointer;
   touch-action: manipulation;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -280,7 +280,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, [previousClimb, viewOnlyMode, setCurrentClimbQueueItem, shouldNavigate, router, buildClimbUrl, boardDetails, isPlayPage]);
 
   const tickBarActive = activeDrawer === 'tick';
-  const [tickCloseCount, setTickCloseCount] = useState(0);
   const canSwipeNext = !viewOnlyMode && !!nextClimb && !tickBarActive;
   const canSwipePrevious = !viewOnlyMode && !!previousClimb && !tickBarActive;
 
@@ -310,7 +309,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         setTickRowVisible(false);
         setTickComment('');
         setTickCommentFocused(false);
-        setTickCloseCount((c) => c + 1);
       }, 200);
       return () => clearTimeout(timer);
     }
@@ -577,7 +575,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         {!tickBarActive && !tickRowVisible && (
           activeSession ? (
             <div
-              key={`session-header-${tickCloseCount}`}
               className={styles.sessionHeader}
               onClick={dispatchOpenSeshSettingsDrawer}
               role="button"

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -610,6 +610,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               role="button"
               tabIndex={0}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setStartSeshOpen(true); }}
+              style={{
+                backgroundColor: gradeTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
+              }}
             >
               <PlayCircleOutlineOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
               <span className={styles.sessionName}>Start sesh</span>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -36,10 +36,15 @@ import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import InputAdornment from '@mui/material/InputAdornment';
+import Avatar from '@mui/material/Avatar';
+import AvatarGroup from '@mui/material/AvatarGroup';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { usePersistentSessionState } from '../persistent-session/persistent-session-context';
+import { dispatchOpenSeshSettingsDrawer } from '../sesh-settings/sesh-settings-drawer-event';
+import { generateSessionName } from '@/app/lib/session-utils';
 import styles from './queue-control-bar.module.css';
 
 export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
@@ -120,6 +125,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const { currentClimb } = useCurrentClimb();
   const { queue } = useQueueList();
   const { viewOnlyMode, connectionState, sessionId, isDisconnected, users } = useSessionData();
+  const { activeSession, session: persistentSession, users: sessionUsers } = usePersistentSessionState();
   const {
     mirrorClimb,
     setQueue,
@@ -271,6 +277,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, [previousClimb, viewOnlyMode, setCurrentClimbQueueItem, shouldNavigate, router, buildClimbUrl, boardDetails, isPlayPage]);
 
   const tickBarActive = activeDrawer === 'tick';
+  const [tickCloseCount, setTickCloseCount] = useState(0);
   const canSwipeNext = !viewOnlyMode && !!nextClimb && !tickBarActive;
   const canSwipePrevious = !viewOnlyMode && !!previousClimb && !tickBarActive;
 
@@ -288,16 +295,20 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // The climb shown in the queue bar — frozen during tick mode.
   const displayedClimb = tickBarActive ? (tickClimb ?? currentClimb) : currentClimb;
   const gradeTintColor = useMemo(() => getGradeTintColor(displayedClimb?.difficulty, 'default', isDark), [displayedClimb?.difficulty, isDark]);
+  const sessionTintColor = useMemo(() => getGradeTintColor(displayedClimb?.difficulty, 'session', isDark), [displayedClimb?.difficulty, isDark]);
 
   // Reset all tick-bar state on close; keep the row mounted during the 200ms collapse.
   useEffect(() => {
     if (tickBarActive) {
       setTickRowVisible(true);
     } else {
-      setTickComment('');
-      setTickCommentFocused(false);
       setTickSwipeOffset(0);
-      const timer = setTimeout(() => setTickRowVisible(false), 200);
+      const timer = setTimeout(() => {
+        setTickRowVisible(false);
+        setTickComment('');
+        setTickCommentFocused(false);
+        setTickCloseCount((c) => c + 1);
+      }, 200);
       return () => clearTimeout(timer);
     }
   }, [tickBarActive]);
@@ -559,6 +570,36 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         sx={{ border: 'none', backgroundColor: 'transparent' }}
       >
         <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+        {/* Session header — name + avatars */}
+        {activeSession && !tickBarActive && !tickRowVisible && (
+          <div
+            key={`session-header-${tickCloseCount}`}
+            className={styles.sessionHeader}
+            onClick={dispatchOpenSeshSettingsDrawer}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') dispatchOpenSeshSettingsDrawer(); }}
+            style={{
+              backgroundColor: sessionTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
+            }}
+          >
+            <span className={styles.sessionName}>
+              {persistentSession?.name || activeSession.sessionName || generateSessionName(persistentSession?.startedAt ?? new Date().toISOString(), [boardDetails.board_name])}
+            </span>
+            {sessionUsers.length > 0 && (
+              <AvatarGroup
+                max={3}
+                sx={{
+                  '& .MuiAvatar-root': { width: 28, height: 28, fontSize: 11, border: '2px solid transparent' },
+                }}
+              >
+                {sessionUsers.map((user) => (
+                  <Avatar key={user.id} alt={user.username} src={user.avatarUrl ?? undefined} />
+                ))}
+              </AvatarGroup>
+            )}
+          </div>
+        )}
         {/* Tick-mode controls — expands/collapses via CSS grid transition.
             Swipe-to-dismiss handlers are on the tick row only, not the whole card. */}
         {(tickBarActive || tickRowVisible) && (

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -43,8 +43,10 @@ import { useColorMode } from '@/app/hooks/use-color-mode';
 import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { usePersistentSessionState } from '../persistent-session/persistent-session-context';
+import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import { dispatchOpenSeshSettingsDrawer } from '../sesh-settings/sesh-settings-drawer-event';
 import { generateSessionName } from '@/app/lib/session-utils';
+import StartSeshDrawer from '../session-creation/start-sesh-drawer';
 import styles from './queue-control-bar.module.css';
 
 export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
@@ -64,6 +66,7 @@ export interface QueueControlBarProps {
 
 const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }) => {
   const [activeDrawer, setActiveDrawer] = useState<ActiveDrawer>('none');
+  const [startSeshOpen, setStartSeshOpen] = useState(false);
   const pathname = usePathname();
   const params = useParams<BoardRouteParameters>();
   const searchParams = useSearchParams();
@@ -570,35 +573,48 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         sx={{ border: 'none', backgroundColor: 'transparent' }}
       >
         <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
-        {/* Session header — name + avatars */}
-        {activeSession && !tickBarActive && !tickRowVisible && (
-          <div
-            key={`session-header-${tickCloseCount}`}
-            className={styles.sessionHeader}
-            onClick={dispatchOpenSeshSettingsDrawer}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') dispatchOpenSeshSettingsDrawer(); }}
-            style={{
-              backgroundColor: sessionTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
-            }}
-          >
-            <span className={styles.sessionName}>
-              {persistentSession?.name || activeSession.sessionName || generateSessionName(persistentSession?.startedAt ?? new Date().toISOString(), [boardDetails.board_name])}
-            </span>
-            {sessionUsers.length > 0 && (
-              <AvatarGroup
-                max={3}
-                sx={{
-                  '& .MuiAvatar-root': { width: 28, height: 28, fontSize: 11, border: '2px solid transparent' },
-                }}
-              >
-                {sessionUsers.map((user) => (
-                  <Avatar key={user.id} alt={user.username} src={user.avatarUrl ?? undefined} />
-                ))}
-              </AvatarGroup>
-            )}
-          </div>
+        {/* Session header — name + avatars, or start sesh prompt */}
+        {!tickBarActive && !tickRowVisible && (
+          activeSession ? (
+            <div
+              key={`session-header-${tickCloseCount}`}
+              className={styles.sessionHeader}
+              onClick={dispatchOpenSeshSettingsDrawer}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') dispatchOpenSeshSettingsDrawer(); }}
+              style={{
+                backgroundColor: sessionTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
+              }}
+            >
+              <span className={styles.sessionName}>
+                {persistentSession?.name || activeSession.sessionName || generateSessionName(persistentSession?.startedAt ?? new Date().toISOString(), [boardDetails.board_name])}
+              </span>
+              {sessionUsers.length > 0 && (
+                <AvatarGroup
+                  max={3}
+                  sx={{
+                    '& .MuiAvatar-root': { width: 28, height: 28, fontSize: 11, border: '2px solid transparent' },
+                  }}
+                >
+                  {sessionUsers.map((user) => (
+                    <Avatar key={user.id} alt={user.username} src={user.avatarUrl ?? undefined} />
+                  ))}
+                </AvatarGroup>
+              )}
+            </div>
+          ) : (
+            <div
+              className={styles.sessionHeader}
+              onClick={() => setStartSeshOpen(true)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setStartSeshOpen(true); }}
+            >
+              <PlayCircleOutlineOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+              <span className={styles.sessionName}>Start sesh</span>
+            </div>
+          )
         )}
         {/* Tick-mode controls — expands/collapses via CSS grid transition.
             Swipe-to-dismiss handlers are on the tick row only, not the whole card. */}
@@ -861,6 +877,11 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         setActiveDrawer={setActiveDrawer}
         boardDetails={boardDetails}
         angle={angle}
+      />
+
+      <StartSeshDrawer
+        open={startSeshOpen}
+        onClose={() => setStartSeshOpen(false)}
       />
     </div>
   );

--- a/packages/web/app/components/search-drawer/__tests__/search-drawer-bridge-context.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/search-drawer-bridge-context.test.tsx
@@ -248,6 +248,110 @@ describe('search-drawer-bridge-context', () => {
       expect(result.current.searchPillSummary).toBe('V5-V7');
     });
 
+    it('propagates nameFilter value through the bridge', () => {
+      const { result } = renderWithInjector({
+        openDrawer: mockOpenDrawer,
+        summary: 'V5-V7',
+        hasActiveFilters: true,
+        isOnListPage: true,
+      });
+
+      // Default nameFilter is empty string from renderWithInjector
+      expect(result.current.nameFilter).toBe('');
+    });
+
+    it('updates nameFilter when injector prop changes', () => {
+      let nameFilter = '';
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SearchDrawerBridgeProvider>
+          {children}
+          <SearchDrawerBridgeInjector
+            openDrawer={mockOpenDrawer}
+            summary="V5-V7"
+            hasActiveFilters={false}
+            isOnListPage={true}
+            nameFilter={nameFilter}
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
+          />
+        </SearchDrawerBridgeProvider>
+      );
+
+      const { result, rerender } = renderHook(() => useSearchDrawerBridge(), { wrapper });
+      expect(result.current.nameFilter).toBe('');
+
+      nameFilter = 'crimpy';
+      rerender();
+
+      expect(result.current.nameFilter).toBe('crimpy');
+    });
+
+    it('calls onNameFilterChange via setNameFilter bridge callback', () => {
+      const onNameFilterChange = vi.fn();
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SearchDrawerBridgeProvider>
+          {children}
+          <SearchDrawerBridgeInjector
+            openDrawer={mockOpenDrawer}
+            summary="V5-V7"
+            hasActiveFilters={false}
+            isOnListPage={true}
+            nameFilter=""
+            onNameFilterChange={onNameFilterChange}
+            hasActiveNonNameFilters={false}
+          />
+        </SearchDrawerBridgeProvider>
+      );
+
+      const { result } = renderHook(() => useSearchDrawerBridge(), { wrapper });
+
+      expect(result.current.setNameFilter).not.toBeNull();
+
+      act(() => {
+        result.current.setNameFilter!('slab master');
+      });
+
+      expect(onNameFilterChange).toHaveBeenCalledTimes(1);
+      expect(onNameFilterChange).toHaveBeenCalledWith('slab master');
+    });
+
+    it('propagates hasActiveNonNameFilters through the bridge', () => {
+      let nonNameActive = false;
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SearchDrawerBridgeProvider>
+          {children}
+          <SearchDrawerBridgeInjector
+            openDrawer={mockOpenDrawer}
+            summary="V5-V7"
+            hasActiveFilters={true}
+            isOnListPage={true}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={nonNameActive}
+          />
+        </SearchDrawerBridgeProvider>
+      );
+
+      const { result, rerender } = renderHook(() => useSearchDrawerBridge(), { wrapper });
+      expect(result.current.hasActiveNonNameFilters).toBe(false);
+
+      nonNameActive = true;
+      rerender();
+
+      expect(result.current.hasActiveNonNameFilters).toBe(true);
+    });
+
+    it('returns null setNameFilter when not on list page', () => {
+      const { result } = renderWithInjector({
+        openDrawer: mockOpenDrawer,
+        summary: 'V5-V7',
+        hasActiveFilters: false,
+        isOnListPage: false,
+      });
+
+      expect(result.current.setNameFilter).toBeNull();
+    });
+
     it('updates the openDrawer callback when it changes', () => {
       const openDrawer1 = vi.fn();
       const openDrawer2 = vi.fn();

--- a/packages/web/app/components/search-drawer/__tests__/search-drawer-bridge-context.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/search-drawer-bridge-context.test.tsx
@@ -59,7 +59,7 @@ describe('search-drawer-bridge-context', () => {
       const wrapper = ({ children }: { children: React.ReactNode }) => (
         <SearchDrawerBridgeProvider>
           {children}
-          <SearchDrawerBridgeInjector {...props} />
+          <SearchDrawerBridgeInjector nameFilter="" onNameFilterChange={() => {}} hasActiveNonNameFilters={false} {...props} />
         </SearchDrawerBridgeProvider>
       );
       return renderHook(() => useSearchDrawerBridge(), { wrapper });
@@ -137,6 +137,9 @@ describe('search-drawer-bridge-context', () => {
             summary="V5-V7"
             hasActiveFilters={true}
             isOnListPage={isOnListPage}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
           />
         </SearchDrawerBridgeProvider>
       );
@@ -164,6 +167,9 @@ describe('search-drawer-bridge-context', () => {
             summary={summary}
             hasActiveFilters={hasActiveFilters}
             isOnListPage={true}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
           />
         </SearchDrawerBridgeProvider>
       );
@@ -192,6 +198,9 @@ describe('search-drawer-bridge-context', () => {
             summary={summary}
             hasActiveFilters={hasActiveFilters}
             isOnListPage={true}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
           />
         </SearchDrawerBridgeProvider>
       );
@@ -219,6 +228,9 @@ describe('search-drawer-bridge-context', () => {
             summary="V5-V7"
             hasActiveFilters={true}
             isOnListPage={isOnListPage}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
           />
         </SearchDrawerBridgeProvider>
       );
@@ -249,6 +261,9 @@ describe('search-drawer-bridge-context', () => {
             summary="V5-V7"
             hasActiveFilters={false}
             isOnListPage={true}
+            nameFilter=""
+            onNameFilterChange={() => {}}
+            hasActiveNonNameFilters={false}
           />
         </SearchDrawerBridgeProvider>
       );

--- a/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { hasActiveNonNameFilters, hasActiveFilters } from '../search-summary-utils';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import type { SearchRequestPagination } from '@/app/lib/types';
+
+function makeParams(overrides: Partial<SearchRequestPagination> = {}): SearchRequestPagination {
+  return { ...DEFAULT_SEARCH_PARAMS, ...overrides } as SearchRequestPagination;
+}
+
+describe('hasActiveNonNameFilters', () => {
+  it('returns false when all params match defaults', () => {
+    expect(hasActiveNonNameFilters(makeParams())).toBe(false);
+  });
+
+  it('returns false when only the name filter is active', () => {
+    expect(hasActiveNonNameFilters(makeParams({ name: 'Cool Boulder' }))).toBe(false);
+  });
+
+  it('returns true when minGrade is set', () => {
+    expect(hasActiveNonNameFilters(makeParams({ minGrade: 16 }))).toBe(true);
+  });
+
+  it('returns true when maxGrade is set', () => {
+    expect(hasActiveNonNameFilters(makeParams({ maxGrade: 24 }))).toBe(true);
+  });
+
+  it('returns true when grade filters are active even with a name filter', () => {
+    expect(
+      hasActiveNonNameFilters(makeParams({ name: 'Test', minGrade: 10, maxGrade: 20 })),
+    ).toBe(true);
+  });
+
+  it('returns true when holdsFilter has entries', () => {
+    expect(
+      hasActiveNonNameFilters(makeParams({ holdsFilter: { 1: { state: 'HAND' as const, color: '#ff0000', displayColor: '#ff0000' } } })),
+    ).toBe(true);
+  });
+
+  it('returns false when holdsFilter is empty object', () => {
+    expect(hasActiveNonNameFilters(makeParams({ holdsFilter: {} }))).toBe(false);
+  });
+
+  it('returns true when onlyClassics is true', () => {
+    expect(hasActiveNonNameFilters(makeParams({ onlyClassics: true }))).toBe(true);
+  });
+
+  it('returns true when minAscents differs from default', () => {
+    expect(hasActiveNonNameFilters(makeParams({ minAscents: 5 }))).toBe(true);
+  });
+
+  it('returns true when minRating differs from default', () => {
+    expect(hasActiveNonNameFilters(makeParams({ minRating: 3 }))).toBe(true);
+  });
+
+  it('returns true when hideAttempted is true', () => {
+    expect(hasActiveNonNameFilters(makeParams({ hideAttempted: true }))).toBe(true);
+  });
+
+  it('returns true when sortBy differs from default', () => {
+    expect(hasActiveNonNameFilters(makeParams({ sortBy: 'quality' }))).toBe(true);
+  });
+});
+
+describe('hasActiveFilters', () => {
+  it('returns false when all params match defaults', () => {
+    expect(hasActiveFilters(makeParams())).toBe(false);
+  });
+
+  it('returns true when name is set (unlike hasActiveNonNameFilters)', () => {
+    expect(hasActiveFilters(makeParams({ name: 'Cool Boulder' }))).toBe(true);
+  });
+
+  it('returns true when grade filters are active', () => {
+    expect(hasActiveFilters(makeParams({ minGrade: 10 }))).toBe(true);
+  });
+
+  it('returns true when holdsFilter has entries', () => {
+    expect(hasActiveFilters(makeParams({ holdsFilter: { 1: { state: 'HAND' as const, color: '#ff0000', displayColor: '#ff0000' } } }))).toBe(true);
+  });
+});

--- a/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
+++ b/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
@@ -16,12 +16,21 @@ interface SearchDrawerBridgeState {
   searchPillSummary: string | null;
   /** Whether any climb filters are active (for indicator dot). */
   hasActiveFilters: boolean;
+  /** Current name filter value for the header search input. */
+  nameFilter: string;
+  /** Callback to update the name filter from the header search input. null when not on list page. */
+  setNameFilter: ((name: string) => void) | null;
+  /** Whether any filters other than name are active (for filter button indicator). */
+  hasActiveNonNameFilters: boolean;
 }
 
 const SearchDrawerBridgeContext = createContext<SearchDrawerBridgeState>({
   openClimbSearchDrawer: null,
   searchPillSummary: null,
   hasActiveFilters: false,
+  nameFilter: '',
+  setNameFilter: null,
+  hasActiveNonNameFilters: false,
 });
 
 export function useSearchDrawerBridge() {
@@ -33,8 +42,8 @@ export function useSearchDrawerBridge() {
 // -------------------------------------------------------------------
 
 interface SearchDrawerBridgeSetters {
-  register: (openDrawer: () => void, summary: string, active: boolean) => void;
-  update: (summary: string, active: boolean) => void;
+  register: (openDrawer: () => void, summary: string, active: boolean, nameFilter: string, setNameFilter: (name: string) => void, nonNameActive: boolean) => void;
+  update: (summary: string, active: boolean, nameFilter: string, nonNameActive: boolean) => void;
   deregister: () => void;
 }
 
@@ -52,36 +61,54 @@ export function SearchDrawerBridgeProvider({ children }: { children: React.React
   const [isRegistered, setIsRegistered] = useState(false);
   const [summary, setSummary] = useState<string | null>(null);
   const [active, setActive] = useState(false);
+  const [nameFilter, setNameFilterState] = useState('');
+  const [nonNameActive, setNonNameActive] = useState(false);
   const openDrawerRef = useRef<(() => void) | null>(null);
+  const setNameFilterRef = useRef<((name: string) => void) | null>(null);
 
-  const register = useCallback((openDrawer: () => void, s: string, a: boolean) => {
+  const register = useCallback((openDrawer: () => void, s: string, a: boolean, nf: string, snf: (name: string) => void, nna: boolean) => {
     openDrawerRef.current = openDrawer;
+    setNameFilterRef.current = snf;
     setSummary(s);
     setActive(a);
+    setNameFilterState(nf);
+    setNonNameActive(nna);
     setIsRegistered(true);
   }, []);
 
-  const update = useCallback((s: string, a: boolean) => {
+  const update = useCallback((s: string, a: boolean, nf: string, nna: boolean) => {
     setSummary(s);
     setActive(a);
+    setNameFilterState(nf);
+    setNonNameActive(nna);
   }, []);
 
   const deregister = useCallback(() => {
     openDrawerRef.current = null;
+    setNameFilterRef.current = null;
     setIsRegistered(false);
     setSummary(null);
     setActive(false);
+    setNameFilterState('');
+    setNonNameActive(false);
   }, []);
 
   const stableOpenDrawer = useCallback(() => {
     openDrawerRef.current?.();
   }, []);
 
+  const stableSetNameFilter = useCallback((name: string) => {
+    setNameFilterRef.current?.(name);
+  }, []);
+
   const state = useMemo<SearchDrawerBridgeState>(() => ({
     openClimbSearchDrawer: isRegistered ? stableOpenDrawer : null,
     searchPillSummary: summary,
     hasActiveFilters: active,
-  }), [isRegistered, stableOpenDrawer, summary, active]);
+    nameFilter,
+    setNameFilter: isRegistered ? stableSetNameFilter : null,
+    hasActiveNonNameFilters: nonNameActive,
+  }), [isRegistered, stableOpenDrawer, stableSetNameFilter, summary, active, nameFilter, nonNameActive]);
 
   const setters = useMemo<SearchDrawerBridgeSetters>(
     () => ({ register, update, deregister }),
@@ -106,6 +133,9 @@ interface SearchDrawerBridgeInjectorProps {
   summary: string;
   hasActiveFilters: boolean;
   isOnListPage: boolean;
+  nameFilter: string;
+  onNameFilterChange: (name: string) => void;
+  hasActiveNonNameFilters: boolean;
 }
 
 export function SearchDrawerBridgeInjector({
@@ -113,6 +143,9 @@ export function SearchDrawerBridgeInjector({
   summary,
   hasActiveFilters: active,
   isOnListPage,
+  nameFilter,
+  onNameFilterChange,
+  hasActiveNonNameFilters: nonNameActive,
 }: SearchDrawerBridgeInjectorProps) {
   const { register, update, deregister } = useContext(SearchDrawerBridgeSetterContext);
 
@@ -120,26 +153,39 @@ export function SearchDrawerBridgeInjector({
   const openDrawerRef = useRef(openDrawer);
   const summaryRef = useRef(summary);
   const activeRef = useRef(active);
+  const nameFilterRef = useRef(nameFilter);
+  const onNameFilterChangeRef = useRef(onNameFilterChange);
+  const nonNameActiveRef = useRef(nonNameActive);
   openDrawerRef.current = openDrawer;
   summaryRef.current = summary;
   activeRef.current = active;
+  nameFilterRef.current = nameFilter;
+  onNameFilterChangeRef.current = onNameFilterChange;
+  nonNameActiveRef.current = nonNameActive;
 
   // Register/deregister based on whether we're on the list page
   useIsomorphicLayoutEffect(() => {
     if (isOnListPage) {
-      register(() => openDrawerRef.current(), summaryRef.current, activeRef.current);
+      register(
+        () => openDrawerRef.current(),
+        summaryRef.current,
+        activeRef.current,
+        nameFilterRef.current,
+        (name: string) => onNameFilterChangeRef.current(name),
+        nonNameActiveRef.current,
+      );
     } else {
       deregister();
     }
     return () => { deregister(); };
   }, [isOnListPage, register, deregister]);
 
-  // Update summary and active filters when they change (while on list page)
+  // Update summary, active filters, and name filter when they change (while on list page)
   useEffect(() => {
     if (isOnListPage) {
-      update(summary, active);
+      update(summary, active, nameFilter, nonNameActive);
     }
-  }, [summary, active, isOnListPage, update]);
+  }, [summary, active, nameFilter, nonNameActive, isOnListPage, update]);
 
   return null;
 }

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -18,6 +18,16 @@ export function hasActiveFilters(params: SearchRequestPagination): boolean {
   });
 }
 
+export function hasActiveNonNameFilters(params: SearchRequestPagination): boolean {
+  return Object.entries(params).some(([key, value]) => {
+    if (key === 'name') return false;
+    if (key === 'holdsFilter') {
+      return Object.keys(value || {}).length > 0;
+    }
+    return value !== DEFAULT_SEARCH_PARAMS[key as keyof typeof DEFAULT_SEARCH_PARAMS];
+  });
+}
+
 export function getClimbPanelSummary(params: SearchRequestPagination): string[] {
   const parts: string[] = [];
 

--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer-event.test.ts
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer-event.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SESH_SETTINGS_DRAWER_EVENT, dispatchOpenSeshSettingsDrawer } from '../sesh-settings-drawer-event';
+
+describe('sesh-settings-drawer-event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exports the expected event name constant', () => {
+    expect(SESH_SETTINGS_DRAWER_EVENT).toBe('boardsesh:open-sesh-settings-drawer');
+  });
+
+  it('dispatches a CustomEvent on the window', () => {
+    const listener = vi.fn();
+    window.addEventListener(SESH_SETTINGS_DRAWER_EVENT, listener);
+
+    dispatchOpenSeshSettingsDrawer();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0][0] as Event;
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(event.type).toBe(SESH_SETTINGS_DRAWER_EVENT);
+
+    window.removeEventListener(SESH_SETTINGS_DRAWER_EVENT, listener);
+  });
+
+  it('does not throw when window is undefined (SSR safety)', () => {
+    const originalWindow = globalThis.window;
+
+    // Temporarily make window undefined to simulate SSR
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    expect(() => dispatchOpenSeshSettingsDrawer()).not.toThrow();
+
+    // Restore window
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+});

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer-event.ts
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer-event.ts
@@ -1,0 +1,14 @@
+/**
+ * Window-level event that asks the GlobalHeader to open the SeshSettingsDrawer.
+ * Dispatched by the SessionMiniBar (bottom bar) which lives outside the
+ * GlobalHeader's React tree. Mirrors play-drawer-event.ts.
+ *
+ * Lives in its own module so the mini-bar can import it without pulling in
+ * the full SeshSettingsDrawer tree.
+ */
+export const SESH_SETTINGS_DRAWER_EVENT = 'boardsesh:open-sesh-settings-drawer';
+
+export const dispatchOpenSeshSettingsDrawer = (): void => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SESH_SETTINGS_DRAWER_EVENT));
+};

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -7,12 +7,16 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import ContentCopyOutlined from '@mui/icons-material/ContentCopyOutlined';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 import { QRCodeSVG } from 'qrcode.react';
 import { useQuery } from '@tanstack/react-query';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import drawerCss from '@/app/components/swipeable-drawer/swipeable-drawer.module.css';
+import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';
+import BoardRenderer from '@/app/components/board-renderer/board-renderer';
 import { usePersistentSession } from '@/app/components/persistent-session/persistent-session-context';
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { useRouter, usePathname } from 'next/navigation';
@@ -54,7 +58,13 @@ export default function SeshSettingsDrawer({ open, onClose, onTransitionEnd }: S
   const sessionId = activeSession?.sessionId ?? null;
   const shareUrl = getShareUrl(sessionId);
   const { showMessage } = useSnackbar();
+  const sessionBoardDetails = activeSession?.boardDetails ?? boardDetails;
   const [isStopped, setIsStopped] = useState(false);
+
+  const { paperRef, dragHandlers } = useDrawerDragResize({
+    open,
+    onClose,
+  });
   const lastSessionRef = useRef<SessionDetail | null>(null);
 
   const copyToClipboard = useCallback(() => {
@@ -227,59 +237,73 @@ export default function SeshSettingsDrawer({ open, onClose, onTransitionEnd }: S
 
   return (
     <SwipeableDrawer
-      title={drawerTitle}
-      placement="top"
-      showCloseButtonOnMobile
-      swipeEnabled
+      title={
+        <div data-swipe-blocked="" {...dragHandlers} className={drawerCss.dragHeaderWrapper}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            {sessionBoardDetails && (
+              <Box sx={{ width: 36, flexShrink: 0, borderRadius: '6px', overflow: 'hidden', background: 'var(--neutral-100)', aspectRatio: '1' }}>
+                <BoardRenderer
+                  boardDetails={sessionBoardDetails}
+                  mirrored={false}
+                  thumbnail
+                  fillHeight
+                />
+              </Box>
+            )}
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {drawerTitle}
+            </Typography>
+            {timerText && (
+              <Typography
+                variant="body2"
+                sx={{
+                  fontFamily: 'monospace',
+                  fontWeight: 600,
+                  color: 'text.secondary',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                }}
+              >
+                {timerText}
+              </Typography>
+            )}
+            {!isStopped ? (
+              <IconButton
+                size="small"
+                onClick={handleStopSession}
+                aria-label="Stop session"
+                sx={{
+                  color: themeTokens.colors.error,
+                  flexShrink: 0,
+                }}
+              >
+                <StopCircleOutlined />
+              </IconButton>
+            ) : (
+              <IconButton
+                size="small"
+                onClick={handleClose}
+                aria-label="Dismiss"
+                sx={{ flexShrink: 0 }}
+              >
+                <CloseOutlined />
+              </IconButton>
+            )}
+          </Box>
+        </div>
+      }
+      placement="bottom"
+      height="60%"
+      paperRef={paperRef}
       open={open}
       onClose={handleClose}
       onTransitionEnd={onTransitionEnd}
-      fullHeight
-      extra={timerText ? (
-        <Typography
-          variant="body2"
-          sx={{
-            fontFamily: 'monospace',
-            fontWeight: 600,
-            color: 'text.secondary',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {timerText}
-        </Typography>
-      ) : undefined}
+      swipeEnabled={false}
       styles={{
-        wrapper: { height: '100dvh' },
-        header: { paddingRight: '48px' },
-        body: { padding: 0, paddingBottom: 0 },
+        wrapper: { width: '100%', touchAction: 'pan-y' as const, transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)' },
+        header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
+        body: { padding: `${themeTokens.spacing[2]}px 0` },
       }}
-      footer={isStopped ? (
-        <Button
-          variant="outlined"
-          onClick={handleClose}
-          fullWidth
-        >
-          Dismiss
-        </Button>
-      ) : (
-        <Button
-          variant="outlined"
-          color="error"
-          startIcon={<StopCircleOutlined />}
-          onClick={handleStopSession}
-          fullWidth
-          sx={{
-            borderColor: themeTokens.colors.error,
-            color: themeTokens.colors.error,
-            '&:hover': {
-              borderColor: themeTokens.colors.error,
-              backgroundColor: `${themeTokens.colors.error}10`,
-            },
-          }}
-        >
-          Stop Session
-        </Button>
-      )}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pb: 2 }}>
         {isLoading && !displaySession && (
@@ -299,7 +323,7 @@ export default function SeshSettingsDrawer({ open, onClose, onTransitionEnd }: S
             key={displaySession.sessionId}
             session={displaySession}
             embedded
-            fallbackBoardDetails={boardDetails}
+            fallbackBoardDetails={sessionBoardDetails}
             inviteContent={inviteContent}
             currentAngle={angle}
             onAngleChange={!isStopped ? handleAngleChange : undefined}

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -78,9 +78,31 @@ vi.mock('@/app/hooks/use-my-boards', () => ({
   }),
 }));
 
+vi.mock('@/app/hooks/use-drawer-drag-resize', () => ({
+  useDrawerDragResize: () => ({
+    paperRef: { current: null },
+    dragHandlers: {},
+  }),
+}));
+
 vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
-  default: ({ children, open, footer }: { children: React.ReactNode; open: boolean; footer?: React.ReactNode }) =>
-    open ? <div data-testid="drawer">{children}{footer}</div> : null,
+  default: ({ children, open, footer, placement, paperRef }: {
+    children: React.ReactNode;
+    open: boolean;
+    footer?: React.ReactNode;
+    placement?: string;
+    paperRef?: React.Ref<HTMLDivElement>;
+  }) =>
+    open ? (
+      <div
+        data-testid="drawer"
+        data-placement={placement}
+        ref={typeof paperRef === 'function' ? undefined : paperRef}
+      >
+        {children}
+        {footer}
+      </div>
+    ) : null,
 }));
 
 vi.mock('@/app/components/board-scroll/board-discovery-scroll', () => ({
@@ -391,6 +413,8 @@ describe('StartSeshDrawer', () => {
           set_ids: [1, 2],
           angle: 40,
         },
+        namedBoardName: 'Kilter',
+        namedBoardUuid: 'board-1',
       });
     });
   });
@@ -424,5 +448,12 @@ describe('StartSeshDrawer', () => {
     });
 
     expect(mockActivateSession).not.toHaveBeenCalled();
+  });
+
+  it('renders with bottom placement', () => {
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    const drawer = screen.getByTestId('drawer');
+    expect(drawer.getAttribute('data-placement')).toBe('bottom');
   });
 });

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -10,6 +10,9 @@ import EditOutlined from '@mui/icons-material/EditOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import CircularProgress from '@mui/material/CircularProgress';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import drawerCss from '../swipeable-drawer/swipeable-drawer.module.css';
+import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';
+import { themeTokens } from '@/app/theme/theme-config';
 import SessionCreationForm from './session-creation-form';
 import type { SessionCreationFormData } from './session-creation-form';
 import BoardSelectorDrawer from '@/app/components/board-selector-drawer/board-selector-drawer';
@@ -40,6 +43,7 @@ interface StartSeshDrawerProps {
 
 export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardConfigs }: StartSeshDrawerProps) {
   const { status } = useSession();
+  const { paperRef, dragHandlers } = useDrawerDragResize({ open, onClose });
   const router = useRouter();
   const { showMessage } = useSnackbar();
   const { createSession, isCreating } = useCreateSession();
@@ -301,13 +305,23 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
   return (
     <>
       <SwipeableDrawer
-        title="Start session"
-        placement="top"
-        showCloseButton={false}
-        swipeEnabled
+        title={
+          <div data-swipe-blocked="" {...dragHandlers} className={drawerCss.dragHeaderWrapper}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>Start session</Typography>
+          </div>
+        }
+        placement="bottom"
+        height="60%"
+        paperRef={paperRef}
+        swipeEnabled={false}
         open={open}
         onClose={handleClose}
         onTransitionEnd={onTransitionEnd}
+        styles={{
+          wrapper: { width: '100%', touchAction: 'pan-y' as const, transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)' },
+          header: { paddingLeft: `${themeTokens.spacing[3]}px`, paddingRight: `${themeTokens.spacing[3]}px` },
+          body: { padding: `${themeTokens.spacing[2]}px 0` },
+        }}
         footer={
           <Button
             variant="contained"

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -123,7 +123,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: `${themeTokens.spacing[4]}px ${themeTokens.spacing[6]}px`,
-          borderBottom: `1px solid ${themeTokens.neutral[200]}`,
+          borderBottom: '1px solid var(--neutral-200)',
           ...userStyles?.header,
         }}
       >
@@ -425,7 +425,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
         <Box
           sx={{
             padding: `${themeTokens.spacing[3]}px ${themeTokens.spacing[4]}px`,
-            borderTop: `1px solid ${themeTokens.neutral[200]}`,
+            borderTop: '1px solid var(--neutral-200)',
             ...userStyles?.footer,
           }}
         >

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -190,15 +190,7 @@ export function useProfileData(userId: string, initialData?: InitialData) {
     if (hasChangedBoard && selectedBoard) {
       // Check if we already have ticks for this board from server data
       if (initialData?.initialAllBoardsTicks?.[selectedBoard]) {
-        const ticks = initialData.initialAllBoardsTicks[selectedBoard];
-        setLogbook(ticks.map((tick) => ({
-          climbed_at: tick.climbed_at,
-          difficulty: tick.difficulty,
-          tries: tick.tries,
-          angle: tick.angle,
-          status: tick.status,
-          climbUuid: tick.climbUuid,
-        })));
+        setLogbook(initialData.initialAllBoardsTicks[selectedBoard]);
         setLoadingStats(false);
       } else {
         fetchLogbook(selectedBoard);

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -29,30 +29,43 @@ import {
   buildVPointsTimeline,
 } from '../utils/chart-data-builders';
 
-export function useProfileData(userId: string) {
+interface InitialData {
+  initialProfile?: UserProfile;
+  initialProfileStats?: GetUserProfileStatsQueryResponse['userProfileStats'];
+  initialAllBoardsTicks?: Record<string, LogbookEntry[]>;
+  initialLogbook?: LogbookEntry[];
+  initialIsOwnProfile?: boolean;
+  initialNotFound?: boolean;
+}
+
+export function useProfileData(userId: string, initialData?: InitialData) {
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
   const { gradeFormat } = useGradeFormat();
 
-  const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(!initialData?.initialProfile && !initialData?.initialNotFound);
+  const [notFound, setNotFound] = useState(initialData?.initialNotFound ?? false);
+  const [profile, setProfile] = useState<UserProfile | null>(initialData?.initialProfile ?? null);
   const [selectedBoard, setSelectedBoard] = useState<string>('kilter');
-  const [logbook, setLogbook] = useState<LogbookEntry[]>([]);
-  const [loadingStats, setLoadingStats] = useState(false);
+  const [logbook, setLogbook] = useState<LogbookEntry[]>(initialData?.initialLogbook ?? []);
+  const [loadingStats, setLoadingStats] = useState(!initialData?.initialLogbook);
   const [timeframe, setTimeframe] = useState<TimeframeType>('all');
   const [fromDate, setFromDate] = useState<string>('');
   const [toDate, setToDate] = useState<string>('');
   const [aggregatedTimeframe, setAggregatedTimeframe] = useState<AggregatedTimeframeType>('all');
-  const [allBoardsTicks, setAllBoardsTicks] = useState<Record<string, LogbookEntry[]>>({});
-  const [loadingAggregated, setLoadingAggregated] = useState(false);
-  const [profileStats, setProfileStats] = useState<GetUserProfileStatsQueryResponse['userProfileStats'] | null>(null);
-  const [loadingProfileStats, setLoadingProfileStats] = useState(false);
+  const [allBoardsTicks, setAllBoardsTicks] = useState<Record<string, LogbookEntry[]>>(
+    initialData?.initialAllBoardsTicks ?? {},
+  );
+  const [loadingAggregated, setLoadingAggregated] = useState(!initialData?.initialAllBoardsTicks);
+  const [profileStats, setProfileStats] = useState<GetUserProfileStatsQueryResponse['userProfileStats'] | null>(
+    initialData?.initialProfileStats ?? null,
+  );
+  const [loadingProfileStats, setLoadingProfileStats] = useState(!initialData?.initialProfileStats);
   const [activeTab, setActiveTab] = useState<'activity' | 'createdClimbs'>('activity');
   const [weeklyFromDate, setWeeklyFromDate] = useState<string>('');
   const [weeklyToDate, setWeeklyToDate] = useState<string>('');
 
-  const isOwnProfile = session?.user?.id === userId;
+  const isOwnProfile = session?.user?.id ? session.user.id === userId : (initialData?.initialIsOwnProfile ?? false);
   const hasCredentials = (profile?.credentials?.length ?? 0) > 0;
   const authToken = (session as { authToken?: string } | null)?.authToken ?? null;
 
@@ -153,10 +166,47 @@ export function useProfileData(userId: string) {
     }
   }, [userId]);
 
-  useEffect(() => { fetchProfile(); }, [fetchProfile]);
-  useEffect(() => { fetchAllBoardsTicks(); }, [fetchAllBoardsTicks]);
-  useEffect(() => { fetchProfileStats(); }, [fetchProfileStats]);
-  useEffect(() => { if (selectedBoard) fetchLogbook(selectedBoard); }, [selectedBoard, fetchLogbook]);
+  // Skip client-side fetches when server data was provided
+  useEffect(() => {
+    if (!initialData?.initialProfile && !initialData?.initialNotFound) fetchProfile();
+  }, [fetchProfile, initialData?.initialProfile, initialData?.initialNotFound]);
+
+  useEffect(() => {
+    if (!initialData?.initialAllBoardsTicks) fetchAllBoardsTicks();
+  }, [fetchAllBoardsTicks, initialData?.initialAllBoardsTicks]);
+
+  useEffect(() => {
+    if (!initialData?.initialProfileStats) fetchProfileStats();
+  }, [fetchProfileStats, initialData?.initialProfileStats]);
+
+  // Fetch logbook when board changes (skip initial if server data was provided for default board)
+  const [hasChangedBoard, setHasChangedBoard] = useState(false);
+  const handleBoardChange = useCallback((board: string) => {
+    setSelectedBoard(board);
+    setHasChangedBoard(true);
+  }, []);
+
+  useEffect(() => {
+    if (hasChangedBoard && selectedBoard) {
+      // Check if we already have ticks for this board from server data
+      if (initialData?.initialAllBoardsTicks?.[selectedBoard]) {
+        const ticks = initialData.initialAllBoardsTicks[selectedBoard];
+        setLogbook(ticks.map((tick) => ({
+          climbed_at: tick.climbed_at,
+          difficulty: tick.difficulty,
+          tries: tick.tries,
+          angle: tick.angle,
+          status: tick.status,
+          climbUuid: tick.climbUuid,
+        })));
+        setLoadingStats(false);
+      } else {
+        fetchLogbook(selectedBoard);
+      }
+    } else if (!initialData?.initialLogbook && selectedBoard) {
+      fetchLogbook(selectedBoard);
+    }
+  }, [selectedBoard, hasChangedBoard, fetchLogbook, initialData?.initialAllBoardsTicks, initialData?.initialLogbook]);
 
   const filteredLogbook = useMemo(
     () => filterLogbookByTimeframe(logbook, timeframe, fromDate, toDate),
@@ -200,7 +250,7 @@ export function useProfileData(userId: string) {
 
     // Board selection
     selectedBoard,
-    setSelectedBoard,
+    setSelectedBoard: handleBoardChange,
 
     // Board stats
     loadingStats,

--- a/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/hooks/use-profile-data.ts
@@ -48,7 +48,7 @@ export function useProfileData(userId: string, initialData?: InitialData) {
   const [profile, setProfile] = useState<UserProfile | null>(initialData?.initialProfile ?? null);
   const [selectedBoard, setSelectedBoard] = useState<string>('kilter');
   const [logbook, setLogbook] = useState<LogbookEntry[]>(initialData?.initialLogbook ?? []);
-  const [loadingStats, setLoadingStats] = useState(!initialData?.initialLogbook);
+  const [loadingStats, setLoadingStats] = useState(false);
   const [timeframe, setTimeframe] = useState<TimeframeType>('all');
   const [fromDate, setFromDate] = useState<string>('');
   const [toDate, setToDate] = useState<string>('');

--- a/packages/web/app/crusher/[user_id]/page.tsx
+++ b/packages/web/app/crusher/[user_id]/page.tsx
@@ -89,9 +89,15 @@ export default async function ProfilePage({ params }: PageProps) {
     viewerUserId = session?.user?.id;
   }
 
-  // Fetch all data in parallel
-  const [initialProfile, initialProfileStats, ...ticksResults] = await Promise.all([
-    getProfileData(user_id, viewerUserId),
+  // Check if user exists before fetching stats/ticks
+  const initialProfile = await getProfileData(user_id, viewerUserId);
+
+  if (!initialProfile) {
+    return <ProfilePageContent userId={user_id} initialNotFound />;
+  }
+
+  // User exists — fetch stats and ticks in parallel
+  const [initialProfileStats, ...ticksResults] = await Promise.all([
     cachedUserProfileStats(user_id),
     ...SUPPORTED_BOARDS.map((boardType) => cachedUserTicks(user_id, boardType)),
   ]);
@@ -117,10 +123,6 @@ export default async function ProfilePage({ params }: PageProps) {
   // Default board logbook
   const defaultBoard = 'kilter';
   const initialLogbook = initialAllBoardsTicks[defaultBoard] ?? [];
-
-  if (!initialProfile) {
-    return <ProfilePageContent userId={user_id} initialNotFound />;
-  }
 
   return (
     <ProfilePageContent

--- a/packages/web/app/crusher/[user_id]/page.tsx
+++ b/packages/web/app/crusher/[user_id]/page.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { Metadata } from 'next';
-import { sql } from '@/app/lib/db/db';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/lib/auth/auth-options';
+import { cachedUserProfileStats, cachedUserTicks } from '@/app/lib/graphql/server-cached-client';
+import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import ProfilePageContent from './profile-page-content';
+import { getProfileData } from './server-profile-data';
+import type { LogbookEntry } from './utils/profile-constants';
 
 type PageProps = {
   params: Promise<{ user_id: string }>;
@@ -11,13 +20,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { user_id } = await params;
 
   try {
-    const rows = await sql`
-      SELECT u.name, p.display_name, p.avatar_url
-      FROM users u
-      LEFT JOIN user_profiles p ON p.user_id = u.id
-      WHERE u.id = ${user_id}
-      LIMIT 1
-    `;
+    const db = getDb();
+    const rows = await db
+      .select({
+        name: schema.users.name,
+        displayName: schema.userProfiles.displayName,
+        avatarUrl: schema.userProfiles.avatarUrl,
+      })
+      .from(schema.users)
+      .leftJoin(schema.userProfiles, eq(schema.userProfiles.userId, schema.users.id))
+      .where(eq(schema.users.id, user_id))
+      .limit(1);
 
     if (rows.length === 0) {
       return {
@@ -27,7 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     }
 
     const row = rows[0];
-    const displayName = (row.display_name as string) || (row.name as string) || 'Crusher';
+    const displayName = row.displayName || row.name || 'Crusher';
     const description = `${displayName}'s climbing profile on Boardsesh`;
 
     const ogImageUrl = new URL('/api/og/profile', 'https://boardsesh.com');
@@ -67,5 +80,56 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProfilePage({ params }: PageProps) {
   const { user_id } = await params;
-  return <ProfilePageContent userId={user_id} />;
+
+  // Only check session if auth cookie exists (skip for anonymous visitors)
+  const authToken = await getServerAuthToken();
+  let viewerUserId: string | undefined;
+  if (authToken) {
+    const session = await getServerSession(authOptions);
+    viewerUserId = session?.user?.id;
+  }
+
+  // Fetch all data in parallel
+  const [initialProfile, initialProfileStats, ...ticksResults] = await Promise.all([
+    getProfileData(user_id, viewerUserId),
+    cachedUserProfileStats(user_id),
+    ...SUPPORTED_BOARDS.map((boardType) => cachedUserTicks(user_id, boardType)),
+  ]);
+
+  // Build allBoardsTicks record
+  const initialAllBoardsTicks: Record<string, LogbookEntry[]> = {};
+  SUPPORTED_BOARDS.forEach((bt, i) => {
+    const ticks = ticksResults[i];
+    initialAllBoardsTicks[bt] = ticks
+      ? ticks.map((tick) => ({
+          climbed_at: tick.climbedAt,
+          difficulty: tick.difficulty,
+          tries: tick.attemptCount,
+          angle: tick.angle,
+          status: tick.status as LogbookEntry['status'],
+          layoutId: tick.layoutId,
+          boardType: bt,
+          climbUuid: tick.climbUuid,
+        }))
+      : [];
+  });
+
+  // Default board logbook
+  const defaultBoard = 'kilter';
+  const initialLogbook = initialAllBoardsTicks[defaultBoard] ?? [];
+
+  if (!initialProfile) {
+    return <ProfilePageContent userId={user_id} initialNotFound />;
+  }
+
+  return (
+    <ProfilePageContent
+      userId={user_id}
+      initialProfile={initialProfile}
+      initialProfileStats={initialProfileStats}
+      initialAllBoardsTicks={initialAllBoardsTicks}
+      initialLogbook={initialLogbook}
+      initialIsOwnProfile={viewerUserId === user_id}
+    />
+  );
 }

--- a/packages/web/app/crusher/[user_id]/profile-page-content.tsx
+++ b/packages/web/app/crusher/[user_id]/profile-page-content.tsx
@@ -16,12 +16,32 @@ import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import AscentsFeed from '@/app/components/activity-feed';
 import SetterClimbList from '@/app/components/climb-list/setter-climb-list';
+import type { GetUserProfileStatsQueryResponse } from '@/app/lib/graphql/operations/ticks';
 import styles from './profile-page.module.css';
 import { useProfileData } from './hooks/use-profile-data';
 import ProfileHeader from './components/profile-header';
 import BoardStatsSection from './components/board-stats-section';
+import type { UserProfile, LogbookEntry } from './utils/profile-constants';
 
-export default function ProfilePageContent({ userId }: { userId: string }) {
+interface ProfilePageContentProps {
+  userId: string;
+  initialProfile?: UserProfile | null;
+  initialProfileStats?: GetUserProfileStatsQueryResponse['userProfileStats'] | null;
+  initialAllBoardsTicks?: Record<string, LogbookEntry[]>;
+  initialLogbook?: LogbookEntry[];
+  initialIsOwnProfile?: boolean;
+  initialNotFound?: boolean;
+}
+
+export default function ProfilePageContent({
+  userId,
+  initialProfile,
+  initialProfileStats,
+  initialAllBoardsTicks,
+  initialLogbook,
+  initialIsOwnProfile,
+  initialNotFound,
+}: ProfilePageContentProps) {
   const {
     loading,
     notFound,
@@ -55,7 +75,14 @@ export default function ProfilePageContent({ userId }: { userId: string }) {
     statisticsSummary,
     activeTab,
     setActiveTab,
-  } = useProfileData(userId);
+  } = useProfileData(userId, {
+    initialProfile: initialProfile ?? undefined,
+    initialProfileStats: initialProfileStats ?? undefined,
+    initialAllBoardsTicks,
+    initialLogbook,
+    initialIsOwnProfile,
+    initialNotFound,
+  });
 
   if (loading) {
     return (

--- a/packages/web/app/crusher/[user_id]/server-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/server-profile-data.ts
@@ -42,7 +42,7 @@ export async function getProfileData(
 
   return {
     id: user.id,
-    email: isOwnProfile ? (user.email ?? '') : '',
+    email: isOwnProfile ? (user.email ?? '') : undefined,
     name: user.name,
     image: user.image,
     profile: profile

--- a/packages/web/app/crusher/[user_id]/server-profile-data.ts
+++ b/packages/web/app/crusher/[user_id]/server-profile-data.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { eq, and, count } from 'drizzle-orm';
+import { getUserBoardMappings } from '@/app/lib/auth/user-board-mappings';
+import type { UserProfile } from './utils/profile-constants';
+
+export async function getProfileData(
+  userId: string,
+  viewerUserId?: string,
+): Promise<UserProfile | null> {
+  const db = getDb();
+
+  const [users, profiles, mappings] = await Promise.all([
+    db.select().from(schema.users).where(eq(schema.users.id, userId)).limit(1),
+    db.select().from(schema.userProfiles).where(eq(schema.userProfiles.userId, userId)).limit(1),
+    getUserBoardMappings(userId),
+  ]);
+
+  if (users.length === 0) return null;
+
+  const user = users[0];
+  const profile = profiles[0] ?? null;
+  const isOwnProfile = viewerUserId === userId;
+
+  const credentials = mappings.map((m) => ({
+    boardType: m.boardType,
+    auroraUsername: m.boardUsername || '',
+    auroraUserId: m.boardUserId,
+  }));
+
+  const [followerCountResult, followingCountResult, followCheck] = await Promise.all([
+    db.select({ count: count() }).from(schema.userFollows).where(eq(schema.userFollows.followingId, userId)),
+    db.select({ count: count() }).from(schema.userFollows).where(eq(schema.userFollows.followerId, userId)),
+    viewerUserId && viewerUserId !== userId
+      ? db
+          .select({ count: count() })
+          .from(schema.userFollows)
+          .where(and(eq(schema.userFollows.followerId, viewerUserId), eq(schema.userFollows.followingId, userId)))
+      : Promise.resolve([{ count: 0 }]),
+  ]);
+
+  return {
+    id: user.id,
+    email: isOwnProfile ? (user.email ?? '') : '',
+    name: user.name,
+    image: user.image,
+    profile: profile
+      ? {
+          displayName: profile.displayName,
+          avatarUrl: profile.avatarUrl,
+          instagramUrl: profile.instagramUrl,
+        }
+      : null,
+    credentials,
+    followerCount: Number(followerCountResult[0]?.count || 0),
+    followingCount: Number(followingCountResult[0]?.count || 0),
+    isFollowedByMe: Number(followCheck[0]?.count || 0) > 0,
+  };
+}

--- a/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
+++ b/packages/web/app/crusher/[user_id]/utils/profile-constants.ts
@@ -3,7 +3,7 @@ import { SUPPORTED_BOARDS, BOULDER_GRADES } from '@/app/lib/board-data';
 
 export interface UserProfile {
   id: string;
-  email: string;
+  email: string | undefined;
   name: string | null;
   image: string | null;
   profile: {

--- a/packages/web/app/lib/__tests__/grade-colors.test.ts
+++ b/packages/web/app/lib/__tests__/grade-colors.test.ts
@@ -6,6 +6,7 @@ import {
   getGradeColorWithOpacity,
   isLightColor,
   getGradeTextColor,
+  getGradeTintColor,
   formatVGrade,
   V_GRADE_COLORS,
   FONT_GRADE_COLORS,
@@ -207,6 +208,82 @@ describe('Grade Colors', () => {
       expect(formatVGrade(null)).toBeNull();
       expect(formatVGrade(undefined)).toBeNull();
       expect(formatVGrade('')).toBeNull();
+    });
+  });
+
+  describe('getGradeTintColor', () => {
+    describe('session variant', () => {
+      it('returns hsl with 35% saturation and 82% lightness in light mode', () => {
+        const result = getGradeTintColor('6a/V3', 'session', false);
+        expect(result).toBeDefined();
+        // Should be hsl(hue, 35%, 82%)
+        expect(result).toMatch(/^hsl\(\d+, 35%, 82%\)$/);
+      });
+
+      it('returns hsla with 40% saturation, 14% lightness, and 0.85 alpha in dark mode', () => {
+        const result = getGradeTintColor('6a/V3', 'session', true);
+        expect(result).toBeDefined();
+        // Should be hsla(hue, 40%, 14%, 0.85)
+        expect(result).toMatch(/^hsla\(\d+, 40%, 14%, 0\.85\)$/);
+      });
+
+      it('returns undefined when difficulty is null', () => {
+        expect(getGradeTintColor(null, 'session')).toBeUndefined();
+      });
+
+      it('returns undefined when difficulty is undefined', () => {
+        expect(getGradeTintColor(undefined, 'session')).toBeUndefined();
+      });
+
+      it('returns undefined when difficulty is empty string', () => {
+        expect(getGradeTintColor('', 'session')).toBeUndefined();
+      });
+
+      it('uses same hue as other variants for the same difficulty', () => {
+        const difficulty = '6c/V5';
+        const sessionLight = getGradeTintColor(difficulty, 'session', false);
+        const defaultLight = getGradeTintColor(difficulty, 'default', false);
+
+        // Both should have the same hue
+        const sessionHue = sessionLight?.match(/\d+/)?.[0];
+        const defaultHue = defaultLight?.match(/\d+/)?.[0];
+        expect(sessionHue).toBe(defaultHue);
+      });
+
+      it('produces different output in light vs dark mode', () => {
+        const lightResult = getGradeTintColor('6a/V3', 'session', false);
+        const darkResult = getGradeTintColor('6a/V3', 'session', true);
+        expect(lightResult).not.toBe(darkResult);
+      });
+    });
+
+    describe('default variant', () => {
+      it('returns hsl with 30% saturation and 88% lightness in light mode', () => {
+        const result = getGradeTintColor('6a/V3', 'default', false);
+        expect(result).toMatch(/^hsl\(\d+, 30%, 88%\)$/);
+      });
+
+      it('returns hsla with 35% saturation, 28% lightness, and 0.6 alpha in dark mode', () => {
+        const result = getGradeTintColor('6a/V3', 'default', true);
+        expect(result).toMatch(/^hsla\(\d+, 35%, 28%, 0\.6\)$/);
+      });
+    });
+
+    describe('light variant', () => {
+      it('returns hsl with 20% saturation and 94% lightness in light mode', () => {
+        const result = getGradeTintColor('6a/V3', 'light', false);
+        expect(result).toMatch(/^hsl\(\d+, 20%, 94%\)$/);
+      });
+
+      it('returns hsl with 25% saturation and 22% lightness in dark mode', () => {
+        const result = getGradeTintColor('6a/V3', 'light', true);
+        expect(result).toMatch(/^hsl\(\d+, 25%, 22%\)$/);
+      });
+    });
+
+    it('returns undefined for unrecognized difficulty strings', () => {
+      expect(getGradeTintColor('hard', 'session')).toBeUndefined();
+      expect(getGradeTintColor('unknown', 'default')).toBeUndefined();
     });
   });
 });

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -251,7 +251,7 @@ function hexToHue(hex: string): number {
  * @param darkMode - When true, uses lower lightness values suitable for dark backgrounds
  * @returns HSL color string or undefined if no grade color found
  */
-export function getGradeTintColor(difficulty: string | null | undefined, variant: 'default' | 'light' = 'default', darkMode?: boolean): string | undefined {
+export function getGradeTintColor(difficulty: string | null | undefined, variant: 'default' | 'light' | 'session' = 'default', darkMode?: boolean): string | undefined {
   const color = getGradeColor(difficulty);
   if (!color) return undefined;
 
@@ -261,11 +261,17 @@ export function getGradeTintColor(difficulty: string | null | undefined, variant
     if (variant === 'light') {
       return `hsl(${hue}, 25%, 22%)`;
     }
+    if (variant === 'session') {
+      return `hsla(${hue}, 40%, 14%, 0.85)`;
+    }
     return `hsla(${hue}, 35%, 28%, 0.6)`;
   }
 
   if (variant === 'light') {
     return `hsl(${hue}, 20%, 94%)`;
+  }
+  if (variant === 'session') {
+    return `hsl(${hue}, 35%, 82%)`;
   }
   return `hsl(${hue}, 30%, 88%)`;
 }

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -201,9 +201,10 @@ export async function cachedUserProfileStats(
   type Response = import('@/app/lib/graphql/operations/ticks').GetUserProfileStatsQueryResponse;
 
   try {
+    const tag = `user-profile-stats-${userId}`;
     const query = createCachedGraphQLQuery<Response>(
       GET_USER_PROFILE_STATS,
-      'user-profile-stats',
+      tag,
       300,
     );
     const result = await query({ userId });
@@ -224,9 +225,10 @@ export async function cachedUserTicks(
   type Response = import('@/app/lib/graphql/operations/ticks').GetUserTicksQueryResponse;
 
   try {
+    const tag = `user-ticks-${userId}`;
     const query = createCachedGraphQLQuery<Response>(
       GET_USER_TICKS,
-      'user-ticks',
+      tag,
       300,
     );
     const result = await query({ userId, boardType });

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -192,6 +192,51 @@ export async function cachedDiscoverPlaylists(
 }
 
 /**
+ * Cached server-side fetch of user profile stats (public, no auth needed).
+ */
+export async function cachedUserProfileStats(
+  userId: string,
+): Promise<import('@/app/lib/graphql/operations/ticks').GetUserProfileStatsQueryResponse['userProfileStats'] | null> {
+  const { GET_USER_PROFILE_STATS } = await import('@/app/lib/graphql/operations/ticks');
+  type Response = import('@/app/lib/graphql/operations/ticks').GetUserProfileStatsQueryResponse;
+
+  try {
+    const query = createCachedGraphQLQuery<Response>(
+      GET_USER_PROFILE_STATS,
+      'user-profile-stats',
+      300,
+    );
+    const result = await query({ userId });
+    return result.userProfileStats;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cached server-side fetch of user ticks for a specific board type (public, no auth needed).
+ */
+export async function cachedUserTicks(
+  userId: string,
+  boardType: string,
+): Promise<import('@/app/lib/graphql/operations/ticks').GetUserTicksQueryResponse['userTicks'] | null> {
+  const { GET_USER_TICKS } = await import('@/app/lib/graphql/operations/ticks');
+  type Response = import('@/app/lib/graphql/operations/ticks').GetUserTicksQueryResponse;
+
+  try {
+    const query = createCachedGraphQLQuery<Response>(
+      GET_USER_TICKS,
+      'user-ticks',
+      300,
+    );
+    const result = await query({ userId, boardType });
+    return result.userTicks;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetch the first page of grouped notifications server-side.
  * Returns null on failure so the client can fall back to client-side fetching.
  */

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -225,7 +225,7 @@ export async function cachedUserTicks(
   type Response = import('@/app/lib/graphql/operations/ticks').GetUserTicksQueryResponse;
 
   try {
-    const tag = `user-ticks-${userId}`;
+    const tag = `user-ticks-${userId}-${boardType}`;
     const query = createCachedGraphQLQuery<Response>(
       GET_USER_TICKS,
       tag,

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -665,10 +665,6 @@ export default function SessionDetailContent({
             getParticipantHref={(userId) => `/crusher/${userId}`}
             afterParticipants={!embedded ? afterParticipants : undefined}
             compact={embedded}
-            boardDetails={embedded ? effectiveBoardDetails : undefined}
-            currentAngle={embedded ? currentAngle : undefined}
-            onAngleChange={embedded ? onAngleChange : undefined}
-            namedBoardName={embedded ? namedBoardName : undefined}
           />
         )}
 


### PR DESCRIPTION
…ding spinner

Move profile, ticks, and stats fetching from client-side useEffect hooks into the page.tsx server component using parallel Promise.all. Extract shared getProfileData() function from the API route to avoid duplication. Add cached GraphQL fetchers (cachedUserProfileStats, cachedUserTicks) to server-cached-client. Migrate generateMetadata from raw SQL to Drizzle ORM.