### PR TITLE
Session bar polish, swipe hints, and analytics

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -23,6 +23,7 @@ import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
+import SwipeHintOrchestrator from './swipe-hint-orchestrator';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { SelectionStoreContext, useSelectionStore } from './selected-climb-store';
 import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
@@ -657,6 +658,8 @@ const ClimbsList = ({
         </div>
       )}
       </ErrorBoundary>
+
+      {viewMode === 'list' && climbs.length > 0 && <SwipeHintOrchestrator />}
 
       {/* Sentinel for infinite scroll — only needed for grid mode (list mode uses virtualizer) */}
       <Box ref={viewMode === 'grid' ? sentinelRef : undefined} sx={sentinelBoxSx}>

--- a/packages/web/app/components/board-page/swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/board-page/swipe-hint-orchestrator.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+
+const PREF_KEY = 'swipeHint:climbListSeen' as const;
+const INITIAL_DELAY_MS = 1500;
+const PEEK_DISTANCE = 60; // Matches SHORT_SWIPE_THRESHOLD in climb-list-item.tsx
+const SLIDE_OUT_MS = 400;
+const HOLD_MS = 600;
+const SLIDE_BACK_MS = 300;
+const GAP_BETWEEN_MS = 300;
+const REPEAT_COUNT = 2;
+
+/**
+ * Plays a one-time swipe-hint animation on the first climb list item.
+ * Briefly slides the item left twice to reveal the "add to queue" action,
+ * then slides it back. Uses the Web Animations API for compositor-thread
+ * performance. Renders no visible DOM.
+ */
+export default function SwipeHintOrchestrator() {
+  const animationsRef = useRef<Animation[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const run = async () => {
+      // TODO: remove these bypasses after testing
+      // const seen = await getPreference<boolean>(PREF_KEY);
+      // if (cancelled || seen) return;
+      // if (!window.matchMedia('(pointer: coarse)').matches) return;
+
+      timer = setTimeout(async () => {
+        if (cancelled) return;
+
+        const contentEl = document.querySelector<HTMLElement>(
+          '#onboarding-climb-card [data-swipe-content]',
+        );
+        const actionEl = document.querySelector<HTMLElement>(
+          '#onboarding-climb-card [data-swipe-right-action]',
+        );
+        if (!contentEl || !actionEl) return;
+
+        const iconLayer = actionEl.firstElementChild as HTMLElement | null;
+
+        try {
+          for (let i = 0; i < REPEAT_COUNT; i++) {
+            if (cancelled) return;
+
+            // Show action layer
+            actionEl.style.visibility = 'visible';
+            if (iconLayer) iconLayer.style.opacity = '1';
+
+            // Slide out
+            const slideOut = contentEl.animate(
+              [{ transform: 'translateX(0)' }, { transform: `translateX(-${PEEK_DISTANCE}px)` }],
+              { duration: SLIDE_OUT_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            const fadeIn = actionEl.animate(
+              [{ opacity: 0 }, { opacity: 1 }],
+              { duration: SLIDE_OUT_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            animationsRef.current.push(slideOut, fadeIn);
+
+            await slideOut.finished;
+            if (cancelled) return;
+
+            // Hold
+            await new Promise<void>((r) => { timer = setTimeout(r, HOLD_MS); });
+            if (cancelled) return;
+
+            // Slide back
+            const slideBack = contentEl.animate(
+              [{ transform: `translateX(-${PEEK_DISTANCE}px)` }, { transform: 'translateX(0)' }],
+              { duration: SLIDE_BACK_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            const fadeOut = actionEl.animate(
+              [{ opacity: 1 }, { opacity: 0 }],
+              { duration: SLIDE_BACK_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            animationsRef.current.push(slideBack, fadeOut);
+
+            await slideBack.finished;
+            if (cancelled) return;
+
+            // Clean up inline styles
+            contentEl.style.transform = '';
+            actionEl.style.opacity = '';
+            actionEl.style.visibility = '';
+            if (iconLayer) iconLayer.style.opacity = '';
+
+            // Gap before next repeat
+            if (i < REPEAT_COUNT - 1) {
+              await new Promise<void>((r) => { timer = setTimeout(r, GAP_BETWEEN_MS); });
+            }
+          }
+
+          if (!cancelled) {
+            // TODO: re-enable after testing
+            // setPreference(PREF_KEY, true);
+          }
+        } catch {
+          // Animation cancelled
+        }
+      }, INITIAL_DELAY_MS);
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      for (const anim of animationsRef.current) anim.cancel();
+      animationsRef.current = [];
+    };
+  }, []);
+
+  return null;
+}

--- a/packages/web/app/components/board-page/swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/board-page/swipe-hint-orchestrator.tsx
@@ -26,10 +26,9 @@ export default function SwipeHintOrchestrator() {
     let timer: ReturnType<typeof setTimeout>;
 
     const run = async () => {
-      // TODO: remove these bypasses after testing
-      // const seen = await getPreference<boolean>(PREF_KEY);
-      // if (cancelled || seen) return;
-      // if (!window.matchMedia('(pointer: coarse)').matches) return;
+      const seen = await getPreference<boolean>(PREF_KEY);
+      if (cancelled || seen) return;
+      if (!window.matchMedia('(pointer: coarse)').matches) return;
 
       timer = setTimeout(async () => {
         if (cancelled) return;
@@ -97,8 +96,7 @@ export default function SwipeHintOrchestrator() {
           }
 
           if (!cancelled) {
-            // TODO: re-enable after testing
-            // setPreference(PREF_KEY, true);
+            setPreference(PREF_KEY, true);
           }
         } catch {
           // Animation cancelled

--- a/packages/web/app/components/climb-actions/actions/queue-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/queue-action.tsx
@@ -32,6 +32,7 @@ export function QueueAction({
     queueActions.addToQueue(climb);
 
     track('Add to Queue', {
+      source: 'climbActions',
       boardLayout: boardDetails.layout_name || '',
     });
 

--- a/packages/web/app/components/climb-actions/queue-button.tsx
+++ b/packages/web/app/components/climb-actions/queue-button.tsx
@@ -36,6 +36,7 @@ export default function QueueButton({
       addToQueue(climb);
 
       track('Add to Queue', {
+        source: 'queueButton',
         boardLayout: boardDetails.layout_name || '',
         queueLength: queue.length + 1,
       });

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -138,6 +138,7 @@ export function useClimbActions({
     addToQueue(climb);
 
     track('Add to Queue', {
+      source: 'climbActions',
       boardLayout: boardDetails.layout_name || '',
     });
 

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -7,6 +7,7 @@ import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
+import { track } from '@vercel/analytics';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbThumbnail from './climb-thumbnail';
 import ClimbTitle, { type ClimbTitleProps } from './climb-title';
@@ -259,6 +260,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     // Swipe left (right action): add to queue
     const handleDefaultSwipeLeft = useCallback(() => {
       addToQueueRef.current?.(climb);
+      track('Add to Queue', { source: 'swipe' });
     }, [climb]);
 
     // Swipe right short (left action): open playlist selector
@@ -526,11 +528,11 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
 
               {/* Right action (revealed on swipe left) */}
               {hasRightOverride ? (
-                <div ref={rightActionRef} style={rightOverrideActionStyle}>
+                <div ref={rightActionRef} style={rightOverrideActionStyle} data-swipe-right-action="">
                   {swipeRightAction?.icon ?? null}
                 </div>
               ) : (
-                <div ref={rightActionRef} style={defaultRightActionStyle}>
+                <div ref={rightActionRef} style={defaultRightActionStyle} data-swipe-right-action="">
                   {/* Default layer (Add icon) — opacity driven by swipe gesture via ref */}
                   <div ref={rightActionLayerRef} style={rightActionDefaultLayerStyle}>
                     <AddOutlined style={iconStyle} />
@@ -550,6 +552,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
             ref={contentCombinedRef}
             onClick={handleRowClick}
             style={swipeableContentStyle}
+            data-swipe-content=""
           >
             {/* Thumbnail with ascent status badge */}
             <div

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, useDeferredValue } from 'react';
+import { track } from '@vercel/analytics';
 import MuiBadge from '@mui/material/Badge';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
@@ -438,12 +439,14 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     const next = getNextClimbQueueItem();
     if (!next || viewOnlyMode) return;
     setCurrentClimbQueueItem(next);
+    track('Queue Navigation', { direction: 'next', method: 'swipePlayViewDrawer' });
   }, [getNextClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode]);
 
   const handleSwipePrevious = useCallback(() => {
     const prev = getPreviousClimbQueueItem();
     if (!prev || viewOnlyMode) return;
     setCurrentClimbQueueItem(prev);
+    track('Queue Navigation', { direction: 'previous', method: 'swipePlayViewDrawer' });
   }, [getPreviousClimbQueueItem, setCurrentClimbQueueItem, viewOnlyMode]);
 
   const canSwipeNext = !viewOnlyMode && !!nextItem;
@@ -470,11 +473,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
 
   const handlePrevNavClick = useCallback(() => {
     const prev = getPreviousClimbQueueItem();
-    if (prev) setCurrentClimbQueueItem(prev);
+    if (!prev) return;
+    setCurrentClimbQueueItem(prev);
+    track('Queue Navigation', { direction: 'previous', method: 'playViewDrawer' });
   }, [getPreviousClimbQueueItem, setCurrentClimbQueueItem]);
   const handleNextNavClick = useCallback(() => {
     const next = getNextClimbQueueItem();
-    if (next) setCurrentClimbQueueItem(next);
+    if (!next) return;
+    setCurrentClimbQueueItem(next);
+    track('Queue Navigation', { direction: 'next', method: 'playViewDrawer' });
   }, [getNextClimbQueueItem, setCurrentClimbQueueItem]);
   const handleOpenActionsMenu = useCallback(() => {
     setIsQueueOpen(false);

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -70,6 +70,7 @@ export default function NextClimbButton({ navigate = false, boardDetails }: Next
     setCurrentClimbQueueItem(nextClimb);
     track('Queue Navigation', {
       direction: 'next',
+      method: 'button',
       boardLayout: boardDetails?.layout_name || '',
     });
 

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -71,6 +71,7 @@ export default function PreviousClimbButton({ navigate = false, boardDetails }: 
     setCurrentClimbQueueItem(previousClimb);
     track('Queue Navigation', {
       direction: 'previous',
+      method: 'button',
       boardLayout: boardDetails?.layout_name || '',
     });
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -400,48 +400,58 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, [sessionId]);
 
   // One-time swipe hint on the queue bar — briefly peek the text left
-  // to show users they can swipe to navigate between queued climbs.
+  // twice to show users they can swipe to navigate between queued climbs.
+  // Triggers when there's an active climb (suggestions provide next/prev).
   const queueHintPlayedRef = useRef(false);
   useEffect(() => {
-    if (!currentClimb || queue.length < 2 || tickBarActive || queueHintPlayedRef.current) return;
+    if (!currentClimb || tickBarActive || queueHintPlayedRef.current) return;
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
     const animations: Animation[] = [];
 
+    const peekOnce = (el: HTMLElement): Promise<void> => {
+      const slideOut = el.animate(
+        [{ transform: 'translateX(0)' }, { transform: 'translateX(-40px)' }],
+        { duration: 350, easing: 'ease-out', fill: 'forwards' },
+      );
+      animations.push(slideOut);
+
+      return slideOut.finished.then(() => {
+        if (cancelled) return;
+        return new Promise<void>((r) => { timer = setTimeout(r, 500); });
+      }).then(() => {
+        if (cancelled) return;
+        const slideBack = el.animate(
+          [{ transform: 'translateX(-40px)' }, { transform: 'translateX(0)' }],
+          { duration: 250, easing: 'ease-out', fill: 'forwards' },
+        );
+        animations.push(slideBack);
+        return slideBack.finished as Promise<unknown> as Promise<void>;
+      });
+    };
+
     getPreference<boolean>('swipeHint:queueBarSeen').then((seen) => {
       if (cancelled || seen) return;
       if (!window.matchMedia('(pointer: coarse)').matches) return;
 
-      timer = setTimeout(() => {
+      timer = setTimeout(async () => {
         if (cancelled) return;
         const el = document.getElementById('onboarding-queue-toggle');
         if (!el) return;
 
         queueHintPlayedRef.current = true;
 
-        const slideOut = el.animate(
-          [{ transform: 'translateX(0)' }, { transform: 'translateX(-40px)' }],
-          { duration: 350, easing: 'ease-out', fill: 'forwards' },
-        );
-        animations.push(slideOut);
-
-        slideOut.finished.then(() => {
+        try {
+          await peekOnce(el);
           if (cancelled) return;
-          return new Promise<void>((r) => { timer = setTimeout(r, 500); });
-        }).then(() => {
+          await new Promise<void>((r) => { timer = setTimeout(r, 300); });
           if (cancelled) return;
-          const slideBack = el.animate(
-            [{ transform: 'translateX(-40px)' }, { transform: 'translateX(0)' }],
-            { duration: 250, easing: 'ease-out', fill: 'forwards' },
-          );
-          animations.push(slideBack);
-          return slideBack.finished;
-        }).then(() => {
+          await peekOnce(el);
           if (cancelled) return;
           el.style.transform = '';
           setPreference('swipeHint:queueBarSeen', true);
-        }).catch(() => { /* cancelled */ });
+        } catch { /* cancelled */ }
       }, 800);
     });
 
@@ -450,7 +460,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       clearTimeout(timer);
       for (const a of animations) a.cancel();
     };
-  }, [currentClimb, queue.length, tickBarActive]);
+  }, [currentClimb, tickBarActive]);
 
   // Close expanded participants when tick mode opens
   useEffect(() => {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -53,6 +53,7 @@ import IosShare from '@mui/icons-material/IosShare';
 import QrCode2Outlined from '@mui/icons-material/QrCode2Outlined';
 import { QRCodeSVG } from 'qrcode.react';
 import { shareWithFallback } from '@/app/lib/share-utils';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import styles from './queue-control-bar.module.css';
 
 export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
@@ -301,7 +302,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     setCurrentClimbQueueItem(nextClimb);
     track('Queue Navigation', {
       direction: 'next',
-      method: 'swipe',
+      method: 'swipeQueueBar',
       boardLayout: boardDetails?.layout_name || '',
     });
 
@@ -323,7 +324,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     setCurrentClimbQueueItem(previousClimb);
     track('Queue Navigation', {
       direction: 'previous',
-      method: 'swipe',
+      method: 'swipeQueueBar',
       boardLayout: boardDetails?.layout_name || '',
     });
 
@@ -397,6 +398,62 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   useEffect(() => {
     setLocalTickedClimbs(new Set());
   }, [sessionId]);
+
+  // One-time swipe hint on the queue bar — briefly peek the text left
+  // to show users they can swipe to navigate between queued climbs.
+  const queueHintPlayedRef = useRef(false);
+  useEffect(() => {
+    if (!currentClimb || queue.length < 2 || tickBarActive || queueHintPlayedRef.current) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const animations: Animation[] = [];
+
+    // TODO: remove these bypasses after testing
+    Promise.resolve().then(() => {
+      // const seen = await getPreference('swipeHint:queueBarSeen');
+      // if (cancelled || seen) return;
+      // if (!window.matchMedia('(pointer: coarse)').matches) return;
+
+      timer = setTimeout(() => {
+        if (cancelled) return;
+        const el = document.getElementById('onboarding-queue-toggle');
+        if (!el) return;
+
+        queueHintPlayedRef.current = true;
+
+        const slideOut = el.animate(
+          [{ transform: 'translateX(0)' }, { transform: 'translateX(-40px)' }],
+          { duration: 350, easing: 'ease-out', fill: 'forwards' },
+        );
+        animations.push(slideOut);
+
+        slideOut.finished.then(() => {
+          if (cancelled) return;
+          return new Promise<void>((r) => { timer = setTimeout(r, 500); });
+        }).then(() => {
+          if (cancelled) return;
+          const slideBack = el.animate(
+            [{ transform: 'translateX(-40px)' }, { transform: 'translateX(0)' }],
+            { duration: 250, easing: 'ease-out', fill: 'forwards' },
+          );
+          animations.push(slideBack);
+          return slideBack.finished;
+        }).then(() => {
+          if (cancelled) return;
+          el.style.transform = '';
+          // TODO: re-enable after testing
+          // setPreference('swipeHint:queueBarSeen', true);
+        }).catch(() => { /* cancelled */ });
+      }, 800);
+    });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      for (const a of animations) a.cancel();
+    };
+  }, [currentClimb, queue.length, tickBarActive]);
 
   // Close expanded participants when tick mode opens
   useEffect(() => {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -409,11 +409,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     let timer: ReturnType<typeof setTimeout>;
     const animations: Animation[] = [];
 
-    // TODO: remove these bypasses after testing
-    Promise.resolve().then(() => {
-      // const seen = await getPreference('swipeHint:queueBarSeen');
-      // if (cancelled || seen) return;
-      // if (!window.matchMedia('(pointer: coarse)').matches) return;
+    getPreference<boolean>('swipeHint:queueBarSeen').then((seen) => {
+      if (cancelled || seen) return;
+      if (!window.matchMedia('(pointer: coarse)').matches) return;
 
       timer = setTimeout(() => {
         if (cancelled) return;
@@ -442,8 +440,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         }).then(() => {
           if (cancelled) return;
           el.style.transform = '';
-          // TODO: re-enable after testing
-          // setPreference('swipeHint:queueBarSeen', true);
+          setPreference('swipeHint:queueBarSeen', true);
         }).catch(() => { /* cancelled */ });
       }, 800);
     });

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { track } from '@vercel/analytics';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -234,6 +235,12 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
       }
 
       router.push(navigateUrl);
+
+      track('Session Started', {
+        boardName: localBoardDetails?.board_name ?? '',
+        hasGoal: !!formData.goal,
+        isDiscoverable: !!formData.discoverable,
+      });
 
       handleClose();
       showMessage('Session started!', 'success');

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -6,6 +6,8 @@ const STORE_NAME = 'preferences';
 export type UserPreferenceKeyMap = {
   libraryTab: 'playlists' | 'logbook';
   logbookPreferences: LogbookPreferences;
+  'swipeHint:climbListSeen': boolean;
+  'swipeHint:queueBarSeen': boolean;
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration


### PR DESCRIPTION
## Summary

- **Session bar polish**: Expandable participant bar (tap avatars to expand/collapse), offline banner overlays session header, tick badges on participant avatars, session header smooth CSS grid collapse instead of hard unmount
- **Session drawer moved to root**: Works on every page including home, lazy-loaded with `next/dynamic`
- **User deduplication**: Added stable `userId` (DB UUID) to `SessionUser` type to eliminate ghost participants from WebSocket reconnections
- **Swipe hint animations**: One-time peek animations on first climb list item and queue control bar to demo swipe gestures, tracked via IndexedDB preferences, touch-only
- **Analytics instrumentation**: Added `source` metadata to Add to Queue events (swipe/climbActions/queueButton), `method` to Queue Navigation events (swipeQueueBar/swipePlayViewDrawer/playViewDrawer/button), Session Started event
- **Animation fixes**: Aligned transition durations, added hover/active states, fixed overflow transitions, increased touch targets, added `will-change` hints, `touch-action: pan-y` for proper swipe handling
- **Removed participants from SessionOverviewPanel**: Moved to expandable bar in session header instead

## Test plan

- [ ] Start a session, verify session header shows name + avatar group
- [ ] Tap avatars to expand participant bar, tap close to collapse
- [ ] Tick a climb, verify checkmark badge appears on your avatar
- [ ] Go to home page, tap session header to open session drawer
- [ ] Disconnect network, verify offline banner overlays session header with dismiss X
- [ ] On mobile, load climb list for first time — verify swipe peek animation plays twice on first item
- [ ] Add a climb to queue — verify queue bar swipe peek animation plays twice
- [ ] Refresh — verify hints don't replay
- [ ] Check Vercel Analytics for Add to Queue (source), Queue Navigation (method), Session Started events

🤖 Generated with [Claude Code](https://claude.com/claude-code)