### PR TITLE
Add iOS install action card to home landing

### DIFF
--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { ActiveSessionInfo } from '@/app/components/persistent-session/types';
@@ -11,6 +11,15 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn() }),
   usePathname: () => '/',
   useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockIsNativeApp = vi.fn<() => boolean>(() => false);
+const mockIsCapacitorWebView = vi.fn<() => boolean>(() => false);
+const mockWaitForCapacitor = vi.fn<() => Promise<boolean>>(() => Promise.resolve(false));
+vi.mock('@/app/lib/ble/capacitor-utils', () => ({
+  isNativeApp: () => mockIsNativeApp(),
+  isCapacitorWebView: () => mockIsCapacitorWebView(),
+  waitForCapacitor: () => mockWaitForCapacitor(),
 }));
 
 vi.mock('@/app/lib/climb-session-cookie', () => ({
@@ -185,6 +194,82 @@ describe('HomePageContent', () => {
       fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
       expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
       expect(mockPush).toHaveBeenCalledWith('/b/tension-board/-20/list');
+    });
+  });
+
+  describe('install app card', () => {
+    const originalUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent');
+    const ANDROID_UA =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Mobile Safari/537.36';
+    const IOS_SAFARI_UA =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+    function setUserAgent(ua: string) {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: ua,
+        configurable: true,
+      });
+    }
+
+    beforeEach(() => {
+      mockIsNativeApp.mockReturnValue(false);
+      mockIsCapacitorWebView.mockReturnValue(false);
+      mockWaitForCapacitor.mockResolvedValue(false);
+    });
+
+    afterEach(() => {
+      if (originalUA) {
+        Object.defineProperty(window.navigator, 'userAgent', originalUA);
+      }
+    });
+
+    it('shows the iOS App Store CTA on a regular browser', async () => {
+      setUserAgent(IOS_SAFARI_UA);
+      render(<HomePageContent {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/Get the Boardsesh app/i)).toBeTruthy();
+      });
+      expect(
+        screen.getByText(/Lights up holds on your board straight from your phone/i),
+      ).toBeTruthy();
+    });
+
+    it('shows the Android pre-launch sideload CTA on Android UA', async () => {
+      setUserAgent(ANDROID_UA);
+      render(<HomePageContent {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/Android app is almost here/i)).toBeTruthy();
+      });
+      expect(screen.getByText(/Tap to sideload the preview build/i)).toBeTruthy();
+    });
+
+    it('hides the install card once running in the native Capacitor app', async () => {
+      mockIsNativeApp.mockReturnValue(true);
+      render(<HomePageContent {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.queryByText(/Get the Boardsesh app/i)).toBeNull();
+        expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
+      });
+    });
+
+    it('waits for the Capacitor bridge before classifying a WebView as web', async () => {
+      setUserAgent(ANDROID_UA);
+      mockIsCapacitorWebView.mockReturnValue(true);
+      // Simulate the bridge appearing: waitForCapacitor resolves true and
+      // a subsequent isNativeApp() check then returns true.
+      let nativeAfterBridge = false;
+      mockIsNativeApp.mockImplementation(() => nativeAfterBridge);
+      mockWaitForCapacitor.mockImplementation(() => {
+        nativeAfterBridge = true;
+        return Promise.resolve(true);
+      });
+
+      render(<HomePageContent {...defaultProps} />);
+      await waitFor(() => {
+        // Card must not render since we now know we're native.
+        expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
+      });
+      expect(mockWaitForCapacitor).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -215,9 +215,15 @@ describe('HomePageContent', () => {
       mockIsNativeApp.mockReturnValue(false);
       mockIsCapacitorWebView.mockReturnValue(false);
       mockWaitForCapacitor.mockResolvedValue(false);
+      // Freeze Date so pre-/post-launch assertions don't drift once real
+      // time passes ANDROID_LAUNCH_DATE. `toFake: ['Date']` keeps
+      // setTimeout/setInterval real so waitFor still works.
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-04-17T00:00:00Z'));
     });
 
     afterEach(() => {
+      vi.useRealTimers();
       if (originalUA) {
         Object.defineProperty(window.navigator, 'userAgent', originalUA);
       }
@@ -241,6 +247,17 @@ describe('HomePageContent', () => {
         expect(screen.getByText(/Android app is almost here/i)).toBeTruthy();
       });
       expect(screen.getByText(/Tap to sideload the preview build/i)).toBeTruthy();
+    });
+
+    it('switches to the Google Play CTA on Android once the launch date has passed', async () => {
+      vi.setSystemTime(new Date('2026-05-01T00:00:00Z'));
+      setUserAgent(ANDROID_UA);
+      render(<HomePageContent {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/Now on Google Play/i)).toBeTruthy();
+      });
+      expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
+      expect(screen.queryByText(/Tap to sideload the preview build/i)).toBeNull();
     });
 
     it('hides the install card once running in the native Capacitor app', async () => {

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -105,7 +105,7 @@ export const ShareBoardButton = () => {
             <Button
               variant="contained"
               startIcon={<AppleOutlined />}
-              href="https://apps.apple.com/au/app/boardsesh/id6761350784"
+              href="https://apps.apple.com/app/boardsesh/id6761350784"
               target="_blank"
               onClick={() => setUnsupportedOpen(false)}
             >

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -18,6 +18,7 @@ import AndroidOutlined from '@mui/icons-material/Android';
 import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
 import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
+import { useCountdown } from '@/app/lib/hooks/use-countdown';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -148,26 +149,6 @@ function InstallAppShadowCard() {
       </Box>
     </Card>
   );
-}
-
-function useCountdown(target: Date, active: boolean) {
-  const [remaining, setRemaining] = useState(() => Math.max(0, target.getTime() - Date.now()));
-
-  useEffect(() => {
-    if (!active) return;
-    setRemaining(Math.max(0, target.getTime() - Date.now()));
-    const id = setInterval(() => {
-      setRemaining(Math.max(0, target.getTime() - Date.now()));
-    }, 1000);
-    return () => clearInterval(id);
-  }, [active, target]);
-
-  const totalSeconds = Math.floor(remaining / 1000);
-  const days = Math.floor(totalSeconds / 86400);
-  const hours = Math.floor((totalSeconds % 86400) / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  return { days, hours, minutes, seconds, done: remaining <= 0 };
 }
 
 function InstallAppCard({ platform }: { platform: InstallPlatform }) {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -116,7 +116,8 @@ function OnboardingCard({ icon, title, description, onClick }: OnboardingCardPro
   );
 }
 
-const IOS_APP_STORE_URL = 'https://apps.apple.com/au/app/boardsesh/id6761350784';
+const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
+const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
 const ANDROID_LAUNCH_DATE = new Date('2026-04-29T00:00:00Z');
 
 type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
@@ -129,6 +130,7 @@ function InstallAppShadowCard() {
       sx={{
         borderRadius: `${themeTokens.borderRadius.lg}px`,
         border: '1px solid var(--neutral-200)',
+        transition: themeTokens.transitions.fast,
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2, px: 2.5 }}>
@@ -175,14 +177,21 @@ function InstallAppCard({ platform }: { platform: InstallPlatform }) {
   if (platform === 'native') return null;
 
   if (isAndroid) {
-    const description = done
-      ? 'The Android app is live — check Google Play.'
-      : `Landing in ${days}d ${hours}h ${minutes}m ${seconds}s`;
+    if (done) {
+      return (
+        <OnboardingCard
+          icon={<AndroidOutlined />}
+          title="Get the Boardsesh app"
+          description="Now on Google Play"
+          onClick={() => window.open(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer')}
+        />
+      );
+    }
     return (
       <OnboardingCard
         icon={<AndroidOutlined />}
         title="Android app is almost here"
-        description={description}
+        description={`Landing in ${days}d ${hours}h ${minutes}m ${seconds}s`}
         onClick={() => {}}
       />
     );
@@ -215,8 +224,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
       setInstallPlatform('native');
       return;
     }
-    const ua = typeof navigator === 'undefined' ? '' : navigator.userAgent;
-    setInstallPlatform(/Android/i.test(ua) ? 'android-web' : 'other-web');
+    setInstallPlatform(/Android/i.test(navigator.userAgent) ? 'android-web' : 'other-web');
   }, []);
 
   useEffect(() => {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -14,7 +14,7 @@ import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
 import AppleOutlined from '@mui/icons-material/Apple';
-import AndroidOutlined from '@mui/icons-material/Android';
+import AndroidOutlined from '@mui/icons-material/AndroidOutlined';
 import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
 import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -17,7 +17,7 @@ import AppleOutlined from '@mui/icons-material/Apple';
 import AndroidOutlined from '@mui/icons-material/Android';
 import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -118,6 +118,7 @@ function OnboardingCard({ icon, title, description, onClick }: OnboardingCardPro
 
 const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
 const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
+const ANDROID_SIDELOAD_URL = 'https://github.com/boardsesh/boardsesh/releases/tag/android-build-138';
 const ANDROID_LAUNCH_DATE = new Date('2026-04-29T00:00:00Z');
 
 type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
@@ -191,8 +192,8 @@ function InstallAppCard({ platform }: { platform: InstallPlatform }) {
       <OnboardingCard
         icon={<AndroidOutlined />}
         title="Android app is almost here"
-        description={`Landing in ${days}d ${hours}h ${minutes}m ${seconds}s`}
-        onClick={() => {}}
+        description={`Landing in ${days}d ${hours}h ${minutes}m ${seconds}s. Tap to sideload the preview build.`}
+        onClick={() => window.open(ANDROID_SIDELOAD_URL, '_blank', 'noopener,noreferrer')}
       />
     );
   }
@@ -220,11 +221,28 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
   const [installPlatform, setInstallPlatform] = useState<InstallPlatform>('unknown');
 
   useEffect(() => {
+    let cancelled = false;
+    const classifyWeb = () => /Android/i.test(navigator.userAgent) ? 'android-web' : 'other-web';
+
     if (isNativeApp()) {
       setInstallPlatform('native');
       return;
     }
-    setInstallPlatform(/Android/i.test(navigator.userAgent) ? 'android-web' : 'other-web');
+
+    // UA heuristic says we're in a Capacitor WebView but the bridge hasn't
+    // injected window.Capacitor yet. Wait for it before classifying as web,
+    // otherwise native users get stuck with install CTAs.
+    if (isCapacitorWebView()) {
+      waitForCapacitor().then((appeared) => {
+        if (cancelled) return;
+        setInstallPlatform(appeared && isNativeApp() ? 'native' : classifyWeb());
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setInstallPlatform(classifyWeb());
   }, []);
 
   useEffect(() => {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -13,7 +13,11 @@ import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
+import AppleOutlined from '@mui/icons-material/Apple';
+import AndroidOutlined from '@mui/icons-material/Android';
+import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -112,6 +116,88 @@ function OnboardingCard({ icon, title, description, onClick }: OnboardingCardPro
   );
 }
 
+const IOS_APP_STORE_URL = 'https://apps.apple.com/au/app/boardsesh/id6761350784';
+const ANDROID_LAUNCH_DATE = new Date('2026-04-29T00:00:00Z');
+
+type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
+
+function InstallAppShadowCard() {
+  return (
+    <Card
+      variant="outlined"
+      aria-hidden
+      sx={{
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        border: '1px solid var(--neutral-200)',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2, px: 2.5 }}>
+        <Skeleton
+          variant="rounded"
+          width={44}
+          height={44}
+          sx={{ borderRadius: `${themeTokens.borderRadius.md}px`, flexShrink: 0 }}
+        />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Skeleton variant="text" width="60%" height={20} />
+          <Skeleton variant="text" width="85%" height={18} />
+        </Box>
+      </Box>
+    </Card>
+  );
+}
+
+function useCountdown(target: Date, active: boolean) {
+  const [remaining, setRemaining] = useState(() => Math.max(0, target.getTime() - Date.now()));
+
+  useEffect(() => {
+    if (!active) return;
+    setRemaining(Math.max(0, target.getTime() - Date.now()));
+    const id = setInterval(() => {
+      setRemaining(Math.max(0, target.getTime() - Date.now()));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [active, target]);
+
+  const totalSeconds = Math.floor(remaining / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return { days, hours, minutes, seconds, done: remaining <= 0 };
+}
+
+function InstallAppCard({ platform }: { platform: InstallPlatform }) {
+  const isAndroid = platform === 'android-web';
+  const { days, hours, minutes, seconds, done } = useCountdown(ANDROID_LAUNCH_DATE, isAndroid);
+
+  if (platform === 'unknown') return <InstallAppShadowCard />;
+  if (platform === 'native') return null;
+
+  if (isAndroid) {
+    const description = done
+      ? 'The Android app is live — check Google Play.'
+      : `Landing in ${days}d ${hours}h ${minutes}m ${seconds}s`;
+    return (
+      <OnboardingCard
+        icon={<AndroidOutlined />}
+        title="Android app is almost here"
+        description={description}
+        onClick={() => {}}
+      />
+    );
+  }
+
+  return (
+    <OnboardingCard
+      icon={<AppleOutlined />}
+      title="Get the Boardsesh app"
+      description="Lights up holds on your board straight from your phone"
+      onClick={() => window.open(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer')}
+    />
+  );
+}
+
 export default function HomePageContent({ boardConfigs, initialPopularConfigs }: HomePageContentProps) {
   const { status } = useSession();
   const router = useRouter();
@@ -122,6 +208,16 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
   const [seshDrawerMounted, setSeshDrawerMounted] = useState(false);
   const [findClimbersMounted, setFindClimbersMounted] = useState(false);
   const [createBoardMounted, setCreateBoardMounted] = useState(false);
+  const [installPlatform, setInstallPlatform] = useState<InstallPlatform>('unknown');
+
+  useEffect(() => {
+    if (isNativeApp()) {
+      setInstallPlatform('native');
+      return;
+    }
+    const ua = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+    setInstallPlatform(/Android/i.test(ua) ? 'android-web' : 'other-web');
+  }, []);
 
   useEffect(() => {
     if (seshDrawerOpen) setSeshDrawerMounted(true);
@@ -277,6 +373,8 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
           >
             Make it yours
           </Typography>
+
+          <InstallAppCard platform={installPlatform} />
 
           <OnboardingCard
             icon={<WarningAmberOutlined />}

--- a/packages/web/app/lib/hooks/__tests__/use-countdown.test.ts
+++ b/packages/web/app/lib/hooks/__tests__/use-countdown.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCountdown } from '../use-countdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-17T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns all zeros and done=true when inactive', () => {
+    const target = new Date('2026-04-29T00:00:00Z');
+    const { result } = renderHook(() => useCountdown(target, false));
+
+    expect(result.current).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 0, done: true });
+  });
+
+  it('computes initial remaining from target minus now when active', () => {
+    const target = new Date('2026-04-20T03:04:05Z'); // +3d 3h 4m 5s
+    const { result } = renderHook(() => useCountdown(target, true));
+
+    expect(result.current).toEqual({ days: 3, hours: 3, minutes: 4, seconds: 5, done: false });
+  });
+
+  it('decrements each second while active', () => {
+    const target = new Date('2026-04-17T00:00:10Z'); // +10s
+    const { result } = renderHook(() => useCountdown(target, true));
+
+    expect(result.current.seconds).toBe(10);
+    expect(result.current.done).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.seconds).toBe(7);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.seconds).toBe(2);
+  });
+
+  it('clamps to zero and flips done=true at the boundary', () => {
+    const target = new Date('2026-04-17T00:00:02Z'); // +2s
+    const { result } = renderHook(() => useCountdown(target, true));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 0, done: true });
+  });
+
+  it('treats a target already in the past as done from the start', () => {
+    const target = new Date('2026-04-01T00:00:00Z');
+    const { result } = renderHook(() => useCountdown(target, true));
+
+    expect(result.current.done).toBe(true);
+    expect(result.current.days).toBe(0);
+  });
+
+  it('stops scheduling ticks once remaining hits zero', () => {
+    const target = new Date('2026-04-17T00:00:01Z'); // +1s
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+    const { result } = renderHook(() => useCountdown(target, true));
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    const intervalId = setIntervalSpy.mock.results[0].value;
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.done).toBe(true);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+
+    // Further time should not change state (interval is gone).
+    const snapshot = result.current;
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toBe(snapshot);
+  });
+
+  it('does not schedule an interval when inactive', () => {
+    const target = new Date('2026-04-29T00:00:00Z');
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    renderHook(() => useCountdown(target, false));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not schedule an interval when target is already past', () => {
+    const target = new Date('2026-04-01T00:00:00Z');
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    renderHook(() => useCountdown(target, true));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears the interval when active flips false', () => {
+    const target = new Date('2026-04-29T00:00:00Z');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+    const { rerender } = renderHook(({ active }) => useCountdown(target, active), {
+      initialProps: { active: true },
+    });
+    const priorCalls = clearIntervalSpy.mock.calls.length;
+
+    rerender({ active: false });
+    expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(priorCalls);
+  });
+});

--- a/packages/web/app/lib/hooks/use-countdown.ts
+++ b/packages/web/app/lib/hooks/use-countdown.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+export interface Countdown {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  /** True once the target time has been reached. */
+  done: boolean;
+}
+
+/**
+ * Live countdown to `target`. Only schedules a 1s interval when `active`
+ * is true and the target is still in the future — the interval stops
+ * itself the moment remaining hits zero, so a long-mounted card doesn't
+ * re-render every second forever after launch.
+ */
+export function useCountdown(target: Date, active: boolean): Countdown {
+  const [remaining, setRemaining] = useState(() =>
+    active ? Math.max(0, target.getTime() - Date.now()) : 0,
+  );
+
+  useEffect(() => {
+    if (!active) return;
+    const compute = () => Math.max(0, target.getTime() - Date.now());
+    const initial = compute();
+    setRemaining(initial);
+    if (initial === 0) return;
+    const id = setInterval(() => {
+      const next = compute();
+      setRemaining(next);
+      if (next === 0) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [active, target]);
+
+  const totalSeconds = Math.floor(remaining / 1000);
+  return {
+    days: Math.floor(totalSeconds / 86400),
+    hours: Math.floor((totalSeconds % 86400) / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+    done: remaining <= 0,
+  };
+}


### PR DESCRIPTION
Surfaces the App Store link at the top of the "Make it yours" cards so new
users don't have to discover the app through the lightbulb → Bluetooth-unsupported
dialog. Renders a skeleton shadow on SSR and flips once on mount:
Capacitor native users see nothing, Android web gets a live countdown to
the 2026-04-29 launch, everyone else gets the App Store CTA.

https://claude.ai/code/session_01S9ucmcty475hcGnfUxZPv3