### PR TITLE
Fix back button returning to board list instead of profile when opening a climb

### DIFF
--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { usePathname } from 'next/navigation';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
 import BoardImageLayers from '@/app/components/board-renderer/board-image-layers';
@@ -34,6 +35,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   onClick,
 }) => {
   const canvasReady = useCanvasRendererReady();
+  const pathname = usePathname();
   // Memoize board details to avoid recomputing on every render
   const boardDetails = useMemo<BoardDetails | null>(() => {
     if (!layoutId) return null;
@@ -86,8 +88,16 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
     );
   }, [boardDetails, boardType, layoutId, angle, climbUuid, climbName]);
 
+  const climbViewHref = useMemo(() => {
+    if (!climbViewPath) return null;
+    if (pathname && pathname.startsWith('/')) {
+      return `${climbViewPath}${climbViewPath.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(pathname)}`;
+    }
+    return climbViewPath;
+  }, [climbViewPath, pathname]);
+
   // If we can't render the thumbnail, don't show anything
-  if (!boardDetails || (!onClick && !climbViewPath)) {
+  if (!boardDetails || (!onClick && !climbViewHref)) {
     return null;
   }
 
@@ -138,7 +148,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   }
 
   return (
-    <LocaleLink href={climbViewPath!} className={styles.thumbnailLink} title={`View ${climbName}`}>
+    <LocaleLink href={climbViewHref!} className={styles.thumbnailLink} title={`View ${climbName}`}>
       <div className={styles.thumbnailContainer}>{thumbnailContent}</div>
     </LocaleLink>
   );

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -9,7 +9,7 @@ import BoardCanvasRenderer from '@/app/components/board-renderer/board-canvas-re
 import { useCanvasRendererReady } from '@/app/lib/board-render-worker/worker-manager';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
