### PR TITLE
fix: address map search bugs and code quality issues

### DIFF
--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
@@ -188,7 +188,8 @@ describe('BoardSearchDrawer', () => {
     expect(lastSearchInput!.query).toBe('');
   });
 
-  it('resets coords to null when the drawer is closed and reopened', () => {
+  it('resets coords to null when the drawer is closed and reopened without geolocation', () => {
+    // userCoords is null (no geo) — only a manual pan had resolved coords.
     const { rerender } = render(
       <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
     );
@@ -201,10 +202,55 @@ describe('BoardSearchDrawer', () => {
     // Close the drawer — locationResolved should reset
     rerender(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
 
-    // Reopen without any further panning — coords must be null again
+    // Reopen without geo or further panning — coords must be null again
     rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
     expect(lastSearchInput!.latitude).toBeNull();
     expect(lastSearchInput!.longitude).toBeNull();
+  });
+
+  it('auto-centers to user location when geolocation has resolved, and re-centers after reopen', () => {
+    // Geolocation was already granted before the drawer opens.
+    mockUserCoords = { latitude: 48.8, longitude: 2.3, accuracy: 10 };
+
+    const { rerender } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+
+    // Should auto-center to the resolved location immediately
+    expect(lastSearchInput!.latitude).toBe(48.8);
+    expect(lastSearchInput!.longitude).toBe(2.3);
+
+    // Close and reopen — the close-effect reset must NOT leave coords null on
+    // the next open when geolocation is still resolved. The !open guard in the
+    // userCoords effect defers re-centering until open=true.
+    rerender(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+
+    expect(lastSearchInput!.latitude).toBe(48.8);
+    expect(lastSearchInput!.longitude).toBe(2.3);
+  });
+
+  it('does not override a board-card selection when geolocation resolves afterward', () => {
+    // Start with no geolocation — user picks a board first.
+    mockBoards = [makeBoard('b1', { latitude: 51.5, longitude: -0.1 })];
+    mockUserCoords = null;
+
+    const { rerender } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+
+    // Click the card — handleCardClick sets center and locationResolved=true
+    fireEvent.click(screen.getByTestId('board-card-b1'));
+    expect(lastSearchInput!.latitude).toBe(51.5);
+    expect(lastSearchInput!.longitude).toBe(-0.1);
+
+    // Geolocation now resolves to a different location
+    mockUserCoords = { latitude: 48.8, longitude: 2.3, accuracy: 10 };
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+
+    // Center must stay at the board's location, not jump to the user's coords
+    expect(lastSearchInput!.latitude).toBe(51.5);
+    expect(lastSearchInput!.longitude).toBe(-0.1);
   });
 
   it('invokes onBoardOpen when the Open button on a selected board is clicked', () => {

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
@@ -188,6 +188,25 @@ describe('BoardSearchDrawer', () => {
     expect(lastSearchInput!.query).toBe('');
   });
 
+  it('resets coords to null when the drawer is closed and reopened', () => {
+    const { rerender } = render(
+      <BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />,
+    );
+
+    // Simulate the user panning the map to a real location
+    fireEvent.click(screen.getByTestId('board-search-map'));
+    expect(lastSearchInput!.latitude).toBe(51.5);
+    expect(lastSearchInput!.longitude).toBe(-0.1);
+
+    // Close the drawer — locationResolved should reset
+    rerender(<BoardSearchDrawer open={false} onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+
+    // Reopen without any further panning — coords must be null again
+    rerender(<BoardSearchDrawer open onClose={vi.fn()} onBoardOpen={vi.fn()} />);
+    expect(lastSearchInput!.latitude).toBeNull();
+    expect(lastSearchInput!.longitude).toBeNull();
+  });
+
   it('invokes onBoardOpen when the Open button on a selected board is clicked', () => {
     mockBoards = [makeBoard('b1')];
     const onBoardOpen = vi.fn();

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
@@ -176,9 +176,7 @@ describe('BoardSearchDrawer', () => {
     const input = container.querySelector('input') as HTMLInputElement;
     expect(input).toBeTruthy();
 
-    act(() => {
-      fireEvent.change(input, { target: { value: 'kilter' } });
-    });
+    fireEvent.change(input, { target: { value: 'kilter' } });
     expect(lastSearchInput!.query).toBe('kilter');
 
     // Close and reopen — query should be empty

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -59,11 +59,14 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
   }, [open, requestedGeo, requestPermission]);
 
   useEffect(() => {
-    if (!userCoords || locationResolved) return;
+    // !open guard: the close-effect sets locationResolved=false which re-triggers
+    // this effect while the drawer is still closed. Bail out then; the dep change
+    // on open=true when the drawer reopens will run the effect at the right time.
+    if (!userCoords || !open || locationResolved) return;
     setCenter({ lat: userCoords.latitude, lng: userCoords.longitude });
     setZoom((prev) => (prev === DEFAULT_ZOOM ? NEARBY_ZOOM : prev));
     setLocationResolved(true);
-  }, [userCoords, locationResolved]);
+  }, [userCoords, open, locationResolved]);
 
   // Reset transient drawer state each time the drawer is closed. Clearing
   // requestedGeo lets us retry the permission prompt if the user denied it
@@ -135,6 +138,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     setSelectedBoardUuid(board.uuid);
     if (board.latitude != null && board.longitude != null) {
       setCenter({ lat: board.latitude, lng: board.longitude });
+      setLocationResolved(true);
       // Keep zoom — user's spatial context shouldn't jump
     }
   }, []);

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -43,6 +43,10 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [selectedBoardUuid, setSelectedBoardUuid] = useState<string | null>(null);
   const [requestedGeo, setRequestedGeo] = useState(false);
+  // True once the map has been panned by the user or geolocation has resolved.
+  // Kept separate from `center` to avoid the footgun where center === DEFAULT_CENTER
+  // would silently suppress coordinate-based queries for users at exactly (20, 0).
+  const [locationResolved, setLocationResolved] = useState(false);
 
   const carouselRef = useRef<HTMLDivElement>(null);
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -55,14 +59,11 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
   }, [open, requestedGeo, requestPermission]);
 
   useEffect(() => {
-    if (!userCoords) return;
-    setCenter((prev) => {
-      // Only auto-center if we're still at the default world view
-      if (prev.lat !== DEFAULT_CENTER.lat || prev.lng !== DEFAULT_CENTER.lng) return prev;
-      return { lat: userCoords.latitude, lng: userCoords.longitude };
-    });
+    if (!userCoords || locationResolved) return;
+    setCenter({ lat: userCoords.latitude, lng: userCoords.longitude });
     setZoom((prev) => (prev === DEFAULT_ZOOM ? NEARBY_ZOOM : prev));
-  }, [userCoords]);
+    setLocationResolved(true);
+  }, [userCoords, locationResolved]);
 
   // Reset transient drawer state each time the drawer is closed. Clearing
   // requestedGeo lets us retry the permission prompt if the user denied it
@@ -77,18 +78,17 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
       setRequestedGeo(false);
       setCenter(DEFAULT_CENTER);
       setZoom(DEFAULT_ZOOM);
+      setLocationResolved(false);
     }
   }, [open]);
 
