### PR TITLE
fix(android): drop dead 24px tab-bar floor, anchor CSS vars in :root

### DIFF
--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -8,7 +8,7 @@
 
 .header {
   touch-action: manipulation;
-  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  padding-top: var(--safe-area-inset-top);
 }
 
 .header button,

--- a/packages/web/app/components/board-page/header.module.css
+++ b/packages/web/app/components/board-page/header.module.css
@@ -8,7 +8,7 @@
 
 .header {
   touch-action: manipulation;
-  padding-top: var(--safe-area-inset-top);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
 }
 
 .header button,

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -40,14 +40,21 @@
    (which creates a visible backdrop-filter seam), extend the BottomNavigation
    below the wrapper via negative margin so the frosted glass is one element.
    The wrapper has no overflow:hidden, so the child visually overflows to
-   cover the 2dvh gap plus any safe area beyond it. */
+   cover the 2dvh gap plus any safe area beyond it.
+
+   Use raw env(safe-area-inset-bottom) here instead of the :root-defined
+   var(--safe-area-inset-bottom). iOS Safari resolves var()-of-env() to 0
+   inside nested calc/max in some contexts, which collapses the negative
+   bottom-extension and leaves the Safari URL-bar area uncovered (visible
+   body background, which is black in dark mode). env() is reliable here
+   because this block only matches iOS Safari. */
 @supports (-webkit-touch-callout: none) {
   @media (hover: none) and (pointer: coarse) {
     .bottomBarWrapper:not(.nativeApp) {
       --tab-bar-top-radius: 0px;
       --tab-bar-bottom-radius: 0px;
-      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
-      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))));
+      --tab-bar-safe-area-padding: max(2dvh, env(safe-area-inset-bottom, 0px));
+      --tab-bar-bottom-extension: calc(-1 * max(2dvh, env(safe-area-inset-bottom, 0px)));
       bottom: 2dvh;
       left: 0;
       right: 0;

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -28,10 +28,6 @@
 
 @media (min-width: 768px) {
   .bottomBarWrapper {
-    /* Desktop gets a flat 16px bottom gutter on the wrapper, so the
-       BottomNavigation child must stop adding its own safe-area padding
-       or the two stack. Zero the child's padding var in this breakpoint. */
-    --tab-bar-safe-area-padding: 0px;
     left: 0;
     right: 0;
     padding-bottom: 16px;

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -28,6 +28,10 @@
 
 @media (min-width: 768px) {
   .bottomBarWrapper {
+    /* Desktop gets a flat 16px bottom gutter on the wrapper, so the
+       BottomNavigation child must stop adding its own safe-area padding
+       or the two stack. Zero the child's padding var in this breakpoint. */
+    --tab-bar-safe-area-padding: 0px;
     left: 0;
     right: 0;
     padding-bottom: 16px;

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,7 +1,7 @@
 .bottomBarWrapper {
   --tab-bar-top-radius: 16px;
   --tab-bar-bottom-radius: 16px;
-  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom);
+  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
   --tab-bar-bottom-extension: 0px;
   position: fixed;
   bottom: 0;
@@ -46,8 +46,8 @@
     .bottomBarWrapper:not(.nativeApp) {
       --tab-bar-top-radius: 0px;
       --tab-bar-bottom-radius: 0px;
-      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom));
-      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom)));
+      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))));
       bottom: 2dvh;
       left: 0;
       right: 0;

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,7 +1,7 @@
 .bottomBarWrapper {
   --tab-bar-top-radius: 16px;
   --tab-bar-bottom-radius: 16px;
-  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom);
   --tab-bar-bottom-extension: 0px;
   position: fixed;
   bottom: 0;
@@ -16,8 +16,10 @@
    is already handled: on Android the @capacitor-community/safe-area plugin
    pads the WebView decorView (Chromium < 140) or passes real insets through
    to env() (Chromium 140+); on iOS WKWebView env() reports home-indicator
-   inset natively. The wrapper's inner --safe-area-inset-bottom picks up
-   whatever env() reports — no extra Android floor is needed. */
+   inset natively. --tab-bar-safe-area-padding (inherited from the base
+   .bottomBarWrapper rule above, which reads --safe-area-inset-bottom from
+   :root) therefore picks up the correct inset automatically — no extra
+   Android floor or native-specific override is needed here. */
 .nativeApp {
   --tab-bar-top-radius: 0px;
   --tab-bar-bottom-radius: 0px;

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,7 +1,7 @@
 .bottomBarWrapper {
   --tab-bar-top-radius: 16px;
   --tab-bar-bottom-radius: 16px;
-  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom);
   --tab-bar-bottom-extension: 0px;
   position: fixed;
   bottom: 0;
@@ -12,23 +12,18 @@
   border-radius: 16px;
 }
 
