### PR TITLE
Add Search and Bluetooth Quick Start cards to board selector

### DIFF
--- a/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
+++ b/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
+import BoardThumbnailGrid from './board-thumbnail-grid';
+import styles from './board-scroll.module.css';
+
+interface BluetoothQuickStartCardProps {
+  size?: 'default' | 'small';
+}
+
+export default function BluetoothQuickStartCard({ size = 'default' }: BluetoothQuickStartCardProps) {
+  const isSmall = size === 'small';
+  const iconSize = isSmall ? 28 : 36;
+
+  return (
+    <div
+      className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''} ${styles.cardScrollDisabled}`}
+      aria-disabled="true"
+    >
+      <div className={`${styles.cardSquare} ${styles.cardSquareDisabled}`}>
+        <BoardThumbnailGrid />
+        <div className={styles.findNearbyOverlay}>
+          <BluetoothOutlined sx={{ fontSize: iconSize, color: 'var(--neutral-500)' }} />
+        </div>
+      </div>
+      <div className={`${styles.cardName} ${styles.cardNameDisabled}`}>Quick start (coming soon)</div>
+    </div>
+  );
+}

--- a/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
+++ b/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
@@ -16,7 +16,10 @@ export default function BluetoothQuickStartCard({ size = 'default' }: BluetoothQ
   return (
     <div
       className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''} ${styles.cardScrollDisabled}`}
+      role="button"
+      tabIndex={-1}
       aria-disabled="true"
+      aria-label="Bluetooth quick start (coming soon)"
     >
       <div className={`${styles.cardSquare} ${styles.cardSquareDisabled}`}>
         <BoardThumbnailGrid />

--- a/packages/web/app/components/board-scroll/board-discovery-scroll.tsx
+++ b/packages/web/app/components/board-scroll/board-discovery-scroll.tsx
@@ -6,6 +6,9 @@ import BoardScrollSection from './board-scroll-section';
 import BoardScrollCard from './board-scroll-card';
 import FindNearbyCard, { type FindNearbyStatus } from './find-nearby-card';
 import CustomBoardCard from './custom-board-card';
+import SearchBoardsCard from './search-boards-card';
+import BluetoothQuickStartCard from './bluetooth-quick-start-card';
+import BoardSearchDrawer from '../board-search-drawer/board-search-drawer';
 import { useDiscoverBoards } from '@/app/hooks/use-discover-boards';
 import { usePopularBoardConfigs } from '@/app/hooks/use-popular-board-configs';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