-  // While the drawer is still at the default world-view fallback, don't fire a
-  // coordinate-based search — the 300 km bucket at zoom 3 would surface a
-  // cluster of boards in Kansas to every user until geolocation resolves.
-  const hasResolvedLocation = center.lat !== DEFAULT_CENTER.lat || center.lng !== DEFAULT_CENTER.lng;
-
   const { boards, isLoading, isFetching, radiusKm, hasMore, isFetchingNextPage, fetchNextPage } = useSearchBoardsMap({
     query,
-    latitude: hasResolvedLocation ? center.lat : null,
-    longitude: hasResolvedLocation ? center.lng : null,
+    // While the map is still at the default world-view fallback (locationResolved=false),
+    // don't fire a coordinate-based search — the 300 km bucket at zoom 3 would surface a
+    // cluster of boards in Kansas to every user until geolocation resolves.
+    latitude: locationResolved ? center.lat : null,
+    longitude: locationResolved ? center.lng : null,
     zoom,
     enabled: open,
   });
@@ -111,6 +111,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     ({ lat, lng, zoom: z }: { lat: number; lng: number; zoom: number }) => {
       setCenter({ lat, lng });
       setZoom(z);
+      setLocationResolved(true);
     },
     [],
   );

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -50,6 +50,10 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
 
   const carouselRef = useRef<HTMLDivElement>(null);
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  // Mirrors locationResolved state so the geolocation effect can guard against
+  // re-running without adding locationResolved to its dep array (which would
+  // cause a second no-op run every time the effect sets it to true).
+  const locationResolvedRef = useRef(false);
 
   // Ask for the user's location on first open. If granted we'll recenter to ~20km view.
   useEffect(() => {
@@ -62,11 +66,14 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     // !open guard: the close-effect sets locationResolved=false which re-triggers
     // this effect while the drawer is still closed. Bail out then; the dep change
     // on open=true when the drawer reopens will run the effect at the right time.
-    if (!userCoords || !open || locationResolved) return;
+    // locationResolvedRef (not state) is used here so adding it to deps doesn't
+    // cause a second no-op run after this effect sets locationResolved=true.
+    if (!userCoords || !open || locationResolvedRef.current) return;
     setCenter({ lat: userCoords.latitude, lng: userCoords.longitude });
     setZoom((prev) => (prev === DEFAULT_ZOOM ? NEARBY_ZOOM : prev));
+    locationResolvedRef.current = true;
     setLocationResolved(true);
-  }, [userCoords, open, locationResolved]);
+  }, [userCoords, open]);
 
   // Reset transient drawer state each time the drawer is closed. Clearing
   // requestedGeo lets us retry the permission prompt if the user denied it
