### PR TITLE
feat: show ascent badge on grid mode climb cards (fix #1559)

### DIFF
--- a/packages/web/app/components/climb-card/ascent-status.module.css
+++ b/packages/web/app/components/climb-card/ascent-status.module.css
@@ -1,2 +1,31 @@
-/* No longer used — mirroring badge positioning is now handled by
-   the caller via className/mirroredClassName props. */
+/* Ascent status badge — frosted glass circle, bottom-right */
+.badge {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+/* Mirrored ascent badge — bottom-left */
+.badgeMirrored {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}

--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -57,12 +57,12 @@ export const AscentStatus = ({ climbUuid, fontSize, className, mirroredClassName
     return (
       <>
         {regularBadge && (
-          <span className={className ?? ''} style={{ backgroundColor: regularBadge.color }}>
+          <span data-testid="ascent-badge" className={className ?? ''} style={{ backgroundColor: regularBadge.color }}>
             <regularBadge.Icon style={{ color: 'white', fontSize }} />
           </span>
         )}
         {mirroredBadge && (
-          <span className={mirroredClassName ?? className ?? ''} style={{ backgroundColor: mirroredBadge.color }}>
+          <span data-testid="ascent-badge-mirrored" className={mirroredClassName ?? className ?? ''} style={{ backgroundColor: mirroredBadge.color }}>
             <mirroredBadge.Icon style={{ color: 'white', fontSize, transform: 'scaleX(-1)' }} />
           </span>
         )}
@@ -73,11 +73,11 @@ export const AscentStatus = ({ climbUuid, fontSize, className, mirroredClassName
   // Single icon for non-mirroring boards
   const wrapperClass = className ?? '';
   return hasSuccessfulAscent ? (
-    <span className={wrapperClass} style={{ backgroundColor: successColor }}>
+    <span data-testid="ascent-badge" className={wrapperClass} style={{ backgroundColor: successColor }}>
       <CheckOutlined style={{ color: 'white', fontSize }} />
     </span>
   ) : (
-    <span className={wrapperClass} style={{ backgroundColor: attemptColor }}>
+    <span data-testid="ascent-badge" className={wrapperClass} style={{ backgroundColor: attemptColor }}>
       <CloseOutlined style={{ color: 'white', fontSize }} />
     </span>
   );

--- a/packages/web/app/components/climb-card/climb-card-cover.tsx
+++ b/packages/web/app/components/climb-card/climb-card-cover.tsx
@@ -5,6 +5,8 @@ import BoardImageLayers from '@/app/components/board-renderer/board-image-layers
 import BoardCanvasRenderer from '@/app/components/board-renderer/board-canvas-renderer';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { useCanvasRendererReady } from '@/app/lib/board-render-worker/worker-manager';
+import { AscentStatus } from './ascent-status';
+import styles from './ascent-status.module.css';
 
 type ClimbCardCoverProps = {
   climb?: Climb;
@@ -65,6 +67,14 @@ const ClimbCardCover = ({
       }}
     >
       {renderContent}
+      {climb && (
+        <AscentStatus
+          climbUuid={climb.uuid}
+          fontSize={12}
+          className={styles.badge}
+          mirroredClassName={styles.badgeMirrored}
+        />
+      )}
     </div>
   );
 };

--- a/packages/web/app/components/climb-card/climb-list-item.module.css
+++ b/packages/web/app/components/climb-card/climb-list-item.module.css
@@ -3,35 +3,3 @@
   align-items: center;
   gap: 4px;
 }
-
-/* Ascent status badge on the thumbnail — frosted glass, bottom-right */
-.thumbnailBadge {
-  position: absolute;
-  bottom: 2px;
-  right: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-}
-
-/* Mirrored ascent badge — bottom-left */
-.thumbnailBadgeMirrored {
-  position: absolute;
-  bottom: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-}

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -28,6 +28,7 @@ import { InlineListTickBar } from '../logbook/inline-list-tick-bar';
 import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 import { useSnackbar } from '../providers/snackbar-provider';
 import styles from './climb-list-item.module.css';
+import ascentStyles from './ascent-status.module.css';
 import drawerCss from '../swipeable-drawer/swipeable-drawer.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), { ssr: false });
@@ -570,7 +571,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
                 fetchPriority={fetchPriority}
               />
               <HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} size={32} />
-              <AscentStatus climbUuid={climb.uuid} fontSize={12} className={styles.thumbnailBadge} mirroredClassName={styles.thumbnailBadgeMirrored} />
+              <AscentStatus climbUuid={climb.uuid} fontSize={12} className={ascentStyles.badge} mirroredClassName={ascentStyles.badgeMirrored} />
             </div>
 
             {/* Center: Name, stars, setter, colorized grade */}

--- a/packages/web/e2e/grid-mode-ascent-badge.spec.ts
+++ b/packages/web/e2e/grid-mode-ascent-badge.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E tests for the ascent badge in grid mode.
+ *
+ * The list mode has always shown a tick badge (✓ or ✗) on climbs the
+ * logged-in user has attempted. Grid mode previously didn't show this.
+ * These tests verify that the badge now renders correctly in grid mode.
+ *
+ * Requires the seeded dev database (bun run db:up). The test user
+ * (test@boardsesh.com / test) has ~2000 Kilter logbook entries from the
+ * social seed script, so there will always be visible badges.
+ *
+ * See: https://github.com/boardsesh/boardsesh/issues/1559
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const BOARD_URL = '/kilter/original/12x12-square/screw_bolt/40/list';
+const ASCENT_BADGE = '[data-testid="ascent-badge"]';
+const CLIMB_CARD = '[data-testid="climb-card"]';
+
+async function login(page: Page) {
+  await page.goto('/auth/login?callbackUrl=' + encodeURIComponent(BOARD_URL));
+  await page.getByLabel('Email').fill('test@boardsesh.com');
+  await page.getByLabel('Password').fill('test');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await page.waitForURL(BOARD_URL, { timeout: 20_000 });
+}
+
+async function waitForClimbs(page: Page) {
+  await page.waitForSelector(`${CLIMB_CARD}, #onboarding-climb-card`, { timeout: 30_000 });
+}
+
+test.describe('Grid mode — ascent badge', () => {
+  test.setTimeout(90_000);
+
+  test('ascent badge appears on climb cards in grid mode', async ({ page }) => {
+    await login(page);
+    await waitForClimbs(page);
+
+    // Switch to grid mode
+    const gridButton = page.getByRole('button', { name: 'Grid view' });
+    await expect(gridButton).toBeVisible({ timeout: 10_000 });
+    await gridButton.click();
+
+    // Wait for at least one grid card to render
+    await expect(page.locator(CLIMB_CARD).first()).toBeVisible({ timeout: 15_000 });
+
+    // At least one badge must appear — the seeded test user has ~2000 Kilter ticks
+    const badges = page.locator(CLIMB_CARD).locator(ASCENT_BADGE);
+    await expect(badges.first()).toBeVisible({ timeout: 10_000 });
+    expect(await badges.count()).toBeGreaterThan(0);
+  });
+
+  test('ascent badge is visible in both list and grid mode', async ({ page }) => {
+    await login(page);
+    await waitForClimbs(page);
+
+    // List mode: count visible badges in the first few rendered items
+    const listBadges = page.locator(ASCENT_BADGE);
+    await expect(listBadges.first()).toBeVisible({ timeout: 10_000 });
+    const listCount = await listBadges.count();
+    expect(listCount).toBeGreaterThan(0);
+
+    // Switch to grid mode
+    await page.getByRole('button', { name: 'Grid view' }).click();
+    await expect(page.locator(CLIMB_CARD).first()).toBeVisible({ timeout: 15_000 });
+
+    // Grid mode must also show badges
+    const gridBadges = page.locator(CLIMB_CARD).locator(ASCENT_BADGE);
+    await expect(gridBadges.first()).toBeVisible({ timeout: 10_000 });
+    expect(await gridBadges.count()).toBeGreaterThan(0);
+  });
+
+  test('no ascent badge shown when logged out', async ({ page }) => {
+    // Visit without logging in
+    await page.goto(BOARD_URL, { waitUntil: 'domcontentloaded' });
+    await waitForClimbs(page);
+
+    // Switch to grid mode
+    await page.getByRole('button', { name: 'Grid view' }).click();
+    await expect(page.locator(CLIMB_CARD).first()).toBeVisible({ timeout: 15_000 });
+
+    // No badges should appear when unauthenticated
+    await expect(page.locator(CLIMB_CARD).locator(ASCENT_BADGE).first()).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
List mode showed a tick/cross badge on ticked climbs via AscentStatus.
Grid mode was missing this because ClimbCardCover didn't include it.

- Move badge positioning CSS from climb-list-item.module.css into the
  shared ascent-status.module.css so both modes use the same classes
- Render AscentStatus inside ClimbCardCover (position:relative wrapper
  around the board image) when a climb is provided
- Add data-testid="ascent-badge" to AscentStatus spans for testability
- Add E2E spec (grid-mode-ascent-badge.spec.ts) covering authenticated
  badge visibility, list→grid parity, and logged-out (no badge) case

https://claude.ai/code/session_01JS1UX5jzTYFqiz2PFo7aCF