### PR TITLE
Fix iOS export provisioning profile mapping for app archive export

### DIFF
--- a/mobile/ios/ExportOptions.plist
+++ b/mobile/ios/ExportOptions.plist
@@ -11,7 +11,7 @@
     <key>provisioningProfiles</key>
     <dict>
         <key>com.boardsesh.app</key>
-        <string>Boardsesh App Store Distribution Second</string>
+        <string>Boardsesh App Store Distribution</string>
         <key>com.boardsesh.app.widgets</key>
         <string>Boardsesh Widgets App Store Distribution</string>
     </dict>


### PR DESCRIPTION
### Motivation
- The App Store export step failed because `ExportOptions.plist` referenced `Boardsesh App Store Distribution Second`, a provisioning profile that did not include the `com.apple.developer.healthkit` entitlement required by the app, causing `xcodebuild -exportArchive` to fail.

### Description
- Update `mobile/ios/ExportOptions.plist` to map `com.boardsesh.app` to the `Boardsesh App Store Distribution` provisioning profile instead of the outdated `Boardsesh App Store Distribution Second` name.

### Testing
- Ran `plutil -lint mobile/ios/ExportOptions.plist` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06fba9dec8326895713b7d14bac00)