### PR TITLE
Fix session mini bar not updating after Start Sesh

### DIFF
--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -46,9 +46,10 @@ vi.mock('@/app/hooks/use-create-session', () => ({
 }));
 
 const mockRouterPush = vi.fn();
+let mockPathname: string | null = null;
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockRouterPush }),
-  usePathname: () => null,
+  usePathname: () => mockPathname,
 }));
 
 vi.mock('next-auth/react', () => ({
@@ -135,10 +136,21 @@ vi.mock('@/app/components/board-selector-drawer/board-selector-drawer', () => ({
   default: () => null,
 }));
 
+let mockBridgeBoardDetails: {
+  board_name: string;
+  layout_id: number;
+  size_id: number;
+  set_ids: number[];
+  angle?: number;
+} | null = null;
+let mockBridgeAngle = 0;
+let mockBridgeQueue: unknown[] = [];
+let mockBridgeCurrentClimbQueueItem: unknown = null;
+
 vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({
   useQueueBridgeBoardInfo: () => ({
-    boardDetails: null,
-    angle: 0,
+    boardDetails: mockBridgeBoardDetails,
+    angle: mockBridgeAngle,
     hasActiveQueue: false,
     isHydrated: false,
   }),
@@ -146,11 +158,11 @@ vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({
 
 vi.mock('@/app/components/graphql-queue', () => ({
   useQueueList: () => ({
-    queue: [],
+    queue: mockBridgeQueue,
     suggestedClimbs: [],
   }),
   useCurrentClimb: () => ({
-    currentClimbQueueItem: null,
+    currentClimbQueueItem: mockBridgeCurrentClimbQueueItem,
     currentClimb: null,
   }),
 }));
@@ -177,6 +189,11 @@ describe('StartSeshDrawer', () => {
     mockLocalCurrentClimbQueueItem = null;
     mockLocalBoardPath = null;
     mockLocalBoardDetails = null;
+    mockBridgeBoardDetails = null;
+    mockBridgeAngle = 0;
+    mockBridgeQueue = [];
+    mockBridgeCurrentClimbQueueItem = null;
+    mockPathname = null;
     mockCreateSession.mockResolvedValue('new-session-id');
   });
 
@@ -455,9 +472,10 @@ describe('StartSeshDrawer', () => {
     expect(mockActivateSession).not.toHaveBeenCalled();
   });
 
-  it('does not call activateSession when localBoardPath is null', async () => {
+  it('does not call activateSession when local and bridge state are both null', async () => {
     mockLocalBoardPath = null;
     mockLocalBoardDetails = null;
+    mockBridgeBoardDetails = null;
 
     render(<StartSeshDrawer open onClose={vi.fn()} />);
 
@@ -468,6 +486,55 @@ describe('StartSeshDrawer', () => {
     });
 
     expect(mockActivateSession).not.toHaveBeenCalled();
+  });
+
+  it('activates session via bridge fallback when local state is null (board route injector active)', async () => {
+    // This is the core bug scenario: user is on a board route, the bridge injector
+    // is active so localBoardPath/localBoardDetails are null, but the bridge context
+    // has valid board details and queue data.
+    mockLocalBoardPath = null;
+    mockLocalBoardDetails = null;
+    mockPathname = '/b/kilter-original-12x12/40/list';
+    mockBridgeBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+    mockBridgeAngle = 40;
+
+    const bridgeItem = makeQueueItem('bq1', 'Bridge Climb');
+    mockBridgeQueue = [bridgeItem];
+    mockBridgeCurrentClimbQueueItem = bridgeItem;
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Board is auto-selected via pathname match, just submit
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+
+    // Queue should be transferred from bridge state
+    expect(mockSetInitialQueueForSession).toHaveBeenCalledWith(
+      'new-session-id',
+      [bridgeItem],
+      bridgeItem,
+      undefined,
+    );
+
+    // activateSession should fire using bridge board details
+    expect(mockActivateSession).toHaveBeenCalledWith({
+      sessionId: 'new-session-id',
+      sessionName: undefined,
+      boardPath: '/b/kilter-original-12x12',
+      boardDetails: mockBridgeBoardDetails,
+      parsedParams: {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+      namedBoardName: 'Kilter',
+      namedBoardUuid: 'board-1',
+    });
   });
 
   it('renders with bottom placement', () => {

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -135,6 +135,26 @@ vi.mock('@/app/components/board-selector-drawer/board-selector-drawer', () => ({
   default: () => null,
 }));
 
+vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({
+  useQueueBridgeBoardInfo: () => ({
+    boardDetails: null,
+    angle: 0,
+    hasActiveQueue: false,
+    isHydrated: false,
+  }),
+}));
+
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueList: () => ({
+    queue: [],
+    suggestedClimbs: [],
+  }),
+  useCurrentClimb: () => ({
+    currentClimbQueueItem: null,
+    currentClimb: null,
+  }),
+}));
+
 import StartSeshDrawer from '../start-sesh-drawer';
 
 // --- Helpers ---
@@ -404,7 +424,7 @@ describe('StartSeshDrawer', () => {
       expect(mockActivateSession).toHaveBeenCalledWith({
         sessionId: 'new-session-id',
         sessionName: undefined,
-        boardPath: '/b/kilter-original-12x12/40/list',
+        boardPath: '/b/kilter-original-12x12',
         boardDetails: mockLocalBoardDetails,
         parsedParams: {
           board_name: 'kilter',

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -29,6 +29,8 @@ import { isBoardRoutePath } from '@/app/lib/board-route-paths';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { setClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { usePersistentSession } from '@/app/components/persistent-session/persistent-session-context';
+import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
+import { useQueueList, useCurrentClimb } from '@/app/components/graphql-queue';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { StoredBoardConfig } from '@/app/lib/saved-boards-db';
@@ -57,6 +59,9 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     localBoardDetails,
   } = usePersistentSession();
   const pathname = usePathname();
+  const { boardDetails: bridgeBoardDetails, angle: bridgeAngle } = useQueueBridgeBoardInfo();
+  const { queue: bridgeQueue } = useQueueList();
+  const { currentClimbQueueItem: bridgeCurrentClimbQueueItem } = useCurrentClimb();
   const { boards, error: boardsError } = useMyBoards(open);
 
   const [selectedBoard, setSelectedBoard] = useState<(typeof boards)[number] | null>(null);
@@ -201,32 +206,34 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     try {
       const sessionId = await createSession(formData, boardPath);
 
-      if (
-        localBoardPath &&
-        (localQueue.length > 0 || localCurrentClimbQueueItem) &&
-        getBaseBoardPath(localBoardPath) === getBaseBoardPath(boardPath)
-      ) {
-        setInitialQueueForSession(sessionId, localQueue, localCurrentClimbQueueItem, formData.name);
+      // Effective values: prefer local state, fall back to bridge context
+      // (local state may be empty when the bridge injector is active on a board route)
+      const effectiveBoardDetails = localBoardDetails ?? bridgeBoardDetails;
+      const effectiveBoardPath = localBoardPath ?? (bridgeBoardDetails && pathname ? getBaseBoardPath(pathname) : null);
+      const effectiveQueue = localQueue.length > 0 ? localQueue : bridgeQueue;
+      const effectiveCurrentClimb = localCurrentClimbQueueItem ?? bridgeCurrentClimbQueueItem;
+      const boardsMatch = effectiveBoardPath != null && getBaseBoardPath(effectiveBoardPath) === getBaseBoardPath(boardPath);
+
+      // Transfer existing queue to the new session if on the same board
+      if (boardsMatch && (effectiveQueue.length > 0 || effectiveCurrentClimb)) {
+        setInitialQueueForSession(sessionId, effectiveQueue, effectiveCurrentClimb, formData.name);
       }
 
       setClimbSessionCookie(sessionId);
 
-      if (
-        localBoardPath &&
-        localBoardDetails &&
-        getBaseBoardPath(localBoardPath) === getBaseBoardPath(boardPath)
-      ) {
-        const angle = selectedBoard?.angle ?? selectedCustomConfig?.angle ?? 0;
+      // Activate the session immediately so the UI updates without needing a reload
+      if (effectiveBoardDetails && boardsMatch) {
+        const angle = selectedBoard?.angle ?? selectedCustomConfig?.angle ?? bridgeAngle ?? 0;
         activateSession({
           sessionId,
           sessionName: formData.name,
-          boardPath: localBoardPath,
-          boardDetails: localBoardDetails,
+          boardPath,
+          boardDetails: effectiveBoardDetails,
           parsedParams: {
-            board_name: localBoardDetails.board_name,
-            layout_id: localBoardDetails.layout_id,
-            size_id: localBoardDetails.size_id,
-            set_ids: localBoardDetails.set_ids,
+            board_name: effectiveBoardDetails.board_name,
+            layout_id: effectiveBoardDetails.layout_id,
+            size_id: effectiveBoardDetails.size_id,
+            set_ids: effectiveBoardDetails.set_ids,
             angle,
           },
           namedBoardName: selectedBoard?.name,
@@ -237,7 +244,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
       router.push(navigateUrl);
 
       track('Session Started', {
-        boardName: localBoardDetails?.board_name ?? '',
+        boardName: effectiveBoardDetails?.board_name ?? '',
         hasGoal: !!formData.goal,
         isDiscoverable: !!formData.discoverable,
       });

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -206,13 +206,16 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     try {
       const sessionId = await createSession(formData, boardPath);
 
-      // Effective values: prefer local state, fall back to bridge context
-      // (local state may be empty when the bridge injector is active on a board route)
+      // Effective values: prefer local state, fall back to bridge context.
+      // Local state may be empty when the QueueBridgeInjector is active on a
+      // board route — it only syncs to local state on cleanup (navigating away).
       const effectiveBoardDetails = localBoardDetails ?? bridgeBoardDetails;
-      const effectiveBoardPath = localBoardPath ?? (bridgeBoardDetails && pathname ? getBaseBoardPath(pathname) : null);
+      const effectiveBaseBoardPath = localBoardPath
+        ? getBaseBoardPath(localBoardPath)
+        : (bridgeBoardDetails && pathname ? getBaseBoardPath(pathname) : null);
       const effectiveQueue = localQueue.length > 0 ? localQueue : bridgeQueue;
       const effectiveCurrentClimb = localCurrentClimbQueueItem ?? bridgeCurrentClimbQueueItem;
-      const boardsMatch = effectiveBoardPath != null && getBaseBoardPath(effectiveBoardPath) === getBaseBoardPath(boardPath);
+      const boardsMatch = effectiveBaseBoardPath != null && effectiveBaseBoardPath === getBaseBoardPath(boardPath);
 
       // Transfer existing queue to the new session if on the same board
       if (boardsMatch && (effectiveQueue.length > 0 || effectiveCurrentClimb)) {
@@ -221,7 +224,10 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
 
       setClimbSessionCookie(sessionId);
 
-      // Activate the session immediately so the UI updates without needing a reload
+      // Activate the session immediately so the UI updates without needing a reload.
+      // We pass boardPath (the form-derived base path, e.g. /b/slug) rather than
+      // the full route pathname — this is the canonical path for the session and
+      // matches what BoardSessionBridge compares against.
       if (effectiveBoardDetails && boardsMatch) {
         const angle = selectedBoard?.angle ?? selectedCustomConfig?.angle ?? bridgeAngle ?? 0;
         activateSession({


### PR DESCRIPTION
## Summary

- Fixed a bug where clicking "Start sesh" on the queue control bar showed the "Session started!" snackbar but the mini bar didn't switch to session mode (still showed "Start sesh") until a full app reload
- Root cause: `activateSession()` was guarded by `localBoardPath && localBoardDetails`, which are null while the `QueueBridgeInjector` is active on a board route (it only syncs to local state on cleanup/navigation away)
- Now reads effective board details and queue state from the bridge context (`useQueueBridgeBoardInfo`, `useQueueList`, `useCurrentClimb`) as fallbacks, so `activateSession()` fires immediately

## Test plan

- [ ] Navigate to a board route, add a climb to the queue
- [ ] Click "Start sesh" on the queue control bar
- [ ] Verify the mini bar immediately shows the session header (name + avatars) instead of "Start sesh"
- [ ] Verify queue items are preserved in the session
- [ ] Verify starting a session from the home page still works (cookie-based fallback)
- [ ] Verify selecting a different board in the Start Sesh drawer doesn't cause mismatched data
- [ ] All 16 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)