### PR TITLE
fix(ui): replace attempt cross icon with person-falling icon

### DIFF
--- a/LEGAL.md
+++ b/LEGAL.md
@@ -80,7 +80,7 @@ We take intellectual property concerns seriously. If you believe any material in
 
 We will review all valid requests promptly and in good faith. We may also file a counter-notice where we believe a takedown request is based on a misidentification of the material or a misunderstanding of the law.
 
-**Contact:** legal@mdj.ac
+**Contact:** legal@boardsesh.com
 
 ---
 

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -62,6 +62,12 @@ We use board and product names (e.g. "Kilter Board", "MoonBoard", "Tension Board
 
 ---
 
+## Third-Party Notices
+
+- **Person Falling icon** from [Font Awesome Free 6.7.2](https://fontawesome.com) by @fontawesome. License: [CC BY 4.0](https://fontawesome.com/license/free). Copyright 2024 Fonticons, Inc.
+
+---
+
 ## DMCA & Takedown Requests
 
 We take intellectual property concerns seriously. If you believe any material in this project infringes your copyright, please contact us with the following information:

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -41,12 +41,6 @@ export const SaveTickInputSchema = z.object({
     return true;
   },
   { message: 'Flash requires attemptCount of 1', path: ['attemptCount'] }
-).refine(
-  (data) => {
-    if (data.status === 'attempt' && data.quality !== undefined && data.quality !== null) return false;
-    return true;
-  },
-  { message: 'Attempts cannot have quality ratings', path: ['quality'] }
 );
 
 /**

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -12,7 +12,7 @@ import IconButton from '@mui/material/IconButton';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
-import CancelOutlined from '@mui/icons-material/CancelOutlined';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import dayjs from 'dayjs';
@@ -88,7 +88,7 @@ const getGroupStatusSummary = (group: GroupedAscentFeedItem): { text: string; ic
     icon = <CheckCircleOutlined />;
     color = 'green';
   } else {
-    icon = <CancelOutlined />;
+    icon = <PersonFallingIcon />;
     color = 'default';
   }
 

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -12,7 +12,7 @@ import IconButton from '@mui/material/IconButton';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
-import CancelOutlined from '@mui/icons-material/CancelOutlined';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import Link from 'next/link';
@@ -54,7 +54,7 @@ const getStatusDisplay = (status: string) => {
     case 'send':
       return { label: 'Send', icon: <CheckCircleOutlined />, chipColor: 'success' as const };
     case 'attempt':
-      return { label: 'Attempt', icon: <CancelOutlined />, chipColor: undefined };
+      return { label: 'Attempt', icon: <PersonFallingIcon />, chipColor: undefined };
     default:
       return { label: status, icon: null, chipColor: undefined };
   }

--- a/packages/web/app/components/ascent-status/ascent-status-icon.tsx
+++ b/packages/web/app/components/ascent-status/ascent-status-icon.tsx
@@ -2,9 +2,9 @@
 
 import React from 'react';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
-import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { normalizeAscentStatus, type AscentStatusValue, type NormalizeAscentStatusInput } from './ascent-status-utils';
 
 interface AscentStatusIconProps extends NormalizeAscentStatusInput {
@@ -35,7 +35,7 @@ const STATUS_CONFIG: Record<AscentStatusValue, {
     badgeIconColor: 'white',
   },
   attempt: {
-    Icon: CloseOutlined,
+    Icon: PersonFallingIcon,
     iconColor: themeTokens.colors.error,
     badgeBackgroundColor: themeTokens.colors.error,
     badgeIconColor: 'white',

--- a/packages/web/app/components/icons/person-falling-icon.tsx
+++ b/packages/web/app/components/icons/person-falling-icon.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { createSvgIcon } from '@mui/material/utils';
+
+/**
+ * Person-falling icon from Font Awesome Free 6.7.2 (fa-person-falling, solid).
+ * License: CC BY 4.0 (https://fontawesome.com/license/free)
+ * Used to represent climb attempts (failed ascents).
+ *
+ * The original FA path uses a 512x512 viewBox; the <g transform> scales it
+ * to fit MUI's default 24x24 viewBox (24/512 ≈ 0.046875).
+ */
+export const PersonFallingIcon = createSvgIcon(
+  <g transform="scale(0.046875) rotate(-30 256 256)">
+    <path d="M288 0c17.7 0 32 14.3 32 32l0 9.8c0 54.6-27.9 104.6-72.5 133.6l.2 .3L304.5 256l87.5 0c15.1 0 29.3 7.1 38.4 19.2l43.2 57.6c10.6 14.1 7.7 34.2-6.4 44.8s-34.2 7.7-44.8-6.4L384 320l-96 0-1.4 0 92.3 142.6c9.6 14.8 5.4 34.6-9.5 44.3s-34.6 5.4-44.3-9.5L164.5 249.2c-2.9 9.2-4.5 19-4.5 29l0 73.8c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-73.8c0-65.1 39.6-123.7 100.1-147.9C232.3 115.8 256 80.8 256 41.8l0-9.8c0-17.7 14.3-32 32-32zM112 32a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
+  </g>,
+  'PersonFalling',
+);

--- a/packages/web/app/components/icons/person-falling-icon.tsx
+++ b/packages/web/app/components/icons/person-falling-icon.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { createSvgIcon } from '@mui/material/utils';
 
 /**

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -19,6 +19,7 @@ import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutl
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import SaveOutlined from '@mui/icons-material/SaveOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import CircularProgress from '@mui/material/CircularProgress';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
@@ -805,7 +806,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
           <ListItemText>Send</ListItemText>
         </MenuItem>
         <MenuItem onClick={() => handleStatusSelect('attempt')}>
-          <ListItemIcon><CloseOutlined sx={{ color: themeTokens.colors.error }} /></ListItemIcon>
+          <ListItemIcon><PersonFallingIcon sx={{ color: themeTokens.colors.error }} /></ListItemIcon>
           <ListItemText>Attempt</ListItemText>
         </MenuItem>
       </Popover>

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -376,7 +376,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(({
         input: {
           status: editStatus,
           attemptCount: editAttemptCount,
-          quality: editStatus === 'attempt' ? null : (editQuality ?? null),
+          quality: editQuality ?? null,
           difficulty: editDifficulty ?? null,
           comment: editComment,
         },

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -200,6 +200,7 @@ describe('QuickTickBar', () => {
 
   describe('save behaviour — history-aware default', () => {
     it('saves as flash with attemptCount 1 when the logbook is empty', async () => {
+      vi.useFakeTimers();
       mockLogbookRef.current = [];
       const ref = React.createRef<QuickTickBarHandle>();
       render(<QuickTickBar ref={ref} {...defaultProps} />);
@@ -213,6 +214,8 @@ describe('QuickTickBar', () => {
       expect(call.status).toBe('flash');
       expect(call.attemptCount).toBe(1);
       expect(call.climbUuid).toBe('climb-1');
+      // Flash saves have a 300ms delay before calling onSave (for button pulse animation).
+      await act(async () => { vi.advanceTimersByTime(300); });
       expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -504,7 +504,7 @@ describe('QuickTickBar', () => {
   });
 
   describe('grade picker selection', () => {
-    it('marks the matched grade as selected when the picker opens', async () => {
+    it('shows consensus grade as focused but not selected when the picker opens', async () => {
       const climb = makeClimb({ difficulty: '6c/V5' });
       render(<QuickTickBar {...defaultProps} currentClimb={climb} />);
 
@@ -515,9 +515,14 @@ describe('QuickTickBar', () => {
 
       await waitFor(() => {
         const items = screen.getAllByRole('option');
+        // Only the "—" (clear) option is selected since no grade is chosen by default
         const selectedItems = items.filter((el) => el.getAttribute('aria-selected') === 'true');
         expect(selectedItems).toHaveLength(1);
-        expect(selectedItems[0].textContent).toBe('V5');
+        expect(selectedItems[0].textContent).toBe('—');
+        // The consensus grade should be labeled as such but not selected
+        const consensusItem = items.find((el) => el.getAttribute('aria-label') === 'V5 (consensus)');
+        expect(consensusItem).toBeTruthy();
+        expect(consensusItem?.getAttribute('aria-selected')).toBe('false');
       });
     });
 
@@ -853,6 +858,68 @@ describe('QuickTickBar', () => {
       mockLogbookRef.current = [];
       // Should not throw
       expect(() => render(<QuickTickBar {...defaultProps} />)).not.toThrow();
+    });
+  });
+
+  describe('onAscentTypeChange callback', () => {
+    it('calls onAscentTypeChange when ascent type changes', async () => {
+      mockLogbookRef.current = [];
+      const onAscentTypeChange = vi.fn();
+      render(<QuickTickBar {...defaultProps} onAscentTypeChange={onAscentTypeChange} />);
+
+      // On mount with no prior history and 1 try, inferred type is flash.
+      expect(onAscentTypeChange).toHaveBeenCalledWith('flash');
+
+      // Open tries picker and select 2 — should change ascent type to send.
+      await act(async () => {
+        screen.getByTestId('quick-tick-attempt').click();
+      });
+      await act(async () => {
+        screen.getByRole('option', { name: '2 tries' }).click();
+      });
+
+      expect(onAscentTypeChange).toHaveBeenCalledWith('send');
+    });
+  });
+
+  describe('expanded mode', () => {
+    it('disables flash option when user has prior history', () => {
+      mockLogbookRef.current = [];
+      const climbWithHistory = makeClimb({ userAscents: 2, userAttempts: 0 });
+      const onExpandedChange = vi.fn();
+      render(
+        <QuickTickBar
+          {...defaultProps}
+          currentClimb={climbWithHistory}
+          expanded={true}
+          onExpandedChange={onExpandedChange}
+        />,
+      );
+
+      // The ascent type picker should be visible in expanded mode.
+      const ascentTypeListbox = screen.getByRole('listbox', { name: 'Ascent type' });
+      expect(ascentTypeListbox).toBeTruthy();
+
+      // The Flash option should be disabled because the climb has prior history.
+      const flashOption = screen.getByRole('option', { name: 'Flash' });
+      expect(flashOption.getAttribute('aria-disabled')).toBe('true');
+      expect(flashOption.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('does not render save button in expanded mode', () => {
+      const onExpandedChange = vi.fn();
+      render(
+        <QuickTickBar
+          {...defaultProps}
+          expanded={true}
+          onExpandedChange={onExpandedChange}
+        />,
+      );
+
+      // There should be no "Save tick" button in expanded mode.
+      expect(screen.queryByRole('button', { name: /save tick/i })).toBeNull();
+      // Also verify by text content.
+      expect(screen.queryByText(/save tick/i)).toBeNull();
     });
   });
 

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -111,23 +111,23 @@ describe('TickButton', () => {
   });
 
   describe('icon rendering', () => {
-    it('renders CheckOutlined when isFlash is false and tickBarActive', () => {
+    it('renders SaveOutlined when tickBarActive', () => {
       const { container } = render(
         <TickButton {...defaultProps} tickBarActive={true} isFlash={false} />,
       );
       const svg = container.querySelector('#button-tick svg');
-      expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
+      expect(svg?.getAttribute('data-testid')).toBe('SaveOutlinedIcon');
     });
 
-    it('renders ElectricBoltOutlined when isFlash is true and tickBarActive', () => {
+    it('renders SaveOutlined when tickBarActive regardless of isFlash', () => {
       const { container } = render(
         <TickButton {...defaultProps} tickBarActive={true} isFlash={true} />,
       );
       const svg = container.querySelector('#button-tick svg');
-      expect(svg?.getAttribute('data-testid')).toBe('ElectricBoltOutlinedIcon');
+      expect(svg?.getAttribute('data-testid')).toBe('SaveOutlinedIcon');
     });
 
-    it('renders CheckOutlined when isFlash is true but tickBarActive is false', () => {
+    it('renders CheckOutlined when tickBarActive is false', () => {
       const { container } = render(
         <TickButton {...defaultProps} tickBarActive={false} isFlash={true} />,
       );
@@ -135,9 +135,9 @@ describe('TickButton', () => {
       expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
     });
 
-    it('renders CheckOutlined when isFlash is undefined', () => {
+    it('renders CheckOutlined when isFlash is undefined and not active', () => {
       const { container } = render(
-        <TickButton {...defaultProps} tickBarActive={true} isFlash={undefined} />,
+        <TickButton {...defaultProps} tickBarActive={false} isFlash={undefined} />,
       );
       const svg = container.querySelector('#button-tick svg');
       expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
@@ -145,34 +145,33 @@ describe('TickButton', () => {
   });
 
   describe('label rendering', () => {
-    it('shows "tick" label when tickBarActive and not flash', () => {
+    it('shows "save" label when tickBarActive', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={false} />);
-      expect(screen.getByText('tick')).toBeTruthy();
+      expect(screen.getByText('save')).toBeTruthy();
     });
 
-    it('shows "flash" label when tickBarActive and isFlash', () => {
+    it('shows "save" label when tickBarActive regardless of isFlash', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={true} />);
-      expect(screen.getByText('flash')).toBeTruthy();
+      expect(screen.getByText('save')).toBeTruthy();
     });
 
     it('does not show a label when tickBarActive is false', () => {
       render(<TickButton {...defaultProps} tickBarActive={false} isFlash={false} />);
-      expect(screen.queryByText('tick')).toBeNull();
-      expect(screen.queryByText('flash')).toBeNull();
+      expect(screen.queryByText('save')).toBeNull();
     });
   });
 
   describe('accessibility', () => {
-    it('has aria-label "Log flash" when tickBarActive and isFlash', () => {
+    it('has aria-label "Save tick" when tickBarActive', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={true} />);
       const button = document.getElementById('button-tick');
-      expect(button?.getAttribute('aria-label')).toBe('Log flash');
+      expect(button?.getAttribute('aria-label')).toBe('Save tick');
     });
 
-    it('has aria-label "Log ascent" when tickBarActive and not isFlash', () => {
+    it('has aria-label "Save tick" when tickBarActive and not isFlash', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={false} />);
       const button = document.getElementById('button-tick');
-      expect(button?.getAttribute('aria-label')).toBe('Log ascent');
+      expect(button?.getAttribute('aria-label')).toBe('Save tick');
     });
 
     it('has aria-label "Log ascent" when tickBarActive is false', () => {

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -111,20 +111,20 @@ describe('TickButton', () => {
   });
 
   describe('icon rendering', () => {
-    it('renders SaveOutlined when tickBarActive', () => {
+    it('renders CheckOutlined when tickBarActive and isFlash is false', () => {
       const { container } = render(
         <TickButton {...defaultProps} tickBarActive={true} isFlash={false} />,
       );
       const svg = container.querySelector('#button-tick svg');
-      expect(svg?.getAttribute('data-testid')).toBe('SaveOutlinedIcon');
+      expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
     });
 
-    it('renders SaveOutlined when tickBarActive regardless of isFlash', () => {
+    it('renders ElectricBoltOutlined when tickBarActive and isFlash is true', () => {
       const { container } = render(
         <TickButton {...defaultProps} tickBarActive={true} isFlash={true} />,
       );
       const svg = container.querySelector('#button-tick svg');
-      expect(svg?.getAttribute('data-testid')).toBe('SaveOutlinedIcon');
+      expect(svg?.getAttribute('data-testid')).toBe('ElectricBoltOutlinedIcon');
     });
 
     it('renders CheckOutlined when tickBarActive is false', () => {
@@ -142,22 +142,68 @@ describe('TickButton', () => {
       const svg = container.querySelector('#button-tick svg');
       expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
     });
+
+    it('renders person-falling icon and "attempt" label when ascentType is attempt', () => {
+      const { container } = render(
+        <TickButton {...defaultProps} tickBarActive={true} ascentType="attempt" />,
+      );
+      const svg = container.querySelector('#button-tick svg');
+      expect(svg?.getAttribute('data-testid')).toBe('PersonFallingIcon');
+      expect(screen.getByText('attempt')).toBeTruthy();
+    });
+
+    it('renders flash icon and "flash" label when ascentType is flash', () => {
+      const { container } = render(
+        <TickButton {...defaultProps} tickBarActive={true} ascentType="flash" />,
+      );
+      const svg = container.querySelector('#button-tick svg');
+      expect(svg?.getAttribute('data-testid')).toBe('ElectricBoltOutlinedIcon');
+      expect(screen.getByText('flash')).toBeTruthy();
+    });
+
+    it('renders check icon and "tick" label when ascentType is send', () => {
+      const { container } = render(
+        <TickButton {...defaultProps} tickBarActive={true} ascentType="send" />,
+      );
+      const svg = container.querySelector('#button-tick svg');
+      expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
+      expect(screen.getByText('tick')).toBeTruthy();
+    });
+
+    it('renders flash icon when isFlash is true and no ascentType', () => {
+      const { container } = render(
+        <TickButton {...defaultProps} tickBarActive={true} isFlash={true} ascentType={undefined} />,
+      );
+      const svg = container.querySelector('#button-tick svg');
+      expect(svg?.getAttribute('data-testid')).toBe('ElectricBoltOutlinedIcon');
+      expect(screen.getByText('flash')).toBeTruthy();
+    });
+
+    it('renders check icon when isFlash is false and no ascentType', () => {
+      const { container } = render(
+        <TickButton {...defaultProps} tickBarActive={true} isFlash={false} ascentType={undefined} />,
+      );
+      const svg = container.querySelector('#button-tick svg');
+      expect(svg?.getAttribute('data-testid')).toBe('CheckOutlinedIcon');
+      expect(screen.getByText('tick')).toBeTruthy();
+    });
   });
 
   describe('label rendering', () => {
-    it('shows "save" label when tickBarActive', () => {
+    it('shows "tick" label when tickBarActive and not flash', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={false} />);
-      expect(screen.getByText('save')).toBeTruthy();
+      expect(screen.getByText('tick')).toBeTruthy();
     });
 
-    it('shows "save" label when tickBarActive regardless of isFlash', () => {
+    it('shows "flash" label when tickBarActive and isFlash', () => {
       render(<TickButton {...defaultProps} tickBarActive={true} isFlash={true} />);
-      expect(screen.getByText('save')).toBeTruthy();
+      expect(screen.getByText('flash')).toBeTruthy();
     });
 
     it('does not show a label when tickBarActive is false', () => {
       render(<TickButton {...defaultProps} tickBarActive={false} isFlash={false} />);
-      expect(screen.queryByText('save')).toBeNull();
+      expect(screen.queryByText('tick')).toBeNull();
+      expect(screen.queryByText('flash')).toBeNull();
     });
   });
 

--- a/packages/web/app/components/logbook/inline-list-tick-bar.tsx
+++ b/packages/web/app/components/logbook/inline-list-tick-bar.tsx
@@ -5,6 +5,7 @@ import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
@@ -191,9 +192,6 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
             >
               <CheckOutlined sx={{ fontSize: 18 }} />
             </IconButton>
-            {/* Intentional: both the attempt and cancel buttons use CloseOutlined.
-                The red "X" (attempt/fail) vs small muted "X" (cancel) distinction is
-                a deliberate design choice — do not change these icons. */}
             <IconButton
               ref={attemptButtonRef}
               size="small"
@@ -207,7 +205,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
                 '&:hover': { backgroundColor: themeTokens.colors.error },
               }}
             >
