### PR TITLE
Show error snackbar when setCurrentClimb fails in logbook feed item

### DIFF
--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -16,6 +16,7 @@ type SwipeOptions = {
 let capturedSwipeOptions: SwipeOptions | null = null;
 const updateTickAsyncMock = vi.fn();
 const setCurrentClimbMock = vi.fn();
+const showMessageMock = vi.fn();
 const dispatchOpenPlayDrawerMock = vi.fn();
 // Holder so tests can swap queue-actions availability without remounting.
 const queueActionsState: { value: { setCurrentClimb: typeof setCurrentClimbMock } | null } = {
@@ -115,6 +116,10 @@ vi.mock('@/app/components/graphql-queue', () => ({
   useOptionalQueueActions: () => queueActionsState.value,
 }));
 
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: showMessageMock }),
+}));
+
 vi.mock('@/app/components/queue-control/play-drawer-event', () => ({
   dispatchOpenPlayDrawer: () => dispatchOpenPlayDrawerMock(),
 }));
@@ -197,6 +202,7 @@ beforeEach(() => {
   capturedSwipeOptions = null;
   updateTickAsyncMock.mockReset();
   setCurrentClimbMock.mockReset();
+  showMessageMock.mockReset();
   dispatchOpenPlayDrawerMock.mockReset();
   queueActionsState.value = { setCurrentClimb: setCurrentClimbMock };
   updateTickState.isPending = false;
@@ -335,12 +341,12 @@ describe('LogbookFeedItem', () => {
   it('reflects updateTick.isPending via the getter mock without remount', () => {
     updateTickState.isPending = true;
     const { rerender } = render(<LogbookFeedItem item={makeItem()} isEditing />);
-    const saveBtn = screen.getByLabelText('Save') as HTMLButtonElement;
+    const saveBtn = screen.getByLabelText('Save');
     expect(saveBtn.disabled).toBe(true);
 
     updateTickState.isPending = false;
     rerender(<LogbookFeedItem item={makeItem()} isEditing />);
-    const saveBtn2 = screen.getByLabelText('Save') as HTMLButtonElement;
+    const saveBtn2 = screen.getByLabelText('Save');
     expect(saveBtn2.disabled).toBe(false);
   });
 
@@ -366,6 +372,7 @@ describe('LogbookFeedItem', () => {
     const row = container.querySelector('.swipeableContent') as HTMLElement;
     fireEvent.click(row);
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
+    expect(showMessageMock).not.toHaveBeenCalled();
   });
 
   it('row is keyboard-accessible with role/tabIndex/aria-label', () => {
@@ -432,6 +439,25 @@ describe('LogbookFeedItem', () => {
     render(<LogbookFeedItem item={makeItem()} />);
     fireEvent.click(screen.getByLabelText('More actions'));
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
+  });
+
+  it('shows an error snackbar when row click rejects', async () => {
+    setCurrentClimbMock.mockRejectedValueOnce(new Error('network'));
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    await act(async () => {
+      fireEvent.click(row);
+    });
+    expect(showMessageMock).toHaveBeenCalledWith('Could not load climb — try again', 'error');
+  });
+
+  it('shows an error snackbar when thumbnail click rejects', async () => {
+    setCurrentClimbMock.mockRejectedValueOnce(new Error('network'));
+    render(<LogbookFeedItem item={makeItem()} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ascent-thumbnail'));
+    });
+    expect(showMessageMock).toHaveBeenCalledWith('Could not load climb — try again', 'error');
   });
 
   it('keeps the comment row container mounted in both modes (U8)', () => {

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -30,6 +30,7 @@ import { track } from '@vercel/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
 import { useOptionalQueueActions } from '@/app/components/graphql-queue';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { dispatchOpenPlayDrawer } from '@/app/components/queue-control/play-drawer-event';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { ClimbActions } from '@/app/components/climb-actions';
@@ -315,6 +316,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
     const queueActions = useOptionalQueueActions();
+    const { showMessage } = useSnackbar();
 
     // --- Edit state ---
     const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -444,8 +446,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
         track('Logbook Row Clicked', { climbUuid: climb.uuid });
       } catch (err) {
         console.error('Failed to set active climb from logbook row', err);
+        showMessage('Could not load climb — try again', 'error');
       }
-    }, [isEditing, queueActions, climb]);
+    }, [isEditing, queueActions, climb, showMessage]);
 
     const handleRowKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
@@ -468,9 +471,10 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
           track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
         } catch (err) {
           console.error('Failed to set active climb from logbook thumbnail', err);
+          showMessage('Could not load climb — try again', 'error');
         }
       },
-      [isEditing, queueActions, climb],
+      [isEditing, queueActions, climb, showMessage],
     );
 
     // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)


### PR DESCRIPTION
Silent console.error calls in handleRowClick and handleThumbnailClick gave no user feedback on failure. Now shows a brief error snackbar via useSnackbar so the user knows the action failed.

Also adds test coverage for both error paths, and a runtime edge-case test for isBenchmark with undefined consensusDifficultyName in ascent-to-climb.

https://claude.ai/code/session_01WpAGq7PYvE7tpV7CeYv6e8