### PR TITLE
fix: address swipe test gaps and orchestrator write robustness

### DIFF
--- a/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-swipe-hint-orchestrator.test.tsx
@@ -2,12 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import React from 'react';
 
-// Mirrors REPEAT_COUNT in logbook-swipe-hint-orchestrator.tsx. The
-// orchestrator invokes element.animate 4x per cycle (slide out, fade in,
-// slide back, fade out), so total calls = REPEAT_COUNT * ANIMATIONS_PER_CYCLE.
-const REPEAT_COUNT = 2;
-const ANIMATIONS_PER_CYCLE = 4;
-
 const getPreferenceMock = vi.fn();
 const setPreferenceMock = vi.fn();
 
@@ -16,7 +10,10 @@ vi.mock('@/app/lib/user-preferences-db', () => ({
   setPreference: (...args: unknown[]) => setPreferenceMock(...args),
 }));
 
-import LogbookSwipeHintOrchestrator from '../logbook-swipe-hint-orchestrator';
+import LogbookSwipeHintOrchestrator, {
+  REPEAT_COUNT,
+  ANIMATIONS_PER_CYCLE,
+} from '../logbook-swipe-hint-orchestrator';
 
 type FakeAnimation = {
   finished: Promise<void>;
@@ -76,6 +73,8 @@ function mountTarget() {
 beforeEach(() => {
   getPreferenceMock.mockReset();
   setPreferenceMock.mockReset();
+  // Default to a resolved promise so the orchestrator's .catch() chain is safe.
+  setPreferenceMock.mockResolvedValue(undefined);
   document.body.innerHTML = '';
   vi.useFakeTimers();
 });
@@ -149,6 +148,28 @@ describe('LogbookSwipeHintOrchestrator', () => {
 
     expect(animate).toHaveBeenCalledTimes(totalAnimations);
     expect(setPreferenceMock).toHaveBeenCalledWith('swipeHint:logbookSeen', true);
+  });
+
+  it('swallows setPreference rejection without raising unhandled errors', async () => {
+    getPreferenceMock.mockResolvedValue(null);
+    setPreferenceMock.mockRejectedValue(new Error('idb write failed'));
+    installMatchMedia(true);
+    const { animations } = installFakeAnimations();
+    mountTarget();
+
+    render(<LogbookSwipeHintOrchestrator />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+
+    const totalAnimations = REPEAT_COUNT * ANIMATIONS_PER_CYCLE;
+    for (let i = 0; i < totalAnimations; i++) {
+      if (animations[i]) {
+        animations[i].resolve();
+      }
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    }
+
+    expect(setPreferenceMock).toHaveBeenCalledWith('swipeHint:logbookSeen', true);
+    // A missing .catch() here would surface as an unhandled rejection and fail the test.
   });
 
   it('cancels in-flight animations and does not mark seen when unmounted early', async () => {

--- a/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
+++ b/packages/web/app/components/library/logbook-swipe-hint-orchestrator.tsx
@@ -13,7 +13,10 @@ const SLIDE_OUT_MS = 400;
 const HOLD_MS = 600;
 const SLIDE_BACK_MS = 300;
 const GAP_BETWEEN_MS = 300;
-const REPEAT_COUNT = 2;
+export const REPEAT_COUNT = 2;
+// Each iteration invokes element.animate() 4 times: slide out, fade in,
+// slide back, fade out. Exported so tests stay in sync if the sequence changes.
+export const ANIMATIONS_PER_CYCLE = 4;
 
 /**
  * Plays a one-time swipe-hint animation on the first logbook feed item.
@@ -110,7 +113,8 @@ export default function LogbookSwipeHintOrchestrator() {
           }
 
           if (!cancelled) {
-            setPreference(PREF_KEY, true);
+            // Fire-and-forget: if this write fails, the hint replays next visit.
+            setPreference(PREF_KEY, true).catch(() => {});
           }
         } catch {
           // Animation cancelled

--- a/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
+++ b/packages/web/app/hooks/__tests__/use-swipe-actions.test.ts
@@ -468,6 +468,50 @@ describe('useSwipeActions', () => {
     expect(mockContent.style.transform).toBe('translateX(0px)');
   });
 
+  it('syncs offsetRef to peek offset during confirmation so a follow-up gesture snaps back', () => {
+    // Regression: before the E4 fix, offsetRef retained the gesture's end delta
+    // (e.g. -110) while the visual state was at the peek offset (-76). A touch/mouse-up
+    // landing during confirmation would see |offsetRef| >= threshold and skip resetOffset,
+    // leaving the content stuck at the peek position.
+    const options = createDefaultOptions();
+    const { result } = renderHook(() => useSwipeActions(options));
+
+    const mockContent = {
+      style: { transform: '', transition: '', opacity: '', visibility: '' },
+    } as unknown as HTMLElement;
+
+    act(() => {
+      result.current.contentRef(mockContent);
+    });
+
+    mockIsHorizontalRef.current = true;
+    mockDetect.mockReturnValue(true);
+
+    // Commit a left swipe past threshold — content is now at peek offset.
+    act(() => {
+      capturedSwipeableConfig.onSwiping({
+        deltaX: -110,
+        deltaY: 0,
+        event: { nativeEvent: { preventDefault: vi.fn() } },
+      });
+    });
+    act(() => {
+      capturedSwipeableConfig.onSwipedLeft({ deltaX: -110 });
+    });
+
+    expect(mockContent.style.transform).toBe('translateX(-76px)');
+
+    // A new touch/mouse-up fires while the confirmation peek is still visible.
+    // With the sync, |offsetRef| = 76 < threshold(100), so resetOffset runs and
+    // content snaps back to 0. Without the sync, offsetRef would still be -110
+    // and the content would remain stuck at -76 until the confirmation timer fires.
+    act(() => {
+      capturedSwipeableConfig.onTouchEndOrOnMouseUp();
+    });
+
+    expect(mockContent.style.transform).toBe('translateX(0px)');
+  });
+
   it('handles rapid double-swipe without duplicate actions', () => {
     const options = createDefaultOptions();
     renderHook(() => useSwipeActions(options));


### PR DESCRIPTION
- Export REPEAT_COUNT and ANIMATIONS_PER_CYCLE from the logbook swipe-hint orchestrator so tests don't silently validate the wrong totals when the animation sequence changes. Tests now import the real constants.
- Add .catch(() => {}) to setPreference() in the orchestrator so a failed IndexedDB write is explicitly fire-and-forget rather than an unhandled rejection. A rejection-path test locks in the behavior.
- Add a unit test for the E4 fix in use-swipe-actions: a touch/mouse-up landing while the post-confirmation peek is visible must snap the content back to 0 (relies on offsetRef being synced to -confirmationPeekOffset).