### PR TITLE
feat(logbook): add Crew Logbook section showing followed users' ticks

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/feed.ts
@@ -8,7 +8,7 @@ import {
   consensusGradeTable,
   consensusGradeJoinCondition,
 } from '../shared/sql-expressions';
-import { FollowingAscentsFeedInputSchema } from '../../../validation/schemas';
+import { FollowingAscentsFeedInputSchema, FollowingClimbAscentsInputSchema } from '../../../validation/schemas';
 
 export const socialFeedQueries = {
   /**
@@ -231,5 +231,76 @@ export const socialFeedQueries = {
       totalCount: 0, // Intentionally 0 — full COUNT(*) was too expensive. No frontend uses this value.
       hasMore,
     };
+  },
+
+  /**
+   * Get ticks from followed users for a specific climb
+   * Requires authentication
+   */
+  followingClimbAscents: async (
+    _: unknown,
+    { input }: { input: { boardType: string; climbUuid: string } },
+    ctx: ConnectionContext,
+  ) => {
+    requireAuthenticated(ctx);
+    const myUserId = ctx.userId!;
+
+    const validatedInput = validateInput(FollowingClimbAscentsInputSchema, input, 'input');
+
+    // Cap results to avoid runaway payloads on highly-trafficked climbs.
+    // The UI is a collapsed list — 100 recent ticks is plenty.
+    const MAX_ITEMS = 100;
+
+    try {
+      const results = await db
+        .select({
+          tick: dbSchema.boardseshTicks,
+          userName: dbSchema.users.name,
+          userImage: dbSchema.users.image,
+          userDisplayName: dbSchema.userProfiles.displayName,
+          userAvatarUrl: dbSchema.userProfiles.avatarUrl,
+        })
+        .from(dbSchema.boardseshTicks)
+        .innerJoin(
+          dbSchema.userFollows,
+          and(
+            eq(dbSchema.userFollows.followingId, dbSchema.boardseshTicks.userId),
+            eq(dbSchema.userFollows.followerId, myUserId),
+          ),
+        )
+        .innerJoin(dbSchema.users, eq(dbSchema.boardseshTicks.userId, dbSchema.users.id))
+        .leftJoin(dbSchema.userProfiles, eq(dbSchema.boardseshTicks.userId, dbSchema.userProfiles.userId))
+        .where(
+          and(
+            eq(dbSchema.boardseshTicks.boardType, validatedInput.boardType),
+            eq(dbSchema.boardseshTicks.climbUuid, validatedInput.climbUuid),
+          ),
+        )
+        .orderBy(desc(dbSchema.boardseshTicks.climbedAt))
+        .limit(MAX_ITEMS);
+
+      const items = results.map(({ tick, userName, userImage, userDisplayName, userAvatarUrl }) => ({
+        uuid: tick.uuid,
+        userId: tick.userId,
+        userDisplayName: userDisplayName || userName || undefined,
+        userAvatarUrl: userAvatarUrl || userImage || undefined,
+        climbUuid: tick.climbUuid,
+        boardType: tick.boardType,
+        angle: tick.angle,
+        isMirror: tick.isMirror ?? false,
+        status: tick.status,
+        attemptCount: tick.attemptCount,
+        quality: tick.quality,
+        difficulty: tick.difficulty,
+        isBenchmark: tick.isBenchmark ?? false,
+        comment: tick.comment || '',
+        climbedAt: tick.climbedAt,
+      }));
+
+      return { items };
+    } catch (err) {
+      console.error('[followingClimbAscents] DB error:', err);
+      throw err;
+    }
   },
 };

