### PR TITLE
Load logbook in play view drawer on non-board routes

### DIFF
--- a/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
@@ -79,7 +79,7 @@ const baseEntry = {
 
 describe('LogbookEntryCard', () => {
   it('renders entry fields without a user header when user is absent', () => {
-    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
+    render(<LogbookEntryCard entry={baseEntry} showMirrorTag={false} />);
 
     expect(screen.getByText('Attempts: 3')).toBeTruthy();
     expect(screen.getByText('Nice moves')).toBeTruthy();
@@ -92,7 +92,6 @@ describe('LogbookEntryCard', () => {
     render(
       <LogbookEntryCard
         entry={baseEntry}
-        currentClimbAngle={40}
         showMirrorTag={false}
         user={{ userId: 'user-42', displayName: 'Alex', avatarUrl: 'https://example.test/a.png' }}
       />,
@@ -110,7 +109,6 @@ describe('LogbookEntryCard', () => {
     render(
       <LogbookEntryCard
         entry={baseEntry}
-        currentClimbAngle={40}
         showMirrorTag={false}
         user={{ userId: 'user-42', displayName: null, avatarUrl: null }}
       />,
@@ -119,25 +117,29 @@ describe('LogbookEntryCard', () => {
     expect(screen.getByText('Climber')).toBeTruthy();
   });
 
-  it('hides the angle chip and status icon when the entry angle matches the current climb angle', () => {
-    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
-    expect(screen.queryByTestId('ascent-status-icon')).toBeNull();
-  });
-
-  it('shows the angle chip and status icon when entry angle differs from the current climb angle', () => {
-    render(<LogbookEntryCard entry={{ ...baseEntry, angle: 50 }} currentClimbAngle={40} showMirrorTag={false} />);
+  it('always shows the angle chip and status icon', () => {
+    render(<LogbookEntryCard entry={baseEntry} showMirrorTag={false} />);
     const icon = screen.getByTestId('ascent-status-icon');
     expect(icon.getAttribute('data-status')).toBe('send');
-    expect(screen.getByText('50')).toBeTruthy();
+    expect(screen.getByText('40°')).toBeTruthy();
+  });
+
+  it('renders the entry angle even when it differs from typical board angles', () => {
+    render(<LogbookEntryCard entry={{ ...baseEntry, angle: 50 }} showMirrorTag={false} />);
+    const icon = screen.getByTestId('ascent-status-icon');
+    expect(icon.getAttribute('data-status')).toBe('send');
+    expect(screen.getByText('50°')).toBeTruthy();
   });
 
   it('shows the Mirrored chip only when showMirrorTag is true and the entry is mirrored', () => {
     const { rerender } = render(
-      <LogbookEntryCard entry={{ ...baseEntry, isMirror: true }} currentClimbAngle={40} showMirrorTag={false} />,
+      <LogbookEntryCard entry={{ ...baseEntry, isMirror: true }} showMirrorTag={false} />,
     );
     expect(screen.queryByText('Mirrored')).toBeNull();
 
-    rerender(<LogbookEntryCard entry={{ ...baseEntry, isMirror: true }} currentClimbAngle={40} showMirrorTag />);
+    rerender(
+      <LogbookEntryCard entry={{ ...baseEntry, isMirror: true }} showMirrorTag={true} />,
+    );
     expect(screen.getByText('Mirrored')).toBeTruthy();
   });
 
@@ -145,7 +147,6 @@ describe('LogbookEntryCard', () => {
     render(
       <LogbookEntryCard
         entry={{ ...baseEntry, status: 'attempt', quality: null }}
-        currentClimbAngle={40}
         showMirrorTag={false}
       />,
     );
@@ -161,7 +162,6 @@ describe('LogbookEntryCard', () => {
           quality: null,
           angle: 50,
         }}
-        currentClimbAngle={40}
         showMirrorTag={false}
       />,
     );
@@ -171,7 +171,7 @@ describe('LogbookEntryCard', () => {
   });
 
   it('does not render the social footer when tickUuid is absent', () => {
-    render(<LogbookEntryCard entry={baseEntry} currentClimbAngle={40} showMirrorTag={false} />);
+    render(<LogbookEntryCard entry={baseEntry} showMirrorTag={false} />);
     expect(screen.queryByTestId('vote-button')).toBeNull();
     expect(screen.queryByTestId('feed-comment-button')).toBeNull();
   });
@@ -186,7 +186,6 @@ describe('LogbookEntryCard', () => {
           downvotes: 1,
           commentCount: 3,
         }}
-        currentClimbAngle={40}
         showMirrorTag={false}
       />,
     );

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -93,7 +93,6 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
               downvotes: item.downvotes,
               commentCount: item.commentCount,
             }}
-            currentClimbAngle={currentClimb.angle}
             showMirrorTag={showMirrorTag}
             user={{
               userId: item.userId,

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -51,14 +51,12 @@ export type LogbookEntryCardData = {
 
 export type LogbookEntryCardProps = {
   entry: LogbookEntryCardData;
-  currentClimbAngle: number;
   showMirrorTag: boolean;
   user?: LogbookEntryUser;
 };
 
 export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
   entry,
-  currentClimbAngle,
   showMirrorTag,
   user,
 }) => {
@@ -70,7 +68,6 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
     tries: entry.attemptCount,
   });
   const hasSuccess = ascentStatus !== 'attempt';
-  const showAngleAndStatus = entry.angle !== currentClimbAngle;
 
   return (
     <Card sx={{ width: '100%' }}>
@@ -99,12 +96,8 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
             <Typography variant="body2" component="span" fontWeight={600}>
               {formatTickAbsoluteTime(entry.climbedAt, 'MMM D, YYYY h:mm A')}
             </Typography>
-            {showAngleAndStatus && (
-              <>
-                <Chip label={entry.angle} size="small" color="primary" />
-                <AscentStatusIcon status={ascentStatus} variant="icon" />
-              </>
-            )}
+            <Chip label={`${entry.angle}°`} size="small" color="primary" />
+            <AscentStatusIcon status={ascentStatus} variant="icon" />
             {showMirrorTag && entry.isMirror && (
               <Chip label={t('logbook.entry.mirroredTag')} size="small" color="secondary" />
             )}

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -76,7 +76,6 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
               downvotes: ascent.downvotes,
               commentCount: ascent.commentCount,
             }}
-            currentClimbAngle={currentClimb.angle}
             showMirrorTag={showMirrorTag}
           />
         ))}

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -10,7 +10,7 @@ import { useCurrentClimb, useQueueList } from '../graphql-queue';
 import QueueControlBar from '../queue-control/queue-control-bar';
 import QueueControlBarShell from '../queue-control/queue-control-bar-shell';
 import BottomTabBar from '../bottom-tab-bar/bottom-tab-bar';
-import { BoardProvider } from '../board-provider/board-provider-context';
+import { BoardProvider, useBoardProvider } from '../board-provider/board-provider-context';
 import { ConnectionSettingsProvider } from '../connection-manager/connection-settings-context';
 import { WebSocketConnectionProvider } from '../connection-manager/websocket-connection-provider';
 import { BluetoothProvider } from '../board-bluetooth-control/bluetooth-context';
@@ -216,6 +216,7 @@ function RootQueueControlBarWithProviders({
 }) {
   const { currentClimb } = useCurrentClimb();
   const { queue } = useQueueList();
+  const { getLogbook } = useBoardProvider();
 
   const climbUuids = useMemo(() => {
     const queueUuids = queue.map((item) => item.climb?.uuid).filter(Boolean);
@@ -224,6 +225,18 @@ function RootQueueControlBarWithProviders({
     }
     return Array.from(new Set(queueUuids)).sort();
   }, [queue, currentClimb]);
+
+  // Ensure the play view drawer's "Your Logbook" section has data on
+  // non-board routes (e.g. /you, /profile) where useQueueDataFetching
+  // never mounts. React Query dedupes by key, so this is a no-op when
+  // the board route already requested the same UUIDs.
+  const climbUuidsKey = useMemo(() => climbUuids.join(','), [climbUuids]);
+  useEffect(() => {
+    if (climbUuids.length > 0) {
+      void getLogbook(climbUuids);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- climbUuidsKey covers climbUuids identity changes
+  }, [climbUuidsKey, getLogbook]);
 
   const { favoritesProviderProps, playlistsProviderProps } = useClimbActionsData({
     boardName: boardDetails.board_name,


### PR DESCRIPTION
The play view drawer is rendered globally by RootBottomBar and uses its
own root-level BoardProvider. On board routes, useQueueDataFetching in
the route layout populates the shared logbook cache, so the drawer's
"Your Logbook" section showed entries. On /you, /profile, and other
non-board routes, no fetch ever fired and the section rendered empty
even when the user had ticks.

Trigger getLogbook from RootQueueControlBarWithProviders using the
climbUuids it already derives for favorites/playlists. React Query
dedupes by key, so this is a no-op on board routes.

Always render the angle chip (and status icon) on logbook entries so
users can tell which board angle each tick was logged at — both the
"Your Logbook" and "Crew Logbook" lists already return ascents across
all angles. The currentClimbAngle prop is removed from LogbookEntryCard
since it is no longer used.

https://claude.ai/code/session_01HgUKwEntTWcKJS4nMVeKms