@@ -81,6 +88,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
       setRequestedGeo(false);
       setCenter(DEFAULT_CENTER);
       setZoom(DEFAULT_ZOOM);
+      locationResolvedRef.current = false;
       setLocationResolved(false);
     }
   }, [open]);
@@ -114,6 +122,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     ({ lat, lng, zoom: z }: { lat: number; lng: number; zoom: number }) => {
       setCenter({ lat, lng });
       setZoom(z);
+      locationResolvedRef.current = true;
       setLocationResolved(true);
     },
     [],
@@ -138,6 +147,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
     setSelectedBoardUuid(board.uuid);
     if (board.latitude != null && board.longitude != null) {
       setCenter({ lat: board.latitude, lng: board.longitude });
+      locationResolvedRef.current = true;
       setLocationResolved(true);
       // Keep zoom — user's spatial context shouldn't jump
     }

--- a/packages/web/app/components/board-search-drawer/board-search-map.module.css
+++ b/packages/web/app/components/board-search-drawer/board-search-map.module.css
@@ -1,5 +1,13 @@
+/* Map container — Leaflet requires explicit dimensions on its root element. */
+.mapContainer {
+  width: 100%;
+  height: 100%;
+}
+
 /* Map markers — sized inline by Leaflet's iconSize prop, but coloured /
-   bordered / shadowed via design-token-driven CSS variables. */
+   bordered / shadowed via design-token-driven CSS variables.
+   NOTE: 16px / 22px mirror MARKER_SIZE / MARKER_SIZE_SELECTED in board-search-map.tsx.
+   Update both together. */
 
 .marker {
   width: 16px;

--- a/packages/web/app/components/board-search-drawer/board-search-map.module.css
+++ b/packages/web/app/components/board-search-drawer/board-search-map.module.css
@@ -4,14 +4,12 @@
   height: 100%;
 }
 