-              <CloseOutlined sx={{ fontSize: 18 }} />
+              <PersonFallingIcon sx={{ fontSize: 18 }} />
             </IconButton>
             <IconButton
               size="small"

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -91,6 +91,7 @@
 .expandLabel {
   font-size: 12px;
   font-weight: 600;
+  opacity: 0.7;
 }
 
 /* ------------------------------------------------------------------ */
@@ -149,9 +150,3 @@
   margin-top: 10px;
 }
 
-/* Save button row */
-.saveRow {
-  display: flex;
-  justify-content: flex-end;
-  padding: 4px 0 8px;
-}

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -143,9 +143,10 @@
   justify-content: flex-start;
 }
 
-/* Expanded comment — taller for easier editing */
-.expandedComment {
-  padding: 4px 0;
+/* Comment row label — align to top of multiline field */
+.labeledRow:last-of-type .labeledRowLabel {
+  align-self: flex-start;
+  margin-top: 10px;
 }
 
 /* Save button row */

--- a/packages/web/app/components/logbook/quick-tick-bar.module.css
+++ b/packages/web/app/components/logbook/quick-tick-bar.module.css
@@ -57,3 +57,100 @@
   margin-left: 4px;
   width: 92px;
 }
+
+/* ------------------------------------------------------------------ */
+/*  Expand / collapse header — matches .sessionHeader in queue bar    */
+/* ------------------------------------------------------------------ */
+
+.expandHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.expandDragBar {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.expandDragBarPill {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: var(--neutral-300, #D1D5DB);
+}
+
+:global(html[data-theme="dark"]) .expandDragBarPill {
+  background-color: var(--neutral-500, #6B7280);
+}
+
+.expandLabel {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Expanded mode — all pickers visible at once                       */
+/* ------------------------------------------------------------------ */
+
+.expandedPanel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 200ms ease-out;
+}
+
+.expandedPanelOpen {
+  grid-template-rows: 1fr;
+}
+
+.expandedPanelContent {
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Labeled picker row: [icon + label] [picker] */
+.labeledRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.labeledRowLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  min-width: 56px;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.labeledRowPicker {
+  flex: 1;
+  min-width: 0;
+}
+
+.labeledRowPickerStart {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  justify-content: flex-start;
+}
+
+/* Expanded comment — taller for easier editing */
+.expandedComment {
+  padding: 4px 0;
+}
+
+/* Save button row */
+.saveRow {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 0 8px;
+}

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -2,10 +2,8 @@
 
 import React, { useState, useCallback, useEffect, useMemo, useImperativeHandle, useRef, forwardRef } from 'react';
 import Stack from '@mui/material/Stack';
-import IconButton from '@mui/material/IconButton';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
-import SaveOutlined from '@mui/icons-material/SaveOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
@@ -36,6 +34,8 @@ export interface QuickTickBarProps {
   onDraftRestored?: (comment: string) => void;
   /** Called when the flash state changes (true = will log as flash, false = send/attempt). */
   onIsFlashChange?: (isFlash: boolean) => void;
+  /** Called when the ascent type changes (flash, send, or attempt). */
+  onAscentTypeChange?: (ascentType: TickStatus) => void;
   /** Current comment text. Owned by the parent so the comment field can live
    *  outside this bar (above the queue control bar) without causing reflow. */
   comment: string;
@@ -75,6 +75,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   onError,
   onDraftRestored,
   onIsFlashChange,
+  onAscentTypeChange,
   comment,
   commentSlot,
   expanded = false,
@@ -126,11 +127,15 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     setAscentType(value);
   }, []);
 
-  // Report flash state to the parent so tick buttons can show the flash icon.
+  // Report ascent type to the parent so tick buttons can update their appearance.
   const isFlash = ascentType === 'flash';
   useEffect(() => {
     onIsFlashChange?.(isFlash);
   }, [isFlash, onIsFlashChange]);
+
+  useEffect(() => {
+    onAscentTypeChange?.(ascentType);
+  }, [ascentType, onAscentTypeChange]);
 
   // Restore draft values from a previous failed save for this climb.
   const draftLoaded = useRef(false);
@@ -214,15 +219,6 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     save,
     saveAttempt,
   }), [save, saveAttempt]);
-
-  // Color for the save button based on selected ascent type.
-  const saveButtonColor = ascentType === 'flash'
-    ? themeTokens.colors.amber
-    : ascentType === 'attempt'
-      ? themeTokens.colors.error
-      : themeTokens.colors.success;
-
-  const saveButtonTextColor = ascentType === 'flash' ? 'var(--neutral-900)' : 'white';
 
   return (
     <div data-testid="quick-tick-bar" className={styles.tickBar}>
@@ -308,22 +304,6 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
               {expandedCommentSlot}
             </div>
           )}
-
-          {/* Save button */}
-          <div className={styles.saveRow}>
-            <IconButton
-              onClick={(e) => save(e.currentTarget)}
-              aria-label="Save tick"
-              sx={{
-                backgroundColor: saveButtonColor,
-                color: saveButtonTextColor,
-                transition: 'background-color 150ms ease, color 150ms ease',
-                '&:hover': { backgroundColor: saveButtonColor },
-              }}
-            >
-              <SaveOutlined />
-            </IconButton>
-          </div>
           </div>
         </div>
       )}

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -46,8 +46,6 @@ export interface QuickTickBarProps {
   expanded?: boolean;
   /** Toggle expanded/collapsed state. */
   onExpandedChange?: (expanded: boolean) => void;
-  /** Close the tick bar entirely (cancel). */
-  onClose?: () => void;
   /** Expanded-mode comment slot — taller, for the expanded layout. */
   expandedCommentSlot?: React.ReactNode;
 }
@@ -110,6 +108,11 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   const inferredType: TickStatus = tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
   const [ascentType, setAscentType] = useState<TickStatus>(inferredType);
   const userOverrodeType = useRef(false);
