### PR TITLE
fix(android): restore bottom tab bar + safe-area on Android Capacitor

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -120,7 +120,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
                         paddingLeft: `${themeTokens.spacing[2]}px`,
                         paddingRight: `${themeTokens.spacing[2]}px`,
                         paddingTop: 'var(--global-header-height)',
-                        paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+                        paddingBottom: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
                       }}
                     >
                       <BoardSeshHeader boardDetails={boardDetails} angle={angle} />

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -94,7 +94,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
                           paddingLeft: `${themeTokens.spacing[2]}px`,
                           paddingRight: `${themeTokens.spacing[2]}px`,
                           paddingTop: 'var(--global-header-height)',
-                          paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+                          paddingBottom: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
                         }}
                       >
                         <BoardSeshHeader

--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -8,7 +8,7 @@
 
 .header {
   touch-action: manipulation;
-  padding-top: env(safe-area-inset-top, 0px);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
 }
 
 .header button,

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,7 +1,7 @@
 .bottomBarWrapper {
   --tab-bar-top-radius: 16px;
   --tab-bar-bottom-radius: 16px;
-  --tab-bar-safe-area-padding: env(safe-area-inset-bottom, 0px);
+  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
   --tab-bar-bottom-extension: 0px;
   position: fixed;
   bottom: 0;
@@ -15,10 +15,20 @@
 .nativeApp {
   --tab-bar-top-radius: 0px;
   --tab-bar-bottom-radius: 0px;
-  --tab-bar-safe-area-padding: env(safe-area-inset-bottom, 0px);
+  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
   left: 0;
   right: 0;
   border-radius: 0;
+}
+
+/* Android Capacitor 8 draws the WebView under the gesture/nav bar, but
+   Chromium < 140 does not populate env(safe-area-inset-bottom) even with
+   viewport-fit=cover. The @capacitor-community/safe-area plugin sets
+   --safe-area-inset-bottom on :root once its WindowInsets listener fires;
+   floor at 24px so the tab bar never renders under the gesture pill during
+   the first-paint window before that happens. */
+.androidNative {
+  --tab-bar-safe-area-padding: max(var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)), 24px);
 }
 
 @media (min-width: 768px) {
@@ -41,8 +51,8 @@
     .bottomBarWrapper:not(.nativeApp) {
       --tab-bar-top-radius: 0px;
       --tab-bar-bottom-radius: 0px;
-      --tab-bar-safe-area-padding: max(2dvh, env(safe-area-inset-bottom, 0px));
-      --tab-bar-bottom-extension: calc(-1 * max(2dvh, env(safe-area-inset-bottom, 0px)));
+      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))));
       bottom: 2dvh;
       left: 0;
       right: 0;

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,7 +1,7 @@
 .pageContainer {
   position: fixed;
-  top: env(safe-area-inset-top, 0px);
-  bottom: calc(120px + env(safe-area-inset-bottom, 0px));
+  top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  bottom: calc(120px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   left: 8px;
   right: 8px;
   display: flex;

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -9,7 +9,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: env(safe-area-inset-top, 0px);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.6));
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
@@ -66,7 +66,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: env(safe-area-inset-top, 0px);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
   background: transparent;
   border-bottom: none;
   pointer-events: none;

--- a/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
@@ -371,7 +371,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         fullHeight
         styles={{
           wrapper: { height: '100dvh' },
-          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+          header: { paddingTop: `max(16px, ${themeTokens.layout.safeAreaTop})` },
         }}
       >
         <div className={styles.loadingContainer}>
@@ -395,7 +395,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         fullHeight
         styles={{
           wrapper: { height: '100dvh' },
-          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+          header: { paddingTop: `max(16px, ${themeTokens.layout.safeAreaTop})` },
         }}
       >
         <div className={styles.emptyState}>
@@ -421,7 +421,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         fullHeight
         styles={{
           wrapper: { height: '100dvh' },
-          header: { paddingTop: 'max(16px, env(safe-area-inset-top))' },
+          header: { paddingTop: `max(16px, ${themeTokens.layout.safeAreaTop})` },
         }}
       >
         <div className={styles.completeContainer}>