--- a/packages/backend/src/validation/schemas/social.ts
+++ b/packages/backend/src/validation/schemas/social.ts
@@ -94,6 +94,14 @@ export const FollowingAscentsFeedInputSchema = z.object({
 });
 
 /**
+ * Following climb ascents input validation schema
+ */
+export const FollowingClimbAscentsInputSchema = z.object({
+  boardType: BoardNameSchema,
+  climbUuid: z.string().min(1, 'Climb UUID cannot be empty').max(100),
+});
+
+/**
  * New climb feed schemas
  */
 export const NewClimbSubscriptionInputSchema = z.object({

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -230,6 +230,24 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     hasMore: Boolean!
   }
 
+  """
+  Input for fetching followed users' ticks on a specific climb.
+  """
+  input FollowingClimbAscentsInput {
+    "Board type (kilter, tension, moonboard)"
+    boardType: String!
+    "Climb UUID"
+    climbUuid: String!
+  }
+
+  """
+  Unpaginated result: all ticks from followed users for a given climb.
+  """
+  type FollowingClimbAscentsResult {
+    "List of feed items"
+    items: [FollowingAscentFeedItem!]!
+  }
+
   # ============================================
   # Materialized Activity Feed Types
   # ============================================

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -297,6 +297,12 @@ export const queriesTypeDefs = /* GraphQL */ `
       @deprecated(reason: "Use activityFeed query instead")
 
     """
+    Get ticks from followed users for a specific climb.
+    Requires authentication.
+    """
+    followingClimbAscents(input: FollowingClimbAscentsInput!): FollowingClimbAscentsResult!
+
+    """
     Get global activity feed of all recent ascents.
     No authentication required.
     Deprecated: Use trendingFeed instead.

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -85,6 +85,15 @@ export type FollowingAscentsFeedResult = {
   hasMore: boolean;
 };
 
+export type FollowingClimbAscentsInput = {
+  boardType: string;
+  climbUuid: string;
+};
+
+export type FollowingClimbAscentsResult = {
+  items: FollowingAscentFeedItem[];
+};
+
 export type ActivityFeedItemType = 'ascent' | 'new_climb' | 'comment' | 'proposal_approved' | 'session_summary';
 
 export type ActivityFeedItem = {

--- a/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
@@ -23,6 +23,9 @@ vi.mock('@/app/components/logbook/logbook-section', () => ({
   LogbookSection: () => null,
   useLogbookSummary: () => null,
 }));
+vi.mock('@/app/components/logbook/crew-logbook-view', () => ({
+  CrewLogbookView: () => null,
+}));
 vi.mock('@/app/components/social/climb-social-section', () => ({
   default: () => null,
 }));
@@ -92,13 +95,13 @@ describe('useBuildClimbDetailSections', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns 4 sections when enabled (default)', () => {
+  it('returns 5 sections when enabled (default)', () => {
     const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
       wrapper: createWrapper(),
     });
 
-    expect(result.current).toHaveLength(4);
-    expect(result.current.map((s) => s.key)).toEqual(['beta', 'logbook', 'community', 'analytics']);
+    expect(result.current).toHaveLength(5);
+    expect(result.current.map((s) => s.key)).toEqual(['beta', 'logbook', 'crew-logbook', 'community', 'analytics']);
   });
 
   it('returns empty array when enabled is false', () => {
@@ -130,8 +133,8 @@ describe('useBuildClimbDetailSections', () => {
 
     rerender({ enabled: true });
 
-    expect(result.current).toHaveLength(4);
-    expect(result.current.map((s) => s.key)).toEqual(['beta', 'logbook', 'community', 'analytics']);
+    expect(result.current).toHaveLength(5);
+    expect(result.current.map((s) => s.key)).toEqual(['beta', 'logbook', 'crew-logbook', 'community', 'analytics']);
   });
 
   it('all sections have lazy: true', () => {

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { CollapsibleSectionConfig } from '@/app/components/collapsible-section/collapsible-section';
 import BetaVideos from '@/app/components/beta-videos/beta-videos';
 import { LogbookSection, useLogbookSummary } from '@/app/components/logbook/logbook-section';
+import { CrewLogbookView } from '@/app/components/logbook/crew-logbook-view';
 import ClimbSocialSection from '@/app/components/social/climb-social-section';
 import ClimbAnalytics from '@/app/components/charts/climb-analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
@@ -88,6 +89,14 @@ export function useBuildClimbDetailSections({
       getSummary: getLogbookSummaryParts,
       lazy: true,
       content: <LogbookSection climb={climb} />,
+    },
+    {
+      key: 'crew-logbook',
+      label: 'Crew Logbook',
+      title: 'Crew Logbook',
+      defaultSummary: "See your crew's sends",
+      lazy: true,
+      content: <CrewLogbookView currentClimb={climb} boardType={boardType} />,
     },
     {
       key: 'community',

--- a/packages/web/app/components/collapsible-section/collapsible-section.tsx
+++ b/packages/web/app/components/collapsible-section/collapsible-section.tsx
@@ -8,7 +8,8 @@ export interface CollapsibleSectionConfig {
   label: string;
   title: string;
   defaultSummary: string;
-  getSummary: () => string[];
+  /** Optional dynamic summary parts. When omitted or it returns [], falls back to defaultSummary. */
+  getSummary?: () => string[];
   content: React.ReactNode;
   /** When true, content is only mounted while this section is the active one. */
   lazy?: boolean;
@@ -31,7 +32,7 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defau
     <div className={styles.steppedContainer}>
       {sections.map((section) => {
         const isActive = activeKey === section.key;
-        const summaryParts = section.getSummary();
+        const summaryParts = section.getSummary?.() ?? [];
         const summaryText = summaryParts.length > 0 ? summaryParts.join(' \u00B7 ') : section.defaultSummary;
 
         const shouldRenderContent = section.lazy ? isActive : true;

--- a/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Climb } from '@/app/lib/types';
+
+const mockRequest = vi.fn();
+const mockUseWsAuthToken = vi.fn();
+const mockUseSession = vi.fn();
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => mockUseWsAuthToken(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/components/ui/empty-state', () => ({
+  EmptyState: ({ description }: { description: string }) => (
+    <div data-testid="empty-state">{description}</div>
+  ),
+}));
+
+vi.mock('../logbook-entry-card', () => ({
+  LogbookEntryCard: ({
+    entry,
+    user,
+    showMirrorTag,
+  }: {
+    entry: { attemptCount: number; status?: string | null };
+    user?: { userId: string; displayName?: string | null };
+    showMirrorTag: boolean;
+  }) => (
+    <div
+      data-testid="logbook-entry-card"
+      data-user-id={user?.userId}
+      data-display-name={user?.displayName ?? ''}
+      data-status={entry.status ?? ''}
+      data-attempts={entry.attemptCount}
+      data-mirror-tag={String(showMirrorTag)}
+    />
+  ),
+}));
+
+import { CrewLogbookView } from '../crew-logbook-view';
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    setter_username: 'setter',
+    name: 'Test Climb',
+    frames: 'p1r1',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: 'V5',
+    quality_average: '0',
+    stars: 0,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+    ...overrides,
+  };
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe('CrewLogbookView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue({ data: { user: { id: 'viewer-1' } }, status: 'authenticated' });
+  });
+
+  it('renders a sign-in prompt when unauthenticated', () => {
+    mockUseWsAuthToken.mockReturnValue({ token: null, isAuthenticated: false, isLoading: false });
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+
+    renderWithClient(<CrewLogbookView currentClimb={makeClimb()} boardType="kilter" />);
+
+    expect(screen.getByTestId('empty-state').textContent).toBe(
+      "Sign in to see your crew's logbook for this climb",
+    );
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('renders a spinner while auth is loading and does not hit the server', () => {
+    mockUseWsAuthToken.mockReturnValue({ token: null, isAuthenticated: false, isLoading: true });
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+
+    const { container } = renderWithClient(
+      <CrewLogbookView currentClimb={makeClimb()} boardType="kilter" />,
+    );
+
+    expect(container.querySelector('.MuiCircularProgress-root')).not.toBeNull();
+    expect(screen.queryByTestId('empty-state')).toBeNull();
+    expect(screen.queryByTestId('logbook-entry-card')).toBeNull();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('renders an empty crew message when authenticated but no items returned', async () => {
+    mockUseWsAuthToken.mockReturnValue({ token: 'tk', isAuthenticated: true, isLoading: false });
+    mockRequest.mockResolvedValueOnce({ followingClimbAscents: { items: [] } });
+
+    renderWithClient(<CrewLogbookView currentClimb={makeClimb()} boardType="kilter" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state').textContent).toBe(
+        'None of your crew have logged this climb yet',
+      );
+    });
+  });
+
+  it('renders an error state when the query fails', async () => {
+    mockUseWsAuthToken.mockReturnValue({ token: 'tk', isAuthenticated: true, isLoading: false });
+    mockRequest.mockRejectedValueOnce(new Error('boom'));
+
+    renderWithClient(<CrewLogbookView currentClimb={makeClimb()} boardType="kilter" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state').textContent).toBe(
+        "Couldn't load your crew's logbook. Try again in a bit.",
+      );
+    });
+  });
+
+  it('renders a card per item and passes through status, user, and mirror-tag props', async () => {
+    mockUseWsAuthToken.mockReturnValue({ token: 'tk', isAuthenticated: true, isLoading: false });
+    mockRequest.mockResolvedValueOnce({
+      followingClimbAscents: {
+        items: [
+          {
+            uuid: 'tick-1',
+            userId: 'user-1',
+            userDisplayName: 'Alex',
+            userAvatarUrl: null,
+            climbUuid: 'climb-1',
+            angle: 40,
+            isMirror: true,
+            status: 'flash',
+            attemptCount: 1,
+            quality: 5,
+            comment: 'Nice',
+            climbedAt: '2025-01-01T00:00:00Z',
+          },
+          {
+            uuid: 'tick-2',
+            userId: 'user-2',
+            userDisplayName: 'Sam',
+            userAvatarUrl: null,
+            climbUuid: 'climb-1',
+            angle: 50,
+            isMirror: false,
+            status: 'attempt',
+            attemptCount: 4,
+            quality: null,
+            comment: '',
+            climbedAt: '2025-01-02T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    renderWithClient(<CrewLogbookView currentClimb={makeClimb()} boardType="tension" />);
+
+    const cards = await screen.findAllByTestId('logbook-entry-card');
+    expect(cards).toHaveLength(2);
+
+    expect(cards[0].getAttribute('data-user-id')).toBe('user-1');
+    expect(cards[0].getAttribute('data-display-name')).toBe('Alex');
+    // Raw status is passed through — normalisation happens inside LogbookEntryCard.
+    expect(cards[0].getAttribute('data-status')).toBe('flash');
+    expect(cards[0].getAttribute('data-mirror-tag')).toBe('true');
+
+    expect(cards[1].getAttribute('data-user-id')).toBe('user-2');
+    expect(cards[1].getAttribute('data-status')).toBe('attempt');
+    expect(cards[1].getAttribute('data-attempts')).toBe('4');
+  });
+
+  it('does not show mirror tag for non-tension boards', async () => {
+    mockUseWsAuthToken.mockReturnValue({ token: 'tk', isAuthenticated: true, isLoading: false });
+    mockRequest.mockResolvedValueOnce({
+      followingClimbAscents: {
+        items: [
+          {
+            uuid: 'tick-1',
+            userId: 'user-1',
+            userDisplayName: 'Alex',
+            userAvatarUrl: null,
+            climbUuid: 'climb-1',
+            angle: 40,
+            isMirror: true,
+            status: 'send',
+            attemptCount: 1,
+            quality: 3,
+            comment: '',
+            climbedAt: '2025-01-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    renderWithClient(<CrewLogbookView currentClimb={makeClimb()} boardType="kilter" />);
+
+    const card = await screen.findByTestId('logbook-entry-card');
+    expect(card.getAttribute('data-mirror-tag')).toBe('false');
+  });
+});

--- a/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LogbookEntryCard } from '../logbook-entry-card';
+
+vi.mock('@/app/components/ascent-status/ascent-status-icon', () => ({
+  AscentStatusIcon: ({ status }: { status: string }) => (
+    <div data-testid="ascent-status-icon" data-status={status} />
+  ),
+}));
+
+vi.mock('@mui/material/Rating', () => ({
+  default: ({ value }: { value: number }) => <div data-testid="rating">{value}</div>,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseEntry = {
+  climbedAt: '2025-01-02T12:00:00Z',
+  angle: 40,
+  isMirror: false,
+  status: 'send' as const,
+  attemptCount: 3,
+  quality: 4,
+  comment: 'Nice moves',
+};
+
+describe('LogbookEntryCard', () => {
+  it('renders entry fields without a user header when user is absent', () => {
+    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
+
+    expect(screen.getByText('Attempts: 3')).toBeTruthy();
+    expect(screen.getByText('Nice moves')).toBeTruthy();
+    expect(screen.getByTestId('rating').textContent).toBe('4');
+    // No user link / avatar without a user prop
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('renders a profile link and display name when user is provided', () => {
+    render(
+      <LogbookEntryCard
+        entry={baseEntry}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+        user={{ userId: 'user-42', displayName: 'Alex', avatarUrl: 'https://example.test/a.png' }}
+      />,
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThanOrEqual(2);
+    for (const link of links) {
+      expect(link.getAttribute('href')).toBe('/profile/user-42');
+    }
+    expect(screen.getByText('Alex')).toBeTruthy();
+  });
+
+  it('falls back to "Climber" when the user has no display name', () => {
+    render(
+      <LogbookEntryCard
+        entry={baseEntry}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+        user={{ userId: 'user-42', displayName: null, avatarUrl: null }}
+      />,
+    );
+
+    expect(screen.getByText('Climber')).toBeTruthy();
+  });
+
+  it('hides the angle chip and status icon when the entry angle matches the current climb angle', () => {
+    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
+    expect(screen.queryByTestId('ascent-status-icon')).toBeNull();
+  });
+
+  it('shows the angle chip and status icon when entry angle differs from the current climb angle', () => {
+    render(
+      <LogbookEntryCard
+        entry={{ ...baseEntry, angle: 50 }}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+      />,
+    );
+    const icon = screen.getByTestId('ascent-status-icon');
+    expect(icon.getAttribute('data-status')).toBe('send');
+    expect(screen.getByText('50')).toBeTruthy();
+  });
+
+  it('shows the Mirrored chip only when showMirrorTag is true and the entry is mirrored', () => {
+    const { rerender } = render(
+      <LogbookEntryCard
+        entry={{ ...baseEntry, isMirror: true }}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+      />,
+    );
+    expect(screen.queryByText('Mirrored')).toBeNull();
+
+    rerender(
+      <LogbookEntryCard
+        entry={{ ...baseEntry, isMirror: true }}
+        currentClimbAngle={40}
+        showMirrorTag={true}
+      />,
+    );
+    expect(screen.getByText('Mirrored')).toBeTruthy();
+  });
+
+  it('hides the rating when the entry is an attempt', () => {
+    render(
+      <LogbookEntryCard
+        entry={{ ...baseEntry, status: 'attempt', quality: null }}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+      />,
+    );
+    expect(screen.queryByTestId('rating')).toBeNull();
+  });
+
+  it('falls back to attempt when status is an unknown string', () => {
+    render(
+      <LogbookEntryCard
+        entry={{
+          ...baseEntry,
+          status: 'weird-string',
+          quality: null,
+          angle: 50,
+        }}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+      />,
+    );
+    const icon = screen.getByTestId('ascent-status-icon');
+    expect(icon.getAttribute('data-status')).toBe('attempt');
+    expect(screen.queryByTestId('rating')).toBeNull();
+  });
+});

--- a/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
@@ -63,7 +63,7 @@ describe('LogbookView', () => {
           angle: 50,
           tries: 1,
           is_ascent: true,
-          status: undefined,
+          status: 'flash',
           is_mirror: true,
           quality: 3,
           comment: 'Mirrored flash',

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { EmptyState } from '@/app/components/ui/empty-state';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  GET_FOLLOWING_CLIMB_ASCENTS,
+  type GetFollowingClimbAscentsQueryResponse,
+  type GetFollowingClimbAscentsQueryVariables,
+} from '@/app/lib/graphql/operations';
+import type { Climb } from '@/app/lib/types';
+import { LogbookEntryCard } from './logbook-entry-card';
+
+interface CrewLogbookViewProps {
+  currentClimb: Climb;
+  boardType: string;
+}
+
+export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, boardType }) => {
+  const { token, isAuthenticated, isLoading: authLoading } = useWsAuthToken();
+  const { data: session } = useSession();
+  const userId = session?.user?.id ?? null;
+
+  const enabled = isAuthenticated && !!token && !!boardType && !!currentClimb.uuid;
+
+  const { data, isLoading, isError } = useQuery({
+    // Scope the cache per signed-in user so a user switch can't serve
+    // cached ticks from the previous identity.
+    queryKey: ['followingClimbAscents', userId, boardType, currentClimb.uuid],
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<
+        GetFollowingClimbAscentsQueryResponse,
+        GetFollowingClimbAscentsQueryVariables
+      >(GET_FOLLOWING_CLIMB_ASCENTS, {
+        input: { boardType, climbUuid: currentClimb.uuid },
+      });
+      return response.followingClimbAscents;
+    },
+    enabled,
+    staleTime: 60 * 1000,
+  });
+
+  if (authLoading || (enabled && isLoading)) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <EmptyState description="Sign in to see your crew's logbook for this climb" />;
+  }
+
+  if (isError) {
+    return <EmptyState description="Couldn't load your crew's logbook. Try again in a bit." />;
+  }
+
+  const items = data?.items ?? [];
+
+  if (items.length === 0) {
+    return <EmptyState description="None of your crew have logged this climb yet" />;
+  }
+
+  const showMirrorTag = boardType === 'tension';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {items.map((item) => (
+        <LogbookEntryCard
+          key={item.uuid}
+          entry={{
+            climbedAt: item.climbedAt,
+            angle: item.angle,
+            isMirror: !!item.isMirror,
+            status: item.status,
+            attemptCount: item.attemptCount,
+            quality: item.quality ?? null,
+            comment: item.comment,
+          }}
+          currentClimbAngle={currentClimb.angle}
+          showMirrorTag={showMirrorTag}
+          user={{
+            userId: item.userId,
+            displayName: item.userDisplayName ?? null,
+            avatarUrl: item.userAvatarUrl ?? null,
+          }}
+        />
+      ))}
+    </Box>
+  );
+};

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import React from 'react';
+import NextLink from 'next/link';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Link from '@mui/material/Link';
+import Rating from '@mui/material/Rating';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import PersonOutlined from '@mui/icons-material/PersonOutlined';
+import dayjs from 'dayjs';
+import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
+import {
+  normalizeAscentStatus,
+  type AscentStatusValue,
+} from '@/app/components/ascent-status/ascent-status-utils';
+
+export interface LogbookEntryUser {
+  userId: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+}
+
+export interface LogbookEntryCardData {
+  climbedAt: string;
+  angle: number;
+  isMirror: boolean;
+  /** Raw status from the server. The card normalizes via normalizeAscentStatus. */
+  status?: string | null;
+  attemptCount: number;
+  quality?: number | null;
+  comment?: string | null;
+}
+
+export interface LogbookEntryCardProps {
+  entry: LogbookEntryCardData;
+  currentClimbAngle: number;
+  showMirrorTag: boolean;
+  user?: LogbookEntryUser;
+}
+
+export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
+  entry,
+  currentClimbAngle,
+  showMirrorTag,
+  user,
+}) => {
+  const ascentStatus = normalizeAscentStatus({
+    // normalizeAscentStatus does a runtime check for the three known values
+    // and falls back to 'attempt' for anything else — safe for raw strings.
+    status: entry.status as AscentStatusValue | null | undefined,
+    tries: entry.attemptCount,
+  });
+  const hasSuccess = ascentStatus !== 'attempt';
+  const showAngleAndStatus = entry.angle !== currentClimbAngle;
+
+  return (
+    <Card sx={{ width: '100%' }}>
+      <CardContent sx={{ p: 1.5 }}>
+        {user && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <Link
+              component={NextLink}
+              href={`/profile/${user.userId}`}
+              aria-label={user.displayName || 'Climber profile'}
+              sx={{ display: 'inline-flex' }}
+            >
+              <Avatar src={user.avatarUrl ?? undefined} sx={{ width: 32, height: 32 }}>
+                {!user.avatarUrl && <PersonOutlined sx={{ fontSize: 16 }} />}
+              </Avatar>
+            </Link>
+            <Link
+              component={NextLink}
+              href={`/profile/${user.userId}`}
+              underline="none"
+              color="text.primary"
+            >
+              <Typography variant="body2" fontWeight={600}>
+                {user.displayName || 'Climber'}
+              </Typography>
+            </Link>
+          </Box>
+        )}
+        <Stack spacing={1} sx={{ width: '100%' }}>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+            <Typography variant="body2" component="span" fontWeight={600}>
+              {dayjs(entry.climbedAt).format('MMM D, YYYY h:mm A')}
+            </Typography>
+            {showAngleAndStatus && (
+              <>
+                <Chip label={entry.angle} size="small" color="primary" />
+                <AscentStatusIcon status={ascentStatus} variant="icon" />
+              </>
+            )}
+            {showMirrorTag && entry.isMirror && (
+              <Chip label="Mirrored" size="small" color="secondary" />
+            )}
+          </Stack>
+          {hasSuccess && entry.quality != null && entry.quality > 0 && (
+            <Stack direction="row" spacing={1}>
+              <Rating readOnly value={entry.quality} max={5} size="small" />
+            </Stack>
+          )}
+          <Stack direction="row" spacing={1}>
+            <Typography variant="body2" component="span">
+              Attempts: {entry.attemptCount}
+            </Typography>
+          </Stack>
+          {entry.comment && (
+            <Typography
+              variant="body2"
+              component="span"
+              color="text.secondary"
+              sx={{ whiteSpace: 'pre-wrap' }}
+            >
+              {entry.comment}
+            </Typography>
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+};

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -1,19 +1,12 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import Typography from '@mui/material/Typography';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import Chip from '@mui/material/Chip';
-import Rating from '@mui/material/Rating';
+import dayjs from 'dayjs';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { Climb } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import dayjs from 'dayjs';
-import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
-import { normalizeAscentStatus } from '@/app/components/ascent-status/ascent-status-utils';
+import { LogbookEntryCard } from './logbook-entry-card';
 
 interface LogbookViewProps {
   currentClimb: Climb;
@@ -22,7 +15,6 @@ interface LogbookViewProps {
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const { logbook, boardName } = useBoardProvider();
 
-  // Filter ascents for current climb and sort by climbed_at (newest first)
   const climbAscents = useMemo(
     () =>
       logbook
@@ -39,51 +31,22 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {climbAscents.map((ascent) => {
-        const ascentStatus = normalizeAscentStatus({
-          status: ascent.status,
-          isAscent: ascent.is_ascent,
-          tries: ascent.tries,
-        });
-        const hasSuccess = ascentStatus !== 'attempt';
-
-        return (
-          <Card key={`${ascent.climb_uuid}-${ascent.climbed_at}`} sx={{ width: '100%' }}>
-            <CardContent sx={{ p: 1.5 }}>
-              <Stack spacing={1} style={{ width: '100%' }}>
-                <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-                  <Typography variant="body2" component="span" fontWeight={600}>
-                    {dayjs(ascent.climbed_at).format('MMM D, YYYY h:mm A')}
-                  </Typography>
-                  {ascent.angle !== currentClimb.angle && (
-                    <>
-                      <Chip label={ascent.angle} size="small" color="primary" />
-                      <AscentStatusIcon status={ascentStatus} variant="icon" />
-                    </>
-                  )}
-                  {showMirrorTag && ascent.is_mirror && <Chip label="Mirrored" size="small" color="secondary" />}
-                </Stack>
-                {hasSuccess && ascent.quality && (
-                  <Stack direction="row" spacing={1}>
-                    <Rating readOnly value={ascent.quality} max={5} size="small" />
-                  </Stack>
-                )}
-                <Stack direction="row" spacing={1}>
-                  <Typography variant="body2" component="span">
-                    Attempts: {ascent.tries}
-                  </Typography>
-                </Stack>
-
-                {ascent.comment && (
-                  <Typography variant="body2" component="span" color="text.secondary" sx={{ whiteSpace: 'pre-wrap' }}>
-                    {ascent.comment}
-                  </Typography>
-                )}
-              </Stack>
-            </CardContent>
-          </Card>
-        );
-      })}
+      {climbAscents.map((ascent) => (
+        <LogbookEntryCard
+          key={`${ascent.climb_uuid}-${ascent.climbed_at}`}
+          entry={{
+            climbedAt: ascent.climbed_at,
+            angle: ascent.angle,
+            isMirror: !!ascent.is_mirror,
+            status: ascent.status ?? null,
+            attemptCount: ascent.tries,
+            quality: ascent.quality,
+            comment: ascent.comment,
+          }}
+          currentClimbAngle={currentClimb.angle}
+          showMirrorTag={showMirrorTag}
+        />
+      ))}
     </Box>
   );
 };

--- a/packages/web/app/lib/graphql/operations/social.ts
+++ b/packages/web/app/lib/graphql/operations/social.ts
@@ -4,6 +4,7 @@ import type {
   FollowConnection,
   UserSearchConnection,
   UnifiedSearchConnection,
+  FollowingAscentFeedItem,
   FollowingAscentsFeedResult,
   SetterProfile,
 } from '@boardsesh/shared-schema';
@@ -250,6 +251,60 @@ export interface GetGlobalAscentsFeedQueryVariables {
 
 export interface GetGlobalAscentsFeedQueryResponse {
   globalAscentsFeed: FollowingAscentsFeedResult;
+}
+
+// ============================================
+// Following Climb Ascents (ticks on a specific climb from followed users)
+// ============================================
+
+export const GET_FOLLOWING_CLIMB_ASCENTS = gql`
+  query GetFollowingClimbAscents($input: FollowingClimbAscentsInput!) {
+    followingClimbAscents(input: $input) {
+      items {
+        uuid
+        userId
+        userDisplayName
+        userAvatarUrl
+        climbUuid
+        angle
+        isMirror
+        status
+        attemptCount
+        quality
+        comment
+        climbedAt
+      }
+    }
+  }
+`;
+
+export interface GetFollowingClimbAscentsQueryVariables {
+  input: { boardType: string; climbUuid: string };
+}
+
+/**
+ * Narrow subset of FollowingAscentFeedItem matching exactly the fields
+ * selected by GET_FOLLOWING_CLIMB_ASCENTS. Keeps the type truthful about
+ * what the server returns for this query.
+ */
+export type FollowingClimbAscentItem = Pick<
+  FollowingAscentFeedItem,
+  | 'uuid'
+  | 'userId'
+  | 'userDisplayName'
+  | 'userAvatarUrl'
+  | 'climbUuid'
+  | 'angle'
+  | 'isMirror'
+  | 'status'
+  | 'attemptCount'
+  | 'quality'
+  | 'comment'
+  | 'climbedAt'
+>;
+
+export interface GetFollowingClimbAscentsQueryResponse {
+  followingClimbAscents: { items: FollowingClimbAscentItem[] };
 }
 
 // ============================================


### PR DESCRIPTION
Adds a new collapsible section in the climb detail drawer that mirrors
"Your Logbook" but displays ticks on the current climb from users you
follow. Extracts the existing ascent card into a shared LogbookEntryCard
so both sections render identically, with the crew variant adding an
avatar + profile link header per entry.

Backend: new unpaginated followingClimbAscents GraphQL query filtered by
boardType + climbUuid. Fan-out-on-read from boardseshTicks joined with
the user's follow graph.