+/* In Capacitor native the tab bar sits edge-to-edge. Safe-area clearance
+   is already handled: on Android the @capacitor-community/safe-area plugin
+   pads the WebView decorView (Chromium < 140) or passes real insets through
+   to env() (Chromium 140+); on iOS WKWebView env() reports home-indicator
+   inset natively. The wrapper's inner --safe-area-inset-bottom picks up
+   whatever env() reports — no extra Android floor is needed. */
 .nativeApp {
   --tab-bar-top-radius: 0px;
   --tab-bar-bottom-radius: 0px;
-  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
   left: 0;
   right: 0;
   border-radius: 0;
-}
-
-/* Android Capacitor 8 draws the WebView under the gesture/nav bar, but
-   Chromium < 140 does not populate env(safe-area-inset-bottom) even with
-   viewport-fit=cover. The @capacitor-community/safe-area plugin sets
-   --safe-area-inset-bottom on :root once its WindowInsets listener fires;
-   floor at 24px so the tab bar never renders under the gesture pill during
-   the first-paint window before that happens. */
-.androidNative {
-  --tab-bar-safe-area-padding: max(var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)), 24px);
 }
 
 @media (min-width: 768px) {
@@ -51,8 +46,8 @@
     .bottomBarWrapper:not(.nativeApp) {
       --tab-bar-top-radius: 0px;
       --tab-bar-bottom-radius: 0px;
-      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
-      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))));
+      --tab-bar-safe-area-padding: max(2dvh, var(--safe-area-inset-bottom));
+      --tab-bar-bottom-extension: calc(-1 * max(2dvh, var(--safe-area-inset-bottom)));
       bottom: 2dvh;
       left: 0;
       right: 0;

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,7 +1,7 @@
 .pageContainer {
   position: fixed;
-  top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
-  bottom: calc(120px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+  top: var(--safe-area-inset-top);
+  bottom: calc(120px + var(--safe-area-inset-bottom));
   left: 8px;
   right: 8px;
   display: flex;

--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,7 +1,7 @@
 .pageContainer {
   position: fixed;
-  top: var(--safe-area-inset-top);
-  bottom: calc(120px + var(--safe-area-inset-bottom));
+  top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  bottom: calc(120px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   left: 8px;
   right: 8px;
   display: flex;

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -9,7 +9,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  padding-top: var(--safe-area-inset-top);
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.6));
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
@@ -66,7 +66,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  padding-top: var(--safe-area-inset-top);
   background: transparent;
   border-bottom: none;
   pointer-events: none;

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -9,7 +9,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: var(--safe-area-inset-top);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.6));
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
@@ -66,7 +66,7 @@
   gap: 12px;
   height: var(--global-header-height);
   padding: 0 16px;
-  padding-top: var(--safe-area-inset-top);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
   background: transparent;
   border-bottom: none;
   pointer-events: none;

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -76,13 +76,25 @@
   --input-bg-hover: #f3f4f6;
   --input-bg-focused: #ffffff;
 
-  /* Safe-area insets.
-     On iOS WKWebView and modern browsers (incl. Android Chromium >= 140 with
-     viewport-fit=cover) native env(safe-area-inset-*) reports real values.
-     On Android Chromium < 140 the @capacitor-community/safe-area plugin pads
-     the WebView's decorView natively and leaves env() at 0 — safe, single
-     source. Naming these as CSS vars lets future overrides (per-platform or
-     per-view) work without touching every consumer. */
+  /* Safe-area insets, exposed as CSS vars so consumers resolve through
+     a single indirection (and so future per-platform or per-view overrides
+     don't have to touch every call site).
+
+     Source of inset values, by platform:
+     - iOS WKWebView: WebKit populates env(safe-area-inset-*) natively once
+       viewport-fit=cover is set. No plugin help needed.
+     - Android Chromium >= 140 with viewport-fit=cover: the
+       @capacitor-community/safe-area plugin zeroes the decorView padding
+       and passes real system WindowInsets through, so env() reports the
+       real gesture/nav/status bar insets.
+     - Android Chromium < 140: the same plugin pads the decorView with the
+       real WindowInsets natively and then explicitly rewrites the insets
+       delivered to the WebView to Insets.of(0,0,0,0) — so the WebView
+       coordinate origin is already inside the safe zone, and env() here
+       correctly reports 0 (no inset remaining to account for). Single
+       source of truth in both Android branches.
+     - Desktop and mobile web browsers: env() reports 0 unless the browser
+       itself has a UI chrome inset (Mobile Safari bottom chrome). */
   --safe-area-inset-top: env(safe-area-inset-top, 0px);
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -94,14 +94,22 @@
        correctly reports 0 (no inset remaining to account for). Single
        source of truth in both Android branches.
      - Desktop and mobile web browsers: env() reports 0 unless the browser
