### PR TITLE
Improve Playwright test reliability and debugging

### DIFF
--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -94,8 +94,6 @@ test.describe('Queue Persistence - Local Mode', () => {
     await page.getByLabel('User menu').click();
     const settingsLink = page.locator('a[href="/settings"]');
     await expect(settingsLink).toBeVisible({ timeout: 5000 });
-    // Wait for drawer slide animation to settle before clicking
-    await page.waitForTimeout(500);
     await Promise.all([page.waitForURL(/\/settings/, { timeout: 15000 }), settingsLink.click()]);
     await verifyQueueShowsClimb(page, climbName);
 

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -9,12 +9,17 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* 3 retries in CI to absorb infra timing noise; 1 locally to catch genuine flakes */
+  retries: process.env.CI ? 3 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 2 : undefined,
+  /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */
+  timeout: 60_000,
+  /* Raise the default assertion timeout from Playwright's 5 s to 10 s */
+  expect: { timeout: 10_000 },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'github' : 'html',
+  /* In CI: emit both the HTML report (uploaded as an artifact) and GitHub Annotations */
+  reporter: process.env.CI ? [['html'], ['github']] : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -22,6 +27,12 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    /* Capture a screenshot on failure for easier CI debugging */
+    screenshot: 'only-on-failure',
+    /* Timeout for individual actions (click, fill, etc.) */
+    actionTimeout: 15_000,
+    /* Timeout for page navigations */
+    navigationTimeout: 30_000,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Summary
Enhanced Playwright test configuration to improve reliability in CI environments and make debugging easier by adding better timeouts, retry logic, and failure diagnostics.

## Key Changes

**Playwright Configuration (`playwright.config.ts`)**
- Increased CI retries from 2 to 3 to better absorb infrastructure timing noise, while adding 1 retry locally to catch genuine flakes
- Added global per-test timeout of 60 seconds (some tests like zoom and login flows need more than Playwright's 30s default)
- Increased assertion timeout from Playwright's 5s default to 10s
- Updated CI reporter configuration to emit both HTML reports (for artifact upload) and GitHub Annotations simultaneously
- Added screenshot capture on test failure for easier CI debugging
- Added action timeout of 15 seconds for individual interactions (click, fill, etc.)
- Added navigation timeout of 30 seconds for page navigations

**Test Fixes (`e2e/queue-persistence.spec.ts`)**
- Removed hardcoded 500ms wait for drawer slide animation, relying instead on explicit visibility checks and navigation waits which are more reliable

## Implementation Details
The timeout adjustments are calibrated to handle slower CI environments while the increased retries help absorb transient infrastructure issues. The screenshot-on-failure feature will significantly improve debugging capabilities for flaky tests in CI without cluttering local test runs.

https://claude.ai/code/session_01J25FJdvNS1FuuBN6AmbvDX