-/* Map markers — sized inline by Leaflet's iconSize prop, but coloured /
-   bordered / shadowed via design-token-driven CSS variables.
-   NOTE: 16px / 22px mirror MARKER_SIZE / MARKER_SIZE_SELECTED in board-search-map.tsx.
-   Update both together. */
+/* Map markers — Leaflet overrides width/height with its inline iconSize style,
+   so only the JS constants (MARKER_SIZE / MARKER_SIZE_SELECTED in
+   board-search-map.tsx) control the rendered size. This class handles colour,
+   border, shape, and shadow only. */
 
 .marker {
-  width: 16px;
-  height: 16px;
   background: var(--color-primary);
   border: 3px solid var(--semantic-surface);
   border-radius: 50%;
@@ -19,7 +17,5 @@
 }
 
 .markerSelected {
-  width: 22px;
-  height: 22px;
   border-width: 4px;
 }

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -231,11 +231,10 @@ export default function BoardSearchMap({
       // Suppress the regular fireViewport debounce for this animation so the
       // parent's center/zoom isn't updated mid-flight — that would re-render
       // and trigger the pan effect's setView, racing the flyTo.
-      programmaticMoveRef.current = true;
-      // Once the animation finishes (or the user interrupts it), report the
-      // actual final viewport directly. By that point map.getCenter() matches
-      // the target, so the pan effect's distance guard short-circuits and no
-      // second animation runs.
+      // Register the one-shot listener BEFORE setting programmaticMoveRef and
+      // calling flyTo. In environments where flyTo fires moveend synchronously
+      // (e.g. test mocks), the listener must already be attached or the
+      // viewport callback is silently dropped.
       map.once('moveend', () => {
         const c = map.getCenter();
         onViewportChangeRef.current({
@@ -244,6 +243,10 @@ export default function BoardSearchMap({
           zoom: map.getZoom(),
         });
       });
+      // Suppress the regular fireViewport debounce for this animation so the
+      // parent's center/zoom isn't updated mid-flight — that would re-render
+      // and trigger the pan effect's setView, racing the flyTo.
+      programmaticMoveRef.current = true;
       map.flyTo([coords.latitude, coords.longitude], 13);
     },
     [],
@@ -273,7 +276,7 @@ export default function BoardSearchMap({
       data-swipe-blocked="true"
       sx={{ position: 'relative', width: '100%', height: '100%' }}
     >
-      <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+      <div ref={containerRef} className={markerStyles.mapContainer} />
       {mapReady && (
         <MuiButton
           size="small"

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -228,13 +228,23 @@ export default function BoardSearchMap({
     (coords: { latitude: number; longitude: number }) => {
       const map = mapRef.current;
       if (!map) return;
-      // Suppress the regular fireViewport debounce for this animation so the
-      // parent's center/zoom isn't updated mid-flight — that would re-render
-      // and trigger the pan effect's setView, racing the flyTo.
       // Register the one-shot listener BEFORE setting programmaticMoveRef and
-      // calling flyTo. In environments where flyTo fires moveend synchronously
-      // (e.g. test mocks), the listener must already be attached or the
-      // viewport callback is silently dropped.
+      // calling flyTo. If flyTo fires moveend synchronously (e.g. in test mocks),
+      // the listener must already be attached or the viewport callback is dropped.
+      //
+      // Listener-ordering note: Leaflet fires 'moveend' handlers in registration
+      // order. The persistent fireViewport handler (registered at map init) runs
+      // first, sees programmaticMoveRef=true, clears the flag and returns without
+      // debouncing. This once() callback then fires unconditionally and reports
+      // the final viewport. This relies on Leaflet's stable (but undocumented)
+      // FIFO ordering — if that ever changes, fireViewport must not clear the flag
+      // before the once() handler has read it.
+      //
+      // Edge case: if the map is already at the destination, Leaflet may skip the
+      // animation and not emit moveend at all. In that scenario the once() handler
+      // is never called, so onViewportChangeRef is not invoked and locationResolved
+      // stays false for the session. Pre-existing limitation; fixing it would
+      // require an at-destination guard or a fallback timeout.
       map.once('moveend', () => {
         const c = map.getCenter();
         onViewportChangeRef.current({
@@ -243,9 +253,9 @@ export default function BoardSearchMap({
           zoom: map.getZoom(),
         });
       });
-      // Suppress the regular fireViewport debounce for this animation so the
-      // parent's center/zoom isn't updated mid-flight — that would re-render
-      // and trigger the pan effect's setView, racing the flyTo.
+      // Suppress the regular fireViewport debounce so the parent's center/zoom
+      // isn't updated mid-flight — that would trigger the pan effect's setView,
+      // racing the flyTo.
       programmaticMoveRef.current = true;
       map.flyTo([coords.latitude, coords.longitude], 13);
     },

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -119,8 +119,12 @@ export default function BoardSearchMap({
         }, VIEWPORT_DEBOUNCE_MS);
       };
 
+      // 'moveend' fires after any view change — pan, zoom, or both — so a
+      // separate 'zoomend' handler is redundant. More importantly, flyTo emits
+      // 'zoomend' before 'moveend'; a second handler on 'zoomend' would clear
+      // programmaticMoveRef prematurely, letting the 'moveend' fireViewport and
+      // the once('moveend') callback both fire, producing two updates per flyTo.
       map.on('moveend', fireViewport);
-      map.on('zoomend', fireViewport);
 
       // Observe container size so we can correct Leaflet's internal size whenever
       // the parent (e.g. bottom-sheet drawer) finishes animating in, rotates, or
@@ -228,6 +232,27 @@ export default function BoardSearchMap({
     (coords: { latitude: number; longitude: number }) => {
       const map = mapRef.current;
       if (!map) return;
+
+      // At-destination guard: if the map is already at the target position and
+      // zoom, Leaflet skips the animation and never emits moveend. The once()
+      // handler below would never fire, onViewportChangeRef would not be called,
+      // and locationResolved would stay false for the session. Report the current
+      // viewport immediately and bail out instead.
+      const current = map.getCenter();
+      const FLY_TO_ZOOM = 13;
+      if (
+        Math.abs(current.lat - coords.latitude) < 0.0001 &&
+        Math.abs(current.lng - coords.longitude) < 0.0001 &&
+        map.getZoom() === FLY_TO_ZOOM
+      ) {
+        onViewportChangeRef.current({
+          lat: Math.round(coords.latitude * 1000000) / 1000000,
+          lng: Math.round(coords.longitude * 1000000) / 1000000,
+          zoom: FLY_TO_ZOOM,
+        });
+        return;
+      }
+
       // Register the one-shot listener BEFORE setting programmaticMoveRef and
       // calling flyTo. If flyTo fires moveend synchronously (e.g. in test mocks),
       // the listener must already be attached or the viewport callback is dropped.
@@ -239,12 +264,6 @@ export default function BoardSearchMap({
       // the final viewport. This relies on Leaflet's stable (but undocumented)
       // FIFO ordering — if that ever changes, fireViewport must not clear the flag
       // before the once() handler has read it.
-      //
-      // Edge case: if the map is already at the destination, Leaflet may skip the
-      // animation and not emit moveend at all. In that scenario the once() handler
-      // is never called, so onViewportChangeRef is not invoked and locationResolved
-      // stays false for the session. Pre-existing limitation; fixing it would
-      // require an at-destination guard or a fallback timeout.
       map.once('moveend', () => {
         const c = map.getCenter();
         onViewportChangeRef.current({
@@ -257,7 +276,7 @@ export default function BoardSearchMap({
       // isn't updated mid-flight — that would trigger the pan effect's setView,
       // racing the flyTo.
       programmaticMoveRef.current = true;
-      map.flyTo([coords.latitude, coords.longitude], 13);
+      map.flyTo([coords.latitude, coords.longitude], FLY_TO_ZOOM);
     },
     [],
   );

--- a/packages/web/app/hooks/use-search-boards-map.ts
+++ b/packages/web/app/hooks/use-search-boards-map.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, type InfiniteData, type QueryKey } from '@tanstack/react-query';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useDebouncedValue } from '@/app/hooks/use-debounced-value';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -81,7 +81,7 @@ export function useSearchBoardsMap({
   const client = useMemo(() => createGraphQLHttpClient(token ?? undefined), [token]);
 
   const { data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery<UserBoardConnection, Error>({
+    useInfiniteQuery<UserBoardConnection, Error, InfiniteData<UserBoardConnection>, QueryKey, number>({
       queryKey: ['searchBoardsMap', debouncedQuery, lat, lon, radiusKm, token],
       queryFn: async ({ pageParam }) => {
         const input: SearchBoardsQueryVariables['input'] = {
@@ -90,7 +90,7 @@ export function useSearchBoardsMap({
           longitude: hasCoords ? lon : undefined,
           radiusKm: hasCoords ? radiusKm : undefined,
           limit: PAGE_LIMIT,
-          offset: pageParam as number,
+          offset: pageParam,
         };
         const response = await client.request<SearchBoardsQueryResponse, SearchBoardsQueryVariables>(
           SEARCH_BOARDS,
@@ -101,7 +101,7 @@ export function useSearchBoardsMap({
       initialPageParam: 0,
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (!lastPage.hasMore) return undefined;
-        return (lastPageParam as number) + lastPage.boards.length;
+        return lastPageParam + lastPage.boards.length;
       },
       enabled: queryEnabled,
       staleTime: 30 * 1000,


### PR DESCRIPTION
- Replace hasResolvedLocation magic-value equality with a locationResolved
  boolean flag; eliminates the silent footgun where center===(20,0) would
  suppress coordinate queries for users physically at that coordinate
- Register map.once('moveend') before programmaticMoveRef and flyTo so the
  listener is guaranteed to be attached before any synchronous moveend fires
- Move Leaflet container inline style to a CSS module class (mapContainer),
  satisfying the project rule against inline style props
- Add a comment in the CSS module noting the 16px/22px marker sizes mirror
  MARKER_SIZE/MARKER_SIZE_SELECTED in the TSX file — change both together
- Use explicit TPageParam=number generic on useInfiniteQuery to remove both
  `pageParam as number` and `lastPageParam as number` casts
- Add test asserting latitude/longitude reset to null when the drawer is
  closed and reopened without a subsequent pan

https://claude.ai/code/session_01Acbpk62XVErUnfrJHqaRUv