### PR TITLE
Add error handling for climb loading failures in logbook

### DIFF
--- a/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
+++ b/packages/web/app/components/library/__tests__/ascent-to-climb.test.ts
@@ -82,6 +82,13 @@ describe('ascentFeedItemToClimb', () => {
     expect(result.benchmark_difficulty).toBeNull();
   });
 
+  it('sets benchmark_difficulty to null when isBenchmark is true but consensusDifficultyName is undefined', () => {
+    const result = ascentFeedItemToClimb(
+      makeItem({ isBenchmark: true, consensusDifficultyName: undefined as unknown as null }),
+    );
+    expect(result.benchmark_difficulty).toBeNull();
+  });
+
   it('defaults setter_username to empty string when null', () => {
     const result = ascentFeedItemToClimb(makeItem({ setterUsername: null }));
     expect(result.setter_username).toBe('');

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -27,6 +27,7 @@ let capturedSwipeOptions: SwipeOptions | null = null;
 const updateTickAsyncMock = vi.fn();
 const setCurrentClimbMock = vi.fn();
 const dispatchOpenPlayDrawerMock = vi.fn();
+const showMessageMock = vi.fn();
 const boardDataMocks = vi.hoisted(() => ({
   getGradesForBoard: vi.fn((boardName: string) =>
     boardName === 'moonboard'
@@ -136,6 +137,10 @@ vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: showMessageMock }),
+}));
+
 vi.mock('@/app/components/ascent-status/ascent-status-icon', () => ({
   AscentStatusIcon: () => <span data-testid="status-icon" />,
 }));
@@ -212,6 +217,7 @@ beforeEach(() => {
   setCurrentClimbMock.mockReset();
   dispatchOpenPlayDrawerMock.mockReset();
   boardDataMocks.getGradesForBoard.mockClear();
+  showMessageMock.mockReset();
   queueActionsState.value = { setCurrentClimb: setCurrentClimbMock };
   updateTickState.isPending = false;
 });
@@ -465,6 +471,26 @@ describe('LogbookFeedItem', () => {
     render(<LogbookFeedItem item={makeItem()} />);
     fireEvent.click(screen.getByLabelText('More actions'));
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
+  });
+
+  it('shows error snackbar when row click setCurrentClimb rejects', async () => {
+    setCurrentClimbMock.mockRejectedValue(new Error('network'));
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    await act(async () => {
+      fireEvent.click(row);
+    });
+    expect(showMessageMock).toHaveBeenCalledWith("Couldn't load that climb. Try again.", 'error');
+  });
+
+  it('shows error snackbar when thumbnail click setCurrentClimb rejects', async () => {
+    setCurrentClimbMock.mockRejectedValue(new Error('network'));
+    render(<LogbookFeedItem item={makeItem()} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ascent-thumbnail'));
+    });
+    expect(showMessageMock).toHaveBeenCalledWith("Couldn't load that climb. Try again.", 'error');
+    expect(dispatchOpenPlayDrawerMock).not.toHaveBeenCalled();
   });
 
   it('keeps the comment row container mounted in both modes (U8)', () => {

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -41,6 +41,7 @@ import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { useUpdateTick } from '@/app/hooks/use-update-tick';
 import { themeTokens } from '@/app/theme/theme-config';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
@@ -320,6 +321,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
     const queueActions = useOptionalQueueActions();
+    const { showMessage } = useSnackbar();
 
     // --- Edit state ---
     const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -449,8 +451,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
         track('Logbook Row Clicked', { climbUuid: climb.uuid });
       } catch (err) {
         console.error('Failed to set active climb from logbook row', err);
+        showMessage("Couldn't load that climb. Try again.", 'error');
       }
-    }, [isEditing, queueActions, climb]);
+    }, [isEditing, queueActions, climb, showMessage]);
 
     const handleRowKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
@@ -473,9 +476,10 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
           track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
         } catch (err) {
           console.error('Failed to set active climb from logbook thumbnail', err);
+          showMessage("Couldn't load that climb. Try again.", 'error');
         }
       },
-      [isEditing, queueActions, climb],
+      [isEditing, queueActions, climb, showMessage],
     );
 
     // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)


### PR DESCRIPTION
## Summary
This PR adds error handling and user feedback when loading a climb fails in the logbook feed. When users click on a logbook row or thumbnail and the climb fails to load, they now see a snackbar error message instead of a silent failure.

## Key Changes
- **Error messaging**: Integrated `useSnackbar` hook into `LogbookFeedItem` to display user-friendly error messages when `setCurrentClimb` fails
- **Row click handling**: Added error handling to `handleRowClick` callback to show error message and log failures
- **Thumbnail click handling**: Added error handling to `handleThumbnailClick` callback with the same error messaging
- **Test coverage**: Added two new test cases to verify error snackbar is displayed for both row and thumbnail click scenarios
- **Test infrastructure**: Mocked the `snackbar-provider` in tests and added `showMessageMock` reset in `beforeEach`
- **Edge case test**: Added test case for `ascentFeedItemToClimb` to handle undefined `consensusDifficultyName` when `isBenchmark` is true

## Implementation Details
- Error message: "Couldn't load that climb. Try again." with 'error' severity level
- Both click handlers now properly catch errors and provide feedback to users
- Updated dependency arrays in both callbacks to include `showMessage` function
- Maintains existing behavior for successful climb loads and edit mode

https://claude.ai/code/session_016HucHEjkPhtshNh8XF6gz2