### PR TITLE
Add row and thumbnail click handlers to logbook feed items

### DIFF
--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -20,9 +20,7 @@ interface AscentThumbnailProps {
   climbName: string;
   frames: string | null;
   isMirror: boolean;
-  /** When provided, the thumbnail renders as a <button> and calls this
-   * instead of navigating to the climb view page. Used by the logbook to
-   * set the climb active + open the play drawer. */
+  /** When provided, renders as a <button> instead of the climb-view <Link>. */
   onClick?: (e: React.MouseEvent) => void;
 }
 

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -130,8 +130,8 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
         type="button"
         onClick={onClick}
         className={styles.thumbnailLink}
-        title={`Open ${climbName}`}
-        aria-label={`Open ${climbName}`}
+        title={`Set ${climbName} as active climb`}
+        aria-label={`Set ${climbName} as active climb`}
       >
         <div className={styles.thumbnailContainer}>{thumbnailContent}</div>
       </button>

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -20,6 +20,10 @@ interface AscentThumbnailProps {
   climbName: string;
   frames: string | null;
   isMirror: boolean;
+  /** When provided, the thumbnail renders as a <button> and calls this
+   * instead of navigating to the climb view page. Used by the logbook to
+   * set the climb active + open the play drawer. */
+  onClick?: (e: React.MouseEvent) => void;
 }
 
 const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
@@ -30,6 +34,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   climbName,
   frames,
   isMirror,
+  onClick,
 }) => {
   const canvasReady = useCanvasRendererReady();
   // Memoize board details to avoid recomputing on every render
@@ -85,7 +90,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   }, [boardDetails, boardType, layoutId, angle, climbUuid, climbName]);
 
   // If we can't render the thumbnail, don't show anything
-  if (!boardDetails || !climbViewPath) {
+  if (!boardDetails || (!onClick && !climbViewPath)) {
     return null;
   }
 
@@ -121,8 +126,22 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
     );
   }
 
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={styles.thumbnailLink}
+        title={`Open ${climbName}`}
+        aria-label={`Open ${climbName}`}
+      >
+        <div className={styles.thumbnailContainer}>{thumbnailContent}</div>
+      </button>
+    );
+  }
+
   return (
-    <Link href={climbViewPath} className={styles.thumbnailLink} title={`View ${climbName}`}>
+    <Link href={climbViewPath!} className={styles.thumbnailLink} title={`View ${climbName}`}>
       <div className={styles.thumbnailContainer}>{thumbnailContent}</div>
     </Link>
   );

--- a/packages/web/app/components/activity-feed/ascents-feed.module.css
+++ b/packages/web/app/components/activity-feed/ascents-feed.module.css
@@ -23,10 +23,14 @@
   min-width: 0;
 }
 
