### PR TITLE
iOS: remove unsupported HealthKit Access entitlement from app entitlements

### DIFF
--- a/mobile/ios/App/App/App.entitlements
+++ b/mobile/ios/App/App/App.entitlements
@@ -13,7 +13,5 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
### Motivation
- The App Store export step failed with `xcodebuild -exportArchive` because the distribution provisioning profile does not include the HealthKit Access (Verifiable Health Records) capability, causing a capability/entitlement mismatch. 

### Description
- Removed the `com.apple.developer.healthkit.access` key from `mobile/ios/App/App/App.entitlements`. 
- Kept the base `com.apple.developer.healthkit` entitlement enabled so normal HealthKit APIs remain available. 

### Testing
- Ran `plutil -lint mobile/ios/App/App/App.entitlements` and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0691361948326a253e6bfb856e0a1)