@@ -52,6 +55,7 @@ export default function BoardDiscoveryScroll({
   const isAuthenticated = status === 'authenticated';
 
   const [locationEnabled, setLocationEnabled] = useState(false);
+  const [searchDrawerOpen, setSearchDrawerOpen] = useState(false);
   const {
     boards: discoverBoards,
     isLoading: isBoardsLoading,
@@ -61,7 +65,6 @@ export default function BoardDiscoveryScroll({
 
   const {
     configs: popularConfigs,
-    isLoading: isConfigsLoading,
     isLoadingMore,
     hasMore,
     loadMore,
@@ -84,66 +87,90 @@ export default function BoardDiscoveryScroll({
     setLocationEnabled(true);
   }, []);
 
-  const showSection = isBoardsLoading || isConfigsLoading || discoverBoards.length > 0 || popularConfigs.length > 0 || myBoards.length > 0;
+  const handleSearchClick = useCallback(() => {
+    setSearchDrawerOpen(true);
+  }, []);
 
-  if (!showSection) return null;
+  const handleSearchDrawerClose = useCallback(() => {
+    setSearchDrawerOpen(false);
+  }, []);
+
+  const handleSearchDrawerBoardClick = useCallback(
+    (board: UserBoard) => {
+      setSearchDrawerOpen(false);
+      onBoardClick(board);
+    },
+    [onBoardClick],
+  );
 
   return (
-    <BoardScrollSection
-      title="Boards near you"
-      loading={isBoardsLoading && popularConfigs.length === 0 && myBoards.length === 0}
-      onLoadMore={loadMore}
-      hasMore={hasMore}
-      isLoadingMore={isLoadingMore}
-    >
-      {/* Find Nearby + Custom stacked vertically as half-height cards */}
-      {discoverBoards.length === 0 && (
-        <div className={styles.stackedCards}>
-          <FindNearbyCard
-            onClick={handleFindNearbyClick}
-            status={deriveFindNearbyStatus({
-              locationEnabled,
-              isLoading: isBoardsLoading,
-              error: discoverError,
-              hasLocation,
-            })}
-          />
-          <CustomBoardCard onClick={onCustomClick} />
-        </div>
-      )}
-      {discoverBoards.length > 0 && (
-        <>
-          {discoverBoards.map((board) => (
-            <BoardScrollCard
-              key={board.uuid}
-              userBoard={board}
-              selected={selectedBoardUuid === board.uuid}
-              onClick={() => onBoardClick(board)}
+    <>
+      <BoardScrollSection
+        title="Boards near you"
+        loading={isBoardsLoading && popularConfigs.length === 0 && myBoards.length === 0}
+        onLoadMore={loadMore}
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+      >
+        {/* Always-visible 2x2 mini-card cluster: Find Nearby + Search / Custom + Bluetooth */}
+        <div className={styles.stackedCardsDouble}>
+          <div className={styles.stackedCards}>
+            <FindNearbyCard
+              onClick={handleFindNearbyClick}
+              status={deriveFindNearbyStatus({
+                locationEnabled,
+                isLoading: isBoardsLoading,
+                error: discoverError,
+                hasLocation,
+              })}
+              size="small"
             />
-          ))}
-          <CustomBoardCard onClick={onCustomClick} />
-        </>
-      )}
-      {/* My boards - animate in between Custom and Popular */}
-      {myBoards.map((board) => (
-        <div
-          key={board.uuid}
-          className={`${styles.myBoardCardFadeIn} ${myBoardsVisible ? styles.myBoardCardFadeInVisible : ''}`}
-        >
+            <CustomBoardCard onClick={onCustomClick} size="small" />
+          </div>
+          <div className={styles.stackedCards}>
+            <SearchBoardsCard onClick={handleSearchClick} size="small" />
+            <BluetoothQuickStartCard size="small" />
+          </div>
+        </div>
+
+        {/* Nearby boards (if any) */}
+        {discoverBoards.map((board) => (
           <BoardScrollCard
+            key={board.uuid}
             userBoard={board}
             selected={selectedBoardUuid === board.uuid}
             onClick={() => onBoardClick(board)}
           />
-        </div>
-      ))}
-      {popularConfigs.map((config) => (
-        <BoardScrollCard
-          key={`${config.boardType}-${config.layoutId}-${config.sizeId}`}
-          popularConfig={config}
-          onClick={() => onConfigClick(config)}
-        />
-      ))}
-    </BoardScrollSection>
+        ))}
+
+        {/* My boards - animate in between cluster and popular */}
+        {myBoards.map((board) => (
+          <div
+            key={board.uuid}
+            className={`${styles.myBoardCardFadeIn} ${myBoardsVisible ? styles.myBoardCardFadeInVisible : ''}`}
+          >
+            <BoardScrollCard
+              userBoard={board}
+              selected={selectedBoardUuid === board.uuid}
+              onClick={() => onBoardClick(board)}
+            />
+          </div>
+        ))}
+
+        {popularConfigs.map((config) => (
+          <BoardScrollCard
+            key={`${config.boardType}-${config.layoutId}-${config.sizeId}`}
+            popularConfig={config}
+            onClick={() => onConfigClick(config)}
+          />
+        ))}
+      </BoardScrollSection>
+
+      <BoardSearchDrawer
+        open={searchDrawerOpen}
+        onClose={handleSearchDrawerClose}
+        onBoardOpen={handleSearchDrawerBoardClick}
+      />
+    </>
   );
 }

--- a/packages/web/app/components/board-scroll/board-scroll.module.css
+++ b/packages/web/app/components/board-scroll/board-scroll.module.css
@@ -191,6 +191,29 @@
   height: calc(182px + 8px + 18px + 16px);
 }
 
+/* Two-column variant: 4 cards in a 2x2 cluster */
+.stackedCardsDouble {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  flex-shrink: 0;
+  scroll-snap-align: start;
+  height: calc(182px + 8px + 18px + 16px);
+}
+
+.stackedCardsDouble .stackedCards {
+  height: 100%;
+}
+
+/* Disabled card (Bluetooth coming soon) */
+.cardScrollDisabled {
+  cursor: default;
+}
+
+.cardScrollDisabled:active .cardSquare::after {
+  display: none;
+}
+
 .stackedCards .cardScroll {
   width: 100%;
   flex: 1;
@@ -227,6 +250,10 @@
 @media (min-width: 768px) {
   .stackedCards {
     width: 120px;
+    height: calc(208px + 8px + 18px + 16px);
+  }
+
+  .stackedCardsDouble {
     height: calc(208px + 8px + 18px + 16px);
   }
 }

--- a/packages/web/app/components/board-scroll/board-scroll.module.css
+++ b/packages/web/app/components/board-scroll/board-scroll.module.css
@@ -179,26 +179,28 @@
   opacity: 0.35;
 }
 
-/* Stacked cards - Find Nearby + Custom stacked vertically */
-.stackedCards {
+/* Stacked-card layouts share a height that mirrors a normal card:
+   square image + 8px margin + ~18px name + ~16px meta. Both the single-
+   column (.stackedCards) and the 2x2 cluster (.stackedCardsDouble) reuse it. */
+.stackedCards,
+.stackedCardsDouble {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
   flex-shrink: 0;
   scroll-snap-align: start;
-  width: 100px;
-  /* Match the height of a normal card: square image + 8px margin + ~18px name + ~16px meta */
   height: calc(182px + 8px + 18px + 16px);
+}
+
+/* Stacked cards - Find Nearby + Custom stacked vertically */
+.stackedCards {
+  flex-direction: column;
+  gap: 6px;
+  width: 100px;
 }
 
 /* Two-column variant: 4 cards in a 2x2 cluster */
 .stackedCardsDouble {
-  display: flex;
   flex-direction: row;
   gap: 6px;
-  flex-shrink: 0;
-  scroll-snap-align: start;
-  height: calc(182px + 8px + 18px + 16px);
 }
 
 .stackedCardsDouble .stackedCards {
@@ -248,13 +250,13 @@
 
 /* Desktop stacked */
 @media (min-width: 768px) {
-  .stackedCards {
-    width: 120px;
+  .stackedCards,
+  .stackedCardsDouble {
     height: calc(208px + 8px + 18px + 16px);
   }
 
-  .stackedCardsDouble {
-    height: calc(208px + 8px + 18px + 16px);
+  .stackedCards {
+    width: 120px;
   }
 }
 

--- a/packages/web/app/components/board-scroll/board-thumbnail-grid.tsx
+++ b/packages/web/app/components/board-scroll/board-thumbnail-grid.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { getBoardDetails } from '@/app/lib/board-constants';
+import BoardRenderer from '../board-renderer/board-renderer';
+import styles from './board-scroll.module.css';
+
+const GRID_CONFIGS = [
+  { board_name: 'kilter' as const, layout_id: 1, size_id: 10, set_ids: [1, 20] },
+  { board_name: 'tension' as const, layout_id: 10, size_id: 6, set_ids: [12, 13] },
+  { board_name: 'kilter' as const, layout_id: 8, size_id: 17, set_ids: [26] },
+  { board_name: 'tension' as const, layout_id: 9, size_id: 3, set_ids: [8, 9] },
+];
+
+export default function BoardThumbnailGrid() {
+  const boardDetailsList = useMemo(
+    () =>
+      GRID_CONFIGS.map((config) => {
+        try {
+          return getBoardDetails(config);
+        } catch {
+          return null;
+        }
+      }),
+    [],
+  );
+
+  return (
+    <div className={styles.customBoardGrid}>
+      {boardDetailsList.map((details, i) => (
+        <div key={i} className={styles.customBoardGridCell}>
+          {details && <BoardRenderer mirrored={false} boardDetails={details} thumbnail fillHeight />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/app/components/board-scroll/board-thumbnail-grid.tsx
+++ b/packages/web/app/components/board-scroll/board-thumbnail-grid.tsx
@@ -16,10 +16,11 @@ export default function BoardThumbnailGrid() {
   const boardDetailsList = useMemo(
     () =>
       GRID_CONFIGS.map((config) => {
+        const key = `${config.board_name}-${config.layout_id}-${config.size_id}`;
         try {
-          return getBoardDetails(config);
+          return { key, details: getBoardDetails(config) };
         } catch {
-          return null;
+          return { key, details: null };
         }
       }),
     [],
@@ -27,8 +28,8 @@ export default function BoardThumbnailGrid() {
 
   return (
     <div className={styles.customBoardGrid}>
-      {boardDetailsList.map((details, i) => (
-        <div key={i} className={styles.customBoardGridCell}>
+      {boardDetailsList.map(({ key, details }) => (
+        <div key={key} className={styles.customBoardGridCell}>
           {details && <BoardRenderer mirrored={false} boardDetails={details} thumbnail fillHeight />}
         </div>
       ))}

--- a/packages/web/app/components/board-scroll/custom-board-card.tsx
+++ b/packages/web/app/components/board-scroll/custom-board-card.tsx
@@ -14,8 +14,22 @@ export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoa
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <div className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={onClick}>
+    <div
+      className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label="Build a custom board"
+    >
       <div className={styles.cardSquare}>
         <BoardThumbnailGrid />
         <div className={styles.findNearbyOverlay}>

--- a/packages/web/app/components/board-scroll/find-nearby-card.tsx
+++ b/packages/web/app/components/board-scroll/find-nearby-card.tsx
@@ -60,8 +60,24 @@ export default function FindNearbyCard({ onClick, status = 'idle', size = 'defau
       break;
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isError) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <div className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={isError ? undefined : onClick}>
+    <div
+      className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`}
+      onClick={isError ? undefined : onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={isError ? -1 : 0}
+      aria-label={label}
+      aria-disabled={isError || undefined}
+    >
       <div className={`${styles.cardSquare} ${isError ? styles.cardSquareDisabled : ''}`}>
         <div className={styles.findNearbyBoard}>
           <BoardRenderer

--- a/packages/web/app/components/board-scroll/search-boards-card.tsx
+++ b/packages/web/app/components/board-scroll/search-boards-card.tsx
@@ -14,8 +14,22 @@ export default function SearchBoardsCard({ onClick, size = 'default' }: SearchBo
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <div className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={onClick}>
+    <div
+      className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label="Search for a board"
+    >
       <div className={styles.cardSquare}>
         <BoardThumbnailGrid />
         <div className={styles.findNearbyOverlay}>

--- a/packages/web/app/components/board-scroll/search-boards-card.tsx
+++ b/packages/web/app/components/board-scroll/search-boards-card.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import React from 'react';
-import AddOutlined from '@mui/icons-material/AddOutlined';
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import BoardThumbnailGrid from './board-thumbnail-grid';
 import styles from './board-scroll.module.css';
 
-interface CustomBoardCardProps {
+interface SearchBoardsCardProps {
   onClick: () => void;
   size?: 'default' | 'small';
 }
 
-export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoardCardProps) {
+export default function SearchBoardsCard({ onClick, size = 'default' }: SearchBoardsCardProps) {
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
@@ -19,10 +19,10 @@ export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoa
       <div className={styles.cardSquare}>
         <BoardThumbnailGrid />
         <div className={styles.findNearbyOverlay}>
-          <AddOutlined sx={{ fontSize: iconSize, color: 'var(--color-primary)' }} />
+          <SearchOutlined sx={{ fontSize: iconSize, color: 'var(--color-primary)' }} />
         </div>
       </div>
-      <div className={styles.cardName}>Custom board</div>
+      <div className={styles.cardName}>Search</div>
     </div>
   );
 }

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// --- Mocks (declared before the import that pulls them in) ---
+
+const mockRequestPermission = vi.fn();
+let mockUserCoords: { latitude: number; longitude: number; accuracy: number } | null = null;
+
+vi.mock('@/app/hooks/use-geolocation', () => ({
+  useGeolocation: () => ({
+    coordinates: mockUserCoords,
+    error: null,
+    loading: false,
+    permissionState: null,
+    requestPermission: mockRequestPermission,
+    refresh: vi.fn(),
+  }),
+}));
+
+interface SearchBoardsMapInputCapture {
+  query: string;
+  latitude: number | null;
+  longitude: number | null;
+  zoom: number;
+  enabled: boolean;
+}
+let lastSearchInput: SearchBoardsMapInputCapture | null = null;
+let mockBoards: UserBoard[] = [];
+const mockFetchNextPage = vi.fn();
+
+vi.mock('@/app/hooks/use-search-boards-map', () => ({
+  useSearchBoardsMap: (input: SearchBoardsMapInputCapture) => {
+    lastSearchInput = input;
+    return {
+      boards: mockBoards,
+      isLoading: false,
+      isFetching: false,
+      hasMore: false,
+      isFetchingNextPage: false,
+      fetchNextPage: mockFetchNextPage,
+      radiusKm: 20,
+    };
+  },
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+}));
+
+vi.mock('@/app/components/board-entity/board-card', () => ({
+  default: ({ board, onClick, trailingAction }: {
+    board: UserBoard;
+    onClick?: (b: UserBoard) => void;
+    trailingAction?: React.ReactNode;
+  }) => (
+    <div data-testid={`board-card-${board.uuid}`} onClick={() => onClick?.(board)}>
+      <div>{board.name}</div>
+      {trailingAction}
+    </div>
+  ),
+}));
+
+vi.mock('@/app/components/ui/follow-button', () => ({
+  default: () => <div data-testid="follow-button" />,
+}));
+
+vi.mock('../board-search-map', () => ({
+  default: ({ onViewportChange }: {
+    onViewportChange: (v: { lat: number; lng: number; zoom: number }) => void;
+  }) => (
+    <div
+      data-testid="board-search-map"
+      onClick={() => onViewportChange({ lat: 51.5, lng: -0.1, zoom: 12 })}
+    />
+  ),
+}));
+
+vi.mock('@/app/lib/graphql/operations', () => ({
+  FOLLOW_BOARD: 'FOLLOW_BOARD',
+  UNFOLLOW_BOARD: 'UNFOLLOW_BOARD',
+}));
+
+// --- Import under test ---
+
+import BoardSearchDrawer from '../board-search-drawer';
+
+function makeBoard(uuid: string, overrides: Partial<UserBoard> = {}): UserBoard {
+  return {
+    uuid,
+    name: `Board ${uuid}`,
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 1,
+    setIds: '1',
+    angle: 40,
+    totalAscents: 0,
+    slug: `kilter/1/1/1`,
+    locationName: null,
+    latitude: 51.5,
+    longitude: -0.1,
+    isFollowedByMe: false,
+    ownerId: 'owner-1',
+    isPublic: true,
+    isOwned: false,
+    isAngleAdjustable: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    ...overrides,
+  } as UserBoard;
+}
+
+describe('BoardSearchDrawer', () => {
+  beforeEach(() => {
+    mockRequestPermission.mockReset();
+    mockFetchNextPage.mockReset();
+    mockUserCoords = null;
+    mockBoards = [];
+    lastSearchInput = null;
+  });
+
+  it('does not request geolocation while the drawer is closed', () => {
+    render(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    expect(mockRequestPermission).not.toHaveBeenCalled();
+  });
+
+  it('requests geolocation exactly once on the first open', () => {
+    const { rerender } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+
+    // Re-rendering while still open must not re-fire the prompt
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-requests geolocation when the drawer is reopened (requestedGeo resets on close)', () => {
+    const { rerender } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+
+    rerender(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes null coords to the hook until the user pans or geolocation resolves', () => {
+    render(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    expect(lastSearchInput).not.toBeNull();
+    expect(lastSearchInput!.latitude).toBeNull();
+    expect(lastSearchInput!.longitude).toBeNull();
+    expect(lastSearchInput!.enabled).toBe(true);
+  });
+
+  it('forwards real coords once the map reports a viewport change', () => {
+    render(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('board-search-map'));
+    expect(lastSearchInput!.latitude).toBe(51.5);
+    expect(lastSearchInput!.longitude).toBe(-0.1);
+    expect(lastSearchInput!.zoom).toBe(12);
+  });
+
+  it('clears the typed query when the drawer closes', () => {
+    mockBoards = [makeBoard('b1')];
+
+    const { rerender, container } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'kilter' } });
+    });
+    expect(lastSearchInput!.query).toBe('kilter');
+
+    // Close and reopen — query should be empty
+    rerender(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+
+    expect(lastSearchInput!.query).toBe('');
+  });
+
+  it('invokes onBoardOpen when the Open button on a selected board is clicked', () => {
+    mockBoards = [makeBoard('b1')];
+    const onBoardOpen = vi.fn();
+
+    render(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={onBoardOpen} />);
+
+    // Click the card to select it
+    fireEvent.click(screen.getByTestId('board-card-b1'));
+
+    // The Open button is rendered for the selected board
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+
+    expect(onBoardOpen).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'b1' }));
+  });
+});

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -61,18 +61,26 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     setZoom((prev) => (prev === DEFAULT_ZOOM ? NEARBY_ZOOM : prev));
   }, [userCoords]);
 
-  // Reset selection + query each time the drawer is closed
+  // Reset transient drawer state each time the drawer is closed. Clearing
+  // requestedGeo lets us retry the permission prompt if the user denied it
+  // last time (e.g. after they grant it in site settings).
   useEffect(() => {
     if (!open) {
       setSelectedBoardUuid(null);
       setQuery('');
+      setRequestedGeo(false);
     }
   }, [open]);
 
+  // While the drawer is still at the default world-view fallback, don't fire a
+  // coordinate-based search — the 300 km bucket at zoom 3 would surface a
+  // cluster of boards in Kansas to every user until geolocation resolves.
+  const hasResolvedLocation = center.lat !== DEFAULT_CENTER.lat || center.lng !== DEFAULT_CENTER.lng;
+
   const { boards, isLoading, isFetching, radiusKm, hasMore, isFetchingNextPage, fetchNextPage } = useSearchBoardsMap({
     query,
-    latitude: center.lat,
-    longitude: center.lng,
+    latitude: hasResolvedLocation ? center.lat : null,
+    longitude: hasResolvedLocation ? center.lng : null,
     zoom,
     enabled: open,
   });
@@ -150,7 +158,6 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
           <TextField
             fullWidth
             size="small"
-            autoFocus
             placeholder="Search boards by name or location"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -222,7 +229,6 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                 px: 2,
                 py: 1.5,
                 scrollSnapType: 'x proximity',
-                WebkitOverflowScrolling: 'touch',
                 scrollbarWidth: 'none',
                 '&::-webkit-scrollbar': { display: 'none' },
               }}

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -66,12 +66,17 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
 
   // Reset transient drawer state each time the drawer is closed. Clearing
   // requestedGeo lets us retry the permission prompt if the user denied it
-  // last time (e.g. after they grant it in site settings).
+  // last time (e.g. after they grant it in site settings). Resetting the
+  // viewport ensures the next open either auto-centers on the user's
+  // location (if granted) or shows the world fallback — not a half-panned
+  // state left over from the previous session.
   useEffect(() => {
     if (!open) {
       setSelectedBoardUuid(null);
       setQuery('');
       setRequestedGeo(false);
+      setCenter(DEFAULT_CENTER);
+      setZoom(DEFAULT_ZOOM);
     }
   }, [open]);
 
@@ -196,6 +201,8 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
             zoom={zoom}
             boards={boards}
             selectedBoardUuid={selectedBoardUuid}
+            userCoords={userCoords}
+            requestPermission={requestPermission}
             onBoardClick={handleMarkerClick}
             onViewportChange={handleViewportChange}
           />

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -22,9 +22,12 @@ import { themeTokens } from '@/app/theme/theme-config';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import BoardSearchMap from './board-search-map';
 
-const DEFAULT_CENTER = { lat: 40, lng: -95 };
+const DEFAULT_CENTER = { lat: 20, lng: 0 }; // World view — neutral starting point until geolocation resolves
 const DEFAULT_ZOOM = 3;
 const NEARBY_ZOOM = 11; // ~20 km radius via the zoomToRadiusKm table
+const CAROUSEL_CARD_WIDTH = 280; // Empirically picked to fit the BoardCard layout without truncation
+const CAROUSEL_LOAD_INDICATOR_WIDTH = 80;
+const INFINITE_SCROLL_THRESHOLD = 300; // Trigger fetchNextPage when within this many px of the right edge
 
 interface BoardSearchDrawerProps {
   open: boolean;
@@ -94,7 +97,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
       if (!hasMore || isFetchingNextPage) return;
       const el = e.currentTarget;
       const remaining = el.scrollWidth - (el.scrollLeft + el.clientWidth);
-      if (remaining < 300) fetchNextPage();
+      if (remaining < INFINITE_SCROLL_THRESHOLD) fetchNextPage();
     },
     [hasMore, isFetchingNextPage, fetchNextPage],
   );
@@ -240,7 +243,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                     key={board.uuid}
                     ref={setCardRef(board.uuid)}
                     sx={{
-                      width: 280,
+                      width: CAROUSEL_CARD_WIDTH,
                       flexShrink: 0,
                       scrollSnapAlign: 'start',
                       outline: isSelected ? `2px solid var(--color-primary)` : 'none',
@@ -287,7 +290,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    width: 80,
+                    width: CAROUSEL_LOAD_INDICATOR_WIDTH,
                     flexShrink: 0,
                   }}
                 >

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Button from '@mui/material/Button';
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import OpenInNewOutlined from '@mui/icons-material/OpenInNewOutlined';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import BoardCard from '@/app/components/board-entity/board-card';
+import FollowButton from '@/app/components/ui/follow-button';
+import { useGeolocation } from '@/app/hooks/use-geolocation';
+import { useSearchBoardsMap } from '@/app/hooks/use-search-boards-map';
+import { FOLLOW_BOARD, UNFOLLOW_BOARD } from '@/app/lib/graphql/operations';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import BoardSearchMap from './board-search-map';
+
+const DEFAULT_CENTER = { lat: 40, lng: -95 };
+const DEFAULT_ZOOM = 3;
+const NEARBY_ZOOM = 11; // ~20 km radius via the zoomToRadiusKm table
+
+interface BoardSearchDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  onBoardOpen: (board: UserBoard) => void;
+}
+
+export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardSearchDrawerProps) {
+  const { coordinates: userCoords, requestPermission } = useGeolocation();
+
+  const [query, setQuery] = useState('');
+  const [center, setCenter] = useState(DEFAULT_CENTER);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [selectedBoardUuid, setSelectedBoardUuid] = useState<string | null>(null);
+  const [requestedGeo, setRequestedGeo] = useState(false);
+
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Ask for the user's location on first open. If granted we'll recenter to ~20km view.
+  useEffect(() => {
+    if (!open || requestedGeo) return;
+    setRequestedGeo(true);
+    requestPermission();
+  }, [open, requestedGeo, requestPermission]);
+
+  useEffect(() => {
+    if (!userCoords) return;
+    setCenter((prev) => {
+      // Only auto-center if we're still at the default world view
+      if (prev.lat !== DEFAULT_CENTER.lat || prev.lng !== DEFAULT_CENTER.lng) return prev;
+      return { lat: userCoords.latitude, lng: userCoords.longitude };
+    });
+    setZoom((prev) => (prev === DEFAULT_ZOOM ? NEARBY_ZOOM : prev));
+  }, [userCoords]);
+
+  // Reset selection + query each time the drawer is closed
+  useEffect(() => {
+    if (!open) {
+      setSelectedBoardUuid(null);
+      setQuery('');
+    }
+  }, [open]);
+
+  const { boards, isLoading, isFetching, radiusKm } = useSearchBoardsMap({
+    query,
+    latitude: center.lat,
+    longitude: center.lng,
+    zoom,
+    enabled: open,
+  });
+
+  const handleViewportChange = useCallback(
+    ({ lat, lng, zoom: z }: { lat: number; lng: number; zoom: number }) => {
+      setCenter({ lat, lng });
+      setZoom(z);
+    },
+    [],
+  );
+
+  const scrollCardIntoView = useCallback((uuid: string) => {
+    const node = cardRefs.current.get(uuid);
+    if (!node) return;
+    node.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+  }, []);
+
+  const handleMarkerClick = useCallback(
+    (board: UserBoard) => {
+      setSelectedBoardUuid(board.uuid);
+      // Defer scroll so the new layout (if expanded) settles first
+      requestAnimationFrame(() => scrollCardIntoView(board.uuid));
+    },
+    [scrollCardIntoView],
+  );
+
+  const handleCardClick = useCallback((board: UserBoard) => {
+    setSelectedBoardUuid(board.uuid);
+    if (board.latitude != null && board.longitude != null) {
+      setCenter({ lat: board.latitude, lng: board.longitude });
+      // Keep zoom — user's spatial context shouldn't jump
+    }
+  }, []);
+
+  const handleOpenBoard = useCallback(
+    (board: UserBoard) => {
+      onBoardOpen(board);
+    },
+    [onBoardOpen],
+  );
+
+  const setCardRef = useCallback(
+    (uuid: string) => (node: HTMLDivElement | null) => {
+      if (node) cardRefs.current.set(uuid, node);
+      else cardRefs.current.delete(uuid);
+    },
+    [],
+  );
+
+  const radiusLabel = useMemo(() => `${radiusKm} km`, [radiusKm]);
+  const showSpinner = isLoading || (isFetching && boards.length === 0);
+
+  return (
+    <SwipeableDrawer
+      placement="bottom"
+      open={open}
+      onClose={onClose}
+      title="Find a board"
+      fullHeight
+      height="100dvh"
+      showCloseButton
+      showCloseButtonOnMobile
+      styles={{ body: { padding: 0 } }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {/* Search bar */}
+        <Box sx={{ px: 2, pt: 1.5, pb: 1, borderBottom: '1px solid var(--neutral-200)' }}>
+          <TextField
+            fullWidth
+            size="small"
+            autoFocus
+            placeholder="Search boards by name or location"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchOutlined fontSize="small" color="action" />
+                  </InputAdornment>
+                ),
+                endAdornment: query ? (
+                  <InputAdornment position="end">
+                    <IconButton size="small" onClick={() => setQuery('')} aria-label="Clear">
+                      <CloseOutlined fontSize="small" />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          />
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 0.75 }}>
+            <Typography variant="caption" color="text.secondary">
+              Showing boards within {radiusLabel} of map center
+            </Typography>
+            {isFetching && boards.length > 0 && <CircularProgress size={14} />}
+          </Box>
+        </Box>
+
+        {/* Map */}
+        <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
+          <BoardSearchMap
+            center={center}
+            zoom={zoom}
+            boards={boards}
+            selectedBoardUuid={selectedBoardUuid}
+            onBoardClick={handleMarkerClick}
+            onViewportChange={handleViewportChange}
+          />
+        </Box>
+
+        {/* Results carousel */}
+        <Box
+          sx={{
+            borderTop: '1px solid var(--neutral-200)',
+            backgroundColor: 'var(--semantic-background)',
+            flexShrink: 0,
+          }}
+        >
+          {showSpinner ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
+              <CircularProgress size={20} />
+            </Box>
+          ) : boards.length === 0 ? (
+            <Box sx={{ py: 3, textAlign: 'center', px: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                {query.trim().length >= 2
+                  ? `No boards match "${query.trim()}" here. Try zooming out or searching elsewhere.`
+                  : 'No boards in this area. Pan or zoom out to find more.'}
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              ref={carouselRef}
+              sx={{
+                display: 'flex',
+                gap: 1.5,
+                overflowX: 'auto',
+                px: 2,
+                py: 1.5,
+                scrollSnapType: 'x proximity',
+                WebkitOverflowScrolling: 'touch',
+                scrollbarWidth: 'none',
+                '&::-webkit-scrollbar': { display: 'none' },
+              }}
+            >
+              {boards.map((board) => {
+                const isSelected = board.uuid === selectedBoardUuid;
+                return (
+                  <Box
+                    key={board.uuid}
+                    ref={setCardRef(board.uuid)}
+                    sx={{
+                      width: 280,
+                      flexShrink: 0,
+                      scrollSnapAlign: 'start',
+                      outline: isSelected ? `2px solid var(--color-primary)` : 'none',
+                      borderRadius: `${themeTokens.borderRadius.lg}px`,
+                      transition: themeTokens.transitions.fast,
+                    }}
+                  >
+                    <BoardCard
+                      board={board}
+                      onClick={handleCardClick}
+                      trailingAction={
+                        isSelected ? (
+                          <Stack direction="row" spacing={1} alignItems="center">
+                            <FollowButton
+                              entityId={board.uuid}
+                              initialIsFollowing={board.isFollowedByMe}
+                              followMutation={FOLLOW_BOARD}
+                              unfollowMutation={UNFOLLOW_BOARD}
+                              entityLabel="board"
+                              getFollowVariables={(id) => ({ input: { boardUuid: id } })}
+                            />
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<OpenInNewOutlined />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleOpenBoard(board);
+                              }}
+                              sx={{ textTransform: 'none' }}
+                            >
+                              Open
+                            </Button>
+                          </Stack>
+                        ) : undefined
+                      }
+                    />
+                  </Box>
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </SwipeableDrawer>
+  );
+}

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -69,13 +69,27 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     }
   }, [open]);
 
-  const { boards, isLoading, isFetching, radiusKm } = useSearchBoardsMap({
+  const { boards, isLoading, isFetching, radiusKm, hasMore, isFetchingNextPage, fetchNextPage } = useSearchBoardsMap({
     query,
     latitude: center.lat,
     longitude: center.lng,
     zoom,
     enabled: open,
   });
+
+  // Infinite scroll inside the horizontal carousel: load the next page when the
+  // user scrolls within 300px of the right edge. We can't reuse the shared
+  // `useInfiniteScroll` hook here because it observes against the viewport,
+  // whereas the sentinel lives inside an overflow:auto horizontal container.
+  const handleCarouselScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      if (!hasMore || isFetchingNextPage) return;
+      const el = e.currentTarget;
+      const remaining = el.scrollWidth - (el.scrollLeft + el.clientWidth);
+      if (remaining < 300) fetchNextPage();
+    },
+    [hasMore, isFetchingNextPage, fetchNextPage],
+  );
 
   const handleViewportChange = useCallback(
     ({ lat, lng, zoom: z }: { lat: number; lng: number; zoom: number }) => {
@@ -108,13 +122,6 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     }
   }, []);
 
-  const handleOpenBoard = useCallback(
-    (board: UserBoard) => {
-      onBoardOpen(board);
-    },
-    [onBoardOpen],
-  );
-
   const setCardRef = useCallback(
     (uuid: string) => (node: HTMLDivElement | null) => {
       if (node) cardRefs.current.set(uuid, node);
@@ -123,7 +130,6 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     [],
   );
 
-  const radiusLabel = useMemo(() => `${radiusKm} km`, [radiusKm]);
   const showSpinner = isLoading || (isFetching && boards.length === 0);
 
   return (
@@ -167,7 +173,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
           />
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 0.75 }}>
             <Typography variant="caption" color="text.secondary">
-              Showing boards within {radiusLabel} of map center
+              Showing boards within {radiusKm} km of map center
             </Typography>
             {isFetching && boards.length > 0 && <CircularProgress size={14} />}
           </Box>
@@ -208,6 +214,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
           ) : (
             <Box
               ref={carouselRef}
+              onScroll={handleCarouselScroll}
               sx={{
                 display: 'flex',
                 gap: 1.5,
@@ -255,7 +262,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                               startIcon={<OpenInNewOutlined />}
                               onClick={(e) => {
                                 e.stopPropagation();
-                                handleOpenBoard(board);
+                                onBoardOpen(board);
                               }}
                               sx={{ textTransform: 'none' }}
                             >
@@ -268,6 +275,19 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                   </Box>
                 );
               })}
+              {isFetchingNextPage && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 80,
+                    flexShrink: 0,
+                  }}
+                >
+                  <CircularProgress size={20} />
+                </Box>
+              )}
             </Box>
           )}
         </Box>

--- a/packages/web/app/components/board-search-drawer/board-search-map.module.css
+++ b/packages/web/app/components/board-search-drawer/board-search-map.module.css
@@ -1,0 +1,17 @@
+/* Map markers — sized inline by Leaflet's iconSize prop, but coloured /
+   bordered / shadowed via design-token-driven CSS variables. */
+
+.marker {
+  width: 16px;
+  height: 16px;
+  background: var(--color-primary);
+  border: 3px solid var(--semantic-surface);
+  border-radius: 50%;
+  box-shadow: var(--shadow-sm);
+}
+
+.markerSelected {
+  width: 22px;
+  height: 22px;
+  border-width: 4px;
+}

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -6,7 +6,6 @@ import MuiButton from '@mui/material/Button';
 import MyLocationOutlined from '@mui/icons-material/MyLocationOutlined';
 import type { Map as LeafletMap, Marker as LeafletMarker, LayerGroup as LeafletLayerGroup } from 'leaflet';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { useGeolocation } from '@/app/hooks/use-geolocation';
 import { themeTokens } from '@/app/theme/theme-config';
 import markerStyles from './board-search-map.module.css';
 
@@ -19,6 +18,11 @@ interface BoardSearchMapProps {
   zoom: number;
   boards: UserBoard[];
   selectedBoardUuid: string | null;
+  /** Resolved geolocation coordinates (null until the user grants permission). */
+  userCoords: { latitude: number; longitude: number } | null;
+  /** Trigger the browser/OS geolocation prompt. Parent owns the state so this
+   *  doesn't fire a duplicate permission request — the drawer already asked on open. */
+  requestPermission: () => void | Promise<void>;
   onBoardClick: (board: UserBoard) => void;
   onViewportChange: (viewport: { lat: number; lng: number; zoom: number }) => void;
 }
@@ -36,6 +40,8 @@ export default function BoardSearchMap({
   zoom,
   boards,
   selectedBoardUuid,
+  userCoords,
+  requestPermission,
   onBoardClick,
   onViewportChange,
 }: BoardSearchMapProps) {
@@ -63,8 +69,6 @@ export default function BoardSearchMap({
   zoomRef.current = zoom;
   selectedBoardUuidRef.current = selectedBoardUuid;
 
-  const { coordinates: userCoords, requestPermission } = useGeolocation();
-
   // Initialize the map once.
   useEffect(() => {
     const container = containerRef.current;
@@ -73,6 +77,11 @@ export default function BoardSearchMap({
     let cancelled = false;
     let resizeObserver: ResizeObserver | null = null;
 
+    // The `leaflet/dist/leaflet.css` import loads the Leaflet stylesheet via
+    // Next.js's CSS import handling. It isn't a real ES module so TypeScript
+    // can't type-check it — hence the @ts-expect-error. Do NOT remove the
+    // import thinking it's dead code: without it, tile panes, zoom controls,
+    // and attribution render unstyled.
     // @ts-expect-error — CSS dynamic import handled by Next.js bundler
     Promise.all([import('leaflet'), import('leaflet/dist/leaflet.css')]).then(([L]) => {
       if (cancelled || !containerRef.current) return;

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -42,10 +42,18 @@ export default function BoardSearchMap({
   const onBoardClickRef = useRef(onBoardClick);
   const viewportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const programmaticMoveRef = useRef(false);
+  // Keep the latest center/zoom accessible to the async Leaflet import callback
+  // so the map mounts at whatever the parent has settled on by then, not the
+  // values that were current at first render.
+  const centerRef = useRef(center);
+  const zoomRef = useRef(zoom);
   const [mapReady, setMapReady] = useState(false);
+  const [pendingMyLocation, setPendingMyLocation] = useState(false);
 
   onViewportChangeRef.current = onViewportChange;
   onBoardClickRef.current = onBoardClick;
+  centerRef.current = center;
+  zoomRef.current = zoom;
 
   const { coordinates: userCoords, requestPermission } = useGeolocation();
 
@@ -64,7 +72,7 @@ export default function BoardSearchMap({
       const map = L.map(containerRef.current, {
         zoomControl: true,
         attributionControl: true,
-      }).setView([center.lat, center.lng], zoom);
+      }).setView([centerRef.current.lat, centerRef.current.lng], zoomRef.current);
 
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
@@ -193,19 +201,39 @@ export default function BoardSearchMap({
     }
   }, [selectedBoardUuid]);
 
-  const handleUseMyLocation = useCallback(() => {
-    if (userCoords) {
+  const flyToUserCoords = useCallback(
+    (coords: { latitude: number; longitude: number }) => {
+      const map = mapRef.current;
+      if (!map) return;
       programmaticMoveRef.current = true;
-      mapRef.current?.flyTo([userCoords.latitude, userCoords.longitude], 13);
+      map.flyTo([coords.latitude, coords.longitude], 13);
       onViewportChangeRef.current({
-        lat: Math.round(userCoords.latitude * 1000000) / 1000000,
-        lng: Math.round(userCoords.longitude * 1000000) / 1000000,
+        lat: Math.round(coords.latitude * 1000000) / 1000000,
+        lng: Math.round(coords.longitude * 1000000) / 1000000,
         zoom: 13,
       });
+    },
+    [],
+  );
+
+  const handleUseMyLocation = useCallback(() => {
+    if (userCoords) {
+      flyToUserCoords(userCoords);
     } else {
+      // Remember the user's intent so we can finish the recenter once the
+      // async permission request resolves — otherwise the first tap just
+      // triggers the permission prompt and looks like a no-op.
+      setPendingMyLocation(true);
       requestPermission();
     }
-  }, [userCoords, requestPermission]);
+  }, [userCoords, requestPermission, flyToUserCoords]);
+
+  // Finish a pending "My location" tap once geolocation resolves.
+  useEffect(() => {
+    if (!pendingMyLocation || !userCoords || !mapReady) return;
+    setPendingMyLocation(false);
+    flyToUserCoords(userCoords);
+  }, [pendingMyLocation, userCoords, mapReady, flyToUserCoords]);
 
   return (
     <Box

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import React, { useEffect, useRef, useCallback, useState } from 'react';
+import Box from '@mui/material/Box';
+import MuiButton from '@mui/material/Button';
+import MyLocationOutlined from '@mui/icons-material/MyLocationOutlined';
+import type { Map as LeafletMap, Marker as LeafletMarker, LayerGroup as LeafletLayerGroup } from 'leaflet';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { useGeolocation } from '@/app/hooks/use-geolocation';
+
+const VIEWPORT_DEBOUNCE_MS = 250;
+
+interface BoardSearchMapProps {
+  center: { lat: number; lng: number };
+  zoom: number;
+  boards: UserBoard[];
+  selectedBoardUuid: string | null;
+  onBoardClick: (board: UserBoard) => void;
+  onViewportChange: (viewport: { lat: number; lng: number; zoom: number }) => void;
+}
+
+function buildMarkerHtml(selected: boolean): string {
+  const size = selected ? 22 : 16;
+  const ring = selected ? '4px solid #fff' : '3px solid #fff';
+  return `<div style="width:${size}px;height:${size}px;background:#8C4A52;border:${ring};border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>`;
+}
+
+export default function BoardSearchMap({
+  center,
+  zoom,
+  boards,
+  selectedBoardUuid,
+  onBoardClick,
+  onViewportChange,
+}: BoardSearchMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const leafletRef = useRef<typeof import('leaflet') | null>(null);
+  const markersLayerRef = useRef<LeafletLayerGroup | null>(null);
+  const markersByUuidRef = useRef<Map<string, LeafletMarker>>(new Map());
+  const onViewportChangeRef = useRef(onViewportChange);
+  const onBoardClickRef = useRef(onBoardClick);
+  const viewportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const programmaticMoveRef = useRef(false);
+  const [mapReady, setMapReady] = useState(false);
+
+  onViewportChangeRef.current = onViewportChange;
+  onBoardClickRef.current = onBoardClick;
+
+  const { coordinates: userCoords, requestPermission } = useGeolocation();
+
+  // Initialize the map once.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let cancelled = false;
+
+    // @ts-expect-error — CSS dynamic import handled by Next.js bundler
+    Promise.all([import('leaflet'), import('leaflet/dist/leaflet.css')]).then(([L]) => {
+      if (cancelled || !containerRef.current) return;
+
+      const map = L.map(containerRef.current, {
+        zoomControl: true,
+        attributionControl: false,
+      }).setView([center.lat, center.lng], zoom);
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+      }).addTo(map);
+
+      const markersLayer = L.layerGroup().addTo(map);
+
+      leafletRef.current = L;
+      mapRef.current = map;
+      markersLayerRef.current = markersLayer;
+      setMapReady(true);
+
+      const fireViewport = () => {
+        if (programmaticMoveRef.current) {
+          programmaticMoveRef.current = false;
+          return;
+        }
+        if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
+        viewportTimerRef.current = setTimeout(() => {
+          const c = map.getCenter();
+          onViewportChangeRef.current({
+            lat: Math.round(c.lat * 1000000) / 1000000,
+            lng: Math.round(c.lng * 1000000) / 1000000,
+            zoom: map.getZoom(),
+          });
+        }, VIEWPORT_DEBOUNCE_MS);
+      };
+
+      map.on('moveend', fireViewport);
+      map.on('zoomend', fireViewport);
+
+      // Fix sizing after the drawer slide-in animation
+      setTimeout(() => map.invalidateSize(), 250);
+    });
+
+    return () => {
+      cancelled = true;
+      if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+        markersLayerRef.current = null;
+        markersByUuidRef.current.clear();
+        leafletRef.current = null;
+        setMapReady(false);
+      }
+    };
+    // Only initialize once — center/zoom updates are handled separately.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Pan / zoom programmatically when parent controls the viewport (e.g. carousel selection).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const current = map.getCenter();
+    const distLat = Math.abs(current.lat - center.lat);
+    const distLng = Math.abs(current.lng - center.lng);
+    const zoomChanged = map.getZoom() !== zoom;
+    // Avoid feedback loop: only re-pan if the parent's coords differ meaningfully.
+    if (distLat < 0.0005 && distLng < 0.0005 && !zoomChanged) return;
+    programmaticMoveRef.current = true;
+    map.setView([center.lat, center.lng], zoom, { animate: true });
+  }, [center.lat, center.lng, zoom]);
+
+  // Sync markers whenever boards change.
+  useEffect(() => {
+    const L = leafletRef.current;
+    const layer = markersLayerRef.current;
+    if (!L || !layer) return;
+
+    const nextUuids = new Set(boards.filter((b) => b.latitude != null && b.longitude != null).map((b) => b.uuid));
+
+    // Remove markers no longer in results
+    for (const [uuid, marker] of markersByUuidRef.current.entries()) {
+      if (!nextUuids.has(uuid)) {
+        layer.removeLayer(marker);
+        markersByUuidRef.current.delete(uuid);
+      }
+    }
+
+    // Add new markers
+    for (const board of boards) {
+      if (board.latitude == null || board.longitude == null) continue;
+      if (markersByUuidRef.current.has(board.uuid)) continue;
+
+      const isSelected = board.uuid === selectedBoardUuid;
+      const icon = L.divIcon({
+        className: '',
+        html: buildMarkerHtml(isSelected),
+        iconSize: [isSelected ? 22 : 16, isSelected ? 22 : 16],
+        iconAnchor: [isSelected ? 11 : 8, isSelected ? 11 : 8],
+      });
+      const marker = L.marker([board.latitude, board.longitude], { icon });
+      marker.on('click', () => onBoardClickRef.current(board));
+      marker.addTo(layer);
+      markersByUuidRef.current.set(board.uuid, marker);
+    }
+  }, [boards, selectedBoardUuid]);
+
+  // Update marker icons when selection changes (without recreating all markers).
+  useEffect(() => {
+    const L = leafletRef.current;
+    if (!L) return;
+    for (const [uuid, marker] of markersByUuidRef.current.entries()) {
+      const isSelected = uuid === selectedBoardUuid;
+      const icon = L.divIcon({
+        className: '',
+        html: buildMarkerHtml(isSelected),
+        iconSize: [isSelected ? 22 : 16, isSelected ? 22 : 16],
+        iconAnchor: [isSelected ? 11 : 8, isSelected ? 11 : 8],
+      });
+      marker.setIcon(icon);
+    }
+  }, [selectedBoardUuid]);
+
+  const handleUseMyLocation = useCallback(() => {
+    if (userCoords) {
+      programmaticMoveRef.current = true;
+      mapRef.current?.flyTo([userCoords.latitude, userCoords.longitude], 13);
+      onViewportChangeRef.current({
+        lat: Math.round(userCoords.latitude * 1000000) / 1000000,
+        lng: Math.round(userCoords.longitude * 1000000) / 1000000,
+        zoom: 13,
+      });
+    } else {
+      requestPermission();
+    }
+  }, [userCoords, requestPermission]);
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+      <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+      {mapReady && (
+        <MuiButton
+          size="small"
+          variant="contained"
+          startIcon={<MyLocationOutlined />}
+          onClick={handleUseMyLocation}
+          sx={{
+            position: 'absolute',
+            bottom: 8,
+            right: 8,
+            zIndex: 1000,
+            fontSize: '0.75rem',
+            textTransform: 'none',
+          }}
+        >
+          My location
+        </MuiButton>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -7,8 +7,12 @@ import MyLocationOutlined from '@mui/icons-material/MyLocationOutlined';
 import type { Map as LeafletMap, Marker as LeafletMarker, LayerGroup as LeafletLayerGroup } from 'leaflet';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useGeolocation } from '@/app/hooks/use-geolocation';
+import { themeTokens } from '@/app/theme/theme-config';
+import markerStyles from './board-search-map.module.css';
 
 const VIEWPORT_DEBOUNCE_MS = 250;
+const MARKER_SIZE = 16;
+const MARKER_SIZE_SELECTED = 22;
 
 interface BoardSearchMapProps {
   center: { lat: number; lng: number };
@@ -19,10 +23,12 @@ interface BoardSearchMapProps {
   onViewportChange: (viewport: { lat: number; lng: number; zoom: number }) => void;
 }
 
-function buildMarkerHtml(selected: boolean): string {
-  const size = selected ? 22 : 16;
-  const ring = selected ? '4px solid #fff' : '3px solid #fff';
-  return `<div style="width:${size}px;height:${size}px;background:var(--color-primary);border:${ring};border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>`;
+function markerClassName(selected: boolean): string {
+  return selected ? `${markerStyles.marker} ${markerStyles.markerSelected}` : markerStyles.marker;
+}
+
+function markerSize(selected: boolean): number {
+  return selected ? MARKER_SIZE_SELECTED : MARKER_SIZE;
 }
 
 export default function BoardSearchMap({
@@ -178,11 +184,12 @@ export default function BoardSearchMap({
       if (markersByUuidRef.current.has(board.uuid)) continue;
 
       const isSelected = board.uuid === selectedBoardUuidRef.current;
+      const size = markerSize(isSelected);
       const icon = L.divIcon({
-        className: '',
-        html: buildMarkerHtml(isSelected),
-        iconSize: [isSelected ? 22 : 16, isSelected ? 22 : 16],
-        iconAnchor: [isSelected ? 11 : 8, isSelected ? 11 : 8],
+        className: markerClassName(isSelected),
+        html: '',
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
       });
       const marker = L.marker([board.latitude, board.longitude], { icon });
       marker.on('click', () => onBoardClickRef.current(board));
@@ -197,11 +204,12 @@ export default function BoardSearchMap({
     if (!L) return;
     for (const [uuid, marker] of markersByUuidRef.current.entries()) {
       const isSelected = uuid === selectedBoardUuid;
+      const size = markerSize(isSelected);
       const icon = L.divIcon({
-        className: '',
-        html: buildMarkerHtml(isSelected),
-        iconSize: [isSelected ? 22 : 16, isSelected ? 22 : 16],
-        iconAnchor: [isSelected ? 11 : 8, isSelected ? 11 : 8],
+        className: markerClassName(isSelected),
+        html: '',
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
       });
       marker.setIcon(icon);
     }
@@ -211,12 +219,22 @@ export default function BoardSearchMap({
     (coords: { latitude: number; longitude: number }) => {
       const map = mapRef.current;
       if (!map) return;
-      // Leaflet's own `moveend` event — fired when the flyTo animation
-      // finishes — propagates the new viewport back to the parent through
-      // `fireViewport`. We deliberately don't set `programmaticMoveRef` or
-      // call `onViewportChangeRef` directly here: doing both would update
-      // parent state during the animation and trigger the pan effect's
-      // `map.setView`, running a second animation that interrupts the flyTo.
+      // Suppress the regular fireViewport debounce for this animation so the
+      // parent's center/zoom isn't updated mid-flight — that would re-render
+      // and trigger the pan effect's setView, racing the flyTo.
+      programmaticMoveRef.current = true;
+      // Once the animation finishes (or the user interrupts it), report the
+      // actual final viewport directly. By that point map.getCenter() matches
+      // the target, so the pan effect's distance guard short-circuits and no
+      // second animation runs.
+      map.once('moveend', () => {
+        const c = map.getCenter();
+        onViewportChangeRef.current({
+          lat: Math.round(c.lat * 1000000) / 1000000,
+          lng: Math.round(c.lng * 1000000) / 1000000,
+          zoom: map.getZoom(),
+        });
+      });
       map.flyTo([coords.latitude, coords.longitude], 13);
     },
     [],
@@ -255,10 +273,10 @@ export default function BoardSearchMap({
           onClick={handleUseMyLocation}
           sx={{
             position: 'absolute',
-            bottom: 8,
-            right: 8,
-            zIndex: 1000,
-            fontSize: '0.75rem',
+            bottom: themeTokens.spacing[2],
+            right: themeTokens.spacing[2],
+            zIndex: themeTokens.zIndex.dropdown,
+            fontSize: `${themeTokens.typography.fontSize.xs}px`,
             textTransform: 'none',
           }}
         >

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -47,6 +47,7 @@ export default function BoardSearchMap({
   // values that were current at first render.
   const centerRef = useRef(center);
   const zoomRef = useRef(zoom);
+  const selectedBoardUuidRef = useRef(selectedBoardUuid);
   const [mapReady, setMapReady] = useState(false);
   const [pendingMyLocation, setPendingMyLocation] = useState(false);
 
@@ -54,6 +55,7 @@ export default function BoardSearchMap({
   onBoardClickRef.current = onBoardClick;
   centerRef.current = center;
   zoomRef.current = zoom;
+  selectedBoardUuidRef.current = selectedBoardUuid;
 
   const { coordinates: userCoords, requestPermission } = useGeolocation();
 
@@ -150,7 +152,11 @@ export default function BoardSearchMap({
     map.setView([center.lat, center.lng], zoom, { animate: true });
   }, [center.lat, center.lng, zoom]);
 
-  // Sync markers whenever boards change.
+  // Sync markers whenever boards change. The selection-to-icon mapping is
+  // handled by the separate "Update marker icons when selection changes"
+  // effect below, so this effect only adds/removes markers. We read the
+  // current selection through a ref to pick the correct initial icon for
+  // newly-added markers without re-running on every selection change.
   useEffect(() => {
     const L = leafletRef.current;
     const layer = markersLayerRef.current;
@@ -171,7 +177,7 @@ export default function BoardSearchMap({
       if (board.latitude == null || board.longitude == null) continue;
       if (markersByUuidRef.current.has(board.uuid)) continue;
 
-      const isSelected = board.uuid === selectedBoardUuid;
+      const isSelected = board.uuid === selectedBoardUuidRef.current;
       const icon = L.divIcon({
         className: '',
         html: buildMarkerHtml(isSelected),
@@ -183,7 +189,7 @@ export default function BoardSearchMap({
       marker.addTo(layer);
       markersByUuidRef.current.set(board.uuid, marker);
     }
-  }, [boards, selectedBoardUuid]);
+  }, [boards]);
 
   // Update marker icons when selection changes (without recreating all markers).
   useEffect(() => {
@@ -205,13 +211,13 @@ export default function BoardSearchMap({
     (coords: { latitude: number; longitude: number }) => {
       const map = mapRef.current;
       if (!map) return;
-      programmaticMoveRef.current = true;
+      // Leaflet's own `moveend` event — fired when the flyTo animation
+      // finishes — propagates the new viewport back to the parent through
+      // `fireViewport`. We deliberately don't set `programmaticMoveRef` or
+      // call `onViewportChangeRef` directly here: doing both would update
+      // parent state during the animation and trigger the pan effect's
+      // `map.setView`, running a second animation that interrupts the flyTo.
       map.flyTo([coords.latitude, coords.longitude], 13);
-      onViewportChangeRef.current({
-        lat: Math.round(coords.latitude * 1000000) / 1000000,
-        lng: Math.round(coords.longitude * 1000000) / 1000000,
-        zoom: 13,
-      });
     },
     [],
   );

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -22,7 +22,7 @@ interface BoardSearchMapProps {
 function buildMarkerHtml(selected: boolean): string {
   const size = selected ? 22 : 16;
   const ring = selected ? '4px solid #fff' : '3px solid #fff';
-  return `<div style="width:${size}px;height:${size}px;background:#8C4A52;border:${ring};border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>`;
+  return `<div style="width:${size}px;height:${size}px;background:var(--color-primary);border:${ring};border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>`;
 }
 
 export default function BoardSearchMap({
@@ -55,6 +55,7 @@ export default function BoardSearchMap({
     if (!container) return;
 
     let cancelled = false;
+    let resizeObserver: ResizeObserver | null = null;
 
     // @ts-expect-error — CSS dynamic import handled by Next.js bundler
     Promise.all([import('leaflet'), import('leaflet/dist/leaflet.css')]).then(([L]) => {
@@ -62,11 +63,12 @@ export default function BoardSearchMap({
 
       const map = L.map(containerRef.current, {
         zoomControl: true,
-        attributionControl: false,
+        attributionControl: true,
       }).setView([center.lat, center.lng], zoom);
 
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       }).addTo(map);
 
       const markersLayer = L.layerGroup().addTo(map);
@@ -95,13 +97,24 @@ export default function BoardSearchMap({
       map.on('moveend', fireViewport);
       map.on('zoomend', fireViewport);
 
-      // Fix sizing after the drawer slide-in animation
-      setTimeout(() => map.invalidateSize(), 250);
+      // Observe container size so we can correct Leaflet's internal size whenever
+      // the parent (e.g. bottom-sheet drawer) finishes animating in, rotates, or
+      // otherwise resizes. Replaces a flakey setTimeout(250) after mount.
+      if (typeof ResizeObserver !== 'undefined' && containerRef.current) {
+        resizeObserver = new ResizeObserver(() => {
+          map.invalidateSize();
+        });
+        resizeObserver.observe(containerRef.current);
+      }
     });
 
     return () => {
       cancelled = true;
       if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
       if (mapRef.current) {
         mapRef.current.remove();
         mapRef.current = null;
@@ -195,7 +208,10 @@ export default function BoardSearchMap({
   }, [userCoords, requestPermission]);
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+    <Box
+      data-swipe-blocked="true"
+      sx={{ position: 'relative', width: '100%', height: '100%' }}
+    >
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
       {mapReady && (
         <MuiButton

--- a/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The hook module also pulls in auth + GraphQL client modules via path aliases.
+// We only exercise the pure `zoomToRadiusKm` helper here, so stub its peers.
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: null, isAuthenticated: false }),
+}));
+vi.mock('@/app/hooks/use-debounced-value', () => ({
+  useDebouncedValue: <T>(v: T) => v,
+}));
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: vi.fn() }),
+}));
+vi.mock('@/app/lib/graphql/operations', () => ({
+  SEARCH_BOARDS: 'SEARCH_BOARDS_QUERY',
+}));
+
+import { zoomToRadiusKm } from '../use-search-boards-map';
+
+describe('zoomToRadiusKm', () => {
+  it('returns 5 km at high zoom levels (14+)', () => {
+    expect(zoomToRadiusKm(14)).toBe(5);
+    expect(zoomToRadiusKm(15)).toBe(5);
+    expect(zoomToRadiusKm(18)).toBe(5);
+    expect(zoomToRadiusKm(19)).toBe(5);
+  });
+
+  it('steps 10 → 15 → 20 km for zoom 13, 12, 11', () => {
+    expect(zoomToRadiusKm(13)).toBe(10);
+    expect(zoomToRadiusKm(12)).toBe(15);
+    expect(zoomToRadiusKm(11)).toBe(20);
+  });
+
+  it('doubles roughly every zoom step below 11', () => {
+    expect(zoomToRadiusKm(10)).toBe(40);
+    expect(zoomToRadiusKm(9)).toBe(80);
+    expect(zoomToRadiusKm(8)).toBe(160);
+  });
+
+  it('caps the radius at 300 km for zoom 7 and below', () => {
+    expect(zoomToRadiusKm(7)).toBe(300);
+    expect(zoomToRadiusKm(5)).toBe(300);
+    expect(zoomToRadiusKm(0)).toBe(300);
+    expect(zoomToRadiusKm(-1)).toBe(300);
+  });
+
+  it('uses the default 20 km bucket at zoom 11 (the drawer default)', () => {
+    expect(zoomToRadiusKm(11)).toBe(20);
+  });
+
+  it('is monotonically non-decreasing as zoom decreases', () => {
+    let prev = zoomToRadiusKm(19);
+    for (let z = 18; z >= 0; z--) {
+      const next = zoomToRadiusKm(z);
+      expect(next).toBeGreaterThanOrEqual(prev);
+      prev = next;
+    }
+  });
+});

--- a/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
@@ -1,21 +1,62 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { UserBoard, UserBoardConnection } from '@boardsesh/shared-schema';
 
-// The hook module also pulls in auth + GraphQL client modules via path aliases.
-// We only exercise the pure `zoomToRadiusKm` helper here, so stub its peers.
-vi.mock('@/app/hooks/use-ws-auth-token', () => ({
-  useWsAuthToken: () => ({ token: null, isAuthenticated: false }),
+// --- Mocks (declared before importing the hook) ---
+
+const mockRequest = vi.fn();
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
 }));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
 vi.mock('@/app/hooks/use-debounced-value', () => ({
   useDebouncedValue: <T>(v: T) => v,
 }));
-vi.mock('@/app/lib/graphql/client', () => ({
-  createGraphQLHttpClient: () => ({ request: vi.fn() }),
-}));
+
 vi.mock('@/app/lib/graphql/operations', () => ({
   SEARCH_BOARDS: 'SEARCH_BOARDS_QUERY',
 }));
 
-import { zoomToRadiusKm } from '../use-search-boards-map';
+import { createQueryWrapper } from '@/app/test-utils/test-providers';
+import { useSearchBoardsMap, zoomToRadiusKm } from '../use-search-boards-map';
+
+// --- Helpers ---
+
+function makeBoard(uuid: string, overrides?: Partial<UserBoard>): UserBoard {
+  return {
+    uuid,
+    name: `Board ${uuid}`,
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27',
+    angle: 40,
+    totalAscents: 0,
+    slug: `kilter/8/25/26,27`,
+    locationName: null,
+    latitude: null,
+    longitude: null,
+    isFollowedByMe: false,
+    ownerId: 'owner-1',
+    isPublic: true,
+    isOwned: false,
+    isAngleAdjustable: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    ...overrides,
+  } as UserBoard;
+}
+
+function makeSearchResponse(boards: UserBoard[], hasMore = false): { searchBoards: UserBoardConnection } {
+  return { searchBoards: { boards, totalCount: boards.length + (hasMore ? 100 : 0), hasMore } };
+}
 
 describe('zoomToRadiusKm', () => {
   it('returns 5 km at high zoom levels (14+)', () => {
@@ -55,5 +96,182 @@ describe('zoomToRadiusKm', () => {
       expect(next).toBeGreaterThanOrEqual(prev);
       prev = next;
     }
+  });
+});
+
+describe('useSearchBoardsMap query gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call SEARCH_BOARDS when enabled is false', async () => {
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: '',
+          latitude: 40.7,
+          longitude: -74.0,
+          zoom: 11,
+          enabled: false,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    // Give react-query a chance to settle
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.boards).toEqual([]);
+  });
+
+  it('does not call SEARCH_BOARDS without coords and with a short query', async () => {
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: 'a', // below the 2-char threshold
+          latitude: null,
+          longitude: null,
+          zoom: 11,
+          enabled: true,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.boards).toEqual([]);
+  });
+
+  it('fires the query when coords are present even with no query text', async () => {
+    mockRequest.mockResolvedValueOnce(makeSearchResponse([makeBoard('b1')]));
+
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: '',
+          latitude: 40.7,
+          longitude: -74.0,
+          zoom: 11,
+          enabled: true,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.boards).toHaveLength(1);
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledWith(
+      'SEARCH_BOARDS_QUERY',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          latitude: 40.7,
+          longitude: -74.0,
+          radiusKm: 20,
+          offset: 0,
+        }),
+      }),
+    );
+  });
+
+  it('fires the query when only a >= 2-char text query is provided', async () => {
+    mockRequest.mockResolvedValueOnce(makeSearchResponse([makeBoard('b1')]));
+
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: 'kilter',
+          latitude: null,
+          longitude: null,
+          zoom: 11,
+          enabled: true,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.boards).toHaveLength(1);
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const calledWith = mockRequest.mock.calls[0][1] as { input: Record<string, unknown> };
+    expect(calledWith.input.query).toBe('kilter');
+    expect(calledWith.input.latitude).toBeUndefined();
+    expect(calledWith.input.longitude).toBeUndefined();
+    expect(calledWith.input.radiusKm).toBeUndefined();
+  });
+});
+
+describe('useSearchBoardsMap pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports hasMore=false when the server has no more pages', async () => {
+    mockRequest.mockResolvedValueOnce(makeSearchResponse([makeBoard('b1')], false));
+
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: '',
+          latitude: 40.7,
+          longitude: -74.0,
+          zoom: 11,
+          enabled: true,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.boards).toHaveLength(1);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('fetches the next page with offset = sum of boards seen so far', async () => {
+    const firstPage = [makeBoard('a1'), makeBoard('a2'), makeBoard('a3')];
+    const secondPage = [makeBoard('b1'), makeBoard('b2')];
+
+    mockRequest
+      .mockResolvedValueOnce(makeSearchResponse(firstPage, true))
+      .mockResolvedValueOnce(makeSearchResponse(secondPage, false));
+
+    const { result } = renderHook(
+      () =>
+        useSearchBoardsMap({
+          query: '',
+          latitude: 40.7,
+          longitude: -74.0,
+          zoom: 11,
+          enabled: true,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.boards).toHaveLength(3);
+    });
+
+    expect(result.current.hasMore).toBe(true);
+    // First fetch at offset 0
+    expect((mockRequest.mock.calls[0][1] as { input: { offset: number } }).input.offset).toBe(0);
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => {
+      expect(result.current.boards).toHaveLength(5);
+    });
+
+    // Second fetch at offset 3 (size of first page)
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect((mockRequest.mock.calls[1][1] as { input: { offset: number } }).input.offset).toBe(3);
+    expect(result.current.hasMore).toBe(false);
   });
 });

--- a/packages/web/app/hooks/use-search-boards-map.ts
+++ b/packages/web/app/hooks/use-search-boards-map.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useDebouncedValue } from '@/app/hooks/use-debounced-value';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  SEARCH_BOARDS,
+  type SearchBoardsQueryResponse,
+  type SearchBoardsQueryVariables,
+} from '@/app/lib/graphql/operations';
+import type { UserBoard, UserBoardConnection } from '@boardsesh/shared-schema';
+
+export interface SearchBoardsMapInput {
+  query: string;
+  latitude: number | null;
+  longitude: number | null;
+  zoom: number;
+  enabled: boolean;
+}
+
+export interface SearchBoardsMapResult {
+  boards: UserBoard[];
+  isLoading: boolean;
+  isFetching: boolean;
+  hasMore: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  radiusKm: number;
+}
+
+const PAGE_LIMIT = 30;
+
+/**
+ * Map zoom level → search radius in km.
+ * Roughly tracks the visible radius at common Leaflet zoom levels on a typical
+ * mobile/desktop viewport. Capped at 300 km so a fully-zoomed-out view doesn't
+ * fire a planet-wide query.
+ */
+export function zoomToRadiusKm(zoom: number): number {
+  if (zoom >= 14) return 5;
+  if (zoom === 13) return 10;
+  if (zoom === 12) return 15;
+  if (zoom === 11) return 20;
+  if (zoom === 10) return 40;
+  if (zoom === 9) return 80;
+  if (zoom === 8) return 160;
+  return 300;
+}
+
+/**
+ * Round coordinates to ~1km precision so small map pans don't refire the query.
+ * 2 decimals ≈ 1.1 km at the equator.
+ */
+function roundCoord(n: number | null): number | null {
+  if (n == null) return null;
+  return Math.round(n * 100) / 100;
+}
+
+export function useSearchBoardsMap({
+  query,
+  latitude,
+  longitude,
+  zoom,
+  enabled,
+}: SearchBoardsMapInput): SearchBoardsMapResult {
+  const { token } = useWsAuthToken();
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const radiusKm = useMemo(() => zoomToRadiusKm(zoom), [zoom]);
+  const lat = roundCoord(latitude);
+  const lon = roundCoord(longitude);
+
+  const hasCoords = lat != null && lon != null;
+  const hasQuery = debouncedQuery.trim().length >= 2;
+  const queryEnabled = enabled && (hasCoords || hasQuery);
+
+  const { data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery<UserBoardConnection, Error>({
+      queryKey: ['searchBoardsMap', debouncedQuery, lat, lon, radiusKm, token],
+      queryFn: async ({ pageParam }) => {
+        const client = createGraphQLHttpClient(token ?? undefined);
+        const input: SearchBoardsQueryVariables['input'] = {
+          query: hasQuery ? debouncedQuery.trim() : undefined,
+          latitude: hasCoords ? lat : undefined,
+          longitude: hasCoords ? lon : undefined,
+          radiusKm: hasCoords ? radiusKm : undefined,
+          limit: PAGE_LIMIT,
+          offset: pageParam as number,
+        };
+        const response = await client.request<SearchBoardsQueryResponse, SearchBoardsQueryVariables>(
+          SEARCH_BOARDS,
+          { input },
+        );
+        return response.searchBoards;
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (!lastPage.hasMore) return undefined;
+        return (lastPageParam as number) + lastPage.boards.length;
+      },
+      enabled: queryEnabled,
+      staleTime: 30 * 1000,
+    });
+
+  const boards = useMemo<UserBoard[]>(
+    () => data?.pages.flatMap((p) => p.boards) ?? [],
+    [data],
+  );
+
+  return {
+    boards,
+    isLoading,
+    isFetching,
+    hasMore: hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
+    radiusKm,
+  };
+}

--- a/packages/web/app/hooks/use-search-boards-map.ts
+++ b/packages/web/app/hooks/use-search-boards-map.ts
@@ -75,11 +75,15 @@ export function useSearchBoardsMap({
   const hasQuery = debouncedQuery.trim().length >= 2;
   const queryEnabled = enabled && (hasCoords || hasQuery);
 
+  // Construct a single GraphQL client per token; reused across every page
+  // fetch. Without this we'd allocate a new client object on every queryFn
+  // invocation (every page, every refetch) for no benefit.
+  const client = useMemo(() => createGraphQLHttpClient(token ?? undefined), [token]);
+
   const { data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<UserBoardConnection, Error>({
       queryKey: ['searchBoardsMap', debouncedQuery, lat, lon, radiusKm, token],
       queryFn: async ({ pageParam }) => {
-        const client = createGraphQLHttpClient(token ?? undefined);
         const input: SearchBoardsQueryVariables['input'] = {
           query: hasQuery ? debouncedQuery.trim() : undefined,
           latitude: hasCoords ? lat : undefined,


### PR DESCRIPTION
The home-screen board selector now shows a 2x2 cluster of mini cards
(Find Nearby, Custom, Search, Bluetooth) that's always visible at the
start of the horizontal scroll, instead of disappearing once nearby
boards load.

The Search card opens a full-height drawer with a Leaflet map, a search
input, and a horizontal carousel of matching boards. The query uses the
user's geolocation with a 20 km radius by default; panning/zooming the
map widens or narrows the search via a stepped zoom-to-radius table
(5/10/15/20/40/80/160/300 km). Selecting a board (marker or card)
surfaces inline Follow + Open actions on the carousel card.

The Bluetooth card is greyed out and labelled "Quick start (coming
soon)" — non-interactive placeholder for the upcoming flow.