### PR TITLE
Remove Board Render Complete and List Batch Render analytics events

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -89,8 +89,6 @@ vi.mock('@/app/hooks/use-infinite-scroll', () => ({
 }));
 
 vi.mock('@/app/lib/rendering-metrics', () => ({
-  trackListBatchRender: vi.fn(),
-  trackRenderComplete: vi.fn(),
   trackRenderError: vi.fn(),
 }));
 

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -21,7 +21,6 @@ import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton'
 import { themeTokens } from '@/app/theme/theme-config';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
-import { trackListBatchRender } from '@/app/lib/rendering-metrics';
 import { classifyClimbListChange } from './climb-list-utils';
 import SwipeHintOrchestrator from './swipe-hint-orchestrator';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
@@ -299,27 +298,11 @@ const ClimbsList = ({
   const [visibleCount, setVisibleCount] = useState(climbs.length);
   const prevClimbsRef = useRef(climbs);
 
-  // --- Batch render timing ---
-  // Records when a new batch of climbs arrives (data change) so we can measure
-  // render duration in useEffect (fires after DOM commit).
-  const batchStartRef = useRef<{ time: number; prevLength: number; isInitial: boolean } | null>(
-    climbs.length > 0 ? { time: performance.now(), prevLength: 0, isInitial: true } : null,
-  );
-
   if (climbs !== prevClimbsRef.current) {
     const prevClimbs = prevClimbsRef.current;
     prevClimbsRef.current = climbs;
 
     const changeType = classifyClimbListChange(climbs, prevClimbs);
-
-    // Record batch start for any data change that adds items
-    if (climbs.length > prevClimbs.length) {
-      batchStartRef.current = {
-        time: performance.now(),
-        prevLength: prevClimbs.length,
-        isInitial: prevClimbs.length === 0,
-      };
-    }
 
     if (changeType === 'append' || changeType === 'same') {
       // Show all items immediately — no batching for appended pages or unchanged data
@@ -341,22 +324,6 @@ const ClimbsList = ({
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => setHydrated(true), []);
-
-  // Track batch render timing after DOM commit
-  useEffect(() => {
-    const batch = batchStartRef.current;
-    if (!batch || climbs.length === 0) return;
-    // Only fire once per batch (when all items are visible)
-    if (visibleCount < climbs.length) return;
-    batchStartRef.current = null;
-    trackListBatchRender(performance.now() - batch.time, {
-      viewMode,
-      renderer: 'wasm',
-      batchSize: climbs.length - batch.prevLength,
-      totalItems: climbs.length,
-      isInitial: batch.isInitial,
-    });
-  }, [climbs.length, visibleCount, viewMode]);
 
   const onClimbSelectRef = useRef(onClimbSelect);
   onClimbSelectRef.current = onClimbSelect;

--- a/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-canvas-renderer-cleanup.test.tsx
@@ -34,9 +34,7 @@ vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({
 }));
 
 vi.mock('@/app/lib/rendering-metrics', () => ({
-  trackRenderComplete: vi.fn(),
   trackRenderError: vi.fn(),
-  trackListBatchRender: vi.fn(),
 }));
 
 vi.mock('../board-image-layers', () => ({

--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { BoardDetails } from '@/app/lib/types';
 import { isWorkerRenderingSupported, renderBoard, computeCropTop } from '@/app/lib/board-render-worker/worker-manager';
-import { trackRenderComplete, trackRenderError, type RenderContext } from '@/app/lib/rendering-metrics';
+import { trackRenderError, type RenderContext } from '@/app/lib/rendering-metrics';
 import { THUMBNAIL_WIDTH } from './types';
 import BoardImageLayers from './board-image-layers';
 
@@ -34,7 +34,6 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   style,
 }: BoardCanvasRendererProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const hasFired = useRef(false);
   const [failed, setFailed] = useState(false);
   const workerSupported = isWorkerRenderingSupported();
 
@@ -57,9 +56,7 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
     if (!canvas) return;
 
     let cancelled = false;
-    // Capture context and time at effect start so metrics are never stale
     const context: RenderContext = thumbnail ? 'thumbnail' : contain ? 'full-board' : 'card';
-    const startTime = performance.now();
 
     renderBoard({ boardDetails, frames, mirrored, thumbnail, cropTop })
       .then((bitmap) => {
@@ -69,10 +66,6 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
         const ctx = canvas.getContext('2d');
         if (ctx) {
           ctx.drawImage(bitmap, 0, 0);
-        }
-        if (!hasFired.current) {
-          hasFired.current = true;
-          trackRenderComplete(performance.now() - startTime, context, 'wasm');
         }
       })
       .catch((err) => {

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { BoardDetails } from '@/app/lib/types';
 import { getImageUrl, buildOverlayUrl } from './util';
 import { THUMBNAIL_WIDTH } from './types';
-import { trackRenderComplete, trackRenderError, type RenderContext } from '@/app/lib/rendering-metrics';
+import { trackRenderError, type RenderContext } from '@/app/lib/rendering-metrics';
 
 // Use CSS Grid stacking (gridArea: 1/1) instead of absolute positioning to avoid
 // iOS 18.x WebKit bugs with absolutely positioned images in aspect-ratio containers.
@@ -65,16 +65,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
 
   const imgStyle = (contain || thumbnail) ? layerContainStyle : layerStyle;
 
-  // Render timing: measure mount → overlay loaded
-  const mountTime = useRef(performance.now());
-  const hasFired = useRef(false);
   const renderContext: RenderContext = thumbnail ? 'thumbnail' : contain ? 'full-board' : 'card';
-
-  const handleOverlayLoad = useCallback(() => {
-    if (hasFired.current) return;
-    hasFired.current = true;
-    trackRenderComplete(performance.now() - mountTime.current, renderContext, 'wasm');
-  }, [renderContext]);
 
   const handleOverlayError = useCallback(() => {
     trackRenderError(renderContext, 'wasm');
@@ -99,7 +90,6 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
           height={imgHeight}
           style={imgStyle}
           fetchPriority={fetchPriority}
-          onLoad={handleOverlayLoad}
           onError={handleOverlayError}
         />
       ) : (

--- a/packages/web/app/components/board-renderer/board-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-renderer.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { getImageUrl } from './util';
 import { BoardDetails } from '@/app/lib/types';
 import BoardLitupHolds from './board-litup-holds';
 import { LitUpHoldsMap } from './types';
 import styles from './board-renderer.module.css';
 import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
-import { trackRenderComplete, type RenderContext } from '@/app/lib/rendering-metrics';
 
 export type BoardProps = {
   boardDetails: BoardDetails;
@@ -21,16 +20,7 @@ export type BoardProps = {
 
 const BoardRenderer = React.memo(
   ({ boardDetails, thumbnail, maxHeight, fillHeight, litUpHoldsMap, mirrored, onHoldClick }: BoardProps) => {
-    // Render timing: measure mount → paint (useEffect fires after DOM update)
-    const mountTime = useRef(performance.now());
-    const hasFired = useRef(false);
     const isMoonBoard = boardDetails.board_name === 'moonboard' && !!boardDetails.layoutFolder;
-    const renderContext: RenderContext = thumbnail ? 'thumbnail' : fillHeight ? 'full-board' : 'card';
-    useEffect(() => {
-      if (hasFired.current || isMoonBoard) return;
-      hasFired.current = true;
-      trackRenderComplete(performance.now() - mountTime.current, renderContext, 'svg');
-    }, [isMoonBoard, renderContext]);
 
     // Delegate to MoonBoardRenderer for Moonboard (uses grid-based rendering)
     if (isMoonBoard) {

--- a/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
+++ b/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
@@ -23,9 +23,7 @@ vi.mock('@/app/components/board-renderer/util', () => ({
 // Mock rendering-metrics so analytics calls don't hit @vercel/analytics during tests
 vi.mock('@/app/lib/rendering-metrics', () => ({
   trackWorkerRenderingDisabled: vi.fn(),
-  trackRenderComplete: vi.fn(),
   trackRenderError: vi.fn(),
-  trackListBatchRender: vi.fn(),
 }));
 
 // Mock HOLD_STATE_MAP

--- a/packages/web/app/lib/rendering-metrics.ts
+++ b/packages/web/app/lib/rendering-metrics.ts
@@ -2,21 +2,8 @@ import { track } from '@vercel/analytics';
 
 export type RenderContext = 'thumbnail' | 'card' | 'full-board' | 'feed';
 
-// Cap render events per session to avoid flooding analytics on long lists.
-// Counter persists across SPA navigations (only resets on full page load).
 const MAX_RENDER_EVENTS = 5;
-let renderEventCount = 0;
 let errorEventCount = 0;
-
-export function trackRenderComplete(durationMs: number, context: RenderContext, renderer: 'svg' | 'wasm') {
-  if (renderEventCount >= MAX_RENDER_EVENTS) return;
-  renderEventCount++;
-  track('Board Render Complete', {
-    durationMs: Math.round(durationMs),
-    context,
-    renderer,
-  });
-}
 
 export function trackRenderError(context: RenderContext, renderer: 'svg' | 'wasm') {
   if (errorEventCount >= MAX_RENDER_EVENTS) return;
@@ -33,25 +20,4 @@ export function trackWorkerRenderingDisabled(reason: WorkerDisabledReason) {
   if (workerDisabledReported) return;
   workerDisabledReported = true;
   track('Board Worker Rendering Disabled', { reason });
-}
-
-const MAX_LIST_EVENTS = 10;
-let listEventCount = 0;
-
-export function trackListBatchRender(
-  durationMs: number,
-  props: {
-    viewMode: 'grid' | 'list';
-    renderer: 'svg' | 'wasm';
-    batchSize: number;
-    totalItems: number;
-    isInitial: boolean;
-  },
-) {
-  if (listEventCount >= MAX_LIST_EVENTS) return;
-  listEventCount++;
-  track('List Batch Render', {
-    durationMs: Math.round(durationMs),
-    ...props,
-  });
 }


### PR DESCRIPTION
Drops trackRenderComplete and trackListBatchRender and all associated instrumentation: render-timing refs, hasFired guards, batchStartRef, and the batch-timing useEffect in ClimbsList.

Keeps trackRenderError and trackWorkerRenderingDisabled, which track failures rather than performance samples.

https://claude.ai/code/session_01GixFujtTp5XHg2VSthaEx9