-import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
+import { constructClimbViewUrlWithSlugs, constructClimbViewUrl, appendReturnUrl } from '@/app/lib/url-utils';
 import styles from './ascents-feed.module.css';
 
 type AscentThumbnailProps = {
@@ -90,10 +90,7 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
 
   const climbViewHref = useMemo(() => {
     if (!climbViewPath) return null;
-    if (pathname && pathname.startsWith('/')) {
-      return `${climbViewPath}${climbViewPath.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(pathname)}`;
-    }
-    return climbViewPath;
+    return appendReturnUrl(climbViewPath, pathname);
   }, [climbViewPath, pathname]);
 
   // If we can't render the thumbnail, don't show anything

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -27,7 +27,11 @@ export function ViewDetailsAction({
 }: ClimbActionProps): ClimbActionResult {
   const { iconSize, shouldShowLabel } = computeActionDisplay(viewMode, size, showLabel);
 
-  const url = getContextAwareClimbViewUrl(currentPathname ?? '', boardDetails, angle, climb.uuid, climb.name);
+  const baseUrl = getContextAwareClimbViewUrl(currentPathname ?? '', boardDetails, angle, climb.uuid, climb.name);
+  const url =
+    currentPathname && currentPathname.startsWith('/')
+      ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(currentPathname)}`
+      : baseUrl;
 
   const handleClick = () => {
     track('Climb Info Viewed', {

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -7,7 +7,7 @@ import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
-import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import { getContextAwareClimbViewUrl, appendReturnUrl } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
 
@@ -28,10 +28,7 @@ export function ViewDetailsAction({
   const { iconSize, shouldShowLabel } = computeActionDisplay(viewMode, size, showLabel);
 
   const baseUrl = getContextAwareClimbViewUrl(currentPathname ?? '', boardDetails, angle, climb.uuid, climb.name);
-  const url =
-    currentPathname && currentPathname.startsWith('/')
-      ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(currentPathname)}`
-      : baseUrl;
+  const url = appendReturnUrl(baseUrl, currentPathname);
 
   const handleClick = () => {
     track('Climb Info Viewed', {

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -59,7 +59,11 @@ export function useClimbActions({
   // URLs
   const viewDetailsUrl = useMemo(() => {
     if (!climb) return '';
-    return getContextAwareClimbViewUrl(pathname, boardDetails, angle, climb.uuid, climb.name);
+    const base = getContextAwareClimbViewUrl(pathname, boardDetails, angle, climb.uuid, climb.name);
+    if (pathname && pathname.startsWith('/')) {
+      return `${base}${base.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(pathname)}`;
+    }
+    return base;
   }, [climb, pathname, boardDetails, angle]);
 
   const forkUrl = useMemo(() => {

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -7,7 +7,12 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { track } from '@/app/lib/analytics';
 import { useQueueActions } from '../graphql-queue';
 import { useFavorite } from './use-favorite';
-import { constructCreateClimbUrl, constructClimbInfoUrl, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
+import {
+  constructCreateClimbUrl,
+  constructClimbInfoUrl,
+  getContextAwareClimbViewUrl,
+  appendReturnUrl,
+} from '@/app/lib/url-utils';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import type { UseClimbActionsReturn } from './types';
 import { openExternalUrl } from '@/app/lib/open-external-url';
@@ -60,10 +65,7 @@ export function useClimbActions({
   const viewDetailsUrl = useMemo(() => {
     if (!climb) return '';
     const base = getContextAwareClimbViewUrl(pathname, boardDetails, angle, climb.uuid, climb.name);
-    if (pathname && pathname.startsWith('/')) {
-      return `${base}${base.includes('?') ? '&' : '?'}returnUrl=${encodeURIComponent(pathname)}`;
-    }
-    return base;
+    return appendReturnUrl(base, pathname);
   }, [climb, pathname, boardDetails, angle]);
 
   const forkUrl = useMemo(() => {

--- a/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-page.server.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import ClimbViewActions from '@/app/components/climb-view/climb-view-actions';
 import ClimbDetailInfoShellClient from '@/app/components/climb-detail/climb-detail-info-shell.client';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
@@ -29,7 +29,9 @@ export default function ClimbDetailPageServer({
   return (
     <div className={styles.pageContainer}>
       <div className={styles.actionsSection}>
-        <ClimbViewActions climb={climb} boardDetails={boardDetails} auroraAppUrl={auroraAppUrl} angle={angle} />
+        <Suspense>
+          <ClimbViewActions climb={climb} boardDetails={boardDetails} auroraAppUrl={auroraAppUrl} angle={angle} />
+        </Suspense>
       </div>
 
       <div className={styles.contentWrapper}>

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -137,14 +137,19 @@ export default function MultiboardClimbList({
   // to the climb's view page so the user is never stranded.
   const navigateToClimb = useCallback(
     async (climb: Climb) => {
+      // Capture the current path before the async fetch so back-button returnUrl is correct.
+      const returnUrl = typeof window !== 'undefined' ? window.location.pathname : null;
       try {
         const bt = climb.boardType || selectedBoard?.boardType;
         if (!bt) return;
         const params = new URLSearchParams({ boardType: bt, climbUuid: climb.uuid });
         const res = await fetch(`/api/internal/climb-redirect?${params}`);
         if (!res.ok) return;
-        const { url } = await res.json();
-        if (url) window.location.href = url;
+        const { url } = (await res.json()) as { url?: string };
+        if (url) {
+          const sep = url.includes('?') ? '&' : '?';
+          window.location.href = returnUrl ? `${url}${sep}returnUrl=${encodeURIComponent(returnUrl)}` : url;
+        }
       } catch (error) {
         console.error('Failed to navigate to climb:', error);
       }

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -15,6 +15,7 @@ import ClimbsList from '@/app/components/board-page/climbs-list';
 import { FavoritesProvider } from '@/app/components/climb-actions/favorites-batch-context';
 import { PlaylistsProvider } from '@/app/components/climb-actions/playlists-batch-context';
 import { getDefaultAngleForBoard, type SessionBoardConfig } from '@/app/lib/board-config-for-playlist';
+import { appendReturnUrl } from '@/app/lib/url-utils';
 import { useOptionalQueueActions } from '@/app/components/graphql-queue';
 import { usePersistentSessionState } from '@/app/components/persistent-session/persistent-session-context';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -147,8 +148,7 @@ export default function MultiboardClimbList({
         if (!res.ok) return;
         const { url } = (await res.json()) as { url?: string };
         if (url) {
-          const sep = url.includes('?') ? '&' : '?';
-          window.location.href = returnUrl ? `${url}${sep}returnUrl=${encodeURIComponent(returnUrl)}` : url;
+          window.location.href = appendReturnUrl(url, returnUrl);
         }
       } catch (error) {
         console.error('Failed to navigate to climb:', error);

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import styles from './climb-view-actions.module.css';
-import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import { constructClimbListWithSlugs, sanitizeReturnUrl } from '@/app/lib/url-utils';
 import BackButton from '../back-button';
 import { ClimbActions } from '../climb-actions';
 
@@ -22,12 +22,8 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
   const getBackToListUrl = () => {
     const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
 
-    // If a returnUrl was embedded in the URL when navigating here, use it.
-    // Validate it is a relative same-origin path to prevent open-redirect.
-    const returnUrl = searchParams.get('returnUrl');
-    if (returnUrl && returnUrl.startsWith('/')) {
-      return returnUrl;
-    }
+    const safe = sanitizeReturnUrl(searchParams.get('returnUrl'));
+    if (safe) return safe;
 
     // Use slug-based URL construction if slug names are available
     if (layout_name && size_name && set_names) {

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import styles from './climb-view-actions.module.css';
 import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
@@ -17,9 +17,17 @@ type ClimbViewActionsProps = {
 
 const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbViewActionsProps) => {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const getBackToListUrl = () => {
     const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
+
+    // If a returnUrl was embedded in the URL when navigating here, use it.
+    // Validate it is a relative same-origin path to prevent open-redirect.
+    const returnUrl = searchParams.get('returnUrl');
+    if (returnUrl && returnUrl.startsWith('/')) {
+      return returnUrl;
+    }
 
     // Use slug-based URL construction if slug names are available
     if (layout_name && size_name && set_names) {

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -30,6 +30,8 @@ import {
   tryConstructSlugListUrl,
   DEFAULT_SEARCH_PARAMS,
   constructCreateClimbUrl,
+  sanitizeReturnUrl,
+  appendReturnUrl,
 } from '../url-utils';
 import type { SearchRequestPagination, BoardDetails } from '../types';
 
@@ -1596,5 +1598,66 @@ describe('constructCreateClimbUrl', () => {
       name: 'Fork',
     });
     expect(url).not.toContain('editClimbUuid');
+  });
+});
+
+describe('sanitizeReturnUrl', () => {
+  it('accepts a normal relative path', () => {
+    expect(sanitizeReturnUrl('/profile/123/climbs')).toBe('/profile/123/climbs');
+  });
+
+  it('accepts the root path', () => {
+    expect(sanitizeReturnUrl('/')).toBe('/');
+  });
+
+  it('rejects null', () => {
+    expect(sanitizeReturnUrl(null)).toBeNull();
+  });
+
+  it('rejects empty string', () => {
+    expect(sanitizeReturnUrl('')).toBeNull();
+  });
+
+  it('rejects absolute URLs', () => {
+    expect(sanitizeReturnUrl('https://evil.com')).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs (open-redirect vector)', () => {
+    expect(sanitizeReturnUrl('//evil.com')).toBeNull();
+    expect(sanitizeReturnUrl('//evil.com/path')).toBeNull();
+  });
+
+  it('rejects paths without leading slash', () => {
+    expect(sanitizeReturnUrl('profile/123')).toBeNull();
+  });
+});
+
+describe('appendReturnUrl', () => {
+  it('appends returnUrl as first query param when URL has none', () => {
+    expect(appendReturnUrl('/kilter/s/12/1/40/view/abc', '/profile/123')).toBe(
+      '/kilter/s/12/1/40/view/abc?returnUrl=%2Fprofile%2F123',
+    );
+  });
+
+  it('appends returnUrl with & when URL already has query params', () => {
+    expect(appendReturnUrl('/view/abc?proposalUuid=xyz', '/profile/123')).toBe(
+      '/view/abc?proposalUuid=xyz&returnUrl=%2Fprofile%2F123',
+    );
+  });
+
+  it('returns the original URL unchanged when fromPathname is null', () => {
+    expect(appendReturnUrl('/view/abc', null)).toBe('/view/abc');
+  });
+
+  it('returns the original URL unchanged when fromPathname is empty', () => {
+    expect(appendReturnUrl('/view/abc', '')).toBe('/view/abc');
+  });
+
+  it('does not append when fromPathname is a protocol-relative URL', () => {
+    expect(appendReturnUrl('/view/abc', '//evil.com')).toBe('/view/abc');
+  });
+
+  it('does not append when fromPathname lacks a leading slash', () => {
+    expect(appendReturnUrl('/view/abc', 'profile/123')).toBe('/view/abc');
   });
 });

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -1006,3 +1006,25 @@ export const getPlaylistsBasePath = (pathname: string): string => {
  */
 export const getContextAwarePlaylistUrl = (pathname: string, playlistUuid: string): string =>
   `${getPlaylistsBasePath(pathname)}/${playlistUuid}`;
+
+/**
+ * Validate a returnUrl value before using it as a navigation destination.
+ * Accepts only relative same-origin paths (starts with "/" but not "//") to
+ * prevent open-redirect attacks via protocol-relative URLs like //evil.com.
+ */
+export const sanitizeReturnUrl = (returnUrl: string | null): string | null => {
+  if (!returnUrl) return null;
+  if (returnUrl.startsWith('/') && !returnUrl.startsWith('//')) return returnUrl;
+  return null;
+};
+
+/**
+ * Append a `returnUrl` query parameter to a climb-view URL so the back button
+ * can return to the page the user came from.
+ * Only appends when `fromPathname` is a valid relative path.
+ */
+export const appendReturnUrl = (url: string, fromPathname: string | null | undefined): string => {
+  if (!fromPathname || !fromPathname.startsWith('/') || fromPathname.startsWith('//')) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}returnUrl=${encodeURIComponent(fromPathname)}`;
+};


### PR DESCRIPTION
When a user navigates to a climb view from a profile page (e.g. Created
Climbs, Sessions activity feed) via any Next.js client-side link, the back
button wrongly sent them to the board's climb list. Client-side navigation
does not update document.referrer, so the BackButton's referrer check failed
and the fallback URL (board list) was used instead of the page they came from.

Fix: embed the current pathname as a `returnUrl` query parameter whenever
navigating to a climb view internally. ClimbViewActions reads this param and
uses it as the BackButton fallback, so the user is returned to the profile
page they were on.

https://claude.ai/code/session_01To2kwBWpLZCGBh8rYw9HcD