### PR TITLE
Add mirroring support for Decoy climbing board

### DIFF
--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -32,7 +32,7 @@ export const AscentStatus = ({ climbUuid, fontSize, className, mirroredClassName
   const hasRegularAttempt = ascentsForClimb.some(({ is_mirror }) => !is_mirror);
   const hasMirroredAttempt = ascentsForClimb.some(({ is_mirror }) => is_mirror);
   const hasAttempts = ascentsForClimb.length > 0;
-  const supportsMirroring = boardName === 'tension';
+  const supportsMirroring = boardName === 'tension' || boardName === 'decoy';
 
   if (!hasAttempts) return null;
 

--- a/packages/web/app/lib/board-constants.ts
+++ b/packages/web/app/lib/board-constants.ts
@@ -99,7 +99,7 @@ export const getBoardDetails = ({
     layout_id,
     size_id,
     set_ids,
-    supportsMirroring: board_name === 'tension' && layout_id !== 11,
+    supportsMirroring: (board_name === 'tension' && layout_id !== 11) || board_name === 'decoy',
     layout_name: layoutData?.name,
     size_name: sizeData.name,
     size_description: sizeData.description,


### PR DESCRIPTION
## Summary
This change extends mirroring functionality to the Decoy climbing board, which was previously only supported on Tension boards.

## Key Changes
- Updated `AscentStatus` component to recognize Decoy board as supporting mirroring
- Updated `getBoardDetails` function to enable mirroring support for Decoy boards (all layouts)
- Maintained existing Tension board mirroring logic with layout restrictions (layout_id !== 11)

## Implementation Details
The mirroring support is now determined by:
- **Tension board**: Supported for all layouts except layout 11
- **Decoy board**: Supported for all layouts (no layout restrictions)

This allows users to track and view both regular and mirrored ascent attempts on Decoy boards, consistent with the existing Tension board functionality.

https://claude.ai/code/session_01WZZMdjxckcPmbt5nhsVZ6D