### PR TITLE
fix: logbook instagram bugs and code quality issues

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -49,6 +49,16 @@
   --overlay-dark: rgba(0, 0, 0, 0.6);
   --overlay-text: rgba(255, 255, 255, 0.9);
 
+  /* Typography scale (matches themeTokens.typography.fontSize in theme-config.ts) */
+  --font-size-2xs: 8px;
+  --font-size-xs: 12px;
+  --font-size-sm: 14px;
+  --font-size-base: 16px;
+  --font-size-lg: 18px;
+  --font-size-xl: 20px;
+  --font-size-2xl: 24px;
+  --font-size-3xl: 30px;
+
   /* Spacing scale (matches themeTokens.spacing in theme-config.ts) */
   --spacing-1: 4px;
   --spacing-2: 8px;

--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -13,8 +13,8 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding-left: 16px;
-  gap: 8px;
+  padding-left: var(--spacing-4);
+  gap: var(--spacing-2);
   background-color: var(--color-primary);
   opacity: 0;
   will-change: opacity;
@@ -54,7 +54,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding-right: 16px;
+  padding-right: var(--spacing-4);
   background-color: var(--color-success);
   opacity: 0;
   will-change: opacity;
@@ -79,8 +79,8 @@
 .content {
   display: flex;
   align-items: flex-start;
-  padding: 12px 8px;
-  gap: 12px;
+  padding: var(--spacing-3) var(--spacing-2);
+  gap: var(--spacing-3);
 }
 
 /* Thumbnail — 50% larger than the standard 64px via scale transform.
@@ -134,13 +134,13 @@
 }
 
 .statValue {
-  font-size: 14px;
+  font-size: var(--font-size-sm);
   font-weight: 700;
   line-height: 1;
 }
 
 .statLabel {
-  font-size: 8px;
+  font-size: var(--font-size-2xs);
   font-weight: 500;
   line-height: 1;
   letter-spacing: 0.02em;
@@ -211,10 +211,10 @@
 }
 
 .compactStarPicker svg {
-  font-size: 18px !important;
+  font-size: var(--font-size-lg) !important;
 }
 
 /* Full-width comment row below the content row */
 .commentRow {
-  padding: 0 8px 8px;
+  padding: 0 var(--spacing-2) var(--spacing-2);
 }

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -54,6 +54,10 @@ import styles from './logbook-feed-item.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), { ssr: false });
 const PostToInstagramDialog = dynamic(() => import('./post-to-instagram-dialog'), { ssr: false });
+const AttachBetaLinkDialog = dynamic(
+  () => import('@/app/components/beta-videos/attach-beta-link-dialog').then((m) => ({ default: m.AttachBetaLinkDialog })),
+  { ssr: false },
+);
 
 dayjs.extend(relativeTime);
 
@@ -278,6 +282,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
 }) => {
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [instagramDialogOpen, setInstagramDialogOpen] = useState(false);
+  const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
   // --- Edit state ---
   const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -509,6 +514,15 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
     setInstagramDialogOpen(false);
   }, []);
 
+  const handleOpenBetaLink = useCallback(() => {
+    handleCloseActions();
+    setBetaLinkDialogOpen(true);
+  }, [handleCloseActions]);
+
+  const handleCloseBetaLink = useCallback(() => {
+    setBetaLinkDialogOpen(false);
+  }, []);
+
   return (
     <>
       <div className={styles.container}>
@@ -699,7 +713,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
               }}
               sx={{
                 '& .MuiOutlinedInput-root': {
-                  borderRadius: '8px',
+                  borderRadius: `${themeTokens.borderRadius.md}px`,
                   backgroundColor: 'var(--input-bg)',
                   '& .MuiOutlinedInput-notchedOutline': {
                     borderColor: 'var(--neutral-200)',
@@ -778,7 +792,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
             </MenuItem>
           )}
           {allowInstagramLinking && (
-            <MenuItem onClick={handleOpenInstagram}>
+            <MenuItem onClick={handleOpenBetaLink}>
               <ListItemIcon><LinkOutlined fontSize="small" /></ListItemIcon>
               <ListItemText>Link Instagram post</ListItemText>
             </MenuItem>
@@ -796,7 +810,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
         </SwipeableDrawer>
       )}
 
-      {(allowInstagramPosting || allowInstagramLinking) && (
+      {allowInstagramPosting && (
         <PostToInstagramDialog
           open={instagramDialogOpen}
           onClose={handleCloseInstagram}
@@ -806,6 +820,16 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
             climbName: item.climbName,
             angle: item.angle,
           } : null}
+        />
+      )}
+      {allowInstagramLinking && (
+        <AttachBetaLinkDialog
+          open={betaLinkDialogOpen}
+          onClose={handleCloseBetaLink}
+          boardType={item.boardType}
+          climbUuid={item.climbUuid}
+          climbName={item.climbName}
+          angle={item.angle}
         />
       )}
     </>

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -350,16 +350,18 @@ export default function LogbookFeed() {
     benchmarkOnly: filters.benchmarkOnly || undefined,
   }), [filters]);
 
