### PR TITLE
Drop healthkit.access entitlement so App Store export stops requiring Apple approval

### DIFF
--- a/mobile/ios/App/App/App.entitlements
+++ b/mobile/ios/App/App/App.entitlements
@@ -13,7 +13,5 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 </dict>
 </plist>

--- a/mobile/ios/App/App/App.release.entitlements
+++ b/mobile/ios/App/App/App.release.entitlements
@@ -13,7 +13,5 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
The TestFlight publish build failed at xcodebuild -exportArchive because
com.apple.developer.healthkit.access is a restricted entitlement tied to
the Verifiable Health Records capability and needs explicit approval from
Apple — Apple's own error says "remove entitlement and add upon approval."

Our HealthKit plugin is strictly write-only (requestAuthorization is called
with toShare: [workoutType] and read: nil), so we don't need clinical-record
read access. Keeping com.apple.developer.healthkit = true is enough for
writing workouts.

A matching provisioning profile refresh in the Apple Developer portal and
an update to the IOS_APP_PROVISIONING_PROFILE_BASE64 GitHub secret are
still required outside this repo, because the profile currently pinned in
ExportOptions.plist predates HealthKit being enabled on the App ID.