### PR TITLE
Add Instagram posting flow and mobile logbook fixes

### DIFF
--- a/packages/backend/src/__tests__/cors.test.ts
+++ b/packages/backend/src/__tests__/cors.test.ts
@@ -167,6 +167,16 @@ describe('CORS Handler', () => {
       expect(isOriginAllowed('http://localhost:3000')).toBe(true);
       expect(isOriginAllowed('http://127.0.0.1:3001')).toBe(true);
     });
+
+    it('returns true for private LAN origins in non-production', () => {
+      expect(isOriginAllowed('http://192.168.0.42:3000')).toBe(true);
+      expect(isOriginAllowed('http://10.0.1.15:3001')).toBe(true);
+      expect(isOriginAllowed('http://172.20.10.3:3000')).toBe(true);
+    });
+
+    it('returns false for non-dev ports on private LAN origins', () => {
+      expect(isOriginAllowed('http://192.168.0.42:8080')).toBe(false);
+    });
   });
 
   describe('applyCorsHeaders', () => {

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -6,7 +6,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { getConsensusDifficultyName } from '../shared/sql-expressions';
-import { SaveTickInputSchema, UpdateTickInputSchema } from '../../../validation/schemas';
+import { SaveTickInputSchema, UpdateTickInputSchema, AttachBetaLinkInputSchema } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
 import { publishSocialEvent } from '../../../events';
 import { assignInferredSession } from '../../../jobs/inferred-session-builder';
@@ -154,6 +154,27 @@ export const tickMutations = {
           .where(eq(sessions.id, validatedInput.sessionId));
       }
 
+      // Attach the Instagram URL as community beta for this climb if the
+      // user provided one on a successful ascent. Zod already validated the
+      // URL format; the (boardType, climbUuid, link) PK makes re-submission
+      // idempotent.
+      const shouldAttachBeta =
+        validatedInput.videoUrl &&
+        (validatedInput.status === 'flash' || validatedInput.status === 'send');
+      if (shouldAttachBeta) {
+        await tx
+          .insert(dbSchema.boardBetaLinks)
+          .values({
+            boardType: validatedInput.boardType,
+            climbUuid: validatedInput.climbUuid,
+            link: validatedInput.videoUrl!,
+            angle: validatedInput.angle,
+            isListed: true,
+            createdAt: now,
+          })
+          .onConflictDoNothing();
+      }
+
       return [createdTick];
     });
 
@@ -202,6 +223,35 @@ export const tickMutations = {
     }
 
     return result;
+  },
+
+  /**
+   * Attach an Instagram post or reel as beta for a climb.
+   * Idempotent on (boardType, climbUuid, link).
+   */
+  attachBetaLink: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+
+    const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
+    const now = new Date().toISOString();
+
+    await db
+      .insert(dbSchema.boardBetaLinks)
+      .values({
+        boardType: validated.boardType,
+        climbUuid: validated.climbUuid,
+        link: validated.link,
+        angle: validated.angle ?? null,
+        isListed: true,
+        createdAt: now,
+      })
+      .onConflictDoNothing();
+
+    return true;
   },
 
   /**

--- a/packages/backend/src/handlers/cors.ts
+++ b/packages/backend/src/handlers/cors.ts
@@ -6,6 +6,8 @@ const VERCEL_PREVIEW_REGEX = /^https:\/\/boardsesh-[a-z0-9]+-marcodejonghs-proje
 
 // Homelab branch deploy pattern: https://{N}.preview.boardsesh.com
 const PREVIEW_ORIGIN_REGEX = /^https:\/\/\d+\.preview\.boardsesh\.com$/;
+const DEV_PRIVATE_LAN_ORIGIN_REGEX =
+  /^http:\/\/(?:(?:10(?:\.\d{1,3}){3})|(?:192\.168(?:\.\d{1,3}){2})|(?:172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})):(?:3000|3001)$/;
 const DEV_WEB_PORTS = [3000, 3001];
 const TAILSCALE_STATUS_TIMEOUT_MS = 1500;
 
@@ -117,6 +119,7 @@ export function isOriginAllowed(origin: string): boolean {
   if (allowedOrigins.includes(origin)) return true;
   if (VERCEL_PREVIEW_REGEX.test(origin)) return true;
   if (PREVIEW_ORIGIN_REGEX.test(origin)) return true;
+  if (process.env.NODE_ENV !== 'production' && DEV_PRIVATE_LAN_ORIGIN_REGEX.test(origin)) return true;
   return false;
 }
 

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
+const INSTAGRAM_URL_REGEX = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+
 /**
  * Tick status validation schema
  */
