### PR TITLE
Block swipe gestures in data-swipe-blocked zones

### DIFF
--- a/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
+++ b/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
@@ -156,4 +156,69 @@ describe('SwipeableDrawer', () => {
       expect(screen.getByText('My title')).toBeTruthy();
     });
   });
+
+  describe('swipe blocking', () => {
+    // MUI's handleBodyTouchStart bails out when nativeEvent.defaultMuiPrevented
+    // is true (SwipeableDrawer.js:398), but also sets the flag itself when the
+    // drawer is open and the touch is inside the paper (line 426). To isolate
+    // what OUR handler did, we observe the flag from a bubble-phase listener
+    // on document.body — React's delegated listener on the root container
+    // dispatches synthetic handlers during bubble phase before the event
+    // reaches document.body, while MUI's listener is on document (one step
+    // later in the bubble chain).
+    function dispatchAndReadFlagPostReact(target: HTMLElement): boolean {
+      let flag = false;
+      const read = (e: Event) => {
+        flag = Boolean((e as unknown as Record<string, unknown>).defaultMuiPrevented);
+      };
+      document.body.addEventListener('touchstart', read);
+      const event = new Event('touchstart', { bubbles: true, cancelable: true });
+      // jsdom lacks a TouchEvent constructor; stub `touches` so MUI's
+      // calculateCurrentX/Y don't throw when its document listener fires.
+      Object.defineProperty(event, 'touches', {
+        value: [{ pageX: 0, pageY: 0, clientX: 0, clientY: 0 }],
+      });
+      try {
+        target.dispatchEvent(event);
+      } finally {
+        document.body.removeEventListener('touchstart', read);
+      }
+      return flag;
+    }
+
+    it('sets defaultMuiPrevented when touchstart originates inside a [data-swipe-blocked] zone', () => {
+      // Override disablePortal: the nested-drawer branch otherwise sets the
+      // flag unconditionally, which would hide whether the zone check ran.
+      render(
+        <SwipeableDrawer {...baseProps} disablePortal={false} placement="bottom">
+          <div data-swipe-blocked="true">
+            <div data-testid="inner">map content</div>
+          </div>
+        </SwipeableDrawer>,
+      );
+
+      expect(dispatchAndReadFlagPostReact(screen.getByTestId('inner'))).toBe(true);
+    });
+
+    it('does not set defaultMuiPrevented when touchstart originates outside a [data-swipe-blocked] zone', () => {
+      render(
+        <SwipeableDrawer {...baseProps} disablePortal={false} placement="bottom">
+          <div data-testid="unblocked">regular content</div>
+        </SwipeableDrawer>,
+      );
+
+      expect(dispatchAndReadFlagPostReact(screen.getByTestId('unblocked'))).toBe(false);
+    });
+
+    it('sets defaultMuiPrevented on any touch when disablePortal is set (nested-drawer case)', () => {
+      render(
+        <SwipeableDrawer {...baseProps} placement="bottom">
+          <div data-testid="anywhere">regular content</div>
+        </SwipeableDrawer>,
+      );
+
+      // baseProps.disablePortal is true → handler sets flag regardless of zone.
+      expect(dispatchAndReadFlagPostReact(screen.getByTestId('anywhere'))).toBe(true);
+    });
+  });
 });

--- a/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
+++ b/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
@@ -200,7 +200,12 @@ describe('SwipeableDrawer', () => {
       expect(dispatchAndReadFlagPostReact(screen.getByTestId('inner'))).toBe(true);
     });
 
