### PR TITLE
feat(tick): backdrop overlay + persist expanded state

### DIFF
--- a/packages/web/app/components/play-view/__tests__/play-view-tick-bar-overlay.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-tick-bar-overlay.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — must come before imports
+// ---------------------------------------------------------------------------
+
+const mockGetPreference = vi.fn().mockResolvedValue(null);
+const mockSetPreference = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+}));
+
+// Stable reference — a new [] on every render causes the climb-change effect
+// to re-fire and reset tickBarExpanded.
+const stableLogbook: never[] = [];
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ logbook: stableLogbook }),
+}));
+
+vi.mock('@/app/hooks/use-tick-save', () => ({
+  hasPriorHistoryForClimb: () => false,
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/lib/grade-colors', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app/lib/grade-colors')>();
+  return {
+    ...actual,
+    getGradeTintColor: () => null,
+  };
+});
+
+vi.mock('@/app/components/logbook/quick-tick-bar', () => ({
+  QuickTickBar: React.forwardRef((_props: unknown, _ref: unknown) =>
+    React.createElement('div', { 'data-testid': 'quick-tick-bar' }),
+  ),
+}));
+
+vi.mock('@/app/components/logbook/tick-icon', () => ({
+  TickIcon: () => React.createElement('svg', { 'data-testid': 'tick-icon' }),
+  TickButtonWithLabel: ({ children, label }: { children: React.ReactNode; label: string }) =>
+    React.createElement('div', { 'data-testid': `tick-label-${label}` }, children),
+}));
+
+vi.mock('@/app/components/icons/person-falling-icon', () => ({
+  PersonFallingIcon: () => React.createElement('svg', { 'data-testid': 'person-falling-icon' }),
+}));
+
+vi.mock('@mui/icons-material/CloseOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-close' }),
+}));
+vi.mock('@mui/icons-material/KeyboardArrowUpOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-arrow-up' }),
+}));
+vi.mock('@mui/icons-material/KeyboardArrowDownOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-arrow-down' }),
+}));
+vi.mock('@mui/icons-material/ChatBubbleOutlineOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-chat' }),
+}));
+vi.mock('@mui/icons-material/CheckOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-check' }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+// Import after mocks
+import { PlayViewTickBar } from '../play-view-drawer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockClimb = {
+  uuid: 'climb-1',
+  setter_username: 'setter1',
+  name: 'Test Climb',
+  description: '',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: '7',
+  quality_average: '3.5',
+  stars: 3,
+  difficulty_error: '',
+  mirrored: false,
+  benchmark_difficulty: null,
+  userAscents: 0,
+  userAttempts: 0,
+};
+
+const defaultProps = {
+  isTickBarActive: false,
+  currentClimb: mockClimb as never,
+  angle: 40 as never,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+  onClose: vi.fn(),
+  onError: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PlayViewTickBar expanded state persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('does not read preference when tick bar is inactive', () => {
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={false} />);
+
+    expect(mockGetPreference).not.toHaveBeenCalledWith('tickBarExpanded');
+  });
+
+  it('reads persisted expanded state when tick bar becomes active', async () => {
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+
+    await waitFor(() => {
+      expect(mockGetPreference).toHaveBeenCalledWith('tickBarExpanded');
+    });
+  });
+
+  it('restores expanded state when persisted value is true', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+
+    // Should show "Collapse" label (meaning it's in expanded mode)
+    await waitFor(() => {
+      expect(screen.getByText('Collapse')).toBeTruthy();
+    });
+  });
+
+  it('starts collapsed when persisted value is null', async () => {
+    mockGetPreference.mockResolvedValue(null);
+
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+
+    // Wait for async preference read to complete
+    await waitFor(() => {
+      expect(mockGetPreference).toHaveBeenCalledWith('tickBarExpanded');
+    });
+
+    // Should show "Expand" label (meaning it's in collapsed mode)
+    expect(screen.getByText('Expand')).toBeTruthy();
+  });
+
+  it('persists expanded state when user clicks expand', async () => {
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+
+    await waitFor(() => {
+      expect(mockGetPreference).toHaveBeenCalledWith('tickBarExpanded');
+    });
+
+    // Click expand button
+    const expandButton = screen.getByLabelText('Expand tick bar');
+    act(() => {
+      fireEvent.click(expandButton);
+    });
+
+    expect(mockSetPreference).toHaveBeenCalledWith('tickBarExpanded', true);
+  });
+
+  it('persists collapsed state when user clicks collapse', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+
+    // Wait for expanded state to be restored from IndexedDB
+    const collapseText = await screen.findByText('Collapse');
+    expect(collapseText).toBeTruthy();
+
+    // Click collapse via the parent button element
+    const collapseButton = collapseText.closest('[role="button"]')!;
+    act(() => {
+      fireEvent.click(collapseButton);
+    });
+
+    expect(mockSetPreference).toHaveBeenCalledWith('tickBarExpanded', false);
+  });
+
+  it('does not persist state on close reset', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <PlayViewTickBar {...defaultProps} isTickBarActive={true} onClose={onClose} />,
+    );
+
+    mockSetPreference.mockClear();
+
+    // Close the tick bar by rerendering with inactive
+    rerender(<PlayViewTickBar {...defaultProps} isTickBarActive={false} onClose={onClose} />);
+
+    // Should not persist the reset
+    expect(mockSetPreference).not.toHaveBeenCalledWith('tickBarExpanded', false);
+  });
+
+  it('does not persist state on climb change reset', () => {
+    const { rerender } = render(
+      <PlayViewTickBar {...defaultProps} isTickBarActive={true} />,
+    );
+
+    mockSetPreference.mockClear();
+
+    // Change the climb — this triggers the climb-change useEffect reset
+    const newClimb = { ...mockClimb, uuid: 'climb-2' };
+    rerender(
+      <PlayViewTickBar {...defaultProps} isTickBarActive={true} currentClimb={newClimb as never} />,
+    );
+
+    // Should not persist the automatic reset
+    expect(mockSetPreference).not.toHaveBeenCalledWith('tickBarExpanded', false);
+  });
+
+  it('toggles between expand and collapse labels', async () => {
+    await act(async () => {
+      render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} />);
+    });
+
+    // Starts collapsed
+    expect(screen.getByText('Expand')).toBeTruthy();
+
+    // Click expand
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Expand tick bar'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Collapse')).toBeTruthy();
+    });
+    expect(screen.queryByText('Expand')).toBeNull();
+
+    // Click collapse
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Collapse tick bar'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Expand')).toBeTruthy();
+    });
+    expect(screen.queryByText('Collapse')).toBeNull();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<PlayViewTickBar {...defaultProps} isTickBarActive={true} onClose={onClose} />);
+
+    const closeButton = screen.getByLabelText('Close tick bar');
+    fireEvent.click(closeButton);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -101,6 +101,22 @@
   font-size: 20px;
 }
 