@@ -454,7 +454,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         wrapper: { height: '100dvh' },
         header: {
           borderBottom: '1px solid var(--neutral-200)',
-          paddingTop: 'max(16px, env(safe-area-inset-top))',
+          paddingTop: `max(16px, ${themeTokens.layout.safeAreaTop})`,
         },
         body: {
           padding: 16,

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -77,7 +77,7 @@
   --input-bg-focused: #ffffff;
 
   /* Layout */
-  --global-header-height: calc(max(8dvh, 48px) + env(safe-area-inset-top, 0px));
+  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -25,7 +25,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 
@@ -128,15 +128,21 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathname();
   const isNative = isNativeApp();
+  const isAndroidNative = isNative && getPlatform() === 'android';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
+  const wrapperClass = [
+    bottomBarStyles.bottomBarWrapper,
+    isNative && bottomBarStyles.nativeApp,
+    isAndroidNative && bottomBarStyles.androidNative,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div
-      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
-      data-testid="bottom-bar-wrapper"
-    >
+    <div className={wrapperClass} data-testid="bottom-bar-wrapper">
       {hasActiveQueue && boardDetails && (
         <ErrorBoundary>
           <BoardProvider boardName={boardDetails.board_name}>

--- a/packages/web/app/components/providers/snackbar-provider.tsx
+++ b/packages/web/app/components/providers/snackbar-provider.tsx
@@ -5,6 +5,7 @@ import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import type { AlertColor } from '@mui/material/Alert';
+import { themeTokens } from '@/app/theme/theme-config';
 
 type SnackbarAction = {
   label: string;
@@ -50,7 +51,7 @@ export function SnackbarProvider({ children }: { children: React.ReactNode }) {
           autoHideDuration={msg.duration ?? 3000}
           onClose={() => handleClose(msg.key)}
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-          sx={{ top: 'calc(8px + env(safe-area-inset-top, 0px)) !important' }}
+          sx={{ top: `calc(8px + ${themeTokens.layout.safeAreaTop}) !important` }}
         >
           <Alert
             onClose={() => handleClose(msg.key)}

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -255,7 +255,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
     // safe-area-inset-top padding to avoid rendering behind the device notch/pill.
     // (Top/left/right anchors get this from the MUI theme overrides.)
     if (isFullHeightDrawer && placement === 'bottom' && !sx.paddingTop) {
-      sx.paddingTop = 'env(safe-area-inset-top, 0px)';
+      sx.paddingTop = themeTokens.layout.safeAreaTop;
     }
 
     return sx;

--- a/packages/web/app/feed/feed-page-content.tsx
+++ b/packages/web/app/feed/feed-page-content.tsx
@@ -15,6 +15,7 @@ import type { SessionFeedResult } from '@boardsesh/shared-schema';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import UnifiedSearchDrawer from '@/app/components/search-drawer/unified-search-drawer';
+import { themeTokens } from '@/app/theme/theme-config';
 
 type FeedTab = 'sessions' | 'proposals' | 'comments';
 const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
@@ -89,7 +90,7 @@ export default function FeedPageContent({
         minHeight: '100dvh',
         display: 'flex',
         flexDirection: 'column',
-        pb: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+        pb: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
       }}
     >
       {/* Feed */}

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -302,7 +302,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
         minHeight: '100dvh',
         display: 'flex',
         flexDirection: 'column',
-        pb: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+        pb: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
       }}
     >
       <Box

--- a/packages/web/app/notifications/layout.tsx
+++ b/packages/web/app/notifications/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { themeTokens } from '@/app/theme/theme-config';
 
 export default function NotificationsLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -6,7 +7,7 @@ export default function NotificationsLayout({ children }: { children: React.Reac
       style={{
         minHeight: '100dvh',
         paddingTop: 'var(--global-header-height)',
-        paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+        paddingBottom: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
       }}
     >
       {children}

--- a/packages/web/app/playlists/layout.tsx
+++ b/packages/web/app/playlists/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { themeTokens } from '@/app/theme/theme-config';
 
 export default function MyLibraryLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -6,7 +7,7 @@ export default function MyLibraryLayout({ children }: { children: React.ReactNod
       style={{
         minHeight: '100dvh',
         paddingTop: 'var(--global-header-height)',
-        paddingBottom: 'env(safe-area-inset-bottom)',
+        paddingBottom: themeTokens.layout.safeAreaBottom,
       }}
     >
       {children}

--- a/packages/web/app/profile/[user_id]/profile-page.module.css
+++ b/packages/web/app/profile/[user_id]/profile-page.module.css
@@ -27,7 +27,7 @@
 
 .content {
   padding: 24px; /* spacing.6 */
-  padding-bottom: calc(170px + env(safe-area-inset-bottom, 0px));
+  padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   max-width: 800px;
   margin: 0 auto;
   width: 100%;
@@ -265,7 +265,7 @@
 @media (max-width: 768px) {
   .content {
     padding: 16px; /* spacing.4 */
-    padding-bottom: calc(170px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   }
 
   .header {

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -20,6 +20,7 @@ import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Logo from '@/app/components/brand/logo';
+import { themeTokens } from '@/app/theme/theme-config';
 import AuroraCredentialsSection from '@/app/components/settings/aurora-credentials-section';
 import ControllersSection from '@/app/components/settings/controllers-section';
 import DeleteAccountSection from '@/app/components/settings/delete-account-section';
@@ -382,7 +383,7 @@ export default function SettingsPageContent() {
         component="main"
         sx={{
           padding: '24px',
-          paddingBottom: 'calc(120px + env(safe-area-inset-bottom, 0px))',
+          paddingBottom: `calc(120px + ${themeTokens.layout.safeAreaBottom})`,
           maxWidth: 600,
           margin: '0 auto',
           width: '100%',

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -79,21 +79,21 @@ const sharedComponents: Components<Theme> = {
       },
       paperAnchorBottom: {
         borderRadius: `${themeTokens.borderRadius.lg}px ${themeTokens.borderRadius.lg}px 0 0`,
-        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        paddingBottom: themeTokens.layout.safeAreaBottom,
       },
       paperAnchorLeft: {
         borderRadius: `0 ${themeTokens.borderRadius.lg}px ${themeTokens.borderRadius.lg}px 0`,
-        paddingTop: 'env(safe-area-inset-top, 0px)',
-        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        paddingTop: themeTokens.layout.safeAreaTop,
+        paddingBottom: themeTokens.layout.safeAreaBottom,
       },
       paperAnchorRight: {
         borderRadius: `${themeTokens.borderRadius.lg}px 0 0 ${themeTokens.borderRadius.lg}px`,
-        paddingTop: 'env(safe-area-inset-top, 0px)',
-        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        paddingTop: themeTokens.layout.safeAreaTop,
+        paddingBottom: themeTokens.layout.safeAreaBottom,
       },
       paperAnchorTop: {
         borderRadius: `0 0 ${themeTokens.borderRadius.lg}px ${themeTokens.borderRadius.lg}px`,
-        paddingTop: 'env(safe-area-inset-top, 0px)',
+        paddingTop: themeTokens.layout.safeAreaTop,
       },
     },
   },

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -152,7 +152,12 @@ export const themeTokens = {
   layout: {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
-    bottomNavSpacer: 'calc(80px + env(safe-area-inset-bottom, 0px))',
+    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
+    /** Safe-area bottom inset. Prefers the @capacitor-community/safe-area plugin's CSS var
+     *  (needed on Android Capacitor where env() is not populated), falls back to native env(). */
+    safeAreaBottom: 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))',
+    /** Safe-area top inset. Same rationale as safeAreaBottom. */
+    safeAreaTop: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',
   },
 } as const;
 


### PR DESCRIPTION
Capacitor 8 draws the WebView edge-to-edge under Android's gesture/nav bar, but Chromium < 140 does not populate env(safe-area-inset-bottom), so the fixed bottom tab bar was rendering under the gesture pill and disappearing. Page bottom paddings (home, feed, notifications, settings, profile, board shells, drawers) had the same silent bug — content sat flush against the bar instead of clearing it.

- Consume @capacitor-community/safe-area's CSS variables: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)). The plugin sets these on :root from native WindowInsets; env() stays as the web fallback.
- Add themeTokens.layout.safeAreaBottom / safeAreaTop so consumers use one token instead of repeating the var/env expression.
- Floor the tab bar to 24px on Android native via a new .androidNative class, gated on getPlatform() === 'android' in PersistentSessionWrapper. Protects the first-paint window before the plugin's WindowInsets listener fires.