### PR TITLE
Bump iOS marketing version to 1.1

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -621,7 +621,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -644,7 +644,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -663,7 +663,7 @@
 				DEVELOPMENT_TEAM = 9L3HKPZBH3;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.AppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -681,7 +681,7 @@
 				DEVELOPMENT_TEAM = 9L3HKPZBH3;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.AppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -701,7 +701,7 @@
 				INFOPLIST_FILE = BoardseshWidgets/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -722,7 +722,7 @@
 				INFOPLIST_FILE = BoardseshWidgets/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
### Motivation
- App Store export/upload failed because `CFBundleShortVersionString` resolved to `1.0` while the `1.0` pre-release train is closed, so the iOS marketing version must be increased to `1.1` to satisfy App Store Connect validation.

### Description
- Updated `MARKETING_VERSION` from `1.0` to `1.1` in `mobile/ios/App/App.xcodeproj/project.pbxproj` across all affected build configurations/targets (App, AppTests, BoardseshWidgets) so `CFBundleShortVersionString` resolves to `1.1` at archive/export time.
- Committed the change on the working branch with a descriptive message and created the PR entry.

### Testing
- Reproduced the prior `xcodebuild -exportArchive` validation failure which reported the closed pre-release train and the `CFBundleShortVersionString` version error (upload failed). 
- Ran `rg` to locate version keys and verified the project file now contains `MARKETING_VERSION = 1.1;` in all expected entries. 
- Printed the relevant region of `project.pbxproj` with `nl`/`sed` to confirm the six updated lines and successfully committed the change; no full archive/export was executed after the bump in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07b1a48448326913f2bb93485838a)