### PR TITLE
Navigate from /you/logbook entry clicks to the climb's board view

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -303,5 +303,11 @@
     "speedNormal": "1×",
     "speedCustom": "{{value}}×",
     "speedCustomLabel": "Custom speed"
+  },
+  "logbook": {
+    "session": {
+      "added": "Added {{climbName}} to your session",
+      "addError": "Could not add to your session"
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -303,5 +303,11 @@
     "speedNormal": "1×",
     "speedCustom": "{{value}}×",
     "speedCustomLabel": "Velocidad personalizada"
+  },
+  "logbook": {
+    "session": {
+      "added": "Se anadio {{climbName}} a tu sesion",
+      "addError": "No se pudo anadir a tu sesion"
+    }
   }
 }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -303,5 +303,11 @@
     "speedNormal": "1×",
     "speedCustom": "{{value}}×",
     "speedCustomLabel": "Vitesse personnalisée"
+  },
+  "logbook": {
+    "session": {
+      "added": "{{climbName}} ajoute a ta session",
+      "addError": "Impossible d'ajouter a ta session"
+    }
   }
 }

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -28,6 +28,7 @@ const updateTickAsyncMock = vi.fn();
 const setCurrentClimbMock = vi.fn();
 const previewClimbFromBrowseMock = vi.fn();
 const dispatchOpenPlayDrawerMock = vi.fn();