+/* Backdrop overlay — covers the board area when the tick bar is active */
+.tickBarOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 9;
+  background-color: var(--overlay-light);
+  opacity: 0;
+  transition: opacity 200ms ease-out;
+  pointer-events: none;
+}
+
+.tickBarOverlayActive {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* Floating tick bar — overlays the bottom of the board section, no reflow */
 .tickBarContainer {
   position: absolute;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -51,6 +51,7 @@ import { usePullToClose, findScrollContainer } from '@/app/lib/hooks/pull-to-clo
 import { useSnackbar } from '../providers/snackbar-provider';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import QueueDrawer from './queue-drawer';
 
 
@@ -167,7 +168,7 @@ interface PlayViewTickBarProps {
   onError: () => void;
 }
 
-const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBar({
+export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBar({
   isTickBarActive,
   currentClimb,
   angle,
@@ -190,6 +191,21 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
     () => getGradeTintColor(currentClimb.difficulty, 'default', isDark),
     [currentClimb.difficulty, isDark],
   );
+
+  // Restore persisted tick bar expanded state when tick bar opens
+  useEffect(() => {
+    if (isTickBarActive) {
+      getPreference<boolean>('tickBarExpanded').then((persisted) => {
+        if (persisted === true) setTickBarExpanded(true);
+      });
+    }
+  }, [isTickBarActive]);
+
+  // Persist expanded state on user-initiated toggle (not on automatic resets)
+  const handleTickBarExpandedChange = useCallback((expanded: boolean) => {
+    setTickBarExpanded(expanded);
+    setPreference('tickBarExpanded', expanded);
+  }, []);
 
   const handleCommentFocus = useCallback(() => setCommentFocused(true), []);
   const handleCommentBlur = useCallback(() => setCommentFocused(false), []);
@@ -227,10 +243,10 @@ const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayViewTickBa
             <div className={styles.tickBarToolbar}>
               <div
                 className={styles.tickBarExpandButton}
-                onClick={() => setTickBarExpanded((v) => !v)}
+                onClick={() => handleTickBarExpandedChange(!tickBarExpanded)}
                 role="button"
                 tabIndex={0}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setTickBarExpanded((v) => !v); }}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleTickBarExpandedChange(!tickBarExpanded); }}
                 aria-label={tickBarExpanded ? 'Collapse tick bar' : 'Expand tick bar'}
               >
                 {tickBarExpanded ? (
@@ -731,6 +747,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               )}
             </button>
           </div>
+        )}
+
+        {/* Tick bar backdrop overlay */}
+        {isOpen && (
+          <div
+            className={`${styles.tickBarOverlay} ${isTickBarActive ? styles.tickBarOverlayActive : ''}`}
+            onClick={handleTickBarClose}
+            aria-hidden="true"
+          />
         )}
 
         {/* Floating tick bar — overlays bottom of board section, no reflow */}

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
@@ -1,0 +1,463 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// -- All mocks before imports --
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockGetPreference = vi.fn().mockResolvedValue(null);
+const mockSetPreference = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+}));
+
+let mockQueueContext: Record<string, unknown> = {};
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueContext: () => mockQueueContext,
+  useQueueData: () => mockQueueContext,
+  useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({ currentClimb: (mockQueueContext as Record<string, unknown>).currentClimb }),
+  useQueueList: () => ({ queue: (mockQueueContext as Record<string, unknown>).queue, suggestedClimbs: [] }),
+  useSessionData: () => ({
+    viewOnlyMode: (mockQueueContext as Record<string, unknown>).viewOnlyMode ?? false,
+    isSessionActive: !!(mockQueueContext as Record<string, unknown>).sessionId,
+    sessionId: (mockQueueContext as Record<string, unknown>).sessionId ?? null,
+    sessionSummary: null,
+    sessionGoal: null,
+    connectionState: (mockQueueContext as Record<string, unknown>).connectionState ?? 'idle',
+    canMutate: (mockQueueContext as Record<string, unknown>).canMutate ?? true,
+    isDisconnected: (mockQueueContext as Record<string, unknown>).isDisconnected ?? false,
+    users: (mockQueueContext as Record<string, unknown>).users ?? [],
+    clientId: null,
+    isLeader: true,
+    isBackendMode: false,
+    hasConnected: true,
+    connectionError: null,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/1/1/1/40',
+  useParams: () => ({ board_name: 'kilter', layout_id: '1', size_id: '1', set_ids: '1', angle: '40' }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', props, children),
+}));
+
+vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
+  useCardSwipeNavigation: () => ({
+    swipeHandlers: {},
+    swipeOffset: 0,
+    isAnimating: false,
+    navigateToNext: vi.fn(),
+    navigateToPrev: vi.fn(),
+    peekIsNext: true,
+    exitOffset: 0,
+    enterDirection: null,
+    clearEnterAnimation: vi.fn(),
+  }),
+  EXIT_DURATION: 300,
+  SNAP_BACK_DURATION: 200,
+  ENTER_ANIMATION_DURATION: 300,
+}));
+
+vi.mock('@/app/hooks/use-color-mode', () => ({
+  useColorMode: () => ({ mode: 'light' }),
+}));
+
+vi.mock('@/app/lib/grade-colors', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app/lib/grade-colors')>();
+  return {
+    ...actual,
+    getGradeTintColor: () => null,
+  };
+});
+
+vi.mock('@/app/components/climb-card/climb-thumbnail', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-thumbnail' }),
+}));
+
+vi.mock('@/app/components/climb-card/climb-title', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-title' }),
+}));
+
+vi.mock('@/app/components/queue-control/queue-list', () => ({
+  default: React.forwardRef(() => React.createElement('div', { 'data-testid': 'queue-list' })),
+}));
+
+vi.mock('@/app/components/queue-control/next-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'next-climb' }),
+}));
+
+vi.mock('@/app/components/queue-control/previous-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'prev-climb' }),
+}));
+
+vi.mock('@/app/components/logbook/tick-button', () => ({
+  TickButton: (props: { onActivateTickBar?: () => void; tickBarActive?: boolean }) =>
+    React.createElement('button', {
+      'data-testid': 'tick-button',
+      onClick: props.onActivateTickBar,
+      'data-tick-active': props.tickBarActive,
+    }),
+}));
+
+vi.mock('@/app/components/board-page/share-button', () => ({
+  ShareBoardButton: () => null,
+}));
+
+vi.mock('@/app/components/play-view/play-view-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/onboarding/onboarding-tour', () => ({
+  TOUR_DRAWER_EVENT: 'tour-drawer',
+}));
+
+vi.mock('@/app/components/ui/confirm-popover', () => ({
+  ConfirmPopover: () => null,
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+vi.mock('@/app/components/persistent-session/persistent-session-context', () => ({
+  usePersistentSessionState: () => ({
+    activeSession: null,
+    localBoardDetails: null,
+    localCurrentClimbQueueItem: null,
+    session: null,
+    users: [],
+  }),
+}));
+
+vi.mock('@/app/components/board-bluetooth-control/bluetooth-context', () => ({
+  useBluetoothContext: () => ({
+    isConnected: false,
+    isConnecting: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    sendLedUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ logbook: [] }),
+}));
+
+vi.mock('@/app/components/logbook/quick-tick-bar', () => ({
+  QuickTickBar: React.forwardRef((_props: unknown, _ref: unknown) =>
+    React.createElement('div', { 'data-testid': 'quick-tick-bar' }),
+  ),
+}));
+
+vi.mock('@/app/hooks/use-tick-save', () => ({
+  hasPriorHistoryForClimb: () => false,
+}));
+
+vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/sesh-settings/sesh-settings-drawer-event', () => ({
+  dispatchOpenSeshSettingsDrawer: vi.fn(),
+}));
+
+vi.mock('@/app/lib/session-utils', () => ({
+  generateSessionName: () => 'Test Session',
+}));
+
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: () => null,
+}));
+
+vi.mock('@/app/lib/share-utils', () => ({
+  shareWithFallback: vi.fn(),
+}));
+
+// jsdom doesn't provide window.matchMedia — stub it before the component
+// accesses it (the swipe-hint effect calls matchMedia on mount).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Import after mocks
+import QueueControlBar from '../queue-control-bar';
+
+const mockClimb = {
+  uuid: 'climb-1',
+  setter_username: 'setter1',
+  name: 'Test Climb',
+  description: '',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: '7',
+  quality_average: '3.5',
+  stars: 3,
+  difficulty_error: '',
+  mirrored: false,
+  benchmark_difficulty: null,
+  userAscents: 0,
+  userAttempts: 0,
+};
+
+const baseQueueContext = {
+  queue: [{ uuid: 'item-1', climb: mockClimb, addedBy: 'user-1', suggested: false }],
+  currentClimbQueueItem: { uuid: 'item-1', climb: mockClimb, addedBy: 'user-1', suggested: false },
+  currentClimb: mockClimb,
+  climbSearchResults: [],
+  suggestedClimbs: [],
+  isFetchingClimbs: false,
+  isFetchingNextPage: false,
+  hasDoneFirstFetch: true,
+  viewOnlyMode: false,
+  parsedParams: { board_name: 'kilter', layout_id: '1', size_id: '1', set_ids: ['1'], angle: '40' },
+  connectionState: 'connected',
+  sessionId: 'session-1',
+  canMutate: true,
+  isDisconnected: false,
+  users: [],
+  endSession: vi.fn(),
+  disconnect: vi.fn(),
+  addToQueue: vi.fn(),
+  removeFromQueue: vi.fn(),
+  setCurrentClimb: vi.fn(),
+  setCurrentClimbQueueItem: vi.fn(),
+  setClimbSearchParams: vi.fn(),
+  setCountSearchParams: vi.fn(),
+  mirrorClimb: vi.fn(),
+  fetchMoreClimbs: vi.fn(),
+  getNextClimbQueueItem: vi.fn().mockReturnValue(null),
+  getPreviousClimbQueueItem: vi.fn().mockReturnValue(null),
+  setQueue: vi.fn(),
+};
+
+const defaultProps = {
+  angle: '40' as unknown as number,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+};
+
+const getOverlay = () => document.querySelector('[data-testid="tick-backdrop-overlay"]');
+
+// Helper: activate the tick bar and wait for async effects to settle
+const activateTickBar = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('tick-button'));
+  });
+};
+
+describe('QueueControlBar tick overlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = { ...baseQueueContext };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('does not render overlay when tick bar is inactive', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+    expect(getOverlay()).toBeNull();
+  });
+
+  it('renders overlay when tick bar is activated', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    expect(getOverlay()).toBeTruthy();
+  });
+
+  it('dismisses tick bar when overlay is clicked', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+    const overlay = getOverlay();
+    expect(overlay).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(overlay!);
+    });
+
+    // QuickTickBar should unmount when tick bar closes
+    expect(screen.queryByTestId('quick-tick-bar')).toBeNull();
+  });
+
+  it('overlay has active class when open and loses it on close', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    const overlay = getOverlay();
+    expect(overlay).toBeTruthy();
+    expect(overlay!.getAttribute('class')).toMatch(/tickOverlayActive/);
+
+    await act(async () => {
+      fireEvent.click(overlay!);
+    });
+
+    const overlayAfter = getOverlay();
+    if (overlayAfter) {
+      expect(overlayAfter.getAttribute('class')).not.toMatch(/tickOverlayActive/);
+    }
+  });
+});
+
+describe('QueueControlBar tick bar expanded persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = { ...baseQueueContext };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('reads persisted expanded state when tick bar opens', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    expect(mockGetPreference).toHaveBeenCalledWith('tickBarExpanded');
+  });
+
+  it('does not read preference when tick bar is not opening', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(mockGetPreference).not.toHaveBeenCalledWith('tickBarExpanded');
+  });
+
+  it('persists expanded state when user clicks expand button', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Expand tick bar'));
+    });
+
+    expect(mockSetPreference).toHaveBeenCalledWith('tickBarExpanded', true);
+  });
+
+  it('persists collapsed state when user clicks collapse button', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    // Wait for expanded state to be restored from IndexedDB
+    await waitFor(() => {
+      expect(screen.getByLabelText('Collapse tick bar')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Collapse tick bar'));
+    });
+
+    expect(mockSetPreference).toHaveBeenCalledWith('tickBarExpanded', false);
+  });
+
+  it('does not persist state on automatic close reset', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    mockSetPreference.mockClear();
+
+    // Dismiss tick bar via overlay click
+    const overlay = getOverlay();
+    await act(async () => {
+      fireEvent.click(overlay!);
+    });
+
+    expect(mockSetPreference).not.toHaveBeenCalledWith('tickBarExpanded', false);
+  });
+
+  it('restores expanded state on re-open after close', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Collapse tick bar')).toBeTruthy();
+    });
+
+    // Close
+    const overlay = getOverlay();
+    await act(async () => {
+      fireEvent.click(overlay!);
+    });
+
+    // Wait for collapse animation timer (200ms)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 250));
+    });
+
+    mockGetPreference.mockClear();
+    mockGetPreference.mockResolvedValue(true);
+
+    // Re-open
+    await activateTickBar();
+
+    expect(mockGetPreference).toHaveBeenCalledWith('tickBarExpanded');
+  });
+});

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -480,6 +480,23 @@
   will-change: transform;
 }
 
