### PR TITLE
Fix four latent code quality issues

### DIFF
--- a/packages/web/app/components/logbook/tick-icon.module.css
+++ b/packages/web/app/components/logbook/tick-icon.module.css
@@ -12,7 +12,7 @@
   left: 50%;
   transform: translateX(-50%);
   margin-top: 1px;
-  font-size: 8px;
+  font-size: var(--font-size-2xs);
   font-weight: 500;
   line-height: 1;
   letter-spacing: 0.02em;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -246,7 +246,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
     setCommentFocused(false);
     setIsFlash(!hasPriorHistoryForClimb(currentClimb, logbook));
     setTickBarExpanded(false);
-  }, [currentClimb.uuid, currentClimb, logbook]);
+  }, [currentClimb, logbook]);
 
   return (
     <div className={`${styles.tickBarContainer} ${isTickBarActive ? styles.tickBarContainerActive : ''}`}>

--- a/packages/web/app/hooks/use-confetti.ts
+++ b/packages/web/app/hooks/use-confetti.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 import confetti from 'canvas-confetti';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -172,6 +172,7 @@ export function useTickSave(options: UseTickSaveOptions): {
             hasComment: comment.length > 0,
           });
           void clearTickDraft(climb.uuid, Number(targetAngle));
+          saving.current = false;
         })
         .catch(() => {
           track('Quick Tick Failed', {


### PR DESCRIPTION
- Reset saving.current on success in useTickSave to prevent the hook from permanently locking if the component stays alive between saves
- Add 'use client' to use-confetti.ts to make the module boundary explicit and prevent accidental server import
- Replace hardcoded 8px with var(--font-size-2xs) in tick-icon.module.css to actually consume the design token
- Remove redundant currentClimb.uuid from useEffect deps in play-view-drawer (currentClimb already covers it)

https://claude.ai/code/session_011UTKBwmQbg8pVTU6EfnBJU