-       itself has a UI chrome inset (Mobile Safari bottom chrome). */
+       itself has a UI chrome inset (Mobile Safari bottom chrome).
+
+     Consumers use `var(--safe-area-inset-*)` directly, no `env()` fallback
+     — these vars are always defined here, so the fallback is dead code.
+     The one exception is the iOS Safari `@supports (-webkit-touch-callout:
+     none)` block in bottom-bar-wrapper.module.css, which uses raw `env()`
+     directly inside its nested calc/max expression. iOS Safari has a
+     long-standing bug where var-of-env collapses to 0 inside such
+     expressions, so raw env() is the only reliable option there. */
   --safe-area-inset-top: env(safe-area-inset-top, 0px);
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
 
   /* Layout */
-  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)));
+  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -76,8 +76,20 @@
   --input-bg-hover: #f3f4f6;
   --input-bg-focused: #ffffff;
 
+  /* Safe-area insets.
+     On iOS WKWebView and modern browsers (incl. Android Chromium >= 140 with
+     viewport-fit=cover) native env(safe-area-inset-*) reports real values.
+     On Android Chromium < 140 the @capacitor-community/safe-area plugin pads
+     the WebView's decorView natively and leaves env() at 0 — safe, single
+     source. Naming these as CSS vars lets future overrides (per-platform or
+     per-view) work without touching every consumer. */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+
   /* Layout */
-  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)));
+  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -101,7 +101,7 @@
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
 
   /* Layout */
-  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top));
+  --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -25,7 +25,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 
@@ -128,21 +128,15 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathname();
   const isNative = isNativeApp();
