### PR TITLE
Fix review feedback from PR #1587

### DIFF
--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
-const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/i;
 
 /**
  * Tick status validation schema

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
-const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/i;
+const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)\/?(?:[?#].*)?$/i;
 
 /**
  * Tick status validation schema

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
-const INSTAGRAM_URL_REGEX = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
 
 /**
  * Tick status validation schema

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -52,7 +52,7 @@ export default function PostToInstagramDialog({
 }: PostToInstagramDialogProps) {
   const { showMessage } = useSnackbar();
   const [isLaunching, setIsLaunching] = useState(false);
-  const { data: betaLinks = [], isLoading: betaLinksLoading, isError: betaLinksError } = useQuery<BetaLink[]>({
+  const { data: betaLinks = [], isLoading: betaLinksLoading, isError: betaLinksError, refetch: refetchBetaLinks } = useQuery<BetaLink[]>({
     queryKey: ['betaLinks', item?.boardType, item?.climbUuid],
     queryFn: async () => {
       if (!item) return [];
@@ -311,9 +311,14 @@ export default function PostToInstagramDialog({
                 <CircularProgress size={24} />
               </Box>
             ) : betaLinksError ? (
-              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
-                Couldn&apos;t load beta videos. Check your connection and try again.
-              </Typography>
+              <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Typography variant="body2" color="error">
+                  Couldn&apos;t load beta videos.
+                </Typography>
+                <Button size="small" onClick={() => refetchBetaLinks()}>
+                  Retry
+                </Button>
+              </Box>
             ) : (
               <Box sx={{ mt: 1 }}>
                 <BetaVideos betaLinks={betaLinks} />

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -52,7 +52,7 @@ export default function PostToInstagramDialog({
 }: PostToInstagramDialogProps) {
   const { showMessage } = useSnackbar();
   const [isLaunching, setIsLaunching] = useState(false);
-  const { data: betaLinks = [], isLoading: betaLinksLoading } = useQuery<BetaLink[]>({
+  const { data: betaLinks = [], isLoading: betaLinksLoading, isError: betaLinksError } = useQuery<BetaLink[]>({
     queryKey: ['betaLinks', item?.boardType, item?.climbUuid],
     queryFn: async () => {
       if (!item) return [];
@@ -310,6 +310,10 @@ export default function PostToInstagramDialog({
               <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
                 <CircularProgress size={24} />
               </Box>
+            ) : betaLinksError ? (
+              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+                Couldn&apos;t load beta videos. Check your connection and try again.
+              </Typography>
             ) : (
               <Box sx={{ mt: 1 }}>
                 <BetaVideos betaLinks={betaLinks} />

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -52,7 +52,12 @@ export default function PostToInstagramDialog({
 }: PostToInstagramDialogProps) {
   const { showMessage } = useSnackbar();
   const [isLaunching, setIsLaunching] = useState(false);
-  const { data: betaLinks = [], isLoading: betaLinksLoading, isError: betaLinksError, refetch: refetchBetaLinks } = useQuery<BetaLink[]>({
+  const {
+    data: betaLinks = [],
+    isLoading: betaLinksLoading,
+    isError: betaLinksError,
+    refetch: refetchBetaLinks,
+  } = useQuery<BetaLink[]>({
     queryKey: ['betaLinks', item?.boardType, item?.climbUuid],
     queryFn: async () => {
       if (!item) return [];
@@ -315,7 +320,7 @@ export default function PostToInstagramDialog({
                 <Typography variant="body2" color="error">
                   Couldn&apos;t load beta videos.
                 </Typography>
-                <Button size="small" onClick={() => refetchBetaLinks()}>
+                <Button size="small" onClick={() => { void refetchBetaLinks(); }}>
                   Retry
                 </Button>
               </Box>

--- a/packages/web/app/lib/__tests__/instagram-url.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
-import { dedupeBetaLinks, getInstagramEmbedUrl, getInstagramMediaId } from '../instagram-url';
+import { dedupeBetaLinks, getInstagramEmbedUrl, getInstagramMediaId, isInstagramUrl } from '../instagram-url';
 
 function makeBetaLink(overrides: Partial<BetaLink>): BetaLink {
   return {
@@ -27,6 +27,27 @@ describe('instagram-url', () => {
     );
   });
 
+  describe('isInstagramUrl', () => {
+    it('accepts valid Instagram post and reel URLs', () => {
+      expect(isInstagramUrl('https://www.instagram.com/reel/DJ5Cw5OIS82/')).toBe(true);
+      expect(isInstagramUrl('https://www.instagram.com/p/DEdQNTzScjp/')).toBe(true);
+      expect(isInstagramUrl('https://instagram.com/reel/DJ5Cw5OIS82/')).toBe(true);
+      expect(isInstagramUrl('https://instagr.am/p/DEdQNTzScjp/')).toBe(true);
+    });
+
+    it('rejects URLs that contain instagram.com as a path or query parameter', () => {
+      expect(isInstagramUrl('https://evil.com?ref=instagram.com/reel/ABC')).toBe(false);
+      expect(isInstagramUrl('https://evil.com/redirect?url=https://instagram.com/p/ABC')).toBe(false);
+      expect(isInstagramUrl('https://notinstagram.com/reel/ABC')).toBe(false);
+    });
+
+    it('rejects non-URL strings', () => {
+      expect(isInstagramUrl('instagram.com/reel/ABC')).toBe(false);
+      expect(isInstagramUrl('just some text')).toBe(false);
+      expect(isInstagramUrl('')).toBe(false);
+    });
+  });
+
   it('dedupes beta links that point to the same Instagram media and preserves richer metadata', () => {
     const deduped = dedupeBetaLinks([
       makeBetaLink({
@@ -47,6 +68,25 @@ describe('instagram-url', () => {
     expect(deduped[0]?.foreign_username).toBe('climber');
     expect(deduped[0]?.angle).toBe(35);
     expect(deduped[0]?.thumbnail).toBe('https://cdn.example.com/thumb.jpg');
+  });
+
+  it('keeps first entry metadata when both entries are equally populated', () => {
+    const deduped = dedupeBetaLinks([
+      makeBetaLink({
+        link: 'https://www.instagram.com/reel/DJ5Cw5OIS82/',
+        foreign_username: 'first_climber',
+        angle: 30,
+      }),
+      makeBetaLink({
+        link: 'https://www.instagram.com/p/DJ5Cw5OIS82/',
+        foreign_username: 'second_climber',
+        angle: 40,
+      }),
+    ]);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.foreign_username).toBe('first_climber');
+    expect(deduped[0]?.angle).toBe(30);
   });
 
   it('keeps distinct Instagram media as separate videos', () => {

--- a/packages/web/app/lib/__tests__/instagram-url.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-url.test.ts
@@ -33,6 +33,13 @@ describe('instagram-url', () => {
       expect(isInstagramUrl('https://www.instagram.com/p/DEdQNTzScjp/')).toBe(true);
       expect(isInstagramUrl('https://instagram.com/reel/DJ5Cw5OIS82/')).toBe(true);
       expect(isInstagramUrl('https://instagr.am/p/DEdQNTzScjp/')).toBe(true);
+      expect(isInstagramUrl('https://www.instagram.com/p/DEdQNTzScjp/?img_index=1')).toBe(true);
+      expect(isInstagramUrl('HTTPS://WWW.INSTAGRAM.COM/reel/DJ5Cw5OIS82/')).toBe(true);
+    });
+
+    it('rejects URLs with extra path segments after the media ID', () => {
+      expect(isInstagramUrl('https://instagram.com/reel/ABC/extra-garbage')).toBe(false);
+      expect(isInstagramUrl('https://www.instagram.com/p/ABC/comments')).toBe(false);
     });
 
     it('rejects URLs that contain instagram.com as a path or query parameter', () => {

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -29,6 +29,7 @@ const CLIPBOARD_SETTLE_DELAY_MS = 180;
 function legacyTextareaCopy(text: string): boolean {
   if (typeof document === 'undefined') return false;
 
+  const previouslyFocused = document.activeElement as HTMLElement | null;
   const textarea = document.createElement('textarea');
   textarea.value = text;
   textarea.style.position = 'fixed';
@@ -46,12 +47,14 @@ function legacyTextareaCopy(text: string): boolean {
     return document.execCommand('copy');
   } finally {
     document.body.removeChild(textarea);
+    previouslyFocused?.focus();
   }
 }
 
 function legacyContentEditableCopy(text: string): boolean {
   if (typeof document === 'undefined' || typeof window === 'undefined') return false;
 
+  const previouslyFocused = document.activeElement as HTMLElement | null;
   const container = document.createElement('div');
   container.textContent = text;
   container.contentEditable = 'true';
@@ -77,6 +80,7 @@ function legacyContentEditableCopy(text: string): boolean {
   } finally {
     selection?.removeAllRanges();
     document.body.removeChild(container);
+    previouslyFocused?.focus();
   }
 }
 

--- a/packages/web/app/lib/instagram-url.ts
+++ b/packages/web/app/lib/instagram-url.ts
@@ -1,6 +1,6 @@
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 
-export const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+export const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/i;
 
 export function isInstagramUrl(url: string): boolean {
   return INSTAGRAM_URL_REGEX.test(url);

--- a/packages/web/app/lib/instagram-url.ts
+++ b/packages/web/app/lib/instagram-url.ts
@@ -1,6 +1,6 @@
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 
-export const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/i;
+export const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)\/?(?:[?#].*)?$/i;
 
 export function isInstagramUrl(url: string): boolean {
   return INSTAGRAM_URL_REGEX.test(url);

--- a/packages/web/app/lib/instagram-url.ts
+++ b/packages/web/app/lib/instagram-url.ts
@@ -1,6 +1,6 @@
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 
-export const INSTAGRAM_URL_REGEX = /(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
+export const INSTAGRAM_URL_REGEX = /^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/(?:p|reel|tv)\/([\w-]+)/;
 
 export function isInstagramUrl(url: string): boolean {
   return INSTAGRAM_URL_REGEX.test(url);


### PR DESCRIPTION
- Fix getCompactRelativeTime so plurals compact correctly ("3 years ago" → "3y ago" instead of "3 y ago"); use ^$ anchors instead of \b and capture groups for the number; also map "a few seconds ago" → "now"
- Anchor Instagram URL regex with ^https?:// prefix in both the frontend util and the backend Zod schema to prevent injection bypass via URLs like evil.com?ref=instagram.com/reel/ABC
- Expose isError from the beta-links useQuery in PostToInstagramDialog so a network failure shows an error message instead of silently rendering an empty list
- Restore focus to the previously focused element after legacyTextareaCopy and legacyContentEditableCopy to prevent focus loss in dialogs
- Add isInstagramUrl injection and non-URL tests; add dedup "first entry wins" case to document expected metadata-merge behaviour

https://claude.ai/code/session_01BjC9VS28Nw5SVHA4m7g6LA