### PR TITLE
Fix Android bottom tab bar sitting under the system gesture bar

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -30,6 +30,14 @@
   }
 }
 
+/* Android Capacitor: env(safe-area-inset-bottom) is not forwarded from
+   WindowInsets by Capacitor 8 and reports 0, but with targetSdk 35+ the
+   WebView draws under the gesture/nav bar. Use a minimum of 24px so the
+   tab-bar icons sit above the Android system gesture area. */
+.androidNative {
+  --tab-bar-safe-area-padding: max(env(safe-area-inset-bottom, 0px), 24px);
+}
+
 @media (min-width: 768px) {
   .bottomBarWrapper {
     left: 0;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -25,7 +25,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 
@@ -136,13 +136,14 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathname();
   const isNative = isNativeApp();
+  const isAndroidNative = isNative && getPlatform() === 'android';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
   return (
     <div
-      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
+      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''} ${isAndroidNative ? bottomBarStyles.androidNative : ''}`}
       data-testid="bottom-bar-wrapper"
     >
       {hasActiveQueue && boardDetails && (


### PR DESCRIPTION
Android WebView in Capacitor 8 does not forward WindowInsets into
env(safe-area-inset-bottom), so with targetSdk 36 (edge-to-edge
enforced) the tab-bar icons render under the nav/gesture bar and are
nearly impossible to tap. Add an .androidNative modifier that enforces
a 24px minimum on --tab-bar-safe-area-padding, mirroring the existing
iOS 34px fallback.