### PR TITLE
Address #1599 logbook inline edit follow-up items

### DIFF
--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -316,9 +316,12 @@ describe('LogbookFeedItem', () => {
 
   it('marks both swipe action layers aria-hidden', () => {
     const { container } = render(<LogbookFeedItem item={makeItem()} />);
-    const hiddenLayers = container.querySelectorAll('[aria-hidden="true"]');
-    // At minimum the two action layer divs must be aria-hidden.
-    expect(hiddenLayers.length).toBeGreaterThanOrEqual(2);
+    // The CSS-module Proxy mock returns the prop name as the class,
+    // so both action layers are reachable via their source class names.
+    const left = container.querySelector('.leftActionLayer');
+    const right = container.querySelector('.rightActionLayer');
+    expect(left?.getAttribute('aria-hidden')).toBe('true');
+    expect(right?.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('reflects updateTick.isPending via the getter mock without remount', () => {

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -15,7 +15,10 @@ type SwipeOptions = {
 
 let capturedSwipeOptions: SwipeOptions | null = null;
 const updateTickAsyncMock = vi.fn();
-let updateTickIsPending = false;
+// Holder object so tests can mutate isPending and the mock reads the
+// current value on every render (avoids the stale-by-value closure
+// that would result from binding a plain `let` into the mock factory).
+const updateTickState = { isPending: false };
 
 // --- Mocks ---
 
@@ -47,7 +50,9 @@ vi.mock('@/app/hooks/use-swipe-actions', () => ({
 vi.mock('@/app/hooks/use-update-tick', () => ({
   useUpdateTick: () => ({
     mutateAsync: updateTickAsyncMock,
-    isPending: updateTickIsPending,
+    get isPending() {
+      return updateTickState.isPending;
+    },
   }),
 }));
 
@@ -173,7 +178,7 @@ function makeItem(overrides: Partial<AscentFeedItem> = {}): AscentFeedItem {
 beforeEach(() => {
   capturedSwipeOptions = null;
   updateTickAsyncMock.mockReset();
-  updateTickIsPending = false;
+  updateTickState.isPending = false;
 });
 
 // --- Tests ---
@@ -314,6 +319,18 @@ describe('LogbookFeedItem', () => {
     const hiddenLayers = container.querySelectorAll('[aria-hidden="true"]');
     // At minimum the two action layer divs must be aria-hidden.
     expect(hiddenLayers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reflects updateTick.isPending via the getter mock without remount', () => {
+    updateTickState.isPending = true;
+    const { rerender } = render(<LogbookFeedItem item={makeItem()} isEditing />);
+    const saveBtn = screen.getByLabelText('Save') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+
+    updateTickState.isPending = false;
+    rerender(<LogbookFeedItem item={makeItem()} isEditing />);
+    const saveBtn2 = screen.getByLabelText('Save') as HTMLButtonElement;
+    expect(saveBtn2.disabled).toBe(false);
   });
 
   it('keeps the comment row container mounted in both modes (U8)', () => {

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+
+// --- Capture hooks ---
+
+type SwipeOptions = {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  onSwipeRightLong?: () => void;
+  onSwipeZoneChange?: (zone: string) => void;
+  disabled?: boolean;
+};
+
+let capturedSwipeOptions: SwipeOptions | null = null;
+const updateTickAsyncMock = vi.fn();
+let updateTickIsPending = false;
+
+// --- Mocks ---
+
+vi.mock('../logbook-feed-item.module.css', () => ({
+  default: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+
+vi.mock('@/app/components/climb-card/ascent-status.module.css', () => ({
+  default: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer.module.css', () => ({
+  default: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+
+vi.mock('@/app/hooks/use-swipe-actions', () => ({
+  useSwipeActions: (options: SwipeOptions) => {
+    capturedSwipeOptions = options;
+    return {
+      swipeHandlers: { ref: vi.fn() },
+      swipeLeftConfirmed: false,
+      contentRef: vi.fn(),
+      leftActionRef: vi.fn(),
+      rightActionRef: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('@/app/hooks/use-update-tick', () => ({
+  useUpdateTick: () => ({
+    mutateAsync: updateTickAsyncMock,
+    isPending: updateTickIsPending,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-drawer-drag-resize', () => ({
+  useDrawerDragResize: () => ({
+    paperRef: { current: null },
+    dragHandlers: {},
+  }),
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    formatGrade: (g: string) => g,
+    getGradeColor: () => '#888',
+  }),
+}));
+
+vi.mock('@/app/lib/default-board-configs', () => ({
+  getDefaultBoardConfig: () => ({ sizeId: 10, setIds: '1,26' }),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: () => ({
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,26',
+  }),
+}));
+
+vi.mock('@/app/lib/climb-action-utils', () => ({
+  getExcludedClimbActions: () => [],
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  TENSION_KILTER_GRADES: [
+    { difficulty_id: 20, difficulty_name: '7a/V6', v_grade: 'V6' },
+    { difficulty_id: 21, difficulty_name: '7a+/V7', v_grade: 'V7' },
+  ],
+  getGradesForBoard: () => [
+    { difficulty_id: 20, difficulty_name: '7a/V6', v_grade: 'V6' },
+  ],
+}));
+
+vi.mock('@/app/components/activity-feed/ascent-thumbnail', () => ({
+  default: () => <div data-testid="ascent-thumbnail" />,
+}));
+
+vi.mock('@/app/components/ascent-status/ascent-status-icon', () => ({
+  AscentStatusIcon: () => <span data-testid="status-icon" />,
+}));
+
+vi.mock('@/app/components/climb-actions', () => ({
+  ClimbActions: () => <div data-testid="climb-actions" />,
+}));
+
+vi.mock('@/app/components/climb-card/drawer-climb-header', () => ({
+  default: () => <div data-testid="drawer-climb-header" />,
+}));
+
+vi.mock('../ascent-to-climb', () => ({
+  ascentFeedItemToClimb: (item: AscentFeedItem) => ({ uuid: item.climbUuid, name: item.climbName }),
+}));
+
+vi.mock('../../logbook/tick-controls', () => ({
+  InlineStarPicker: ({ onSelect }: { onSelect: (v: number | null) => void }) => (
+    <button data-testid="inline-star-picker" onClick={() => onSelect(3)}>
+      stars
+    </button>
+  ),
+  InlineGradePicker: ({ onSelect }: { onSelect: (v: number) => void }) => (
+    <button data-testid="inline-grade-picker" onClick={() => onSelect(21)}>
+      grade
+    </button>
+  ),
+  InlineTriesPicker: ({ onSelect }: { onSelect: (v: number) => void }) => (
+    <button data-testid="inline-tries-picker" onClick={() => onSelect(5)}>
+      tries
+    </button>
+  ),
+}));
+
+// Dynamic imports: next/dynamic resolves the loader; return a simple component from each.
+vi.mock('next/dynamic', () => ({
+  default: () => () => null,
+}));
+
+// --- Import component after mocks ---
+import LogbookFeedItem from '../logbook-feed-item';
+
+// --- Helpers ---
+
+function makeItem(overrides: Partial<AscentFeedItem> = {}): AscentFeedItem {
+  return {
+    uuid: 'tick-1',
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    setterUsername: null,
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 2,
+    quality: 4,
+    difficulty: 20,
+    difficultyName: '7a/V6',
+    consensusDifficulty: 20,
+    consensusDifficultyName: '7a/V6',
+    qualityAverage: 3.5,
+    isBenchmark: false,
+    comment: 'Nice send!',
+    climbedAt: new Date('2026-04-01T12:00:00Z').toISOString(),
+    frames: 'p1r14',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  capturedSwipeOptions = null;
+  updateTickAsyncMock.mockReset();
+  updateTickIsPending = false;
+});
+
+// --- Tests ---
+
+describe('LogbookFeedItem', () => {
+  it('renders non-edit mode with comment and more-actions button', () => {
+    render(<LogbookFeedItem item={makeItem()} />);
+    expect(screen.getByText('Test Climb')).toBeDefined();
+    expect(screen.getByText('Nice send!')).toBeDefined();
+    expect(screen.getByLabelText('More actions')).toBeDefined();
+  });
+
+  it('renders edit mode with TextField and save/cancel buttons', () => {
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    expect(screen.getByLabelText('Edit tick comment')).toBeDefined();
+    expect(screen.getByLabelText('Save')).toBeDefined();
+    expect(screen.getByLabelText('Cancel editing')).toBeDefined();
+    expect(screen.queryByLabelText('More actions')).toBeNull();
+  });
+
+  it('disables swipe actions while editing', () => {
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    expect(capturedSwipeOptions?.disabled).toBe(true);
+  });
+
+  it('fires onEdit when left-swipe completes', () => {
+    const onEdit = vi.fn();
+    const item = makeItem();
+    render(<LogbookFeedItem item={item} onEdit={onEdit} />);
+    capturedSwipeOptions?.onSwipeLeft();
+    expect(onEdit).toHaveBeenCalledWith(item);
+  });
+
+  it('fires onDelete when long right-swipe completes', () => {
+    const onDelete = vi.fn();
+    const item = makeItem();
+    render(<LogbookFeedItem item={item} onDelete={onDelete} />);
+    capturedSwipeOptions?.onSwipeRightLong?.();
+    expect(onDelete).toHaveBeenCalledWith('tick-1');
+  });
+
+  it('calls onCancelEdit after successful save', async () => {
+    updateTickAsyncMock.mockResolvedValue({ uuid: 'tick-1' });
+    const onCancelEdit = vi.fn();
+    render(
+      <LogbookFeedItem
+        item={makeItem()}
+        isEditing
+        onCancelEdit={onCancelEdit}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Save'));
+    });
+    expect(updateTickAsyncMock).toHaveBeenCalledWith({
+      uuid: 'tick-1',
+      input: expect.objectContaining({
+        status: 'send',
+        attemptCount: 2,
+        comment: 'Nice send!',
+      }),
+    });
+    expect(onCancelEdit).toHaveBeenCalledOnce();
+  });
+
+  it('keeps edit open when save fails', async () => {
+    updateTickAsyncMock.mockRejectedValue(new Error('boom'));
+    const onCancelEdit = vi.fn();
+    render(
+      <LogbookFeedItem
+        item={makeItem()}
+        isEditing
+        onCancelEdit={onCancelEdit}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Save'));
+    });
+    expect(onCancelEdit).not.toHaveBeenCalled();
+  });
+
+  it('opens status popover when status badge is clicked', () => {
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Change ascent status/));
+    expect(screen.getByText('Flash')).toBeDefined();
+    expect(screen.getByText('Send')).toBeDefined();
+    expect(screen.getByText('Attempt')).toBeDefined();
+  });
+
+  it('nulls quality in save payload when status is attempt', async () => {
+    updateTickAsyncMock.mockResolvedValue({});
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Change ascent status/));
+    fireEvent.click(screen.getByText('Attempt'));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Save'));
+    });
+    expect(updateTickAsyncMock).toHaveBeenCalledWith({
+      uuid: 'tick-1',
+      input: expect.objectContaining({ status: 'attempt', quality: null }),
+    });
+  });
+
+  it('expands star picker when user-stars cell is clicked in edit mode', () => {
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Quality:/));
+    expect(screen.getByTestId('inline-star-picker')).toBeDefined();
+  });
+
+  it('selecting a star updates edit state and collapses the picker', async () => {
+    updateTickAsyncMock.mockResolvedValue({});
+    render(<LogbookFeedItem item={makeItem()} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Quality:/));
+    fireEvent.click(screen.getByTestId('inline-star-picker'));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Save'));
+    });
+    expect(updateTickAsyncMock).toHaveBeenCalledWith({
+      uuid: 'tick-1',
+      input: expect.objectContaining({ quality: 3 }),
+    });
+  });
+
+  it('tags the container for the swipe-hint when isSwipeHintTarget is true', () => {
+    const { container } = render(
+      <LogbookFeedItem item={makeItem()} isSwipeHintTarget />,
+    );
+    expect(container.querySelector('#onboarding-logbook-card')).not.toBeNull();
+  });
+
+  it('does not tag the container when isSwipeHintTarget is false', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    expect(container.querySelector('#onboarding-logbook-card')).toBeNull();
+  });
+
+  it('marks both swipe action layers aria-hidden', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const hiddenLayers = container.querySelectorAll('[aria-hidden="true"]');
+    // At minimum the two action layer divs must be aria-hidden.
+    expect(hiddenLayers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps the comment row container mounted in both modes (U8)', () => {
+    const { container, rerender } = render(
+      <LogbookFeedItem item={makeItem({ comment: '' })} />,
+    );
+    const emptyRow = container.querySelector('.commentRow');
+    expect(emptyRow).not.toBeNull();
+
+    rerender(<LogbookFeedItem item={makeItem({ comment: '' })} isEditing />);
+    const editRow = container.querySelector('.commentRow');
+    expect(editRow).not.toBeNull();
+  });
+});

--- a/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
@@ -137,8 +137,10 @@ describe('LogbookSwipeHintOrchestrator', () => {
     expect(animate).toHaveBeenCalledTimes(2);
 
     // Drive every animation to completion; advance holds/gaps between them.
+    // One iteration per scheduled animation is enough — each call's
+    // advanceTimersByTimeAsync covers any pending HOLD/GAP setTimeout.
     const totalAnimations = REPEAT_COUNT * ANIMATIONS_PER_CYCLE;
-    for (let i = 0; i < totalAnimations + 4; i++) {
+    for (let i = 0; i < totalAnimations; i++) {
       if (animations[i]) {
         animations[i].resolve();
       }

--- a/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+
+const getPreferenceMock = vi.fn();
+const setPreferenceMock = vi.fn();
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => getPreferenceMock(...args),
+  setPreference: (...args: unknown[]) => setPreferenceMock(...args),
+}));
+
+import LogbookSwipeHintOrchestrator from '../logbook-swipe-hint-orchestrator';
+
+type FakeAnimation = {
+  finished: Promise<void>;
+  cancel: () => void;
+  resolve: () => void;
+  cancelled: boolean;
+};
+
+function installFakeAnimations() {
+  const animations: FakeAnimation[] = [];
+  const animate = vi.fn(function (this: Element) {
+    let resolveFn!: () => void;
+    const finished = new Promise<void>((r) => { resolveFn = r; });
+    const anim: FakeAnimation = {
+      finished,
+      cancelled: false,
+      cancel() {
+        anim.cancelled = true;
+      },
+      resolve: resolveFn,
+    };
+    animations.push(anim);
+    return anim as unknown as Animation;
+  });
+  (Element.prototype as unknown as { animate: typeof animate }).animate = animate;
+  return { animations, animate };
+}
+
+function installMatchMedia(coarse: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: q.includes('coarse') ? coarse : false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+function mountTarget() {
+  const root = document.createElement('div');
+  root.id = 'onboarding-logbook-card';
+  const content = document.createElement('div');
+  content.setAttribute('data-swipe-content', '');
+  const action = document.createElement('div');
+  action.setAttribute('data-swipe-right-action', '');
+  const icon = document.createElement('span');
+  action.appendChild(icon);
+  root.appendChild(content);
+  root.appendChild(action);
+  document.body.appendChild(root);
+  return { root, content, action };
+}
+
+beforeEach(() => {
+  getPreferenceMock.mockReset();
+  setPreferenceMock.mockReset();
+  document.body.innerHTML = '';
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('LogbookSwipeHintOrchestrator', () => {
+  it('skips animation and preference write when hint already seen', async () => {
+    getPreferenceMock.mockResolvedValue(true);
+    installMatchMedia(true);
+    const { animate } = installFakeAnimations();
+    mountTarget();
+
+    render(<LogbookSwipeHintOrchestrator />);
+    await act(async () => { await vi.runAllTimersAsync(); });
+
+    expect(animate).not.toHaveBeenCalled();
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it('skips animation on non-coarse pointer devices (desktop)', async () => {
+    getPreferenceMock.mockResolvedValue(null);
+    installMatchMedia(false);
+    const { animate } = installFakeAnimations();
+    mountTarget();
+
+    render(<LogbookSwipeHintOrchestrator />);
+    await act(async () => { await vi.runAllTimersAsync(); });
+
+    expect(animate).not.toHaveBeenCalled();
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing and does not mark seen when target element is missing', async () => {
+    getPreferenceMock.mockResolvedValue(null);
+    installMatchMedia(true);
+    const { animate } = installFakeAnimations();
+    // no mountTarget() — the card is not on screen
+
+    render(<LogbookSwipeHintOrchestrator />);
+    await act(async () => { await vi.runAllTimersAsync(); });
+
+    expect(animate).not.toHaveBeenCalled();
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the animation sequence twice and marks the hint seen on completion', async () => {
+    getPreferenceMock.mockResolvedValue(null);
+    installMatchMedia(true);
+    const { animations, animate } = installFakeAnimations();
+    mountTarget();
+
+    render(<LogbookSwipeHintOrchestrator />);
+
+    // Flush the initial pref read + setTimeout trigger + first pair of animate() calls.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+    expect(animate).toHaveBeenCalledTimes(2);
+
+    // Drive every animation to completion; advance holds/gaps between them.
+    for (let i = 0; i < 12; i++) {
+      if (animations[i]) {
+        animations[i].resolve();
+      }
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    }
+
+    // REPEAT_COUNT=2 cycles × (slideOut + fadeIn + slideBack + fadeOut) = 8 animate calls
+    expect(animate).toHaveBeenCalledTimes(8);
+    expect(setPreferenceMock).toHaveBeenCalledWith('swipeHint:logbookSeen', true);
+  });
+
+  it('cancels in-flight animations and does not mark seen when unmounted early', async () => {
+    getPreferenceMock.mockResolvedValue(null);
+    installMatchMedia(true);
+    const { animations } = installFakeAnimations();
+    mountTarget();
+
+    const view = render(<LogbookSwipeHintOrchestrator />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+    expect(animations.length).toBeGreaterThan(0);
+
+    view.unmount();
+
+    expect(animations[0].cancelled).toBe(true);
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import React from 'react';
 
+// Mirrors REPEAT_COUNT in logbook-swipe-hint-orchestrator.tsx. The
+// orchestrator invokes element.animate 4x per cycle (slide out, fade in,
+// slide back, fade out), so total calls = REPEAT_COUNT * ANIMATIONS_PER_CYCLE.
+const REPEAT_COUNT = 2;
+const ANIMATIONS_PER_CYCLE = 4;
+
 const getPreferenceMock = vi.fn();
 const setPreferenceMock = vi.fn();
 
@@ -131,15 +137,15 @@ describe('LogbookSwipeHintOrchestrator', () => {
     expect(animate).toHaveBeenCalledTimes(2);
 
     // Drive every animation to completion; advance holds/gaps between them.
-    for (let i = 0; i < 12; i++) {
+    const totalAnimations = REPEAT_COUNT * ANIMATIONS_PER_CYCLE;
+    for (let i = 0; i < totalAnimations + 4; i++) {
       if (animations[i]) {
         animations[i].resolve();
       }
       await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
     }
 
-    // REPEAT_COUNT=2 cycles × (slideOut + fadeIn + slideBack + fadeOut) = 8 animate calls
-    expect(animate).toHaveBeenCalledTimes(8);
+    expect(animate).toHaveBeenCalledTimes(totalAnimations);
     expect(setPreferenceMock).toHaveBeenCalledWith('swipeHint:logbookSeen', true);
   });
 

--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -215,18 +215,21 @@
 }
 
 /* Full-width comment row below the content row.
-   Height and padding transition to avoid a jump when the comment field
-   swaps between Typography and TextField on edit-mode toggle. */
+   Uses the grid-template-rows 0fr/1fr trick to get a smooth collapse
+   between edit and non-edit modes — height auto cannot interpolate. */
 .commentRow {
+  display: grid;
+  grid-template-rows: 1fr;
   padding: 0 var(--spacing-2) var(--spacing-2);
-  transition: height 180ms ease-out, padding 180ms ease-out;
+  transition: grid-template-rows 180ms ease-out, padding 180ms ease-out;
 }
 
-/* When empty (no comment, not editing) the row collapses to zero height
-   with no padding. Explicit height:0 + overflow:hidden so a stray
-   conditional child can't reopen the row by its own intrinsic size. */
 .commentRowEmpty {
+  grid-template-rows: 0fr;
   padding: 0 var(--spacing-2);
-  height: 0;
+}
+
+.commentRowContent {
   overflow: hidden;
+  min-height: 0;
 }

--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -219,12 +219,14 @@
    swaps between Typography and TextField on edit-mode toggle. */
 .commentRow {
   padding: 0 var(--spacing-2) var(--spacing-2);
-  transition: min-height 180ms ease-out, padding 180ms ease-out;
+  transition: height 180ms ease-out, padding 180ms ease-out;
 }
 
 /* When empty (no comment, not editing) the row collapses to zero height
-   with no padding, so transitioning back into edit preserves a visible frame. */
+   with no padding. Explicit height:0 + overflow:hidden so a stray
+   conditional child can't reopen the row by its own intrinsic size. */
 .commentRowEmpty {
   padding: 0 var(--spacing-2);
-  min-height: 0;
+  height: 0;
+  overflow: hidden;
 }

--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -71,7 +71,6 @@
 .swipeableContent {
   position: relative;
   background-color: var(--semantic-surface, #fff);
-  cursor: pointer;
   user-select: none;
 }
 
@@ -84,7 +83,8 @@
 }
 
 /* Thumbnail — 50% larger than the standard 64px via scale transform.
-   The wrapper reserves 96px of space while the inner 64px content scales up to fill it. */
+   The wrapper reserves 96px of space while the inner 64px content scales up to fill it.
+   overflow:hidden keeps the scale(1.5) transform clipped to the 96px box. */
 .thumbnail {
   width: 96px;
   height: 96px;
@@ -93,6 +93,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 
 .thumbnail > :first-child {
@@ -213,7 +214,17 @@
   font-size: var(--font-size-lg) !important;
 }
 
-/* Full-width comment row below the content row */
+/* Full-width comment row below the content row.
+   Height and padding transition to avoid a jump when the comment field
+   swaps between Typography and TextField on edit-mode toggle. */
 .commentRow {
   padding: 0 var(--spacing-2) var(--spacing-2);
+  transition: min-height 180ms ease-out, padding 180ms ease-out;
+}
+
+/* When empty (no comment, not editing) the row collapses to zero height
+   with no padding, so transitioning back into edit preserves a visible frame. */
+.commentRowEmpty {
+  padding: 0 var(--spacing-2);
+  min-height: 0;
 }

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -554,199 +554,199 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           className={styles.swipeableContent}
           data-swipe-content=""
         >
-        <div className={styles.content}>
-          {/* Thumbnail with ascent status badge */}
-          <div className={styles.thumbnail}>
-            {item.frames && item.layoutId && (
-              <AscentThumbnail
-                boardType={item.boardType}
-                layoutId={item.layoutId}
-                angle={item.angle}
-                climbUuid={item.climbUuid}
-                climbName={item.climbName}
-                frames={item.frames}
-                isMirror={item.isMirror}
-              />
-            )}
-            {isEditing ? (
-              <ButtonBase
-                className={`${ascentStyles.badge} ${styles.statusBadgeButton}`}
-                onClick={handleStatusBadgeClick}
-                aria-label={`Change ascent status, currently ${editStatus}`}
-              >
-                <AscentStatusIcon
-                  status={editStatus}
-                  variant="badge"
-                  fontSize={12}
+          <div className={styles.content}>
+            {/* Thumbnail with ascent status badge */}
+            <div className={styles.thumbnail}>
+              {item.frames && item.layoutId && (
+                <AscentThumbnail
+                  boardType={item.boardType}
+                  layoutId={item.layoutId}
+                  angle={item.angle}
+                  climbUuid={item.climbUuid}
+                  climbName={item.climbName}
+                  frames={item.frames}
+                  isMirror={item.isMirror}
                 />
-              </ButtonBase>
-            ) : (
-              <div className={ascentStyles.badge} style={{ bottom: 6 }}>
-                <AscentStatusIcon
-                  status={item.status}
-                  variant="badge"
-                  fontSize={12}
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Center section */}
-          <div className={styles.center}>
-            <Typography variant="body2" component="div" sx={nameSx}>
-              {item.climbName}
-            </Typography>
-            <Typography variant="body2" component="div" color="text.secondary" sx={subtitleSx}>
-              {subtitle}
-            </Typography>
-
-            {/* Picker panel (edit mode only) */}
-            {isEditing && (
-              <div className={styles.pickerPanel + (expandedControl ? ' ' + styles.pickerPanelExpanded : '')}>
-                <div className={styles.pickerPanelContent}>
-                  {renderedControl === 'stars' && (
-                    <div className={styles.compactStarPicker}>
-                      <InlineStarPicker quality={editQuality} onSelect={handleStarSelect} />
-                    </div>
-                  )}
-                  {renderedControl === 'grade' && (
-                    <InlineGradePicker
-                      grades={grades}
-                      currentGradeId={editDifficulty}
-                      focusGradeId={focusGradeId}
-                      onSelect={handleGradeSelect}
-                      gradeButtonRef={gradeButtonRef}
-                    />
-                  )}
-                  {renderedControl === 'tries' && (
-                    <InlineTriesPicker
-                      attemptCount={editAttemptCount}
-                      onSelect={handleTriesSelect}
-                      triesButtonRef={triesButtonRef}
-                    />
-                  )}
+              )}
+              {isEditing ? (
+                <ButtonBase
+                  className={`${ascentStyles.badge} ${styles.statusBadgeButton}`}
+                  onClick={handleStatusBadgeClick}
+                  aria-label={`Change ascent status, currently ${editStatus}`}
+                >
+                  <AscentStatusIcon
+                    status={editStatus}
+                    variant="badge"
+                    fontSize={12}
+                  />
+                </ButtonBase>
+              ) : (
+                <div className={ascentStyles.badge} style={{ bottom: 6 }}>
+                  <AscentStatusIcon
+                    status={item.status}
+                    variant="badge"
+                    fontSize={12}
+                  />
                 </div>
-              </div>
-            )}
-
-            <LogbookGradeRow
-              consensusDifficultyName={item.consensusDifficultyName}
-              qualityAverage={item.qualityAverage}
-              difficultyName={item.difficultyName}
-              quality={item.quality}
-              attemptCount={item.attemptCount}
-              isEditing={isEditing}
-              editQuality={editQuality}
-              editDifficulty={editDifficulty}
-              editAttemptCount={editAttemptCount}
-              expandedControl={expandedControl}
-              onExpandControl={setExpandedControl}
-              gradeButtonRef={gradeButtonRef}
-              triesButtonRef={triesButtonRef}
-            />
-
-          </div>
-
-          {/* Menu / save-cancel buttons */}
-          {isEditing ? (
-            <div className={styles.editControls}>
-              <IconButton
-                size="small"
-                onClick={onCancelEdit}
-                aria-label="Cancel editing"
-                sx={{
-                  width: 44,
-                  height: 44,
-                  color: 'text.disabled',
-                }}
-              >
-                <CloseOutlined sx={{ fontSize: 18 }} />
-              </IconButton>
-              <IconButton
-                size="small"
-                onClick={handleSave}
-                disabled={isSaving}
-                aria-label="Save"
-                sx={{
-                  width: 44,
-                  height: 44,
-                  backgroundColor: themeTokens.colors.success,
-                  color: 'common.white',
-                  '&:hover': { backgroundColor: themeTokens.colors.success },
-                }}
-              >
-                {isSaving ? (
-                  <CircularProgress size={18} color="inherit" />
-                ) : (
-                  <SaveOutlined sx={{ fontSize: 18 }} />
-                )}
-              </IconButton>
+              )}
             </div>
-          ) : (
-            <IconButton
-              size="small"
-              aria-label="More actions"
-              onClick={handleOpenActions}
-              className={styles.menuButton}
-              disableRipple
-            >
-              <MoreHorizOutlined />
-            </IconButton>
-          )}
-        </div>
 
-        {/* Comment area — always mounted so edit-mode toggling animates
-            via grid-template-rows rather than popping in/out. */}
-        <div
-          className={
-            !isEditing && !item.comment
-              ? `${styles.commentRow} ${styles.commentRowEmpty}`
-              : styles.commentRow
-          }
-        >
-          <div className={styles.commentRowContent}>
-            {isEditing ? (
-              <TextField
-                fullWidth
-                size="small"
-                variant="outlined"
-                placeholder="Comment..."
-                multiline
-                minRows={1}
-                maxRows={commentFocused ? 4 : 1}
-                value={editComment}
-                onChange={(event) => setEditComment(event.target.value)}
-                onFocus={handleCommentFocus}
-                onBlur={handleCommentBlur}
-                slotProps={{
-                  htmlInput: { maxLength: 2000, 'aria-label': 'Edit tick comment' },
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-                sx={{
-                  '& .MuiOutlinedInput-root': {
-                    borderRadius: `${themeTokens.borderRadius.md}px`,
-                    backgroundColor: 'var(--input-bg)',
-                    '& .MuiOutlinedInput-notchedOutline': {
-                      borderColor: 'var(--neutral-200)',
-                    },
-                  },
-                }}
+            {/* Center section */}
+            <div className={styles.center}>
+              <Typography variant="body2" component="div" sx={nameSx}>
+                {item.climbName}
+              </Typography>
+              <Typography variant="body2" component="div" color="text.secondary" sx={subtitleSx}>
+                {subtitle}
+              </Typography>
+
+              {/* Picker panel (edit mode only) */}
+              {isEditing && (
+                <div className={styles.pickerPanel + (expandedControl ? ' ' + styles.pickerPanelExpanded : '')}>
+                  <div className={styles.pickerPanelContent}>
+                    {renderedControl === 'stars' && (
+                      <div className={styles.compactStarPicker}>
+                        <InlineStarPicker quality={editQuality} onSelect={handleStarSelect} />
+                      </div>
+                    )}
+                    {renderedControl === 'grade' && (
+                      <InlineGradePicker
+                        grades={grades}
+                        currentGradeId={editDifficulty}
+                        focusGradeId={focusGradeId}
+                        onSelect={handleGradeSelect}
+                        gradeButtonRef={gradeButtonRef}
+                      />
+                    )}
+                    {renderedControl === 'tries' && (
+                      <InlineTriesPicker
+                        attemptCount={editAttemptCount}
+                        onSelect={handleTriesSelect}
+                        triesButtonRef={triesButtonRef}
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <LogbookGradeRow
+                consensusDifficultyName={item.consensusDifficultyName}
+                qualityAverage={item.qualityAverage}
+                difficultyName={item.difficultyName}
+                quality={item.quality}
+                attemptCount={item.attemptCount}
+                isEditing={isEditing}
+                editQuality={editQuality}
+                editDifficulty={editDifficulty}
+                editAttemptCount={editAttemptCount}
+                expandedControl={expandedControl}
+                onExpandControl={setExpandedControl}
+                gradeButtonRef={gradeButtonRef}
+                triesButtonRef={triesButtonRef}
               />
+
+            </div>
+
+            {/* Menu / save-cancel buttons */}
+            {isEditing ? (
+              <div className={styles.editControls}>
+                <IconButton
+                  size="small"
+                  onClick={onCancelEdit}
+                  aria-label="Cancel editing"
+                  sx={{
+                    width: 44,
+                    height: 44,
+                    color: 'text.disabled',
+                  }}
+                >
+                  <CloseOutlined sx={{ fontSize: 18 }} />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={handleSave}
+                  disabled={isSaving}
+                  aria-label="Save"
+                  sx={{
+                    width: 44,
+                    height: 44,
+                    backgroundColor: themeTokens.colors.success,
+                    color: 'common.white',
+                    '&:hover': { backgroundColor: themeTokens.colors.success },
+                  }}
+                >
+                  {isSaving ? (
+                    <CircularProgress size={18} color="inherit" />
+                  ) : (
+                    <SaveOutlined sx={{ fontSize: 18 }} />
+                  )}
+                </IconButton>
+              </div>
             ) : (
-              item.comment && (
-                <Typography sx={commentBoxSx}>
-                  {item.comment}
-                </Typography>
-              )
+              <IconButton
+                size="small"
+                aria-label="More actions"
+                onClick={handleOpenActions}
+                className={styles.menuButton}
+                disableRipple
+              >
+                <MoreHorizOutlined />
+              </IconButton>
             )}
           </div>
-        </div>
+
+          {/* Comment area — always mounted so edit-mode toggling animates
+              via grid-template-rows rather than popping in/out. */}
+          <div
+            className={
+              !isEditing && !item.comment
+                ? `${styles.commentRow} ${styles.commentRowEmpty}`
+                : styles.commentRow
+            }
+          >
+            <div className={styles.commentRowContent}>
+              {isEditing ? (
+                <TextField
+                  fullWidth
+                  size="small"
+                  variant="outlined"
+                  placeholder="Comment..."
+                  multiline
+                  minRows={1}
+                  maxRows={commentFocused ? 4 : 1}
+                  value={editComment}
+                  onChange={(event) => setEditComment(event.target.value)}
+                  onFocus={handleCommentFocus}
+                  onBlur={handleCommentBlur}
+                  slotProps={{
+                    htmlInput: { maxLength: 2000, 'aria-label': 'Edit tick comment' },
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                  sx={{
+                    '& .MuiOutlinedInput-root': {
+                      borderRadius: `${themeTokens.borderRadius.md}px`,
+                      backgroundColor: 'var(--input-bg)',
+                      '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: 'var(--neutral-200)',
+                      },
+                    },
+                  }}
+                />
+              ) : (
+                item.comment && (
+                  <Typography sx={commentBoxSx}>
+                    {item.comment}
+                  </Typography>
+                )
+              )}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -695,9 +695,8 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           )}
         </div>
 
-        {/* Comment area — full width below the content row.
-            Container is always rendered so edit-mode toggling transitions
-            smoothly rather than popping the row in and out. */}
+        {/* Comment area — always mounted so edit-mode toggling animates
+            via grid-template-rows rather than popping in/out. */}
         <div
           className={
             !isEditing && !item.comment
@@ -705,46 +704,48 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
               : styles.commentRow
           }
         >
-          {isEditing ? (
-            <TextField
-              fullWidth
-              size="small"
-              variant="outlined"
-              placeholder="Comment..."
-              multiline
-              minRows={1}
-              maxRows={commentFocused ? 4 : 1}
-              value={editComment}
-              onChange={(event) => setEditComment(event.target.value)}
-              onFocus={handleCommentFocus}
-              onBlur={handleCommentBlur}
-              slotProps={{
-                htmlInput: { maxLength: 2000, 'aria-label': 'Edit tick comment' },
-                input: {
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
-                    </InputAdornment>
-                  ),
-                },
-              }}
-              sx={{
-                '& .MuiOutlinedInput-root': {
-                  borderRadius: `${themeTokens.borderRadius.md}px`,
-                  backgroundColor: 'var(--input-bg)',
-                  '& .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--neutral-200)',
+          <div className={styles.commentRowContent}>
+            {isEditing ? (
+              <TextField
+                fullWidth
+                size="small"
+                variant="outlined"
+                placeholder="Comment..."
+                multiline
+                minRows={1}
+                maxRows={commentFocused ? 4 : 1}
+                value={editComment}
+                onChange={(event) => setEditComment(event.target.value)}
+                onFocus={handleCommentFocus}
+                onBlur={handleCommentBlur}
+                slotProps={{
+                  htmlInput: { maxLength: 2000, 'aria-label': 'Edit tick comment' },
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
+                      </InputAdornment>
+                    ),
                   },
-                },
-              }}
-            />
-          ) : (
-            item.comment && (
-              <Typography sx={commentBoxSx}>
-                {item.comment}
-              </Typography>
-            )
-          )}
+                }}
+                sx={{
+                  '& .MuiOutlinedInput-root': {
+                    borderRadius: `${themeTokens.borderRadius.md}px`,
+                    backgroundColor: 'var(--input-bg)',
+                    '& .MuiOutlinedInput-notchedOutline': {
+                      borderColor: 'var(--neutral-200)',
+                    },
+                  },
+                }}
+              />
+            ) : (
+              item.comment && (
+                <Typography sx={commentBoxSx}>
+                  {item.comment}
+                </Typography>
+              )
+            )}
+          </div>
         </div>
         </div>
       </div>

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -268,6 +268,8 @@ interface LogbookFeedItemProps {
   allowInstagramPosting?: boolean;
   /** When true, show "Link Instagram post" option in the actions menu. */
   allowInstagramLinking?: boolean;
+  /** When true, tag this item so the first-visit swipe-hint animation can target it. */
+  isSwipeHintTarget?: boolean;
 }
 
 const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
@@ -279,6 +281,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   onCancelEdit,
   allowInstagramPosting,
   allowInstagramLinking,
+  isSwipeHintTarget,
 }) => {
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [instagramDialogOpen, setInstagramDialogOpen] = useState(false);
@@ -525,15 +528,22 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
 
   return (
     <>
-      <div className={styles.container}>
-        {/* Left action layer — Delete (revealed on long swipe right) */}
-        <div ref={leftActionCombinedRef} className={styles.leftActionLayer}>
+      <div className={styles.container} id={isSwipeHintTarget ? 'onboarding-logbook-card' : undefined}>
+        {/* Left action layer — Delete (revealed on long swipe right).
+            Decorative; the three-dot menu exposes Delete to assistive tech. */}
+        <div ref={leftActionCombinedRef} className={styles.leftActionLayer} aria-hidden="true">
           <DeleteOutlined className={styles.swipeIcon} />
           <span className={styles.deleteLabel}>Delete</span>
         </div>
 
-        {/* Right action layer — Edit (revealed on swipe left) */}
-        <div ref={rightActionRef} className={styles.rightActionLayer}>
+        {/* Right action layer — Edit (revealed on swipe left).
+            Decorative; the three-dot menu exposes Edit to assistive tech. */}
+        <div
+          ref={rightActionRef}
+          className={styles.rightActionLayer}
+          aria-hidden="true"
+          data-swipe-right-action=""
+        >
           <EditOutlined className={styles.swipeIcon} />
         </div>
 
@@ -685,9 +695,17 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           )}
         </div>
 
-        {/* Comment area — full width below the content row */}
-        {isEditing ? (
-          <div className={styles.commentRow}>
+        {/* Comment area — full width below the content row.
+            Container is always rendered so edit-mode toggling transitions
+            smoothly rather than popping the row in and out. */}
+        <div
+          className={
+            !isEditing && !item.comment
+              ? `${styles.commentRow} ${styles.commentRowEmpty}`
+              : styles.commentRow
+          }
+        >
+          {isEditing ? (
             <TextField
               fullWidth
               size="small"
@@ -720,16 +738,14 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
                 },
               }}
             />
-          </div>
-        ) : (
-          item.comment && (
-            <div className={styles.commentRow}>
+          ) : (
+            item.comment && (
               <Typography sx={commentBoxSx}>
                 {item.comment}
               </Typography>
-            </div>
-          )
-        )}
+            )
+          )}
+        </div>
         </div>
       </div>
 

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -497,10 +497,7 @@ export default function LogbookFeed() {
 
   const showBoardType = boardFilter === 'all';
   const hasFilters = boardFilter !== 'all' || debouncedSearch.length > 0 || !isDefaultFilters(filters);
-  // Posting and linking are mutually exclusive (see `allowInstagramLinking` prop below).
-  // Posting opens PostToInstagramDialog — full caption/copy flow, mobile-only where
-  // the Instagram app can be launched. Linking opens AttachBetaLinkDialog — a compact
-  // form to paste an existing Instagram URL, shown everywhere else on /you/logbook.
+  // Posting and linking are mutually exclusive — see `allowInstagramLinking` below.
   const enableInstagramPosting = pathname === '/you/logbook' && isNarrowViewport && isInstagramPostingSupported();
   const enableInstagramLinking = pathname === '/you/logbook';
 

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -661,6 +661,7 @@ export default function LogbookFeed() {
               onCancelEdit={handleCloseEdit}
               allowInstagramPosting={enableInstagramPosting}
               allowInstagramLinking={enableInstagramLinking && !enableInstagramPosting}
+              // Orchestrator re-queries DOM at animation time, so re-sorts are safe.
               isSwipeHintTarget={index === 0}
             />
           ))}

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -60,6 +60,7 @@ import {
 } from '@/app/lib/graphql/operations/ticks';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import LogbookFeedItem from './logbook-feed-item';
+import LogbookSwipeHintOrchestrator from './logbook-swipe-hint-orchestrator';
 import { isInstagramPostingSupported } from '@/app/lib/instagram-posting';
 import styles from './library.module.css';
 import feedStyles from '@/app/components/activity-feed/ascents-feed.module.css';
@@ -416,13 +417,20 @@ export default function LogbookFeed() {
     };
   }, []);
 
+  // Keep token in a ref so handleDelete stays stable across auth refreshes,
+  // which would otherwise invalidate React.memo on every LogbookFeedItem.
+  const tokenRef = useRef(token);
+  useEffect(() => {
+    tokenRef.current = token;
+  }, [token]);
+
   const handleDelete = useCallback((uuid: string) => {
     // If there's already a pending delete for a different item, flush it immediately
     if (pendingDeleteRef.current && pendingDeleteRef.current.uuid !== uuid) {
       const { uuid: prevUuid, timerId } = pendingDeleteRef.current;
       clearTimeout(timerId);
       pendingDeleteRef.current = null;
-      const client = createGraphQLHttpClient(token ?? null);
+      const client = createGraphQLHttpClient(tokenRef.current ?? null);
       client.request<{ deleteTick: boolean }, DeleteTickMutationVariables>(DELETE_TICK, { uuid: prevUuid }).catch(() => {
         showMessage('Failed to delete tick', 'error');
       });
@@ -449,7 +457,7 @@ export default function LogbookFeed() {
 
     const timerId = setTimeout(() => {
       pendingDeleteRef.current = null;
-      const client = createGraphQLHttpClient(token ?? null);
+      const client = createGraphQLHttpClient(tokenRef.current ?? null);
       client
         .request<{ deleteTick: boolean }, DeleteTickMutationVariables>(DELETE_TICK, { uuid })
         .then(() => {
@@ -477,7 +485,7 @@ export default function LogbookFeed() {
         }
       },
     }, 5000);
-  }, [token, queryClient, showMessage, feedQueryKey]);
+  }, [queryClient, showMessage, feedQueryKey]);
 
   const handleEdit = useCallback((item: AscentFeedItem) => {
     setEditingItemUuid(item.uuid);
@@ -489,6 +497,10 @@ export default function LogbookFeed() {
 
   const showBoardType = boardFilter === 'all';
   const hasFilters = boardFilter !== 'all' || debouncedSearch.length > 0 || !isDefaultFilters(filters);
+  // Posting and linking are mutually exclusive (see `allowInstagramLinking` prop below).
+  // Posting opens PostToInstagramDialog — full caption/copy flow, mobile-only where
+  // the Instagram app can be launched. Linking opens AttachBetaLinkDialog — a compact
+  // form to paste an existing Instagram URL, shown everywhere else on /you/logbook.
   const enableInstagramPosting = pathname === '/you/logbook' && isNarrowViewport && isInstagramPostingSupported();
   const enableInstagramLinking = pathname === '/you/logbook';
 
@@ -638,9 +650,10 @@ export default function LogbookFeed() {
   return (
     <>
       {filterBar}
+      <LogbookSwipeHintOrchestrator />
       <div className={feedStyles.feed}>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          {items.map((item) => (
+          {items.map((item, index) => (
             <LogbookFeedItem
               key={item.uuid}
               item={item}
@@ -651,6 +664,7 @@ export default function LogbookFeed() {
               onCancelEdit={handleCloseEdit}
               allowInstagramPosting={enableInstagramPosting}
               allowInstagramLinking={enableInstagramLinking && !enableInstagramPosting}
+              isSwipeHintTarget={index === 0}
             />
           ))}
         </Box>

--- a/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
@@ -30,14 +30,21 @@ export default function LogbookSwipeHintOrchestrator() {
 
   useEffect(() => {
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
+    // Collect every timer we schedule so unmount can clear all of them.
+    // A single `let timer` would only track the most recently assigned id.
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const schedule = (cb: () => void, ms: number) => {
+      const id = setTimeout(cb, ms);
+      timers.push(id);
+      return id;
+    };
 
     const run = async () => {
       const seen = await getPreference<boolean>(PREF_KEY);
       if (cancelled || seen) return;
       if (!window.matchMedia('(pointer: coarse)').matches) return;
 
-      timer = setTimeout(async () => {
+      schedule(async () => {
         if (cancelled) return;
 
         const contentEl = document.querySelector<HTMLElement>(
@@ -73,7 +80,7 @@ export default function LogbookSwipeHintOrchestrator() {
             if (cancelled) return;
 
             // Hold
-            await new Promise<void>((r) => { timer = setTimeout(r, HOLD_MS); });
+            await new Promise<void>((r) => { schedule(r, HOLD_MS); });
             if (cancelled) return;
 
             // Slide back
@@ -98,7 +105,7 @@ export default function LogbookSwipeHintOrchestrator() {
 
             // Gap before next repeat
             if (i < REPEAT_COUNT - 1) {
-              await new Promise<void>((r) => { timer = setTimeout(r, GAP_BETWEEN_MS); });
+              await new Promise<void>((r) => { schedule(r, GAP_BETWEEN_MS); });
             }
           }
 
@@ -115,7 +122,7 @@ export default function LogbookSwipeHintOrchestrator() {
 
     return () => {
       cancelled = true;
-      clearTimeout(timer);
+      for (const id of timers) clearTimeout(id);
       for (const anim of animationsRef.current) anim.cancel();
       animationsRef.current = [];
     };

--- a/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
@@ -2,10 +2,13 @@
 
 import { useEffect, useRef } from 'react';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { DEFAULT_CONFIRMATION_PEEK_OFFSET } from '@/app/hooks/use-swipe-actions';
 
 const PREF_KEY = 'swipeHint:logbookSeen' as const;
 const INITIAL_DELAY_MS = 1500;
-const PEEK_DISTANCE = 60; // Matches SWIPE_THRESHOLD in logbook-feed-item.tsx
+// Matches the confirmation peek users see after a real swipe-left commit,
+// so the hint previews the exact resting state of the gesture.
+const PEEK_DISTANCE = DEFAULT_CONFIRMATION_PEEK_OFFSET;
 const SLIDE_OUT_MS = 400;
 const HOLD_MS = 600;
 const SLIDE_BACK_MS = 300;

--- a/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+
+const PREF_KEY = 'swipeHint:logbookSeen' as const;
+const INITIAL_DELAY_MS = 1500;
+const PEEK_DISTANCE = 60; // Matches SWIPE_THRESHOLD in logbook-feed-item.tsx
+const SLIDE_OUT_MS = 400;
+const HOLD_MS = 600;
+const SLIDE_BACK_MS = 300;
+const GAP_BETWEEN_MS = 300;
+const REPEAT_COUNT = 2;
+
+/**
+ * Plays a one-time swipe-hint animation on the first logbook feed item.
+ * Briefly slides the item left twice to reveal the "edit" action,
+ * then slides it back. Uses the Web Animations API for compositor-thread
+ * performance. Renders no visible DOM.
+ *
+ * Mirrors the climb-list SwipeHintOrchestrator. The first LogbookFeedItem
+ * opts in with `id="onboarding-logbook-card"` and its right action layer
+ * is marked with `data-swipe-right-action`.
+ */
+export default function LogbookSwipeHintOrchestrator() {
+  const animationsRef = useRef<Animation[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const run = async () => {
+      const seen = await getPreference<boolean>(PREF_KEY);
+      if (cancelled || seen) return;
+      if (!window.matchMedia('(pointer: coarse)').matches) return;
+
+      timer = setTimeout(async () => {
+        if (cancelled) return;
+
+        const contentEl = document.querySelector<HTMLElement>(
+          '#onboarding-logbook-card [data-swipe-content]',
+        );
+        const actionEl = document.querySelector<HTMLElement>(
+          '#onboarding-logbook-card [data-swipe-right-action]',
+        );
+        if (!contentEl || !actionEl) return;
+
+        const iconLayer = actionEl.firstElementChild as HTMLElement | null;
+
+        try {
+          for (let i = 0; i < REPEAT_COUNT; i++) {
+            if (cancelled) return;
+
+            // Show action layer
+            actionEl.style.visibility = 'visible';
+            if (iconLayer) iconLayer.style.opacity = '1';
+
+            // Slide out
+            const slideOut = contentEl.animate(
+              [{ transform: 'translateX(0)' }, { transform: `translateX(-${PEEK_DISTANCE}px)` }],
+              { duration: SLIDE_OUT_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            const fadeIn = actionEl.animate(
+              [{ opacity: 0 }, { opacity: 1 }],
+              { duration: SLIDE_OUT_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            animationsRef.current.push(slideOut, fadeIn);
+
+            await slideOut.finished;
+            if (cancelled) return;
+
+            // Hold
+            await new Promise<void>((r) => { timer = setTimeout(r, HOLD_MS); });
+            if (cancelled) return;
+
+            // Slide back
+            const slideBack = contentEl.animate(
+              [{ transform: `translateX(-${PEEK_DISTANCE}px)` }, { transform: 'translateX(0)' }],
+              { duration: SLIDE_BACK_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            const fadeOut = actionEl.animate(
+              [{ opacity: 1 }, { opacity: 0 }],
+              { duration: SLIDE_BACK_MS, easing: 'ease-out', fill: 'forwards' },
+            );
+            animationsRef.current.push(slideBack, fadeOut);
+
+            await slideBack.finished;
+            if (cancelled) return;
+
+            // Clean up inline styles
+            contentEl.style.transform = '';
+            actionEl.style.opacity = '';
+            actionEl.style.visibility = '';
+            if (iconLayer) iconLayer.style.opacity = '';
+
+            // Gap before next repeat
+            if (i < REPEAT_COUNT - 1) {
+              await new Promise<void>((r) => { timer = setTimeout(r, GAP_BETWEEN_MS); });
+            }
+          }
+
+          if (!cancelled) {
+            setPreference(PREF_KEY, true);
+          }
+        } catch {
+          // Animation cancelled
+        }
+      }, INITIAL_DELAY_MS);
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      for (const anim of animationsRef.current) anim.cancel();
+      animationsRef.current = [];
+    };
+  }, []);
+
+  return null;
+}

--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -10,6 +10,12 @@ const DEFAULT_SWIPE_THRESHOLD = 100;
 const DEFAULT_MAX_SWIPE = 120;
 // Duration the confirmation checkmark is shown before snapping back
 const CONFIRMATION_DISPLAY_MS = 600;
+/**
+ * Default peek distance in pixels shown while the post-swipe confirmation
+ * is displayed. Shared so coach-mark animations can preview the same offset
+ * users see during a real gesture.
+ */
+export const DEFAULT_CONFIRMATION_PEEK_OFFSET = 76;
 
 export type SwipeZone = 'none' | 'left-short' | 'left-long' | 'right-short' | 'right-long';
 
@@ -80,7 +86,7 @@ export function useSwipeActions({
   maxSwipeLeft,
   maxSwipeRight,
   disabled = false,
-  confirmationPeekOffset = 76,
+  confirmationPeekOffset = DEFAULT_CONFIRMATION_PEEK_OFFSET,
 }: UseSwipeActionsOptions): UseSwipeActionsReturn {
   const [swipeLeftConfirmed, setSwipeLeftConfirmed] = useState(false);
   const confirmationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/packages/web/app/hooks/use-swipe-actions.ts
+++ b/packages/web/app/hooks/use-swipe-actions.ts
@@ -170,6 +170,9 @@ export function useSwipeActions({
       contentEl.current.style.transition = 'transform 120ms ease-out';
       contentEl.current.style.transform = `translateX(${-confirmationPeekOffset}px)`;
     }
+    // Keep offsetRef in sync with the visual peek state so gesture handlers
+    // (e.g. onTouchEndOrOnMouseUp) read the true position if a new gesture lands.
+    offsetRef.current = -confirmationPeekOffset;
 
     // Keep the right action layer fully visible during confirmation
     if (rightActionEl.current) {
@@ -180,15 +183,18 @@ export function useSwipeActions({
     // After the confirmation display, snap back
     confirmationTimerRef.current = setTimeout(() => {
       confirmationTimerRef.current = null;
+      // If the element has unmounted (e.g. list virtualization), skip DOM work.
+      if (!contentEl.current) {
+        setSwipeLeftConfirmed(false);
+        return;
+      }
       // Set transition on right action before applyOffset changes values so it fades out smoothly
       if (rightActionEl.current) {
         rightActionEl.current.style.transition = 'opacity 200ms ease-out, visibility 0s 200ms';
       }
       applyOffset(0);
       // Override content transition with a gentler one for the confirmation snap-back
-      if (contentEl.current) {
-        contentEl.current.style.transition = 'transform 200ms ease-out';
-      }
+      contentEl.current.style.transition = 'transform 200ms ease-out';
       updateSwipeZone('none');
       setSwipeLeftConfirmed(false);
     }, CONFIRMATION_DISPLAY_MS);

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -8,6 +8,7 @@ export type UserPreferenceKeyMap = {
   logbookPreferences: LogbookPreferences;
   'swipeHint:climbListSeen': boolean;
   'swipeHint:queueBarSeen': boolean;
+  'swipeHint:logbookSeen': boolean;
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration


### PR DESCRIPTION
Engineering:
- E4: keep offsetRef in sync with peek position during swipe-left
  confirmation, so a gesture landing mid-confirmation reads the true offset.
- E5: guard the confirmation setTimeout against a detached contentEl (list
  virtualization), and skip DOM work when the node is gone.
- E9: stabilize handleDelete across auth token refreshes via a tokenRef so
  React.memo on LogbookFeedItem is not invalidated on every refresh.

UX:
- U2: one-time swipe-hint animation on the first logbook item on
  coarse-pointer devices (mirrors the climb-list orchestrator).
- U8: keep the comment-row container mounted in both modes and transition
  min-height/padding so edit-mode toggle no longer jumps.
- U9: drop the misleading cursor: pointer from the entire swipeable row.
- U10: clip the 1.5x thumbnail transform to the 96px box.
- U11: mark both decorative swipe action layers aria-hidden.
- U12: document that Instagram posting/linking open distinct dialogs and
  are mutually exclusive by viewport.

Tests:
- New component test for LogbookFeedItem covering edit mode, save flow,
  status popover, inline pickers, swipe actions, and U8/U11 invariants.

https://claude.ai/code/session_01GuaqSqZM4wj1zp4KRna5QQ