### PR TITLE
[improvement] Login modal has labels that are difficult to see since they overlap with the actual field #1609

### DIFF
--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -221,7 +221,6 @@ export default function AuthModal({
             >
               <TextField
                 id="login_email"
-                label="Email"
                 placeholder="your@email.com"
                 variant="outlined"
                 size="medium"
@@ -235,6 +234,8 @@ export default function AuthModal({
                 helperText={loginErrors.email}
                 slotProps={{
                   input: {
+                    type: 'email',
+                    autoCapitalize: 'none',
                     startAdornment: (
                       <InputAdornment position="start">
                         <MailOutlined />
@@ -246,7 +247,6 @@ export default function AuthModal({
 
               <TextField
                 id="login_password"
-                label="Password"
                 type="password"
                 placeholder="Password"
                 variant="outlined"
@@ -328,6 +328,8 @@ export default function AuthModal({
                 helperText={registerErrors.email}
                 slotProps={{
                   input: {
+                    type: 'email',
+                    autoCapitalize: 'none',
                     startAdornment: (
                       <InputAdornment position="start">
                         <MailOutlined />


### PR DESCRIPTION
- Remove label from Email and Password since they overlap with the actual field making them difficult to read. The Placeholder provides enough information for the user
- Make the email field type email and set the autocapitalize to none, so it doesn't autocapitalize emails