### PR TITLE
fix: BLE scan tests, device name lookup, tailnet in plist, debug log

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -59,7 +59,6 @@
 	<array>
 		<string>boardsesh.com</string>
 		<string>www.boardsesh.com</string>
-		<string>tailedd9d5.ts.net</string>
 	</array>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Boardsesh reads your Apple Health data to avoid duplicate workout entries when saving climbing sessions.</string>

--- a/packages/web/app/lib/healthkit/healthkit-bridge.ts
+++ b/packages/web/app/lib/healthkit/healthkit-bridge.ts
@@ -65,9 +65,7 @@ export async function saveSessionToHealthKit(
   const startMs = new Date(summary.startedAt).getTime();
   const endMs = new Date(summary.endedAt).getTime();
   const durationSec = Math.round((endMs - startMs) / 1000);
-  console.info(
-    `[HealthKit] Saving workout: startedAt=${summary.startedAt} endedAt=${summary.endedAt} duration=${durationSec}s durationMinutes=${summary.durationMinutes}`,
-  );
+
   if (durationSec < 60) {
     console.warn(`[HealthKit] Duration is only ${durationSec}s — workout will appear as <1 min in Apple Health`);
   }


### PR DESCRIPTION
- Fix BLE scan tests: mock addListener to route by event name so
  onScanResult callbacks are captured and can deliver scan results;
  remove the stale requestLEScan(opts, callback) pattern that never
  matched the real implementation
- Fix selectedDeviceName lookup: devices Map keys by name for iOS dedup,
  but post-picker lookup used raw deviceId; add deviceIdToKey secondary
  map so the lookup resolves correctly
- Remove personal tailnet domain (tailedd9d5.ts.net) from iOS Info.plist
  NSAppTransportSecurity and WKAppBoundDomains — not appropriate in a
  public production config
- Remove diagnostic console.info from healthkit-bridge saveWorkout path

https://claude.ai/code/session_01XJrga9QcFHaGSZzAefYjKd