### PR TITLE
[Docs] CONTRIBUTING.md has the wrong path to setup script #1585

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 Run the automated setup script:
 
 ```bash
-./setup-dev.sh
+./packages/web/setup-dev.sh
 ```
 
 This script will:


### PR DESCRIPTION
This solves issue #1585 which has the wrong path for the dev setup script