-    it('does not set defaultMuiPrevented when touchstart originates outside a [data-swipe-blocked] zone', () => {
+    it('leaves defaultMuiPrevented unset when touchstart target has no [data-swipe-blocked] ancestor', () => {
+      // The target still sits inside the drawer paper; what matters is that
+      // no ancestor in its chain carries the swipe-blocked attribute, so our
+      // handler should not claim the touch. (MUI's own document listener
+      // will set the flag later — our helper reads it at document.body,
+      // before that listener runs.)
       render(
         <SwipeableDrawer {...baseProps} disablePortal={false} placement="bottom">
           <div data-testid="unblocked">regular content</div>
@@ -219,6 +224,32 @@ describe('SwipeableDrawer', () => {
 
       // baseProps.disablePortal is true → handler sets flag regardless of zone.
       expect(dispatchAndReadFlagPostReact(screen.getByTestId('anywhere'))).toBe(true);
+    });
+
+    // Regression test for #1621: a touchstart inside a [data-swipe-blocked]
+    // zone must not trigger the swipe-to-close flow. We can't simulate a full
+    // touchmove/touchend swipe gesture under jsdom (no TouchEvent
+    // constructor), but we can verify the upstream guard: because our handler
+    // sets defaultMuiPrevented on touchstart, MUI's handleBodyTouchStart
+    // returns early (SwipeableDrawer.js:398-400) without calling
+    // startMaybeSwiping, so the subsequent touchend will not dispatch onClose.
+    it('does not call onClose from a touchstart originating in a [data-swipe-blocked] zone', () => {
+      const onClose = vi.fn();
+      render(
+        <SwipeableDrawer {...baseProps} disablePortal={false} placement="bottom" onClose={onClose}>
+          <div data-swipe-blocked="true">
+            <div data-testid="inner">map content</div>
+          </div>
+        </SwipeableDrawer>,
+      );
+
+      const event = new Event('touchstart', { bubbles: true, cancelable: true });
+      Object.defineProperty(event, 'touches', {
+        value: [{ pageX: 0, pageY: 0, clientX: 0, clientY: 0 }],
+      });
+      screen.getByTestId('inner').dispatchEvent(event);
+
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -395,7 +395,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
       nativeEvent.defaultMuiPrevented = true;
       return;
     }
-    const target = e.target as HTMLElement | null;
+    const target = e.target as Element | null;
     if (target?.closest('[data-swipe-blocked]')) {
       nativeEvent.defaultMuiPrevented = true;
     }

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -374,14 +374,30 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
     [paperSx],
   );
 
-  // Prevent parent MUI SwipeableDrawer from claiming touches inside nested
-  // drawers. MUI registers touchstart handlers on `document` in effect order,
-  // so the parent's handler always fires first and sets defaultMuiPrevented,
-  // stealing the touch from the child. React synthetic handlers fire at the
-  // React root (before document), so we can set the flag first.
+  // Prevent MUI SwipeableDrawer from claiming touches that belong to the
+  // drawer's inner content. We set `defaultMuiPrevented` on the native event
+  // before MUI's document-level touchstart listener fires — React synthetic
+  // handlers dispatch from the React root during bubbling, which beats
+  // document listeners. Two cases:
+  //
+  // 1. Nested drawers (disablePortal + open): the parent drawer's document
+  //    listener would otherwise claim every touch inside the child.
+  //
+  // 2. Any open drawer with a touch starting inside `[data-swipe-blocked]`:
+  //    the attribute is also checked in `allowSwipeInChildren`, but that
+  //    callback is only consulted when the drawer is closed (MUI v7 gates
+  //    it behind `if (!open)`), so we need this second path to actually
+  //    block swipe-to-close from map/zoom/drag-handle zones.
   const handleNestedTouchStart = useCallback((e: React.TouchEvent) => {
-    if (disablePortal && (open ?? false)) {
-      (e.nativeEvent as unknown as Record<string, unknown>).defaultMuiPrevented = true;
+    if (!(open ?? false)) return;
+    const nativeEvent = e.nativeEvent as unknown as Record<string, unknown>;
+    if (disablePortal) {
+      nativeEvent.defaultMuiPrevented = true;
+      return;
+    }
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('[data-swipe-blocked]')) {
+      nativeEvent.defaultMuiPrevented = true;
     }
   }, [disablePortal, open]);
 


### PR DESCRIPTION
## Summary
Enhanced the SwipeableDrawer component to prevent swipe-to-close gestures from being triggered by touches originating inside zones marked with the `data-swipe-blocked` attribute. This allows interactive content like maps, zoom controls, and drag handles to function properly without being intercepted by the drawer's swipe handler.

## Key Changes
- **Expanded swipe-blocking logic**: The `handleNestedTouchStart` handler now checks for `[data-swipe-blocked]` elements in addition to the existing nested drawer case
- **Improved event handling**: Refactored the handler to set `defaultMuiPrevented` on the native event before MUI's document-level listener fires, ensuring the flag is set during React's synthetic event phase
- **Added comprehensive tests**: Three new test cases verify:
  - Swipe is blocked when touch originates inside a `[data-swipe-blocked]` zone
  - Swipe is allowed when touch originates outside such zones
  - Swipe is blocked on any touch when `disablePortal` is set (nested drawer case)

## Implementation Details
The solution leverages React's event delegation model: React synthetic handlers fire at the React root during the bubbling phase, which occurs before MUI's document-level listeners. By setting `defaultMuiPrevented` in our handler, we can prevent MUI's swipe detection from claiming touches that should be handled by inner content.

The `data-swipe-blocked` attribute provides a declarative way to mark regions where swipe gestures should be disabled, complementing the existing `allowSwipeInChildren` callback (which only works when the drawer is closed in MUI v7).

https://claude.ai/code/session_01V7RpeyGzGN8pg81TsnPSU2