### PR TITLE
feat(mobile): runtime dev URL switcher for debug builds

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -159,8 +159,14 @@ jobs:
             **Minimum Android version:** 13 (API 33)
 
             The AAB has been uploaded to Google Play internal testing track.
-            Download the APK below to sideload on your Android device.
-          files: mobile/android/app/build/outputs/apk/release/*.apk
+            Sideload options:
+            - `app-release.apk` — signed production build.
+            - `app-debug.apk` — debug build with the in-app Dev URL switcher
+              unlocked (user drawer → Dev URL). Cannot be installed alongside
+              the release build; uninstall one before installing the other.
+          files: |
+            mobile/android/app/build/outputs/apk/release/*.apk
+            mobile/android/app/build/outputs/apk/debug/*.apk
           draft: false
           prerelease: false
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,18 @@ You can also run pieces independently:
 - `vp run dev:backend` - Database + backend only
 - `vp run dev:web` - Database + web only
 
+## Testing web changes on Android
+
+You don't have to rebuild the Android app every time you change the web UI. The **debug APK** shipped with each main build includes a Dev URL switcher that points the in-app WebView at any origin you choose — a Tailscale tunnel to your laptop, a Vercel preview, etc.
+
+1. Grab `app-debug.apk` from the most recent [Android Build release](https://github.com/boardsesh/boardsesh/releases?q=android-build). Uninstall the release build first if you have it — both variants use the same package id.
+2. Install the APK (enable "Install unknown apps" for your source if Android prompts you).
+3. Open the app, tap the avatar in the top left, and choose **Dev URL** from the drawer.
+4. Paste your dev origin (e.g. `https://your-host.ts.net`) and tap **Save & restart**. The app relaunches against that URL.
+5. If the dev server dies and the WebView can't load, the offline fallback page shows a **Reset dev URL to production** link to get you back to `www.boardsesh.com`.
+
+The menu item is only visible in debug builds; release builds don't expose it.
+
 ## Keeping local data up to date
 
 ### Shared Data Sync (Public Climbs)

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -3,6 +3,11 @@ apply plugin: 'com.android.application'
 android {
     namespace = "com.boardsesh.app"
     compileSdk = rootProject.ext.compileSdkVersion
+    // BuildConfig is generated on-demand in AGP 8+; the DevUrl plugin and
+    // MainActivity gate on BuildConfig.DEBUG, so generation must be opted in.
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         applicationId = "com.boardsesh.app"
         minSdkVersion = rootProject.ext.minSdkVersion

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-only manifest overlay. Merged into the main manifest only for debug
+  builds so local dev URLs (http://10.0.2.2:3000, http://100.x.y.z, etc.) load
+  in the WebView. Release builds are untouched.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic" />
+</manifest>

--- a/mobile/android/app/src/main/java/com/boardsesh/app/DevUrlPrefs.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/DevUrlPrefs.java
@@ -1,0 +1,45 @@
+package com.boardsesh.app;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.text.TextUtils;
+
+/**
+ * Debug-only persistence for overriding the Capacitor server URL at runtime.
+ * Release callers should gate on {@link BuildConfig#DEBUG} — this class itself
+ * is storage-only and does not enforce that guard.
+ */
+public final class DevUrlPrefs {
+    private static final String PREFS_NAME = "dev_url_prefs";
+    private static final String KEY_OVERRIDE_URL = "override_url";
+
+    private DevUrlPrefs() {}
+
+    private static SharedPreferences prefs(Context context) {
+        return context.getApplicationContext()
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static String getOverrideUrl(Context context) {
+        String stored = prefs(context).getString(KEY_OVERRIDE_URL, null);
+        if (TextUtils.isEmpty(stored)) {
+            return null;
+        }
+        return stored;
+    }
+
+    public static void setOverrideUrl(Context context, String url) {
+        SharedPreferences.Editor editor = prefs(context).edit();
+        if (url == null) {
+            editor.remove(KEY_OVERRIDE_URL);
+        } else {
+            String trimmed = url.trim();
+            if (trimmed.isEmpty()) {
+                editor.remove(KEY_OVERRIDE_URL);
+            } else {
+                editor.putString(KEY_OVERRIDE_URL, trimmed);
+            }
+        }
+        editor.apply();
+    }
+}

--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -33,7 +33,6 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DevUrlPlugin.class);
-        applyDevUrlOverride();
 
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
@@ -48,18 +47,21 @@ public class MainActivity extends BridgeActivity {
         webView.setWebViewClient(new OfflineAwareBridgeWebViewClient(bridge));
     }
 
