### PR TITLE
Add NSHealthShareUsageDescription to iOS Info.plist

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -78,6 +78,8 @@
 	</array>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Boardsesh saves your climbing sessions to Apple Health as workouts so they count toward your activity rings.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Boardsesh reads your workout data from Apple Health to display your climbing activity history and workout insights.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Boardsesh uses Bluetooth to connect to your Kilter Board, Tension Board, or MoonBoard and light up climbing holds. No personal data is sent over Bluetooth.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
### Motivation
- App Store Connect reported `ITMS-90683` for missing HealthKit read purpose string because the app references Health APIs, so a user-facing `NSHealthShareUsageDescription` is required to explain why workouts are read.

### Description
- Added the `NSHealthShareUsageDescription` key with a clear purpose string to `mobile/ios/App/App/Info.plist` alongside the existing `NSHealthUpdateUsageDescription` so both read and write HealthKit purpose strings are present.

### Testing
- Ran `plutil -lint mobile/ios/App/App/Info.plist` which returned OK, confirming the plist is valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07eb59b088326beed9adb37f2cabd)