+const routerPushMock = vi.fn();
 const boardDataMocks = vi.hoisted(() => ({
   getGradesForBoard: vi.fn((boardName: string) =>
     boardName === 'moonboard'
@@ -104,7 +105,7 @@ vi.mock('@/app/hooks/use-grade-format', () => ({
 }));
 
 vi.mock('@/app/lib/default-board-configs', () => ({
-  getDefaultBoardConfig: () => ({ sizeId: 10, setIds: '1,26' }),
+  getDefaultBoardConfig: () => ({ sizeId: 10, setIds: [1, 26] }),
 }));
 
 vi.mock('@/app/lib/board-utils', () => ({
@@ -181,6 +182,17 @@ vi.mock('next/dynamic', () => ({
   default: () => () => null,
 }));
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
 // --- Import component after mocks ---
 
 // --- Helpers ---
@@ -219,6 +231,7 @@ beforeEach(() => {
   previewClimbFromBrowseMock.mockReset();
   dispatchOpenPlayDrawerMock.mockReset();
   boardDataMocks.getGradesForBoard.mockClear();
+  routerPushMock.mockReset();
   queueActionsState.value = {
     setCurrentClimb: setCurrentClimbMock,
     previewClimbFromBrowse: previewClimbFromBrowseMock,
@@ -406,12 +419,17 @@ describe('LogbookFeedItem', () => {
     expect(previewClimbFromBrowseMock).not.toHaveBeenCalled();
   });
 
-  it('row tap is a no-op when queue actions are unavailable', () => {
+  it('row tap navigates to the climb view when queue actions are unavailable', () => {
     queueActionsState.value = null;
     const { container } = render(<LogbookFeedItem item={makeItem()} />);
     const row = container.querySelector('.swipeableContent') as HTMLElement;
     fireEvent.click(row);
     expect(previewClimbFromBrowseMock).not.toHaveBeenCalled();
+    expect(setCurrentClimbMock).not.toHaveBeenCalled();
+    expect(routerPushMock).toHaveBeenCalledTimes(1);
+    const url = routerPushMock.mock.calls[0][0] as string;
+    expect(url.startsWith('/kilter/1/10/1,26/40/view/')).toBe(true);
+    expect(url.endsWith('-climb-1')).toBe(true);
   });
 
   it('row is keyboard-accessible with role/tabIndex/aria-label', () => {

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -29,6 +29,9 @@ const setCurrentClimbMock = vi.fn();
 const previewClimbFromBrowseMock = vi.fn();
 const dispatchOpenPlayDrawerMock = vi.fn();
 const routerPushMock = vi.fn();
+const psAddQueueItemMock = vi.fn();
+const psSetCurrentClimbMock = vi.fn();
+const showMessageMock = vi.fn();
 const boardDataMocks = vi.hoisted(() => ({
   getGradesForBoard: vi.fn((boardName: string) =>
     boardName === 'moonboard'
@@ -36,6 +39,20 @@ const boardDataMocks = vi.hoisted(() => ({
       : [{ difficulty_id: 20, difficulty_name: '7a/V6', v_grade: 'V6' }],
   ),
 }));
+
+// Holder so tests can swap the persistent-session state without remounting.
+const persistentSessionState: {
+  activeSession: {
+    boardDetails: { board_name: string; layout_id: number };
+    parsedParams: { angle: number };
+  } | null;
+  session: object | null;
+  clientId: string | null;
+} = {
+  activeSession: null,
+  session: null,
+  clientId: null,
+};
 // Holder so tests can swap queue-actions availability without remounting.
 const queueActionsState: {
   value: {
@@ -135,6 +152,26 @@ vi.mock('@/app/components/graphql-queue', () => ({
   useOptionalQueueActions: () => queueActionsState.value,
 }));
 
+vi.mock('@/app/components/persistent-session', () => ({
+  usePersistentSession: () => persistentSessionState,
+  usePersistentSessionActions: () => ({
+    addQueueItem: psAddQueueItemMock,
+    setCurrentClimb: psSetCurrentClimbMock,
+  }),
+}));
+
+vi.mock('@/app/components/party-manager/party-profile-context', () => ({
+  usePartyProfile: () => ({ profile: { id: 'user-1' }, username: 'tester', avatarUrl: null }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: showMessageMock }),
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'mock-queue-item-uuid',
+}));
+
 vi.mock('@/app/components/queue-control/play-drawer-event', () => ({
   dispatchOpenPlayDrawer: () => dispatchOpenPlayDrawerMock(),
 }));
@@ -232,6 +269,14 @@ beforeEach(() => {
   dispatchOpenPlayDrawerMock.mockReset();
   boardDataMocks.getGradesForBoard.mockClear();
   routerPushMock.mockReset();
+  psAddQueueItemMock.mockReset();
+  psAddQueueItemMock.mockResolvedValue(undefined);
+  psSetCurrentClimbMock.mockReset();
+  psSetCurrentClimbMock.mockResolvedValue(undefined);
+  showMessageMock.mockReset();
+  persistentSessionState.activeSession = null;
+  persistentSessionState.session = null;
+  persistentSessionState.clientId = null;
   queueActionsState.value = {
     setCurrentClimb: setCurrentClimbMock,
     previewClimbFromBrowse: previewClimbFromBrowseMock,
@@ -419,17 +464,64 @@ describe('LogbookFeedItem', () => {
     expect(previewClimbFromBrowseMock).not.toHaveBeenCalled();
   });
 
-  it('row tap navigates to the climb view when queue actions are unavailable', () => {
+  it('row tap navigates to the climb view when queue actions are unavailable and no session matches', () => {
     queueActionsState.value = null;
     const { container } = render(<LogbookFeedItem item={makeItem()} />);
     const row = container.querySelector('.swipeableContent') as HTMLElement;
     fireEvent.click(row);
     expect(previewClimbFromBrowseMock).not.toHaveBeenCalled();
     expect(setCurrentClimbMock).not.toHaveBeenCalled();
+    expect(psAddQueueItemMock).not.toHaveBeenCalled();
     expect(routerPushMock).toHaveBeenCalledTimes(1);
     const url = routerPushMock.mock.calls[0][0] as string;
     expect(url.startsWith('/kilter/1/10/1,26/40/view/')).toBe(true);
     expect(url.endsWith('-climb-1')).toBe(true);
+  });
+
+  it('row tap adds to the active party session instead of navigating when board+layout+angle match', async () => {
+    queueActionsState.value = null;
+    persistentSessionState.activeSession = {
+      boardDetails: { board_name: 'kilter', layout_id: 1 },
+      parsedParams: { angle: 40 },
+    };
+    persistentSessionState.session = {};
+    persistentSessionState.clientId = 'client-1';
+
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    await act(async () => {
+      fireEvent.click(row);
+    });
+
+    expect(psAddQueueItemMock).toHaveBeenCalledTimes(1);
+    expect(psAddQueueItemMock.mock.calls[0][0]).toMatchObject({
+      uuid: 'mock-queue-item-uuid',
+      climb: expect.objectContaining({ uuid: 'climb-1' }),
+      addedBy: 'client-1',
+    });
+    expect(psSetCurrentClimbMock).toHaveBeenCalledTimes(1);
+    expect(psSetCurrentClimbMock.mock.calls[0][0]).toMatchObject({ uuid: 'mock-queue-item-uuid' });
+    expect(psSetCurrentClimbMock.mock.calls[0][1]).toBe(false);
+    expect(showMessageMock).toHaveBeenCalledWith(expect.stringContaining('Test Climb'), 'success');
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it('row tap falls back to navigation when the active session is for a different board', () => {
+    queueActionsState.value = null;
+    persistentSessionState.activeSession = {
+      boardDetails: { board_name: 'tension', layout_id: 9 },
+      parsedParams: { angle: 40 },
+    };
+    persistentSessionState.session = {};
+    persistentSessionState.clientId = 'client-1';
+
+    const { container } = render(<LogbookFeedItem item={makeItem()} />);
+    const row = container.querySelector('.swipeableContent') as HTMLElement;
+    fireEvent.click(row);
+
+    expect(psAddQueueItemMock).not.toHaveBeenCalled();
+    expect(psSetCurrentClimbMock).not.toHaveBeenCalled();
+    expect(routerPushMock).toHaveBeenCalledTimes(1);
   });
 
   it('row is keyboard-accessible with role/tabIndex/aria-label', () => {

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -25,6 +25,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
 import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
 import { track } from '@/app/lib/analytics';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations/ticks';
@@ -42,6 +43,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { constructClimbViewUrl } from '@/app/lib/url-utils';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { getGradesForBoard } from '@/app/lib/board-data';
 import AscentThumbnail from '@/app/components/activity-feed/ascent-thumbnail';
@@ -319,6 +321,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
 
     const queueActions = useOptionalQueueActions();
+    const router = useRouter();
 
     // --- Edit state ---
     const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -441,31 +444,68 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     // Map ascent to Climb for ClimbActions + set-active handlers
     const climb = useMemo(() => ascentFeedItemToClimb(item), [item]);
 
+    // URL used when there's no queue session (e.g., /you/logbook). Navigates to
+    // the climb's board view, where the QueueProvider mounts and loads it as current.
+    const fallbackViewUrl = useMemo(() => {
+      const boardName = item.boardType as BoardName;
+      if (!item.layoutId) return null;
+      const config = getDefaultBoardConfig(boardName, item.layoutId);
+      if (!config) return null;
+      return constructClimbViewUrl(
+        {
+          board_name: boardName,
+          layout_id: item.layoutId,
+          size_id: config.sizeId,
+          set_ids: config.setIds,
+          angle: item.angle,
+        },
+        item.climbUuid,
+        item.climbName,
+      );
+    }, [item.boardType, item.layoutId, item.angle, item.climbUuid, item.climbName]);
+
+    const isRowInteractive = !isEditing && (queueActions != null || fallbackViewUrl != null);
+
     const handleRowClick = useCallback(() => {
-      if (isEditing || !queueActions) return;
-      queueActions.previewClimbFromBrowse(climb);
-      track('Logbook Row Clicked', { climbUuid: climb.uuid });
-    }, [isEditing, queueActions, climb]);
+      if (isEditing) return;
+      if (queueActions) {
+        queueActions.previewClimbFromBrowse(climb);
+        track('Logbook Row Clicked', { climbUuid: climb.uuid });
+        return;
+      }
+      if (fallbackViewUrl) {
+        track('Logbook Row Clicked', { climbUuid: climb.uuid, navigated: true });
+        router.push(fallbackViewUrl);
+      }
+    }, [isEditing, queueActions, climb, fallbackViewUrl, router]);
 
     const handleRowKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
-        if (isEditing || !queueActions) return;
+        if (!isRowInteractive) return;
         if (e.key !== 'Enter' && e.key !== ' ') return;
         if (e.target !== e.currentTarget) return;
         e.preventDefault();
         handleRowClick();
       },
-      [isEditing, queueActions, handleRowClick],
+      [isRowInteractive, handleRowClick],
     );
 
     const handleThumbnailClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (isEditing || !queueActions) return;
-        queueActions.previewClimbFromBrowse(climb);
-        track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+        if (isEditing) return;
+        if (queueActions) {
+          queueActions.previewClimbFromBrowse(climb);
+          dispatchOpenPlayDrawer();
+          track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+          return;
+        }
+        if (fallbackViewUrl) {
+          track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid, navigated: true });
+          router.push(fallbackViewUrl);
+        }
       },
-      [isEditing, queueActions, climb],
+      [isEditing, queueActions, climb, fallbackViewUrl, router],
     );
 
     // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)
@@ -621,9 +661,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
             ref={contentCombinedRef}
             className={styles.swipeableContent}
             data-swipe-content=""
-            role={!isEditing && queueActions ? 'button' : undefined}
-            tabIndex={!isEditing && queueActions ? 0 : undefined}
-            aria-label={!isEditing && queueActions ? `Set ${item.climbName} as active climb` : undefined}
+            role={isRowInteractive ? 'button' : undefined}
+            tabIndex={isRowInteractive ? 0 : undefined}
+            aria-label={isRowInteractive ? `Set ${item.climbName} as active climb` : undefined}
             onClick={handleRowClick}
             onKeyDown={handleRowKeyDown}
           >
@@ -639,7 +679,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                     climbName={item.climbName}
                     frames={item.frames}
                     isMirror={item.isMirror}
-                    onClick={queueActions && !isEditing ? handleThumbnailClick : undefined}
+                    onClick={isRowInteractive ? handleThumbnailClick : undefined}
                   />
                 )}
                 {isEditing ? (

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -26,11 +26,16 @@ import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
 import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
 import { track } from '@/app/lib/analytics';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
 import { useOptionalQueueActions } from '@/app/components/graphql-queue';
+import { usePersistentSession, usePersistentSessionActions } from '@/app/components/persistent-session';
+import { usePartyProfile } from '@/app/components/party-manager/party-profile-context';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import type { ClimbQueueItem } from '@/app/components/queue-control/types';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { ClimbActions } from '@/app/components/climb-actions';
 import DrawerClimbHeader from '@/app/components/climb-card/drawer-climb-header';
@@ -322,6 +327,10 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
 
     const queueActions = useOptionalQueueActions();
     const router = useRouter();
+    const { activeSession, session, clientId } = usePersistentSession();
+    const { addQueueItem: psAddQueueItem, setCurrentClimb: psSetCurrentClimb } = usePersistentSessionActions();
+    const { profile, username, avatarUrl } = usePartyProfile();
+    const { showMessage } = useSnackbar();
 
     // --- Edit state ---
     const { mutateAsync: updateTickAsync, isPending: isSaving } = useUpdateTick();
@@ -464,7 +473,56 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
       );
     }, [item.boardType, item.layoutId, item.angle, item.climbUuid, item.climbName]);
 
-    const isRowInteractive = !isEditing && (queueActions != null || fallbackViewUrl != null);
+    // True when the user has a live party session whose board/angle/layout
+    // matches this logbook entry — so we can push the climb into it without
+    // leaving the page.
+    const activeSessionMatches =
+      !!activeSession &&
+      !!session &&
+      !!clientId &&
+      activeSession.boardDetails.board_name === item.boardType &&
+      activeSession.boardDetails.layout_id === item.layoutId &&
+      activeSession.parsedParams.angle === item.angle;
+
+    const addedByUser = useMemo(
+      () => (profile?.id ? { id: profile.id, username: username ?? '', avatarUrl } : undefined),
+      [profile?.id, username, avatarUrl],
+    );
+
+    // Push the clicked climb into the already-connected party session's queue
+    // and mark it current, without navigating. Callers gate on
+    // `activeSessionMatches` before invoking, so the guard here is a safety net.
+    const addToActiveSession = useCallback(async (): Promise<void> => {
+      if (!activeSessionMatches || !clientId) return;
+      const newItem: ClimbQueueItem = {
+        uuid: uuidv4(),
+        climb,
+        addedBy: clientId,
+        addedByUser,
+        suggested: false,
+      };
+      try {
+        await psAddQueueItem(newItem);
+        await psSetCurrentClimb(newItem, false);
+        showMessage(t('logbook.session.added', { climbName: item.climbName }), 'success');
+        track('Logbook Row Clicked', { climbUuid: climb.uuid, addedToSession: true });
+      } catch (err) {
+        console.error('Failed to add logbook climb to active session', err);
+        showMessage(t('logbook.session.addError'), 'error');
+      }
+    }, [
+      activeSessionMatches,
+      clientId,
+      addedByUser,
+      climb,
+      psAddQueueItem,
+      psSetCurrentClimb,
+      showMessage,
+      item.climbName,
+      t,
+    ]);
+
+    const isRowInteractive = !isEditing && (queueActions != null || activeSessionMatches || fallbackViewUrl != null);
 
     const handleRowClick = useCallback(() => {
       if (isEditing) return;
@@ -473,11 +531,17 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
         track('Logbook Row Clicked', { climbUuid: climb.uuid });
         return;
       }
+      // A live session for this exact board/angle takes the climb directly
+      // (async mutation); otherwise navigate synchronously to the board view.
+      if (activeSessionMatches) {
+        void addToActiveSession();
+        return;
+      }
       if (fallbackViewUrl) {
         track('Logbook Row Clicked', { climbUuid: climb.uuid, navigated: true });
         router.push(fallbackViewUrl);
       }
-    }, [isEditing, queueActions, climb, fallbackViewUrl, router]);
+    }, [isEditing, queueActions, climb, activeSessionMatches, addToActiveSession, fallbackViewUrl, router]);
 
     const handleRowKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
@@ -496,8 +560,12 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
         if (isEditing) return;
         if (queueActions) {
           queueActions.previewClimbFromBrowse(climb);
-          dispatchOpenPlayDrawer();
           track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid });
+          return;
+        }
+        if (activeSessionMatches) {
+          track('Logbook Thumbnail Clicked', { climbUuid: climb.uuid, addedToSession: true });
+          void addToActiveSession();
           return;
         }
         if (fallbackViewUrl) {
@@ -505,7 +573,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
           router.push(fallbackViewUrl);
         }
       },
-      [isEditing, queueActions, climb, fallbackViewUrl, router],
+      [isEditing, queueActions, climb, activeSessionMatches, addToActiveSession, fallbackViewUrl, router],
     );
 
     // Build BoardDetails for ClimbActions (same pattern as AscentThumbnail)


### PR DESCRIPTION
LogbookFeedItem's row-click and thumbnail-click already invoke
setCurrentClimb when a QueueProvider is in scope, but the user's
cross-board logbook at /you/logbook sits outside any board layout — so
useOptionalQueueActions returns null and the handlers silently no-op.
Fall back to router.push with the view URL built from the entry's
boardType, layoutId, angle, and the default size/set pair (same config
already used for the BoardDetails memo), so clicking a previous climb
jumps straight to the board view.