@@ -27,6 +29,7 @@ export const SaveTickInputSchema = z.object({
   layoutId: z.number().int().positive().optional(),
   sizeId: z.number().int().positive().optional(),
   setIds: z.string().min(1).optional(),
+  videoUrl: z.string().max(500).regex(INSTAGRAM_URL_REGEX, 'Must be an Instagram post or reel URL').optional().nullable(),
 }).refine(
   (data) => {
     // A flash is by definition a first-try ascent, so attemptCount must be 1.
@@ -52,6 +55,16 @@ export const SaveTickInputSchema = z.object({
 export const GetTicksInputSchema = z.object({
   boardType: BoardNameSchema,
   climbUuids: z.array(ExternalUUIDSchema).optional(),
+});
+
+/**
+ * Attach beta link input validation schema
+ */
+export const AttachBetaLinkInputSchema = z.object({
+  boardType: BoardNameSchema,
+  climbUuid: ExternalUUIDSchema,
+  link: z.string().max(500).regex(INSTAGRAM_URL_REGEX, 'Must be an Instagram post or reel URL'),
+  angle: z.number().int().min(0).max(90).optional().nullable(),
 });
 
 /**

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -129,6 +129,12 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     updateTick(uuid: ID!, input: UpdateTickInput!): Tick!
 
+    """
+    Attach an Instagram post or reel as beta for a climb. Idempotent on
+    (boardType, climbUuid, link).
+    """
+    attachBetaLink(input: AttachBetaLinkInput!): Boolean!
+
 
     # ============================================
     # Climb Mutations (require auth)

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -97,6 +97,8 @@ export const ticksTypeDefs = /* GraphQL */ `
     sizeId: Int
     "Set IDs for board resolution"
     setIds: String
+    "Optional Instagram post or reel URL to attach as beta for the climb"
+    videoUrl: String
   }
 
   """
@@ -126,5 +128,19 @@ export const ticksTypeDefs = /* GraphQL */ `
     boardType: String!
     "Optional list of climb UUIDs to filter by"
     climbUuids: [String!]
+  }
+
+  """
+  Input for attaching an Instagram video as beta for a climb.
+  """
+  input AttachBetaLinkInput {
+    "Board type"
+    boardType: String!
+    "Climb UUID"
+    climbUuid: String!
+    "Instagram post or reel URL"
+    link: String!
+    "Optional angle the video was climbed at"
+    angle: Int
   }
 `;

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -42,9 +42,17 @@ export type SaveTickInput = {
   layoutId?: number;
   sizeId?: number;
   setIds?: string;
+  videoUrl?: string | null;
 };
 
 export type GetTicksInput = {
   boardType: string;
   climbUuids?: string[];
+};
+
+export type AttachBetaLinkInput = {
+  boardType: string;
+  climbUuid: string;
+  link: string;
+  angle?: number | null;
 };

--- a/packages/web/app/components/activity-feed/activity-feed.tsx
+++ b/packages/web/app/components/activity-feed/activity-feed.tsx
@@ -41,7 +41,7 @@ export default function ActivityFeed({
   onFindClimbers,
   initialFeedResult,
 }: ActivityFeedProps) {
-  const { token, isLoading: authLoading } = useWsAuthToken();
+  const { token, isLoading: authLoading, error: authError } = useWsAuthToken();
 
   const hasInitialData = !!initialFeedResult && initialFeedResult.sessions.length > 0;
 
@@ -116,6 +116,14 @@ export default function ActivityFeed({
       {!isAuthenticated && (
         <MuiAlert severity="info" sx={{ mb: 1 }}>
           Sign in to see a personalized feed from climbers you follow.
+        </MuiAlert>
+      )}
+
+      {isAuthenticated && !authLoading && !token && (
+        <MuiAlert severity="warning" sx={{ mb: 1 }}>
+          {authError
+            ? 'Signed in, but Boardsesh could not load authenticated session data on this device.'
+            : 'Signed in, but Boardsesh could not access authenticated session data on this device.'}
         </MuiAlert>
       )}
 

--- a/packages/web/app/components/activity-feed/ascents-feed.module.css
+++ b/packages/web/app/components/activity-feed/ascents-feed.module.css
@@ -110,7 +110,8 @@
 
 @media (max-width: 768px) {
   .climbName {
-    max-width: 150px;
+    max-width: 180px;
+    font-size: 15px;
   }
 
   .feedItem {
@@ -120,5 +121,14 @@
   .thumbnailContainer {
     width: 56px;
     height: 56px;
+  }
+
+  .statusTag {
+    max-width: 84px;
+  }
+
+  .timeAgo {
+    font-size: 11px;
+    letter-spacing: -0.01em;
   }
 }

--- a/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import AttachBetaLinkForm from './attach-beta-link-form';
+
+interface AttachBetaLinkDialogProps {
+  open: boolean;
+  onClose: () => void;
+  boardType: string;
+  climbUuid: string;
+  climbName?: string;
+  angle?: number | null;
+}
+
+export const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
+  open,
+  onClose,
+  boardType,
+  climbUuid,
+  climbName,
+  angle,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {climbName ? `Share beta for ${climbName}` : 'Share beta video'}
+      </DialogTitle>
+      <DialogContent>
+        <AttachBetaLinkForm
+          boardType={boardType}
+          climbUuid={climbUuid}
+          climbName={climbName}
+          angle={angle}
+          resetTrigger={open}
+          submitLabel="Share beta"
+          helperText="Paste a reel or post link so others can see your beta."
+          onSuccess={onClose}
+          onCancel={onClose}
+          showCancel
+          autoFocus
+          compact
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AttachBetaLinkDialog;

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import {
+  ATTACH_BETA_LINK,
+  type AttachBetaLinkMutationVariables,
+  type AttachBetaLinkMutationResponse,
+} from '@/app/lib/graphql/operations';
+import { isInstagramUrl } from '@/app/lib/instagram-url';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+
+interface AttachBetaLinkFormProps {
+  boardType: string;
+  climbUuid: string;
+  climbName?: string;
+  angle?: number | null;
+  resetTrigger?: unknown;
+  submitLabel?: string;
+  helperText?: string;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+  showCancel?: boolean;
+  autoFocus?: boolean;
+  compact?: boolean;
+}
+
+export const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
+  boardType,
+  climbUuid,
+  climbName,
+  angle,
+  resetTrigger,
+  submitLabel = 'Share beta',
+  helperText = 'Paste a reel or post link so others can see your beta.',
+  onSuccess,
+  onCancel,
+  showCancel = false,
+  autoFocus = false,
+  compact = false,
+}) => {
+  const [url, setUrl] = useState('');
+  const { token } = useWsAuthToken();
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackbar();
+
+  useEffect(() => {
+    setUrl('');
+  }, [resetTrigger]);
+
+  const trimmed = url.trim();
+  const validationError =
+    trimmed && !isInstagramUrl(trimmed)
+      ? 'Needs to be an Instagram post or reel URL'
+      : null;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!token) throw new Error('Auth token not available');
+      const client = createGraphQLHttpClient(token);
+      const variables: AttachBetaLinkMutationVariables = {
+        input: {
+          boardType,
+          climbUuid,
+          link: trimmed,
+          angle: angle ?? undefined,
+        },
+      };
+      await client.request<AttachBetaLinkMutationResponse>(ATTACH_BETA_LINK, variables);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['betaLinks', boardType, climbUuid] });
+      showMessage('Video added to beta', 'success');
+      setUrl('');
+      onSuccess?.();
+    },
+    onError: () => {
+      showMessage('Couldn’t add video. Try again.', 'error');
+    },
+  });
+
+  const canSubmit = !!trimmed && !validationError && !mutation.isPending;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: compact ? 1.25 : 1.5 }}>
+      <TextField
+        autoFocus={autoFocus}
+        fullWidth
+        placeholder="https://www.instagram.com/reel/..."
+        label={climbName ? `Instagram URL for ${climbName}` : 'Instagram URL'}
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        error={!!validationError}
+        helperText={validationError ?? helperText}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && canSubmit) {
+            e.preventDefault();
+            mutation.mutate();
+          }
+        }}
+      />
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+        {showCancel && onCancel && (
+          <Button onClick={onCancel} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={() => mutation.mutate()}
+          disabled={!canSubmit}
+          startIcon={mutation.isPending ? <CircularProgress size={16} /> : undefined}
+        >
+          {submitLabel}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default AttachBetaLinkForm;

--- a/packages/web/app/components/beta-videos/beta-videos.tsx
+++ b/packages/web/app/components/beta-videos/beta-videos.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -14,6 +14,7 @@ import { Instagram, PersonOutlined, ExpandLessOutlined } from '@mui/icons-materi
 import ExpandMoreOutlined from '@mui/icons-material/ExpandMoreOutlined';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { dedupeBetaLinks, getInstagramEmbedUrl } from '@/app/lib/instagram-url';
 import { themeTokens } from '@/app/theme/theme-config';
 
 interface BetaVideosProps {
@@ -25,17 +26,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
   const [selectedVideo, setSelectedVideo] = useState<BetaLink | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
   const [showAllVideos, setShowAllVideos] = useState(false);
-
-  const getInstagramEmbedUrl = (link: string) => {
-    const instagramRegex = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
-    const match = link.match(instagramRegex);
-
-    if (match && match[1]) {
-      return `https://www.instagram.com/p/${match[1]}/embed`;
-    }
-
-    return null;
-  };
+  const uniqueBetaLinks = useMemo(() => dedupeBetaLinks(betaLinks), [betaLinks]);
 
   const handleVideoClick = (betaLink: BetaLink) => {
     setSelectedVideo(betaLink);
@@ -134,12 +125,12 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
     );
   };
 
-  if (betaLinks.length === 0) {
+  if (uniqueBetaLinks.length === 0) {
     return <EmptyState description="No beta videos available" />;
   }
 
-  const visibleVideos = showAllVideos ? betaLinks : betaLinks.slice(0, 1);
-  const hasMoreVideos = betaLinks.length > 1;
+  const visibleVideos = showAllVideos ? uniqueBetaLinks : uniqueBetaLinks.slice(0, 1);
+  const hasMoreVideos = uniqueBetaLinks.length > 1;
 
   return (
     <>
@@ -157,7 +148,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
           }}
           startIcon={showAllVideos ? <ExpandLessOutlined /> : <ExpandMoreOutlined />}
         >
-          {showAllVideos ? 'Show less' : `Show ${betaLinks.length - 1} more video${betaLinks.length - 1 !== 1 ? 's' : ''}`}
+          {showAllVideos ? 'Show less' : `Show ${uniqueBetaLinks.length - 1} more video${uniqueBetaLinks.length - 1 !== 1 ? 's' : ''}`}
         </Button>
       )}
 

--- a/packages/web/app/components/climb-actions/actions/index.ts
+++ b/packages/web/app/components/climb-actions/actions/index.ts
@@ -8,4 +8,5 @@ export { TickAction } from './tick-action';
 export { OpenInAppAction } from './open-in-app-action';
 export { MirrorAction } from './mirror-action';
 export { ShareAction } from './share-action';
+export { InstagramAction } from './instagram-action';
 export { PlaylistAction } from './playlist-action';

--- a/packages/web/app/components/climb-actions/actions/instagram-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/instagram-action.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import InstagramIcon from '@mui/icons-material/Instagram';
+import { ClimbActionProps, ClimbActionResult } from '../types';
+import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
+import PostToInstagramDialog from '@/app/components/library/post-to-instagram-dialog';
+import AttachBetaLinkDialog from '@/app/components/beta-videos/attach-beta-link-dialog';
+import { isInstagramPostingSupported } from '@/app/lib/instagram-posting';
+
+export function InstagramAction({
+  climb,
+  boardDetails,
+  angle,
+  viewMode,
+  size = 'default',
+  showLabel,
+  disabled,
+  className,
+  onComplete,
+}: ClimbActionProps): ClimbActionResult {
+  const { iconSize } = computeActionDisplay(viewMode, size, showLabel);
+  const [postDialogOpen, setPostDialogOpen] = useState(false);
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+
+  const isKilter = boardDetails.board_name === 'kilter';
+  const canPost = isKilter && isInstagramPostingSupported();
+  const canLink = isKilter && !canPost;
+  const available = canPost || canLink;
+
+  const label = canPost ? 'Post to Instagram' : 'Link Instagram video';
+
+  const handleClick = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    e?.preventDefault();
+
+    if (canPost) {
+      setPostDialogOpen(true);
+      return;
+    }
+
+    if (canLink) {
+      setLinkDialogOpen(true);
+    }
+  }, [canPost, canLink]);
+
+  const dialogTarget = useMemo(
+    () => ({
+      boardType: boardDetails.board_name,
+      climbUuid: climb.uuid,
+      climbName: climb.name,
+      angle,
+    }),
+    [boardDetails.board_name, climb.uuid, climb.name, angle],
+  );
+
+  const extraContent = (
+    <>
+      <PostToInstagramDialog
+        open={postDialogOpen}
+        onClose={() => {
+          setPostDialogOpen(false);
+          onComplete?.();
+        }}
+        item={dialogTarget}
+      />
+      <AttachBetaLinkDialog
+        open={linkDialogOpen}
+        onClose={() => {
+          setLinkDialogOpen(false);
+          onComplete?.();
+        }}
+        boardType={boardDetails.board_name}
+        climbUuid={climb.uuid}
+        climbName={climb.name}
+        angle={angle}
+      />
+    </>
+  );
+
+  return buildActionResult({
+    key: 'instagram',
+    label,
+    icon: <InstagramIcon sx={{ fontSize: iconSize }} />,
+    onClick: handleClick,
+    viewMode,
+    size,
+    showLabel,
+    disabled,
+    className,
+    available,
+    extraContent,
+  });
+}
+
+export default InstagramAction;