-/* Thumbnail styles */
+/* Thumbnail styles — shared by both the <Link> and the <button> variant. */
 .thumbnailLink {
   display: block;
   flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -420,10 +420,21 @@ describe('LogbookFeedItem', () => {
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
   });
 
-  it('thumbnail tap sets active and opens the play drawer', () => {
+  it('thumbnail tap sets active then opens the play drawer after the promise settles', async () => {
+    // Make the mock actually return a Promise so we can assert ordering.
+    let resolveSet: (() => void) | undefined;
+    setCurrentClimbMock.mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveSet = () => resolve(); }),
+    );
     render(<LogbookFeedItem item={makeItem()} />);
     fireEvent.click(screen.getByTestId('ascent-thumbnail'));
+    // setCurrentClimb called synchronously; drawer NOT opened yet (still awaiting).
     expect(setCurrentClimbMock).toHaveBeenCalledTimes(1);
+    expect(dispatchOpenPlayDrawerMock).not.toHaveBeenCalled();
+    // Resolve and flush microtasks.
+    await act(async () => {
+      resolveSet?.();
+    });
     expect(dispatchOpenPlayDrawerMock).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -15,6 +15,12 @@ type SwipeOptions = {
 
 let capturedSwipeOptions: SwipeOptions | null = null;
 const updateTickAsyncMock = vi.fn();
+const setCurrentClimbMock = vi.fn();
+const dispatchOpenPlayDrawerMock = vi.fn();
+// Holder so tests can swap queue-actions availability without remounting.
+const queueActionsState: { value: { setCurrentClimb: typeof setCurrentClimbMock } | null } = {
+  value: { setCurrentClimb: setCurrentClimbMock },
+};
 // Holder object so tests can mutate isPending and the mock reads the
 // current value on every render (avoids the stale-by-value closure
 // that would result from binding a plain `let` into the mock factory).
@@ -102,7 +108,25 @@ vi.mock('@/app/lib/board-data', () => ({
 }));
 
 vi.mock('@/app/components/activity-feed/ascent-thumbnail', () => ({
-  default: () => <div data-testid="ascent-thumbnail" />,
+  default: ({ onClick }: { onClick?: (e: React.MouseEvent) => void }) => (
+    <button
+      type="button"
+      data-testid="ascent-thumbnail"
+      onClick={(e) => onClick?.(e)}
+    />
+  ),
+}));
+
+vi.mock('@/app/components/graphql-queue', () => ({
+  useOptionalQueueActions: () => queueActionsState.value,
+}));
+
+vi.mock('@/app/components/queue-control/play-drawer-event', () => ({
+  dispatchOpenPlayDrawer: () => dispatchOpenPlayDrawerMock(),
+}));
+
+vi.mock('@vercel/analytics', () => ({
+  track: vi.fn(),
 }));
 
 vi.mock('@/app/components/ascent-status/ascent-status-icon', () => ({
@@ -178,6 +202,9 @@ function makeItem(overrides: Partial<AscentFeedItem> = {}): AscentFeedItem {
 beforeEach(() => {
   capturedSwipeOptions = null;
   updateTickAsyncMock.mockReset();
+  setCurrentClimbMock.mockReset();
+  dispatchOpenPlayDrawerMock.mockReset();
+  queueActionsState.value = { setCurrentClimb: setCurrentClimbMock };
   updateTickState.isPending = false;
 });
 
@@ -334,6 +361,53 @@ describe('LogbookFeedItem', () => {
     rerender(<LogbookFeedItem item={makeItem()} isEditing />);
     const saveBtn2 = screen.getByLabelText('Save') as HTMLButtonElement;
     expect(saveBtn2.disabled).toBe(false);
+  });
+
+  it('row tap calls setCurrentClimb without opening the play drawer', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.click(row);
+    expect(setCurrentClimbMock).toHaveBeenCalledTimes(1);
+    expect(setCurrentClimbMock).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'climb-1', name: 'Test Climb' }),
+    );
+    expect(dispatchOpenPlayDrawerMock).not.toHaveBeenCalled();
+  });
+
+  it('row tap is a no-op in edit mode', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} isEditing />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.click(row);
+    expect(setCurrentClimbMock).not.toHaveBeenCalled();
+  });
+
+  it('row tap is a no-op when queue actions are unavailable', () => {
+    queueActionsState.value = null;
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.click(row);
+    expect(setCurrentClimbMock).not.toHaveBeenCalled();
+  });
+
+  it('thumbnail tap sets active and opens the play drawer', () => {
+    render(<LogbookFeedItem item={makeItem()} />);
+    fireEvent.click(screen.getByTestId('ascent-thumbnail'));
+    expect(setCurrentClimbMock).toHaveBeenCalledTimes(1);
+    expect(dispatchOpenPlayDrawerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('thumbnail tap does not bubble to the row handler', () => {
+    render(<LogbookFeedItem item={makeItem()} />);
+    fireEvent.click(screen.getByTestId('ascent-thumbnail'));
+    // Thumbnail fires setCurrentClimb once; the row handler would fire it a
+    // second time if propagation wasn't stopped.
+    expect(setCurrentClimbMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('3-dot menu click opens the actions drawer without setting active', () => {
+    render(<LogbookFeedItem item={makeItem()} />);
+    fireEvent.click(screen.getByLabelText('More actions'));
+    expect(setCurrentClimbMock).not.toHaveBeenCalled();
   });
 
   it('keeps the comment row container mounted in both modes (U8)', () => {

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -389,6 +389,37 @@ describe('LogbookFeedItem', () => {
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
   });
 
+  it('row is keyboard-accessible with role/tabIndex/aria-label', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    expect(row.getAttribute('role')).toBe('button');
+    expect(row.getAttribute('tabIndex')).toBe('0');
+    expect(row.getAttribute('aria-label')).toBe('Set Test Climb as active climb');
+  });
+
+  it('row is not focusable when edit mode is active', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} isEditing />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    expect(row.getAttribute('role')).toBeNull();
+    expect(row.getAttribute('tabIndex')).toBeNull();
+  });
+
+  it('Enter/Space on the row fires setCurrentClimb', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.keyDown(row, { key: 'Enter', target: row, currentTarget: row });
+    fireEvent.keyDown(row, { key: ' ', target: row, currentTarget: row });
+    expect(setCurrentClimbMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('other keys on the row do not fire setCurrentClimb', () => {
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.keyDown(row, { key: 'Tab', target: row, currentTarget: row });
+    fireEvent.keyDown(row, { key: 'a', target: row, currentTarget: row });
+    expect(setCurrentClimbMock).not.toHaveBeenCalled();
+  });
+
   it('thumbnail tap sets active and opens the play drawer', () => {
     render(<LogbookFeedItem item={makeItem()} />);
     fireEvent.click(screen.getByTestId('ascent-thumbnail'));

--- a/packages/web/app/components/library/ascent-to-climb.ts
+++ b/packages/web/app/components/library/ascent-to-climb.ts
@@ -8,6 +8,7 @@ export function ascentFeedItemToClimb(item: AscentFeedItem): Climb {
     setter_username: item.setterUsername ?? '',
     frames: item.frames ?? '',
     angle: item.angle,
+    // Populated so downstream ClimbTitle renders the grade instead of "project".
     difficulty: item.consensusDifficultyName ?? item.difficultyName ?? '',
     quality_average: item.qualityAverage != null ? String(item.qualityAverage) : '0',
     stars: 0,

--- a/packages/web/app/components/library/ascent-to-climb.ts
+++ b/packages/web/app/components/library/ascent-to-climb.ts
@@ -2,9 +2,12 @@ import type { Climb } from '@/app/lib/types';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 
 /**
- * Maps an AscentFeedItem (logbook tick) to a Climb object so it can be
- * rendered by ClimbListItem. Fields not available on the ascent get safe
- * defaults — the logbook wrapper overrides title/subtitle via titleProps.
+ * Maps an AscentFeedItem (logbook tick) to a Climb object. The logbook row
+ * has its own layout (LogbookGradeRow) so it doesn't render ClimbTitle —
+ * but this Climb is still fed to ClimbActions / setCurrentClimb, meaning
+ * the queue bar and play drawer render it via ClimbTitle. Populate
+ * difficulty + quality_average from the consensus so those surfaces show
+ * the real grade instead of falling back to "project".
  */
 export function ascentFeedItemToClimb(item: AscentFeedItem): Climb {
   return {
@@ -13,10 +16,8 @@ export function ascentFeedItemToClimb(item: AscentFeedItem): Climb {
     setter_username: item.setterUsername ?? '',
     frames: item.frames ?? '',
     angle: item.angle,
-    // Empty string suppresses ClimbTitle's built-in grade — logbook renders
-    // both consensus and user grades in a shared grid via rightAddon.
-    difficulty: '',
-    quality_average: '0',
+    difficulty: item.consensusDifficultyName ?? item.difficultyName ?? '',
+    quality_average: item.qualityAverage != null ? String(item.qualityAverage) : '0',
     stars: 0,
     difficulty_error: '0',
     ascensionist_count: 0,

--- a/packages/web/app/components/library/ascent-to-climb.ts
+++ b/packages/web/app/components/library/ascent-to-climb.ts
@@ -1,14 +1,6 @@
 import type { Climb } from '@/app/lib/types';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 
-/**
- * Maps an AscentFeedItem (logbook tick) to a Climb object. The logbook row
- * has its own layout (LogbookGradeRow) so it doesn't render ClimbTitle —
- * but this Climb is still fed to ClimbActions / setCurrentClimb, meaning
- * the queue bar and play drawer render it via ClimbTitle. Populate
- * difficulty + quality_average from the consensus so those surfaces show
- * the real grade instead of falling back to "project".
- */
 export function ascentFeedItemToClimb(item: AscentFeedItem): Climb {
   return {
     uuid: item.climbUuid,

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -404,15 +404,12 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   // Map ascent to Climb for ClimbActions + set-active handlers
   const climb = useMemo(() => ascentFeedItemToClimb(item), [item]);
 
-  // Row tap: set active (no drawer). Mirrors climb-list-item.handleRowClick.
   const handleRowClick = useCallback(() => {
     if (isEditing || !queueActions) return;
     queueActions.setCurrentClimb(climb);
     track('Logbook Row Clicked', { climbUuid: climb.uuid });
   }, [isEditing, queueActions, climb]);
 
-  // Thumbnail tap: set active + open play drawer. Mirrors
-  // climb-list-item.handleThumbnailClick.
   const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (isEditing || !queueActions) return;
@@ -551,15 +548,11 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   return (
     <>
       <div className={styles.container} id={isSwipeHintTarget ? 'onboarding-logbook-card' : undefined}>
-        {/* Left action layer — Delete (revealed on long swipe right).
-            Decorative; the three-dot menu exposes Delete to assistive tech. */}
         <div ref={leftActionCombinedRef} className={styles.leftActionLayer} aria-hidden="true">
           <DeleteOutlined className={styles.swipeIcon} />
           <span className={styles.deleteLabel}>Delete</span>
         </div>
 
-        {/* Right action layer — Edit (revealed on swipe left).
-            Decorative; the three-dot menu exposes Edit to assistive tech. */}
         <div
           ref={rightActionRef}
           className={styles.rightActionLayer}
@@ -569,9 +562,6 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           <EditOutlined className={styles.swipeIcon} />
         </div>
 
-        {/* Swipeable wrapper — covers entire item including comment row.
-            Tapping anywhere that isn't a nested interactive element sets the
-            climb active (no drawer). */}
         <div
           {...swipeHandlers}
           ref={contentCombinedRef}

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -410,6 +410,13 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
     track('Logbook Row Clicked', { climbUuid: climb.uuid });
   }, [isEditing, queueActions, climb]);
 
+  const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    if (e.target !== e.currentTarget) return;
+    e.preventDefault();
+    handleRowClick();
+  }, [handleRowClick]);
+
   const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (isEditing || !queueActions) return;
@@ -548,11 +555,13 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   return (
     <>
       <div className={styles.container} id={isSwipeHintTarget ? 'onboarding-logbook-card' : undefined}>
+        {/* aria-hidden: the 3-dot menu exposes Delete to assistive tech. */}
         <div ref={leftActionCombinedRef} className={styles.leftActionLayer} aria-hidden="true">
           <DeleteOutlined className={styles.swipeIcon} />
           <span className={styles.deleteLabel}>Delete</span>
         </div>
 
+        {/* aria-hidden: the 3-dot menu exposes Edit to assistive tech. */}
         <div
           ref={rightActionRef}
           className={styles.rightActionLayer}
@@ -567,7 +576,11 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           ref={contentCombinedRef}
           className={styles.swipeableContent}
           data-swipe-content=""
+          role={!isEditing && queueActions ? 'button' : undefined}
+          tabIndex={!isEditing && queueActions ? 0 : undefined}
+          aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
           onClick={handleRowClick}
+          onKeyDown={!isEditing && queueActions ? handleRowKeyDown : undefined}
         >
           <div className={styles.content}>
             {/* Thumbnail with ascent status badge */}

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -25,8 +25,11 @@ import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { track } from '@vercel/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
+import { useOptionalQueueActions } from '@/app/components/graphql-queue';
+import { dispatchOpenPlayDrawer } from '@/app/components/queue-control/play-drawer-event';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { ClimbActions } from '@/app/components/climb-actions';
 import DrawerClimbHeader from '@/app/components/climb-card/drawer-climb-header';
@@ -287,6 +290,8 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   const [instagramDialogOpen, setInstagramDialogOpen] = useState(false);
   const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
+  const queueActions = useOptionalQueueActions();
+
   // --- Edit state ---
   const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
   const grades = useMemo(() => getGradesForBoard(item.boardType as BoardName), [item.boardType]);
@@ -396,8 +401,34 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
     setStatusAnchorEl(null);
   }, []);
 
-  // Map ascent to Climb for ClimbActions
+  // Map ascent to Climb for ClimbActions + set-active handlers
   const climb = useMemo(() => ascentFeedItemToClimb(item), [item]);
+
+  // Row tap: set active (no drawer). Mirrors climbs-list.handleClimbClickByIndex.
+  const handleRowClick = useCallback(() => {
+    if (isEditing || !queueActions) return;
+    queueActions.setCurrentClimb(climb);
+    track('Logbook Row Clicked', { climbUuid: climb.uuid });
+  }, [isEditing, queueActions, climb]);
+
+  // Row keyboard activation (Enter/Space) to match role=button semantics.
+  const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (isEditing || !queueActions) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    if (e.target !== e.currentTarget) return;
+    e.preventDefault();
+    handleRowClick();
+  }, [isEditing, queueActions, handleRowClick]);
+
+  // Thumbnail tap: set active + open play drawer. Mirrors
+  // climbs-list.handleClimbThumbnailClickByIndex.
+  const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isEditing || !queueActions) return;
+    queueActions.setCurrentClimb(climb);
+    dispatchOpenPlayDrawer();
+    track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+  }, [isEditing, queueActions, climb]);
 
   // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)
   const boardDetails = useMemo<BoardDetails | null>(() => {
@@ -547,12 +578,19 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           <EditOutlined className={styles.swipeIcon} />
         </div>
 
-        {/* Swipeable wrapper — covers entire item including comment row */}
+        {/* Swipeable wrapper — covers entire item including comment row.
+            Tapping anywhere that isn't a nested interactive element sets the
+            climb active (no drawer). */}
         <div
           {...swipeHandlers}
           ref={contentCombinedRef}
           className={styles.swipeableContent}
           data-swipe-content=""
+          role={!isEditing && queueActions ? 'button' : undefined}
+          tabIndex={!isEditing && queueActions ? 0 : undefined}
+          onClick={handleRowClick}
+          onKeyDown={handleRowKeyDown}
+          aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
         >
           <div className={styles.content}>
             {/* Thumbnail with ascent status badge */}
@@ -566,6 +604,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
                   climbName={item.climbName}
                   frames={item.frames}
                   isMirror={item.isMirror}
+                  onClick={queueActions && !isEditing ? handleThumbnailClick : undefined}
                 />
               )}
               {isEditing ? (

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -404,23 +404,24 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   // Map ascent to Climb for ClimbActions + set-active handlers
   const climb = useMemo(() => ascentFeedItemToClimb(item), [item]);
 
-  const handleRowClick = useCallback(() => {
+  const handleRowClick = useCallback(async () => {
     if (isEditing || !queueActions) return;
-    queueActions.setCurrentClimb(climb);
+    await queueActions.setCurrentClimb(climb);
     track('Logbook Row Clicked', { climbUuid: climb.uuid });
   }, [isEditing, queueActions, climb]);
 
   const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (isEditing || !queueActions) return;
     if (e.key !== 'Enter' && e.key !== ' ') return;
     if (e.target !== e.currentTarget) return;
     e.preventDefault();
-    handleRowClick();
-  }, [handleRowClick]);
+    void handleRowClick();
+  }, [isEditing, queueActions, handleRowClick]);
 
-  const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
+  const handleThumbnailClick = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (isEditing || !queueActions) return;
-    queueActions.setCurrentClimb(climb);
+    await queueActions.setCurrentClimb(climb);
     dispatchOpenPlayDrawer();
     track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
   }, [isEditing, queueActions, climb]);
@@ -580,7 +581,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           tabIndex={!isEditing && queueActions ? 0 : undefined}
           aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
           onClick={handleRowClick}
-          onKeyDown={!isEditing && queueActions ? handleRowKeyDown : undefined}
+          onKeyDown={handleRowKeyDown}
         >
           <div className={styles.content}>
             {/* Thumbnail with ascent status badge */}

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -404,24 +404,15 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   // Map ascent to Climb for ClimbActions + set-active handlers
   const climb = useMemo(() => ascentFeedItemToClimb(item), [item]);
 
-  // Row tap: set active (no drawer). Mirrors climbs-list.handleClimbClickByIndex.
+  // Row tap: set active (no drawer). Mirrors climb-list-item.handleRowClick.
   const handleRowClick = useCallback(() => {
     if (isEditing || !queueActions) return;
     queueActions.setCurrentClimb(climb);
     track('Logbook Row Clicked', { climbUuid: climb.uuid });
   }, [isEditing, queueActions, climb]);
 
-  // Row keyboard activation (Enter/Space) to match role=button semantics.
-  const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (isEditing || !queueActions) return;
-    if (e.key !== 'Enter' && e.key !== ' ') return;
-    if (e.target !== e.currentTarget) return;
-    e.preventDefault();
-    handleRowClick();
-  }, [isEditing, queueActions, handleRowClick]);
-
   // Thumbnail tap: set active + open play drawer. Mirrors
-  // climbs-list.handleClimbThumbnailClickByIndex.
+  // climb-list-item.handleThumbnailClick.
   const handleThumbnailClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (isEditing || !queueActions) return;
@@ -586,11 +577,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           ref={contentCombinedRef}
           className={styles.swipeableContent}
           data-swipe-content=""
-          role={!isEditing && queueActions ? 'button' : undefined}
-          tabIndex={!isEditing && queueActions ? 0 : undefined}
           onClick={handleRowClick}
-          onKeyDown={handleRowKeyDown}
-          aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
         >
           <div className={styles.content}>
             {/* Thumbnail with ascent status badge */}


### PR DESCRIPTION
## Summary
Adds interactive click handlers to logbook feed items that set the climb as active in the queue system. Tapping the row sets the climb active without opening the play drawer, while tapping the thumbnail sets it active and opens the play drawer.

## Key Changes
- **LogbookFeedItem**: Added `handleRowClick` and `handleThumbnailClick` handlers that integrate with `useOptionalQueueActions()` to set the current climb. Row clicks are guarded by edit mode and queue availability.
- **Row interactivity**: Made the swipeable content div a keyboard-accessible button (role, tabIndex, aria-label) with click and keydown handlers. Includes analytics tracking via `@vercel/analytics`.
- **Thumbnail enhancement**: Modified `AscentThumbnail` to accept an optional `onClick` prop. When provided, renders as a `<button>` instead of a `<Link>`, allowing the logbook to customize behavior (set active + open drawer) while preventing event propagation.
- **Climb mapping**: Updated `ascentFeedItemToClimb` to populate `difficulty` and `quality_average` from consensus data instead of empty defaults, so the queue bar and play drawer display the correct grade.
- **CSS**: Updated `.thumbnailLink` styles to work as both a link and button (added padding, border, background, cursor reset).
- **Tests**: Added comprehensive test coverage for row clicks, thumbnail clicks, edit mode guards, queue availability checks, and event propagation.

## Implementation Details
- Row clicks are no-ops when in edit mode or when queue actions are unavailable
- Thumbnail clicks stop propagation to prevent the row handler from firing
- The 3-dot menu (More actions) doesn't trigger the row handler due to event target checks
- Keyboard activation (Enter/Space) on the row mirrors button semantics

https://claude.ai/code/session_01EKT3D8qEScFHontuYLGjfh