+/* Backdrop overlay — covers page behind the queue bar when tick mode is active.
+   Rendered via portal to document.body so it escapes the fixed bottom-bar stacking context. */
+.tickOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9;
+  background-color: var(--overlay-light);
+  opacity: 0;
+  transition: opacity 200ms ease-out;
+  pointer-events: none;
+}
+
+.tickOverlayActive {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 @keyframes thumbnailFadeIn {
   from { opacity: 0; transform: scale(0.85); }
   to { opacity: 1; transform: scale(1); }

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import MuiButton from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import MuiCard from '@mui/material/Card';
@@ -479,6 +480,21 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     };
   }, [currentClimb, tickBarActive]);
 
+  // Restore persisted tick bar expanded state when tick mode opens
+  useEffect(() => {
+    if (tickBarActive) {
+      getPreference<boolean>('tickBarExpanded').then((persisted) => {
+        if (persisted === true) setTickBarExpanded(true);
+      });
+    }
+  }, [tickBarActive]);
+
+  // Persist expanded state on user-initiated toggle (not on automatic resets)
+  const handleTickBarExpandedChange = useCallback((expanded: boolean) => {
+    setTickBarExpanded(expanded);
+    setPreference('tickBarExpanded', expanded);
+  }, []);
+
   // Close expanded participants when tick mode opens
   useEffect(() => {
     if (tickBarActive) setParticipantsExpanded(false);
@@ -524,7 +540,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       const target = eventData.event.target as HTMLElement | null;
       if (target?.closest('[data-scrollable-picker]')) return;
       if (!tickBarExpanded && Math.abs(eventData.deltaY) >= 50) {
-        setTickBarExpanded(true);
+        handleTickBarExpandedChange(true);
       }
       setTickSwipeOffset(0);
     },
@@ -536,7 +552,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         if (Math.abs(eventData.deltaY) >= 120 || eventData.velocity > 0.5) {
           setActiveDrawer('none');
         } else if (Math.abs(eventData.deltaY) >= 50) {
-          setTickBarExpanded(false);
+          handleTickBarExpandedChange(false);
         }
       } else {
         if (Math.abs(eventData.deltaY) >= 80) {
@@ -920,10 +936,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               <div className={styles.tickDragHandleRow}>
                 <div
                   className={styles.tickExpandButton}
-                  onClick={() => setTickBarExpanded((v) => !v)}
+                  onClick={() => handleTickBarExpandedChange(!tickBarExpanded)}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setTickBarExpanded((v) => !v); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleTickBarExpandedChange(!tickBarExpanded); }}
                   aria-label={tickBarExpanded ? 'Collapse tick bar' : 'Expand tick bar'}
                 >
                   {tickBarExpanded ? (
@@ -1221,6 +1237,17 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         open={startSeshOpen}
         onClose={() => setStartSeshOpen(false)}
       />
+
+      {/* Backdrop overlay — rendered via portal so it escapes the fixed bottom-bar stacking context */}
+      {typeof document !== 'undefined' && (tickBarActive || tickRowVisible) && createPortal(
+        <div
+          data-testid="tick-backdrop-overlay"
+          className={`${styles.tickOverlay} ${tickBarActive ? styles.tickOverlayActive : ''}`}
+          onClick={() => setActiveDrawer('none')}
+          aria-hidden="true"
+        />,
+        document.body,
+      )}
     </div>
   );
 };

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -9,6 +9,7 @@ export type UserPreferenceKeyMap = {
   'swipeHint:climbListSeen': boolean;
   'swipeHint:queueBarSeen': boolean;
   'swipeHint:logbookSeen': boolean;
+  tickBarExpanded: boolean;
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration


### PR DESCRIPTION
## Summary
- Adds a semi-transparent backdrop overlay when the tick bar is active in both the queue control bar and the play view drawer, matching drawer-style UX — tapping the overlay dismisses the tick bar
- Queue control bar overlay is rendered via `createPortal` to escape the fixed bottom-bar stacking context (`z-index: 9`, just below the bar's `z-index: 10`)
- Play view overlay is positioned absolutely within the board section wrapper
- Persists the tick bar expanded/collapsed state to IndexedDB via `tickBarExpanded` preference key, restored on each open

Closes #1637

## Test plan
- [x] 10 new tests for queue control bar overlay + persistence (`queue-control-bar-tick-overlay.test.tsx`)
- [x] 10 new tests for play view tick bar overlay + persistence (`play-view-tick-bar-overlay.test.tsx`)
- [x] Existing `user-preferences-db.test.ts` and `play-view-action-bar.test.tsx` still pass
- [ ] Manual: open tick bar from queue control bar → overlay appears, tap overlay to dismiss
- [ ] Manual: open tick bar in play view drawer → overlay covers board, tap to dismiss
- [ ] Manual: expand tick bar → close → reopen → opens expanded
- [ ] Manual: dark mode overlay uses correct darker opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)