### PR TITLE
feat(search): surface ascent status filters and enrich analytics

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -78,6 +78,7 @@ export const climbQueries = {
       showOnlyAttempted: input.showOnlyAttempted,
       showOnlyCompleted: input.showOnlyCompleted,
       onlyDrafts: input.onlyDrafts,
+      projectsOnly: input.projectsOnly,
     };
 
     if (DEBUG) {

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -85,6 +85,7 @@ export const ClimbSearchInputSchema = z.object({
   showOnlyAttempted: z.boolean().optional(),
   showOnlyCompleted: z.boolean().optional(),
   onlyDrafts: z.boolean().optional(),
+  projectsOnly: z.boolean().optional(),
 });
 
 export const SaveClimbInputSchema = z.object({

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -55,7 +55,7 @@
     "lint-fix": "oxlint --fix .",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun scripts/migrate.ts",
-    "test": "tsx --test scripts/**/*.test.ts",
+    "test": "tsx --test scripts/**/*.test.ts src/**/*.test.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-aurora-unified": "tsx scripts/import-aurora-board-unified.ts",

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import type { SQL } from 'drizzle-orm';
 import { createClimbFilters } from '../create-climb-filters';
 import type { BoardRouteParams, ClimbSearchParams } from '../types';
 
@@ -13,35 +14,79 @@ const params: BoardRouteParams = {
 
 const baseSearch: ClimbSearchParams = {};
 
+/**
+ * Flatten a Drizzle SQL fragment into a single inspectable string so tests can
+ * assert on the actual SQL produced, not just that *some* condition exists.
+ *
+ * queryChunks is a mix of:
+ *   - { value: ['literal sql'] }
+ *   - { name: 'column_name' } (Column/Table instances)
+ *   - nested SQL fragments with their own queryChunks
+ *   - param markers ({ value: <runtime val> })
+ */
+function sqlToString(fragment: SQL): string {
+  const chunks = (fragment as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return chunks.map((chunk) => {
+    if (chunk && typeof chunk === 'object' && 'queryChunks' in chunk) {
+      return sqlToString(chunk as SQL);
+    }
+    if (chunk && typeof chunk === 'object' && 'value' in chunk) {
+      const value = (chunk as { value: unknown }).value;
+      if (Array.isArray(value)) return value.join('');
+      return String(value);
+    }
+    if (chunk && typeof chunk === 'object' && 'name' in chunk) {
+      return String((chunk as { name: unknown }).name);
+    }
+    return '';
+  }).join('');
+}
+
 describe('createClimbFilters: projectsOnly', () => {
   it('produces no projectsOnly condition by default', () => {
     const f = createClimbFilters(params, baseSearch);
     assert.equal(f.projectsOnlyConditions.length, 0);
   });
 
-  it('produces one projectsOnly condition when the flag is set', () => {
+  it('emits a COALESCE(ascensionist_count, 0) = 0 condition when projectsOnly is on', () => {
     const f = createClimbFilters(params, { projectsOnly: true });
     assert.equal(f.projectsOnlyConditions.length, 1);
+    const rendered = sqlToString(f.projectsOnlyConditions[0]);
+    // Match both the column reference and the zero-equality shape so a future
+    // refactor that swaps the condition fails the test.
+    assert.match(rendered, /COALESCE/i);
+    assert.match(rendered, /ascensionist_count/);
+    assert.match(rendered, /= 0/);
   });
 
-  it('adds the projectsOnly condition to the climb WHERE conditions', () => {
-    const baselineCount = createClimbFilters(params, baseSearch).getClimbWhereConditions().length;
+  it('adds the projectsOnly condition to the climb WHERE array', () => {
+    const baseline = createClimbFilters(params, baseSearch).getClimbWhereConditions();
     const withProjects = createClimbFilters(params, { projectsOnly: true }).getClimbWhereConditions();
-    assert.equal(withProjects.length, baselineCount + 1);
+    assert.equal(withProjects.length, baseline.length + 1);
+    // The new entry must be the COALESCE zero-ascents condition.
+    const rendered = withProjects.map(sqlToString).join(' || ');
+    assert.match(rendered, /COALESCE[^|]*ascensionist_count[^|]*= 0/i);
   });
 
   it('skips the minAscents stats condition when projectsOnly is on (prevents contradictory SQL)', () => {
     const f = createClimbFilters(params, { projectsOnly: true, minAscents: 10 });
-    assert.equal(f.climbStatsConditions.length, 0);
+    // No stats condition should reference ascensionist_count >= 10 when projectsOnly is on.
+    const rendered = f.climbStatsConditions.map(sqlToString).join(' || ');
+    assert.doesNotMatch(rendered, /ascensionist_count/);
   });
 
-  it('applies the minAscents stats condition when projectsOnly is off', () => {
+  it('emits ascensionist_count >= N when projectsOnly is off and minAscents is set', () => {
     const f = createClimbFilters(params, { projectsOnly: false, minAscents: 10 });
     assert.equal(f.climbStatsConditions.length, 1);
+    const rendered = sqlToString(f.climbStatsConditions[0]);
+    assert.match(rendered, /ascensionist_count/);
+    // Drizzle's gte renders as "... >= $param"; the literal operator is enough
+    // to confirm we're asserting on the comparison, not some unrelated predicate.
+    assert.match(rendered, />=/);
   });
 
   it('keeps stats conditions empty so the stats-driven INNER JOIN path is not selected by projectsOnly alone', () => {
-    // search-climbs uses `climbStatsConditions.length > 0` to pick the INNER JOIN
+    // search-climbs uses climbStatsConditions.length > 0 to pick the INNER JOIN
     // fast path. projectsOnly must live outside climbStatsConditions so climbs
     // with no stats row are not dropped by the INNER JOIN.
     const f = createClimbFilters(params, { projectsOnly: true });

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createClimbFilters } from '../create-climb-filters';
+import type { BoardRouteParams, ClimbSearchParams } from '../types';
+
+const params: BoardRouteParams = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+  angle: 40,
+};
+
+const baseSearch: ClimbSearchParams = {};
+
+describe('createClimbFilters: projectsOnly', () => {
+  it('produces no projectsOnly condition by default', () => {
+    const f = createClimbFilters(params, baseSearch);
+    assert.equal(f.projectsOnlyConditions.length, 0);
+  });
+
+  it('produces one projectsOnly condition when the flag is set', () => {
+    const f = createClimbFilters(params, { projectsOnly: true });
+    assert.equal(f.projectsOnlyConditions.length, 1);
+  });
+
+  it('adds the projectsOnly condition to the climb WHERE conditions', () => {
+    const baselineCount = createClimbFilters(params, baseSearch).getClimbWhereConditions().length;
+    const withProjects = createClimbFilters(params, { projectsOnly: true }).getClimbWhereConditions();
+    assert.equal(withProjects.length, baselineCount + 1);
+  });
+
+  it('skips the minAscents stats condition when projectsOnly is on (prevents contradictory SQL)', () => {
+    const f = createClimbFilters(params, { projectsOnly: true, minAscents: 10 });
+    assert.equal(f.climbStatsConditions.length, 0);
+  });
+
+  it('applies the minAscents stats condition when projectsOnly is off', () => {
+    const f = createClimbFilters(params, { projectsOnly: false, minAscents: 10 });
+    assert.equal(f.climbStatsConditions.length, 1);
+  });
+
+  it('keeps stats conditions empty so the stats-driven INNER JOIN path is not selected by projectsOnly alone', () => {
+    // search-climbs uses `climbStatsConditions.length > 0` to pick the INNER JOIN
+    // fast path. projectsOnly must live outside climbStatsConditions so climbs
+    // with no stats row are not dropped by the INNER JOIN.
+    const f = createClimbFilters(params, { projectsOnly: true });
+    assert.equal(f.climbStatsConditions.length, 0);
+  });
+});

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -90,10 +90,19 @@ export const createClimbFilters = (
     sql`${params.size_id} = ANY(${boardClimbs.compatibleSizeIds})`,
   ];
 
+  // Projects-only: match climbs with 0 ascents OR no stats row at all.
+  // Must live outside climbStatsConditions so it doesn't trigger the stats-driven
+  // INNER JOIN path (which would exclude no-stats climbs).
+  const projectsOnlyConditions: SQL[] = searchParams.projectsOnly
+    ? [sql`COALESCE(${boardClimbStats.ascensionistCount}, 0) = 0`]
+    : [];
+
   // Conditions for climb stats
   const climbStatsConditions: SQL[] = [];
 
-  if (searchParams.minAscents) {
+  // Skip minAscents when projectsOnly is active (they're mutually exclusive in the UI,
+  // but guard here too so a stale query param can't produce a contradictory filter).
+  if (searchParams.minAscents && !searchParams.projectsOnly) {
     climbStatsConditions.push(gte(boardClimbStats.ascensionistCount, searchParams.minAscents));
   }
 
@@ -290,6 +299,7 @@ export const createClimbFilters = (
       ...tallClimbsConditions,
       ...setIdsConditions,
       ...personalProgressConditions,
+      ...projectsOnlyConditions,
     ],
     getSizeConditions: () => sizeConditions,
     getClimbStatsConditions: () => climbStatsConditions,
@@ -320,6 +330,7 @@ export const createClimbFilters = (
     setIdsConditions,
     sizeConditions,
     personalProgressConditions,
+    projectsOnlyConditions,
     anyHolds,
     notHolds,
     holdStateFilters,

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -83,8 +83,10 @@ export const searchClimbs = async (
   // making LEFT JOIN and INNER JOIN equivalent.
   // When no stats filters are active, fall through to the LEFT JOIN path.
   const hasStatsFilters = filters.getClimbStatsConditions().length > 0;
+  // projectsOnly includes climbs with NO stats row (ascents NULL), so the INNER-JOIN
+  // stats-driven path would drop exactly the climbs we want. Force the LEFT-JOIN path.
   const useStatsDriven = sortBy === 'ascents' && sortOrder === 'desc'
-    && !isDraftsQuery && hasStatsFilters;
+    && !isDraftsQuery && hasStatsFilters && !searchParams.projectsOnly;
 
   if (useStatsDriven) {
     return statsDrivenSearch(db, params, filters, page, pageSize);

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -42,6 +42,7 @@ export interface ClimbSearchParams {
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
   onlyDrafts?: boolean;
+  projectsOnly?: boolean;
   // Allow dynamic hold keys (e.g., hold_123)
   [key: `hold_${number}`]: any;
 }

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -135,6 +135,8 @@ export const climbTypeDefs = /* GraphQL */ `
     showOnlyCompleted: Boolean
     "Show only the user's draft climbs (requires auth)"
     onlyDrafts: Boolean
+    "Show only unclimbed projects (climbs with 0 ascents)"
+    projectsOnly: Boolean
   }
 
   """

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -92,6 +92,7 @@ export type ClimbSearchInput = {
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
   onlyDrafts?: boolean;
+  projectsOnly?: boolean;
 };
 
 /**

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -168,6 +168,7 @@ describe('hasUserSpecificFilters', () => {
     showOnlyAttempted: false,
     showOnlyCompleted: false,
     onlyDrafts: false,
+    projectsOnly: false,
     page: 0,
     pageSize: 20,
   };

--- a/packages/web/app/components/graphql-queue/__tests__/context-split.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/context-split.test.tsx
@@ -136,6 +136,7 @@ function makeSearchParams(overrides: Partial<SearchRequestPagination> = {}): Sea
     showOnlyAttempted: false,
     showOnlyCompleted: false,
     onlyDrafts: false,
+    projectsOnly: false,
     page: 0,
     pageSize: 20,
     ...overrides,

--- a/packages/web/app/components/graphql-queue/__tests__/set-current-climb-mutation.test.ts
+++ b/packages/web/app/components/graphql-queue/__tests__/set-current-climb-mutation.test.ts
@@ -49,6 +49,7 @@ const mockSearchParams: SearchRequestPagination = {
   showOnlyAttempted: false,
   showOnlyCompleted: false,
   onlyDrafts: false,
+  projectsOnly: false,
 };
 
 const initialState: QueueState = {

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -101,7 +101,8 @@ const mockSearchParams: SearchRequestPagination = {
   hideCompleted: false,
   showOnlyAttempted: false,
   showOnlyCompleted: false,
-  onlyDrafts: false
+  onlyDrafts: false,
+  projectsOnly: false,
 };
 
 const mockParsedParams: ParsedBoardRouteParameters = {

--- a/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
@@ -41,7 +41,8 @@ const mockSearchParams: SearchRequestPagination = {
   hideCompleted: false,
   showOnlyAttempted: false,
   showOnlyCompleted: false,
-  onlyDrafts: false
+  onlyDrafts: false,
+  projectsOnly: false,
 };
 
 const initialState: QueueState = {

--- a/packages/web/app/components/queue-control/__tests__/reducer.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/reducer.test.ts
@@ -48,7 +48,8 @@ const mockSearchParams: SearchRequestPagination = {
   hideCompleted: false,
   showOnlyAttempted: false,
   showOnlyCompleted: false,
-  onlyDrafts: false
+  onlyDrafts: false,
+  projectsOnly: false,
 };
 
 const initialState: QueueState = {
@@ -299,7 +300,8 @@ describe('queueReducer', () => {
         hideCompleted: false,
         showOnlyAttempted: false,
         showOnlyCompleted: false,
-        onlyDrafts: false
+        onlyDrafts: false,
+        projectsOnly: false,
       };
 
       const action: QueueAction = {

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -76,6 +76,7 @@ export const useQueueDataFetching = ({
     showOnlyAttempted: searchParams.showOnlyAttempted || undefined,
     showOnlyCompleted: searchParams.showOnlyCompleted || undefined,
     onlyDrafts: searchParams.onlyDrafts || undefined,
+    projectsOnly: searchParams.projectsOnly || undefined,
   }), [searchParams, parsedParams]);
 
   const {
@@ -153,6 +154,7 @@ export const useQueueDataFetching = ({
     showOnlyAttempted: countSearchParams.showOnlyAttempted || undefined,
     showOnlyCompleted: countSearchParams.showOnlyCompleted || undefined,
     onlyDrafts: countSearchParams.onlyDrafts || undefined,
+    projectsOnly: countSearchParams.projectsOnly || undefined,
   }), [countSearchParams, parsedParams]);
 
   const countQueryKey = useMemo(() => {

--- a/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
+++ b/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
@@ -44,11 +44,31 @@ export const UISearchParamsProvider: React.FC<{ children: React.ReactNode }> = (
     if (uiSearchParams.showOnlyAttempted) activeFilters.push('showOnlyAttempted');
     if (uiSearchParams.showOnlyCompleted) activeFilters.push('showOnlyCompleted');
     if (uiSearchParams.onlyDrafts) activeFilters.push('onlyDrafts');
+    if (uiSearchParams.projectsOnly) activeFilters.push('projectsOnly');
 
     if (activeFilters.length > 0) {
       track('Climb Search Performed', {
         searchType: 'filters',
         activeFiltersCount: activeFilters.length,
+        sortBy: uiSearchParams.sortBy,
+        sortOrder: uiSearchParams.sortOrder,
+        hasName: Boolean(uiSearchParams.name),
+        minGrade: uiSearchParams.minGrade,
+        maxGrade: uiSearchParams.maxGrade,
+        minAscents: uiSearchParams.minAscents,
+        minRating: uiSearchParams.minRating,
+        gradeAccuracy: uiSearchParams.gradeAccuracy,
+        onlyClassics: uiSearchParams.onlyClassics,
+        projectsOnly: uiSearchParams.projectsOnly,
+        establishedOnly: uiSearchParams.minAscents >= 2,
+        onlyTallClimbs: uiSearchParams.onlyTallClimbs,
+        onlyDrafts: uiSearchParams.onlyDrafts,
+        hideAttempted: uiSearchParams.hideAttempted,
+        hideCompleted: uiSearchParams.hideCompleted,
+        showOnlyAttempted: uiSearchParams.showOnlyAttempted,
+        showOnlyCompleted: uiSearchParams.showOnlyCompleted,
+        holdsCount: Object.keys(uiSearchParams.holdsFilter || {}).length,
+        setterCount: uiSearchParams.settername.length,
       });
     }
 

--- a/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
+++ b/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
@@ -60,7 +60,7 @@ export const UISearchParamsProvider: React.FC<{ children: React.ReactNode }> = (
         gradeAccuracy: uiSearchParams.gradeAccuracy,
         onlyClassics: uiSearchParams.onlyClassics,
         projectsOnly: uiSearchParams.projectsOnly,
-        establishedOnly: uiSearchParams.minAscents >= 2,
+        establishedOnly: uiSearchParams.minAscents >= 2 && !uiSearchParams.projectsOnly,
         onlyTallClimbs: uiSearchParams.onlyTallClimbs,
         onlyDrafts: uiSearchParams.onlyDrafts,
         hideAttempted: uiSearchParams.hideAttempted,

--- a/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { hasActiveNonNameFilters, hasActiveFilters } from '../search-summary-utils';
+import {
+  hasActiveNonNameFilters,
+  hasActiveFilters,
+  getStatusPanelSummary,
+  getQualityPanelSummary,
+  getSearchPillSummary,
+} from '../search-summary-utils';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { SearchRequestPagination } from '@/app/lib/types';
 
@@ -76,5 +82,64 @@ describe('hasActiveFilters', () => {
 
   it('returns true when holdsFilter has entries', () => {
     expect(hasActiveFilters(makeParams({ holdsFilter: { 1: { state: 'HAND' as const, color: '#ff0000', displayColor: '#ff0000' } } }))).toBe(true);
+  });
+});
+
+describe('getStatusPanelSummary', () => {
+  it('returns empty for defaults', () => {
+    expect(getStatusPanelSummary(makeParams())).toEqual([]);
+  });
+
+  it('returns ["Drafts"] when onlyDrafts is true (takes precedence over minAscents)', () => {
+    expect(getStatusPanelSummary(makeParams({ onlyDrafts: true, minAscents: 5 }))).toEqual(['Drafts']);
+  });
+
+  it('returns ["Projects"] when projectsOnly is true', () => {
+    expect(getStatusPanelSummary(makeParams({ projectsOnly: true }))).toEqual(['Projects']);
+  });
+
+  it('returns ["Established"] when minAscents is exactly 2', () => {
+    expect(getStatusPanelSummary(makeParams({ minAscents: 2 }))).toEqual(['Established']);
+  });
+
+  it('returns ["Established"] when minAscents is >= 2 (e.g. 3, 10)', () => {
+    expect(getStatusPanelSummary(makeParams({ minAscents: 3 }))).toEqual(['Established']);
+    expect(getStatusPanelSummary(makeParams({ minAscents: 10 }))).toEqual(['Established']);
+  });
+
+  it('returns empty when minAscents is 1 (below the established threshold)', () => {
+    expect(getStatusPanelSummary(makeParams({ minAscents: 1 }))).toEqual([]);
+  });
+});
+
+describe('getQualityPanelSummary vs Status (no duplication)', () => {
+  it('includes "1+ ascents" when minAscents is 1 (below Established)', () => {
+    expect(getQualityPanelSummary(makeParams({ minAscents: 1 }))).toContain('1+ ascents');
+  });
+
+  it('does not include "N+ ascents" when minAscents is 2 (Established handles it)', () => {
+    const parts = getQualityPanelSummary(makeParams({ minAscents: 2 }));
+    expect(parts.find((p) => p.includes('ascents'))).toBeUndefined();
+  });
+
+  it('does not include "N+ ascents" when minAscents is 3 (Established handles it)', () => {
+    const parts = getQualityPanelSummary(makeParams({ minAscents: 3 }));
+    expect(parts.find((p) => p.includes('ascents'))).toBeUndefined();
+  });
+
+  it('pill summary for minAscents=3 shows "Established" only, no duplicate', () => {
+    const pill = getSearchPillSummary(makeParams({ minAscents: 3 }));
+    expect(pill).toContain('Established');
+    expect(pill).not.toContain('3+ ascents');
+  });
+
+  it('pill summary for projects shows "Projects"', () => {
+    const pill = getSearchPillSummary(makeParams({ projectsOnly: true }));
+    expect(pill).toContain('Projects');
+  });
+
+  it('pill summary for drafts shows "Drafts"', () => {
+    const pill = getSearchPillSummary(makeParams({ onlyDrafts: true }));
+    expect(pill).toContain('Drafts');
   });
 });

--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -135,6 +135,9 @@
   align-items: center;
   padding: 10px 16px;
   transition: background-color 150ms ease;
+  /* Reset MUI FormControlLabel's default margins and let the label fill the row. */
+  margin: 0;
+  width: 100%;
 }
 
 .switchRow:hover {
@@ -144,6 +147,48 @@
 /* Subtle divider between switch rows */
 .switchRow + .switchRow {
   border-top: 1px solid var(--neutral-200, #E5E7EB);
+}
+
+/* Let the label text expand to the full available width so the whole row is clickable. */
+.switchRow :global(.MuiFormControlLabel-label) {
+  flex: 1;
+}
+
+/* Radio group inside the Ascent Status panel */
+.radioGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background-color: var(--neutral-50, #F9FAFB);
+  border-radius: 12px;
+  padding: 4px 0;
+}
+
+.radioRow {
+  display: flex;
+  align-items: center;
+  padding: 6px 12px;
+  margin: 0;
+  transition: background-color 150ms ease;
+}
+
+.radioRow:hover {
+  background-color: var(--neutral-100, #F3F4F6);
+}
+
+.radioRow + .radioRow {
+  border-top: 1px solid var(--neutral-200, #E5E7EB);
+}
+
+.radioRow :global(.MuiFormControlLabel-label) {
+  flex: 1;
+  font-size: 14px;
+}
+
+.radioHint {
+  font-size: 12px;
+  color: var(--neutral-500, #6B7280);
+  padding: 8px 16px 4px;
 }
 
 /* Sort toggle */

--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -185,12 +185,6 @@
   font-size: 14px;
 }
 
-.radioHint {
-  font-size: 12px;
-  color: var(--neutral-500, #6B7280);
-  padding: 8px 16px 4px;
-}
-
 /* Sort toggle */
 .sortToggle {
   font-size: 13px;

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -9,6 +9,9 @@ import MuiSelect, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import MuiSwitch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import ArrowUpwardOutlined from '@mui/icons-material/ArrowUpwardOutlined';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
@@ -22,6 +25,7 @@ import { buildGradeRangeUpdate } from './grade-range-utils';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import {
   getQualityPanelSummary,
+  getStatusPanelSummary,
   getUserPanelSummary,
   getHoldsPanelSummary,
 } from './search-summary-utils';
@@ -50,6 +54,12 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
   const isKilterHomewall = boardDetails.board_name === 'kilter' && boardDetails.layout_id === KILTER_HOMEWALL_LAYOUT_ID;
   const isLargestSize = boardDetails.size_name?.toLowerCase().includes('12');
   const showTallClimbsFilter = isKilterHomewall && isLargestSize;
+
+  const statusValue: 'any' | 'drafts' | 'established' | 'projects' =
+    uiSearchParams.onlyDrafts ? 'drafts'
+    : uiSearchParams.projectsOnly ? 'projects'
+    : uiSearchParams.minAscents >= 2 ? 'established'
+    : 'any';
 
   const handleGradeChange = (type: 'min' | 'max', value: number | undefined) => {
     updateFilters(buildGradeRangeUpdate(type, value, uiSearchParams.minGrade, uiSearchParams.maxGrade));
@@ -100,17 +110,23 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
 
       {showTallClimbsFilter && (
         <div className={styles.switchGroup}>
-          <div className={styles.switchRow}>
-            <MuiTooltip title="Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)">
-              <MuiTypography variant="body2" component="span">Tall Climbs Only</MuiTypography>
-            </MuiTooltip>
-            <MuiSwitch
-              size="small"
-              color="primary"
-              checked={uiSearchParams.onlyTallClimbs}
-              onChange={(_, checked) => updateFilters({ onlyTallClimbs: checked })}
-            />
-          </div>
+          <FormControlLabel
+            className={styles.switchRow}
+            labelPlacement="start"
+            control={
+              <MuiSwitch
+                size="small"
+                color="primary"
+                checked={uiSearchParams.onlyTallClimbs}
+                onChange={(_, checked) => updateFilters({ onlyTallClimbs: checked })}
+              />
+            }
+            label={
+              <MuiTooltip title="Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)">
+                <MuiTypography variant="body2" component="span">Tall Climbs Only</MuiTypography>
+              </MuiTooltip>
+            }
+          />
         </div>
       )}
 
@@ -215,16 +231,130 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
           </div>
 
           <div className={styles.switchGroup}>
-            <div className={styles.switchRow}>
-              <MuiTypography variant="body2" component="span">Classics Only</MuiTypography>
-              <MuiSwitch
-                size="small"
-                color="primary"
-                checked={uiSearchParams.onlyClassics}
-                onChange={(_, checked) => updateFilters({ onlyClassics: checked })}
-              />
-            </div>
+            <FormControlLabel
+              className={styles.switchRow}
+              labelPlacement="start"
+              control={
+                <MuiSwitch
+                  size="small"
+                  color="primary"
+                  checked={uiSearchParams.onlyClassics}
+                  onChange={(_, checked) => updateFilters({ onlyClassics: checked })}
+                />
+              }
+              label={<MuiTypography variant="body2" component="span">Classics Only</MuiTypography>}
+            />
           </div>
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'Ascent Status',
+      title: 'Ascent Status',
+      defaultSummary: 'Any',
+      getSummary: () => getStatusPanelSummary(uiSearchParams),
+      content: (
+        <div className={styles.panelContent}>
+          <RadioGroup
+            className={styles.radioGroup}
+            value={statusValue}
+            onChange={(e) => {
+              const value = e.target.value as 'any' | 'drafts' | 'established' | 'projects';
+              if (value === 'drafts' && !isAuthenticated) {
+                openAuthModal({
+                  title: 'Sign in to Boardsesh',
+                  description: 'Sign in to browse your draft climbs.',
+                });
+                return;
+              }
+              if (value === 'drafts') {
+                updateFilters({
+                  onlyDrafts: true,
+                  projectsOnly: false,
+                  minAscents: 0,
+                  sortBy: 'creation',
+                  sortOrder: 'desc',
+                });
+              } else if (value === 'established') {
+                updateFilters({
+                  onlyDrafts: false,
+                  projectsOnly: false,
+                  minAscents: 2,
+                });
+              } else if (value === 'projects') {
+                updateFilters({
+                  onlyDrafts: false,
+                  projectsOnly: true,
+                  minAscents: 0,
+                });
+              } else {
+                updateFilters({
+                  onlyDrafts: false,
+                  projectsOnly: false,
+                });
+              }
+            }}
+          >
+            <FormControlLabel
+              className={styles.radioRow}
+              value="any"
+              control={<Radio size="small" color="primary" />}
+              label={<MuiTypography variant="body2" component="span">Any</MuiTypography>}
+            />
+            <FormControlLabel
+              className={styles.radioRow}
+              value="established"
+              control={<Radio size="small" color="primary" />}
+              label={
+                <MuiTooltip title="Climbs with 2 or more ascents">
+                  <MuiTypography variant="body2" component="span">Established</MuiTypography>
+                </MuiTooltip>
+              }
+            />
+            <FormControlLabel
+              className={styles.radioRow}
+              value="projects"
+              control={<Radio size="small" color="primary" />}
+              label={
+                <MuiTooltip title="Unclimbed — zero recorded ascents">
+                  <MuiTypography variant="body2" component="span">Projects</MuiTypography>
+                </MuiTooltip>
+              }
+            />
+            <FormControlLabel
+              className={styles.radioRow}
+              value="drafts"
+              disabled={!isAuthenticated}
+              control={<Radio size="small" color="primary" />}
+              label={
+                <MuiTypography variant="body2" component="span">
+                  My Drafts{!isAuthenticated ? ' (sign in)' : ''}
+                </MuiTypography>
+              }
+            />
+          </RadioGroup>
+          {!isAuthenticated && (
+            <MuiAlert
+              severity="info"
+              className={styles.progressAlert}
+              action={
+                <MuiButton
+                  size="small"
+                  variant="contained"
+                  startIcon={<LoginOutlined />}
+                  onClick={() => openAuthModal({
+                    title: 'Sign in to Boardsesh',
+                    description: 'Sign in to browse your draft climbs.',
+                  })}
+                >
+                  Sign In
+                </MuiButton>
+              }
+            >
+              Sign in to filter by your drafts.
+            </MuiAlert>
+          )}
         </div>
       ),
     },
@@ -257,54 +387,58 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
             </MuiAlert>
           ) : (
             <div className={styles.switchGroup}>
-              <div className={styles.switchRow}>
-                <MuiTypography variant="body2" component="span">My Drafts</MuiTypography>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.onlyDrafts}
-                  onChange={(_, checked) => updateFilters({
-                    onlyDrafts: checked,
-                    ...(checked ? { sortBy: 'creation', sortOrder: 'desc' } : {}),
-                  })}
-                />
-              </div>
-              <div className={styles.switchRow}>
-                <MuiTypography variant="body2" component="span">Hide Attempted</MuiTypography>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.hideAttempted}
-                  onChange={(_, checked) => updateFilters({ hideAttempted: checked })}
-                />
-              </div>
-              <div className={styles.switchRow}>
-                <MuiTypography variant="body2" component="span">Hide Completed</MuiTypography>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.hideCompleted}
-                  onChange={(_, checked) => updateFilters({ hideCompleted: checked })}
-                />
-              </div>
-              <div className={styles.switchRow}>
-                <MuiTypography variant="body2" component="span">Only Attempted</MuiTypography>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.showOnlyAttempted}
-                  onChange={(_, checked) => updateFilters({ showOnlyAttempted: checked })}
-                />
-              </div>
-              <div className={styles.switchRow}>
-                <MuiTypography variant="body2" component="span">Only Completed</MuiTypography>
-                <MuiSwitch
-                  size="small"
-                  color="primary"
-                  checked={uiSearchParams.showOnlyCompleted}
-                  onChange={(_, checked) => updateFilters({ showOnlyCompleted: checked })}
-                />
-              </div>
+              <FormControlLabel
+                className={styles.switchRow}
+                labelPlacement="start"
+                control={
+                  <MuiSwitch
+                    size="small"
+                    color="primary"
+                    checked={uiSearchParams.hideAttempted}
+                    onChange={(_, checked) => updateFilters({ hideAttempted: checked })}
+                  />
+                }
+                label={<MuiTypography variant="body2" component="span">Hide Attempted</MuiTypography>}
+              />
+              <FormControlLabel
+                className={styles.switchRow}
+                labelPlacement="start"
+                control={
+                  <MuiSwitch
+                    size="small"
+                    color="primary"
+                    checked={uiSearchParams.hideCompleted}
+                    onChange={(_, checked) => updateFilters({ hideCompleted: checked })}
+                  />
+                }
+                label={<MuiTypography variant="body2" component="span">Hide Completed</MuiTypography>}
+              />
+              <FormControlLabel
+                className={styles.switchRow}
+                labelPlacement="start"
+                control={
+                  <MuiSwitch
+                    size="small"
+                    color="primary"
+                    checked={uiSearchParams.showOnlyAttempted}
+                    onChange={(_, checked) => updateFilters({ showOnlyAttempted: checked })}
+                  />
+                }
+                label={<MuiTypography variant="body2" component="span">Only Attempted</MuiTypography>}
+              />
+              <FormControlLabel
+                className={styles.switchRow}
+                labelPlacement="start"
+                control={
+                  <MuiSwitch
+                    size="small"
+                    color="primary"
+                    checked={uiSearchParams.showOnlyCompleted}
+                    onChange={(_, checked) => updateFilters({ showOnlyCompleted: checked })}
+                  />
+                }
+                label={<MuiTypography variant="body2" component="span">Only Completed</MuiTypography>}
+              />
             </div>
           )}
         </div>

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -261,13 +261,6 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
             value={statusValue}
             onChange={(e) => {
               const value = e.target.value as 'any' | 'drafts' | 'established' | 'projects';
-              if (value === 'drafts' && !isAuthenticated) {
-                openAuthModal({
-                  title: 'Sign in to Boardsesh',
-                  description: 'Sign in to browse your draft climbs.',
-                });
-                return;
-              }
               if (value === 'drafts') {
                 updateFilters({
                   onlyDrafts: true,
@@ -318,7 +311,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
               value="projects"
               control={<Radio size="small" color="primary" />}
               label={
-                <MuiTooltip title="Unclimbed — zero recorded ascents">
+                <MuiTooltip title="Climbs with zero recorded ascents">
                   <MuiTypography variant="body2" component="span">Projects</MuiTypography>
                 </MuiTooltip>
               }

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -292,6 +292,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({
                 updateFilters({
                   onlyDrafts: false,
                   projectsOnly: false,
+                  minAscents: 0,
                 });
               }
             }}

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -57,8 +57,8 @@ export function getClimbPanelSummary(params: SearchRequestPagination): string[] 
 export function getQualityPanelSummary(params: SearchRequestPagination): string[] {
   const parts: string[] = [];
 
-  // minAscents === 2 is reflected by the Ascent Status "Established" chip; avoid dup.
-  if (params.minAscents && params.minAscents !== 2) {
+  // minAscents >= 2 is reflected by the Ascent Status "Established" chip; avoid dup.
+  if (params.minAscents && params.minAscents < 2) {
     parts.push(`${params.minAscents}+ ascents`);
   }
   if (params.minRating) {

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -57,7 +57,8 @@ export function getClimbPanelSummary(params: SearchRequestPagination): string[] 
 export function getQualityPanelSummary(params: SearchRequestPagination): string[] {
   const parts: string[] = [];
 
-  if (params.minAscents) {
+  // minAscents === 2 is reflected by the Ascent Status "Established" chip; avoid dup.
+  if (params.minAscents && params.minAscents !== 2) {
     parts.push(`${params.minAscents}+ ascents`);
   }
   if (params.minRating) {
@@ -77,6 +78,13 @@ export function getQualityPanelSummary(params: SearchRequestPagination): string[
   return parts;
 }
 
+export function getStatusPanelSummary(params: SearchRequestPagination): string[] {
+  if (params.onlyDrafts) return ['Drafts'];
+  if (params.projectsOnly) return ['Projects'];
+  if (params.minAscents >= 2) return ['Established'];
+  return [];
+}
+
 export function getUserPanelSummary(params: SearchRequestPagination): string[] {
   // Merge "Hide" filters into single entry
   const hideFilters: string[] = [];
@@ -89,9 +97,6 @@ export function getUserPanelSummary(params: SearchRequestPagination): string[] {
   if (params.showOnlyCompleted) onlyFilters.push('completed');
 
   const parts: string[] = [];
-  if (params.onlyDrafts) {
-    parts.push('Drafts');
-  }
   if (hideFilters.length > 0) {
     parts.push(`Hide ${hideFilters.join(', ')}`);
   }
@@ -115,6 +120,7 @@ export function getSearchPillSummary(params: SearchRequestPagination): string {
   const allParts = [
     ...getClimbPanelSummary(params),
     ...getQualityPanelSummary(params),
+    ...getStatusPanelSummary(params),
     ...getUserPanelSummary(params),
     ...getHoldsPanelSummary(params),
   ];
@@ -137,6 +143,7 @@ export function getSearchPillFullSummary(params: SearchRequestPagination): strin
   const allParts = [
     ...getClimbPanelSummary(params),
     ...getQualityPanelSummary(params),
+    ...getStatusPanelSummary(params),
     ...getUserPanelSummary(params),
     ...getHoldsPanelSummary(params),
   ];

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -64,6 +64,7 @@ async function _executeClimbSearch(
     showOnlyAttempted: searchParams.showOnlyAttempted || undefined,
     showOnlyCompleted: searchParams.showOnlyCompleted || undefined,
     onlyDrafts: searchParams.onlyDrafts || undefined,
+    projectsOnly: searchParams.projectsOnly || undefined,
   }, userId);
 
   const climbs: Climb[] = result.climbs.map((row) => ({
@@ -153,6 +154,7 @@ export async function cachedSearchClimbs(
     showOnlyAttempted: searchParams.showOnlyAttempted,
     showOnlyCompleted: searchParams.showOnlyCompleted,
     onlyDrafts: searchParams.onlyDrafts,
+    projectsOnly: searchParams.projectsOnly,
   }));
 
   if (!cacheable) {

--- a/packages/web/app/lib/graphql/operations/climb-search.ts
+++ b/packages/web/app/lib/graphql/operations/climb-search.ts
@@ -135,6 +135,7 @@ export interface ClimbSearchInputVariables {
     showOnlyAttempted?: boolean;
     showOnlyCompleted?: boolean;
     onlyDrafts?: boolean;
+    projectsOnly?: boolean;
   };
 }
 

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -107,6 +107,7 @@ export type SearchRequest = {
   showOnlyAttempted: boolean;
   showOnlyCompleted: boolean;
   onlyDrafts: boolean;
+  projectsOnly: boolean;
   [key: `hold_${number}`]: HoldFilterValue; // Allow dynamic hold keys directly in the search params
 };
 

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -85,6 +85,7 @@ export const searchParamsToUrlParams = ({
   showOnlyAttempted,
   showOnlyCompleted,
   onlyDrafts,
+  projectsOnly,
   page,
   pageSize,
 }: SearchRequestPagination): URLSearchParams => {
@@ -148,6 +149,9 @@ export const searchParamsToUrlParams = ({
   if (onlyDrafts !== DEFAULT_SEARCH_PARAMS.onlyDrafts) {
     params.onlyDrafts = onlyDrafts.toString();
   }
+  if (projectsOnly !== DEFAULT_SEARCH_PARAMS.projectsOnly) {
+    params.projectsOnly = projectsOnly.toString();
+  }
 
   // Add holds filter entries only if they exist
   if (holdsFilter && Object.keys(holdsFilter).length > 0) {
@@ -177,6 +181,7 @@ export const DEFAULT_SEARCH_PARAMS: SearchRequestPagination = {
   showOnlyAttempted: false,
   showOnlyCompleted: false,
   onlyDrafts: false,
+  projectsOnly: false,
   page: 0,
   pageSize: PAGE_LIMIT,
 };
@@ -209,6 +214,7 @@ export const urlParamsToSearchParams = (urlParams: URLSearchParams): SearchReque
     showOnlyAttempted: urlParams.get('showOnlyAttempted') === 'true',
     showOnlyCompleted: urlParams.get('showOnlyCompleted') === 'true',
     onlyDrafts: urlParams.get('onlyDrafts') === 'true',
+    projectsOnly: urlParams.get('projectsOnly') === 'true',
     page: Number(urlParams.get('page') ?? DEFAULT_SEARCH_PARAMS.page),
     pageSize: Number(urlParams.get('pageSize') ?? DEFAULT_SEARCH_PARAMS.pageSize),
   };


### PR DESCRIPTION
- New "Ascent Status" collapsible in the search drawer with a mutually
  exclusive radio group (Any / Established / Projects / My Drafts).
  "Established" maps to minAscents=2; "Projects" is a new filter that
  matches climbs with zero or NULL ascensionist_count. Moves "My Drafts"
  out of the Progress panel into this group so all three are one choice.
- Add projectsOnly across SearchRequest, DEFAULT_SEARCH_PARAMS, URL
  serde, ClimbSearchParams, and the SQL filter. Goes into climb where
  conditions (not stats conditions) and forces the LEFT-JOIN path so
  climbs without stats rows are included.
- Switch labels are now clickable: refactor the switchRow pattern to
  FormControlLabel with labelPlacement="start" across all drawer
  switches, plus CSS tweaks so the label fills the row.
- Climb Search Performed analytics event now includes every filter
  value (sortBy, grades, flags, counts) instead of just a total count.