### PR TITLE
Add App.release.entitlements and reference it from Release build config

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
+				CODE_SIGN_ENTITLEMENTS = App/App.release.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/mobile/ios/App/App/App.release.entitlements
+++ b/mobile/ios/App/App/App.release.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:boardsesh.com</string>
+		<string>applinks:www.boardsesh.com</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.boardsesh.app</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
### Motivation
- Provide separate Release entitlements to enable Associated Domains and App Group settings for production builds.

### Description
- Add `mobile/ios/App/App/App.release.entitlements` that declares `com.apple.developer.associated-domains` and `com.apple.security.application-groups` entries.
- Update `mobile/ios/App/App.xcodeproj/project.pbxproj` Release build configuration to reference `App/App.release.entitlements` instead of the previous `App/App.entitlements`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06fba9dec8326895713b7d14bac00)