+
+  // Reset userOverrodeType when the tick target (climb) changes so auto-inference works for new climbs.
+  useEffect(() => {
+    userOverrodeType.current = false;
+  }, [tickTarget]);
 
   // Auto-update ascent type when tries or prior history changes (unless user explicitly chose).
   useEffect(() => {

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -5,6 +5,7 @@ import Stack from '@mui/material/Stack';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
+import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
@@ -298,10 +299,15 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
               </div>
             </div>
 
-          {/* Expanded comment */}
+          {/* Comment row — same layout as other labeled rows */}
           {expandedCommentSlot && (
-            <div className={styles.expandedComment}>
-              {expandedCommentSlot}
+            <div className={styles.labeledRow}>
+              <span className={styles.labeledRowLabel}>
+                <ChatBubbleOutlineOutlined sx={{ fontSize: 14 }} />
+              </span>
+              <div className={styles.labeledRowPicker}>
+                {expandedCommentSlot}
+              </div>
             </div>
           )}
           </div>

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -259,7 +259,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
                 type
               </span>
               <div className={styles.labeledRowPicker}>
-                <InlineAscentTypePicker ascentType={ascentType} onSelect={handleAscentTypeSelect} />
+                <InlineAscentTypePicker ascentType={ascentType} onSelect={handleAscentTypeSelect} canFlash={!tickTarget?.hasPriorHistory && attemptCount === 1} />
               </div>
             </div>
 

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -2,17 +2,25 @@
 
 import React, { useState, useCallback, useEffect, useMemo, useImperativeHandle, useRef, forwardRef } from 'react';
 import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
+import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
+import SaveOutlined from '@mui/icons-material/SaveOutlined';
+import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { loadTickDraft } from '@/app/lib/tick-draft-db';
 import { useTickSave, buildTickTarget, type TickTarget } from '@/app/hooks/use-tick-save';
+import type { TickStatus } from '@/app/hooks/use-logbook';
+import { themeTokens } from '@/app/theme/theme-config';
 import {
   TickControls,
   TickGradeButton,
   InlineStarPicker,
   InlineGradePicker,
   InlineTriesPicker,
+  InlineAscentTypePicker,
   type ExpandedControl,
 } from './tick-controls';
 import styles from './quick-tick-bar.module.css';
@@ -33,22 +41,31 @@ export interface QuickTickBarProps {
   comment: string;
   /** Comment input element rendered by the parent — placed in the row next to tick controls. */
   commentSlot: React.ReactNode;
+  /** Whether the tick bar is in expanded mode (all pickers visible). */
+  expanded?: boolean;
+  /** Toggle expanded/collapsed state. */
+  onExpandedChange?: (expanded: boolean) => void;
+  /** Close the tick bar entirely (cancel). */
+  onClose?: () => void;
+  /** Expanded-mode comment slot — taller, for the expanded layout. */
+  expandedCommentSlot?: React.ReactNode;
 }
 
 export interface QuickTickBarHandle {
-  /** Trigger a save (ascent). Pass the origin element for confetti positioning. */
+  /** Trigger a save using the selected ascent type. Pass the origin element for confetti positioning. */
   save: (originElement?: HTMLElement | null) => void;
-  /** Trigger a save (attempt). Pass the origin element for confetti positioning. */
+  /** Trigger a save as attempt. Pass the origin element for confetti positioning. */
   saveAttempt: (originElement?: HTMLElement | null) => void;
 }
 
 /**
  * Stateful tick entry wrapper. Manages the tick target snapshot, form state
- * (quality, difficulty, attempts), expansion state, and save logic.
+ * (quality, difficulty, attempts, ascent type), expansion state, and save logic.
  *
- * Layout mirrors the queue control bar below:
+ * Compact layout mirrors the queue control bar below:
  *   [comment (flex:1) + grade] [stars + tries]
- * so the user grade aligns vertically with the consensus grade.
+ *
+ * Expanded layout shows all pickers simultaneously with icon+label on the left.
  */
 export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   currentClimb,
@@ -60,14 +77,13 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   onIsFlashChange,
   comment,
   commentSlot,
+  expanded = false,
+  onExpandedChange,
+  expandedCommentSlot,
 }, ref) => {
   const { logbook } = useBoardProvider();
 
   // Snapshot the target climb the first time we get a non-null climb.
-  // Uses a ref flag so it only fires once, avoiding re-snapshot when
-  // angle/boardDetails/logbook change after the initial capture.
-  // NOTE: tickTargetTaken resets only on unmount — this works because
-  // QuickTickBar is unmounted when tick mode closes (see queue-control-bar).
   const tickTargetTaken = useRef(false);
   const [tickTarget, setTickTarget] = useState<TickTarget | null>(() => {
     if (currentClimb) {
@@ -88,8 +104,30 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
   const [attemptCount, setAttemptCount] = useState<number>(1);
   const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
 
+  // Explicit ascent type — initialized from inferred value, auto-updated on state changes.
+  const inferredType: TickStatus = tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
+  const [ascentType, setAscentType] = useState<TickStatus>(inferredType);
+  const userOverrodeType = useRef(false);
+
+  // Auto-update ascent type when tries or prior history changes (unless user explicitly chose).
+  useEffect(() => {
+    if (userOverrodeType.current) {
+      // If user manually selected flash but now tries > 1, correct to send.
+      if (ascentType === 'flash' && (attemptCount > 1 || tickTarget?.hasPriorHistory)) {
+        setAscentType('send');
+      }
+      return;
+    }
+    setAscentType(inferredType);
+  }, [inferredType, attemptCount, tickTarget?.hasPriorHistory, ascentType]);
+
+  const handleAscentTypeSelect = useCallback((value: TickStatus) => {
+    userOverrodeType.current = true;
+    setAscentType(value);
+  }, []);
+
   // Report flash state to the parent so tick buttons can show the flash icon.
-  const isFlash = !!tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1;
+  const isFlash = ascentType === 'flash';
   useEffect(() => {
     onIsFlashChange?.(isFlash);
   }, [isFlash, onIsFlashChange]);
@@ -111,6 +149,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     });
     return () => { cancelled = true; };
   }, [tickTarget, onDraftRestored]);
+
   // Track which picker was last open so we can keep it mounted during collapse.
   const [lastExpandedControl, setLastExpandedControl] = useState<ExpandedControl>(null);
   const [pickerVisible, setPickerVisible] = useState(false);
@@ -120,21 +159,22 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
       setLastExpandedControl(expandedControl);
       setPickerVisible(true);
     } else {
-      // Keep content mounted during the 200ms CSS grid collapse transition.
       const timer = setTimeout(() => setPickerVisible(false), 200);
       return () => clearTimeout(timer);
     }
   }, [expandedControl]);
 
-  // The control to actually render — either the currently expanded one, or
-  // the last one that was open (kept alive during the collapse animation).
   const renderedControl = expandedControl ?? (pickerVisible ? lastExpandedControl : null);
+
+  // Collapse any open individual picker when entering expanded mode.
+  useEffect(() => {
+    if (expanded) setExpandedControl(null);
+  }, [expanded]);
 
   const gradeButtonRef = useRef<HTMLButtonElement>(null);
   const triesButtonRef = useRef<HTMLButtonElement>(null);
 
   const grades = TENSION_KILTER_GRADES;
-
   const currentGradeId = difficulty;
 
   const consensusGradeId = useMemo(() => {
@@ -143,21 +183,21 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     return grades.find((g) => g.difficulty_name === source)?.difficulty_id;
   }, [tickTarget, grades]);
 
-  // Picker selection handlers — select the value and collapse the picker.
+  // Picker selection handlers.
   const handleStarSelect = useCallback((value: number | null) => {
     setQuality(value);
-    setExpandedControl(null);
-  }, []);
+    if (!expanded) setExpandedControl(null);
+  }, [expanded]);
 
   const handleGradeSelect = useCallback((value: number | undefined) => {
     setDifficulty(value);
-    setExpandedControl(null);
-  }, []);
+    if (!expanded) setExpandedControl(null);
+  }, [expanded]);
 
   const handleTriesSelect = useCallback((value: number) => {
     setAttemptCount(value);
-    setExpandedControl(null);
-  }, []);
+    if (!expanded) setExpandedControl(null);
+  }, [expanded]);
 
   const { save, saveAttempt } = useTickSave({
     tickTarget,
@@ -165,6 +205,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     difficulty,
     attemptCount,
     comment,
+    ascentType,
     onSave,
     onError,
   });
@@ -174,63 +215,170 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(({
     saveAttempt,
   }), [save, saveAttempt]);
 
