### PR TITLE
fix(logbook): route queue actions through party session and tint the active tick

### DIFF
--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -107,6 +107,7 @@ vi.mock('@/app/lib/grade-colors', () => ({
   getSoftVGradeColor: () => '#888',
   getSoftGradeColorByFormat: () => '#888',
   getGradeTintColor: () => null,
+  getActiveClimbTint: () => 'var(--semantic-selected)',
   getGradeColorWithOpacity: () => '#888',
   getGradeTextColor: () => '#000',
   isLightColor: () => false,

--- a/packages/web/app/components/climb-card/climb-card.tsx
+++ b/packages/web/app/components/climb-card/climb-card.tsx
@@ -14,7 +14,7 @@ import { Climb, BoardDetails } from '@/app/lib/types';
 import { ClimbActions } from '../climb-actions';
 import { useDoubleTapFavorite } from '../climb-actions/use-double-tap-favorite';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeTintColor } from '@/app/lib/grade-colors';
+import { getActiveClimbTint } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { useIsClimbSelected } from '../board-page/selected-climb-store';
@@ -107,9 +107,7 @@ function ClimbCardWithActions({
         <CardContent
           sx={{
             padding: `${themeTokens.spacing[1] + 2}px`,
-            backgroundColor: selected
-              ? (getGradeTintColor(climb.difficulty, 'light', isDark) ?? 'var(--semantic-selected-light)')
-              : undefined,
+            backgroundColor: selected ? getActiveClimbTint(climb.difficulty, isDark, 'selected-light') : undefined,
           }}
         >
           <div style={{ position: 'relative' }}>
@@ -178,9 +176,7 @@ const ClimbCardStatic = React.memo(
           <CardContent
             sx={{
               padding: `${themeTokens.spacing[1] + 2}px`,
-              backgroundColor: selected
-                ? (getGradeTintColor(climb?.difficulty, 'light', isDark) ?? 'var(--semantic-selected-light)')
-                : undefined,
+              backgroundColor: selected ? getActiveClimbTint(climb?.difficulty, isDark, 'selected-light') : undefined,
             }}
           >
             <div style={{ position: 'relative' }}>

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -21,7 +21,7 @@ import { useSwipeActions } from '@/app/hooks/use-swipe-actions';
 import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';
 import { useDoubleTap } from '@/app/lib/hooks/use-double-tap';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeTintColor } from '@/app/lib/grade-colors';
+import { getActiveClimbTint } from '@/app/lib/grade-colors';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { useIsClimbSelected } from '../board-page/selected-climb-store';
 import { InlineListTickBar } from '../logbook/inline-list-tick-bar';
@@ -501,9 +501,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       [rightActionRevealWidth, swipeRightAction?.color],
     );
 
-    const resolvedBg =
-      backgroundColor ??
-      (selected ? (getGradeTintColor(climb.difficulty, 'light', isDark) ?? 'var(--semantic-selected)') : 'transparent');
+    const resolvedBg = backgroundColor ?? (selected ? getActiveClimbTint(climb.difficulty, isDark) : 'transparent');
 
     const swipeableContentStyle = useMemo(
       () => ({

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -21,6 +21,11 @@ const dispatchOpenPlayDrawerMock = vi.fn();
 const queueActionsState: { value: { setCurrentClimb: typeof setCurrentClimbMock } | null } = {
   value: { setCurrentClimb: setCurrentClimbMock },
 };
+// Holder for the currently-active climb data so tests can exercise the
+// "this row is the active climb" branch.
+const currentClimbState: {
+  value: { currentClimb: { uuid: string } | null; currentClimbQueueItem: null } | null;
+} = { value: null };
 // Holder object so tests can mutate isPending and the mock reads the
 // current value on every render (avoids the stale-by-value closure
 // that would result from binding a plain `let` into the mock factory).
@@ -102,6 +107,10 @@ vi.mock('@/app/lib/board-data', () => ({
     { difficulty_id: 20, difficulty_name: '7a/V6', v_grade: 'V6' },
     { difficulty_id: 21, difficulty_name: '7a+/V7', v_grade: 'V7' },
   ],
+  // grade-colors.ts reads BOULDER_GRADES at module eval time to build its
+  // "V-grades with multiple Font-grade mappings" set. The data only needs to
+  // satisfy the `{ v_grade }` shape the loop reads.
+  BOULDER_GRADES: [{ v_grade: 'V6' }, { v_grade: 'V7' }],
   getGradesForBoard: () => [{ difficulty_id: 20, difficulty_name: '7a/V6', v_grade: 'V6' }],
 }));
 
@@ -113,6 +122,7 @@ vi.mock('@/app/components/activity-feed/ascent-thumbnail', () => ({
 
 vi.mock('@/app/components/graphql-queue', () => ({
   useOptionalQueueActions: () => queueActionsState.value,
+  useOptionalCurrentClimb: () => currentClimbState.value,
 }));
 
 vi.mock('@/app/components/queue-control/play-drawer-event', () => ({
@@ -199,6 +209,7 @@ beforeEach(() => {
   setCurrentClimbMock.mockReset();
   dispatchOpenPlayDrawerMock.mockReset();
   queueActionsState.value = { setCurrentClimb: setCurrentClimbMock };
+  currentClimbState.value = null;
   updateTickState.isPending = false;
 });
 
@@ -442,5 +453,50 @@ describe('LogbookFeedItem', () => {
     rerender(<LogbookFeedItem item={makeItem({ comment: '' })} isEditing />);
     const editRow = container.querySelector('.commentRow');
     expect(editRow).not.toBeNull();
+  });
+
+  describe('active climb tint', () => {
+    it('marks the row data-active-climb when the item matches the current climb', () => {
+      currentClimbState.value = {
+        currentClimb: { uuid: 'climb-1' },
+        currentClimbQueueItem: null,
+      };
+      const { container } = render(<LogbookFeedItem item={makeItem()} />);
+      const row = container.querySelector('.swipeableContent') as HTMLElement;
+      expect(row.hasAttribute('data-active-climb')).toBe(true);
+      // CSS variable is set inline so the module stylesheet can paint the tint.
+      expect(row.style.getPropertyValue('--active-climb-bg')).not.toBe('');
+    });
+
+    it('does not set the active CSS variable when no climb is current', () => {
+      currentClimbState.value = null;
+      const { container } = render(<LogbookFeedItem item={makeItem()} />);
+      const row = container.querySelector('.swipeableContent') as HTMLElement;
+      expect(row.hasAttribute('data-active-climb')).toBe(false);
+      expect(row.style.getPropertyValue('--active-climb-bg')).toBe('');
+    });
+
+    it('does not mark the row active when a different climb is current', () => {
+      currentClimbState.value = {
+        currentClimb: { uuid: 'some-other-climb' },
+        currentClimbQueueItem: null,
+      };
+      const { container } = render(<LogbookFeedItem item={makeItem()} />);
+      const row = container.querySelector('.swipeableContent') as HTMLElement;
+      expect(row.hasAttribute('data-active-climb')).toBe(false);
+      expect(row.style.getPropertyValue('--active-climb-bg')).toBe('');
+    });
+
+    it('falls back to the user difficulty name when no consensus grade exists', () => {
+      currentClimbState.value = {
+        currentClimb: { uuid: 'climb-1' },
+        currentClimbQueueItem: null,
+      };
+      const { container } = render(
+        <LogbookFeedItem item={makeItem({ consensusDifficultyName: null, difficultyName: '7a/V6' })} />,
+      );
+      const row = container.querySelector('.swipeableContent') as HTMLElement;
+      expect(row.style.getPropertyValue('--active-climb-bg')).not.toBe('');
+    });
   });
 });

--- a/packages/web/app/components/library/logbook-feed-item.module.css
+++ b/packages/web/app/components/library/logbook-feed-item.module.css
@@ -69,10 +69,11 @@
   transition: transform 120ms ease-out;
 }
 
-/* Swipeable wrapper — covers entire item so swipe gesture works everywhere */
+/* --active-climb-bg is set inline only when the row's climb is the current
+   active climb, tinted by the climb's grade (see getActiveClimbTint). */
 .swipeableContent {
   position: relative;
-  background-color: var(--semantic-surface, #fff);
+  background-color: var(--active-climb-bg, var(--semantic-surface, #fff));
   user-select: none;
 }
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -29,8 +29,9 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { track } from '@vercel/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
-import { useOptionalQueueActions } from '@/app/components/graphql-queue';
+import { useOptionalQueueActions, useOptionalCurrentClimb } from '@/app/components/graphql-queue';
 import { dispatchOpenPlayDrawer } from '@/app/components/queue-control/play-drawer-event';
+import { getActiveClimbTint } from '@/app/lib/grade-colors';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { ClimbActions } from '@/app/components/climb-actions';
 import DrawerClimbHeader from '@/app/components/climb-card/drawer-climb-header';
@@ -141,6 +142,7 @@ function LogbookGradeRow({
   difficultyName,
   quality,
   attemptCount,
+  isDark,
   isEditing,
   editQuality,
   editDifficulty,
@@ -155,6 +157,7 @@ function LogbookGradeRow({
   difficultyName: string | null;
   quality: number | null;
   attemptCount: number;
+  isDark: boolean;
   isEditing?: boolean;
   editQuality?: number | null;
   editDifficulty?: number | undefined;
@@ -164,7 +167,6 @@ function LogbookGradeRow({
   gradeButtonRef?: React.RefObject<HTMLButtonElement | null>;
   triesButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }) {
-  const isDark = useIsDarkMode();
   const { formatGrade, getGradeColor } = useGradeFormat();
 
   const consensusFormatted = consensusDifficultyName ? formatGrade(consensusDifficultyName) : null;
@@ -314,6 +316,17 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
     const queueActions = useOptionalQueueActions();
+    const currentClimbData = useOptionalCurrentClimb();
+    const isActiveClimb =
+      !!currentClimbData?.currentClimb && currentClimbData.currentClimb.uuid === item.climbUuid;
+    const isDark = useIsDarkMode();
+    const activeBackground = useMemo(
+      () =>
+        isActiveClimb
+          ? getActiveClimbTint(item.consensusDifficultyName ?? item.difficultyName, isDark)
+          : undefined,
+      [isActiveClimb, item.consensusDifficultyName, item.difficultyName, isDark],
+    );
 
     // --- Edit state ---
     const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -623,7 +636,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
             {...swipeHandlers}
             ref={contentCombinedRef}
             className={styles.swipeableContent}
+            style={activeBackground ? ({ '--active-climb-bg': activeBackground } as React.CSSProperties) : undefined}
             data-swipe-content=""
+            data-active-climb={isActiveClimb ? '' : undefined}
             role={!isEditing && queueActions ? 'button' : undefined}
             tabIndex={!isEditing && queueActions ? 0 : undefined}
             aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
@@ -704,6 +719,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                   difficultyName={item.difficultyName}
                   quality={item.quality}
                   attemptCount={item.attemptCount}
+                  isDark={isDark}
                   isEditing={isEditing}
                   editQuality={editQuality}
                   editDifficulty={editDifficulty}

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -16,11 +16,20 @@ const mockDeactivateSession = vi.fn();
 const mockClearLocalQueue = vi.fn();
 
 let mockPersistentSession: Record<string, unknown> = {};
+let mockPartyProfile: {
+  profile: { id: string } | null;
+  username: string | undefined;
+  avatarUrl: string | undefined;
+} = { profile: null, username: undefined, avatarUrl: undefined };
 
 vi.mock('../../persistent-session', () => ({
   usePersistentSession: () => mockPersistentSession,
   usePersistentSessionState: () => mockPersistentSession,
   usePersistentSessionActions: () => mockPersistentSession,
+}));
+
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => mockPartyProfile,
 }));
 
 vi.mock('../../graphql-queue/QueueContext', () => {
@@ -357,6 +366,7 @@ describe('queue-bridge-context', () => {
     vi.clearAllMocks();
     mockUuidCounter = 0;
     mockPersistentSession = createDefaultPersistentSession();
+    mockPartyProfile = { profile: null, username: undefined, avatarUrl: undefined };
   });
 
   // -----------------------------------------------------------------------
@@ -481,6 +491,24 @@ describe('queue-bridge-context', () => {
         expect(newQueue[0].climb.uuid).toBe('c1');
         // When current is null, new item becomes current
         expect(newCurrent.climb.uuid).toBe('c1');
+      });
+
+      it('addToQueue also attaches addedByUser metadata in local mode', () => {
+        mockPartyProfile = {
+          profile: { id: 'user-42' },
+          username: 'alex',
+          avatarUrl: 'https://example.com/alex.png',
+        };
+        const { result } = renderWithLocalQueue([], null);
+        act(() => {
+          result.current!.addToQueue(climb1);
+        });
+        const [newQueue] = mockSetLocalQueueState.mock.calls[0];
+        expect(newQueue[0].addedByUser).toEqual({
+          id: 'user-42',
+          username: 'alex',
+          avatarUrl: 'https://example.com/alex.png',
+        });
       });
 
       it('removeFromQueue filters item and updates state', () => {
@@ -673,6 +701,228 @@ describe('queue-bridge-context', () => {
           result.current!.setCurrentClimb(climb);
         });
         expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+    });
+
+    // -------------------------------------------------------------------
+    // Party-mode dispatch: with an active session, setLocalQueueState no-ops
+    // inside the persistent session, so the adapter must route through
+    // ps.addQueueItem / ps.setCurrentClimb instead.
+    // -------------------------------------------------------------------
+    describe('adapter party-mode dispatch', () => {
+      const bd = createTestBoardDetails();
+      const climbA = createTestClimb({ uuid: 'c-a', name: 'A' });
+      const climbB = createTestClimb({ uuid: 'c-b', name: 'B' });
+
+      function renderPartyBridge({
+        queue = [],
+        current = null,
+        addQueueItem = vi.fn().mockResolvedValue(undefined),
+        setCurrentClimb = vi.fn().mockResolvedValue(undefined),
+        removeQueueItem = vi.fn().mockResolvedValue(undefined),
+      }: {
+        queue?: ClimbQueueItem[];
+        current?: ClimbQueueItem | null;
+        addQueueItem?: ReturnType<typeof vi.fn>;
+        setCurrentClimb?: ReturnType<typeof vi.fn>;
+        removeQueueItem?: ReturnType<typeof vi.fn>;
+      } = {}) {
+        mockPersistentSession = createDefaultPersistentSession({
+          activeSession: {
+            sessionId: 'party-42',
+            boardPath: '/kilter/1/10/1,2/40',
+            boardDetails: bd,
+            parsedParams: { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2], angle: 40 },
+          },
+          queue,
+          currentClimbQueueItem: current,
+          clientId: 'client-xyz',
+          hasConnected: true,
+          addQueueItem,
+          setCurrentClimb,
+          removeQueueItem,
+          isLocalQueueLoaded: true,
+        });
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+          <QueueBridgeProvider>{children}</QueueBridgeProvider>
+        );
+        return {
+          ...renderHook(() => useTestQueueContext(), { wrapper }),
+          addQueueItem,
+          setCurrentClimb,
+          removeQueueItem,
+        };
+      }
+
+      it('addToQueue dispatches through ps.addQueueItem instead of setLocalQueueState', () => {
+        const { result, addQueueItem } = renderPartyBridge();
+        act(() => {
+          result.current!.addToQueue(climbA);
+        });
+        expect(addQueueItem).toHaveBeenCalledTimes(1);
+        const [newItem] = addQueueItem.mock.calls[0];
+        expect(newItem.climb.uuid).toBe('c-a');
+        expect(newItem.addedBy).toBe('client-xyz');
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+
+      it('addToQueue attaches addedByUser metadata when a party profile exists', () => {
+        mockPartyProfile = {
+          profile: { id: 'user-77' },
+          username: 'marco',
+          avatarUrl: 'https://example.com/marco.png',
+        };
+        const { result, addQueueItem } = renderPartyBridge();
+        act(() => {
+          result.current!.addToQueue(climbA);
+        });
+        const [newItem] = addQueueItem.mock.calls[0];
+        expect(newItem.addedByUser).toEqual({
+          id: 'user-77',
+          username: 'marco',
+          avatarUrl: 'https://example.com/marco.png',
+        });
+      });
+
+      it('addToQueue leaves addedByUser undefined when no profile is available', () => {
+        mockPartyProfile = { profile: null, username: undefined, avatarUrl: undefined };
+        const { result, addQueueItem } = renderPartyBridge();
+        act(() => {
+          result.current!.addToQueue(climbA);
+        });
+        const [newItem] = addQueueItem.mock.calls[0];
+        expect(newItem.addedByUser).toBeUndefined();
+      });
+
+      it('addToQueue leaves addedByUser undefined when the profile has no username', () => {
+        // A signed-in user without a chosen display name — we'd rather peers
+        // fall back to the Bluetooth placeholder than show a blank name.
+        mockPartyProfile = {
+          profile: { id: 'user-99' },
+          username: undefined,
+          avatarUrl: undefined,
+        };
+        const { result, addQueueItem } = renderPartyBridge();
+        act(() => {
+          result.current!.addToQueue(climbA);
+        });
+        const [newItem] = addQueueItem.mock.calls[0];
+        expect(newItem.addedByUser).toBeUndefined();
+      });
+
+      it('addToQueue swallows ps.addQueueItem rejections without throwing', async () => {
+        const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const addQueueItem = vi.fn().mockRejectedValue(new Error('ws down'));
+        const { result } = renderPartyBridge({ addQueueItem });
+        act(() => {
+          result.current!.addToQueue(climbA);
+        });
+        await Promise.resolve();
+        expect(addQueueItem).toHaveBeenCalled();
+        expect(consoleErr).toHaveBeenCalled();
+        consoleErr.mockRestore();
+      });
+
+      it('setCurrentClimb sends addQueueItem(position) then setCurrentClimb to the session', async () => {
+        const existing = createTestQueueItem(createTestClimb({ uuid: 'c-a' }), 'u-a');
+        const { result, addQueueItem, setCurrentClimb } = renderPartyBridge({
+          queue: [existing],
+          current: existing,
+        });
+        let returned: ClimbQueueItem | null = null;
+        await act(async () => {
+          returned = await result.current!.setCurrentClimb(climbB);
+        });
+        expect(returned).not.toBeNull();
+        expect(returned!.climb.uuid).toBe('c-b');
+        expect(addQueueItem).toHaveBeenCalledTimes(1);
+        expect(addQueueItem.mock.calls[0][1]).toBe(1);
+        expect(setCurrentClimb).toHaveBeenCalledTimes(1);
+        expect(setCurrentClimb.mock.calls[0][0].climb.uuid).toBe('c-b');
+        expect(setCurrentClimb.mock.calls[0][1]).toBe(false);
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+
+      it('setCurrentClimb uses undefined position when there is no current climb', async () => {
+        const { result, addQueueItem } = renderPartyBridge({ queue: [], current: null });
+        await act(async () => {
+          await result.current!.setCurrentClimb(climbA);
+        });
+        expect(addQueueItem.mock.calls[0][1]).toBeUndefined();
+      });
+
+      it('setCurrentClimb returns null and does not call removeQueueItem when ps.addQueueItem rejects', async () => {
+        const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const addQueueItem = vi.fn().mockRejectedValue(new Error('ws down'));
+        const setCurrentClimb = vi.fn().mockResolvedValue(undefined);
+        const removeQueueItem = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderPartyBridge({ addQueueItem, setCurrentClimb, removeQueueItem });
+        let returned: ClimbQueueItem | null = null;
+        await act(async () => {
+          returned = await result.current!.setCurrentClimb(climbA);
+        });
+        expect(returned).toBeNull();
+        expect(setCurrentClimb).not.toHaveBeenCalled();
+        // Nothing made it into the queue — nothing to roll back.
+        expect(removeQueueItem).not.toHaveBeenCalled();
+        expect(consoleErr).toHaveBeenCalled();
+        consoleErr.mockRestore();
+      });
+
+      it('setCurrentClimb returns null and rolls back the queue add when ps.setCurrentClimb rejects', async () => {
+        const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const addQueueItem = vi.fn().mockResolvedValue(undefined);
+        const setCurrentClimb = vi.fn().mockRejectedValue(new Error('no session'));
+        const removeQueueItem = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderPartyBridge({ addQueueItem, setCurrentClimb, removeQueueItem });
+        let returned: ClimbQueueItem | null = null;
+        await act(async () => {
+          returned = await result.current!.setCurrentClimb(climbA);
+        });
+        expect(returned).toBeNull();
+        expect(addQueueItem).toHaveBeenCalled();
+        // Item landed in the queue but couldn't be promoted — roll it back.
+        expect(removeQueueItem).toHaveBeenCalledTimes(1);
+        const addedItem = addQueueItem.mock.calls[0][0];
+        expect(removeQueueItem.mock.calls[0][0]).toBe(addedItem.uuid);
+        expect(consoleErr).toHaveBeenCalled();
+        consoleErr.mockRestore();
+      });
+
+      it('setCurrentClimb logs when the rollback removeQueueItem also rejects', async () => {
+        const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const addQueueItem = vi.fn().mockResolvedValue(undefined);
+        const setCurrentClimb = vi.fn().mockRejectedValue(new Error('no session'));
+        const removeQueueItem = vi.fn().mockRejectedValue(new Error('rollback failed'));
+        const { result } = renderPartyBridge({ addQueueItem, setCurrentClimb, removeQueueItem });
+        await act(async () => {
+          await result.current!.setCurrentClimb(climbA);
+        });
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(removeQueueItem).toHaveBeenCalled();
+        const messages = consoleErr.mock.calls.map((call) => String(call[0]));
+        expect(messages.some((m) => m.includes('Failed to roll back'))).toBe(true);
+        consoleErr.mockRestore();
+      });
+
+      it('setCurrentClimb attaches addedByUser metadata to the queued item', async () => {
+        mockPartyProfile = {
+          profile: { id: 'user-77' },
+          username: 'marco',
+          avatarUrl: undefined,
+        };
+        const { result, addQueueItem } = renderPartyBridge();
+        await act(async () => {
+          await result.current!.setCurrentClimb(climbA);
+        });
+        const [newItem] = addQueueItem.mock.calls[0];
+        expect(newItem.addedByUser).toEqual({
+          id: 'user-77',
+          username: 'marco',
+          avatarUrl: undefined,
+        });
       });
     });
   });

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@/app/lib/grade-colors', () => ({
   getSoftVGradeColor: () => '#888',
   getSoftGradeColorByFormat: () => '#888',
   getGradeTintColor: (_d: unknown, _s: unknown, _dark: unknown) => null,
+  getActiveClimbTint: () => 'var(--semantic-selected)',
   getGradeColorWithOpacity: () => '#888',
   getGradeTextColor: () => '#000',
   isLightColor: () => false,

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -29,13 +29,14 @@ import { usePersistentSession } from '../persistent-session';
 import { getBaseBoardPath } from '@/app/lib/url-utils';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { BoardDetails, Angle, Climb, SearchRequestPagination } from '@/app/lib/types';
-import type { ClimbQueueItem } from './types';
+import type { ClimbQueueItem, QueueItemUser } from './types';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
 import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
 import { useSnackbar } from '../providers/snackbar-provider';
 import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
+import { usePartyProfile } from '../party-manager/party-profile-context';
 
 const LiveActivityBridge = dynamic(() => import('@/app/lib/live-activity/live-activity-bridge'), {
   ssr: false,
@@ -130,6 +131,12 @@ function usePersistentSessionQueueAdapter(): {
 } {
   const ps = usePersistentSession();
   const { showMessage } = useSnackbar();
+  const { profile, username, avatarUrl } = usePartyProfile();
+
+  const currentUserInfo: QueueItemUser | undefined = useMemo(() => {
+    if (!profile?.id || !username) return undefined;
+    return { id: profile.id, username, avatarUrl };
+  }, [profile?.id, username, avatarUrl]);
 
   const isParty = !!ps.activeSession;
   const queue = isParty ? ps.queue : ps.localQueue;
@@ -169,6 +176,7 @@ function usePersistentSessionQueueAdapter(): {
     baseBoardPath,
     ps,
     showMessage,
+    currentUserInfo,
   });
   latestRef.current = {
     queue,
@@ -177,6 +185,7 @@ function usePersistentSessionQueueAdapter(): {
     baseBoardPath,
     ps,
     showMessage,
+    currentUserInfo,
   };
 
   // Validates a climb against the locked board (session) or the current
@@ -220,10 +229,19 @@ function usePersistentSessionQueueAdapter(): {
       if (!validateClimbForQueue(climb)) return;
       const newItem: ClimbQueueItem = {
         climb,
-        addedBy: null,
+        addedBy: r.ps.clientId ?? null,
+        addedByUser: r.currentUserInfo,
         uuid: uuidv4(),
         suggested: false,
       };
+      // setLocalQueueState no-ops while a party session is active, so the
+      // adapter has to talk to ps directly instead.
+      if (r.ps.activeSession) {
+        r.ps.addQueueItem(newItem).catch((error: unknown) => {
+          console.error('Failed to add queue item from bridge adapter:', error);
+        });
+        return;
+      }
       if (!r.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
@@ -277,10 +295,37 @@ function usePersistentSessionQueueAdapter(): {
       if (!validateClimbForQueue(climb)) return null;
       const newItem: ClimbQueueItem = {
         climb,
-        addedBy: null,
+        addedBy: r.ps.clientId ?? null,
+        addedByUser: r.currentUserInfo,
         uuid: uuidv4(),
         suggested: false,
       };
+      // setLocalQueueState no-ops while a party session is active, so the
+      // adapter has to talk to ps directly instead.
+      if (r.ps.activeSession) {
+        const currentIdx = r.currentClimbQueueItem
+          ? r.queue.findIndex((q) => q.uuid === r.currentClimbQueueItem!.uuid)
+          : -1;
+        const position = currentIdx === -1 ? undefined : currentIdx + 1;
+        try {
+          await r.ps.addQueueItem(newItem, position);
+        } catch (error) {
+          console.error('Failed to add queue item from bridge adapter:', error);
+          return null;
+        }
+        try {
+          await r.ps.setCurrentClimb(newItem, false);
+        } catch (error) {
+          console.error('Failed to set current climb from bridge adapter:', error);
+          // The item landed in the queue but we couldn't promote it to current —
+          // roll it back so the user doesn't see a ghost entry they never chose.
+          r.ps.removeQueueItem(newItem.uuid).catch((rollbackError: unknown) => {
+            console.error('Failed to roll back orphaned queue item:', rollbackError);
+          });
+          return null;
+        }
+        return newItem;
+      }
       if (!r.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.

--- a/packages/web/app/components/queue-control/queue-climb-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-climb-list-item.tsx
@@ -20,7 +20,7 @@ import { ClimbQueueItem } from './types';
 import ClimbListItem, { type SwipeActionOverride } from '../climb-card/climb-list-item';
 import { dispatchOpenPlayDrawer } from './play-drawer-event';
 import { themeTokens } from '@/app/theme/theme-config';
-import { getGradeTintColor } from '@/app/lib/grade-colors';
+import { getActiveClimbTint } from '@/app/lib/grade-colors';
 
 type QueueClimbListItemProps = {
   item: ClimbQueueItem;
@@ -81,9 +81,7 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
 
   // Background color based on current/history state
   const backgroundColor = useMemo(() => {
-    if (isCurrent) {
-      return getGradeTintColor(item.climb.difficulty, 'light', isDark) ?? 'var(--semantic-selected)';
-    }
+    if (isCurrent) return getActiveClimbTint(item.climb.difficulty, isDark);
     if (isHistory) return 'var(--neutral-100)';
     return 'transparent';
   }, [isCurrent, isHistory, item.climb.difficulty, isDark]);

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -279,3 +279,13 @@ export function getGradeTintColor(
   }
   return `hsl(${hue}, 30%, 88%)`;
 }
+
+export function getActiveClimbTint(
+  difficulty: string | null | undefined,
+  darkMode: boolean,
+  fallback: 'selected' | 'selected-light' = 'selected',
+): string {
+  const fallbackVar =
+    fallback === 'selected-light' ? 'var(--semantic-selected-light)' : 'var(--semantic-selected)';
+  return getGradeTintColor(difficulty, 'light', darkMode) ?? fallbackVar;
+}


### PR DESCRIPTION
Bridge adapter's addToQueue/setCurrentClimb silently no-opped during
party mode because setLocalQueueState bails while a session is active.
Route the mutations to the persistent session's backend handlers so the
Add to Queue menu item and logbook thumbnail both update the party queue.

Tint the logbook feed item background with the grade tint when its climb
is the current one, matching the queue list item treatment.