### PR TITLE
Warn when linked board filter doesn't match; test empty ?boards= param

### DIFF
--- a/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
@@ -12,6 +12,7 @@ import type { LayoutStats } from '@/app/lib/graphql/operations/ticks';
 const mockRequest = vi.fn();
 const getPreferenceMock = vi.fn().mockResolvedValue(null);
 const searchFormSpy = vi.fn();
+const showMessageSpy = vi.fn();
 
 // --- Mocks (must come before component import) ---
 
@@ -65,7 +66,7 @@ vi.mock('@/app/lib/user-preferences-db', () => ({
 }));
 
 vi.mock('@/app/components/providers/snackbar-provider', () => ({
-  useSnackbar: () => ({ showMessage: vi.fn() }),
+  useSnackbar: () => ({ showMessage: showMessageSpy }),
 }));
 
 vi.mock('@/app/lib/instagram-posting', () => ({
@@ -159,6 +160,7 @@ beforeEach(() => {
   });
   searchFormSpy.mockClear();
   getPreferenceMock.mockClear();
+  showMessageSpy.mockClear();
   mockSearchParams.current = new URLSearchParams();
 });
 
@@ -221,7 +223,7 @@ describe('LogbookFeed — boards URL round-trip', () => {
     expect(lastSelectedBoards().map((b) => b.uuid)).toEqual(['logbook-kilter-1']);
   });
 
-  it('drops unknown UUIDs silently and fires the query with no board filter', async () => {
+  it('drops unknown UUIDs, fires query with no board filter, and shows a warning', async () => {
     mockSearchParams.current = new URLSearchParams('boards=logbook-kilter-999');
 
     renderFeed(false, [makeLayoutStats('kilter', 1)]);
@@ -236,6 +238,28 @@ describe('LogbookFeed — boards URL round-trip', () => {
     expect(variables.input.layoutIds).toBeUndefined();
 
     expect(lastSelectedBoards()).toEqual([]);
+    expect(showMessageSpy).toHaveBeenCalledWith(
+      "Couldn't find the linked board — showing all your entries.",
+      'warning',
+    );
+  });
+
+  it('treats ?boards= (empty string) identically to no boards param', async () => {
+    mockSearchParams.current = new URLSearchParams('boards=');
+
+    renderFeed(false, [makeLayoutStats('kilter', 1)]);
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    const [, variables] = mockRequest.mock.calls[0];
+    expect(variables.input.boardType).toBeUndefined();
+    expect(variables.input.boardTypes).toBeUndefined();
+    expect(variables.input.layoutIds).toBeUndefined();
+
+    expect(lastSelectedBoards()).toEqual([]);
+    expect(showMessageSpy).not.toHaveBeenCalled();
   });
 
   it('supports multiple UUIDs and sends boardTypes when they span board types', async () => {

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -203,6 +203,8 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       const matched = logbookBoards.filter((b) => uuids.includes(b.uuid));
       if (matched.length > 0) {
         setSelectedBoards(matched);
+      } else {
+        showMessage("Couldn't find the linked board — showing all your entries.", 'warning');
       }
     }
     setBoardsInitialized(true);
@@ -210,7 +212,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   // stats load, not re-evaluated on every URL change (URL is output, not input
   // for this effect).
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadingLayoutStats, logbookBoards]);
+  }, [loadingLayoutStats, logbookBoards, showMessage]);
 
   // Update URL query params when state changes
   const updateUrlRef = useRef<ReturnType<typeof setTimeout>>(undefined);


### PR DESCRIPTION
When all UUIDs in ?boards= are unknown (e.g. stale shared link), show a
snackbar warning instead of silently returning all entries. Adds a test
confirming ?boards= (empty string) behaves identically to no param.

https://claude.ai/code/session_01U7Fy2eq2BiEoqcuVhFeYE8