-    private void applyDevUrlOverride() {
-        if (!BuildConfig.DEBUG) {
-            return;
+    @Override
+    protected void load() {
+        // Runs after super.onCreate() has loaded CapConfig from assets but before
+        // Bridge.Builder consumes it. Setting this.config here is respected by
+        // the builder path; setting it before super.onCreate() is not.
+        if (BuildConfig.DEBUG) {
+            String devUrl = DevUrlPrefs.getOverrideUrl(this);
+            if (devUrl != null) {
+                this.config = new CapConfig.Builder(this)
+                    .setServerUrl(devUrl)
+                    .setAllowNavigation(new String[]{"*"})
+                    .create();
+            }
         }
-        String devUrl = DevUrlPrefs.getOverrideUrl(this);
-        if (devUrl == null) {
-            return;
-        }
-        this.config = new CapConfig.Builder(this)
-            .setServerUrl(devUrl)
-            .setAllowNavigation(new String[]{"*"})
-            .create();
+        super.load();
     }
 
     private String currentRetryUrl() {
@@ -167,9 +169,10 @@ public class MainActivity extends BridgeActivity {
             if (url != null && DEV_RESET_SCHEME.equalsIgnoreCase(url.getScheme())) {
                 if (BuildConfig.DEBUG) {
                     DevUrlPrefs.setOverrideUrl(MainActivity.this, null);
-                    new Handler(Looper.getMainLooper()).postDelayed(
-                        () -> Process.killProcess(Process.myPid()),
-                        100
+                    // No JS promise to flush here — post to the main looper so the
+                    // WebView finishes handling the click before the process dies.
+                    new Handler(Looper.getMainLooper()).post(
+                        () -> Process.killProcess(Process.myPid())
                     );
                 }
                 return true;

--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -6,6 +6,9 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Process;
 import android.text.TextUtils;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
@@ -16,16 +19,22 @@ import android.webkit.WebView;
 import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
 
+import com.boardsesh.app.plugins.DevUrlPlugin;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
+import com.getcapacitor.CapConfig;
 
 public class MainActivity extends BridgeActivity {
-    private static final String DEFAULT_RETRY_URL = "https://www.boardsesh.com";
+    private static final String PRODUCTION_URL = "https://www.boardsesh.com";
+    private static final String DEV_RESET_SCHEME = "boardsesh-dev";
     private final OfflineFallbackStateMachine fallbackState = new OfflineFallbackStateMachine();
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(DevUrlPlugin.class);
+        applyDevUrlOverride();
+
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
 
@@ -37,6 +46,30 @@ public class MainActivity extends BridgeActivity {
         WebSettings settings = webView.getSettings();
         settings.setCacheMode(WebSettings.LOAD_DEFAULT);
         webView.setWebViewClient(new OfflineAwareBridgeWebViewClient(bridge));
+    }
+
+    private void applyDevUrlOverride() {
+        if (!BuildConfig.DEBUG) {
+            return;
+        }
+        String devUrl = DevUrlPrefs.getOverrideUrl(this);
+        if (devUrl == null) {
+            return;
+        }
+        this.config = new CapConfig.Builder(this)
+            .setServerUrl(devUrl)
+            .setAllowNavigation(new String[]{"*"})
+            .create();
+    }
+
+    private String currentRetryUrl() {
+        if (BuildConfig.DEBUG) {
+            String devUrl = DevUrlPrefs.getOverrideUrl(this);
+            if (devUrl != null) {
+                return devUrl;
+            }
+        }
+        return PRODUCTION_URL;
     }
 
     private boolean isOffline() {
@@ -71,6 +104,8 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
+        String devResetLink = buildDevResetLink();
+
         String errorHtml = "<!DOCTYPE html><html><head><meta charset='utf-8' />"
             + "<meta name='viewport' content='width=device-width, initial-scale=1' />"
             + "<title>You're offline</title>"
@@ -84,25 +119,38 @@ public class MainActivity extends BridgeActivity {
             + "<p><a href='" + safeHref + "'"
             + " style='display:inline-block;margin-top:8px;padding:10px 14px;border-radius:10px;"
             + "background:#fff;color:#0A0A0A;text-decoration:none;font-weight:600;'>Try again</a></p>"
+            + devResetLink
             + "</main></body></html>";
 
         view.loadDataWithBaseURL(null, errorHtml, "text/html", "UTF-8", null);
     }
 
+    private String buildDevResetLink() {
+        if (!BuildConfig.DEBUG || DevUrlPrefs.getOverrideUrl(this) == null) {
+            return "";
+        }
+        return "<p style='margin-top:16px;color:#888;font-size:13px'>Dev override active</p>"
+            + "<p><a href='" + DEV_RESET_SCHEME + "://reset'"
+            + " style='display:inline-block;padding:8px 12px;border-radius:8px;"
+            + "border:1px solid #444;color:#ccc;text-decoration:none;font-size:13px;'>"
+            + "Reset dev URL to production</a></p>";
+    }
+
     private String sanitizeRetryUrl(String candidateUrl) {
+        String fallback = currentRetryUrl();
         if (candidateUrl == null || candidateUrl.isEmpty()) {
-            return DEFAULT_RETRY_URL;
+            return fallback;
         }
 
         Uri parsed = Uri.parse(candidateUrl);
         String scheme = parsed.getScheme();
         if (scheme == null) {
-            return DEFAULT_RETRY_URL;
+            return fallback;
         }
 
         String normalizedScheme = scheme.toLowerCase();
         if (!"http".equals(normalizedScheme) && !"https".equals(normalizedScheme)) {
-            return DEFAULT_RETRY_URL;
+            return fallback;
         }
 
         return candidateUrl;
@@ -111,6 +159,22 @@ public class MainActivity extends BridgeActivity {
     private final class OfflineAwareBridgeWebViewClient extends BridgeWebViewClient {
         OfflineAwareBridgeWebViewClient(Bridge bridge) {
             super(bridge);
+        }
+
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+            Uri url = request.getUrl();
+            if (url != null && DEV_RESET_SCHEME.equalsIgnoreCase(url.getScheme())) {
+                if (BuildConfig.DEBUG) {
+                    DevUrlPrefs.setOverrideUrl(MainActivity.this, null);
+                    new Handler(Looper.getMainLooper()).postDelayed(
+                        () -> Process.killProcess(Process.myPid()),
+                        100
+                    );
+                }
+                return true;
+            }
+            return super.shouldOverrideUrlLoading(view, request);
         }
 
         @Override

--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -26,7 +26,6 @@ import com.getcapacitor.BridgeWebViewClient;
 import com.getcapacitor.CapConfig;
 
 public class MainActivity extends BridgeActivity {
-    private static final String PRODUCTION_URL = "https://www.boardsesh.com";
     private static final String DEV_RESET_SCHEME = "boardsesh-dev";
     private final OfflineFallbackStateMachine fallbackState = new OfflineFallbackStateMachine();
 
@@ -71,7 +70,7 @@ public class MainActivity extends BridgeActivity {
                 return devUrl;
             }
         }
-        return PRODUCTION_URL;
+        return DevUrlPlugin.DEFAULT_URL;
     }
 
     private boolean isOffline() {

--- a/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
@@ -12,6 +12,8 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import org.json.JSONObject;
+
 /**
  * Lets debug builds swap the Capacitor server URL at runtime.
  *
@@ -27,7 +29,10 @@ public class DevUrlPlugin extends Plugin {
     public void getState(PluginCall call) {
         JSObject ret = new JSObject();
         ret.put("isDebug", BuildConfig.DEBUG);
-        ret.put("currentUrl", DevUrlPrefs.getOverrideUrl(getContext()));
+        String current = DevUrlPrefs.getOverrideUrl(getContext());
+        // Use JSONObject.NULL so the key serializes as JS `null` (not `undefined`)
+        // to match the TypeScript contract `string | null`.
+        ret.put("currentUrl", current != null ? current : JSONObject.NULL);
         ret.put("defaultUrl", DEFAULT_URL);
         call.resolve(ret);
     }

--- a/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
@@ -1,0 +1,65 @@
+package com.boardsesh.app.plugins;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Process;
+
+import com.boardsesh.app.BuildConfig;
+import com.boardsesh.app.DevUrlPrefs;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Lets debug builds swap the Capacitor server URL at runtime.
+ *
+ * The web UI (packages/web/app/lib/dev-url.ts) calls {@code getState} to decide
+ * whether to render the Dev URL menu. In release builds {@code isDebug} is
+ * always false and {@code setUrl} / {@code clearUrl} no-op.
+ */
+@CapacitorPlugin(name = "DevUrl")
+public class DevUrlPlugin extends Plugin {
+    private static final String DEFAULT_URL = "https://www.boardsesh.com";
+
+    @PluginMethod
+    public void getState(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("isDebug", BuildConfig.DEBUG);
+        ret.put("currentUrl", DevUrlPrefs.getOverrideUrl(getContext()));
+        ret.put("defaultUrl", DEFAULT_URL);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void setUrl(PluginCall call) {
+        if (!BuildConfig.DEBUG) {
+            call.resolve();
+            return;
+        }
+        String url = call.getString("url");
+        DevUrlPrefs.setOverrideUrl(getContext(), url);
+        call.resolve();
+        scheduleRestart();
+    }
+
+    @PluginMethod
+    public void clearUrl(PluginCall call) {
+        if (!BuildConfig.DEBUG) {
+            call.resolve();
+            return;
+        }
+        DevUrlPrefs.setOverrideUrl(getContext(), null);
+        call.resolve();
+        scheduleRestart();
+    }
+
+    private void scheduleRestart() {
+        // Small delay so the JS-side promise resolves before we tear the process down.
+        new Handler(Looper.getMainLooper()).postDelayed(
+            () -> Process.killProcess(Process.myPid()),
+            150
+        );
+    }
+}

--- a/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/plugins/DevUrlPlugin.java
@@ -1,8 +1,10 @@
 package com.boardsesh.app.plugins;
 
+import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
+import android.text.TextUtils;
 
 import com.boardsesh.app.BuildConfig;
 import com.boardsesh.app.DevUrlPrefs;
@@ -23,7 +25,7 @@ import org.json.JSONObject;
  */
 @CapacitorPlugin(name = "DevUrl")
 public class DevUrlPlugin extends Plugin {
-    private static final String DEFAULT_URL = "https://www.boardsesh.com";
+    public static final String DEFAULT_URL = "https://www.boardsesh.com";
 
     @PluginMethod
     public void getState(PluginCall call) {
@@ -44,9 +46,24 @@ public class DevUrlPlugin extends Plugin {
             return;
         }
         String url = call.getString("url");
+        if (!isValidHttpUrl(url)) {
+            call.reject("Invalid URL: must be an http:// or https:// URL");
+            return;
+        }
         DevUrlPrefs.setOverrideUrl(getContext(), url);
         call.resolve();
         scheduleRestart();
+    }
+
+    /** Only accept absolute http(s) URLs — guards against garbage blocking the app. */
+    static boolean isValidHttpUrl(String url) {
+        if (TextUtils.isEmpty(url)) return false;
+        Uri parsed = Uri.parse(url.trim());
+        String scheme = parsed.getScheme();
+        if (scheme == null) return false;
+        String normalized = scheme.toLowerCase();
+        if (!"http".equals(normalized) && !"https".equals(normalized)) return false;
+        return !TextUtils.isEmpty(parsed.getHost());
     }
 
     @PluginMethod

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -27,8 +27,8 @@
 		LA100007 /* LiveActivityPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200007 /* LiveActivityPlugin.m */; };
 		LA100008 /* HealthKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200008 /* HealthKitPlugin.swift */; };
 		LA100009 /* HealthKitPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200009 /* HealthKitPlugin.m */; };
-		LA100014 /* DevUrlPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200014 /* DevUrlPlugin.swift */; };
-		LA100015 /* DevUrlPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200015 /* DevUrlPlugin.m */; };
+		LA100050 /* DevUrlPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200050 /* DevUrlPlugin.swift */; };
+		LA100051 /* DevUrlPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200051 /* DevUrlPlugin.m */; };
 		LA100010 /* BoardseshWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200010 /* BoardseshWidgetsBundle.swift */; };
 		LA100011 /* ClimbSessionLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200011 /* ClimbSessionLiveActivity.swift */; };
 		LA100012 /* NextClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200012 /* NextClimbIntent.swift */; };
@@ -101,8 +101,8 @@
 		LA200007 /* LiveActivityPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LiveActivityPlugin.m; sourceTree = "<group>"; };
 		LA200008 /* HealthKitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitPlugin.swift; sourceTree = "<group>"; };
 		LA200009 /* HealthKitPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HealthKitPlugin.m; sourceTree = "<group>"; };
-		LA200014 /* DevUrlPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevUrlPlugin.swift; sourceTree = "<group>"; };
-		LA200015 /* DevUrlPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DevUrlPlugin.m; sourceTree = "<group>"; };
+		LA200050 /* DevUrlPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevUrlPlugin.swift; sourceTree = "<group>"; };
+		LA200051 /* DevUrlPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DevUrlPlugin.m; sourceTree = "<group>"; };
 		LA200010 /* BoardseshWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardseshWidgetsBundle.swift; sourceTree = "<group>"; };
 		LA200011 /* ClimbSessionLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbSessionLiveActivity.swift; sourceTree = "<group>"; };
 		LA200012 /* NextClimbIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextClimbIntent.swift; sourceTree = "<group>"; };
@@ -191,8 +191,8 @@
 				LA200007 /* LiveActivityPlugin.m */,
 				LA200008 /* HealthKitPlugin.swift */,
 				LA200009 /* HealthKitPlugin.m */,
-				LA200014 /* DevUrlPlugin.swift */,
-				LA200015 /* DevUrlPlugin.m */,
+				LA200050 /* DevUrlPlugin.swift */,
+				LA200051 /* DevUrlPlugin.m */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -445,8 +445,8 @@
 				LA100007 /* LiveActivityPlugin.m in Sources */,
 				LA100008 /* HealthKitPlugin.swift in Sources */,
 				LA100009 /* HealthKitPlugin.m in Sources */,
-				LA100014 /* DevUrlPlugin.swift in Sources */,
-				LA100015 /* DevUrlPlugin.m in Sources */,
+				LA100050 /* DevUrlPlugin.swift in Sources */,
+				LA100051 /* DevUrlPlugin.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		LA100007 /* LiveActivityPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200007 /* LiveActivityPlugin.m */; };
 		LA100008 /* HealthKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200008 /* HealthKitPlugin.swift */; };
 		LA100009 /* HealthKitPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200009 /* HealthKitPlugin.m */; };