-  const isAndroidNative = isNative && getPlatform() === 'android';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
-  const wrapperClass = [
-    bottomBarStyles.bottomBarWrapper,
-    isNative && bottomBarStyles.nativeApp,
-    isAndroidNative && bottomBarStyles.androidNative,
-  ]
-    .filter(Boolean)
-    .join(' ');
-
   return (
-    <div className={wrapperClass} data-testid="bottom-bar-wrapper">
+    <div
+      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
+      data-testid="bottom-bar-wrapper"
+    >
       {hasActiveQueue && boardDetails && (
         <ErrorBoundary>
           <BoardProvider boardName={boardDetails.board_name}>

--- a/packages/web/app/profile/[user_id]/profile-page.module.css
+++ b/packages/web/app/profile/[user_id]/profile-page.module.css
@@ -27,7 +27,7 @@
 
 .content {
   padding: 24px; /* spacing.6 */
-  padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-bottom: calc(170px + var(--safe-area-inset-bottom));
   max-width: 800px;
   margin: 0 auto;
   width: 100%;
@@ -265,7 +265,7 @@
 @media (max-width: 768px) {
   .content {
     padding: 16px; /* spacing.4 */
-    padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+    padding-bottom: calc(170px + var(--safe-area-inset-bottom));
   }
 
   .header {

--- a/packages/web/app/profile/[user_id]/profile-page.module.css
+++ b/packages/web/app/profile/[user_id]/profile-page.module.css
@@ -27,7 +27,7 @@
 
 .content {
   padding: 24px; /* spacing.6 */
-  padding-bottom: calc(170px + var(--safe-area-inset-bottom));
+  padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   max-width: 800px;
   margin: 0 auto;
   width: 100%;
@@ -265,7 +265,7 @@
 @media (max-width: 768px) {
   .content {
     padding: 16px; /* spacing.4 */
-    padding-bottom: calc(170px + var(--safe-area-inset-bottom));
+    padding-bottom: calc(170px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   }
 
   .header {

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -152,14 +152,11 @@ export const themeTokens = {
   layout: {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
-    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
-    /** Safe-area bottom inset. Reads the --safe-area-inset-bottom CSS var
-     *  defined in index.css (which resolves to env(safe-area-inset-bottom, 0px)),
-     *  with env() inlined as a belt-and-braces fallback if the var is missing
-     *  (e.g. during SSR before global styles mount). */
-    safeAreaBottom: 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))',
-    /** Safe-area top inset. Same rationale as safeAreaBottom. */
-    safeAreaTop: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',
+    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom))',
+    /** Safe-area bottom inset. Resolves via --safe-area-inset-bottom defined in index.css. */
+    safeAreaBottom: 'var(--safe-area-inset-bottom)',
+    /** Safe-area top inset. Resolves via --safe-area-inset-top defined in index.css. */
+    safeAreaTop: 'var(--safe-area-inset-top)',
   },
 } as const;
 

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -153,8 +153,10 @@ export const themeTokens = {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
     bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
-    /** Safe-area bottom inset. Prefers the @capacitor-community/safe-area plugin's CSS var
-     *  (needed on Android Capacitor where env() is not populated), falls back to native env(). */
+    /** Safe-area bottom inset. Reads the --safe-area-inset-bottom CSS var
+     *  defined in index.css (which resolves to env(safe-area-inset-bottom, 0px)),
+     *  with env() inlined as a belt-and-braces fallback if the var is missing
+     *  (e.g. during SSR before global styles mount). */
     safeAreaBottom: 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))',
     /** Safe-area top inset. Same rationale as safeAreaBottom. */
     safeAreaTop: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -152,15 +152,11 @@ export const themeTokens = {
   layout: {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
-    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
-    /** Safe-area bottom inset. The `, env(...)` fallback is not strictly needed on browsers that honor
-     *  the :root definition in index.css, but iOS Safari has historically resolved `var(--X)` to its
-     *  initial value (0) when --X is defined as `env(...)` on :root in some contexts. Keeping env() as
-     *  the direct fallback is cheap belt-and-braces insurance that guarantees the home-indicator inset
-     *  is always respected. */
-    safeAreaBottom: 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))',
-    /** Safe-area top inset. Same rationale as safeAreaBottom. */
-    safeAreaTop: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',
+    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom))',
+    /** Safe-area bottom inset. Resolves through --safe-area-inset-bottom defined on :root in index.css. */
+    safeAreaBottom: 'var(--safe-area-inset-bottom)',
+    /** Safe-area top inset. Resolves through --safe-area-inset-top defined on :root in index.css. */
+    safeAreaTop: 'var(--safe-area-inset-top)',
   },
 } as const;
 

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -152,11 +152,15 @@ export const themeTokens = {
   layout: {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.
      *  Accounts for nav height (~72px), iOS Safari 2dvh offset, and safe area inset. */
-    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom))',
-    /** Safe-area bottom inset. Resolves via --safe-area-inset-bottom defined in index.css. */
-    safeAreaBottom: 'var(--safe-area-inset-bottom)',
-    /** Safe-area top inset. Resolves via --safe-area-inset-top defined in index.css. */
-    safeAreaTop: 'var(--safe-area-inset-top)',
+    bottomNavSpacer: 'calc(80px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))',
+    /** Safe-area bottom inset. The `, env(...)` fallback is not strictly needed on browsers that honor
+     *  the :root definition in index.css, but iOS Safari has historically resolved `var(--X)` to its
+     *  initial value (0) when --X is defined as `env(...)` on :root in some contexts. Keeping env() as
+     *  the direct fallback is cheap belt-and-braces insurance that guarantees the home-indicator inset
+     *  is always respected. */
+    safeAreaBottom: 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))',
+    /** Safe-area top inset. Same rationale as safeAreaBottom. */
+    safeAreaTop: 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))',
   },
 } as const;
 


### PR DESCRIPTION
Follow-up to the prior Android safe-area fix. A code review against the @capacitor-community/safe-area v8 source (SafeAreaPlugin.java) corrected two claims from the first PR:

1. The plugin does NOT set --safe-area-inset-* on :root. On Android Chromium < 140 it pads the WebView decorView natively and rewrites WindowInsets to 0 (so env() correctly returns 0). On Chromium >= 140 with viewport-fit=cover it zeroes decorView padding and passes the real insets through to env(). Single source of truth in both branches.

2. The .androidNative 24px floor added in the prior PR was therefore dead weight: on Chromium < 140 the WebView is already inset, so the 24px was rendered as extra interior padding inside the tab bar (visible over-padding); on 140+ env() reports the real inset and the floor rarely kicks in.

Changes:

- Define --safe-area-inset-top/right/bottom/left in :root (index.css) as env() passthroughs so downstream var() consumers resolve cleanly. This also makes the var() fallback layer future-useful if we ever override insets per-platform via a bootstrap.
- Drop the .androidNative class, its 24px max() expression, and the getPlatform() wiring in PersistentSessionWrapper. Tab bar now relies entirely on what the plugin + env() report — which is correct on every Android WebView version today.
- Rewrite the tab-bar wrapper comment to describe actual plugin behavior (decorView padding on <140, env() passthrough on 140+).
- Update the safeAreaBottom/Top token docstrings to explain the env() fallback is a belt-and-braces hedge for pre-mount SSR, not plugin- specific.