### PR TITLE
Add unit tests for ascentFeedItemToClimb and guard async click handlers

### DIFF
--- a/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
+++ b/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+import { ascentFeedItemToClimb } from '../ascent-to-climb';
+
+function makeItem(overrides: Partial<AscentFeedItem> = {}): AscentFeedItem {
+  return {
+    uuid: 'tick-1',
+    climbUuid: 'climb-uuid',
+    climbName: 'Test Climb',
+    setterUsername: 'setter',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: 4,
+    difficulty: 20,
+    difficultyName: '7a/V6',
+    consensusDifficulty: 21,
+    consensusDifficultyName: '7a+/V7',
+    qualityAverage: 3.5,
+    isBenchmark: false,
+    comment: '',
+    climbedAt: '2026-04-01T00:00:00Z',
+    frames: 'p1r14',
+    ...overrides,
+  };
+}
+
+describe('ascentFeedItemToClimb', () => {
+  it('maps basic fields from the feed item', () => {
+    const result = ascentFeedItemToClimb(makeItem());
+    expect(result.uuid).toBe('climb-uuid');
+    expect(result.name).toBe('Test Climb');
+    expect(result.setter_username).toBe('setter');
+    expect(result.frames).toBe('p1r14');
+    expect(result.angle).toBe(40);
+    expect(result.mirrored).toBe(false);
+    expect(result.layoutId).toBe(1);
+    expect(result.boardType).toBe('kilter');
+  });
+
+  it('prefers consensusDifficultyName over difficultyName for difficulty', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ consensusDifficultyName: '7a+/V7', difficultyName: '7a/V6' }),
+    );
+    expect(result.difficulty).toBe('7a+/V7');
+  });
+
+  it('falls back to difficultyName when consensusDifficultyName is null', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ consensusDifficultyName: null, difficultyName: '7a/V6' }),
+    );
+    expect(result.difficulty).toBe('7a/V6');
+  });
+
+  it('uses empty string when both difficulty names are null', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ consensusDifficultyName: null, difficultyName: null }),
+    );
+    expect(result.difficulty).toBe('');
+  });
+
+  it('stringifies qualityAverage when present', () => {
+    const result = ascentFeedItemToClimb(makeItem({ qualityAverage: 3.5 }));
+    expect(result.quality_average).toBe('3.5');
+  });
+
+  it('defaults quality_average to "0" when qualityAverage is null', () => {
+    const result = ascentFeedItemToClimb(makeItem({ qualityAverage: null }));
+    expect(result.quality_average).toBe('0');
+  });
+
+  it('sets benchmark_difficulty to consensusDifficultyName when isBenchmark is true', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ isBenchmark: true, consensusDifficultyName: '7a+/V7' }),
+    );
+    expect(result.benchmark_difficulty).toBe('7a+/V7');
+  });
+
+  it('sets benchmark_difficulty to null when isBenchmark is false', () => {
+    const result = ascentFeedItemToClimb(makeItem({ isBenchmark: false }));
+    expect(result.benchmark_difficulty).toBeNull();
+  });
+
+  it('defaults setter_username to empty string when null', () => {
+    const result = ascentFeedItemToClimb(makeItem({ setterUsername: null }));
+    expect(result.setter_username).toBe('');
+  });
+
+  it('defaults frames to empty string when null', () => {
+    const result = ascentFeedItemToClimb(makeItem({ frames: null }));
+    expect(result.frames).toBe('');
+  });
+
+  it('sets constant fields to expected defaults', () => {
+    const result = ascentFeedItemToClimb(makeItem());
+    expect(result.stars).toBe(0);
+    expect(result.difficulty_error).toBe('0');
+    expect(result.ascensionist_count).toBe(0);
+  });
+});

--- a/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
+++ b/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
@@ -84,6 +84,13 @@ describe('ascentFeedItemToClimb', () => {
     expect(result.benchmark_difficulty).toBeNull();
   });
 
+  it('sets benchmark_difficulty to null when isBenchmark is true but consensusDifficultyName is null', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ isBenchmark: true, consensusDifficultyName: null }),
+    );
+    expect(result.benchmark_difficulty).toBeNull();
+  });
+
   it('defaults setter_username to empty string when null', () => {
     const result = ascentFeedItemToClimb(makeItem({ setterUsername: null }));
     expect(result.setter_username).toBe('');

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -409,8 +409,8 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
     try {
       await queueActions.setCurrentClimb(climb);
       track('Logbook Row Clicked', { climbUuid: climb.uuid });
-    } catch {
-      // ignore – UI stays in its current state
+    } catch (err) {
+      console.error('Failed to set active climb from logbook row', err);
     }
   }, [isEditing, queueActions, climb]);
 
@@ -429,8 +429,8 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
       await queueActions.setCurrentClimb(climb);
       dispatchOpenPlayDrawer();
       track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
-    } catch {
-      // ignore – UI stays in its current state
+    } catch (err) {
+      console.error('Failed to set active climb from logbook thumbnail', err);
     }
   }, [isEditing, queueActions, climb]);
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -406,8 +406,12 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
 
   const handleRowClick = useCallback(async () => {
     if (isEditing || !queueActions) return;
-    await queueActions.setCurrentClimb(climb);
-    track('Logbook Row Clicked', { climbUuid: climb.uuid });
+    try {
+      await queueActions.setCurrentClimb(climb);
+      track('Logbook Row Clicked', { climbUuid: climb.uuid });
+    } catch {
+      // ignore – UI stays in its current state
+    }
   }, [isEditing, queueActions, climb]);
 
   const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -421,9 +425,13 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
   const handleThumbnailClick = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (isEditing || !queueActions) return;
-    await queueActions.setCurrentClimb(climb);
-    dispatchOpenPlayDrawer();
-    track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+    try {
+      await queueActions.setCurrentClimb(climb);
+      dispatchOpenPlayDrawer();
+      track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+    } catch {
+      // ignore – UI stays in its current state
+    }
   }, [isEditing, queueActions, climb]);
 
   // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)


### PR DESCRIPTION
- Add ascent-to-climb.test.ts with 11 cases covering difficulty/quality
  priority logic, null fallbacks, benchmark flag, and constant defaults
- Wrap handleRowClick and handleThumbnailClick in try/catch so a
  rejected setCurrentClimb doesn't become a silent unhandled rejection

https://claude.ai/code/session_01VbkUjTyRqDf55zZGbpA4XA