+		LA100014 /* DevUrlPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200014 /* DevUrlPlugin.swift */; };
+		LA100015 /* DevUrlPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = LA200015 /* DevUrlPlugin.m */; };
 		LA100010 /* BoardseshWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200010 /* BoardseshWidgetsBundle.swift */; };
 		LA100011 /* ClimbSessionLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200011 /* ClimbSessionLiveActivity.swift */; };
 		LA100012 /* NextClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200012 /* NextClimbIntent.swift */; };
@@ -99,6 +101,8 @@
 		LA200007 /* LiveActivityPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LiveActivityPlugin.m; sourceTree = "<group>"; };
 		LA200008 /* HealthKitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitPlugin.swift; sourceTree = "<group>"; };
 		LA200009 /* HealthKitPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HealthKitPlugin.m; sourceTree = "<group>"; };
+		LA200014 /* DevUrlPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevUrlPlugin.swift; sourceTree = "<group>"; };
+		LA200015 /* DevUrlPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DevUrlPlugin.m; sourceTree = "<group>"; };
 		LA200010 /* BoardseshWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardseshWidgetsBundle.swift; sourceTree = "<group>"; };
 		LA200011 /* ClimbSessionLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbSessionLiveActivity.swift; sourceTree = "<group>"; };
 		LA200012 /* NextClimbIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextClimbIntent.swift; sourceTree = "<group>"; };
@@ -187,6 +191,8 @@
 				LA200007 /* LiveActivityPlugin.m */,
 				LA200008 /* HealthKitPlugin.swift */,
 				LA200009 /* HealthKitPlugin.m */,
