### PR TITLE
Remove manual ascent type selection from quick tick bar

### DIFF
--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -868,6 +868,33 @@ describe('QuickTickBar', () => {
 
       expect(onAscentTypeChange).toHaveBeenCalledWith('send');
     });
+
+    it('reports send when the climb already has userAscents on mount', () => {
+      mockLogbookRef.current = [];
+      const onAscentTypeChange = vi.fn();
+      const climbWithHistory = makeClimb({ userAscents: 1, userAttempts: 0 });
+      render(
+        <QuickTickBar {...defaultProps} currentClimb={climbWithHistory} onAscentTypeChange={onAscentTypeChange} />,
+      );
+      expect(onAscentTypeChange).toHaveBeenLastCalledWith('send');
+    });
+
+    it('reports send when the climb already has userAttempts on mount', () => {
+      mockLogbookRef.current = [];
+      const onAscentTypeChange = vi.fn();
+      const climbWithAttempts = makeClimb({ userAscents: 0, userAttempts: 2 });
+      render(
+        <QuickTickBar {...defaultProps} currentClimb={climbWithAttempts} onAscentTypeChange={onAscentTypeChange} />,
+      );
+      expect(onAscentTypeChange).toHaveBeenLastCalledWith('send');
+    });
+
+    it('reports send when the logbook contains a prior entry for this climb', () => {
+      mockLogbookRef.current = [makeLogbookEntry({ uuid: 'p1', climb_uuid: 'climb-1', angle: 40 })];
+      const onAscentTypeChange = vi.fn();
+      render(<QuickTickBar {...defaultProps} onAscentTypeChange={onAscentTypeChange} />);
+      expect(onAscentTypeChange).toHaveBeenLastCalledWith('send');
+    });
   });
 
   describe('expanded mode', () => {

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -871,29 +871,6 @@ describe('QuickTickBar', () => {
   });
 
   describe('expanded mode', () => {
-    it('disables flash option when user has prior history', () => {
-      mockLogbookRef.current = [];
-      const climbWithHistory = makeClimb({ userAscents: 2, userAttempts: 0 });
-      const onExpandedChange = vi.fn();
-      render(
-        <QuickTickBar
-          {...defaultProps}
-          currentClimb={climbWithHistory}
-          expanded={true}
-          onExpandedChange={onExpandedChange}
-        />,
-      );
-
-      // The ascent type picker should be visible in expanded mode.
-      const ascentTypeListbox = screen.getByRole('listbox', { name: 'Ascent type' });
-      expect(ascentTypeListbox).toBeTruthy();
-
-      // The Flash option should be disabled because the climb has prior history.
-      const flashOption = screen.getByRole('option', { name: 'Flash' });
-      expect(flashOption.getAttribute('aria-disabled')).toBe('true');
-      expect(flashOption.hasAttribute('disabled')).toBe(true);
-    });
-
     it('does not render save button in expanded mode', () => {
       const onExpandedChange = vi.fn();
       render(<QuickTickBar {...defaultProps} expanded={true} onExpandedChange={onExpandedChange} />);

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -106,13 +106,9 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
     const [attemptCount, setAttemptCount] = useState<number>(1);
     const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
 
-    // Ascent type is always inferred from state: flash on 1st try with no prior history, else send.
-    const inferredType: TickStatus = tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
-    const [ascentType, setAscentType] = useState<TickStatus>(inferredType);
-
-    useEffect(() => {
-      setAscentType(inferredType);
-    }, [inferredType]);
+    // Ascent type is derived from state: flash on 1st try with no prior history, else send.
+    const ascentType: TickStatus =
+      tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
 
     // Report ascent type to the parent so tick buttons can update their appearance.
     const isFlash = ascentType === 'flash';

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -4,7 +4,6 @@ import React, { useState, useCallback, useEffect, useMemo, useImperativeHandle, 
 import Stack from '@mui/material/Stack';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
-import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
@@ -19,7 +18,6 @@ import {
   InlineStarPicker,
   InlineGradePicker,
   InlineTriesPicker,
-  InlineAscentTypePicker,
   type ExpandedControl,
 } from './tick-controls';
 import styles from './quick-tick-bar.module.css';
@@ -108,32 +106,13 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
     const [attemptCount, setAttemptCount] = useState<number>(1);
     const [expandedControl, setExpandedControl] = useState<ExpandedControl>(null);
 
-    // Explicit ascent type — initialized from inferred value, auto-updated on state changes.
+    // Ascent type is always inferred from state: flash on 1st try with no prior history, else send.
     const inferredType: TickStatus = tickTarget && !tickTarget.hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
     const [ascentType, setAscentType] = useState<TickStatus>(inferredType);
-    const userOverrodeType = useRef(false);
 
-    // Reset userOverrodeType when the tick target (climb) changes so auto-inference works for new climbs.
     useEffect(() => {
-      userOverrodeType.current = false;
-    }, [tickTarget]);
-
-    // Auto-update ascent type when tries or prior history changes (unless user explicitly chose).
-    useEffect(() => {
-      if (userOverrodeType.current) {
-        // If user manually selected flash but now tries > 1, correct to send.
-        if (ascentType === 'flash' && (attemptCount > 1 || tickTarget?.hasPriorHistory)) {
-          setAscentType('send');
-        }
-        return;
-      }
       setAscentType(inferredType);
-    }, [inferredType, attemptCount, tickTarget?.hasPriorHistory, ascentType]);
-
-    const handleAscentTypeSelect = useCallback((value: TickStatus) => {
-      userOverrodeType.current = true;
-      setAscentType(value);
-    }, []);
+    }, [inferredType]);
 
     // Report ascent type to the parent so tick buttons can update their appearance.
     const isFlash = ascentType === 'flash';
@@ -276,21 +255,6 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
         {expanded && (
           <div className={`${styles.expandedPanel} ${styles.expandedPanelOpen}`}>
             <div className={styles.expandedPanelContent}>
-              {/* Ascent type row */}
-              <div className={styles.labeledRow}>
-                <span className={styles.labeledRowLabel}>
-                  <ElectricBoltOutlined sx={{ fontSize: 14 }} />
-                  type
-                </span>
-                <div className={styles.labeledRowPicker}>
-                  <InlineAscentTypePicker
-                    ascentType={ascentType}
-                    onSelect={handleAscentTypeSelect}
-                    canFlash={!tickTarget?.hasPriorHistory && attemptCount === 1}
-                  />
-                </div>
-              </div>
-
               {/* Grade row */}
               <div className={styles.labeledRow}>
                 <span className={styles.labeledRowLabel}>grade</span>

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -287,21 +287,3 @@
   color: var(--grade-color, inherit);
 }
 
-/* Ascent type picker items — icon + label side by side */
-.ascentTypeItem {
-  gap: 6px;
-  padding: 4px 12px;
-}
-
-.ascentTypeIcon {
-  display: flex;
-}
-
-.ascentTypeItemDisabled {
-  opacity: 0.3;
-}
-
-.ascentTypeLabel {
-  font-size: 13px;
-  font-weight: 600;
-}

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -6,13 +6,9 @@ import Skeleton from '@mui/material/Skeleton';
 import StarIcon from '@mui/icons-material/Star';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
-import CheckOutlined from '@mui/icons-material/CheckOutlined';
-import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
-import type { TickStatus } from '@/app/hooks/use-logbook';
 import styles from './tick-controls.module.css';
 
 export type ExpandedControl = 'grade' | 'stars' | 'tries' | null;
@@ -448,67 +444,3 @@ export const InlineTriesPicker: React.FC<{
   );
 };
 
-/* ------------------------------------------------------------------ */
-/*  Ascent type picker — used in expanded tick bar                    */
-/* ------------------------------------------------------------------ */
-
-const ASCENT_TYPE_OPTIONS: readonly {
-  value: TickStatus;
-  label: string;
-  icon: React.ReactNode;
-  color: string;
-}[] = [
-  {
-    value: 'attempt',
-    label: 'Attempt',
-    icon: <PersonFallingIcon sx={{ fontSize: 18 }} />,
-    color: themeTokens.colors.error,
-  },
-  {
-    value: 'send',
-    label: 'Send',
-    icon: <CheckOutlined sx={{ fontSize: 18 }} />,
-    color: themeTokens.colors.success,
-  },
-  {
-    value: 'flash',
-    label: 'Flash',
-    icon: <ElectricBoltOutlined sx={{ fontSize: 18 }} />,
-    color: themeTokens.colors.amber,
-  },
-];
-
-export const InlineAscentTypePicker: React.FC<{
-  ascentType: TickStatus;
-  onSelect: (value: TickStatus) => void;
-  /** Whether flash is available (no prior history and 1 try). */
-  canFlash?: boolean;
-}> = ({ ascentType, onSelect, canFlash = true }) => (
-  <div className={styles.pickerRow} role="listbox" aria-label="Ascent type">
-    {ASCENT_TYPE_OPTIONS.map((opt) => {
-      const disabled = opt.value === 'flash' && !canFlash;
-      return (
-        <ButtonBase
-          key={opt.value}
-          onClick={() => !disabled && onSelect(opt.value)}
-          className={`${styles.pickerItem} ${styles.ascentTypeItem} ${opt.value === ascentType ? styles.pickerItemSelected : ''}`}
-          aria-label={opt.label}
-          aria-selected={opt.value === ascentType}
-          aria-disabled={disabled}
-          role="option"
-          disabled={disabled}
-        >
-          <span
-            className={`${styles.ascentTypeIcon} ${disabled ? styles.ascentTypeItemDisabled : ''}`}
-            style={{ color: opt.value === ascentType ? opt.color : 'inherit' }}
-          >
-            {opt.icon}
-          </span>
-          <span className={`${styles.ascentTypeLabel} ${disabled ? styles.ascentTypeItemDisabled : ''}`}>
-            {opt.label}
-          </span>
-        </ButtonBase>
-      );
-    })}
-  </div>
-);

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -363,9 +363,22 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                 />
               }
             />
-            {/* Action buttons — save + attempt */}
+            {/* Action buttons — attempt + tick (order matches queue control bar) */}
             {
               <div className={styles.tickBarButtons}>
+                <TickButtonWithLabel label="attempt">
+                  <IconButton
+                    onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
+                    sx={{
+                      backgroundColor: themeTokens.colors.errorMuted,
+                      color: themeTokens.colors.error,
+                      '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
+                    }}
+                    aria-label="Log attempt"
+                  >
+                    <PersonFallingIcon />
+                  </IconButton>
+                </TickButtonWithLabel>
                 <TickButtonWithLabel label={isFlash ? 'flash' : 'tick'}>
                   <IconButton
                     id="button-tick"
@@ -381,19 +394,6 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                     aria-label="Save tick"
                   >
                     <TickIcon isFlash={!!isFlash} />
-                  </IconButton>
-                </TickButtonWithLabel>
-                <TickButtonWithLabel label="attempt">
-                  <IconButton
-                    onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
-                    sx={{
-                      backgroundColor: themeTokens.colors.errorMuted,
-                      color: themeTokens.colors.error,
-                      '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
-                    }}
-                    aria-label="Log attempt"
-                  >
-                    <PersonFallingIcon />
                   </IconButton>
                 </TickButtonWithLabel>
               </div>

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
@@ -439,6 +439,33 @@ describe('QueueControlBar tick bar expanded persistence', () => {
     expect(mockSetPreference).not.toHaveBeenCalledWith('tickBarExpanded', false);
   });
 
+  it('keeps the attempt button visible in collapsed tick mode', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    expect(screen.getByLabelText('Log attempt')).toBeTruthy();
+  });
+
+  it('keeps the attempt button visible when the tick bar is expanded', async () => {
+    mockGetPreference.mockResolvedValue(true);
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await activateTickBar();
+
+    // Wait for the persisted expanded state to apply.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Collapse tick bar')).toBeTruthy();
+    });
+
+    expect(screen.getByLabelText('Log attempt')).toBeTruthy();
+  });
+
   it('restores expanded state on re-open after close', async () => {
     mockGetPreference.mockResolvedValue(true);
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1281,8 +1281,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         <NextClimbButton navigate={isViewPage || isPlayPage} boardDetails={boardDetails} />
                       </Stack>
                     </span>
-                    {/* Attempt button — only visible in tick mode (collapsed) */}
-                    {tickBarActive && !tickBarExpanded && (
+                    {/* Attempt button — visible whenever tick mode is active */}
+                    {tickBarActive && (
                       <TickButtonWithLabel label="attempt">
                         <IconButton
                           onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}


### PR DESCRIPTION
## Summary
This PR removes the manual ascent type (flash/send) picker from the quick tick bar's expanded panel and simplifies the ascent type logic to always be automatically inferred based on climb state.

## Key Changes
- **Removed ascent type picker UI**: Deleted the `InlineAscentTypePicker` component and its associated UI row from the expanded panel in `quick-tick-bar.tsx`
- **Simplified ascent type inference**: Removed the `userOverrodeType` ref and related logic that tracked manual user selections. Ascent type is now always automatically inferred from climb state (flash on first attempt with no prior history, otherwise send)
- **Streamlined effect logic**: Replaced two separate useEffect hooks with a single, simpler effect that updates ascent type whenever the inferred value changes
- **Removed handler**: Deleted the `handleAscentTypeSelect` callback that was used to track manual overrides
- **Reordered action buttons**: In `play-view-drawer.tsx`, moved the "attempt" button before the "tick" button to match the queue control bar order
- **Updated attempt button visibility**: In `queue-control-bar.tsx`, changed the attempt button to be visible whenever tick mode is active (not just when collapsed), with updated comment to reflect this behavior
- **Updated tests**: Removed test case that verified flash option disabling based on prior history, as manual selection is no longer possible

## Implementation Details
The ascent type is now purely derived from:
- Whether the climb has prior history (`tickTarget?.hasPriorHistory`)
- The current attempt count (`attemptCount`)

This eliminates the complexity of tracking user overrides and ensures the UI always reflects the actual ascent type that will be recorded.

https://claude.ai/code/session_01Wa1CQSzVK5rLZqaJZXzqHc