--- a/packages/web/app/components/climb-actions/climb-actions.tsx
+++ b/packages/web/app/components/climb-actions/climb-actions.tsx
@@ -27,6 +27,7 @@ import {
   OpenInAppAction,
   MirrorAction,
   ShareAction,
+  InstagramAction,
   PlaylistAction,
 } from './actions';
 
@@ -59,6 +60,7 @@ const ACTION_FUNCTIONS: Record<
   openInApp: OpenInAppAction,
   mirror: MirrorAction,
   share: ShareAction,
+  instagram: InstagramAction,
   playlist: PlaylistAction,
 };
 
@@ -90,6 +92,7 @@ const ACTION_RENDERERS: Record<ClimbActionType, React.FC<ClimbActionProps | Open
   openInApp: createActionRenderer(OpenInAppAction),
   mirror: createActionRenderer(MirrorAction),
   share: createActionRenderer(ShareAction),
+  instagram: createActionRenderer(InstagramAction),
   playlist: createActionRenderer(PlaylistAction),
 };
 

--- a/packages/web/app/components/climb-actions/types.ts
+++ b/packages/web/app/components/climb-actions/types.ts
@@ -14,6 +14,7 @@ export type ClimbActionType =
   | 'openInApp'
   | 'mirror'
   | 'share'
