### PR TITLE
Fix shell bugs, stale docs, and auto-install git hooks

### DIFF
--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 echo "==> Installing dependencies..."
-bun install --frozen-lockfile 2>/dev/null || bun install
+vp install
+
+echo "==> Installing git hooks..."
+vp config
 
 echo "==> Ensuring gh CLI is installed..."
 if ! command -v gh &>/dev/null; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Before working on a specific part of the codebase, check the `docs/` directory f
 
 ### Development Setup
 
-The development database uses a **pre-built Docker image** (`ghcr.io/boardsesh/boardsesh-dev-db`) that already contains all Kilter, Tension, and MoonBoard board data, a test user, and social seed data with migrations applied. This means `bun run db:up` is fast — it just pulls the image, starts containers, and runs any newer migrations.
+The development database uses a **pre-built Docker image** (`ghcr.io/boardsesh/boardsesh-dev-db`) that already contains all Kilter, Tension, and MoonBoard board data, a test user, and social seed data with migrations applied. This means `vp run db:up` is fast — it just pulls the image, starts containers, and runs any newer migrations.
 
 ```bash
 # Install Vite+ CLI (one-time, manages Node.js, linting, formatting, testing)
@@ -60,7 +60,10 @@ TENSION_SYNC_TOKEN=your_tension_token_here
 # For local development, the app defaults to http://localhost:3000
 
 # Install all dependencies (from root)
-bun install
+vp install
+
+# Install Git hooks (runs vp staged on commit)
+vp config
 
 # Start everything (databases, backend, web)
 # First run pulls the pre-built image (~1GB) with all board data included.

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -93,9 +93,9 @@ PG_CONTAINER=$(docker ps --filter "publish=5432" --filter "status=running" -q 2>
 if [ -n "$PG_CONTAINER" ]; then
   PG_IMAGE=$(docker inspect "$PG_CONTAINER" --format='{{.Config.Image}}' 2>/dev/null)
   case "$PG_IMAGE" in
-    *boardsesh*) ;;
+    *boardsesh-dev-db*) ;;
     *)
-      echo "WARNING: A postgres container is running on port 5432 but it is not the boardsesh dev DB (image: $PG_IMAGE). Skipping cross-worktree fast path."
+      echo "WARNING: A postgres container is running on port 5432 but it is not the boardsesh dev DB (expected image matching *boardsesh-dev-db*, got: $PG_IMAGE). Skipping cross-worktree fast path."
       PG_CONTAINER=""
       ;;
   esac

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -116,10 +116,14 @@ else
     print_success "Vite+ installed successfully"
 fi
 
+echo "Setting up Git hooks..."
+vp config
+print_success "Git hooks installed (pre-commit will run vp staged)"
+
 print_step "Step 3: Installing Dependencies"
 
-echo "Installing packages with Bun..."
-if ! bun install; then
+echo "Installing packages..."
+if ! vp install; then
     print_error "Failed to install dependencies"
 fi
 print_success "Dependencies installed successfully"
@@ -190,7 +194,8 @@ get_aurora_token() {
     payload=$(jq -n --arg u "$username" --arg p "$password" \
         '{"username":$u,"password":$p,"tou":"accepted","pp":"accepted","ua":"app"}')
 
-    local token_response=$(curl -s -X POST "$board_url/sessions" \
+    local token_response
+    token_response=$(curl -s -X POST "$board_url/sessions" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
         -H "User-Agent: Kilter%20Board/202 CFNetwork/1568.100.1 Darwin/24.0.0" \
@@ -200,7 +205,8 @@ get_aurora_token() {
         -d "$payload")
 
     if [ $? -eq 0 ]; then
-        local token=$(echo "$token_response" | jq -r '.session.token // empty')
+        local token
+        token=$(echo "$token_response" | jq -r '.session.token // empty')
         if [ -n "$token" ] && [ "$token" != "null" ]; then
             echo "$token"
             return 0


### PR DESCRIPTION
- setup-dev.sh: fix local variable swallowing curl/jq exit codes in get_aurora_token; split declaration from assignment so $? captures the real exit code
- setup-dev.sh, CLAUDE.md: replace bun install with vp install
- setup-dev.sh: run vp config after vp install to set up git hooks
- CLAUDE.md: fix stale bun run db:up → vp run db:up in prose; document vp install and vp config in the setup block
- .claude/setup.sh: replace bun install with vp install; add vp config so git hooks are auto-installed on every session start (covers new worktrees and fresh clones)
- dev-db-up.sh: narrow cross-worktree image check from *boardsesh* to *boardsesh-dev-db* and improve the warning message