+  // Color for the save button based on selected ascent type.
+  const saveButtonColor = ascentType === 'flash'
+    ? themeTokens.colors.amber
+    : ascentType === 'attempt'
+      ? themeTokens.colors.error
+      : themeTokens.colors.success;
+
+  const saveButtonTextColor = ascentType === 'flash' ? 'var(--neutral-900)' : 'white';
+
   return (
     <div data-testid="quick-tick-bar" className={styles.tickBar}>
-      {/* Picker panel — expands above the controls row when a control is active */}
-      <div className={`${styles.pickerPanel} ${expandedControl ? styles.pickerPanelExpanded : ''}`}>
-        <div className={styles.pickerPanelContent}>
-          {renderedControl === 'stars' && (
-            <InlineStarPicker quality={quality} onSelect={handleStarSelect} />
+      {/* Expand/collapse header — styled to match the session header ("Start sesh") strip.
+          Also serves as the swipe-hint drag handle. */}
+      {onExpandedChange && (
+        <div
+          className={styles.expandHeader}
+          onClick={() => onExpandedChange(!expanded)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onExpandedChange(!expanded); }}
+          aria-label={expanded ? 'Collapse tick bar' : 'Expand tick bar'}
+        >
+          {expanded ? (
+            <KeyboardArrowDownOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+          ) : (
+            <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
           )}
-          {renderedControl === 'grade' && (
-            <InlineGradePicker
-              grades={grades}
-              currentGradeId={currentGradeId}
-              focusGradeId={consensusGradeId}
-              onSelect={handleGradeSelect}
-              gradeButtonRef={gradeButtonRef}
-            />
-          )}
-          {renderedControl === 'tries' && (
-            <InlineTriesPicker attemptCount={attemptCount} onSelect={handleTriesSelect} triesButtonRef={triesButtonRef} />
-          )}
-        </div>
-      </div>
-
-      {/* Controls row — mirrors the queue bar layout:
-          [comment + grade (flex:1)] [stars + tries (flex:none)]
-          so user grade aligns with the consensus grade below. */}
-      <div className={styles.controlsRow}>
-        {/* Left section: comment fills space, grade sits at right edge —
-            mirrors the queue bar's [thumbnail + title + grade] column. */}
-        <div className={styles.leftSection}>
-          {/* Collapse any open picker when the comment field gains focus */}
-          <div role="group" onFocus={() => setExpandedControl(null)} className={styles.commentWrapper}>
-            {commentSlot}
+          <span className={styles.expandLabel}>{expanded ? 'collapse' : 'expand'}</span>
+          <div className={styles.expandDragBar} aria-hidden="true">
+            <div className={styles.expandDragBarPill} />
           </div>
-          <TickGradeButton
-            ref={gradeButtonRef}
-            difficulty={difficulty}
-            displayedGrades={grades}
-            expandedControl={expandedControl}
-            onExpandedControlChange={setExpandedControl}
-          />
         </div>
+      )}
 
-        {/* Right section: stars + tries — mirrors the queue bar's button
-            cluster (Close + Tick) so widths match and grades align. */}
-        <div className={styles.rightControls}>
-          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-            <TickControls
-              quality={quality}
-              attemptCount={attemptCount}
-              expandedControl={expandedControl}
-              onExpandedControlChange={setExpandedControl}
-              triesButtonRef={triesButtonRef}
-            />
-          </Stack>
+      {/* Expanded mode — all pickers visible at once with labels.
+          Only mount content when expanded to avoid duplicate picker DOM elements
+          that would confuse screen reader queries and tests. */}
+      {expanded && (
+        <div className={`${styles.expandedPanel} ${styles.expandedPanelOpen}`}>
+          <div className={styles.expandedPanelContent}>
+            {/* Ascent type row */}
+            <div className={styles.labeledRow}>
+              <span className={styles.labeledRowLabel}>
+                <ElectricBoltOutlined sx={{ fontSize: 14 }} />
+                type
+              </span>
+              <div className={styles.labeledRowPicker}>
+                <InlineAscentTypePicker ascentType={ascentType} onSelect={handleAscentTypeSelect} />
+              </div>
+            </div>
+
+            {/* Grade row */}
+            <div className={styles.labeledRow}>
+              <span className={styles.labeledRowLabel}>
+                grade
+              </span>
+              <div className={styles.labeledRowPicker}>
+                <InlineGradePicker
+                  grades={grades}
+                  currentGradeId={currentGradeId}
+                  focusGradeId={consensusGradeId}
+                  onSelect={handleGradeSelect}
+                  gradeButtonRef={gradeButtonRef}
+                />
+              </div>
+            </div>
+
+            {/* Tries row */}
+            <div className={styles.labeledRow}>
+              <span className={styles.labeledRowLabel}>
+                tries
+              </span>
+              <div className={styles.labeledRowPicker}>
+                <InlineTriesPicker attemptCount={attemptCount} onSelect={handleTriesSelect} triesButtonRef={triesButtonRef} />
+              </div>
+            </div>
+
+            {/* Stars row — left-aligned since picker is shorter */}
+            <div className={styles.labeledRow}>
+              <span className={styles.labeledRowLabel}>
+                stars
+              </span>
+              <div className={styles.labeledRowPickerStart}>
+                <InlineStarPicker quality={quality} onSelect={handleStarSelect} />
+              </div>
+            </div>
+
+          {/* Expanded comment */}
+          {expandedCommentSlot && (
+            <div className={styles.expandedComment}>
+              {expandedCommentSlot}
+            </div>
+          )}
+
+          {/* Save button */}
+          <div className={styles.saveRow}>
+            <IconButton
+              onClick={(e) => save(e.currentTarget)}
+              aria-label="Save tick"
+              sx={{
+                backgroundColor: saveButtonColor,
+                color: saveButtonTextColor,
+                transition: 'background-color 150ms ease, color 150ms ease',
+                '&:hover': { backgroundColor: saveButtonColor },
+              }}
+            >
+              <SaveOutlined />
+            </IconButton>
+          </div>
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Compact mode — single picker panel + controls row (hidden when expanded) */}
+      {!expanded && (
+        <>
+          <div className={`${styles.pickerPanel} ${expandedControl ? styles.pickerPanelExpanded : ''}`}>
+            <div className={styles.pickerPanelContent}>
+              {renderedControl === 'stars' && (
+                <InlineStarPicker quality={quality} onSelect={handleStarSelect} />
+              )}
+              {renderedControl === 'grade' && (
+                <InlineGradePicker
+                  grades={grades}
+                  currentGradeId={currentGradeId}
+                  focusGradeId={consensusGradeId}
+                  onSelect={handleGradeSelect}
+                  gradeButtonRef={gradeButtonRef}
+                />
+              )}
+              {renderedControl === 'tries' && (
+                <InlineTriesPicker attemptCount={attemptCount} onSelect={handleTriesSelect} triesButtonRef={triesButtonRef} />
+              )}
+            </div>
+          </div>
+
+          <div className={styles.controlsRow}>
+            <div className={styles.leftSection}>
+              <div role="group" onFocus={() => setExpandedControl(null)} className={styles.commentWrapper}>
+                {commentSlot}
+              </div>
+              <TickGradeButton
+                ref={gradeButtonRef}
+                difficulty={difficulty}
+                displayedGrades={grades}
+                expandedControl={expandedControl}
+                onExpandedControlChange={setExpandedControl}
+              />
+            </div>
+
+            <div className={styles.rightControls}>
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <TickControls
+                  quality={quality}
+                  attemptCount={attemptCount}
+                  expandedControl={expandedControl}
+                  onExpandedControlChange={setExpandedControl}
+                  triesButtonRef={triesButtonRef}
+                />
+              </Stack>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 });

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -17,6 +17,7 @@ import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { useAlwaysTickInApp } from '@/app/hooks/use-always-tick-in-app';
 import { TickIcon, TickButtonWithLabel } from './tick-icon';
 
@@ -30,9 +31,11 @@ interface TickButtonProps {
   tickBarActive?: boolean;
   /** Whether the current tick will be logged as a flash (no prior history, 1 try). */
   isFlash?: boolean;
+  /** The currently selected ascent type in the expanded tick bar. */
+  ascentType?: 'flash' | 'send' | 'attempt';
 }
 
-export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boardDetails, onActivateTickBar, onTickSave, tickBarActive, isFlash }) => {
+export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boardDetails, onActivateTickBar, onTickSave, tickBarActive, isFlash, ascentType }) => {
   const { logbook, isAuthenticated } = useBoardProvider();
   const [drawerVisible, setDrawerVisible] = useState(false);
   const { openAuthModal } = useAuthModal();
@@ -84,8 +87,6 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
   const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
   const badgeCount = filteredLogbook.length;
 
-  const tickLabel = isFlash ? 'flash' : 'tick';
-
   const badge = (
     <MuiBadge
       badgeContent={badgeCount > 0 ? badgeCount : 0}
@@ -100,21 +101,32 @@ export const TickButton: React.FC<TickButtonProps> = ({ currentClimb, angle, boa
       <IconButton
         id="button-tick"
         onClick={showDrawer}
-        aria-label={tickBarActive ? (isFlash ? 'Log flash' : 'Log ascent') : 'Log ascent'}
+        aria-label={tickBarActive ? 'Save tick' : 'Log ascent'}
         sx={tickBarActive
           ? {
-              backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.success,
-              color: isFlash ? themeTokens.neutral[900] : 'common.white',
+              backgroundColor: ascentType === 'attempt' ? themeTokens.colors.error
+                : ascentType === 'flash' || isFlash ? themeTokens.colors.amber
+                : themeTokens.colors.success,
+              color: ascentType === 'flash' || isFlash ? themeTokens.neutral[900] : 'common.white',
               transition: 'background-color 150ms ease, color 150ms ease',
-              '&:hover': { backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.successHover },
+              '&:hover': {
+                backgroundColor: ascentType === 'attempt' ? themeTokens.colors.error
+                  : ascentType === 'flash' || isFlash ? themeTokens.colors.amber
+                  : themeTokens.colors.successHover,
+              },
             }
           : { opacity: themeTokens.opacity.subtle }
         }
       >
-        <TickIcon isFlash={!!isFlash && !!tickBarActive} />
+        {tickBarActive && ascentType === 'attempt'
+          ? <PersonFallingIcon />
+          : <TickIcon isFlash={tickBarActive ? !!(ascentType === 'flash' || isFlash) : false} />
+        }
       </IconButton>
     </MuiBadge>
   );
+
+  const tickLabel = ascentType === 'attempt' ? 'attempt' : (ascentType === 'flash' || isFlash) ? 'flash' : 'tick';
 
   return (
     <>

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -8,6 +8,7 @@
   gap: 2px;
   flex-shrink: 0;
   width: 40px;
+  min-height: 36px;
   padding: 4px 0;
   border-radius: 4px;
   line-height: 1;
@@ -51,6 +52,7 @@
   flex-shrink: 0;
   padding: 4px 0;
   min-width: 24px;
+  min-height: 36px;
   border-radius: 4px;
   line-height: 1;
   color: inherit;
@@ -90,6 +92,7 @@
   justify-content: center;
   flex-shrink: 0;
   width: 40px;
+  min-height: 36px;
   padding: 4px 0;
   border-radius: 4px;
   line-height: 1;
@@ -200,24 +203,16 @@
 
 .scrollIndicatorLeft {
   left: 0;
-  background: linear-gradient(to right, rgba(180, 180, 180, 0.45) 0%, rgba(180, 180, 180, 0) 100%);
+  background: linear-gradient(to right, color-mix(in srgb, var(--neutral-400) 45%, transparent) 0%, transparent 100%);
   mask-image: linear-gradient(to right, black 60%, transparent);
   -webkit-mask-image: linear-gradient(to right, black 60%, transparent);
 }
 
 .scrollIndicatorRight {
   right: 0;
-  background: linear-gradient(to left, rgba(180, 180, 180, 0.45) 0%, rgba(180, 180, 180, 0) 100%);
+  background: linear-gradient(to left, color-mix(in srgb, var(--neutral-400) 45%, transparent) 0%, transparent 100%);
   mask-image: linear-gradient(to left, black 60%, transparent);
   -webkit-mask-image: linear-gradient(to left, black 60%, transparent);
-}
-
-:global(html[data-theme="dark"]) .scrollIndicatorLeft {
-  background: linear-gradient(to right, rgba(120, 120, 120, 0.4) 0%, rgba(120, 120, 120, 0) 100%);
-}
-
-:global(html[data-theme="dark"]) .scrollIndicatorRight {
-  background: linear-gradient(to left, rgba(120, 120, 120, 0.4) 0%, rgba(120, 120, 120, 0) 100%);
 }
 
 .pickerItem {
@@ -294,6 +289,14 @@
 .ascentTypeItem {
   gap: 6px;
   padding: 4px 12px;
+}
+
+.ascentTypeIcon {
+  display: flex;
+}
+
+.ascentTypeItemDisabled {
+  opacity: 0.3;
 }
 
 .ascentTypeLabel {

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -283,3 +283,14 @@
   font-weight: 600;
   color: var(--grade-color, inherit);
 }
+
+/* Ascent type picker items — icon + label side by side */
+.ascentTypeItem {
+  gap: 6px;
+  padding: 4px 12px;
+}
+
+.ascentTypeLabel {
+  font-size: 13px;
+  font-weight: 600;
+}

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -253,6 +253,12 @@
   background-color: rgba(128, 128, 128, 0.18);
 }
 
+.pickerItemFocused {
+  opacity: 1;
+  outline: 1.5px dashed rgba(128, 128, 128, 0.5);
+  outline-offset: -1.5px;
+}
+
 @media (hover: hover) {
   :global(html[data-theme="dark"]) .pickerItem:hover {
     background-color: rgba(255, 255, 255, 0.1);

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -443,7 +443,7 @@ export const InlineTriesPicker: React.FC<{
 
 const ASCENT_TYPE_OPTIONS: readonly { value: TickStatus; label: string; icon: React.ReactNode; color: string }[] = [
   { value: 'attempt', label: 'Attempt', icon: <PersonFallingIcon sx={{ fontSize: 18 }} />, color: themeTokens.colors.error },
-  { value: 'send', label: 'Ascent', icon: <CheckOutlined sx={{ fontSize: 18 }} />, color: themeTokens.colors.success },
+  { value: 'send', label: 'Send', icon: <CheckOutlined sx={{ fontSize: 18 }} />, color: themeTokens.colors.success },
   { value: 'flash', label: 'Flash', icon: <ElectricBoltOutlined sx={{ fontSize: 18 }} />, color: themeTokens.colors.amber },
 ];
 
@@ -467,8 +467,8 @@ export const InlineAscentTypePicker: React.FC<{
           role="option"
           disabled={disabled}
         >
-          <span style={{ color: opt.value === ascentType ? opt.color : 'inherit', display: 'flex', opacity: disabled ? 0.3 : 1 }}>{opt.icon}</span>
-          <span className={styles.ascentTypeLabel} style={{ opacity: disabled ? 0.3 : 1 }}>{opt.label}</span>
+          <span className={`${styles.ascentTypeIcon} ${disabled ? styles.ascentTypeItemDisabled : ''}`} style={{ color: opt.value === ascentType ? opt.color : 'inherit' }}>{opt.icon}</span>
+          <span className={`${styles.ascentTypeLabel} ${disabled ? styles.ascentTypeItemDisabled : ''}`}>{opt.label}</span>
         </ButtonBase>
       );
     })}

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -6,9 +6,13 @@ import Skeleton from '@mui/material/Skeleton';
 import StarIcon from '@mui/icons-material/Star';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
+import CheckOutlined from '@mui/icons-material/CheckOutlined';
+import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
+import type { TickStatus } from '@/app/hooks/use-logbook';
 import styles from './tick-controls.module.css';
 
 export type ExpandedControl = 'grade' | 'stars' | 'tries' | null;
@@ -432,3 +436,34 @@ export const InlineTriesPicker: React.FC<{
     </ScrollIndicatorWrapper>
   );
 };
+
+/* ------------------------------------------------------------------ */
+/*  Ascent type picker — used in expanded tick bar                    */
+/* ------------------------------------------------------------------ */
+
+const ASCENT_TYPE_OPTIONS: readonly { value: TickStatus; label: string; icon: React.ReactNode; color: string }[] = [
+  { value: 'attempt', label: 'Attempt', icon: <PersonFallingIcon sx={{ fontSize: 18 }} />, color: themeTokens.colors.error },
+  { value: 'send', label: 'Ascent', icon: <CheckOutlined sx={{ fontSize: 18 }} />, color: themeTokens.colors.success },
+  { value: 'flash', label: 'Flash', icon: <ElectricBoltOutlined sx={{ fontSize: 18 }} />, color: themeTokens.colors.amber },
+];
+
+export const InlineAscentTypePicker: React.FC<{
+  ascentType: TickStatus;
+  onSelect: (value: TickStatus) => void;
+}> = ({ ascentType, onSelect }) => (
+  <div className={styles.pickerRow} role="listbox" aria-label="Ascent type">
+    {ASCENT_TYPE_OPTIONS.map((opt) => (
+      <ButtonBase
+        key={opt.value}
+        onClick={() => onSelect(opt.value)}
+        className={`${styles.pickerItem} ${styles.ascentTypeItem} ${opt.value === ascentType ? styles.pickerItemSelected : ''}`}
+        aria-label={opt.label}
+        aria-selected={opt.value === ascentType}
+        role="option"
+      >
+        <span style={{ color: opt.value === ascentType ? opt.color : 'inherit', display: 'flex' }}>{opt.icon}</span>
+        <span className={styles.ascentTypeLabel}>{opt.label}</span>
+      </ButtonBase>
+    ))}
+  </div>
+);

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -314,13 +314,13 @@ export const InlineGradePicker: React.FC<{
   useStopHorizontalTouchPropagation(containerRef);
   const { canScrollLeft, canScrollRight } = useScrollIndicators(containerRef);
 
-  // On mount, scroll so the selected (or focus) grade aligns above the grade button.
-  // When no grade is selected, scroll to the consensus grade (focusGradeId) as a reference point.
+  // On mount, scroll so the selected (or focus) grade is visible.
+  // When a gradeButtonRef is available (compact mode), align above the button.
+  // Otherwise (expanded mode), center the grade in the container.
   const scrollTargetId = currentGradeId ?? focusGradeId;
   useLayoutEffect(() => {
     const container = containerRef.current;
-    const gradeButton = gradeButtonRef?.current;
-    if (!container || !gradeButton || scrollTargetId === undefined) return;
+    if (!container || scrollTargetId === undefined) return;
 
     const targetEl = container.querySelector(
       `[data-grade-id="${scrollTargetId}"]`,
@@ -328,14 +328,14 @@ export const InlineGradePicker: React.FC<{
     if (!targetEl) return;
 
     const containerRect = container.getBoundingClientRect();
-    const gradeButtonRect = gradeButton.getBoundingClientRect();
+    const gradeButton = gradeButtonRef?.current;
 
-    const gradeButtonCenterInContainer =
-      gradeButtonRect.left + gradeButtonRect.width / 2 - containerRect.left;
-    const targetItemCenter =
-      targetEl.offsetLeft + targetEl.offsetWidth / 2;
+    const alignCenter = gradeButton
+      ? gradeButton.getBoundingClientRect().left + gradeButton.getBoundingClientRect().width / 2 - containerRect.left
+      : container.clientWidth / 2;
 
-    const targetScrollLeft = targetItemCenter - gradeButtonCenterInContainer;
+    const targetItemCenter = targetEl.offsetLeft + targetEl.offsetWidth / 2;
+    const targetScrollLeft = targetItemCenter - alignCenter;
     const maxScroll = container.scrollWidth - container.clientWidth;
     container.scrollLeft = Math.max(0, Math.min(targetScrollLeft, maxScroll));
   }, [scrollTargetId, gradeButtonRef]);
@@ -362,7 +362,7 @@ export const InlineGradePicker: React.FC<{
               key={grade.difficulty_id}
               data-grade-id={grade.difficulty_id}
               onClick={() => onSelect(grade.difficulty_id)}
-              className={`${styles.pickerItem} ${isSelected || isFocused ? styles.pickerItemSelected : ''}`}
+              className={`${styles.pickerItem} ${isSelected ? styles.pickerItemSelected : ''} ${isFocused ? styles.pickerItemFocused : ''}`}
               aria-label={isFocused ? `${formatted} (consensus)` : formatted}
               aria-selected={isSelected || isFocused}
               role="option"
@@ -450,20 +450,27 @@ const ASCENT_TYPE_OPTIONS: readonly { value: TickStatus; label: string; icon: Re
 export const InlineAscentTypePicker: React.FC<{
   ascentType: TickStatus;
   onSelect: (value: TickStatus) => void;
-}> = ({ ascentType, onSelect }) => (
+  /** Whether flash is available (no prior history and 1 try). */
+  canFlash?: boolean;
+}> = ({ ascentType, onSelect, canFlash = true }) => (
   <div className={styles.pickerRow} role="listbox" aria-label="Ascent type">
-    {ASCENT_TYPE_OPTIONS.map((opt) => (
-      <ButtonBase
-        key={opt.value}
-        onClick={() => onSelect(opt.value)}
-        className={`${styles.pickerItem} ${styles.ascentTypeItem} ${opt.value === ascentType ? styles.pickerItemSelected : ''}`}
-        aria-label={opt.label}
-        aria-selected={opt.value === ascentType}
-        role="option"
-      >
-        <span style={{ color: opt.value === ascentType ? opt.color : 'inherit', display: 'flex' }}>{opt.icon}</span>
-        <span className={styles.ascentTypeLabel}>{opt.label}</span>
-      </ButtonBase>
-    ))}
+    {ASCENT_TYPE_OPTIONS.map((opt) => {
+      const disabled = opt.value === 'flash' && !canFlash;
+      return (
+        <ButtonBase
+          key={opt.value}
+          onClick={() => !disabled && onSelect(opt.value)}
+          className={`${styles.pickerItem} ${styles.ascentTypeItem} ${opt.value === ascentType ? styles.pickerItemSelected : ''}`}
+          aria-label={opt.label}
+          aria-selected={opt.value === ascentType}
+          aria-disabled={disabled}
+          role="option"
+          disabled={disabled}
+        >
+          <span style={{ color: opt.value === ascentType ? opt.color : 'inherit', display: 'flex', opacity: disabled ? 0.3 : 1 }}>{opt.icon}</span>
+          <span className={styles.ascentTypeLabel} style={{ opacity: disabled ? 0.3 : 1 }}>{opt.label}</span>
+        </ButtonBase>
+      );
+    })}
   </div>
 );

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -364,7 +364,7 @@ export const InlineGradePicker: React.FC<{
               onClick={() => onSelect(grade.difficulty_id)}
               className={`${styles.pickerItem} ${isSelected ? styles.pickerItemSelected : ''} ${isFocused ? styles.pickerItemFocused : ''}`}
               aria-label={isFocused ? `${formatted} (consensus)` : formatted}
-              aria-selected={isSelected || isFocused}
+              aria-selected={isSelected}
               role="option"
             >
               <span className={styles.pickerGrade} {...(color ? { style: { '--grade-color': color } as React.CSSProperties } : {})}>

--- a/packages/web/app/components/logbook/tick-icon.tsx
+++ b/packages/web/app/components/logbook/tick-icon.tsx
@@ -14,7 +14,7 @@ export const TickIcon: React.FC<TickIconProps> = ({ isFlash }) => {
 };
 
 interface TickButtonWithLabelProps {
-  label: 'flash' | 'tick' | 'attempt';
+  label: 'flash' | 'tick' | 'attempt' | 'save';
   children: React.ReactNode;
 }
 

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -139,34 +139,29 @@
   overflow: visible;
 }
 
-/* Close button — top-right, identical to queue control bar */
-.tickBarClose {
-  position: absolute;
-  right: 2px;
-  top: 2px;
-  z-index: 2;
-}
-
-/* Drag handle — identical to queue control bar */
-.tickBarDragHandleRow {
-  position: relative;
-  display: flex;
-  justify-content: center;
-  padding: 0 0 4px;
-}
-
-.tickBarDragHandle {
+/* Toolbar: expand left, close right — same pattern as queue-control-bar */
+.tickBarToolbar {
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 2px 0;
+  justify-content: space-between;
+  padding: 4px 4px 0 8px;
 }
 
-.tickBarDragHandleBar {
-  width: 36px;
-  height: 4px;
-  border-radius: 2px;
-  background-color: var(--neutral-200, #E5E7EB);
+.tickBarExpandButton {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.tickBarExpandLabel {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.tickBarCloseButton {
+  flex-shrink: 0;
 }
 
 /* Comment input — identical to queue control bar */

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -16,7 +16,8 @@ import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
-import { TickIcon, TickButtonWithLabel } from '../logbook/tick-icon';
+import SaveOutlined from '@mui/icons-material/SaveOutlined';
+import { TickButtonWithLabel } from '../logbook/tick-icon';
 import { usePathname } from 'next/navigation';
 import { useQueueActions, useCurrentClimb, useQueueList, useSessionData } from '../graphql-queue';
 import { ClimbActions } from '../climb-actions';
@@ -176,6 +177,7 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
   const [tickComment, setTickComment] = useState('');
   const [commentFocused, setCommentFocused] = useState(false);
   const [isFlash, setIsFlash] = useState(() => !hasPriorHistoryForClimb(currentClimb, logbook));
+  const [tickBarExpanded, setTickBarExpanded] = useState(false);
   const quickTickBarRef = useRef<QuickTickBarHandle>(null);
   const isDark = useIsDarkMode();
   // Match queue control bar tint — 'default' variant.
@@ -195,6 +197,7 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
     setTickComment('');
     setCommentFocused(false);
     setIsFlash(false);
+    setTickBarExpanded(false);
     onClose();
   }, [onClose]);
 
@@ -203,6 +206,7 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
     setTickComment('');
     setCommentFocused(false);
     setIsFlash(!hasPriorHistoryForClimb(currentClimb, logbook));
+    setTickBarExpanded(false);
   }, [currentClimb.uuid, currentClimb, logbook]);
 
   return (
@@ -223,21 +227,23 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
         </div>
         {isTickBarActive && (
           <>
-            {/* Close button — top-right corner, identical to queue control bar */}
-            <div className={styles.tickBarClose}>
-              <IconButton
-                size="small"
-                onClick={handleClose}
-                aria-label="Close tick bar"
-                sx={{
-                  color: 'text.primary',
-                  backgroundColor: 'action.selected',
-                  '&:hover': { backgroundColor: 'action.focus' },
-                }}
-              >
-                <CloseOutlined sx={{ fontSize: 16 }} />
-              </IconButton>
-            </div>
+            {/* Close button — top-right corner, hidden when expanded (QuickTickBar shows its own cancel) */}
+            {!tickBarExpanded && (
+              <div className={styles.tickBarClose}>
+                <IconButton
+                  size="small"
+                  onClick={handleClose}
+                  aria-label="Close tick bar"
+                  sx={{
+                    color: 'text.primary',
+                    backgroundColor: 'action.selected',
+                    '&:hover': { backgroundColor: 'action.focus' },
+                  }}
+                >
+                  <CloseOutlined sx={{ fontSize: 16 }} />
+                </IconButton>
+              </div>
+            )}
             <QuickTickBar
               ref={quickTickBarRef}
               currentClimb={currentClimb}
@@ -248,6 +254,9 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
               onDraftRestored={(draftComment) => setTickComment(draftComment)}
               onIsFlashChange={setIsFlash}
               comment={tickComment}
+              expanded={tickBarExpanded}
+              onExpandedChange={setTickBarExpanded}
+              onClose={handleClose}
               commentSlot={
                 <div className={`${styles.tickBarComment} ${commentFocused ? styles.tickBarCommentExpanded : ''}`}>
                   <TextField
@@ -284,38 +293,61 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
                   />
                 </div>
               }
+              expandedCommentSlot={
+                <TextField
+                  fullWidth
+                  size="small"
+                  variant="outlined"
+                  placeholder="Comment..."
+                  multiline
+                  minRows={2}
+                  maxRows={4}
+                  value={tickComment}
+                  onChange={(e) => setTickComment(e.target.value)}
+                  onFocus={handleCommentFocus}
+                  onBlur={handleCommentBlur}
+                  slotProps={{
+                    htmlInput: { maxLength: 2000, 'aria-label': 'Tick comment' },
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                  sx={{
+                    '& .MuiOutlinedInput-root': {
+                      borderRadius: '8px',
+                      backgroundColor: 'var(--input-bg)',
+                      '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: 'var(--neutral-200)',
+                      },
+                    },
+                  }}
+                />
+              }
             />
-            {/* Action buttons — attempt (X) + save (check/flash), both fire confetti from click target */}
-            <div className={styles.tickBarButtons}>
-              <TickButtonWithLabel label="attempt">
-                <IconButton
-                  onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
-                  sx={{
-                    backgroundColor: themeTokens.colors.errorMuted,
-                    color: themeTokens.colors.error,
-                    '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
-                  }}
-                  aria-label="Log attempt"
-                >
-                  <CloseOutlined />
-                </IconButton>
-              </TickButtonWithLabel>
-              <TickButtonWithLabel label={isFlash ? 'flash' : 'tick'}>
-                <IconButton
-                  id="button-tick"
-                  onClick={(e) => quickTickBarRef.current?.save(e.currentTarget)}
-                  sx={{
-                    backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.success,
-                    color: isFlash ? themeTokens.neutral[900] : 'common.white',
-                    transition: 'background-color 150ms ease, color 150ms ease',
-                    '&:hover': { backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.success },
-                  }}
-                  aria-label={isFlash ? "Log flash" : "Log ascent"}
-                >
-                  <TickIcon isFlash={isFlash} />
-                </IconButton>
-              </TickButtonWithLabel>
-            </div>
+            {/* Action buttons — save button, hidden when expanded (QuickTickBar shows its own) */}
+            {!tickBarExpanded && (
+              <div className={styles.tickBarButtons}>
+                <TickButtonWithLabel label="save">
+                  <IconButton
+                    id="button-tick"
+                    onClick={(e) => quickTickBarRef.current?.save(e.currentTarget)}
+                    sx={{
+                      backgroundColor: themeTokens.colors.success,
+                      color: 'common.white',
+                      transition: 'background-color 150ms ease, color 150ms ease',
+                      '&:hover': { backgroundColor: themeTokens.colors.successHover },
+                    }}
+                    aria-label="Save tick"
+                  >
+                    <SaveOutlined />
+                  </IconButton>
+                </TickButtonWithLabel>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -331,8 +331,8 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
                 />
               }
             />
-            {/* Action buttons — save + attempt, hidden when expanded */}
-            {!tickBarExpanded && (
+            {/* Action buttons — save + attempt */}
+            {(
               <div className={styles.tickBarButtons}>
                 <TickButtonWithLabel label={isFlash ? 'flash' : 'tick'}>
                   <IconButton

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -13,11 +13,13 @@ import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
 import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
+import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
-import SaveOutlined from '@mui/icons-material/SaveOutlined';
-import { TickButtonWithLabel } from '../logbook/tick-icon';
+import { TickIcon, TickButtonWithLabel } from '../logbook/tick-icon';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { usePathname } from 'next/navigation';
 import { useQueueActions, useCurrentClimb, useQueueList, useSessionData } from '../graphql-queue';
 import { ClimbActions } from '../climb-actions';
@@ -219,17 +221,26 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
           ...(gradeTintColor ? { backgroundImage: `linear-gradient(${gradeTintColor}, ${gradeTintColor})` } : {}),
         }}
       >
-        {/* Drag handle — identical to queue control bar */}
-        <div className={styles.tickBarDragHandleRow}>
-          <div className={styles.tickBarDragHandle}>
-            <div className={styles.tickBarDragHandleBar} />
-          </div>
-        </div>
         {isTickBarActive && (
           <>
-            {/* Close button — top-right corner, hidden when expanded (QuickTickBar shows its own cancel) */}
-            {!tickBarExpanded && (
-              <div className={styles.tickBarClose}>
+            {/* Toolbar: expand left, close right — same pattern as queue-control-bar */}
+            <div className={styles.tickBarToolbar}>
+              <div
+                className={styles.tickBarExpandButton}
+                onClick={() => setTickBarExpanded((v) => !v)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setTickBarExpanded((v) => !v); }}
+                aria-label={tickBarExpanded ? 'Collapse tick bar' : 'Expand tick bar'}
+              >
+                {tickBarExpanded ? (
+                  <KeyboardArrowDownOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+                ) : (
+                  <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+                )}
+                <span className={styles.tickBarExpandLabel}>{tickBarExpanded ? 'Collapse' : 'Expand'}</span>
+              </div>
+              <div className={styles.tickBarCloseButton}>
                 <IconButton
                   size="small"
                   onClick={handleClose}
@@ -238,12 +249,13 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
                     color: 'text.primary',
                     backgroundColor: 'action.selected',
                     '&:hover': { backgroundColor: 'action.focus' },
+                    padding: '2px',
                   }}
                 >
                   <CloseOutlined sx={{ fontSize: 16 }} />
                 </IconButton>
               </div>
-            )}
+            </div>
             <QuickTickBar
               ref={quickTickBarRef}
               currentClimb={currentClimb}
@@ -255,8 +267,6 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
               onIsFlashChange={setIsFlash}
               comment={tickComment}
               expanded={tickBarExpanded}
-              onExpandedChange={setTickBarExpanded}
-              onClose={handleClose}
               commentSlot={
                 <div className={`${styles.tickBarComment} ${commentFocused ? styles.tickBarCommentExpanded : ''}`}>
                   <TextField
@@ -308,13 +318,6 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
                   onBlur={handleCommentBlur}
                   slotProps={{
                     htmlInput: { maxLength: 2000, 'aria-label': 'Tick comment' },
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
-                        </InputAdornment>
-                      ),
-                    },
                   }}
                   sx={{
                     '& .MuiOutlinedInput-root': {
@@ -328,22 +331,35 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
                 />
               }
             />
-            {/* Action buttons — save button, hidden when expanded (QuickTickBar shows its own) */}
+            {/* Action buttons — save + attempt, hidden when expanded */}
             {!tickBarExpanded && (
               <div className={styles.tickBarButtons}>
-                <TickButtonWithLabel label="save">
+                <TickButtonWithLabel label={isFlash ? 'flash' : 'tick'}>
                   <IconButton
                     id="button-tick"
                     onClick={(e) => quickTickBarRef.current?.save(e.currentTarget)}
                     sx={{
-                      backgroundColor: themeTokens.colors.success,
-                      color: 'common.white',
+                      backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.success,
+                      color: isFlash ? themeTokens.neutral[900] : 'common.white',
                       transition: 'background-color 150ms ease, color 150ms ease',
-                      '&:hover': { backgroundColor: themeTokens.colors.successHover },
+                      '&:hover': { backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.successHover },
                     }}
                     aria-label="Save tick"
                   >
-                    <SaveOutlined />
+                    <TickIcon isFlash={!!isFlash} />
+                  </IconButton>
+                </TickButtonWithLabel>
+                <TickButtonWithLabel label="attempt">
+                  <IconButton
+                    onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
+                    sx={{
+                      backgroundColor: themeTokens.colors.errorMuted,
+                      color: themeTokens.colors.error,
+                      '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
+                    }}
+                    aria-label="Log attempt"
+                  >
+                    <PersonFallingIcon />
                   </IconButton>
                 </TickButtonWithLabel>
               </div>

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -398,38 +398,39 @@
   transition: none;
 }
 
-/* Drag handle row — centered pill at top of tick bar */
-.tickDragHandleRow {
-  display: flex;
-  justify-content: center;
-  padding: 6px 0 2px;
-}
-
+/* Drag handle — absolutely centered across full tick bar width */
 .tickDragHandleBar {
+  position: absolute;
+  left: 50%;
+  top: 8px;
+  transform: translateX(-50%);
   width: 36px;
   height: 4px;
   border-radius: 2px;
   background-color: var(--neutral-200, #E5E7EB);
+  pointer-events: none;
+  z-index: 1;
 }
 
 :global(html[data-theme="dark"]) .tickDragHandleBar {
   background-color: var(--neutral-500, #6B7280);
 }
 
-/* Toolbar row — expand on left, close on right */
-.tickToolbar {
+/* Toolbar row — expand left, close right */
+.tickDragHandleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 4px 0 12px;
 }
 
-.tickExpandHeader {
+/* Expand button — matches .sessionHeader text style */
+.tickExpandButton {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   cursor: pointer;
   touch-action: manipulation;
+  flex-shrink: 0;
 }
 
 .tickExpandLabel {
@@ -437,8 +438,8 @@
   font-weight: 600;
 }
 
+/* Close button */
 .tickCloseButton {
-  position: static;
   flex-shrink: 0;
 }
 

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -398,32 +398,11 @@
   transition: none;
 }
 
-/* Toolbar row — expand on left, drag handle centered, close on right */
-.tickToolbar {
+/* Drag handle row — centered pill at top of tick bar */
+.tickDragHandleRow {
   display: flex;
-  align-items: center;
-  padding: 4px 4px 4px 12px;
-}
-
-.tickExpandHeader {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  touch-action: manipulation;
-  flex-shrink: 0;
-}
-
-.tickExpandLabel {
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.tickDragHandle {
-  flex: 1;
-  display: flex;
-  align-items: center;
   justify-content: center;
+  padding: 6px 0 2px;
 }
 
 .tickDragHandleBar {
@@ -437,7 +416,29 @@
   background-color: var(--neutral-500, #6B7280);
 }
 
+/* Toolbar row — expand on left, close on right */
+.tickToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4px 0 12px;
+}
+
+.tickExpandHeader {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.tickExpandLabel {
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .tickCloseButton {
+  position: static;
   flex-shrink: 0;
 }
 

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -398,24 +398,32 @@
   transition: none;
 }
 
-/* Drag handle row — centers the handle pill with close button at the right */
-.tickDragHandleRow {
-  position: relative;
+/* Toolbar row — expand on left, drag handle centered, close on right */
+.tickToolbar {
   display: flex;
-  justify-content: center;
-  padding: 0 0 4px;
+  align-items: center;
+  padding: 4px 4px 4px 12px;
+}
+
+.tickExpandHeader {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  touch-action: manipulation;
+  flex-shrink: 0;
+}
+
+.tickExpandLabel {
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .tickDragHandle {
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 0;
-  cursor: grab;
-}
-
-.tickDragHandle:active {
-  cursor: grabbing;
 }
 
 .tickDragHandleBar {
@@ -425,11 +433,12 @@
   background-color: var(--neutral-200, #E5E7EB);
 }
 
+:global(html[data-theme="dark"]) .tickDragHandleBar {
+  background-color: var(--neutral-500, #6B7280);
+}
+
 .tickCloseButton {
-  position: absolute;
-  right: 2px;
-  top: 2px;
-  z-index: 2;
+  flex-shrink: 0;
 }
 
 /* Comment input — fills available space in the left section */

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -36,6 +36,7 @@ import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMAT
 import PlayViewDrawer from '../play-view/play-view-drawer';
 import CircularProgress from '@mui/material/CircularProgress';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -1080,7 +1081,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         }}
                         aria-label="Log attempt"
                       >
-                        <CloseOutlined />
+                        <PersonFallingIcon />
                       </IconButton>
                     </TickButtonWithLabel>
                   ) : (

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -23,6 +23,8 @@ import PreviousClimbButton from './previous-climb-button';
 import QueueList, { QueueListHandle } from './queue-list';
 import { useSwipeable } from 'react-swipeable';
 import { TickButton } from '../logbook/tick-button';
+import { TickButtonWithLabel } from '../logbook/tick-icon';
+import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { QuickTickBar, type QuickTickBarHandle } from '../logbook/quick-tick-bar';
 import { hasPriorHistoryForClimb } from '@/app/hooks/use-tick-save';
 import { useBoardProvider } from '../board-provider/board-provider-context';
@@ -202,6 +204,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const [tickCommentFocused, setTickCommentFocused] = useState(false);
   const [isFlash, setIsFlash] = useState(
     () => !!currentClimb && !hasPriorHistoryForClimb(currentClimb, logbook),
+  );
+  const [ascentType, setAscentType] = useState<'flash' | 'send' | 'attempt'>(
+    () => isFlash ? 'flash' : 'send',
   );
   const quickTickBarRef = useRef<QuickTickBarHandle>(null);
 
@@ -486,6 +491,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     } else {
       setTickSwipeOffset(0);
       setIsFlash(false);
+      setAscentType('send');
       setTickBarExpanded(false);
       const timer = setTimeout(() => {
         setTickRowVisible(false);
@@ -907,15 +913,13 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               ...tickDismissStyle,
             }}
           >
+            {/* Drag handle — centered across full tick bar width */}
+            <div className={styles.tickDragHandleBar} />
             <div className={styles.tickRowInner}>
-              {/* Drag handle — swipe hint, always at top */}
+              {/* Toolbar: expand left, close right */}
               <div className={styles.tickDragHandleRow}>
-                <div className={styles.tickDragHandleBar} />
-              </div>
-              {/* Toolbar: expand on left, close on right */}
-              <div className={styles.tickToolbar}>
                 <div
-                  className={styles.tickExpandHeader}
+                  className={styles.tickExpandButton}
                   onClick={() => setTickBarExpanded((v) => !v)}
                   role="button"
                   tabIndex={0}
@@ -927,7 +931,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   ) : (
                     <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
                   )}
-                  <span className={styles.tickExpandLabel}>{tickBarExpanded ? 'collapse' : 'expand'}</span>
+                  <span className={styles.tickExpandLabel}>{tickBarExpanded ? 'Collapse' : 'Expand'}</span>
                 </div>
                 <div className={styles.tickCloseButton}>
                   <IconButton
@@ -961,6 +965,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   onError={() => showMessage('Couldn\u2019t save your tick. Give it another go.', 'error')}
                   onDraftRestored={(draftComment) => setTickComment(draftComment)}
                   onIsFlashChange={setIsFlash}
+                  onAscentTypeChange={setAscentType}
                   comment={tickComment}
                   commentSlot={
                     <div className={`${styles.tickComment} ${tickCommentFocused ? styles.tickCommentExpanded : ''}`}>
@@ -1149,7 +1154,23 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                     </Stack>
                   </span>
-                  <ShareBoardButton />
+                  {/* Attempt button — only visible in tick mode (collapsed) */}
+                  {tickBarActive && !tickBarExpanded && (
+                    <TickButtonWithLabel label="attempt">
+                      <IconButton
+                        onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
+                        sx={{
+                          backgroundColor: themeTokens.colors.errorMuted,
+                          color: themeTokens.colors.error,
+                          '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
+                        }}
+                        aria-label="Log attempt"
+                      >
+                        <PersonFallingIcon />
+                      </IconButton>
+                    </TickButtonWithLabel>
+                  )}
+                  {!tickBarActive && <ShareBoardButton />}
                   {/* Tick button — activates tick mode, or saves when already active */}
                   <TickButton
                     currentClimb={displayedClimb}
@@ -1159,6 +1180,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                     onTickSave={(el) => quickTickBarRef.current?.save(el)}
                     tickBarActive={tickBarActive}
                     isFlash={isFlash}
+                    ascentType={tickBarExpanded ? ascentType : undefined}
                   />
                 </Stack>
               </Box>

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1018,13 +1018,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       onBlur={handleTickCommentBlur}
                       slotProps={{
                         htmlInput: { maxLength: 2000, 'aria-label': 'Tick comment' },
-                        input: {
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
-                            </InputAdornment>
-                          ),
-                        },
                       }}
                       sx={{
                         '& .MuiOutlinedInput-root': {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -908,7 +908,11 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
             }}
           >
             <div className={styles.tickRowInner}>
-              {/* Toolbar: expand on left, drag handle centered, close on right */}
+              {/* Drag handle — swipe hint, always at top */}
+              <div className={styles.tickDragHandleRow}>
+                <div className={styles.tickDragHandleBar} />
+              </div>
+              {/* Toolbar: expand on left, close on right */}
               <div className={styles.tickToolbar}>
                 <div
                   className={styles.tickExpandHeader}
@@ -924,9 +928,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                     <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
                   )}
                   <span className={styles.tickExpandLabel}>{tickBarExpanded ? 'collapse' : 'expand'}</span>
-                </div>
-                <div className={styles.tickDragHandle} aria-hidden="true">
-                  <div className={styles.tickDragHandleBar} />
                 </div>
                 <div className={styles.tickCloseButton}>
                   <IconButton

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -23,7 +23,6 @@ import PreviousClimbButton from './previous-climb-button';
 import QueueList, { QueueListHandle } from './queue-list';
 import { useSwipeable } from 'react-swipeable';
 import { TickButton } from '../logbook/tick-button';
-import { TickButtonWithLabel } from '../logbook/tick-icon';
 import { QuickTickBar, type QuickTickBarHandle } from '../logbook/quick-tick-bar';
 import { hasPriorHistoryForClimb } from '@/app/hooks/use-tick-save';
 import { useBoardProvider } from '../board-provider/board-provider-context';
@@ -36,7 +35,8 @@ import { useCardSwipeNavigation, EXIT_DURATION, SNAP_BACK_DURATION, ENTER_ANIMAT
 import PlayViewDrawer from '../play-view/play-view-drawer';
 import CircularProgress from '@mui/material/CircularProgress';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
-import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
+import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
+import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -204,6 +204,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     () => !!currentClimb && !hasPriorHistoryForClimb(currentClimb, logbook),
   );
   const quickTickBarRef = useRef<QuickTickBarHandle>(null);
+
+  // Whether the tick bar is in expanded mode (all pickers visible).
+  const [tickBarExpanded, setTickBarExpanded] = useState(false);
 
   // Swipe-to-dismiss state — tracks vertical offset during down-swipe gesture.
   const [tickSwipeOffset, setTickSwipeOffset] = useState(0);
@@ -483,6 +486,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     } else {
       setTickSwipeOffset(0);
       setIsFlash(false);
+      setTickBarExpanded(false);
       const timer = setTimeout(() => {
         setTickRowVisible(false);
         setTickComment('');
@@ -499,27 +503,47 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       if (!tickSwipeEnabled) return;
       const target = eventData.event.target as HTMLElement | null;
       if (target?.closest('[data-scrollable-picker]')) return;
-      // Only track downward swipes; ignore horizontal-dominant gestures
       if (Math.abs(eventData.deltaX) > Math.abs(eventData.deltaY)) return;
-      if (eventData.deltaY < 0) { setTickSwipeOffset(0); return; }
-      setTickSwipeOffset(eventData.deltaY);
+      if (tickBarExpanded) {
+        // Expanded: only track downward
+        if (eventData.deltaY > 0) setTickSwipeOffset(eventData.deltaY);
+        else setTickSwipeOffset(0);
+      } else {
+        // Compact: track both directions
+        setTickSwipeOffset(eventData.deltaY);
+      }
+    },
+    onSwipedUp: (eventData) => {
+      if (!tickSwipeEnabled) return;
+      const target = eventData.event.target as HTMLElement | null;
+      if (target?.closest('[data-scrollable-picker]')) return;
+      if (!tickBarExpanded && Math.abs(eventData.deltaY) >= 50) {
+        setTickBarExpanded(true);
+      }
+      setTickSwipeOffset(0);
     },
     onSwipedDown: (eventData) => {
       if (!tickSwipeEnabled) return;
       const target = eventData.event.target as HTMLElement | null;
       if (target?.closest('[data-scrollable-picker]')) return;
-      if (Math.abs(eventData.deltaY) >= 80) {
-        // Just close — the CSS grid collapse animation handles the visual exit
-        setActiveDrawer('none');
+      if (tickBarExpanded) {
+        if (Math.abs(eventData.deltaY) >= 120 || eventData.velocity > 0.5) {
+          setActiveDrawer('none');
+        } else if (Math.abs(eventData.deltaY) >= 50) {
+          setTickBarExpanded(false);
+        }
       } else {
-        setTickSwipeOffset(0);
+        if (Math.abs(eventData.deltaY) >= 80) {
+          setActiveDrawer('none');
+        }
       }
+      setTickSwipeOffset(0);
     },
     onSwiped: (eventData) => {
       if (!tickSwipeEnabled) return;
       const target = eventData.event.target as HTMLElement | null;
       if (target?.closest('[data-scrollable-picker]')) return;
-      if (eventData.dir !== 'Down') setTickSwipeOffset(0);
+      if (eventData.dir !== 'Down' && eventData.dir !== 'Up') setTickSwipeOffset(0);
     },
     trackMouse: false,
     preventScrollOnSwipe: false,
@@ -528,6 +552,11 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   const tickDismissStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (tickSwipeOffset === 0) {
+      return { transition: 'grid-template-rows 200ms ease-out, opacity 200ms ease-out' };
+    }
+    // Only apply visual dismiss feedback for downward swipes (positive offset).
+    // Upward swipes (negative offset) snap back — the expand animation handles the visual.
+    if (tickSwipeOffset < 0) {
       return { transition: 'grid-template-rows 200ms ease-out, opacity 200ms ease-out' };
     }
     const fraction = Math.max(0, 1 - tickSwipeOffset / 150);
@@ -878,26 +907,41 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               ...tickDismissStyle,
             }}
           >
-            {/* Close button — top-right corner of the tick bar */}
-            <div className={styles.tickCloseButton}>
-              <IconButton
-                onClick={() => setActiveDrawer('none')}
-                size="small"
-                aria-label="Close tick bar"
-                sx={{
-                  color: 'text.primary',
-                  backgroundColor: 'action.selected',
-                  '&:hover': { backgroundColor: 'action.focus' },
-                }}
-              >
-                <CloseOutlined sx={{ fontSize: 16 }} />
-              </IconButton>
-            </div>
             <div className={styles.tickRowInner}>
-              {/* Drag handle */}
-              <div className={styles.tickDragHandleRow}>
+              {/* Toolbar: expand on left, drag handle centered, close on right */}
+              <div className={styles.tickToolbar}>
+                <div
+                  className={styles.tickExpandHeader}
+                  onClick={() => setTickBarExpanded((v) => !v)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setTickBarExpanded((v) => !v); }}
+                  aria-label={tickBarExpanded ? 'Collapse tick bar' : 'Expand tick bar'}
+                >
+                  {tickBarExpanded ? (
+                    <KeyboardArrowDownOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+                  ) : (
+                    <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
+                  )}
+                  <span className={styles.tickExpandLabel}>{tickBarExpanded ? 'collapse' : 'expand'}</span>
+                </div>
                 <div className={styles.tickDragHandle} aria-hidden="true">
                   <div className={styles.tickDragHandleBar} />
+                </div>
+                <div className={styles.tickCloseButton}>
+                  <IconButton
+                    onClick={() => setActiveDrawer('none')}
+                    size="small"
+                    aria-label="Close tick bar"
+                    sx={{
+                      color: 'text.primary',
+                      backgroundColor: 'action.selected',
+                      '&:hover': { backgroundColor: 'action.focus' },
+                      padding: '2px',
+                    }}
+                  >
+                    <CloseOutlined sx={{ fontSize: 16 }} />
+                  </IconButton>
                 </div>
               </div>
               {tickBarActive && (
@@ -906,6 +950,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   currentClimb={currentClimb}
                   angle={angle}
                   boardDetails={boardDetails}
+                  expanded={tickBarExpanded}
                   onSave={() => {
                     if (currentClimb) {
                       setLocalTickedClimbs((prev) => new Set(prev).add(currentClimb.uuid));
@@ -951,6 +996,40 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         }}
                       />
                     </div>
+                  }
+                  expandedCommentSlot={
+                    <TextField
+                      fullWidth
+                      size="small"
+                      variant="outlined"
+                      placeholder="Comment..."
+                      multiline
+                      minRows={2}
+                      maxRows={4}
+                      value={tickComment}
+                      onChange={(e) => setTickComment(e.target.value)}
+                      onFocus={handleTickCommentFocus}
+                      onBlur={handleTickCommentBlur}
+                      slotProps={{
+                        htmlInput: { maxLength: 2000, 'aria-label': 'Tick comment' },
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <ChatBubbleOutlineOutlined sx={{ fontSize: 16, opacity: 0.5 }} />
+                            </InputAdornment>
+                          ),
+                        },
+                      }}
+                      sx={{
+                        '& .MuiOutlinedInput-root': {
+                          borderRadius: '8px',
+                          backgroundColor: 'var(--input-bg)',
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: 'var(--neutral-200)',
+                          },
+                        },
+                      }}
+                    />
                   }
                 />
               )}
@@ -1069,24 +1148,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                     </Stack>
                   </span>
-                  {/* Party / Cancel button — swaps to X when tick mode is active */}
-                  {tickBarActive ? (
-                    <TickButtonWithLabel label="attempt">
-                      <IconButton
-                        onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
-                        sx={{
-                          backgroundColor: themeTokens.colors.errorMuted,
-                          color: themeTokens.colors.error,
-                          '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
-                        }}
-                        aria-label="Log attempt"
-                      >
-                        <PersonFallingIcon />
-                      </IconButton>
-                    </TickButtonWithLabel>
-                  ) : (
-                    <ShareBoardButton />
-                  )}
+                  <ShareBoardButton />
                   {/* Tick button — activates tick mode, or saves when already active */}
                   <TickButton
                     currentClimb={displayedClimb}

--- a/packages/web/app/hooks/__tests__/use-confetti.test.ts
+++ b/packages/web/app/hooks/__tests__/use-confetti.test.ts
@@ -95,7 +95,7 @@ describe('useConfetti', () => {
     });
   });
 
-  describe('flash variant (electric arcs)', () => {
+  describe('flash variant (lightning bolts)', () => {
     it('does not fire canvas-confetti', () => {
       const { result } = renderHook(() => useConfetti());
       const el = createMockElement();
@@ -109,45 +109,34 @@ describe('useConfetti', () => {
       const el = createMockElement();
       result.current(el, 'flash');
 
-      const overlay = document.body.querySelector('[style*="z-index: 1500"]') as HTMLElement;
+      const overlay = document.body.querySelector('[style*="z-index"]') as HTMLElement;
       expect(overlay).not.toBeNull();
       expect(overlay.style.position).toBe('fixed');
       expect(overlay.style.pointerEvents).toBe('none');
     });
 
-    it('overlay contains SVG with arc paths', () => {
+    it('overlay contains SVG with filled bolt paths', () => {
       const { result } = renderHook(() => useConfetti());
       const el = createMockElement();
       result.current(el, 'flash');
 
-      const overlay = document.body.querySelector('[style*="z-index: 1500"]') as HTMLElement;
-      // innerHTML should contain SVG path elements for the electric arcs
+      const overlay = document.body.querySelector('[style*="z-index"]') as HTMLElement;
       expect(overlay.innerHTML).toContain('<svg');
       expect(overlay.innerHTML).toContain('<path');
-      expect(overlay.innerHTML).toContain('#FFC107');
+      // Bolts are filled yellow with dark outline
+      expect(overlay.innerHTML).toContain('#FDE74C');
+      expect(overlay.innerHTML).toContain('#333');
     });
 
-    it('arc paths originate near element edge, not center', () => {
-      const { result } = renderHook(() => useConfetti());
-      const el = createMockElement(100, 400, 40, 40);
-      result.current(el, 'flash');
-
-      const overlay = document.body.querySelector('[style*="z-index: 1500"]') as HTMLElement;
-      // Paths should NOT start at the exact center (120, 420)
-      // They start from the button edge (radius ~20px away from center)
-      expect(overlay.innerHTML).not.toContain('M 120 420');
-      // But should still contain path data
-      expect(overlay.innerHTML).toContain('<path');
-    });
-
-    it('does not contain a screen flash div', () => {
+    it('generates 6 bolt groups', () => {
       const { result } = renderHook(() => useConfetti());
       const el = createMockElement();
       result.current(el, 'flash');
 
-      const overlay = document.body.querySelector('[style*="z-index: 1500"]') as HTMLElement;
-      // Should not have a full-screen white flash div
-      expect(overlay.innerHTML).not.toContain('background:white');
+      const overlay = document.body.querySelector('[style*="z-index"]') as HTMLElement;
+      // Each bolt is a <g> with data-tx attribute
+      const boltMatches = overlay.innerHTML.match(/data-tx/g);
+      expect(boltMatches?.length).toBe(6);
     });
 
     it('removes overlay after 300ms', () => {
@@ -155,10 +144,10 @@ describe('useConfetti', () => {
       const el = createMockElement();
       result.current(el, 'flash');
 
-      const overlays = document.body.querySelectorAll('[style*="z-index: 1500"]');
+      const overlays = document.body.querySelectorAll('[style*="z-index"]');
       expect(overlays.length).toBe(1);
       vi.advanceTimersByTime(300);
-      const overlaysAfter = document.body.querySelectorAll('[style*="z-index: 1500"]');
+      const overlaysAfter = document.body.querySelectorAll('[style*="z-index"]');
       expect(overlaysAfter.length).toBe(0);
     });
 
@@ -167,7 +156,7 @@ describe('useConfetti', () => {
       result.current(null, 'flash');
 
       expect(mockConfetti).not.toHaveBeenCalled();
-      const overlays = document.body.querySelectorAll('[style*="z-index: 1500"]');
+      const overlays = document.body.querySelectorAll('[style*="z-index"]');
       expect(overlays.length).toBe(0);
     });
   });

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -492,4 +492,108 @@ describe('useTickSave', () => {
       }),
     );
   });
+
+  describe('forceAttempt parameter', () => {
+    it('saveAttempt forces attempt status even when explicitAscentType is flash', () => {
+      const onSave = vi.fn();
+      const opts = makeOptions({
+        onSave,
+        ascentType: 'flash',
+        tickTarget: {
+          climb: makeClimb(),
+          angle: 40 as Angle,
+          boardDetails: makeBoardDetails(),
+          hasPriorHistory: false,
+        },
+        attemptCount: 1,
+      });
+
+      const { result } = renderHook(() => useTickSave(opts));
+
+      act(() => {
+        result.current.saveAttempt();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('attempt');
+      expect(mockFireConfetti).toHaveBeenCalledWith(null, 'attempt');
+    });
+
+    it('saveAttempt forces attempt status even when explicitAscentType is send', () => {
+      const onSave = vi.fn();
+      const opts = makeOptions({
+        onSave,
+        ascentType: 'send',
+        tickTarget: {
+          climb: makeClimb(),
+          angle: 40 as Angle,
+          boardDetails: makeBoardDetails(),
+          hasPriorHistory: true,
+        },
+        attemptCount: 1,
+      });
+
+      const { result } = renderHook(() => useTickSave(opts));
+
+      act(() => {
+        result.current.saveAttempt();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('attempt');
+      expect(mockFireConfetti).toHaveBeenCalledWith(null, 'attempt');
+    });
+
+    it('save uses explicitAscentType when provided', () => {
+      const onSave = vi.fn();
+      const opts = makeOptions({
+        onSave,
+        ascentType: 'send',
+        tickTarget: {
+          climb: makeClimb(),
+          angle: 40 as Angle,
+          boardDetails: makeBoardDetails(),
+          hasPriorHistory: false,
+        },
+        attemptCount: 1,
+      });
+
+      const { result } = renderHook(() => useTickSave(opts));
+
+      act(() => {
+        result.current.save();
+      });
+
+      // Even though hasPriorHistory=false and attemptCount=1 would normally infer flash,
+      // explicitAscentType='send' should take priority
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('send');
+      expect(mockFireConfetti).toHaveBeenCalledWith(null, 'ascent');
+    });
+
+    it('save infers flash when no prior history and 1 try', () => {
+      const onSave = vi.fn();
+      const opts = makeOptions({
+        onSave,
+        // No ascentType provided — let the hook infer
+        tickTarget: {
+          climb: makeClimb(),
+          angle: 40 as Angle,
+          boardDetails: makeBoardDetails(),
+          hasPriorHistory: false,
+        },
+        attemptCount: 1,
+      });
+
+      const { result } = renderHook(() => useTickSave(opts));
+
+      act(() => {
+        result.current.save();
+      });
+
+      const call = mockSaveTick.mock.calls[0][0];
+      expect(call.status).toBe('flash');
+      expect(mockFireConfetti).toHaveBeenCalledWith(null, 'flash');
+    });
+  });
 });

--- a/packages/web/app/hooks/use-confetti.ts
+++ b/packages/web/app/hooks/use-confetti.ts
@@ -4,46 +4,22 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 export type ConfettiVariant = 'ascent' | 'attempt' | 'flash';
 
-let arcGlowCounter = 0;
-
-function buildArcPath(cx: number, cy: number, angle: number, startDist: number, length: number): string {
-  const startX = cx + Math.cos(angle) * startDist;
-  const startY = cy + Math.sin(angle) * startDist;
-  let d = `M ${startX.toFixed(1)} ${startY.toFixed(1)}`;
-
-  const segments = 4;
-  for (let s = 1; s <= segments; s++) {
-    const progress = s / segments;
-    const jitter = (Math.random() - 0.5) * 14;
-    const px = startX + Math.cos(angle) * length * progress + Math.sin(angle) * jitter;
-    const py = startY + Math.sin(angle) * length * progress - Math.cos(angle) * jitter;
-    d += ` L ${px.toFixed(1)} ${py.toFixed(1)}`;
-  }
-
-  return d;
-}
-
-function buildArcSvgPair(d: string, length: number, delay: string, filterId: string): string {
-  const segLen = Math.round(length * 0.4);
-  const totalLen = Math.round(length * 1.2);
-  return `
-    <path d="${d}" fill="none" stroke="#FFC107" stroke-width="2.5"
-          filter="url(#${filterId})"
-          stroke-dasharray="${segLen} ${totalLen}"
-          stroke-dashoffset="${segLen}"
-          style="animation: arc-crawl 0.25s ${delay}s ease-out forwards"/>
-    <path d="${d}" fill="none" stroke="white" stroke-width="1"
-          stroke-dasharray="${segLen} ${totalLen}"
-          stroke-dashoffset="${segLen}"
-          style="animation: arc-crawl 0.25s ${delay}s ease-out forwards"/>`;
+/**
+ * Generates a small lightning bolt polygon path string (relative coordinates)
+ * that can be placed in an SVG <path> with a transform for positioning/rotation.
+ * The bolt is ~24px tall, ~10px wide, pointing "up" (negative y direction).
+ */
+function buildBoltShape(): string {
+  // A zigzag lightning bolt polygon (~32px tall, ~16px wide)
+  return 'M 0,-16 L 6,-5 L 2,-5 L 7,5 L 3,5 L 8,16 L -1,4 L 3,4 L -3,-4 L 1,-4 L -4,-16 Z';
 }
 
 let activeOverlay: HTMLElement | null = null;
 
 /**
- * Fires short electric arcs radiating outward from the target element's
- * edge. The overlay is appended to document.body so it's independent of
- * React's render tree and survives component unmounts.
+ * Fires small solid lightning bolt shapes radiating outward from the target
+ * element's edge. The overlay is appended to document.body so it's independent
+ * of React's render tree and survives component unmounts.
  */
 function fireThunderstrike(targetElement: HTMLElement) {
   // Respect reduced motion preference
@@ -55,21 +31,34 @@ function fireThunderstrike(targetElement: HTMLElement) {
     activeOverlay = null;
   }
 
-  const filterId = `arc-glow-${++arcGlowCounter}`;
   const rect = targetElement.getBoundingClientRect();
   const cx = rect.left + rect.width / 2;
   const cy = rect.top + rect.height / 2;
   const buttonRadius = Math.max(rect.width, rect.height) / 2;
 
-  const arcCount = 8;
-  let paths = '';
-  for (let i = 0; i < arcCount; i++) {
-    const angle = (i / arcCount) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
-    const length = 45 + Math.random() * 35;
-    const startDist = buttonRadius + 2 + Math.random() * 4;
-    const d = buildArcPath(cx, cy, angle, startDist, length);
-    const delay = (Math.random() * 0.05).toFixed(3);
-    paths += buildArcSvgPair(d, length, delay, filterId);
+  const boltCount = 6;
+  const boltShape = buildBoltShape();
+  let bolts = '';
+
+  for (let i = 0; i < boltCount; i++) {
+    const angle = (i / boltCount) * Math.PI * 2 + (Math.random() - 0.5) * 0.3;
+    const startDist = buttonRadius + 4 + Math.random() * 4;
+    const x = cx + Math.cos(angle) * startDist;
+    const y = cy + Math.sin(angle) * startDist;
+    // Rotate bolt to point outward (angle in degrees, offset by 90 since bolt points up)
+    const rotDeg = (angle * 180 / Math.PI) + 90;
+    // Each bolt translates outward during animation
+    const tx = Math.cos(angle) * 35;
+    const ty = Math.sin(angle) * 35;
+    const delay = (Math.random() * 0.04).toFixed(3);
+
+    bolts += `
+      <g style="animation: bolt-fly 0.25s ${delay}s ease-out both"
+         transform="translate(${x.toFixed(1)}, ${y.toFixed(1)}) rotate(${rotDeg.toFixed(1)})"
+         data-tx="${tx.toFixed(1)}" data-ty="${ty.toFixed(1)}">
+        <path d="${boltShape}" fill="#FDE74C" stroke="#333" stroke-width="2"
+              stroke-linejoin="round"/>
+      </g>`;
   }
 
   const overlay = document.createElement('div');
@@ -80,26 +69,39 @@ function fireThunderstrike(targetElement: HTMLElement) {
     pointer-events: none;
   `;
   overlay.innerHTML = `
-    <svg width="100%" height="100%" style="position:absolute;inset:0">
-      <defs>
-        <filter id="${filterId}">
-          <feGaussianBlur stdDeviation="2" result="blur"/>
-          <feMerge>
-            <feMergeNode in="blur"/>
-            <feMergeNode in="SourceGraphic"/>
-          </feMerge>
-        </filter>
-      </defs>
-      ${paths}
+    <svg width="100%" height="100%" style="position:absolute;inset:0;overflow:visible">
+      ${bolts}
     </svg>
     <style>
-      @keyframes arc-crawl {
-        0% { stroke-dashoffset: ${Math.round(45 * 0.4)}; opacity: 1; }
-        70% { opacity: 0.8; }
-        100% { stroke-dashoffset: -${Math.round(80 * 1.2)}; opacity: 0; }
+      @keyframes bolt-fly {
+        0% { opacity: 0; transform: translate(var(--x), var(--y)) rotate(var(--r)) scale(0.5); }
+        20% { opacity: 1; transform: translate(var(--x), var(--y)) rotate(var(--r)) scale(1); }
+        100% { opacity: 0; transform: translate(calc(var(--x) + var(--tx)), calc(var(--y) + var(--ty))) rotate(var(--r)) scale(0.8); }
       }
     </style>
   `;
+
+  // Apply CSS custom properties to each bolt for the animation
+  const groups = overlay.querySelectorAll('g[data-tx]');
+  groups.forEach((g) => {
+    const el = g as HTMLElement;
+    const transform = el.getAttribute('transform') || '';
+    const txVal = el.dataset.tx || '0';
+    const tyVal = el.dataset.ty || '0';
+    // Extract translate and rotate from the transform attribute
+    const translateMatch = transform.match(/translate\(([\d.-]+),\s*([\d.-]+)\)/);
+    const rotateMatch = transform.match(/rotate\(([\d.-]+)\)/);
+    const xPos = translateMatch ? translateMatch[1] : '0';
+    const yPos = translateMatch ? translateMatch[2] : '0';
+    const rot = rotateMatch ? rotateMatch[1] : '0';
+    el.style.setProperty('--x', `${xPos}px`);
+    el.style.setProperty('--y', `${yPos}px`);
+    el.style.setProperty('--r', `${rot}deg`);
+    el.style.setProperty('--tx', `${txVal}px`);
+    el.style.setProperty('--ty', `${tyVal}px`);
+    // Remove the static transform since animation handles positioning
+    el.removeAttribute('transform');
+  });
 
   document.body.appendChild(overlay);
   activeOverlay = overlay;
@@ -133,7 +135,7 @@ function getOrigin(element?: HTMLElement | null): { x: number; y: number } {
  * Variant controls the style:
  * - 'ascent' (default): multi-colour celebratory confetti burst
  * - 'attempt': red-only confetti, shorter range
- * - 'flash': electric arcs radiate from the origin element
+ * - 'flash': lightning bolt shapes radiate from the origin element
  */
 export function useConfetti() {
   const fireConfetti = useCallback((originElement?: HTMLElement | null, variant: ConfettiVariant = 'ascent') => {

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -23,6 +23,8 @@ export interface UseTickSaveOptions {
   difficulty: number | undefined;
   attemptCount: number;
   comment: string;
+  /** Explicit ascent type. When provided, overrides the inferred status logic. */
+  ascentType?: TickStatus;
   onSave: () => void;
   onError?: () => void;
 }
@@ -71,7 +73,7 @@ export function useTickSave(options: UseTickSaveOptions): {
   save: (originElement?: HTMLElement | null) => void;
   saveAttempt: (originElement?: HTMLElement | null) => void;
 } {
-  const { tickTarget, quality, difficulty, attemptCount, comment, onSave, onError } = options;
+  const { tickTarget, quality, difficulty, attemptCount, comment, ascentType: explicitAscentType, onSave, onError } = options;
   const { saveTick } = useBoardProvider();
   const fireConfetti = useConfetti();
   const saving = useRef(false);
@@ -85,14 +87,18 @@ export function useTickSave(options: UseTickSaveOptions): {
   }, []);
 
   const handleSave = useCallback(
-    (isAscent: boolean, confettiOrigin?: HTMLElement | null) => {
+    (isAscent: boolean, confettiOrigin?: HTMLElement | null, forceAttempt?: boolean) => {
       if (!tickTarget || saving.current) return;
       saving.current = true;
 
       const { climb, angle: targetAngle, boardDetails: targetBoard, hasPriorHistory } = tickTarget;
 
       let status: TickStatus;
-      if (isAscent) {
+      if (forceAttempt) {
+        status = 'attempt';
+      } else if (explicitAscentType) {
+        status = explicitAscentType;
+      } else if (isAscent) {
         status = hasPriorHistory || attemptCount > 1 ? 'send' : 'flash';
       } else {
         status = 'attempt';
@@ -102,7 +108,11 @@ export function useTickSave(options: UseTickSaveOptions): {
       const draftValues = { climbUuid: climb.uuid, angle: Number(targetAngle), quality, difficulty, attemptCount, comment, status };
 
       // Fire celebration and close the bar -- don't wait for the network.
-      const variant = !isAscent ? 'attempt' : status === 'flash' ? 'flash' : 'ascent';
+      // When an explicit ascentType is provided, derive the variant from status
+      // (the isAscent boolean is only meaningful for the legacy two-method API).
+      const variant = explicitAscentType
+        ? (status === 'attempt' ? 'attempt' : status === 'flash' ? 'flash' : 'ascent')
+        : (!isAscent ? 'attempt' : status === 'flash' ? 'flash' : 'ascent');
       fireConfetti(confettiOrigin ?? null, variant);
       // Flash: brief 300ms delay so the button pulse + sparks play before the bar closes.
       if (variant === 'flash') {
@@ -150,11 +160,11 @@ export function useTickSave(options: UseTickSaveOptions): {
         onError?.();
       });
     },
-    [tickTarget, quality, difficulty, comment, saveTick, onSave, attemptCount, fireConfetti, onError],
+    [tickTarget, quality, difficulty, comment, explicitAscentType, saveTick, onSave, attemptCount, fireConfetti, onError],
   );
 
-  const save = useCallback((originElement?: HTMLElement | null) => handleSave(true, originElement), [handleSave]);
-  const saveAttempt = useCallback((originElement?: HTMLElement | null) => handleSave(false, originElement), [handleSave]);
+  const save = useCallback((originElement?: HTMLElement | null) => handleSave(true, originElement, false), [handleSave]);
+  const saveAttempt = useCallback((originElement?: HTMLElement | null) => handleSave(false, originElement, true), [handleSave]);
 
   return { save, saveAttempt };
 }

--- a/packages/web/app/legal/legal-content.tsx
+++ b/packages/web/app/legal/legal-content.tsx
@@ -260,6 +260,34 @@ export default function LegalContent() {
                 </Typography>
               </section>
 
+              {/* Third-Party Notices */}
+              <section>
+                <Typography variant="h3">Third-Party Notices</Typography>
+                <ul className={styles.featureList}>
+                  <li>
+                    <Typography variant="body1" component="span">
+                      <strong>Person Falling icon</strong> from{' '}
+                      <MuiLink
+                        href="https://fontawesome.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Font Awesome Free 6.7.2
+                      </MuiLink>{' '}
+                      by @fontawesome. License:{' '}
+                      <MuiLink
+                        href="https://fontawesome.com/license/free"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        CC BY 4.0
+                      </MuiLink>
+                      . Copyright 2024 Fonticons, Inc.
+                    </Typography>
+                  </li>
+                </ul>
+              </section>
+
               {/* Footer */}
               <section className={styles.callToAction}>
                 <Typography variant="body2" component="p" color="text.secondary">


### PR DESCRIPTION
Users found the X icon for attempts confusing since it overlaps with close buttons on drawers. Uses FA person-falling (CC BY 4.0) as a custom MUI SvgIcon with a 30deg tilt for a clear falling posture.