+				LA200014 /* DevUrlPlugin.swift */,
+				LA200015 /* DevUrlPlugin.m */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -439,6 +445,8 @@
 				LA100007 /* LiveActivityPlugin.m in Sources */,
 				LA100008 /* HealthKitPlugin.swift in Sources */,
 				LA100009 /* HealthKitPlugin.m in Sources */,
+				LA100014 /* DevUrlPlugin.swift in Sources */,
+				LA100015 /* DevUrlPlugin.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -8,15 +8,15 @@ class BoardseshViewController: CAPBridgeViewController {
         super.capacitorDidLoad()
         bridge?.registerPluginInstance(LiveActivityPlugin())
         bridge?.registerPluginInstance(HealthKitPlugin())
-        bridge?.registerPluginInstance(DevUrlPlugin())
+        // DevUrlPlugin is auto-registered via the CAP_PLUGIN macro in DevUrlPlugin.m
     }
 
     override open func instanceDescriptor() -> InstanceDescriptor {
         let descriptor = super.instanceDescriptor()
         #if DEBUG
-        if let devUrl = DevUrlPlugin.currentOverride() {
+        if let devUrl = DevUrlPlugin.currentOverride(), URL(string: devUrl) != nil {
             descriptor.serverURL = devUrl
-            descriptor.allowNavigation = ["*"]
+            descriptor.allowedNavigationHostnames = ["*"]
         }
         #endif
         return descriptor

--- a/mobile/ios/App/App/BoardseshViewController.swift
+++ b/mobile/ios/App/App/BoardseshViewController.swift
@@ -8,6 +8,18 @@ class BoardseshViewController: CAPBridgeViewController {
         super.capacitorDidLoad()
         bridge?.registerPluginInstance(LiveActivityPlugin())
         bridge?.registerPluginInstance(HealthKitPlugin())
+        bridge?.registerPluginInstance(DevUrlPlugin())
+    }
+
+    override open func instanceDescriptor() -> InstanceDescriptor {
+        let descriptor = super.instanceDescriptor()
+        #if DEBUG
+        if let devUrl = DevUrlPlugin.currentOverride() {
+            descriptor.serverURL = devUrl
+            descriptor.allowNavigation = ["*"]
+        }
+        #endif
+        return descriptor
     }
 
     override open func webViewConfiguration(for instanceConfiguration: InstanceConfiguration) -> WKWebViewConfiguration {

--- a/mobile/ios/App/App/DevUrlPlugin.m
+++ b/mobile/ios/App/App/DevUrlPlugin.m
@@ -1,0 +1,7 @@
+#import <Capacitor/Capacitor.h>
+
+CAP_PLUGIN(DevUrlPlugin, "DevUrl",
+    CAP_PLUGIN_METHOD(getState, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(setUrl, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(clearUrl, CAPPluginReturnPromise);
+)

--- a/mobile/ios/App/App/DevUrlPlugin.swift
+++ b/mobile/ios/App/App/DevUrlPlugin.swift
@@ -67,10 +67,13 @@ public class DevUrlPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func scheduleRestart() {
-        // Small delay so the JS-side promise resolves before we tear the process down.
-        // exit(0) is debug-only per the guards above; never reached in release.
+        // Wrap the exit(0) symbol itself in #if DEBUG so it's never emitted into the
+        // release binary — App Store static analysis flags `exit` symbols even when
+        // they are unreachable at runtime.
+        #if DEBUG
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             exit(0)
         }
+        #endif
     }
 }

--- a/mobile/ios/App/App/DevUrlPlugin.swift
+++ b/mobile/ios/App/App/DevUrlPlugin.swift
@@ -1,0 +1,76 @@
+import Capacitor
+import Foundation
+
+/// Lets debug builds swap the Capacitor server URL at runtime.
+///
+/// The web UI (packages/web/app/lib/dev-url.ts) calls `getState` to decide
+/// whether to render the Dev URL menu. In release builds `isDebug` is always
+/// false and `setUrl` / `clearUrl` no-op.
+@objc(DevUrlPlugin)
+public class DevUrlPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "DevUrlPlugin"
+    public let jsName = "DevUrl"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setUrl", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearUrl", returnType: CAPPluginReturnPromise),
+    ]
+
+    static let defaultsKey = "dev_server_url"
+    static let defaultUrl = "https://www.boardsesh.com"
+
+    static var isDebugBuild: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static func currentOverride() -> String? {
+        let stored = UserDefaults.standard.string(forKey: defaultsKey)
+        guard let stored, !stored.isEmpty else { return nil }
+        return stored
+    }
+
+    @objc func getState(_ call: CAPPluginCall) {
+        call.resolve([
+            "isDebug": DevUrlPlugin.isDebugBuild,
+            "currentUrl": DevUrlPlugin.currentOverride() as Any? ?? NSNull(),
+            "defaultUrl": DevUrlPlugin.defaultUrl,
+        ])
+    }
+
+    @objc func setUrl(_ call: CAPPluginCall) {
+        guard DevUrlPlugin.isDebugBuild else {
+            call.resolve()
+            return
+        }
+        let url = (call.getString("url") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if url.isEmpty {
+            UserDefaults.standard.removeObject(forKey: DevUrlPlugin.defaultsKey)
+        } else {
+            UserDefaults.standard.set(url, forKey: DevUrlPlugin.defaultsKey)
+        }
+        call.resolve()
+        scheduleRestart()
+    }
+
+    @objc func clearUrl(_ call: CAPPluginCall) {
+        guard DevUrlPlugin.isDebugBuild else {
+            call.resolve()
+            return
+        }
+        UserDefaults.standard.removeObject(forKey: DevUrlPlugin.defaultsKey)
+        call.resolve()
+        scheduleRestart()
+    }
+
+    private func scheduleRestart() {
+        // Small delay so the JS-side promise resolves before we tear the process down.
+        // exit(0) is debug-only per the guards above; never reached in release.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            exit(0)
+        }
+    }
+}

--- a/mobile/ios/App/App/DevUrlPlugin.swift
+++ b/mobile/ios/App/App/DevUrlPlugin.swift
@@ -47,13 +47,24 @@ public class DevUrlPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         let url = (call.getString("url") ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if url.isEmpty {
-            UserDefaults.standard.removeObject(forKey: DevUrlPlugin.defaultsKey)
-        } else {
-            UserDefaults.standard.set(url, forKey: DevUrlPlugin.defaultsKey)
+        guard DevUrlPlugin.isValidHttpUrl(url) else {
+            call.reject("Invalid URL: must be an http:// or https:// URL")
+            return
         }
+        UserDefaults.standard.set(url, forKey: DevUrlPlugin.defaultsKey)
         call.resolve()
         scheduleRestart()
+    }
+
+    /// Only accept absolute http(s) URLs — guards against garbage blocking the app.
+    static func isValidHttpUrl(_ url: String) -> Bool {
+        guard !url.isEmpty, let parsed = URL(string: url), let scheme = parsed.scheme else {
+            return false
+        }
+        let normalized = scheme.lowercased()
+        guard normalized == "http" || normalized == "https" else { return false }
+        guard let host = parsed.host, !host.isEmpty else { return false }
+        return true
     }
 
     @objc func clearUrl(_ call: CAPPluginCall) {
@@ -67,9 +78,10 @@ public class DevUrlPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func scheduleRestart() {
-        // Wrap the exit(0) symbol itself in #if DEBUG so it's never emitted into the
-        // release binary — App Store static analysis flags `exit` symbols even when
-        // they are unreachable at runtime.
+        // Defense in depth: the compile-time #if DEBUG keeps `exit(0)` out of the
+        // release binary, and the runtime isDebugBuild guard protects against a
+        // future caller accidentally invoking this method in a release context.
+        guard DevUrlPlugin.isDebugBuild else { return }
         #if DEBUG
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             exit(0)

--- a/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
+++ b/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
@@ -9,6 +9,7 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { clearDevUrl, getDevUrlState, setDevUrl, type DevUrlState } from '@/app/lib/dev-url';
 
@@ -17,10 +18,30 @@ interface DevUrlDialogProps {
   onClose: () => void;
 }
 
+// If the native side fails to tear the process down within this window, re-enable
+// the UI so the dialog doesn't stay wedged (e.g. in a web browser preview, or if
+// the plugin call silently no-ops in a release build).
+const RESTART_TIMEOUT_MS = 1500;
+
+function validateUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return 'Enter a URL';
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'URL must start with http:// or https://';
+    }
+    return null;
+  } catch {
+    return 'Not a valid URL';
+  }
+}
+
 export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
   const [state, setState] = useState<DevUrlState | null>(null);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -30,46 +51,71 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
       if (cancelled) return;
       setState(next);
       setInput(next?.currentUrl ?? '');
+      setError(null);
+      setBusy(false);
     })();
     return () => {
       cancelled = true;
     };
   }, [open]);
 
-  const save = async () => {
-    if (!input.trim()) return;
+  const runWithRestartFallback = async (action: () => Promise<void>) => {
     setBusy(true);
-    await setDevUrl(input.trim());
+    setError(null);
+    try {
+      await action();
+      // If the process isn't killed within the timeout, something went wrong —
+      // unlock the dialog so the user can try again.
+      window.setTimeout(() => setBusy(false), RESTART_TIMEOUT_MS);
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : 'Something went wrong');
+    }
   };
 
-  const clear = async () => {
-    setBusy(true);
-    await clearDevUrl();
+  const save = () => {
+    const validationError = validateUrl(input);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    void runWithRestartFallback(() => setDevUrl(input.trim()));
+  };
+
+  const clear = () => {
+    void runWithRestartFallback(() => clearDevUrl());
+  };
+
+  const useDefault = () => {
+    setInput(state?.defaultUrl ?? 'https://www.boardsesh.com');
+    setError(null);
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+    <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="xs">
       <DialogTitle>Dev URL</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <Typography variant="body2" color="text.secondary">
-            Point the WebView at a different origin. The app will relaunch after saving.
+            Point the WebView at a different origin. The app will restart after saving.
           </Typography>
           <TextField
             label="Server URL"
             placeholder={state?.defaultUrl ?? 'https://www.boardsesh.com'}
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={(e) => {
+              setInput(e.target.value);
+              if (error) setError(null);
+            }}
+            error={Boolean(error)}
+            helperText={error ?? ' '}
+            disabled={busy}
             fullWidth
             autoFocus
             autoComplete="off"
             spellCheck={false}
           />
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => setInput(state?.defaultUrl ?? 'https://www.boardsesh.com')}
-          >
+          <Button size="small" variant="outlined" onClick={useDefault} disabled={busy}>
             Use production
           </Button>
           {state?.currentUrl && (
@@ -86,8 +132,13 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
         <Button onClick={clear} disabled={busy || !state?.currentUrl} color="warning">
           Clear override
         </Button>
-        <Button onClick={save} disabled={busy || !input.trim()} variant="contained">
-          Save & restart
+        <Button
+          onClick={save}
+          disabled={busy || !input.trim()}
+          variant="contained"
+          startIcon={busy ? <CircularProgress size={14} color="inherit" /> : undefined}
+        >
+          {busy ? 'Restarting…' : 'Save & restart'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
+++ b/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -42,6 +42,7 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const restartTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -59,17 +60,33 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
     };
   }, [open]);
 
+  useEffect(
+    () => () => {
+      if (restartTimerRef.current !== null) {
+        window.clearTimeout(restartTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const runWithRestartFallback = async (action: () => Promise<void>) => {
     setBusy(true);
     setError(null);
+    let succeeded = false;
     try {
       await action();
-      // If the process isn't killed within the timeout, something went wrong —
-      // unlock the dialog so the user can try again.
-      window.setTimeout(() => setBusy(false), RESTART_TIMEOUT_MS);
+      succeeded = true;
     } catch (e) {
-      setBusy(false);
       setError(e instanceof Error ? e.message : 'Something went wrong');
+    } finally {
+      if (succeeded) {
+        // Plugin resolved — native side should now kill the process. If it
+        // doesn't within the timeout (release no-op, web-browser preview),
+        // unlock the dialog so the user can try again.
+        restartTimerRef.current = window.setTimeout(() => setBusy(false), RESTART_TIMEOUT_MS);
+      } else {
+        setBusy(false);
+      }
     }
   };
 

--- a/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
+++ b/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+
+import { clearDevUrl, getDevUrlState, setDevUrl, type DevUrlState } from '@/app/lib/dev-url';
+
+interface DevUrlDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
+  const [state, setState] = useState<DevUrlState | null>(null);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      const next = await getDevUrlState();
+      if (cancelled) return;
+      setState(next);
+      setInput(next?.currentUrl ?? '');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const save = async () => {
+    if (!input.trim()) return;
+    setBusy(true);
+    await setDevUrl(input.trim());
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    await clearDevUrl();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Dev URL</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Point the WebView at a different origin. The app will relaunch after saving.
+          </Typography>
+          <TextField
+            label="Server URL"
+            placeholder={state?.defaultUrl ?? 'https://www.boardsesh.com'}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            fullWidth
+            autoFocus
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => setInput(state?.defaultUrl ?? 'https://www.boardsesh.com')}
+          >
+            Use production
+          </Button>
+          {state?.currentUrl && (
+            <Typography variant="caption" color="text.secondary">
+              Currently overriding to: {state.currentUrl}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button onClick={clear} disabled={busy || !state?.currentUrl} color="warning">
+          Clear override
+        </Button>
+        <Button onClick={save} disabled={busy || !input.trim()} variant="contained">
+          Save & restart
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -32,7 +32,10 @@ import {
 } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
+import BuildOutlined from '@mui/icons-material/BuildOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import DevUrlDialog from '../dev-url-dialog/dev-url-dialog';
+import { useDevUrl } from '@/app/lib/dev-url';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { HoldClassificationWizard } from '../hold-classification';
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
@@ -77,6 +80,8 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const [showMyBoards, setShowMyBoards] = useState(false);
   const [myBoardsRendered, setMyBoardsRendered] = useState(false);
   const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
+  const [showDevUrl, setShowDevUrl] = useState(false);
+  const { isAvailable: devUrlAvailable } = useDevUrl();
 
   const { mode, toggleMode } = useColorMode();
   const isMoonboard = boardDetails?.board_name === 'moonboard';
@@ -306,6 +311,22 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemLabel}>Settings</span>
               </Link>
 
+              {devUrlAvailable && (
+                <button
+                  type="button"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    handleClose();
+                    setShowDevUrl(true);
+                  }}
+                >
+                  <span className={styles.menuItemIcon}>
+                    <BuildOutlined />
+                  </span>
+                  <span className={styles.menuItemLabel}>Dev URL</span>
+                </button>
+              )}
+
               {boardDetails && !isMoonboard && (
                 <button
                   type="button"
@@ -477,6 +498,8 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
           }}
         />
       )}
+
+      {devUrlAvailable && <DevUrlDialog open={showDevUrl} onClose={() => setShowDevUrl(false)} />}
     </>
   );
 }

--- a/packages/web/app/lib/__tests__/dev-url.test.ts
+++ b/packages/web/app/lib/__tests__/dev-url.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { clearDevUrl, getDevUrlState, setDevUrl, useDevUrl } from '../dev-url';
+
+interface MockPlugin {
+  getState: ReturnType<typeof vi.fn>;
+  setUrl: ReturnType<typeof vi.fn>;
+  clearUrl: ReturnType<typeof vi.fn>;
+}
+
+interface MockCapacitor {
+  isNativePlatform: () => boolean;
+  getPlatform: () => string;
+  Plugins: { DevUrl?: MockPlugin };
+}
+
+function installCapacitor(plugin: MockPlugin | undefined, isNative = true) {
+  const cap: MockCapacitor = {
+    isNativePlatform: () => isNative,
+    getPlatform: () => 'android',
+    Plugins: plugin ? { DevUrl: plugin } : {},
+  };
+  (window as unknown as { Capacitor: MockCapacitor }).Capacitor = cap;
+}
+
+function uninstallCapacitor() {
+  delete (window as unknown as { Capacitor?: unknown }).Capacitor;
+}
+
+function makePlugin(overrides: Partial<MockPlugin> = {}): MockPlugin {
+  return {
+    getState: vi.fn().mockResolvedValue({
+      isDebug: true,
+      currentUrl: null,
+      defaultUrl: 'https://www.boardsesh.com',
+    }),
+    setUrl: vi.fn().mockResolvedValue(undefined),
+    clearUrl: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('dev-url lib', () => {
+  beforeEach(() => {
+    uninstallCapacitor();
+  });
+
+  afterEach(() => {
+    uninstallCapacitor();
+  });
+
+  describe('getDevUrlState', () => {
+    it('returns null when Capacitor is not installed', async () => {
+      expect(await getDevUrlState()).toBeNull();
+    });
+
+    it('returns null when not running as a native app', async () => {
+      installCapacitor(makePlugin(), false);
+      expect(await getDevUrlState()).toBeNull();
+    });
+
+    it('returns null when the plugin is missing', async () => {
+      installCapacitor(undefined, true);
+      expect(await getDevUrlState()).toBeNull();
+    });
+
+    it('returns the plugin state when native and available', async () => {
+      const plugin = makePlugin({
+        getState: vi.fn().mockResolvedValue({
+          isDebug: true,
+          currentUrl: 'https://dev.boardsesh.ts.net',
+          defaultUrl: 'https://www.boardsesh.com',
+        }),
+      });
+      installCapacitor(plugin);
+
+      const state = await getDevUrlState();
+
+      expect(state).toEqual({
+        isDebug: true,
+        currentUrl: 'https://dev.boardsesh.ts.net',
+        defaultUrl: 'https://www.boardsesh.com',
+      });
+    });
+
+    it('normalizes missing currentUrl to null (defensive against Android omitting the key)', async () => {
+      const plugin = makePlugin({
+        getState: vi.fn().mockResolvedValue({
+          isDebug: true,
+          defaultUrl: 'https://www.boardsesh.com',
+          // currentUrl intentionally absent
+        }),
+      });
+      installCapacitor(plugin);
+
+      const state = await getDevUrlState();
+
+      expect(state?.currentUrl).toBeNull();
+    });
+
+    it('returns null when the plugin throws', async () => {
+      const plugin = makePlugin({
+        getState: vi.fn().mockRejectedValue(new Error('boom')),
+      });
+      installCapacitor(plugin);
+
+      expect(await getDevUrlState()).toBeNull();
+    });
+  });
+
+  describe('setDevUrl', () => {
+    it('forwards the URL to the plugin', async () => {
+      const plugin = makePlugin();
+      installCapacitor(plugin);
+
+      await setDevUrl('https://preview.boardsesh.com');
+
+      expect(plugin.setUrl).toHaveBeenCalledWith({ url: 'https://preview.boardsesh.com' });
+    });
+
+    it('is a no-op when Capacitor is not installed', async () => {
+      await setDevUrl('https://preview.boardsesh.com');
+    });
+
+    it('is a no-op when not a native app', async () => {
+      const plugin = makePlugin();
+      installCapacitor(plugin, false);
+
+      await setDevUrl('https://preview.boardsesh.com');
+
+      expect(plugin.setUrl).not.toHaveBeenCalled();
+    });
+
+    it('propagates plugin rejections so callers can surface the error', async () => {
+      const plugin = makePlugin({
+        setUrl: vi.fn().mockRejectedValue(new Error('Invalid URL')),
+      });
+      installCapacitor(plugin);
+
+      await expect(setDevUrl('not a url')).rejects.toThrow('Invalid URL');
+    });
+  });
+
+  describe('clearDevUrl', () => {
+    it('calls the plugin', async () => {
+      const plugin = makePlugin();
+      installCapacitor(plugin);
+
+      await clearDevUrl();
+
+      expect(plugin.clearUrl).toHaveBeenCalled();
+    });
+
+    it('is a no-op when the plugin is missing', async () => {
+      await clearDevUrl();
+    });
+  });
+
+  describe('useDevUrl', () => {
+    it('reports not available when Capacitor is missing', async () => {
+      const { result } = renderHook(() => useDevUrl());
+
+      await waitFor(() => {
+        expect(result.current.state).toBeNull();
+      });
+
+      expect(result.current.isAvailable).toBe(false);
+    });
+
+    it('reports available when native + isDebug is true', async () => {
+      installCapacitor(makePlugin());
+
+      const { result } = renderHook(() => useDevUrl());
+
+      await waitFor(() => {
+        expect(result.current.state?.isDebug).toBe(true);
+      });
+
+      expect(result.current.isAvailable).toBe(true);
+    });
+
+    it('reports not available when native but isDebug is false (release build)', async () => {
+      const plugin = makePlugin({
+        getState: vi.fn().mockResolvedValue({
+          isDebug: false,
+          currentUrl: null,
+          defaultUrl: 'https://www.boardsesh.com',
+        }),
+      });
+      installCapacitor(plugin);
+
+      const { result } = renderHook(() => useDevUrl());
+
+      await waitFor(() => {
+        expect(result.current.state).not.toBeNull();
+      });
+
+      expect(result.current.isAvailable).toBe(false);
+    });
+  });
+});

--- a/packages/web/app/lib/ble/capacitor-types.d.ts
+++ b/packages/web/app/lib/ble/capacitor-types.d.ts
@@ -34,6 +34,12 @@ interface CapacitorAppPlugin {
   ): Promise<{ remove: () => Promise<void> }>;
 }
 
+interface CapacitorDevUrlPlugin {
+  getState(): Promise<{ isDebug: boolean; currentUrl: string | null; defaultUrl: string }>;
+  setUrl(options: { url: string }): Promise<void>;
+  clearUrl(): Promise<void>;
+}
+
 interface CapacitorGlobal {
   isNativePlatform(): boolean;
   getPlatform(): string;
@@ -43,6 +49,7 @@ interface CapacitorGlobal {
     KeepAwake?: CapacitorKeepAwakePlugin;
     Browser?: CapacitorBrowserPlugin;
     App?: CapacitorAppPlugin;
+    DevUrl?: CapacitorDevUrlPlugin;
     LiveActivity?: {
       isAvailable(): Promise<{ available: boolean }>;
       startSession(options: Record<string, unknown>): Promise<void>;

--- a/packages/web/app/lib/dev-url.ts
+++ b/packages/web/app/lib/dev-url.ts
@@ -10,13 +10,19 @@ export type DevUrlState = {
   defaultUrl: string;
 };
 
-const plugin = () => (typeof window === 'undefined' ? undefined : window.Capacitor?.Plugins?.DevUrl);
+const plugin = () => {
+  if (typeof window === 'undefined' || !isNativeApp()) return undefined;
+  return window.Capacitor?.Plugins?.DevUrl;
+};
 
 export async function getDevUrlState(): Promise<DevUrlState | null> {
   const p = plugin();
   if (!p) return null;
   try {
-    return await p.getState();
+    const raw = await p.getState();
+    // Android's JSObject may still omit the key in older plugin builds; normalize
+    // to `null` so the web side's `string | null` contract holds regardless.
+    return { ...raw, currentUrl: raw.currentUrl ?? null };
   } catch {
     return null;
   }

--- a/packages/web/app/lib/dev-url.ts
+++ b/packages/web/app/lib/dev-url.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+
+export type DevUrlState = {
+  isDebug: boolean;
+  currentUrl: string | null;
+  defaultUrl: string;
+};
+
+const plugin = () => (typeof window === 'undefined' ? undefined : window.Capacitor?.Plugins?.DevUrl);
+
+export async function getDevUrlState(): Promise<DevUrlState | null> {
+  const p = plugin();
+  if (!p) return null;
+  try {
+    return await p.getState();
+  } catch {
+    return null;
+  }
+}
+
+export async function setDevUrl(url: string): Promise<void> {
+  const p = plugin();
+  if (!p) return;
+  await p.setUrl({ url });
+}
+
+export async function clearDevUrl(): Promise<void> {
+  const p = plugin();
+  if (!p) return;
+  await p.clearUrl();
+}
+
+export function useDevUrl(): { isAvailable: boolean; state: DevUrlState | null; refresh: () => void } {
+  const [state, setState] = useState<DevUrlState | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!isNativeApp()) {
+      setState(null);
+      return;
+    }
+    void (async () => {
+      const next = await getDevUrlState();
+      if (!cancelled) setState(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tick]);
+
+  return {
+    isAvailable: Boolean(state?.isDebug),
+    state,
+    refresh: () => setTick((n) => n + 1),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a **Dev URL** menu item to the user drawer, visible only on debug native builds, that points the WebView at a Tailscale tunnel, Vercel preview, or any other origin without a rebuild.
- New Capacitor plugin `DevUrl` on both Android (`DevUrlPlugin.java`) and iOS (`DevUrlPlugin.swift/.m`) persists the override (SharedPreferences / UserDefaults) and relaunches the process so the bridge re-reads config on boot.
- Release builds are no-ops: plugin reports `isDebug: false`, mutating calls do nothing, menu item stays hidden.
- Escape hatch: if an override URL fails to load, the Android offline-fallback page now shows a "Reset dev URL to production" link that clears the override via a `boardsesh-dev://reset` scheme intercepted by the WebViewClient.

## Test plan

- [ ] `vp check` passes (done locally).
- [ ] `cd mobile && bunx cap sync android && bunx cap run android` — confirm the user drawer shows "Dev URL" in debug build and prod loads on fresh install.
- [ ] Enter a Tailscale URL, Save & restart → app relaunches against that origin.
- [ ] Kill the dev server → offline fallback page shows "Reset dev URL" link → tapping relaunches on production.
- [ ] `bunx cap sync ios && bunx cap open ios` — run Debug scheme in simulator, repeat the same flow.
- [ ] Release APK / iOS Release build → confirm the menu item stays hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)