+  const feedQueryKey = useMemo(() => [
+    'logbookFeed',
+    userId,
+    boardTypeParam ?? 'all',
+    selectedLayoutIds?.join(',') ?? 'all-layouts',
+    climbNameParam ?? '',
+    JSON.stringify(activeFilters),
+    JSON.stringify(sortParams),
+  ], [userId, boardTypeParam, selectedLayoutIds, climbNameParam, activeFilters, sortParams]);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
-    queryKey: [
-      'logbookFeed',
-      userId,
-      boardTypeParam ?? 'all',
-      selectedLayoutIds?.join(',') ?? 'all-layouts',
-      climbNameParam ?? '',
-      JSON.stringify(activeFilters),
-      JSON.stringify(sortParams),
-    ],
+    queryKey: feedQueryKey,
     queryFn: async ({ pageParam }) => {
       const client = createGraphQLHttpClient(token ?? null);
       const variables: GetUserAscentsFeedQueryVariables = {
@@ -427,14 +429,12 @@ export default function LogbookFeed() {
     }
 
     // Find and capture the item before removing it from the cache
-    const currentData = queryClient.getQueryData<{ pages: { items: AscentFeedItem[]; hasMore: boolean }[] }>(
-      ['logbookFeed', userId, boardTypeParam ?? 'all', selectedLayoutIds?.join(',') ?? 'all-layouts', climbNameParam ?? '', JSON.stringify(activeFilters), JSON.stringify(sortParams)]
-    );
+    const currentData = queryClient.getQueryData<{ pages: { items: AscentFeedItem[]; hasMore: boolean }[] }>(feedQueryKey);
     const itemToDelete = currentData?.pages.flatMap((p) => p.items).find((i) => i.uuid === uuid);
 
     // Optimistically remove the item from the cache
     queryClient.setQueryData(
-      ['logbookFeed', userId, boardTypeParam ?? 'all', selectedLayoutIds?.join(',') ?? 'all-layouts', climbNameParam ?? '', JSON.stringify(activeFilters), JSON.stringify(sortParams)],
+      feedQueryKey,
       (old: { pages: { items: AscentFeedItem[]; hasMore: boolean }[]; pageParams: number[] } | undefined) => {
         if (!old) return old;
         return {
@@ -477,7 +477,7 @@ export default function LogbookFeed() {
         }
       },
     }, 5000);
-  }, [token, queryClient, showMessage, userId, boardTypeParam, selectedLayoutIds, climbNameParam, activeFilters, sortParams]);
+  }, [token, queryClient, showMessage, feedQueryKey]);
 
   const handleEdit = useCallback((item: AscentFeedItem) => {
     setEditingItemUuid(item.uuid);

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -37,6 +37,16 @@ interface PostToInstagramDialogProps {
   item: InstagramPostingTarget | null;
 }
 
+const BOARD_DISPLAY_NAMES: Record<string, string> = {
+  kilter: 'Kilter',
+  tension: 'Tension',
+  moonboard: 'MoonBoard',
+};
+
+function boardDisplayName(boardType: string): string {
+  return BOARD_DISPLAY_NAMES[boardType] ?? boardType.charAt(0).toUpperCase() + boardType.slice(1);
+}
+
 const instructions = [
   'Copy the caption and open Instagram.',
   'Paste the caption when creating your post.',
@@ -68,6 +78,7 @@ export default function PostToInstagramDialog({
     return buildInstagramCaption({
       climbName: item.climbName,
       angle: item.angle,
+      boardType: item.boardType,
     });
   }, [item]);
 
@@ -172,7 +183,7 @@ export default function PostToInstagramDialog({
             </Box>
 
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-              <Chip size="small" label="Kilter" color="primary" variant="outlined" />
+              <Chip size="small" label={boardDisplayName(item.boardType)} color="primary" variant="outlined" />
               <Chip size="small" label={`${item.angle}°`} variant="outlined" />
               <Chip
                 size="small"

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -20,6 +20,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import {
   buildInstagramCaption,
   copyAndOpenInstagram,
+  getBoardDisplayName,
 } from '@/app/lib/instagram-posting';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -35,16 +36,6 @@ interface PostToInstagramDialogProps {
   open: boolean;
   onClose: () => void;
   item: InstagramPostingTarget | null;
-}
-
-const BOARD_DISPLAY_NAMES: Record<string, string> = {
-  kilter: 'Kilter',
-  tension: 'Tension',
-  moonboard: 'MoonBoard',
-};
-
-function boardDisplayName(boardType: string): string {
-  return BOARD_DISPLAY_NAMES[boardType] ?? boardType.charAt(0).toUpperCase() + boardType.slice(1);
 }
 
 const instructions = [
@@ -183,7 +174,7 @@ export default function PostToInstagramDialog({
             </Box>
 
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-              <Chip size="small" label={boardDisplayName(item.boardType)} color="primary" variant="outlined" />
+              <Chip size="small" label={getBoardDisplayName(item.boardType)} color="primary" variant="outlined" />
               <Chip size="small" label={`${item.angle}°`} variant="outlined" />
               <Chip
                 size="small"

--- a/packages/web/app/lib/__tests__/instagram-posting.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-posting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   buildInstagramCaption,
   copyAndOpenInstagram,
+  getBoardDisplayName,
   getInstagramPostingPlatform,
   isInstagramPostingSupported,
 } from '../instagram-posting';
@@ -87,10 +88,13 @@ describe('instagram-posting', () => {
     });
   });
 
-  it('builds the caption for Kilter (default)', () => {
+  it('builds the Kilter caption when boardType is omitted', () => {
     expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35 })).toBe(
       `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
     );
+  });
+
+  it('builds the Kilter caption when boardType is kilter', () => {
     expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35, boardType: 'kilter' })).toBe(
       `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
     );
@@ -106,6 +110,24 @@ describe('instagram-posting', () => {
     expect(buildInstagramCaption({ climbName: 'Wheel of Fortune', angle: 40, boardType: 'moonboard' })).toBe(
       `"Wheel of Fortune" @ 40° on the MoonBoard.\n@moon_climbing #moonboard`,
     );
+  });
+
+  it('falls back to Kilter caption for an unknown boardType', () => {
+    expect(buildInstagramCaption({ climbName: 'Mystery Route', angle: 50, boardType: 'unknownboard' })).toBe(
+      `"Mystery Route" @ 50° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+    );
+  });
+
+  describe('getBoardDisplayName', () => {
+    it('returns the short display name for known boards', () => {
+      expect(getBoardDisplayName('kilter')).toBe('Kilter');
+      expect(getBoardDisplayName('tension')).toBe('Tension');
+      expect(getBoardDisplayName('moonboard')).toBe('MoonBoard');
+    });
+
+    it('capitalises and returns the raw boardType for unknown boards', () => {
+      expect(getBoardDisplayName('futureboard')).toBe('Futureboard');
+    });
   });
 
   it('detects iPhone web as supported', () => {

--- a/packages/web/app/lib/__tests__/instagram-posting.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-posting.test.ts
@@ -87,9 +87,24 @@ describe('instagram-posting', () => {
     });
   });
 
-  it('builds the exact caption format for Kilter', () => {
+  it('builds the caption for Kilter (default)', () => {
     expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35 })).toBe(
       `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+    );
+    expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35, boardType: 'kilter' })).toBe(
+      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+    );
+  });
+
+  it('builds the caption for Tension', () => {
+    expect(buildInstagramCaption({ climbName: 'High Hopes', angle: 40, boardType: 'tension' })).toBe(
+      `"High Hopes" @ 40° on the Tension Board.\n@tensionclimbing #tensionboard`,
+    );
+  });
+
+  it('builds the caption for MoonBoard', () => {
+    expect(buildInstagramCaption({ climbName: 'Wheel of Fortune', angle: 40, boardType: 'moonboard' })).toBe(
+      `"Wheel of Fortune" @ 40° on the MoonBoard.\n@moon_climbing #moonboard`,
     );
   });
 

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -7,7 +7,14 @@ export type InstagramPostingPlatform = 'ios' | 'android' | 'unsupported';
 export interface InstagramCaptionInput {
   climbName: string;
   angle: number;
+  boardType?: string;
 }
+
+const BOARD_CAPTION_CONFIG: Record<string, { name: string; handle: string; hashtags: string }> = {
+  kilter: { name: 'Kilter Board', handle: '@kilterboard', hashtags: '#kilterboard #kiltergrips' },
+  tension: { name: 'Tension Board', handle: '@tensionclimbing', hashtags: '#tensionboard' },
+  moonboard: { name: 'MoonBoard', handle: '@moon_climbing', hashtags: '#moonboard' },
+};
 
 export interface CopyAndOpenInstagramResult {
   copied: boolean;
@@ -121,8 +128,10 @@ export function isInstagramPostingSupported(): boolean {
 export function buildInstagramCaption({
   climbName,
   angle,
+  boardType = 'kilter',
 }: InstagramCaptionInput): string {
-  return `"${climbName}" @ ${angle}\u00b0 on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`;
+  const config = BOARD_CAPTION_CONFIG[boardType] ?? BOARD_CAPTION_CONFIG.kilter;
+  return `"${climbName}" @ ${angle}\u00b0 on the ${config.name}.\n${config.handle} ${config.hashtags}`;
 }
 
 function getInstagramLaunchUrl(platform: InstagramPostingPlatform): string | null {

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -10,10 +10,10 @@ export interface InstagramCaptionInput {
   boardType?: string;
 }
 
-const BOARD_CAPTION_CONFIG: Record<string, { name: string; handle: string; hashtags: string }> = {
-  kilter: { name: 'Kilter Board', handle: '@kilterboard', hashtags: '#kilterboard #kiltergrips' },
-  tension: { name: 'Tension Board', handle: '@tensionclimbing', hashtags: '#tensionboard' },
-  moonboard: { name: 'MoonBoard', handle: '@moon_climbing', hashtags: '#moonboard' },
+const BOARD_CAPTION_CONFIG: Record<string, { name: string; displayName: string; handle: string; hashtags: string }> = {
+  kilter: { name: 'Kilter Board', displayName: 'Kilter', handle: '@kilterboard', hashtags: '#kilterboard #kiltergrips' },
+  tension: { name: 'Tension Board', displayName: 'Tension', handle: '@tensionclimbing', hashtags: '#tensionboard' },
+  moonboard: { name: 'MoonBoard', displayName: 'MoonBoard', handle: '@moon_climbing', hashtags: '#moonboard' },
 };
 
 export interface CopyAndOpenInstagramResult {
@@ -123,6 +123,12 @@ export function getInstagramPostingPlatform(): InstagramPostingPlatform {
 
 export function isInstagramPostingSupported(): boolean {
   return getInstagramPostingPlatform() !== 'unsupported';
+}
+
+export function getBoardDisplayName(boardType: string): string {
+  const config = BOARD_CAPTION_CONFIG[boardType];
+  if (config) return config.displayName;
+  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
 }
 
 export function buildInstagramCaption({


### PR DESCRIPTION
- Bug 1: 'Link Instagram post' now opens AttachBetaLinkDialog (not PostToInstagramDialog)
- Bug 2/user request: Instagram posting enabled for all boards (Kilter, Tension, MoonBoard) — buildInstagramCaption is now board-aware with per-board handles/hashtags, PostToInstagramDialog shows correct board name chip
- Issue 4: Replace hardcoded px values in logbook-feed-item.module.css with CSS custom properties (--spacing-*, --font-size-*); add font-size tokens to index.css; fix borderRadius '8px' literal in TextField sx to use themeTokens
- Issue 5: Extract feedQueryKey to useMemo in logbook-feed.tsx so getQueryData/setQueryData in handleDelete always stay in sync with the useInfiniteQuery key

https://claude.ai/code/session_01KiEprwkD7wF725djseeXVj