### PR TITLE
Rename MAX_RENDER_EVENTS to MAX_ERROR_EVENTS

### DIFF
--- a/packages/web/app/lib/rendering-metrics.ts
+++ b/packages/web/app/lib/rendering-metrics.ts
@@ -2,11 +2,11 @@ import { track } from '@vercel/analytics';
 
 export type RenderContext = 'thumbnail' | 'card' | 'full-board' | 'feed';
 
-const MAX_RENDER_EVENTS = 5;
+const MAX_ERROR_EVENTS = 5;
 let errorEventCount = 0;
 
 export function trackRenderError(context: RenderContext, renderer: 'svg' | 'wasm') {
-  if (errorEventCount >= MAX_RENDER_EVENTS) return;
+  if (errorEventCount >= MAX_ERROR_EVENTS) return;
   errorEventCount++;
   track('Board Render Error', { context, renderer });
 }


### PR DESCRIPTION
The constant is now only used to cap errorEventCount after renderEventCount was removed. Renaming clarifies its actual purpose.

https://claude.ai/code/session_0117iu2EaQnBjQdx7LAR3by6