### PR TITLE
refactor(backend): encapsulate TTL refresh and await client disposal

### DIFF
--- a/packages/backend/src/__tests__/integration.test.ts
+++ b/packages/backend/src/__tests__/integration.test.ts
@@ -213,9 +213,9 @@ describe('Daemon Integration Tests', () => {
     server.httpServer.close();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Dispose all clients created during the test
-    activeClients.forEach((client) => client.dispose());
+    await Promise.all(activeClients.map((client) => client.dispose()));
     activeClients.length = 0;
     // Clear per-test UUID cache
     testClimbUuids.clear();
@@ -605,7 +605,7 @@ describe('Daemon Integration Tests', () => {
       );
 
       // Client 1 disconnects
-      void client1.dispose();
+      await client1.dispose();
       // Remove from activeClients so afterEach doesn't try to dispose again
       const idx = activeClients.indexOf(client1);
       if (idx > -1) activeClients.splice(idx, 1);
@@ -640,7 +640,7 @@ describe('Daemon Integration Tests', () => {
       );
 
       // Client 2 disconnects
-      void client2.dispose();
+      await client2.dispose();
       const idx = activeClients.indexOf(client2);
       if (idx > -1) activeClients.splice(idx, 1);
 
@@ -704,7 +704,7 @@ describe('Daemon Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Client 2 disconnects
-      void client2.dispose();
+      await client2.dispose();
       const idx = activeClients.indexOf(client2);
       if (idx > -1) activeClients.splice(idx, 1);
 
@@ -739,7 +739,7 @@ describe('Daemon Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Client 1 disconnects (leader leaves)
-      void client1.dispose();
+      await client1.dispose();
       const idx = activeClients.indexOf(client1);
       if (idx > -1) activeClients.splice(idx, 1);
 
@@ -773,7 +773,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Disconnect
-      void client1.dispose();
+      await client1.dispose();
       const idx = activeClients.indexOf(client1);
       if (idx > -1) activeClients.splice(idx, 1);
 
@@ -812,7 +812,7 @@ describe('Daemon Integration Tests', () => {
       });
 
       // Client 1 disconnects
-      void client1.dispose();
+      await client1.dispose();
       const idx = activeClients.indexOf(client1);
       if (idx > -1) activeClients.splice(idx, 1);
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -259,25 +259,8 @@ export async function startServer(): Promise<ServerResources> {
   // Periodic TTL refresh for active sessions (every 2 minutes)
   const ttlRefreshInterval = setInterval(async () => {
     try {
-      if (redisClientManager.isRedisConnected() && roomManager['redisStore']) {
-        const activeSessions = roomManager.getAllActiveSessions();
-
-        if (activeSessions.length > 0) {
-          console.info(`[Server] Refreshing TTL for ${activeSessions.length} active sessions`);
-
-          // Batch refresh to avoid overwhelming Redis
-          const batchSize = 50;
-          for (let i = 0; i < activeSessions.length; i += batchSize) {
-            const batch = activeSessions.slice(i, i + batchSize);
-            await Promise.all(
-              batch.map((sessionId) =>
-                roomManager['redisStore']!.refreshTTL(sessionId).catch((err) =>
-                  console.error(`[Server] TTL refresh failed for ${sessionId}:`, err),
-                ),
-              ),
-            );
-          }
-        }
+      if (redisClientManager.isRedisConnected()) {
+        await roomManager.refreshActiveSessionTTLs();
       }
     } catch (error) {
       console.error('[Server] Error in periodic TTL refresh:', error);

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -348,11 +348,26 @@ class RoomManager {
     return this.writeScheduler.flushPendingWrites(this.sessionGraceTimers);
   }
 
-  /**
-   * Get all active session IDs (for TTL refresh).
-   */
-  getAllActiveSessions(): string[] {
-    return Array.from(this.sessions.keys());
+  async refreshActiveSessionTTLs(): Promise<void> {
+    const store = this.redisStore;
+    if (!store) return;
+
+    const activeSessions = Array.from(this.sessions.keys());
+    if (activeSessions.length === 0) return;
+
+    console.info(`[RoomManager] Refreshing TTL for ${activeSessions.length} active sessions`);
+
+    const batchSize = 50;
+    for (let i = 0; i < activeSessions.length; i += batchSize) {
+      const batch = activeSessions.slice(i, i + batchSize);
+      await Promise.all(
+        batch.map((sessionId) =>
+          store.refreshTTL(sessionId).catch((err) =>
+            console.error(`[RoomManager] TTL refresh failed for ${sessionId}:`, err),
+          ),
+        ),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Move private redisStore access from server.ts into a public
refreshActiveSessionTTLs() method on RoomManager. Captures the field
into a local variable so TypeScript can narrow away the null without a
non-null assertion, and removes bracket-notation access from outside
the class.

Replace void client.dispose() with await client.dispose() in
integration tests (including the afterEach cleanup) so any teardown
rejection surfaces instead of being silently swallowed.

https://claude.ai/code/session_01R6kCDdWSA78rEmctwBk5Bd