### PR TITLE
Move isNoMatchClimb to shared-schema and wire isBenchmark into ClimbIcons feeds

### DIFF
--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -11,10 +11,7 @@ import { eq } from 'drizzle-orm';
 export { validateInput } from '../../../validation/schemas';
 // Re-export MAX_RETRIES from types
 export { MAX_RETRIES } from './types';
-
-export function isNoMatchClimb(description: string | null | undefined): boolean {
-  return /^no match/i.test(description || '');
-}
+export { isNoMatchClimb } from '@boardsesh/shared-schema';
 
 /**
  * Configuration for session membership retry behavior.

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -4,3 +4,4 @@
 export * from './types';
 export * from './schema';
 export * from './operations';
+export * from './utils';

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -1,0 +1,3 @@
+export function isNoMatchClimb(description: string | null | undefined): boolean {
+  return /^no match/i.test(description || '');
+}

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -194,7 +194,7 @@ const GroupedFeedItem: React.FC<{
                 />
                 <MuiTypography variant="body2" component="span" fontWeight={600} className={styles.climbName}>
                   {group.climbName}
-                  <ClimbIcons isNoMatch={!!group.isNoMatch} />
+                  <ClimbIcons isNoMatch={!!group.isNoMatch} isBenchmark={!!group.isBenchmark} />
                 </MuiTypography>
               </Box>
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.timeAgo}>

--- a/packages/web/app/components/activity-feed/feed-item-comment.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-comment.tsx
@@ -58,7 +58,7 @@ export default function FeedItemComment({ item }: FeedItemCommentProps) {
                 </MuiTypography>
                 <MuiTypography variant="body2" component="span" fontWeight={600}>
                   {item.climbName}
-                  <ClimbIcons isNoMatch={!!item.isNoMatch} />
+                  <ClimbIcons isNoMatch={!!item.isNoMatch} isBenchmark={!!item.isBenchmark} />
                 </MuiTypography>
               </>
             )}

--- a/packages/web/app/components/activity-feed/feed-item-new-climb.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-new-climb.tsx
@@ -61,7 +61,7 @@ export default function FeedItemNewClimb({ item }: FeedItemNewClimbProps) {
             </MuiTypography>
             <MuiTypography variant="body2" component="span" fontWeight={600}>
               {item.climbName}
-              <ClimbIcons isNoMatch={!!item.isNoMatch} />
+              <ClimbIcons isNoMatch={!!item.isNoMatch} isBenchmark={!!item.isBenchmark} />
             </MuiTypography>
           </Box>
           <MuiTypography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -102,7 +102,7 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
               </MuiTypography>
               <MuiTypography variant="body2" component="span" fontWeight={600}>
                 {item.climbName}
-                <ClimbIcons isNoMatch={!!item.isNoMatch} />
+                <ClimbIcons isNoMatch={!!item.isNoMatch} isBenchmark={!!item.isBenchmark} />
               </MuiTypography>
             </Box>
             <MuiTypography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
@@ -150,7 +150,7 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
                 {!showUserHeader && (
                   <MuiTypography variant="body2" component="span" fontWeight={600} className={styles.climbName}>
                     {item.climbName}
-                    <ClimbIcons isNoMatch={!!item.isNoMatch} />
+                    <ClimbIcons isNoMatch={!!item.isNoMatch} isBenchmark={!!item.isBenchmark} />
                   </MuiTypography>
                 )}
               </Box>

--- a/packages/web/app/components/climb-card/climb-icons.tsx
+++ b/packages/web/app/components/climb-card/climb-icons.tsx
@@ -7,6 +7,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 type ClimbIconsProps = {
   benchmarkDifficulty?: string | number | null;
+  isBenchmark?: boolean;
   isNoMatch?: boolean;
 };
 
@@ -26,9 +27,9 @@ const noMatchIconSx = {
  * Unified icon cluster for climb labels.
  * Note: benchmark_difficulty > 0 represents benchmark/classic climbs in current data feeds.
  */
-export default function ClimbIcons({ benchmarkDifficulty, isNoMatch = false }: ClimbIconsProps) {
+export default function ClimbIcons({ benchmarkDifficulty, isBenchmark = false, isNoMatch = false }: ClimbIconsProps) {
   const benchmarkValue = benchmarkDifficulty != null ? Number(benchmarkDifficulty) : null;
-  const isBenchmarkOrClassic = benchmarkValue !== null && benchmarkValue > 0 && !Number.isNaN(benchmarkValue);
+  const isBenchmarkOrClassic = isBenchmark || (benchmarkValue !== null && benchmarkValue > 0 && !Number.isNaN(benchmarkValue));
 
   return (
     <>

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -667,7 +667,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
               <div className={styles.center}>
                 <Typography variant="body2" component="div" sx={nameSx}>
                   {item.climbName}
-                  <ClimbIcons isNoMatch={!!item.isNoMatch} />
+                  <ClimbIcons isNoMatch={!!item.isNoMatch} isBenchmark={!!item.isBenchmark} />
                 </Typography>
                 <Typography variant="body2" component="div" color="text.secondary" sx={subtitleSx}>
                   {subtitle}

--- a/packages/web/app/lib/no-match-climb.ts
+++ b/packages/web/app/lib/no-match-climb.ts
@@ -1,11 +1,1 @@
-/**
- * Returns `true` when a climb is marked as "no matching".
- *
- * Setters indicate "no matching" by starting the climb description with
- * variations of "no match" — e.g. "No matching", "no match", "NO MATCHING",
- * "No matches", "No matchy", "No matching!", etc.
- */
-export function isNoMatchClimb(description: string | undefined | null): boolean {
-  if (!description) return false;
-  return /^no match/i.test(description);
-}
+export { isNoMatchClimb } from '@boardsesh/shared-schema';


### PR DESCRIPTION
- Add isNoMatchClimb to packages/shared-schema/src/utils.ts so the
  single source of truth lives in the shared package
- packages/web/app/lib/no-match-climb.ts now re-exports from
  @boardsesh/shared-schema instead of duplicating the function
- packages/backend/src/graphql/resolvers/shared/helpers.ts likewise
  re-exports from @boardsesh/shared-schema, removing the duplicate
- ClimbIcons gains an isBenchmark?: boolean prop so callers that have
  the boolean flag (not the raw benchmark_difficulty value) can show
  the benchmark icon; the existing benchmarkDifficulty path is unchanged
- All activity-feed, logbook, and social-feed ClimbIcons usages now
  pass isBenchmark so the benchmark icon renders in feed views

https://claude.ai/code/session_01MxqVrQdRKNnW2yMxuzdNHn