### PR TITLE
Use @capacitor-community/safe-area for real edge-to-edge insets

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -9,10 +9,11 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation project(':capacitor-app')
-    implementation project(':capacitor-browser')
     implementation project(':capacitor-community-bluetooth-le')
     implementation project(':capacitor-community-keep-awake')
+    implementation project(':capacitor-community-safe-area')
+    implementation project(':capacitor-app')
+    implementation project(':capacitor-browser')
     implementation project(':capacitor-geolocation')
 
 }

--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -13,6 +13,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
 
 import com.getcapacitor.Bridge;
@@ -26,6 +27,7 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
 
         if (bridge == null || bridge.getWebView() == null) {
             return;

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -2,17 +2,20 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
-include ':capacitor-app'
-project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
-
-include ':capacitor-browser'
-project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
-
 include ':capacitor-community-bluetooth-le'
 project(':capacitor-community-bluetooth-le').projectDir = new File('../node_modules/@capacitor-community/bluetooth-le/android')
 
 include ':capacitor-community-keep-awake'
 project(':capacitor-community-keep-awake').projectDir = new File('../node_modules/@capacitor-community/keep-awake/android')
+
+include ':capacitor-community-safe-area'
+project(':capacitor-community-safe-area').projectDir = new File('../node_modules/@capacitor-community/safe-area/android')
+
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^8",
         "@capacitor-community/keep-awake": "^8",
+        "@capacitor-community/safe-area": "^8",
         "@capacitor/android": "^8",
         "@capacitor/app": "^8",
         "@capacitor/browser": "^8",
@@ -24,6 +25,8 @@
     "@capacitor-community/bluetooth-le": ["@capacitor-community/bluetooth-le@8.1.3", "", { "dependencies": { "@types/web-bluetooth": "^0.0.20" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-fDwKrxNPZ6muXVGKWsEi971NJ5xNRWmO/N8H7pSTjicT3TXceBdeGSSDDMoT3dRbfcDHjaPI70NfJKwXwf9idg=="],
 
     "@capacitor-community/keep-awake": ["@capacitor-community/keep-awake@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-+bNAILA4R8PU+rm6OuKfgW6T4N24oAb2Idut5whfX5JAz09j7UBKFBEmT5C0QFJ7S8NZzp9d/yBsbIhLj+JkAA=="],
+
+    "@capacitor-community/safe-area": ["@capacitor-community/safe-area@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-zVVQ7k94DbOff1mHP8qrZGTJZWyhGZnKHD2eXdcobIoOBFW9CeVphLNZYDCop/DBsHXfv6r8k0/Ac8xMIlwT+A=="],
 
     "@capacitor/android": ["@capacitor/android@8.3.0", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-EQy6ByUuKayQBJmMm/e0byJiHavqsQHrvW23BuT2GNVQvenAvipqwaePiJHzrv2PZr7A0T0+se4kgDCeROj0mQ=="],
 

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -17,6 +17,13 @@ const config: CapacitorConfig = {
     backgroundColor: '#0A0A0A',
     overScrollMode: 'never',
   },
+  plugins: {
+    // @capacitor-community/safe-area handles inset propagation itself. Disable
+    // Capacitor's built-in SystemBars inset handling so the two don't fight.
+    SystemBars: {
+      insetsHandling: 'disable',
+    },
+  },
 };
 
 export default config;

--- a/mobile/ios/App/Podfile
+++ b/mobile/ios/App/Podfile
@@ -13,6 +13,7 @@ def capacitor_pods
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCommunityBluetoothLe', :path => '../../node_modules/@capacitor-community/bluetooth-le'
   pod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'
+  pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^8",
     "@capacitor-community/keep-awake": "^8",
+    "@capacitor-community/safe-area": "^8",
     "@capacitor/android": "^8",
     "@capacitor/app": "^8",
     "@capacitor/browser": "^8",

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -21,23 +21,6 @@
   border-radius: 0;
 }
 
-/* iOS Capacitor: env(safe-area-inset-bottom) may return 0 depending on
-   how the WKWebView is configured. Use a minimum of 34px to guarantee
-   coverage of the home indicator and screen corner rounding area. */
-@supports (-webkit-touch-callout: none) {
-  .nativeApp {
-    --tab-bar-safe-area-padding: max(env(safe-area-inset-bottom, 0px), 34px);
-  }
-}
-
-/* Android Capacitor: env(safe-area-inset-bottom) is not forwarded from
-   WindowInsets by Capacitor 8 and reports 0, but with targetSdk 35+ the
-   WebView draws under the gesture/nav bar. Use a minimum of 24px so the
-   tab-bar icons sit above the Android system gesture area. */
-.androidNative {
-  --tab-bar-safe-area-padding: max(env(safe-area-inset-bottom, 0px), 24px);
-}
-
 @media (min-width: 768px) {
   .bottomBarWrapper {
     left: 0;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -25,7 +25,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 
@@ -136,14 +136,13 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathname();
   const isNative = isNativeApp();
-  const isAndroidNative = isNative && getPlatform() === 'android';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
   return (
     <div
-      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''} ${isAndroidNative ? bottomBarStyles.androidNative : ''}`}
+      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
       data-testid="bottom-bar-wrapper"
     >
       {hasActiveQueue && boardDetails && (


### PR DESCRIPTION
Capacitor 8 Android with targetSdk 36 draws the WebView under the
gesture/nav bar but does not forward WindowInsets into
env(safe-area-inset-*). The previous hotfix pinned
--tab-bar-safe-area-padding to a fixed 24px on Android, which is too
much for gesture nav and too little for 3-button nav, and ignores
orientation, cutouts, and foldables.

Install @capacitor-community/safe-area (v8, actively maintained) to
get real, dynamic insets:

- For Chromium 140+ the plugin lets the WebView report native
  env(safe-area-inset-*) values
- For older Chromium it pads the WebView itself so the visible area
  is already inside the safe zone

Either way the existing env(safe-area-inset-*) call sites keep working
without migration, and the web fallback is preserved.

Changes:
- Add @capacitor-community/safe-area 8.0.1 to mobile/package.json
- Configure SystemBars.insetsHandling = disable so Capacitor's built-in
  inset handling doesn't fight the plugin
- Call EdgeToEdge.enable(this) from MainActivity.onCreate as required
  by the plugin docs
- Regenerate capacitor.settings.gradle, capacitor.build.gradle and
  Podfile via cap sync
- Remove the .androidNative 24px fallback in bottom-bar-wrapper.module.css
  and the isAndroidNative wiring in persistent-session-wrapper.tsx
- Remove the iOS 34px @supports fallback; the plugin already makes
  env(safe-area-inset-bottom) accurate on iOS out of the box

https://claude.ai/code/session_01CKvRugQwkGrdYtmGkGLoNA