+  | 'instagram'
   | 'playlist';
 
 /**

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import type { CollapsibleSectionConfig } from '@/app/components/collapsible-section/collapsible-section';
@@ -9,6 +9,7 @@ import { LogbookSection, useLogbookSummary } from '@/app/components/logbook/logb
 import ClimbSocialSection from '@/app/components/social/climb-social-section';
 import ClimbAnalytics from '@/app/components/charts/climb-analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { dedupeBetaLinks } from '@/app/lib/instagram-url';
 import type { Climb } from '@/app/lib/types';
 
 interface BuildClimbDetailSectionsProps {
@@ -50,6 +51,7 @@ export function useBuildClimbDetailSections({
     staleTime: 5 * 60 * 1000,
     initialData: initialBetaLinks,
   });
+  const uniqueBetaLinks = useMemo(() => dedupeBetaLinks(betaLinks), [betaLinks]);
   const logbookSummary = useLogbookSummary(climb.uuid);
 
   if (!enabledProp) return [];
@@ -74,11 +76,11 @@ export function useBuildClimbDetailSections({
       title: 'Beta Videos',
       defaultSummary: 'No videos',
       getSummary: () =>
-        betaLinks.length > 0
-          ? [`${betaLinks.length} video${betaLinks.length !== 1 ? 's' : ''}`]
+        uniqueBetaLinks.length > 0
+          ? [`${uniqueBetaLinks.length} video${uniqueBetaLinks.length !== 1 ? 's' : ''}`]
           : [],
       lazy: true,
-      content: <BetaVideos betaLinks={betaLinks} />,
+      content: <BetaVideos betaLinks={uniqueBetaLinks} />,
     },
     {
       key: 'logbook',

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -55,7 +55,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             angle={angle}
             currentPathname={pathname}
             viewMode="dropdown"
-            include={['tick', 'share', 'openInApp']}
+            include={['instagram', 'tick', 'share', 'openInApp']}
             auroraAppUrl={auroraAppUrl}
           />
         </div>
@@ -72,7 +72,7 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
             angle={angle}
             currentPathname={pathname}
             viewMode="button"
-            include={['favorite', 'tick', 'queue', 'share', 'openInApp']}
+            include={['favorite', 'instagram', 'tick', 'queue', 'share', 'openInApp']}
             auroraAppUrl={auroraAppUrl}
           />
         </div>

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import LogbookFeedItem from '../logbook-feed-item';
+import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+
+vi.mock('@/app/components/activity-feed/ascent-thumbnail', () => ({
+  default: () => <div data-testid="ascent-thumbnail" />,
+}));
+
+vi.mock('../post-to-instagram-dialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/beta-videos/attach-beta-link-dialog', () => ({
+  default: () => null,
+}));
+
+const baseItem: AscentFeedItem = {
+  uuid: 'tick-1',
+  climbUuid: 'climb-1',
+  climbName: 'Texas Sun',
+  setterUsername: 'gabe',
+  boardType: 'kilter',
+  layoutId: 8,
+  angle: 35,
+  isMirror: false,
+  status: 'send',
+  attemptCount: 2,
+  quality: 3,
+  difficulty: 22,
+  difficultyName: '7a/V6',
+  consensusDifficulty: 22,
+  consensusDifficultyName: '7a/V6',
+  isBenchmark: false,
+  comment: '',
+  climbedAt: new Date().toISOString(),
+  frames: 'encoded',
+};
+
+describe('LogbookFeedItem', () => {
+  it('shows Post to Instagram for supported Kilter items when enabled', async () => {
+    render(<LogbookFeedItem item={baseItem} allowInstagramPosting />);
+
+    fireEvent.click(screen.getByLabelText('Open climb actions'));
+
+    expect(await screen.findByText('Post to Instagram')).toBeTruthy();
+  });
+
+  it('hides the Instagram action for non-Kilter items', () => {
+    render(
+      <LogbookFeedItem
+        item={{ ...baseItem, boardType: 'tension' }}
+        allowInstagramPosting
+      />,
+    );
+
+    expect(screen.queryByLabelText('Open climb actions')).toBeNull();
+  });
+
+  it('shows Link Instagram video when linking is enabled without posting', async () => {
+    render(<LogbookFeedItem item={baseItem} allowInstagramLinking />);
+
+    fireEvent.click(screen.getByLabelText('Open climb actions'));
+
+    expect(await screen.findByText('Link Instagram video')).toBeTruthy();
+    expect(screen.queryByText('Post to Instagram')).toBeNull();
+  });
+
+  it('hides all Instagram actions when neither posting nor linking is enabled', () => {
+    render(<LogbookFeedItem item={baseItem} allowInstagramPosting={false} allowInstagramLinking={false} />);
+
+    expect(screen.queryByLabelText('Open climb actions')).toBeNull();
+  });
+});

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import MuiTypography from '@mui/material/Typography';
@@ -18,9 +19,12 @@ import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
+import InstagramIcon from '@mui/icons-material/Instagram';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import AscentThumbnail from '@/app/components/activity-feed/ascent-thumbnail';
+import AttachBetaLinkDialog from '@/app/components/beta-videos/attach-beta-link-dialog';
+import PostToInstagramDialog from './post-to-instagram-dialog';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from '@/app/components/activity-feed/ascents-feed.module.css';
@@ -58,14 +62,52 @@ const getStatusDisplay = (status: AscentFeedItem['status'], attemptCount: number
   }
 };
 
+const getCompactStatusDisplay = (status: AscentFeedItem['status'], attemptCount: number) => {
+  switch (status) {
+    case 'flash':
+      return { label: '', icon: <ElectricBoltOutlined />, color: 'gold' as const };
+    case 'send':
+      return { label: `${attemptCount}`, icon: <CheckCircleOutlined />, color: 'green' as const };
+    case 'attempt':
+      return { label: `${attemptCount}`, icon: <CancelOutlined />, color: 'default' as const };
+  }
+};
+
+const getCompactRelativeTime = (isoDate: string) =>
+  dayjs(isoDate)
+    .fromNow()
+    .replace(/\ba year ago\b/i, '1y ago')
+    .replace(/\byears ago\b/i, 'y ago')
+    .replace(/\ba month ago\b/i, '1mo ago')
+    .replace(/\bmonths ago\b/i, 'mo ago')
+    .replace(/\ba day ago\b/i, '1d ago')
+    .replace(/\bdays ago\b/i, 'd ago')
+    .replace(/\ban hour ago\b/i, '1h ago')
+    .replace(/\bhours ago\b/i, 'h ago')
+    .replace(/\ba minute ago\b/i, '1m ago')
+    .replace(/\bminutes ago\b/i, 'm ago')
+    .replace(/\ba second ago\b/i, '1s ago')
+    .replace(/\bseconds ago\b/i, 's ago');
+
 interface LogbookFeedItemProps {
   item: AscentFeedItem;
   showBoardType?: boolean;
   onDelete?: (uuid: string) => void;
+  allowInstagramPosting?: boolean;
+  allowInstagramLinking?: boolean;
 }
 
-const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, onDelete }) => {
+const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({
+  item,
+  showBoardType,
+  onDelete,
+  allowInstagramPosting = false,
+  allowInstagramLinking = false,
+}) => {
+  const isMobile = useMediaQuery('(max-width: 768px)', { noSsr: true });
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [postDialogOpen, setPostDialogOpen] = useState(false);
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const menuOpen = Boolean(anchorEl);
 
   const handleMenuOpen = useCallback((e: React.MouseEvent<HTMLElement>) => {
@@ -82,10 +124,24 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
     onDelete?.(item.uuid);
   }, [onDelete, item.uuid, handleMenuClose]);
 
-  const timeAgo = dayjs(item.climbedAt).fromNow();
-  const statusDisplay = getStatusDisplay(item.status, item.attemptCount);
+  const handlePostToInstagram = useCallback(() => {
+    handleMenuClose();
+    setPostDialogOpen(true);
+  }, [handleMenuClose]);
+
+  const handleLinkInstagram = useCallback(() => {
+    handleMenuClose();
+    setLinkDialogOpen(true);
+  }, [handleMenuClose]);
+
+  const timeAgo = isMobile ? getCompactRelativeTime(item.climbedAt) : dayjs(item.climbedAt).fromNow();
+  const statusDisplay = isMobile
+    ? getCompactStatusDisplay(item.status, item.attemptCount)
+    : getStatusDisplay(item.status, item.attemptCount);
   const boardDisplay = getLayoutDisplayName(item.boardType, item.layoutId);
   const hasSuccess = item.status === 'flash' || item.status === 'send';
+  const canPostToInstagram = allowInstagramPosting && item.boardType === 'kilter';
+  const canLinkInstagram = allowInstagramLinking && hasSuccess;
 
   return (
     <MuiCard className={styles.feedItem}>
@@ -111,7 +167,22 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
                   label={statusDisplay.label}
                   size="small"
                   color={statusDisplay.color === 'green' ? 'success' : undefined}
-                  sx={statusDisplay.color === 'gold' ? { bgcolor: themeTokens.colors.amber, color: 'var(--neutral-900)' } : undefined}
+                  sx={{
+                    ...(statusDisplay.color === 'gold'
+                      ? { bgcolor: themeTokens.colors.amber, color: 'var(--neutral-900)' }
+                      : {}),
+                    ...(isMobile
+                      ? {
+                          minWidth: 0,
+                          '& .MuiChip-label': {
+                            px: statusDisplay.label ? 0.75 : 0.25,
+                          },
+                          '& .MuiChip-icon': {
+                            mx: statusDisplay.label ? 0 : '4px',
+                          },
+                        }
+                      : {}),
+                  }}
                   className={styles.statusTag}
                 />
                 <MuiTypography variant="body2" component="span" fontWeight={600} className={styles.climbName}>
@@ -122,9 +193,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
                 <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.timeAgo}>
                   {timeAgo}
                 </MuiTypography>
-                {onDelete && (
+                {(canPostToInstagram || canLinkInstagram || onDelete) && (
                   <>
-                    <IconButton size="small" onClick={handleMenuOpen} sx={{ ml: 0.25, p: 0.5 }}>
+                    <IconButton size="small" onClick={handleMenuOpen} sx={{ ml: 0.25, p: 0.5 }} aria-label="Open climb actions">
                       <MoreVertOutlined sx={{ fontSize: 18 }} />
                     </IconButton>
                     <Menu
@@ -134,10 +205,24 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
                       anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                     >
-                      <MuiMenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
-                        <ListItemIcon><DeleteOutlined sx={{ color: 'error.main' }} /></ListItemIcon>
-                        <ListItemText>Delete</ListItemText>
-                      </MuiMenuItem>
+                      {canPostToInstagram && (
+                        <MuiMenuItem onClick={handlePostToInstagram}>
+                          <ListItemIcon><InstagramIcon fontSize="small" /></ListItemIcon>
+                          <ListItemText>Post to Instagram</ListItemText>
+                        </MuiMenuItem>
+                      )}
+                      {canLinkInstagram && (
+                        <MuiMenuItem onClick={handleLinkInstagram}>
+                          <ListItemIcon><InstagramIcon fontSize="small" /></ListItemIcon>
+                          <ListItemText>Link Instagram video</ListItemText>
+                        </MuiMenuItem>
+                      )}
+                      {onDelete && (
+                        <MuiMenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
+                          <ListItemIcon><DeleteOutlined sx={{ color: 'error.main' }} /></ListItemIcon>
+                          <ListItemText>Delete</ListItemText>
+                        </MuiMenuItem>
+                      )}
                     </Menu>
                   </>
                 )}
@@ -161,7 +246,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
               {item.isBenchmark && <Chip label="Benchmark" size="small" />}
             </Box>
 
-            {hasSuccess && item.quality && (
+            {(item.status === 'flash' || item.status === 'send') && item.quality && (
               <Rating readOnly value={item.quality} max={5} className={styles.rating} />
             )}
 
@@ -179,6 +264,19 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = ({ item, showBoardType, 
           </Box>
         </Box>
       </CardContent>
+      <PostToInstagramDialog
+        open={postDialogOpen}
+        onClose={() => setPostDialogOpen(false)}
+        item={item}
+      />
+      <AttachBetaLinkDialog
+        open={linkDialogOpen}
+        onClose={() => setLinkDialogOpen(false)}
+        boardType={item.boardType}
+        climbUuid={item.climbUuid}
+        climbName={item.climbName}
+        angle={item.angle}
+      />
     </MuiCard>
   );
 };

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -282,7 +282,8 @@ export default function LogbookFeed() {
     };
     setDraftSortState(nextSortState);
     setSortState(nextSortState);
-  }, [sortState]);
+    closeSortMenu();
+  }, [closeSortMenu, sortState]);
 
   const persistedPreferences = useMemo<LogbookPreferences>(() => ({
     version: 1,

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -16,6 +16,7 @@ import FormControl from '@mui/material/FormControl';
 import Button from '@mui/material/Button';
 import Popover from '@mui/material/Popover';
 import Divider from '@mui/material/Divider';
+import Alert from '@mui/material/Alert';
 import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Slider from '@mui/material/Slider';
@@ -25,6 +26,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import Checkbox from '@mui/material/Checkbox';
 import FormGroup from '@mui/material/FormGroup';
 import IconButton from '@mui/material/IconButton';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { HistoryOutlined, SearchOutlined, FilterListOutlined, SwapVertOutlined, ExpandMoreOutlined, CloseOutlined } from '@mui/icons-material';
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { getAllLayouts } from '@/app/lib/board-constants';
@@ -44,6 +46,7 @@ import {
   type SortPreset,
 } from '@/app/lib/logbook-preferences';
 import { useSession } from 'next-auth/react';
+import { usePathname } from 'next/navigation';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -59,6 +62,7 @@ import {
 } from '@/app/lib/graphql/operations/ticks';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import LogbookFeedItem from './logbook-feed-item';
+import { isInstagramPostingSupported } from '@/app/lib/instagram-posting';
 import styles from './library.module.css';
 import feedStyles from '@/app/components/activity-feed/ascents-feed.module.css';
 
@@ -160,8 +164,10 @@ function getDirectionOptions(field: SortField): { value: SortDirection; label: s
 
 export default function LogbookFeed() {
   const { data: session } = useSession();
-  const { token } = useWsAuthToken();
+  const pathname = usePathname();
+  const { token, isLoading: authLoading, error: authError } = useWsAuthToken();
   const userId = session?.user?.id;
+  const isNarrowViewport = useMediaQuery('(max-width: 768px)', { noSsr: true });
 
   const queryClient = useQueryClient();
   const { showMessage } = useSnackbar();
@@ -420,6 +426,8 @@ export default function LogbookFeed() {
 
   const showBoardType = boardFilter === 'all';
   const hasFilters = boardFilter !== 'all' || debouncedSearch.length > 0 || !isDefaultFilters(filters);
+  const enableInstagramPosting = pathname === '/you/logbook' && isNarrowViewport && isInstagramPostingSupported();
+  const enableInstagramLinking = pathname === '/you/logbook';
 
   const filterButtonActive = !isDefaultFilters(filters);
   const sortButtonActive = !isDefaultSort(sortState);
@@ -432,6 +440,13 @@ export default function LogbookFeed() {
         value={searchText}
         onChange={handleSearchChange}
         slotProps={{
+          htmlInput: {
+            suppressHydrationWarning: true,
+            autoComplete: 'off',
+            autoCapitalize: 'off',
+            autoCorrect: 'off',
+            spellCheck: false,
+          },
           input: {
             startAdornment: (
               <InputAdornment position="start">
@@ -501,13 +516,28 @@ export default function LogbookFeed() {
     return (
       <>
         {filterBar}
+        {userId && !authLoading && !token && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {authError
+              ? 'Signed in, but Boardsesh could not load your authenticated logbook data on this device.'
+              : 'Signed in, but Boardsesh could not access your authenticated logbook data on this device.'}
+          </Alert>
+        )}
         <div className={styles.emptyContainer}>
           <HistoryOutlined className={styles.emptyIcon} />
           <Typography variant="h6" component="h4" sx={{ mb: 1 }}>
-            {hasFilters ? 'No matching climbs' : 'No logged climbs yet'}
+            {userId && !authLoading && !token
+              ? 'Logbook unavailable on this device'
+              : hasFilters
+                ? 'No matching climbs'
+                : 'No logged climbs yet'}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 300 }}>
-            {hasFilters ? 'Try adjusting your filters or sort.' : 'Tick your sends and they show up here.'}
+            {userId && !authLoading && !token
+              ? 'Your account is signed in, but the authenticated data connection did not become available.'
+              : hasFilters
+                ? 'Try adjusting your filters or sort.'
+                : 'Tick your sends and they show up here.'}
           </Typography>
         </div>
         <FilterPopover
@@ -548,7 +578,14 @@ export default function LogbookFeed() {
       <div className={feedStyles.feed}>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
           {items.map((item) => (
-            <LogbookFeedItem key={item.uuid} item={item} showBoardType={showBoardType} onDelete={handleDelete} />
+            <LogbookFeedItem
+              key={item.uuid}
+              item={item}
+              showBoardType={showBoardType}
+              onDelete={handleDelete}
+              allowInstagramPosting={enableInstagramPosting}
+              allowInstagramLinking={enableInstagramLinking && !enableInstagramPosting}
+            />
           ))}
         </Box>
 

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import React, { useMemo, useState, useCallback } from 'react';
+import Dialog from '@mui/material/Dialog';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import CircularProgress from '@mui/material/CircularProgress';
+import Chip from '@mui/material/Chip';
+import OpenInNewOutlined from '@mui/icons-material/OpenInNewOutlined';
+import ArrowBackIosNewOutlined from '@mui/icons-material/ArrowBackIosNewOutlined';
+import InstagramIcon from '@mui/icons-material/Instagram';
+import VideocamOutlined from '@mui/icons-material/VideocamOutlined';
+import { useQuery } from '@tanstack/react-query';
+import BetaVideos from '@/app/components/beta-videos/beta-videos';
+import AttachBetaLinkForm from '@/app/components/beta-videos/attach-beta-link-form';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import {
+  buildInstagramCaption,
+  copyAndOpenInstagram,
+} from '@/app/lib/instagram-posting';
+import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export interface InstagramPostingTarget {
+  boardType: string;
+  climbUuid: string;
+  climbName: string;
+  angle: number;
+}
+
+interface PostToInstagramDialogProps {
+  open: boolean;
+  onClose: () => void;
+  item: InstagramPostingTarget | null;
+}
+
+const instructions = [
+  'Copy the caption and open Instagram.',
+  'Paste the caption when creating your post.',
+  'Once your post is live, come back here.',
+  'Paste the Instagram link so we can display your ascent video here.',
+];
+
+export default function PostToInstagramDialog({
+  open,
+  onClose,
+  item,
+}: PostToInstagramDialogProps) {
+  const { showMessage } = useSnackbar();
+  const [isLaunching, setIsLaunching] = useState(false);
+  const { data: betaLinks = [], isLoading: betaLinksLoading } = useQuery<BetaLink[]>({
+    queryKey: ['betaLinks', item?.boardType, item?.climbUuid],
+    queryFn: async () => {
+      if (!item) return [];
+      const res = await fetch(`/api/v1/${item.boardType}/beta/${item.climbUuid}`);
+      if (!res.ok) return [];
+      return res.json();
+    },
+    enabled: open && !!item,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const caption = useMemo(() => {
+    if (!item) return '';
+    return buildInstagramCaption({
+      climbName: item.climbName,
+      angle: item.angle,
+    });
+  }, [item]);
+
+  const handleCopyAndOpen = useCallback(async () => {
+    if (!caption) return;
+
+    setIsLaunching(true);
+    const result = await copyAndOpenInstagram(caption);
+    setIsLaunching(false);
+
+    if (!result.copied) {
+      showMessage('Couldn’t copy caption. Try again.', 'error');
+      return;
+    }
+
+    if (!result.opened) {
+      showMessage('Couldn’t open Instagram. Open it manually and paste the copied caption.', 'error');
+      return;
+    }
+
+    showMessage('Caption copied. Instagram should open next.', 'success');
+  }, [caption, showMessage]);
+
+  if (!item) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen
+      PaperProps={{
+        sx: {
+          bgcolor: 'background.default',
+          color: 'text.primary',
+        },
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            py: 1.5,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
+        >
+          <IconButton onClick={onClose} sx={{ color: 'text.primary' }} aria-label="Back">
+            <ArrowBackIosNewOutlined />
+          </IconButton>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h6" component="h1" fontWeight={700}>
+              Post to Instagram
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Share your ascent and link it back here.
+            </Typography>
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: 680,
+            mx: 'auto',
+            px: { xs: 2, sm: 3 },
+            py: 3,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2.5,
+          }}
+        >
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: `${themeTokens.borderRadius.lg}px`,
+              p: 2.5,
+              boxShadow: themeTokens.shadows.sm,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1.5 }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="h5" component="h2" fontWeight={700} sx={{ mb: 0.5 }}>
+                  Share your beta video
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  We’ll copy the caption, open Instagram, and let you paste the final link back into Boardsesh.
+                </Typography>
+              </Box>
+              <InstagramIcon sx={{ color: 'primary.main', fontSize: 28, flexShrink: 0 }} />
+            </Box>
+
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              <Chip size="small" label="Kilter" color="primary" variant="outlined" />
+              <Chip size="small" label={`${item.angle}°`} variant="outlined" />
+              <Chip
+                size="small"
+                icon={<VideocamOutlined sx={{ fontSize: '0.9rem !important' }} />}
+                label={item.climbName}
+                variant="outlined"
+              />
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: `${themeTokens.borderRadius.lg}px`,
+              p: 2.5,
+              boxShadow: themeTokens.shadows.sm,
+            }}
+          >
+            <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
+              How It Works
+            </Typography>
+            <Box sx={{ color: 'text.secondary', display: 'flex', flexDirection: 'column', gap: 0.75, mt: 1 }}>
+              {instructions.map((instruction, index) => (
+                <Typography key={instruction} variant="body1" sx={{ lineHeight: 1.5 }}>
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 700, mr: 1 }}>
+                    {index + 1}.
+                  </Box>
+                  {instruction}
+                </Typography>
+              ))}
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: `${themeTokens.borderRadius.lg}px`,
+              p: 2.5,
+              boxShadow: themeTokens.shadows.sm,
+            }}
+          >
+            <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
+              Caption
+            </Typography>
+            <Typography
+              variant="h5"
+              component="pre"
+              sx={{
+                mt: 1,
+                mb: 0,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                fontFamily: 'inherit',
+                fontWeight: 700,
+                lineHeight: 1.35,
+              }}
+            >
+              {caption}
+            </Typography>
+          </Box>
+
+          <Button
+            variant="contained"
+            fullWidth
+            size="large"
+            onClick={handleCopyAndOpen}
+            disabled={isLaunching}
+            startIcon={<OpenInNewOutlined />}
+            sx={{
+              py: 1.6,
+              borderRadius: `${themeTokens.borderRadius.md}px`,
+              textTransform: 'none',
+              fontWeight: 700,
+              fontSize: themeTokens.typography.fontSize.lg,
+            }}
+          >
+            Copy & Open Instagram
+          </Button>
+
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: `${themeTokens.borderRadius.lg}px`,
+              p: 2.5,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+              boxShadow: themeTokens.shadows.sm,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <InstagramIcon sx={{ color: 'text.secondary' }} />
+              <Typography variant="h6" component="h3" fontWeight={700}>
+                Paste your Instagram link
+              </Typography>
+            </Box>
+            <Typography variant="body2" color="text.secondary">
+              When your post is live, paste the reel or post link here so Boardsesh can show your ascent video.
+            </Typography>
+            <AttachBetaLinkForm
+              boardType={item.boardType}
+              climbUuid={item.climbUuid}
+              climbName={item.climbName}
+              angle={item.angle}
+              resetTrigger={open}
+              submitLabel="Add Instagram link"
+              helperText="Paste the live Instagram reel or post URL."
+            />
+          </Box>
+
+          <Divider sx={{ borderColor: 'divider' }} />
+
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: `${themeTokens.borderRadius.lg}px`,
+              p: 2.5,
+              boxShadow: themeTokens.shadows.sm,
+            }}
+          >
+            <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
+              Existing Beta Videos
+            </Typography>
+            {betaLinksLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress size={24} />
+              </Box>
+            ) : (
+              <Box sx={{ mt: 1 }}>
+                <BetaVideos betaLinks={betaLinks} />
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -20,6 +20,7 @@ import { track } from '@vercel/analytics';
 import { Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider, TickStatus } from '../board-provider/board-provider-context';
 import { TENSION_KILTER_GRADES, ANGLES } from '@/app/lib/board-data';
+import { isInstagramUrl } from '@/app/lib/instagram-url';
 
 import dayjs from 'dayjs';
 
@@ -32,6 +33,7 @@ interface LogAscentFormValues {
   quality: number;
   difficulty: number;
   notes?: string;
+  videoUrl?: string;
 }
 
 // Helper to determine tick status from attempt count (for ascents)
@@ -89,6 +91,11 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     setIsMirrored((prev) => !prev);
   };
 
+  const videoUrlError =
+    logType === 'ascent' && formValues.videoUrl && !isInstagramUrl(formValues.videoUrl)
+      ? 'Needs to be an Instagram post or reel URL'
+      : null;
+
   // Validation function matching backend rules
   const validateTickInput = (values: LogAscentFormValues): string | null => {
     // Attempts don't need flash/send validation
@@ -106,6 +113,10 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     // Send requires attemptCount > 1
     if (status === 'send' && values.attempts <= 1) {
       return 'Send requires more than 1 attempt';
+    }
+
+    if (values.videoUrl && !isInstagramUrl(values.videoUrl)) {
+      return 'Needs to be an Instagram post or reel URL';
     }
 
     return null; // Valid
@@ -128,6 +139,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     const status = getTickStatus(logType, values.attempts);
 
     try {
+      const trimmedVideoUrl = values.videoUrl?.trim();
       await saveTick({
         climbUuid: currentClimb.uuid,
         angle: Number(values.angle),
@@ -142,6 +154,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         layoutId: boardDetails.layout_id,
         sizeId: boardDetails.size_id,
         setIds: Array.isArray(boardDetails.set_ids) ? boardDetails.set_ids.join(',') : String(boardDetails.set_ids),
+        videoUrl: logType === 'ascent' && trimmedVideoUrl ? trimmedVideoUrl : undefined,
       });
 
       track('Tick Logged', {
@@ -291,11 +304,29 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         </Box>
       </Box>
 
+      {logType === 'ascent' && (
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
+          <Typography sx={{ width: 120, flexShrink: 0, pt: 1 }}>Video</Typography>
+          <Box sx={{ flex: 1 }}>
+            <TextField
+              placeholder="https://www.instagram.com/reel/..."
+              variant="outlined"
+              size="small"
+              fullWidth
+              value={formValues.videoUrl || ''}
+              onChange={(e) => setFormValues((prev) => ({ ...prev, videoUrl: e.target.value }))}
+              error={!!videoUrlError}
+              helperText={videoUrlError ?? 'Paste a reel link so others can see your beta. (Optional)'}
+            />
+          </Box>
+        </Box>
+      )}
+
       <Box sx={{ mb: 1 }}>
         <Button
           variant="contained"
           type="submit"
-          disabled={isSaving}
+          disabled={isSaving || !!videoUrlError}
           startIcon={isSaving ? <CircularProgress size={16} /> : undefined}
           fullWidth
           size="large"

--- a/packages/web/app/components/play-view/play-view-beta-slider.tsx
+++ b/packages/web/app/components/play-view/play-view-beta-slider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Dialog from '@mui/material/Dialog';
@@ -14,18 +14,10 @@ import VideocamOutlined from '@mui/icons-material/VideocamOutlined';
 import { Instagram, PersonOutlined } from '@mui/icons-material';
 import { useQuery } from '@tanstack/react-query';
 import { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { dedupeBetaLinks, getInstagramEmbedUrl } from '@/app/lib/instagram-url';
 import { themeTokens } from '@/app/theme/theme-config';
 
 const THUMB_SIZE = themeTokens.spacing[16]; // 64px
-
-function getInstagramEmbedUrl(link: string): string | null {
-  const instagramRegex = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
-  const match = link.match(instagramRegex);
-  if (match && match[1]) {
-    return `https://www.instagram.com/p/${match[1]}/embed`;
-  }
-  return null;
-}
 
 interface PlayViewBetaSliderProps {
   boardName: string;
@@ -45,8 +37,9 @@ const PlayViewBetaSlider: React.FC<PlayViewBetaSliderProps> = ({ boardName, clim
   });
   const [selectedVideo, setSelectedVideo] = useState<BetaLink | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
+  const uniqueBetaLinks = useMemo(() => dedupeBetaLinks(betaLinks), [betaLinks]);
 
-  if (betaLinks.length === 0) return null;
+  if (uniqueBetaLinks.length === 0) return null;
 
   const handleClose = () => {
     setIframeKey((prev) => prev + 1);
@@ -71,7 +64,7 @@ const PlayViewBetaSlider: React.FC<PlayViewBetaSliderProps> = ({ boardName, clim
           }}
         >
           <VideocamOutlined sx={{ fontSize: themeTokens.typography.fontSize.sm }} />
-          Beta ({betaLinks.length})
+          Beta ({uniqueBetaLinks.length})
         </Typography>
 
         <Box
@@ -84,7 +77,7 @@ const PlayViewBetaSlider: React.FC<PlayViewBetaSliderProps> = ({ boardName, clim
             pb: `${themeTokens.spacing[1]}px`,
           }}
         >
-          {betaLinks.map((link) => (
+          {uniqueBetaLinks.map((link) => (
             <Box
               key={link.link}
               onClick={() => setSelectedVideo(link)}

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -35,6 +35,7 @@ export interface SaveTickOptions {
   layoutId?: number;
   sizeId?: number;
   setIds?: string;
+  videoUrl?: string;
 }
 
 /**
@@ -74,6 +75,7 @@ export function useSaveTick(boardName: BoardName) {
           layoutId: options.layoutId,
           sizeId: options.sizeId,
           setIds: options.setIds,
+          videoUrl: options.videoUrl,
         },
       };
 
@@ -142,6 +144,14 @@ export function useSaveTick(boardName: BoardName) {
 
       // Clear any IndexedDB draft for this climb (belt-and-suspenders with QuickTickBar's .then)
       clearTickDraft(options.climbUuid, options.angle);
+
+      // If the user attached an Instagram video, refresh the beta-videos section
+      // so the new embed shows up without a page reload.
+      if (options.videoUrl) {
+        queryClient.invalidateQueries({
+          queryKey: ['betaLinks', boardName, options.climbUuid],
+        });
+      }
     },
     onError: (_err, _options, context) => {
       // Rollback optimistic update. User-facing error feedback is handled by

--- a/packages/web/app/lib/__tests__/backend-url.test.ts
+++ b/packages/web/app/lib/__tests__/backend-url.test.ts
@@ -37,6 +37,59 @@ describe('deriveWsUrlFromHost', () => {
   });
 });
 
+describe('getBackendWsUrl (client runtime local-network fallback)', () => {
+  const originalEnv = process.env;
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it('rewrites localhost fallback to the current host for LAN mobile access', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8080/graphql';
+
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: '192.168.1.42',
+          protocol: 'http:',
+        },
+      },
+    });
+
+    const { getBackendWsUrl, getGraphQLHttpUrl } = await import('../backend-url');
+    expect(getBackendWsUrl()).toBe('ws://192.168.1.42:8080/graphql');
+    expect(getGraphQLHttpUrl()).toBe('http://192.168.1.42:8080/graphql');
+  });
+
+  it('keeps the baked URL when it already points to a non-loopback host', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://backend.example.com/graphql';
+
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: '192.168.1.42',
+          protocol: 'https:',
+        },
+      },
+    });
+
+    const { getBackendWsUrl } = await import('../backend-url');
+    expect(getBackendWsUrl()).toBe('wss://backend.example.com/graphql');
+  });
+});
+
 describe('getBackendWsUrl (SSR context)', () => {
   const originalEnv = process.env;
 

--- a/packages/web/app/lib/__tests__/instagram-posting.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-posting.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildInstagramCaption,
+  copyAndOpenInstagram,
+  getInstagramPostingPlatform,
+  isInstagramPostingSupported,
+} from '../instagram-posting';
+
+const originalNavigator = global.navigator;
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+describe('instagram-posting', () => {
+  beforeEach(() => {
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        Capacitor: undefined,
+        location: { href: '' },
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        clearTimeout: vi.fn(),
+        setTimeout: vi.fn((callback: () => void) => {
+          queueMicrotask(callback);
+          return 1;
+        }),
+      },
+    });
+
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)',
+      },
+    });
+
+    Object.defineProperty(global, 'document', {
+      configurable: true,
+      value: {
+        visibilityState: 'hidden',
+        hidden: true,
+        body: {
+          appendChild: vi.fn(),
+          removeChild: vi.fn(),
+        },
+        createElement: vi.fn((tag: string) => ({
+          tagName: tag.toUpperCase(),
+          style: {},
+          value: '',
+          textContent: '',
+          contentEditable: '',
+          focus: vi.fn(),
+          select: vi.fn(),
+          setSelectionRange: vi.fn(),
+          setAttribute: vi.fn(),
+        })),
+        execCommand: vi.fn(() => true),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        createRange: vi.fn(() => ({
+          selectNodeContents: vi.fn(),
+        })),
+      },
+    });
+
+    Object.defineProperty(global.window, 'getSelection', {
+      configurable: true,
+      value: vi.fn(() => ({
+        removeAllRanges: vi.fn(),
+        addRange: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    Object.defineProperty(global, 'document', {
+      configurable: true,
+      value: originalDocument,
+    });
+  });
+
+  it('builds the exact caption format for Kilter', () => {
+    expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35 })).toBe(
+      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+    );
+  });
+
+  it('detects iPhone web as supported', () => {
+    expect(getInstagramPostingPlatform()).toBe('ios');
+    expect(isInstagramPostingSupported()).toBe(true);
+  });
+
+  it('detects Android mobile web as supported', () => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 Chrome/136.0 Mobile Safari/537.36',
+      },
+    });
+
+    expect(getInstagramPostingPlatform()).toBe('android');
+    expect(isInstagramPostingSupported()).toBe(true);
+  });
+
+  it('treats desktop web as unsupported', () => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/136.0 Safari/537.36',
+      },
+    });
+
+    expect(getInstagramPostingPlatform()).toBe('unsupported');
+    expect(isInstagramPostingSupported()).toBe(false);
+  });
+
+  it('falls back to legacy copy and still opens instagram on iPhone web', async () => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)',
+      },
+    });
+
+    const result = await copyAndOpenInstagram('"There, There" @ 40° on the Kilter Board.');
+
+    expect(global.document.execCommand).toHaveBeenCalledWith('copy');
+    expect(result).toEqual({ copied: true, opened: true });
+    expect(global.window.location.href).toBe('instagram://camera');
+  });
+});

--- a/packages/web/app/lib/__tests__/instagram-url.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { dedupeBetaLinks, getInstagramEmbedUrl, getInstagramMediaId } from '../instagram-url';
+
+function makeBetaLink(overrides: Partial<BetaLink>): BetaLink {
+  return {
+    climb_uuid: 'climb-1',
+    link: 'https://www.instagram.com/reel/ABC123xyz/',
+    foreign_username: null,
+    angle: null,
+    thumbnail: null,
+    is_listed: true,
+    created_at: '2026-04-16T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('instagram-url', () => {
+  it('extracts the Instagram media id from post and reel links', () => {
+    expect(getInstagramMediaId('https://www.instagram.com/reel/DJ5Cw5OIS82/')).toBe('DJ5Cw5OIS82');
+    expect(getInstagramMediaId('https://www.instagram.com/p/DEdQNTzScjp/?img_index=1')).toBe('DEdQNTzScjp');
+  });
+
+  it('builds embed URLs from the extracted media id', () => {
+    expect(getInstagramEmbedUrl('https://www.instagram.com/reel/DJ5Cw5OIS82/')).toBe(
+      'https://www.instagram.com/p/DJ5Cw5OIS82/embed',
+    );
+  });
+
+  it('dedupes beta links that point to the same Instagram media and preserves richer metadata', () => {
+    const deduped = dedupeBetaLinks([
+      makeBetaLink({
+        link: 'https://www.instagram.com/reel/DJ5Cw5OIS82/',
+        foreign_username: null,
+        angle: null,
+        thumbnail: null,
+      }),
+      makeBetaLink({
+        link: 'https://www.instagram.com/p/DJ5Cw5OIS82/?img_index=1',
+        foreign_username: 'climber',
+        angle: 35,
+        thumbnail: 'https://cdn.example.com/thumb.jpg',
+      }),
+    ]);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.foreign_username).toBe('climber');
+    expect(deduped[0]?.angle).toBe(35);
+    expect(deduped[0]?.thumbnail).toBe('https://cdn.example.com/thumb.jpg');
+  });
+
+  it('keeps distinct Instagram media as separate videos', () => {
+    const deduped = dedupeBetaLinks([
+      makeBetaLink({ link: 'https://www.instagram.com/reel/FIRST123/' }),
+      makeBetaLink({ link: 'https://www.instagram.com/reel/SECOND456/' }),
+    ]);
+
+    expect(deduped).toHaveLength(2);
+  });
+});

--- a/packages/web/app/lib/backend-url.ts
+++ b/packages/web/app/lib/backend-url.ts
@@ -37,6 +37,36 @@ export function deriveWsUrlFromHost(hostname: string, secure: boolean): string |
   return null;
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '0.0.0.0';
+}
+
+function deriveWsUrlFromFallbackForCurrentHost(
+  hostname: string,
+  secure: boolean,
+  fallbackWsUrl: string | null | undefined,
+): string | null {
+  if (!fallbackWsUrl || isLoopbackHostname(hostname)) {
+    return null;
+  }
+
+  try {
+    const fallbackUrl = new URL(fallbackWsUrl);
+    if (!isLoopbackHostname(fallbackUrl.hostname)) {
+      return null;
+    }
+
+    const protocol = secure ? 'wss:' : 'ws:';
+    const port =
+      fallbackUrl.port ||
+      (fallbackUrl.protocol === 'wss:' || fallbackUrl.protocol === 'https:' ? '443' : '80');
+
+    return `${protocol}//${hostname}:${port}${fallbackUrl.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Resolve the backend WebSocket URL at runtime.
  *
@@ -49,6 +79,8 @@ export function getBackendWsUrl(): string | null {
     return process.env.BACKEND_INTERNAL_URL || process.env.NEXT_PUBLIC_WS_URL || null;
   }
 
+  const fallbackWsUrl = process.env.NEXT_PUBLIC_WS_URL || null;
+
   // 1. Host-derived URL for known domain patterns
   const derived = deriveWsUrlFromHost(
     window.location.hostname,
@@ -56,8 +88,19 @@ export function getBackendWsUrl(): string | null {
   );
   if (derived) return derived;
 
-  // 2. Build-time fallback
-  return process.env.NEXT_PUBLIC_WS_URL || null;
+  // 2. Local-network dev fallback:
+  // If the baked client URL points at localhost but the page is being opened
+  // from another host (for example a laptop IP on a phone), reuse the current
+  // hostname so the browser reaches the same machine that served the page.
+  const localNetworkDerived = deriveWsUrlFromFallbackForCurrentHost(
+    window.location.hostname,
+    window.location.protocol === 'https:',
+    fallbackWsUrl,
+  );
+  if (localNetworkDerived) return localNetworkDerived;
+
+  // 3. Build-time fallback
+  return fallbackWsUrl;
 }
 
 /**

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-request';
-import type { Tick, SaveTickInput, GetTicksInput } from '@boardsesh/shared-schema';
+import type { Tick, SaveTickInput, GetTicksInput, AttachBetaLinkInput } from '@boardsesh/shared-schema';
 
 export const GET_TICKS = gql`
   query GetTicks($input: GetTicksInput!) {
@@ -78,6 +78,20 @@ export interface SaveTickMutationVariables {
 
 export interface SaveTickMutationResponse {
   saveTick: TickFromSaveTick;
+}
+
+export const ATTACH_BETA_LINK = gql`
+  mutation AttachBetaLink($input: AttachBetaLinkInput!) {
+    attachBetaLink(input: $input)
+  }
+`;
+
+export interface AttachBetaLinkMutationVariables {
+  input: AttachBetaLinkInput;
+}
+
+export interface AttachBetaLinkMutationResponse {
+  attachBetaLink: boolean;
 }
 
 export const DELETE_TICK = gql`

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -1,0 +1,200 @@
+'use client';
+
+import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
+
+export type InstagramPostingPlatform = 'ios' | 'android' | 'unsupported';
+
+export interface InstagramCaptionInput {
+  climbName: string;
+  angle: number;
+}
+
+export interface CopyAndOpenInstagramResult {
+  copied: boolean;
+  opened: boolean;
+}
+
+const IOS_INSTAGRAM_CREATE_URL = 'instagram://camera';
+const ANDROID_INSTAGRAM_OPEN_URL = 'instagram://camera';
+
+const CLIPBOARD_SETTLE_DELAY_MS = 180;
+
+function legacyTextareaCopy(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.top = '0';
+  textarea.style.left = '0';
+  textarea.style.pointerEvents = 'none';
+  textarea.style.fontSize = '16px';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+function legacyContentEditableCopy(text: string): boolean {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return false;
+
+  const container = document.createElement('div');
+  container.textContent = text;
+  container.contentEditable = 'true';
+  container.setAttribute('aria-hidden', 'true');
+  container.style.position = 'fixed';
+  container.style.opacity = '0';
+  container.style.top = '0';
+  container.style.left = '0';
+  container.style.whiteSpace = 'pre-wrap';
+  container.style.userSelect = 'text';
+  container.style.webkitUserSelect = 'text';
+  container.style.pointerEvents = 'none';
+  document.body.appendChild(container);
+
+  const selection = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(container);
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+
+  try {
+    return document.execCommand('copy');
+  } finally {
+    selection?.removeAllRanges();
+    document.body.removeChild(container);
+  }
+}
+
+function legacyCopy(text: string, platform: InstagramPostingPlatform): boolean {
+  if (platform === 'ios') {
+    return legacyContentEditableCopy(text) || legacyTextareaCopy(text);
+  }
+
+  return legacyTextareaCopy(text);
+}
+
+async function copyToClipboard(text: string, platform: InstagramPostingPlatform): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+
+    return legacyCopy(text, platform);
+  } catch {
+    return legacyCopy(text, platform);
+  }
+}
+
+function getWebPlatformFromUserAgent(): InstagramPostingPlatform {
+  if (typeof navigator === 'undefined') return 'unsupported';
+
+  const ua = navigator.userAgent || '';
+  if (/iPhone/i.test(ua)) return 'ios';
+  if (/Android/i.test(ua) && /Mobile/i.test(ua)) return 'android';
+  return 'unsupported';
+}
+
+export function getInstagramPostingPlatform(): InstagramPostingPlatform {
+  if (typeof window === 'undefined') return 'unsupported';
+
+  if (isNativeApp()) {
+    const platform = getPlatform();
+    if (platform === 'ios' || platform === 'android') return platform;
+  }
+
+  return getWebPlatformFromUserAgent();
+}
+
+export function isInstagramPostingSupported(): boolean {
+  return getInstagramPostingPlatform() !== 'unsupported';
+}
+
+export function buildInstagramCaption({
+  climbName,
+  angle,
+}: InstagramCaptionInput): string {
+  return `"${climbName}" @ ${angle}\u00b0 on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`;
+}
+
+function getInstagramLaunchUrl(platform: InstagramPostingPlatform): string | null {
+  switch (platform) {
+    case 'ios':
+      return IOS_INSTAGRAM_CREATE_URL;
+    case 'android':
+      return ANDROID_INSTAGRAM_OPEN_URL;
+    default:
+      return null;
+  }
+}
+
+function attemptInstagramLaunch(platform: InstagramPostingPlatform): Promise<boolean> {
+  const launchUrl = getInstagramLaunchUrl(platform);
+  if (!launchUrl || typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    let finished = false;
+
+    const cleanup = () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange, true);
+      window.removeEventListener('pagehide', handlePageHide, true);
+      window.clearTimeout(timeoutId);
+    };
+
+    const finish = (opened: boolean) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve(opened);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' || document.hidden) {
+        finish(true);
+      }
+    };
+
+    const handlePageHide = () => finish(true);
+
+    document.addEventListener('visibilitychange', handleVisibilityChange, true);
+    window.addEventListener('pagehide', handlePageHide, true);
+
+    const timeoutId = window.setTimeout(() => {
+      finish(document.visibilityState === 'hidden' || document.hidden);
+    }, 1400);
+
+    window.location.href = launchUrl;
+  });
+}
+
+function settleClipboardWrite(platform: InstagramPostingPlatform): Promise<void> {
+  if (platform !== 'ios' || isNativeApp() || typeof window === 'undefined') {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, CLIPBOARD_SETTLE_DELAY_MS);
+  });
+}
+
+export async function copyAndOpenInstagram(caption: string): Promise<CopyAndOpenInstagramResult> {
+  const platform = getInstagramPostingPlatform();
+  const copied = await copyToClipboard(caption, platform);
+  if (!copied) {
+    return { copied: false, opened: false };
+  }
+
+  await settleClipboardWrite(platform);
+  const opened = await attemptInstagramLaunch(platform);
+  return { copied, opened };
+}

--- a/packages/web/app/lib/instagram-url.ts
+++ b/packages/web/app/lib/instagram-url.ts
@@ -1,0 +1,48 @@
+import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+
+export const INSTAGRAM_URL_REGEX = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+
+export function isInstagramUrl(url: string): boolean {
+  return INSTAGRAM_URL_REGEX.test(url);
+}
+
+export function getInstagramMediaId(url: string): string | null {
+  const match = url.match(INSTAGRAM_URL_REGEX);
+  return match?.[1] ?? null;
+}
+
+export function getInstagramEmbedUrl(url: string): string | null {
+  const mediaId = getInstagramMediaId(url);
+  if (mediaId) {
+    return `https://www.instagram.com/p/${mediaId}/embed`;
+  }
+  return null;
+}
+
+export function dedupeBetaLinks(betaLinks: BetaLink[]): BetaLink[] {
+  const dedupedLinks: BetaLink[] = [];
+  const indexByIdentity = new Map<string, number>();
+
+  for (const betaLink of betaLinks) {
+    const mediaId = getInstagramMediaId(betaLink.link);
+    const identity = mediaId ? `instagram:${mediaId}` : `raw:${betaLink.link}`;
+    const existingIndex = indexByIdentity.get(identity);
+
+    if (existingIndex === undefined) {
+      indexByIdentity.set(identity, dedupedLinks.length);
+      dedupedLinks.push(betaLink);
+      continue;
+    }
+
+    const existing = dedupedLinks[existingIndex];
+    dedupedLinks[existingIndex] = {
+      ...existing,
+      foreign_username: existing.foreign_username ?? betaLink.foreign_username,
+      angle: existing.angle ?? betaLink.angle,
+      thumbnail: existing.thumbnail ?? betaLink.thumbnail,
+      created_at: existing.created_at || betaLink.created_at,
+    };
+  }
+
+  return dedupedLinks;
+}

--- a/packages/web/app/lib/tick-draft-db.ts
+++ b/packages/web/app/lib/tick-draft-db.ts
@@ -11,6 +11,7 @@ export interface TickDraft {
   attemptCount: number;
   comment: string;
   status: TickStatus;
+  videoUrl?: string;
 }
 
 function draftKey(climbUuid: string, angle: number): string {


### PR DESCRIPTION
## Summary
- add a Kilter-focused Instagram posting flow from logbook items and climb details
- keep desktop linking available while adding a guided mobile Post to Instagram handoff
- fix several mobile/local-dev logbook issues and dedupe duplicate Instagram beta videos

## What changed
- added a new mobile Post to Instagram experience for Kilter climbs from You > Logbook
- added the same Instagram/linking entry point from a climb's detail page
- reused the existing Instagram beta-link attach flow so users can come back and paste the live Instagram URL
- polished the Instagram dialog to better match Boardsesh styling and light/dark themes
- improved iPhone clipboard behavior so caption copy happens before handing off to Instagram
- fixed local mobile access to Sessions and Logbook by allowing private LAN dev origins in backend CORS
- improved local mobile backend URL resolution when the app is opened from a laptop LAN IP
- reduced mobile logbook card density so the climb name gets more room
- close the sort popover immediately when selecting a preset sort
- dedupe duplicate Instagram beta videos that resolve to the same underlying Instagram media

## Notes
- desktop still supports linking Instagram URLs without showing the posting flow
- duplicate Instagram videos are now collapsed across climb-detail and beta video surfaces when different URLs point to the same post or reel

## Verification
- bun run typecheck:web
- bun run typecheck:backend
- bun run --cwd packages/web test:run app/lib/__tests__/instagram-posting.test.ts
- bun run --cwd packages/web test:run app/lib/__tests__/instagram-url.test.ts
- bun run --cwd packages/web test:run app/lib/__tests__/backend-url.test.ts
