### PR TITLE
[improvement] Login modal has labels that are difficult to see since they overlap with the actual field #1609

### DIFF
--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -221,7 +221,6 @@ export default function AuthModal({
             >
               <TextField
                 id="login_email"
-                label="Email"
                 placeholder="your@email.com"
                 variant="outlined"
                 size="medium"
@@ -235,6 +234,8 @@ export default function AuthModal({
                 helperText={loginErrors.email}
                 slotProps={{
                   input: {
+                    type: 'email',
+                    autoCapitalize: 'none',
                     startAdornment: (
                       <InputAdornment position="start">
                         <MailOutlined />
@@ -246,10 +247,9 @@ export default function AuthModal({
 
               <TextField
                 id="login_password"
-                label="Password"
                 type="password"
                 placeholder="Password"
-                variant="outlined"
+                variant='outlined'
                 size="medium"
                 fullWidth
                 value={loginValues.password}
@@ -315,7 +315,7 @@ export default function AuthModal({
 
               <TextField
                 label="Email"
-                placeholder="your@email.com"
+                placeholder="your@emai5.com"
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -328,6 +328,8 @@ export default function AuthModal({
                 helperText={registerErrors.email}
                 slotProps={{
                   input: {
+                    type: 'email',
+                    autoCapitalize: 'none',
                     startAdornment: (
                       <InputAdornment position="start">
                         <MailOutlined />

--- a/packages/web/setup-dev.sh
+++ b/packages/web/setup-dev.sh
@@ -253,7 +253,7 @@ if docker exec db-postgres-1 psql postgresql://postgres:password@localhost:5432/
     print_success "Database is already set up with board data"
 else
     echo "Starting PostgreSQL database with Docker..."
-    cd db/
+    cd packages/web/db/
     if docker compose version >/dev/null 2>&1; then
       if ! docker compose up -d; then
           print_error "Failed to start database container"


### PR DESCRIPTION
- Remove label from Email and Password since they overlap with the actual field making them difficult to read. The Placeholder provides enough information for the user
- Make the email field type email and set the autocapitalize to none, so it doesn't autocapitalize emails