### PR TITLE
Fix tick badge jump and thumbnail shift in logbook edit mode

### DIFF
--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -168,23 +168,22 @@
   gap: 4px;
 }
 
-/* Status badge button — 44x44 touch target in edit mode */
+/* Status badge button — visible 18x18 badge (matches non-edit placement).
+   A ::before pseudo-element extends the tap area to 44x44 for accessibility
+   without affecting layout. */
 .statusBadgeButton {
+  position: absolute;
   bottom: 6px;
-  min-width: 44px;
-  min-height: 44px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  right: 2px;
+  width: 18px;
+  height: 18px;
   cursor: pointer;
 }
 
-/* Badge edit label */
-.badgeEditLabel {
-  margin-top: 2px;
-  width: 18px;
-  text-align: center;
+.statusBadgeButton::before {
+  content: '';
+  position: absolute;
+  inset: -13px;
 }
 
 /* Picker panel — animated expand/collapse */

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -569,7 +569,6 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
                   variant="badge"
                   fontSize={12}
                 />
-                <span className={`${styles.statLabel} ${styles.badgeEditLabel}`}>edit</span>
               </ButtonBase>
             ) : (
               <div className={ascentStyles.badge} style={{ bottom: 6 }}>


### PR DESCRIPTION
The edit-mode status badge was expanding to a 44x44 flex container with an "edit" label, which pushed the icon upward and disturbed thumbnail flex centering. Keep the visible badge at 18x18 pinned to bottom-right in both modes and move the 44x44 touch target to a ::before pseudo-element so the icon and thumbnail do not move when toggling edit mode.

https://claude.ai/code/session_01AaFHha1VMdZFebeP1S1Npp