### PR TITLE
feat(logbook): add likes and comments to play view drawer entries

### DIFF
--- a/packages/backend/src/graphql/resolvers/shared/sql-expressions.ts
+++ b/packages/backend/src/graphql/resolvers/shared/sql-expressions.ts
@@ -63,6 +63,19 @@ export const difficultyNameWithFallbackExpr = sql<string | null>`COALESCE(
 export const consensusDifficultyExpr = sql<number | null>`ROUND(${dbSchema.boardClimbStats.displayDifficulty})`;
 
 /**
+ * Number of non-deleted comments targeting each tick, as a correlated
+ * subquery. Use inside a query whose FROM includes `boardseshTicks` so the
+ * outer `boardseshTicks.uuid` reference resolves per-row.
+ */
+export const tickCommentCountExpr = sql<number>`(
+  SELECT COUNT(*)::int
+  FROM ${dbSchema.comments}
+  WHERE ${dbSchema.comments.entityType} = 'tick'
+    AND ${dbSchema.comments.entityId} = ${dbSchema.boardseshTicks.uuid}
+    AND ${dbSchema.comments.deletedAt} IS NULL
+)`;
+
+/**
  * Imperative query: look up consensus grade name for a specific climb+angle.
  * Used in contexts where an inline SQL expression isn't possible (e.g. event publishing).
  */

--- a/packages/backend/src/graphql/resolvers/shared/sql-expressions.ts
+++ b/packages/backend/src/graphql/resolvers/shared/sql-expressions.ts
@@ -64,8 +64,18 @@ export const consensusDifficultyExpr = sql<number | null>`ROUND(${dbSchema.board
 
 /**
  * Number of non-deleted comments targeting each tick, as a correlated
- * subquery. Use inside a query whose FROM includes `boardseshTicks` so the
- * outer `boardseshTicks.uuid` reference resolves per-row.
+ * subquery.
+ *
+ * PRECONDITION: the outer query's FROM clause MUST include `boardseshTicks`.
+ * The subquery's WHERE references `boardseshTicks.uuid` from the outer row;
+ * using this expression from a query that does not join `boardseshTicks`
+ * produces a Postgres error at runtime (there is no compile-time guard —
+ * Drizzle's SQL template type cannot encode table-scope requirements).
+ *
+ * Correctness is also size-sensitive: this subquery runs once per returned
+ * row. Only use it in queries with a bounded LIMIT (e.g. followingClimbAscents
+ * caps at 100, and ticks is scoped by user + optional climbUuids). For larger
+ * result sets, prefer a single LEFT JOIN on a grouped COUNT(*) CTE instead.
  */
 export const tickCommentCountExpr = sql<number>`(
   SELECT COUNT(*)::int

--- a/packages/backend/src/graphql/resolvers/social/feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/feed.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, inArray, sql } from 'drizzle-orm';
+import { eq, and, desc, inArray } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -7,6 +7,7 @@ import {
   difficultyNameWithFallbackExpr,
   consensusGradeTable,
   consensusGradeJoinCondition,
+  tickCommentCountExpr,
 } from '../shared/sql-expressions';
 import { FollowingAscentsFeedInputSchema, FollowingClimbAscentsInputSchema } from '../../../validation/schemas';
 
@@ -252,14 +253,6 @@ export const socialFeedQueries = {
     const MAX_ITEMS = 100;
 
     try {
-      const commentCountExpr = sql<number>`(
-        SELECT COUNT(*)::int
-        FROM ${dbSchema.comments}
-        WHERE ${dbSchema.comments.entityType} = 'tick'
-          AND ${dbSchema.comments.entityId} = ${dbSchema.boardseshTicks.uuid}
-          AND ${dbSchema.comments.deletedAt} IS NULL
-      )`;
-
       const results = await db
         .select({
           tick: dbSchema.boardseshTicks,
@@ -269,7 +262,7 @@ export const socialFeedQueries = {
           userAvatarUrl: dbSchema.userProfiles.avatarUrl,
           upvotes: dbSchema.voteCounts.upvotes,
           downvotes: dbSchema.voteCounts.downvotes,
-          commentCount: commentCountExpr,
+          commentCount: tickCommentCountExpr,
         })
         .from(dbSchema.boardseshTicks)
         .innerJoin(

--- a/packages/backend/src/graphql/resolvers/social/feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/feed.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, inArray } from 'drizzle-orm';
+import { eq, and, desc, inArray, sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -252,6 +252,14 @@ export const socialFeedQueries = {
     const MAX_ITEMS = 100;
 
     try {
+      const commentCountExpr = sql<number>`(
+        SELECT COUNT(*)::int
+        FROM ${dbSchema.comments}
+        WHERE ${dbSchema.comments.entityType} = 'tick'
+          AND ${dbSchema.comments.entityId} = ${dbSchema.boardseshTicks.uuid}
+          AND ${dbSchema.comments.deletedAt} IS NULL
+      )`;
+
       const results = await db
         .select({
           tick: dbSchema.boardseshTicks,
@@ -259,6 +267,9 @@ export const socialFeedQueries = {
           userImage: dbSchema.users.image,
           userDisplayName: dbSchema.userProfiles.displayName,
           userAvatarUrl: dbSchema.userProfiles.avatarUrl,
+          upvotes: dbSchema.voteCounts.upvotes,
+          downvotes: dbSchema.voteCounts.downvotes,
+          commentCount: commentCountExpr,
         })
         .from(dbSchema.boardseshTicks)
         .innerJoin(
@@ -270,6 +281,13 @@ export const socialFeedQueries = {
         )
         .innerJoin(dbSchema.users, eq(dbSchema.boardseshTicks.userId, dbSchema.users.id))
         .leftJoin(dbSchema.userProfiles, eq(dbSchema.boardseshTicks.userId, dbSchema.userProfiles.userId))
+        .leftJoin(
+          dbSchema.voteCounts,
+          and(
+            eq(dbSchema.voteCounts.entityType, 'tick'),
+            eq(dbSchema.voteCounts.entityId, dbSchema.boardseshTicks.uuid),
+          ),
+        )
         .where(
           and(
             eq(dbSchema.boardseshTicks.boardType, validatedInput.boardType),
@@ -279,23 +297,28 @@ export const socialFeedQueries = {
         .orderBy(desc(dbSchema.boardseshTicks.climbedAt))
         .limit(MAX_ITEMS);
 
-      const items = results.map(({ tick, userName, userImage, userDisplayName, userAvatarUrl }) => ({
-        uuid: tick.uuid,
-        userId: tick.userId,
-        userDisplayName: userDisplayName || userName || undefined,
-        userAvatarUrl: userAvatarUrl || userImage || undefined,
-        climbUuid: tick.climbUuid,
-        boardType: tick.boardType,
-        angle: tick.angle,
-        isMirror: tick.isMirror ?? false,
-        status: tick.status,
-        attemptCount: tick.attemptCount,
-        quality: tick.quality,
-        difficulty: tick.difficulty,
-        isBenchmark: tick.isBenchmark ?? false,
-        comment: tick.comment || '',
-        climbedAt: tick.climbedAt,
-      }));
+      const items = results.map(
+        ({ tick, userName, userImage, userDisplayName, userAvatarUrl, upvotes, downvotes, commentCount }) => ({
+          uuid: tick.uuid,
+          userId: tick.userId,
+          userDisplayName: userDisplayName || userName || undefined,
+          userAvatarUrl: userAvatarUrl || userImage || undefined,
+          climbUuid: tick.climbUuid,
+          boardType: tick.boardType,
+          angle: tick.angle,
+          isMirror: tick.isMirror ?? false,
+          status: tick.status,
+          attemptCount: tick.attemptCount,
+          quality: tick.quality,
+          difficulty: tick.difficulty,
+          isBenchmark: tick.isBenchmark ?? false,
+          comment: tick.comment || '',
+          climbedAt: tick.climbedAt,
+          upvotes: Number(upvotes ?? 0),
+          downvotes: Number(downvotes ?? 0),
+          commentCount: Number(commentCount ?? 0),
+        }),
+      );
 
       return { items };
     } catch (err) {

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -37,11 +37,24 @@ export const tickQueries = {
       conditions.push(inArray(dbSchema.boardseshTicks.climbUuid, input.climbUuids));
     }
 
+    // Per-tick comment count (non-deleted) as a correlated subquery so we can
+    // surface social affordances on each row without an N+1 round trip.
+    const commentCountExpr = sql<number>`(
+      SELECT COUNT(*)::int
+      FROM ${dbSchema.comments}
+      WHERE ${dbSchema.comments.entityType} = 'tick'
+        AND ${dbSchema.comments.entityId} = ${dbSchema.boardseshTicks.uuid}
+        AND ${dbSchema.comments.deletedAt} IS NULL
+    )`;
+
     // Fetch ticks with layoutId from unified board_climbs table
     const results = await db
       .select({
         tick: dbSchema.boardseshTicks,
         layoutId: dbSchema.boardClimbs.layoutId,
+        upvotes: dbSchema.voteCounts.upvotes,
+        downvotes: dbSchema.voteCounts.downvotes,
+        commentCount: commentCountExpr,
       })
       .from(dbSchema.boardseshTicks)
       .leftJoin(
@@ -51,10 +64,17 @@ export const tickQueries = {
           eq(dbSchema.boardClimbs.boardType, input.boardType),
         ),
       )
+      .leftJoin(
+        dbSchema.voteCounts,
+        and(
+          eq(dbSchema.voteCounts.entityType, 'tick'),
+          eq(dbSchema.voteCounts.entityId, dbSchema.boardseshTicks.uuid),
+        ),
+      )
       .where(and(...conditions))
       .orderBy(desc(dbSchema.boardseshTicks.climbedAt));
 
-    return results.map(({ tick, layoutId }) => ({
+    return results.map(({ tick, layoutId, upvotes, downvotes, commentCount }) => ({
       uuid: tick.uuid,
       userId: tick.userId,
       boardType: tick.boardType,
@@ -75,6 +95,9 @@ export const tickQueries = {
       auroraId: tick.auroraId,
       auroraSyncedAt: tick.auroraSyncedAt,
       layoutId,
+      upvotes: Number(upvotes ?? 0),
+      downvotes: Number(downvotes ?? 0),
+      commentCount: Number(commentCount ?? 0),
     }));
   },
 

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, desc, inArray, sql, count, ilike, gte, lte } from 'drizzle-orm';
+import { eq, and, or, desc, inArray, isNull, sql, count, ilike, gte, lte } from 'drizzle-orm';
 import type { ConnectionContext, BoardName } from '@boardsesh/shared-schema';
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -10,7 +10,6 @@ import {
   difficultyNameWithFallbackExpr,
   consensusGradeTable,
   consensusGradeJoinCondition,
-  tickCommentCountExpr,
 } from '../shared/sql-expressions';
 import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas';
 
@@ -43,9 +42,6 @@ export const tickQueries = {
       .select({
         tick: dbSchema.boardseshTicks,
         layoutId: dbSchema.boardClimbs.layoutId,
-        upvotes: dbSchema.voteCounts.upvotes,
-        downvotes: dbSchema.voteCounts.downvotes,
-        commentCount: tickCommentCountExpr,
       })
       .from(dbSchema.boardseshTicks)
       .leftJoin(
@@ -55,41 +51,78 @@ export const tickQueries = {
           eq(dbSchema.boardClimbs.boardType, input.boardType),
         ),
       )
-      .leftJoin(
-        dbSchema.voteCounts,
-        and(
-          eq(dbSchema.voteCounts.entityType, 'tick'),
-          eq(dbSchema.voteCounts.entityId, dbSchema.boardseshTicks.uuid),
-        ),
-      )
       .where(and(...conditions))
       .orderBy(desc(dbSchema.boardseshTicks.climbedAt));
 
-    return results.map(({ tick, layoutId, upvotes, downvotes, commentCount }) => ({
-      uuid: tick.uuid,
-      userId: tick.userId,
-      boardType: tick.boardType,
-      climbUuid: tick.climbUuid,
-      angle: tick.angle,
-      isMirror: tick.isMirror,
-      status: tick.status,
-      attemptCount: tick.attemptCount,
-      quality: tick.quality,
-      difficulty: tick.difficulty,
-      isBenchmark: tick.isBenchmark,
-      comment: tick.comment,
-      climbedAt: tick.climbedAt,
-      createdAt: tick.createdAt,
-      updatedAt: tick.updatedAt,
-      sessionId: tick.sessionId,
-      auroraType: tick.auroraType,
-      auroraId: tick.auroraId,
-      auroraSyncedAt: tick.auroraSyncedAt,
-      layoutId,
-      upvotes: Number(upvotes ?? 0),
-      downvotes: Number(downvotes ?? 0),
-      commentCount: Number(commentCount ?? 0),
-    }));
+    // Batch-fetch social aggregates in two grouped queries instead of running
+    // a correlated subquery per row — this resolver is unbounded (no LIMIT),
+    // so a user with thousands of ticks would otherwise hit thousands of
+    // `comments` / `vote_counts` lookups on every accumulated-logbook refresh.
+    const tickUuids = results.map((r) => r.tick.uuid);
+    const [voteRows, commentRows] =
+      tickUuids.length > 0
+        ? await Promise.all([
+            db
+              .select({
+                entityId: dbSchema.voteCounts.entityId,
+                upvotes: dbSchema.voteCounts.upvotes,
+                downvotes: dbSchema.voteCounts.downvotes,
+              })
+              .from(dbSchema.voteCounts)
+              .where(
+                and(
+                  eq(dbSchema.voteCounts.entityType, 'tick'),
+                  inArray(dbSchema.voteCounts.entityId, tickUuids),
+                ),
+              ),
+            db
+              .select({
+                entityId: dbSchema.comments.entityId,
+                commentCount: sql<number>`COUNT(*)::int`.as('comment_count'),
+              })
+              .from(dbSchema.comments)
+              .where(
+                and(
+                  eq(dbSchema.comments.entityType, 'tick'),
+                  inArray(dbSchema.comments.entityId, tickUuids),
+                  isNull(dbSchema.comments.deletedAt),
+                ),
+              )
+              .groupBy(dbSchema.comments.entityId),
+          ])
+        : [[], []];
+
+    const voteMap = new Map(voteRows.map((v) => [v.entityId, v]));
+    const commentMap = new Map(commentRows.map((c) => [c.entityId, Number(c.commentCount)]));
+
+    return results.map(({ tick, layoutId }) => {
+      const votes = voteMap.get(tick.uuid);
+      return {
+        uuid: tick.uuid,
+        userId: tick.userId,
+        boardType: tick.boardType,
+        climbUuid: tick.climbUuid,
+        angle: tick.angle,
+        isMirror: tick.isMirror,
+        status: tick.status,
+        attemptCount: tick.attemptCount,
+        quality: tick.quality,
+        difficulty: tick.difficulty,
+        isBenchmark: tick.isBenchmark,
+        comment: tick.comment,
+        climbedAt: tick.climbedAt,
+        createdAt: tick.createdAt,
+        updatedAt: tick.updatedAt,
+        sessionId: tick.sessionId,
+        auroraType: tick.auroraType,
+        auroraId: tick.auroraId,
+        auroraSyncedAt: tick.auroraSyncedAt,
+        layoutId,
+        upvotes: votes ? Number(votes.upvotes) : 0,
+        downvotes: votes ? Number(votes.downvotes) : 0,
+        commentCount: commentMap.get(tick.uuid) ?? 0,
+      };
+    });
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -10,6 +10,7 @@ import {
   difficultyNameWithFallbackExpr,
   consensusGradeTable,
   consensusGradeJoinCondition,
+  tickCommentCountExpr,
 } from '../shared/sql-expressions';
 import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas';
 
@@ -37,16 +38,6 @@ export const tickQueries = {
       conditions.push(inArray(dbSchema.boardseshTicks.climbUuid, input.climbUuids));
     }
 
-    // Per-tick comment count (non-deleted) as a correlated subquery so we can
-    // surface social affordances on each row without an N+1 round trip.
-    const commentCountExpr = sql<number>`(
-      SELECT COUNT(*)::int
-      FROM ${dbSchema.comments}
-      WHERE ${dbSchema.comments.entityType} = 'tick'
-        AND ${dbSchema.comments.entityId} = ${dbSchema.boardseshTicks.uuid}
-        AND ${dbSchema.comments.deletedAt} IS NULL
-    )`;
-
     // Fetch ticks with layoutId from unified board_climbs table
     const results = await db
       .select({
@@ -54,7 +45,7 @@ export const tickQueries = {
         layoutId: dbSchema.boardClimbs.layoutId,
         upvotes: dbSchema.voteCounts.upvotes,
         downvotes: dbSchema.voteCounts.downvotes,
-        commentCount: commentCountExpr,
+        commentCount: tickCommentCountExpr,
       })
       .from(dbSchema.boardseshTicks)
       .leftJoin(

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -212,12 +212,17 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     climbedAt: String!
     "Encoded hold frames for thumbnail display"
     frames: String
-    "Number of upvotes (likes) on this tick"
-    upvotes: Int!
-    "Number of downvotes on this tick"
-    downvotes: Int!
-    "Number of (non-deleted) comments on this tick"
-    commentCount: Int!
+    # Social aggregates are only populated by resolvers that opt-in to the
+    # tick comment / vote joins (e.g. \`followingClimbAscents\`). They are
+    # nullable here so adapter paths like activity-feed or the paginated
+    # \`followingAscentsFeed\` / \`globalAscentsFeed\` don't have to compute or
+    # fake counts they don't need.
+    "Number of upvotes (likes) on this tick. Null if the resolver doesn't compute it."
+    upvotes: Int
+    "Number of downvotes on this tick. Null if the resolver doesn't compute it."
+    downvotes: Int
+    "Number of (non-deleted) comments on this tick. Null if the resolver doesn't compute it."
+    commentCount: Int
   }
 
   """

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -212,6 +212,12 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     climbedAt: String!
     "Encoded hold frames for thumbnail display"
     frames: String
+    "Number of upvotes (likes) on this tick"
+    upvotes: Int!
+    "Number of downvotes on this tick"
+    downvotes: Int!
+    "Number of (non-deleted) comments on this tick"
+    commentCount: Int!
   }
 
   """

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -61,6 +61,12 @@ export const ticksTypeDefs = /* GraphQL */ `
     layoutId: Int
     "Board entity ID if tick was associated with a board"
     boardId: Int
+    "Number of upvotes (likes) on this tick. Only populated by read queries."
+    upvotes: Int
+    "Number of downvotes on this tick. Only populated by read queries."
+    downvotes: Int
+    "Number of (non-deleted) comments on this tick. Only populated by read queries."
+    commentCount: Int
   }
 
   """

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -61,11 +61,15 @@ export const ticksTypeDefs = /* GraphQL */ `
     layoutId: Int
     "Board entity ID if tick was associated with a board"
     boardId: Int
-    "Number of upvotes (likes) on this tick. Only populated by read queries."
+    # Social aggregates are only populated by read queries (e.g. \`ticks\`).
+    # Mutation resolvers (\`saveTick\`, \`updateTick\`) don't compute them so they
+    # are nullable here; when a client needs guaranteed counts, prefer
+    # \`FollowingAscentFeedItem\` or a direct \`voteSummary\` / \`comments\` query.
+    "Number of upvotes (likes) on this tick. Null unless populated by a read query."
     upvotes: Int
-    "Number of downvotes on this tick. Only populated by read queries."
+    "Number of downvotes on this tick. Null unless populated by a read query."
     downvotes: Int
-    "Number of (non-deleted) comments on this tick. Only populated by read queries."
+    "Number of (non-deleted) comments on this tick. Null unless populated by a read query."
     commentCount: Int
   }
 

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -24,6 +24,9 @@ export type FollowingAscentFeedItem = {
   comment: string;
   climbedAt: string;
   frames?: string;
+  upvotes: number;
+  downvotes: number;
+  commentCount: number;
 };
 
 export type AscentFeedItem = {

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -24,9 +24,12 @@ export type FollowingAscentFeedItem = {
   comment: string;
   climbedAt: string;
   frames?: string;
-  upvotes: number;
-  downvotes: number;
-  commentCount: number;
+  // Populated only by resolvers that join vote_counts / count comments
+  // (e.g. followingClimbAscents). Null for adapter paths and for the
+  // paginated followingAscentsFeed / globalAscentsFeed endpoints.
+  upvotes?: number | null;
+  downvotes?: number | null;
+  commentCount?: number | null;
 };
 
 export type AscentFeedItem = {

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -24,6 +24,11 @@ export type Tick = {
   auroraSyncedAt: string | null;
   layoutId: number | null;
   boardId?: number | null;
+  // Social aggregates are populated only by read queries (the `ticks`
+  // resolver joins `vote_counts` and counts `comments`). Mutation resolvers
+  // like `saveTick` / `updateTick` don't compute them, so these stay optional
+  // at the type level. Client code that reads a tick via a mutation response
+  // should default to 0 rather than rely on these being present.
   upvotes?: number | null;
   downvotes?: number | null;
   commentCount?: number | null;

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -24,6 +24,9 @@ export type Tick = {
   auroraSyncedAt: string | null;
   layoutId: number | null;
   boardId?: number | null;
+  upvotes?: number | null;
+  downvotes?: number | null;
+  commentCount?: number | null;
 };
 
 export type SaveTickInput = {

--- a/packages/web/app/components/activity-feed/feed-item-ascent.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-ascent.tsx
@@ -35,6 +35,10 @@ export default function FeedItemAscent({ item }: FeedItemAscentProps) {
     comment: item.comment || '',
     climbedAt: item.createdAt,
     frames: item.frames ?? undefined,
+    // Social aggregates aren't carried on ActivityFeedItem. SocialFeedItem
+    // here renders without a tick-scoped like/comment footer, so the zero
+    // defaults are never read by the UI — they exist only to satisfy the
+    // required shape of FollowingAscentFeedItem.
     upvotes: 0,
     downvotes: 0,
     commentCount: 0,

--- a/packages/web/app/components/activity-feed/feed-item-ascent.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-ascent.tsx
@@ -35,13 +35,10 @@ export default function FeedItemAscent({ item }: FeedItemAscentProps) {
     comment: item.comment || '',
     climbedAt: item.createdAt,
     frames: item.frames ?? undefined,
-    // Social aggregates aren't carried on ActivityFeedItem. SocialFeedItem
-    // here renders without a tick-scoped like/comment footer, so the zero
-    // defaults are never read by the UI — they exist only to satisfy the
-    // required shape of FollowingAscentFeedItem.
-    upvotes: 0,
-    downvotes: 0,
-    commentCount: 0,
+    // Social aggregates aren't carried on ActivityFeedItem, so we leave them
+    // null rather than fabricating zeros: a future tickUuid-aware
+    // SocialFeedItem would render null counts as "—" / hidden instead of
+    // silently showing "0 likes, 0 comments" on every activity row.
   };
 
   return (

--- a/packages/web/app/components/activity-feed/feed-item-ascent.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-ascent.tsx
@@ -35,6 +35,9 @@ export default function FeedItemAscent({ item }: FeedItemAscentProps) {
     comment: item.comment || '',
     climbedAt: item.createdAt,
     frames: item.frames ?? undefined,
+    upvotes: 0,
+    downvotes: 0,
+    commentCount: 0,
   };
 
   return (

--- a/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
@@ -115,7 +115,7 @@ describe('AscentStatus', () => {
             status: 'send',
             upvotes: 0,
             downvotes: 0,
-            comment_count: 0,
+            commentCount: 0,
           },
           {
             uuid: '2',
@@ -131,7 +131,7 @@ describe('AscentStatus', () => {
             status: 'flash',
             upvotes: 0,
             downvotes: 0,
-            comment_count: 0,
+            commentCount: 0,
           },
           {
             uuid: '3',
@@ -147,7 +147,7 @@ describe('AscentStatus', () => {
             status: 'attempt',
             upvotes: 0,
             downvotes: 0,
-            comment_count: 0,
+            commentCount: 0,
           },
         ],
       }),
@@ -175,7 +175,7 @@ describe('AscentStatus', () => {
             status: 'send',
             upvotes: 0,
             downvotes: 0,
-            comment_count: 0,
+            commentCount: 0,
           },
           {
             uuid: '2',
@@ -191,7 +191,7 @@ describe('AscentStatus', () => {
             status: 'flash',
             upvotes: 0,
             downvotes: 0,
-            comment_count: 0,
+            commentCount: 0,
           },
         ],
       }),
@@ -230,7 +230,7 @@ describe('AscentStatus', () => {
       status: 'flash',
       upvotes: 0,
       downvotes: 0,
-      comment_count: 0,
+      commentCount: 0,
     };
 
     act(() => {

--- a/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
@@ -113,6 +113,9 @@ describe('AscentStatus', () => {
             climbed_at: '2025-01-01T00:00:00.000Z',
             is_ascent: true,
             status: 'send',
+            upvotes: 0,
+            downvotes: 0,
+            comment_count: 0,
           },
           {
             uuid: '2',
@@ -126,6 +129,9 @@ describe('AscentStatus', () => {
             climbed_at: '2025-01-02T00:00:00.000Z',
             is_ascent: true,
             status: 'flash',
+            upvotes: 0,
+            downvotes: 0,
+            comment_count: 0,
           },
           {
             uuid: '3',
@@ -139,6 +145,9 @@ describe('AscentStatus', () => {
             climbed_at: '2025-01-03T00:00:00.000Z',
             is_ascent: false,
             status: 'attempt',
+            upvotes: 0,
+            downvotes: 0,
+            comment_count: 0,
           },
         ],
       }),
@@ -164,6 +173,9 @@ describe('AscentStatus', () => {
             climbed_at: '2025-01-01T00:00:00.000Z',
             is_ascent: true,
             status: 'send',
+            upvotes: 0,
+            downvotes: 0,
+            comment_count: 0,
           },
           {
             uuid: '2',
@@ -177,6 +189,9 @@ describe('AscentStatus', () => {
             climbed_at: '2025-01-02T00:00:00.000Z',
             is_ascent: true,
             status: 'flash',
+            upvotes: 0,
+            downvotes: 0,
+            comment_count: 0,
           },
         ],
       }),
@@ -213,6 +228,9 @@ describe('AscentStatus', () => {
       climbed_at: '2024-02-01',
       is_ascent: true,
       status: 'flash',
+      upvotes: 0,
+      downvotes: 0,
+      comment_count: 0,
     };
 
     act(() => {

--- a/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
@@ -33,7 +33,14 @@ vi.mock('../logbook-entry-card', () => ({
     user,
     showMirrorTag,
   }: {
-    entry: { attemptCount: number; status?: string | null };
+    entry: {
+      attemptCount: number;
+      status?: string | null;
+      tickUuid?: string | null;
+      upvotes?: number | null;
+      downvotes?: number | null;
+      commentCount?: number | null;
+    };
     user?: { userId: string; displayName?: string | null };
     showMirrorTag: boolean;
   }) => (
@@ -44,8 +51,28 @@ vi.mock('../logbook-entry-card', () => ({
       data-status={entry.status ?? ''}
       data-attempts={entry.attemptCount}
       data-mirror-tag={String(showMirrorTag)}
+      data-tick-uuid={entry.tickUuid ?? ''}
+      data-upvotes={entry.upvotes ?? 0}
+      data-downvotes={entry.downvotes ?? 0}
+      data-comment-count={entry.commentCount ?? 0}
     />
   ),
+}));
+
+const mockVoteSummaryProvider = vi.fn();
+vi.mock('@/app/components/social/vote-summary-context', () => ({
+  VoteSummaryProvider: ({
+    entityType,
+    entityIds,
+    children,
+  }: {
+    entityType: string;
+    entityIds: string[];
+    children: React.ReactNode;
+  }) => {
+    mockVoteSummaryProvider({ entityType, entityIds });
+    return <div data-testid="vote-summary-provider">{children}</div>;
+  },
 }));
 
 import { CrewLogbookView } from '../crew-logbook-view';
@@ -132,7 +159,7 @@ describe('CrewLogbookView', () => {
     });
   });
 
-  it('renders a card per item and passes through status, user, and mirror-tag props', async () => {
+  it('renders a card per item and passes through status, user, social, and mirror-tag props', async () => {
     mockUseWsAuthToken.mockReturnValue({ token: 'tk', isAuthenticated: true, isLoading: false });
     mockRequest.mockResolvedValueOnce({
       followingClimbAscents: {
@@ -150,6 +177,9 @@ describe('CrewLogbookView', () => {
             quality: 5,
             comment: 'Nice',
             climbedAt: '2025-01-01T00:00:00Z',
+            upvotes: 4,
+            downvotes: 0,
+            commentCount: 2,
           },
           {
             uuid: 'tick-2',
@@ -164,6 +194,9 @@ describe('CrewLogbookView', () => {
             quality: null,
             comment: '',
             climbedAt: '2025-01-02T00:00:00Z',
+            upvotes: 0,
+            downvotes: 1,
+            commentCount: 0,
           },
         ],
       },
@@ -179,10 +212,20 @@ describe('CrewLogbookView', () => {
     // Raw status is passed through — normalisation happens inside LogbookEntryCard.
     expect(cards[0].getAttribute('data-status')).toBe('flash');
     expect(cards[0].getAttribute('data-mirror-tag')).toBe('true');
+    expect(cards[0].getAttribute('data-tick-uuid')).toBe('tick-1');
+    expect(cards[0].getAttribute('data-upvotes')).toBe('4');
+    expect(cards[0].getAttribute('data-comment-count')).toBe('2');
 
     expect(cards[1].getAttribute('data-user-id')).toBe('user-2');
     expect(cards[1].getAttribute('data-status')).toBe('attempt');
     expect(cards[1].getAttribute('data-attempts')).toBe('4');
+    expect(cards[1].getAttribute('data-tick-uuid')).toBe('tick-2');
+
+    // Bulk vote-summary provider is wired with every tick UUID exactly once.
+    expect(mockVoteSummaryProvider).toHaveBeenCalledWith({
+      entityType: 'tick',
+      entityIds: ['tick-1', 'tick-2'],
+    });
   });
 
   it('does not show mirror tag for non-tension boards', async () => {
@@ -203,6 +246,9 @@ describe('CrewLogbookView', () => {
             quality: 3,
             comment: '',
             climbedAt: '2025-01-01T00:00:00Z',
+            upvotes: 0,
+            downvotes: 0,
+            commentCount: 0,
           },
         ],
       },

--- a/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
@@ -22,6 +22,44 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/app/components/social/vote-button', () => ({
+  default: ({
+    entityType,
+    entityId,
+    initialUpvotes,
+  }: {
+    entityType: string;
+    entityId: string;
+    initialUpvotes?: number;
+  }) => (
+    <div
+      data-testid="vote-button"
+      data-entity-type={entityType}
+      data-entity-id={entityId}
+      data-initial-upvotes={initialUpvotes ?? 0}
+    />
+  ),
+}));
+
+vi.mock('@/app/components/social/feed-comment-button', () => ({
+  default: ({
+    entityType,
+    entityId,
+    commentCount,
+  }: {
+    entityType: string;
+    entityId: string;
+    commentCount?: number;
+  }) => (
+    <div
+      data-testid="feed-comment-button"
+      data-entity-type={entityType}
+      data-entity-id={entityId}
+      data-comment-count={commentCount ?? 0}
+    />
+  ),
+}));
+
 const baseEntry = {
   climbedAt: '2025-01-02T12:00:00Z',
   angle: 40,
@@ -139,5 +177,37 @@ describe('LogbookEntryCard', () => {
     const icon = screen.getByTestId('ascent-status-icon');
     expect(icon.getAttribute('data-status')).toBe('attempt');
     expect(screen.queryByTestId('rating')).toBeNull();
+  });
+
+  it('does not render the social footer when tickUuid is absent', () => {
+    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
+    expect(screen.queryByTestId('vote-button')).toBeNull();
+    expect(screen.queryByTestId('feed-comment-button')).toBeNull();
+  });
+
+  it('renders a like + comment footer wired to the tick when tickUuid is set', () => {
+    render(
+      <LogbookEntryCard
+        entry={{
+          ...baseEntry,
+          tickUuid: 'tick-99',
+          upvotes: 7,
+          downvotes: 1,
+          commentCount: 3,
+        }}
+        currentClimbAngle={40}
+        showMirrorTag={false}
+      />,
+    );
+
+    const vote = screen.getByTestId('vote-button');
+    expect(vote.getAttribute('data-entity-type')).toBe('tick');
+    expect(vote.getAttribute('data-entity-id')).toBe('tick-99');
+    expect(vote.getAttribute('data-initial-upvotes')).toBe('7');
+
+    const comments = screen.getByTestId('feed-comment-button');
+    expect(comments.getAttribute('data-entity-type')).toBe('tick');
+    expect(comments.getAttribute('data-entity-id')).toBe('tick-99');
+    expect(comments.getAttribute('data-comment-count')).toBe('3');
   });
 });

--- a/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
@@ -79,6 +79,34 @@ describe('LogbookView', () => {
     expect(screen.getByText('No ascents logged for this climb')).toBeTruthy();
   });
 
+  it('caps the vote-summary batch at 100 tick UUIDs to match the backend input limit', () => {
+    const ascents = Array.from({ length: 105 }, (_, i) => ({
+      uuid: `persisted-${String(i).padStart(3, '0')}`,
+      climb_uuid: 'climb-1',
+      // Later index = more recent climbedAt, so ids sort desc by time.
+      climbed_at: new Date(2025, 0, 1, 0, 0, i).toISOString(),
+      angle: 40,
+      tries: 1,
+      is_ascent: true,
+      status: 'send' as const,
+      is_mirror: false,
+      quality: null,
+      comment: '',
+    }));
+
+    mockUseBoardProvider.mockReturnValue({ boardName: 'kilter', logbook: ascents });
+
+    render(<LogbookView currentClimb={makeClimb()} />);
+
+    expect(mockVoteSummaryProvider).toHaveBeenCalledTimes(1);
+    const { entityIds } = mockVoteSummaryProvider.mock.calls[0][0] as { entityIds: string[] };
+    expect(entityIds).toHaveLength(100);
+    // The 100 ids passed to the provider must be the most recent ascents
+    // (newest-first), not an arbitrary slice.
+    expect(entityIds[0]).toBe('persisted-104');
+    expect(entityIds[99]).toBe('persisted-005');
+  });
+
   it('suppresses the social footer and excludes temp- UUIDs from the vote-summary fetch for optimistic entries', () => {
     mockUseBoardProvider.mockReturnValue({
       boardName: 'kilter',

--- a/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
@@ -22,6 +22,18 @@ vi.mock('@/app/components/ui/empty-state', () => ({
   EmptyState: ({ description }: { description: string }) => <div data-testid="empty-state">{description}</div>,
 }));
 
+vi.mock('@/app/components/social/vote-summary-context', () => ({
+  VoteSummaryProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/app/components/social/vote-button', () => ({
+  default: () => <div data-testid="vote-button" />,
+}));
+
+vi.mock('@/app/components/social/feed-comment-button', () => ({
+  default: () => <div data-testid="feed-comment-button" />,
+}));
+
 import { LogbookView } from '../logbook-view';
 
 function makeClimb(overrides: Partial<Climb> = {}): Climb {

--- a/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
@@ -22,16 +22,30 @@ vi.mock('@/app/components/ui/empty-state', () => ({
   EmptyState: ({ description }: { description: string }) => <div data-testid="empty-state">{description}</div>,
 }));
 
+const mockVoteSummaryProvider = vi.fn();
 vi.mock('@/app/components/social/vote-summary-context', () => ({
-  VoteSummaryProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  VoteSummaryProvider: ({
+    entityType,
+    entityIds,
+    children,
+  }: {
+    entityType: string;
+    entityIds: string[];
+    children: React.ReactNode;
+  }) => {
+    mockVoteSummaryProvider({ entityType, entityIds });
+    return <>{children}</>;
+  },
 }));
 
 vi.mock('@/app/components/social/vote-button', () => ({
-  default: () => <div data-testid="vote-button" />,
+  default: ({ entityId }: { entityId: string }) => <div data-testid="vote-button" data-entity-id={entityId} />,
 }));
 
 vi.mock('@/app/components/social/feed-comment-button', () => ({
-  default: () => <div data-testid="feed-comment-button" />,
+  default: ({ entityId }: { entityId: string }) => (
+    <div data-testid="feed-comment-button" data-entity-id={entityId} />
+  ),
 }));
 
 import { LogbookView } from '../logbook-view';
@@ -63,6 +77,56 @@ describe('LogbookView', () => {
     render(<LogbookView currentClimb={makeClimb()} />);
     expect(screen.getByTestId('empty-state')).toBeTruthy();
     expect(screen.getByText('No ascents logged for this climb')).toBeTruthy();
+  });
+
+  it('suppresses the social footer and excludes temp- UUIDs from the vote-summary fetch for optimistic entries', () => {
+    mockUseBoardProvider.mockReturnValue({
+      boardName: 'kilter',
+      logbook: [
+        {
+          uuid: 'temp-123',
+          climb_uuid: 'climb-1',
+          climbed_at: '2025-02-02T12:00:00Z',
+          angle: 40,
+          tries: 1,
+          is_ascent: true,
+          status: 'flash',
+          is_mirror: false,
+          quality: null,
+          comment: 'optimistic',
+        },
+        {
+          uuid: 'persisted-456',
+          climb_uuid: 'climb-1',
+          climbed_at: '2025-02-01T12:00:00Z',
+          angle: 40,
+          tries: 2,
+          is_ascent: true,
+          status: 'send',
+          is_mirror: false,
+          quality: 4,
+          comment: 'saved',
+        },
+      ],
+    });
+
+    render(<LogbookView currentClimb={makeClimb()} />);
+
+    // Only the persisted tick gets a like + comment footer — the optimistic
+    // row must not try to vote on or comment against a tick the server
+    // doesn't know about yet.
+    const voteButtons = screen.getAllByTestId('vote-button');
+    expect(voteButtons).toHaveLength(1);
+    expect(voteButtons[0].getAttribute('data-entity-id')).toBe('persisted-456');
+
+    const commentButtons = screen.getAllByTestId('feed-comment-button');
+    expect(commentButtons).toHaveLength(1);
+    expect(commentButtons[0].getAttribute('data-entity-id')).toBe('persisted-456');
+
+    expect(mockVoteSummaryProvider).toHaveBeenCalledWith({
+      entityType: 'tick',
+      entityIds: ['persisted-456'],
+    });
   });
 
   it('renders normalized status icons, mirrored tags, and ratings for successful ascents', () => {

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -86,6 +86,9 @@ function makeLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
     climbed_at: '2025-01-01T00:00:00Z',
     is_ascent: false,
     status: 'attempt',
+    upvotes: 0,
+    downvotes: 0,
+    comment_count: 0,
     ...overrides,
   };
 }

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -88,7 +88,7 @@ function makeLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
     status: 'attempt',
     upvotes: 0,
     downvotes: 0,
-    comment_count: 0,
+    commentCount: 0,
     ...overrides,
   };
 }

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -252,6 +252,9 @@ describe('TickButton', () => {
           climbed_at: '2025-01-01',
           is_ascent: true,
           status: 'flash',
+          upvotes: 0,
+          downvotes: 0,
+          comment_count: 0,
         },
         {
           uuid: 'log-2',
@@ -265,6 +268,9 @@ describe('TickButton', () => {
           climbed_at: '2025-01-02',
           is_ascent: false,
           status: 'attempt',
+          upvotes: 0,
+          downvotes: 0,
+          comment_count: 0,
         },
       ];
       render(<TickButton {...defaultProps} />);

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -254,7 +254,7 @@ describe('TickButton', () => {
           status: 'flash',
           upvotes: 0,
           downvotes: 0,
-          comment_count: 0,
+          commentCount: 0,
         },
         {
           uuid: 'log-2',
@@ -270,7 +270,7 @@ describe('TickButton', () => {
           status: 'attempt',
           upvotes: 0,
           downvotes: 0,
-          comment_count: 0,
+          commentCount: 0,
         },
       ];
       render(<TickButton {...defaultProps} />);

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +14,7 @@ import {
   type GetFollowingClimbAscentsQueryVariables,
 } from '@/app/lib/graphql/operations';
 import type { Climb } from '@/app/lib/types';
+import { VoteSummaryProvider } from '@/app/components/social/vote-summary-context';
 import { LogbookEntryCard } from './logbook-entry-card';
 
 interface CrewLogbookViewProps {
@@ -62,7 +63,8 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
     return <EmptyState description="Couldn't load your crew's logbook. Try again in a bit." />;
   }
 
-  const items = data?.items ?? [];
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const tickUuids = useMemo(() => items.map((item) => item.uuid), [items]);
 
   if (items.length === 0) {
     return <EmptyState description="None of your crew have logged this climb yet" />;
@@ -71,28 +73,34 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
   const showMirrorTag = boardType === 'tension';
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {items.map((item) => (
-        <LogbookEntryCard
-          key={item.uuid}
-          entry={{
-            climbedAt: item.climbedAt,
-            angle: item.angle,
-            isMirror: !!item.isMirror,
-            status: item.status,
-            attemptCount: item.attemptCount,
-            quality: item.quality ?? null,
-            comment: item.comment,
-          }}
-          currentClimbAngle={currentClimb.angle}
-          showMirrorTag={showMirrorTag}
-          user={{
-            userId: item.userId,
-            displayName: item.userDisplayName ?? null,
-            avatarUrl: item.userAvatarUrl ?? null,
-          }}
-        />
-      ))}
-    </Box>
+    <VoteSummaryProvider entityType="tick" entityIds={tickUuids}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {items.map((item) => (
+          <LogbookEntryCard
+            key={item.uuid}
+            entry={{
+              climbedAt: item.climbedAt,
+              angle: item.angle,
+              isMirror: !!item.isMirror,
+              status: item.status,
+              attemptCount: item.attemptCount,
+              quality: item.quality ?? null,
+              comment: item.comment,
+              tickUuid: item.uuid,
+              upvotes: item.upvotes,
+              downvotes: item.downvotes,
+              commentCount: item.commentCount,
+            }}
+            currentClimbAngle={currentClimb.angle}
+            showMirrorTag={showMirrorTag}
+            user={{
+              userId: item.userId,
+              displayName: item.userDisplayName ?? null,
+              avatarUrl: item.userAvatarUrl ?? null,
+            }}
+          />
+        ))}
+      </Box>
+    </VoteSummaryProvider>
   );
 };

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -47,6 +47,9 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
     staleTime: 60 * 1000,
   });
 
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const tickUuids = useMemo(() => items.map((item) => item.uuid), [items]);
+
   if (authLoading || (enabled && isLoading)) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
@@ -62,9 +65,6 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
   if (isError) {
     return <EmptyState description="Couldn't load your crew's logbook. Try again in a bit." />;
   }
-
-  const items = useMemo(() => data?.items ?? [], [data]);
-  const tickUuids = useMemo(() => items.map((item) => item.uuid), [items]);
 
   if (items.length === 0) {
     return <EmptyState description="None of your crew have logged this climb yet" />;

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -40,12 +40,14 @@ export interface LogbookEntryCardData {
    * Tick UUID. When set, the card renders a like + comment footer targeting
    * this tick via the social `tick` entity type. Omit to render the card
    * without social affordances.
+   *
+   * The current user's vote on the tick is resolved by the enclosing
+   * `VoteSummaryProvider` batch-fetch rather than being threaded through the
+   * card, so there is no `userVote` prop here.
    */
   tickUuid?: string | null;
   upvotes?: number | null;
   downvotes?: number | null;
-  /** Current user's vote on this tick (-1, 0, or 1). */
-  userVote?: number | null;
   commentCount?: number | null;
 }
 
@@ -140,7 +142,6 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
                 entityId={entry.tickUuid}
                 initialUpvotes={entry.upvotes ?? 0}
                 initialDownvotes={entry.downvotes ?? 0}
-                initialUserVote={entry.userVote ?? undefined}
                 likeOnly
               />
               <FeedCommentButton

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -18,6 +18,8 @@ import {
   normalizeAscentStatus,
   type AscentStatusValue,
 } from '@/app/components/ascent-status/ascent-status-utils';
+import VoteButton from '@/app/components/social/vote-button';
+import FeedCommentButton from '@/app/components/social/feed-comment-button';
 
 export interface LogbookEntryUser {
   userId: string;
@@ -34,6 +36,17 @@ export interface LogbookEntryCardData {
   attemptCount: number;
   quality?: number | null;
   comment?: string | null;
+  /**
+   * Tick UUID. When set, the card renders a like + comment footer targeting
+   * this tick via the social `tick` entity type. Omit to render the card
+   * without social affordances.
+   */
+  tickUuid?: string | null;
+  upvotes?: number | null;
+  downvotes?: number | null;
+  /** Current user's vote on this tick (-1, 0, or 1). */
+  userVote?: number | null;
+  commentCount?: number | null;
 }
 
 export interface LogbookEntryCardProps {
@@ -119,6 +132,23 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
             >
               {entry.comment}
             </Typography>
+          )}
+          {entry.tickUuid && (
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
+              <VoteButton
+                entityType="tick"
+                entityId={entry.tickUuid}
+                initialUpvotes={entry.upvotes ?? 0}
+                initialDownvotes={entry.downvotes ?? 0}
+                initialUserVote={entry.userVote ?? undefined}
+                likeOnly
+              />
+              <FeedCommentButton
+                entityType="tick"
+                entityId={entry.tickUuid}
+                commentCount={entry.commentCount ?? 0}
+              />
+            </Stack>
           )}
         </Stack>
       </CardContent>

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box';
 import dayjs from 'dayjs';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import type { Climb } from '@/app/lib/types';
+import { VoteSummaryProvider } from '@/app/components/social/vote-summary-context';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { LogbookEntryCard } from './logbook-entry-card';
 
@@ -23,6 +24,17 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
     [logbook, currentClimb.uuid],
   );
 
+  // Optimistic ticks live under a `temp-` UUID until the save mutation returns
+  // the real one — those rows must not render social affordances or be
+  // included in the bulk vote-summary fetch.
+  const isPersistedUuid = (uuid: string | undefined): uuid is string =>
+    !!uuid && !uuid.startsWith('temp-');
+
+  const tickUuids = useMemo(
+    () => climbAscents.map((ascent) => ascent.uuid).filter(isPersistedUuid),
+    [climbAscents],
+  );
+
   const showMirrorTag = boardName === 'tension';
 
   if (climbAscents.length === 0) {
@@ -30,23 +42,29 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {climbAscents.map((ascent) => (
-        <LogbookEntryCard
-          key={`${ascent.climb_uuid}-${ascent.climbed_at}`}
-          entry={{
-            climbedAt: ascent.climbed_at,
-            angle: ascent.angle,
-            isMirror: !!ascent.is_mirror,
-            status: ascent.status ?? null,
-            attemptCount: ascent.tries,
-            quality: ascent.quality,
-            comment: ascent.comment,
-          }}
-          currentClimbAngle={currentClimb.angle}
-          showMirrorTag={showMirrorTag}
-        />
-      ))}
-    </Box>
+    <VoteSummaryProvider entityType="tick" entityIds={tickUuids}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {climbAscents.map((ascent) => (
+          <LogbookEntryCard
+            key={ascent.uuid || `${ascent.climb_uuid}-${ascent.climbed_at}`}
+            entry={{
+              climbedAt: ascent.climbed_at,
+              angle: ascent.angle,
+              isMirror: !!ascent.is_mirror,
+              status: ascent.status ?? null,
+              attemptCount: ascent.tries,
+              quality: ascent.quality,
+              comment: ascent.comment,
+              tickUuid: isPersistedUuid(ascent.uuid) ? ascent.uuid : null,
+              upvotes: ascent.upvotes,
+              downvotes: ascent.downvotes,
+              commentCount: ascent.comment_count,
+            }}
+            currentClimbAngle={currentClimb.angle}
+            showMirrorTag={showMirrorTag}
+          />
+        ))}
+      </Box>
+    </VoteSummaryProvider>
   );
 };

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -13,6 +13,11 @@ interface LogbookViewProps {
   currentClimb: Climb;
 }
 
+// Optimistic ticks live under a `temp-` UUID until the save mutation returns
+// the real one — those rows must not render social affordances or be included
+// in the bulk vote-summary fetch.
+const isPersistedUuid = (uuid: string | undefined): uuid is string => !!uuid && !uuid.startsWith('temp-');
+
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const { logbook, boardName } = useBoardProvider();
 
@@ -23,12 +28,6 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
         .sort((a, b) => dayjs(b.climbed_at).valueOf() - dayjs(a.climbed_at).valueOf()),
     [logbook, currentClimb.uuid],
   );
-
-  // Optimistic ticks live under a `temp-` UUID until the save mutation returns
-  // the real one — those rows must not render social affordances or be
-  // included in the bulk vote-summary fetch.
-  const isPersistedUuid = (uuid: string | undefined): uuid is string =>
-    !!uuid && !uuid.startsWith('temp-');
 
   const tickUuids = useMemo(
     () => climbAscents.map((ascent) => ascent.uuid).filter(isPersistedUuid),
@@ -58,7 +57,7 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
               tickUuid: isPersistedUuid(ascent.uuid) ? ascent.uuid : null,
               upvotes: ascent.upvotes,
               downvotes: ascent.downvotes,
-              commentCount: ascent.comment_count,
+              commentCount: ascent.commentCount,
             }}
             currentClimbAngle={currentClimb.angle}
             showMirrorTag={showMirrorTag}

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -18,6 +18,14 @@ interface LogbookViewProps {
 // in the bulk vote-summary fetch.
 const isPersistedUuid = (uuid: string | undefined): uuid is string => !!uuid && !uuid.startsWith('temp-');
 
+// Matches BulkVoteSummaryInputSchema.entityIds.max(100) on the backend. A
+// request with more than 100 IDs is rejected outright, so we slice before
+// handing the list to VoteSummaryProvider. Entries beyond this cap still
+// render their social footer, but the current-user vote state on those
+// rows won't be hydrated (VoteButton falls back to a 0 display, not an
+// error).
+const VOTE_SUMMARY_BATCH_LIMIT = 100;
+
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const { logbook, boardName } = useBoardProvider();
 
@@ -30,7 +38,14 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   );
 
   const tickUuids = useMemo(
-    () => climbAscents.map((ascent) => ascent.uuid).filter(isPersistedUuid),
+    () =>
+      climbAscents
+        .map((ascent) => ascent.uuid)
+        .filter(isPersistedUuid)
+        // Ascents are already sorted newest-first, so the most recently
+        // logged ticks (the ones most likely to be scrolled onto screen)
+        // are the ones that get user-vote hydration.
+        .slice(0, VOTE_SUMMARY_BATCH_LIMIT),
     [climbAscents],
   );
 

--- a/packages/web/app/hooks/__tests__/use-logbook.test.ts
+++ b/packages/web/app/hooks/__tests__/use-logbook.test.ts
@@ -418,7 +418,7 @@ describe('useLogbook', () => {
       status: 'flash',
       upvotes: 0,
       downvotes: 0,
-      comment_count: 0,
+      commentCount: 0,
     };
 
     act(() => {

--- a/packages/web/app/hooks/__tests__/use-logbook.test.ts
+++ b/packages/web/app/hooks/__tests__/use-logbook.test.ts
@@ -416,6 +416,9 @@ describe('useLogbook', () => {
       climbed_at: '2024-02-01',
       is_ascent: true,
       status: 'flash',
+      upvotes: 0,
+      downvotes: 0,
+      comment_count: 0,
     };
 
     act(() => {

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -95,6 +95,9 @@ function makeLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
     climbed_at: '2025-01-01T00:00:00Z',
     is_ascent: false,
     status: 'attempt',
+    upvotes: 0,
+    downvotes: 0,
+    comment_count: 0,
     ...overrides,
   };
 }

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -97,7 +97,7 @@ function makeLogbookEntry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
     status: 'attempt',
     upvotes: 0,
     downvotes: 0,
-    comment_count: 0,
+    commentCount: 0,
     ...overrides,
   };
 }

--- a/packages/web/app/hooks/use-logbook.ts
+++ b/packages/web/app/hooks/use-logbook.ts
@@ -24,6 +24,9 @@ export interface LogbookEntry {
   climbed_at: string;
   is_ascent: boolean;
   status?: TickStatus;
+  upvotes: number;
+  downvotes: number;
+  comment_count: number;
 }
 
 type LogbookSourceTick = {
@@ -37,6 +40,9 @@ type LogbookSourceTick = {
   difficulty: number | null;
   comment: string;
   climbedAt: string;
+  upvotes?: number | null;
+  downvotes?: number | null;
+  commentCount?: number | null;
 };
 
 export function toLogbookEntry(tick: LogbookSourceTick): LogbookEntry {
@@ -52,6 +58,9 @@ export function toLogbookEntry(tick: LogbookSourceTick): LogbookEntry {
     climbed_at: tick.climbedAt,
     is_ascent: tick.status === 'flash' || tick.status === 'send',
     status: tick.status,
+    upvotes: tick.upvotes ?? 0,
+    downvotes: tick.downvotes ?? 0,
+    comment_count: tick.commentCount ?? 0,
   };
 }
 

--- a/packages/web/app/hooks/use-logbook.ts
+++ b/packages/web/app/hooks/use-logbook.ts
@@ -26,7 +26,7 @@ export interface LogbookEntry {
   status?: TickStatus;
   upvotes: number;
   downvotes: number;
-  comment_count: number;
+  commentCount: number;
 }
 
 type LogbookSourceTick = {
@@ -60,7 +60,7 @@ export function toLogbookEntry(tick: LogbookSourceTick): LogbookEntry {
     status: tick.status,
     upvotes: tick.upvotes ?? 0,
     downvotes: tick.downvotes ?? 0,
-    comment_count: tick.commentCount ?? 0,
+    commentCount: tick.commentCount ?? 0,
   };
 }
 

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -97,6 +97,9 @@ export function useSaveTick(boardName: BoardName) {
         climbed_at: options.climbedAt,
         is_ascent: options.status === 'flash' || options.status === 'send',
         status: options.status,
+        upvotes: 0,
+        downvotes: 0,
+        comment_count: 0,
       };
 
       queryClient.setQueryData<LogbookEntry[]>(accumulatedKey, (existing = []) => [optimisticEntry, ...existing]);

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -99,7 +99,7 @@ export function useSaveTick(boardName: BoardName) {
         status: options.status,
         upvotes: 0,
         downvotes: 0,
-        comment_count: 0,
+        commentCount: 0,
       };
 
       queryClient.setQueryData<LogbookEntry[]>(accumulatedKey, (existing = []) => [optimisticEntry, ...existing]);

--- a/packages/web/app/lib/graphql/operations/social.ts
+++ b/packages/web/app/lib/graphql/operations/social.ts
@@ -276,6 +276,9 @@ export const GET_FOLLOWING_CLIMB_ASCENTS = gql`
         quality
         comment
         climbedAt
+        upvotes
+        downvotes
+        commentCount
       }
     }
   }
@@ -304,6 +307,9 @@ export type FollowingClimbAscentItem = Pick<
   | 'quality'
   | 'comment'
   | 'climbedAt'
+  | 'upvotes'
+  | 'downvotes'
+  | 'commentCount'
 >;
 
 export interface GetFollowingClimbAscentsQueryResponse {

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -15,6 +15,9 @@ export const GET_TICKS = gql`
       isBenchmark
       comment
       climbedAt
+      upvotes
+      downvotes
+      commentCount
     }
   }
 `;
@@ -64,6 +67,9 @@ type TickFromGetTicks = Pick<
   | 'isBenchmark'
   | 'comment'
   | 'climbedAt'
+  | 'upvotes'
+  | 'downvotes'
+  | 'commentCount'
 >;
 type TickFromGetUserTicks = Pick<
   Tick,


### PR DESCRIPTION
Surface the existing tick-targeted social stack on each ascent/attempt in
the "Your Logbook" and "Crew Logbook" sections of the play view drawer so
climbers can react to and discuss their friends' (and their own) ticks.

Adds upvotes, downvotes, and commentCount aggregates to the
followingClimbAscents and ticks resolvers (LEFT JOIN vote_counts +
correlated comment subquery) and renders an optional VoteButton +
FeedCommentButton footer inside LogbookEntryCard. Each list view wraps its
items in VoteSummaryProvider so the current user's vote on every tick
arrives in a single batched request.

https://claude.ai/code/session_01MKy53MAbQBAv75ugYCkJ64