### PR TITLE
feat(feedback): in-app rating prompt + drawer entries (closes #1644)

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-community-bluetooth-le')
+    implementation project(':capacitor-community-in-app-review')
     implementation project(':capacitor-community-keep-awake')
     implementation project(':capacitor-community-safe-area')
     implementation project(':capacitor-app')

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-community-bluetooth-le'
 project(':capacitor-community-bluetooth-le').projectDir = new File('../node_modules/@capacitor-community/bluetooth-le/android')
 
+include ':capacitor-community-in-app-review'
+project(':capacitor-community-in-app-review').projectDir = new File('../node_modules/@capacitor-community/in-app-review/android')
+
 include ':capacitor-community-keep-awake'
 project(':capacitor-community-keep-awake').projectDir = new File('../node_modules/@capacitor-community/keep-awake/android')
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -6,6 +6,7 @@
       "name": "@boardsesh/mobile",
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^8",
+        "@capacitor-community/in-app-review": "^8.0.0",
         "@capacitor-community/keep-awake": "^8",
         "@capacitor-community/safe-area": "^8",
         "@capacitor/android": "^8",
@@ -23,6 +24,8 @@
   },
   "packages": {
     "@capacitor-community/bluetooth-le": ["@capacitor-community/bluetooth-le@8.1.3", "", { "dependencies": { "@types/web-bluetooth": "^0.0.20" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-fDwKrxNPZ6muXVGKWsEi971NJ5xNRWmO/N8H7pSTjicT3TXceBdeGSSDDMoT3dRbfcDHjaPI70NfJKwXwf9idg=="],
+
+    "@capacitor-community/in-app-review": ["@capacitor-community/in-app-review@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-AYpEkIjdv27WGS3hnlc7xAQ1BhaBvD2svgQBfHF4P2Olw1N6a7MSCOQC6O4SuxmdBdJ2fM6uFeo1jyNjKLtIPw=="],
 
     "@capacitor-community/keep-awake": ["@capacitor-community/keep-awake@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-+bNAILA4R8PU+rm6OuKfgW6T4N24oAb2Idut5whfX5JAz09j7UBKFBEmT5C0QFJ7S8NZzp9d/yBsbIhLj+JkAA=="],
 

--- a/mobile/ios/App/Podfile
+++ b/mobile/ios/App/Podfile
@@ -12,6 +12,7 @@ def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCommunityBluetoothLe', :path => '../../node_modules/@capacitor-community/bluetooth-le'
+  pod 'CapacitorCommunityInAppReview', :path => '../../node_modules/@capacitor-community/in-app-review'
   pod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'
   pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^8",
+    "@capacitor-community/in-app-review": "^8.0.0",
     "@capacitor-community/keep-awake": "^8",
     "@capacitor-community/safe-area": "^8",
     "@capacitor/android": "^8",

--- a/packages/backend/src/graphql/resolvers/feedback/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/feedback/mutations.ts
@@ -1,0 +1,24 @@
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { applyRateLimit, validateInput } from '../shared/helpers';
+import { SubmitAppFeedbackInputSchema } from '../../../validation/schemas';
+
+export const feedbackMutations = {
+  submitAppFeedback: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    await applyRateLimit(ctx, 10, 'submitAppFeedback');
+
+    const validated = validateInput(SubmitAppFeedbackInputSchema, input, 'input');
+
+    await db.insert(dbSchema.appFeedback).values({
+      userId: ctx.userId ?? null,
+      rating: validated.rating,
+      comment: validated.comment?.trim() ? validated.comment.trim() : null,
+      platform: validated.platform,
+      appVersion: validated.appVersion ?? null,
+      source: validated.source,
+    });
+
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -46,6 +46,7 @@ import { socialRoleQueries, socialRoleMutations } from './social/roles';
 import { socialCommunitySettingsQueries, socialCommunitySettingsMutations } from './social/community-settings';
 import { newClimbSubscriptionResolvers } from './social/new-climb-subscriptions';
 import { newClimbFeedSubscription } from './social/new-climb-feed-subscription';
+import { feedbackMutations } from './feedback/mutations';
 import { isNoMatchClimb } from './shared/helpers';
 
 export const resolvers = {
@@ -101,6 +102,7 @@ export const resolvers = {
     ...socialCommunitySettingsMutations,
     ...newClimbSubscriptionResolvers.Mutation,
     ...sessionEditMutations,
+    ...feedbackMutations,
   },
 
   Subscription: {

--- a/packages/backend/src/validation/schemas/feedback.ts
+++ b/packages/backend/src/validation/schemas/feedback.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const SubmitAppFeedbackInputSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().max(2000).optional().nullable(),
+  platform: z.enum(['ios', 'android', 'web']),
+  appVersion: z.string().max(64).optional().nullable(),
+  source: z.enum(['prompt', 'drawer-rate', 'drawer-feedback']),
+});
+
+export type SubmitAppFeedbackInput = z.infer<typeof SubmitAppFeedbackInputSchema>;

--- a/packages/backend/src/validation/schemas/feedback.ts
+++ b/packages/backend/src/validation/schemas/feedback.ts
@@ -5,7 +5,7 @@ export const SubmitAppFeedbackInputSchema = z.object({
   comment: z.string().trim().max(2000).optional().nullable(),
   platform: z.enum(['ios', 'android', 'web']),
   appVersion: z.string().max(64).optional().nullable(),
-  source: z.enum(['prompt', 'drawer-rate', 'drawer-feedback']),
+  source: z.enum(['prompt', 'drawer-feedback']),
 });
 
 export type SubmitAppFeedbackInput = z.infer<typeof SubmitAppFeedbackInputSchema>;

--- a/packages/backend/src/validation/schemas/index.ts
+++ b/packages/backend/src/validation/schemas/index.ts
@@ -12,3 +12,4 @@ export * from './feeds';
 export * from './proposals';
 export * from './boards';
 export * from './gyms';
+export * from './feedback';

--- a/packages/db/drizzle/0080_concerned_prism.sql
+++ b/packages/db/drizzle/0080_concerned_prism.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "app_feedback" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"rating" integer NOT NULL,
+	"comment" text,
+	"platform" text NOT NULL,
+	"app_version" text,
+	"source" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "app_feedback" ADD CONSTRAINT "app_feedback_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "app_feedback_created_at_idx" ON "app_feedback" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "app_feedback_user_idx" ON "app_feedback" USING btree ("user_id");

--- a/packages/db/drizzle/meta/0080_snapshot.json
+++ b/packages/db/drizzle/meta/0080_snapshot.json
@@ -1,0 +1,7538 @@
+{
+  "id": "08a19806-ca52-463d-b6d3-199103977018",
+  "prevId": "244c9140-c772-4572-89e0-fff927ed7b53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": ["board_type", "climb_uuid", "link"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": ["board_type", "climb_uuid", "hold_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": ["board_type", "climb_uuid", "angle"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": ["board_type", "difficulty"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": ["board_type", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": ["board_type", "user_id", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inferred_sessions": {
+      "name": "inferred_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_tick_at": {
+          "name": "first_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sends": {
+          "name": "total_sends",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_flashes": {
+          "name": "total_flashes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tick_count": {
+          "name": "tick_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inferred_sessions_user_idx": {
+          "name": "inferred_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_user_last_tick_idx": {
+          "name": "inferred_sessions_user_last_tick_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_last_tick_idx": {
+          "name": "inferred_sessions_last_tick_idx",
+          "columns": [
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inferred_sessions_user_id_users_id_fk": {
+          "name": "inferred_sessions_user_id_users_id_fk",
+          "tableFrom": "inferred_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_member_overrides": {
+      "name": "session_member_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_member_overrides_session_idx": {
+          "name": "session_member_overrides_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_member_overrides_user_idx": {
+          "name": "session_member_overrides_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_member_overrides_session_id_inferred_sessions_id_fk": {
+          "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_user_id_users_id_fk": {
+          "name": "session_member_overrides_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_added_by_user_id_users_id_fk": {
+          "name": "session_member_overrides_added_by_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": ["added_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_member_overrides_session_user_unique": {
+          "name": "session_member_overrides_session_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_session_id": {
+          "name": "inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_inferred_session_id": {
+          "name": "previous_inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_inferred_session_idx": {
+          "name": "boardsesh_ticks_inferred_session_idx",
+          "columns": [
+            {
+              "expression": "inferred_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["inferred_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["previous_inferred_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "role", "board_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": ["entity_type", "entity_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": ["ascents", "bids"]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": ["flash", "send", "attempt"]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": ["admin", "community_leader"]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": ["open", "approved", "rejected", "superseded"]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": ["grade", "classic", "benchmark"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1776124800000,
       "tag": "0079_backfill_tick_quality_scale",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1776987173785,
+      "tag": "0080_concerned_prism",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/feedback.ts
+++ b/packages/db/src/schema/app/feedback.ts
@@ -1,0 +1,23 @@
+import { pgTable, text, integer, timestamp, bigserial, index } from 'drizzle-orm/pg-core';
+import { users } from '../auth/users';
+
+export const appFeedback = pgTable(
+  'app_feedback',
+  {
+    id: bigserial({ mode: 'bigint' }).primaryKey().notNull(),
+    userId: text('user_id').references(() => users.id, { onDelete: 'set null' }),
+    rating: integer('rating').notNull(),
+    comment: text('comment'),
+    platform: text('platform').notNull(),
+    appVersion: text('app_version'),
+    source: text('source').notNull(),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => ({
+    createdAtIdx: index('app_feedback_created_at_idx').on(table.createdAt),
+    userIdx: index('app_feedback_user_idx').on(table.userId),
+  }),
+);
+
+export type AppFeedback = typeof appFeedback.$inferSelect;
+export type NewAppFeedback = typeof appFeedback.$inferInsert;

--- a/packages/db/src/schema/app/index.ts
+++ b/packages/db/src/schema/app/index.ts
@@ -16,3 +16,4 @@ export * from './proposals';
 export * from './new-climb-subscriptions';
 export * from './vote-counts';
 export * from './session-participants';
+export * from './feedback';

--- a/packages/shared-schema/src/schema/feedback.ts
+++ b/packages/shared-schema/src/schema/feedback.ts
@@ -1,0 +1,31 @@
+export const feedbackTypeDefs = /* GraphQL */ `
+  """
+  Input for submitAppFeedback mutation.
+  """
+  input SubmitAppFeedbackInput {
+    """
+    1–5 star rating.
+    """
+    rating: Int!
+
+    """
+    Optional free-text comment. Typically present when rating is below 3.
+    """
+    comment: String
+
+    """
+    'ios' | 'android' | 'web'.
+    """
+    platform: String!
+
+    """
+    App build version (native) or deployed web version. Optional.
+    """
+    appVersion: String
+
+    """
+    Where the feedback originated: 'prompt' | 'drawer-rate' | 'drawer-feedback'.
+    """
+    source: String!
+  }
+`;

--- a/packages/shared-schema/src/schema/feedback.ts
+++ b/packages/shared-schema/src/schema/feedback.ts
@@ -24,7 +24,7 @@ export const feedbackTypeDefs = /* GraphQL */ `
     appVersion: String
 
     """
-    Where the feedback originated: 'prompt' | 'drawer-rate' | 'drawer-feedback'.
+    Where the feedback originated: 'prompt' | 'drawer-feedback'.
     """
     source: String!
   }

--- a/packages/shared-schema/src/schema/index.ts
+++ b/packages/shared-schema/src/schema/index.ts
@@ -20,6 +20,7 @@ import { mutationsTypeDefs } from './mutations';
 import { subscriptionsTypeDefs } from './subscriptions';
 import { eventsTypeDefs } from './events';
 import { controllerTypeDefs } from './controller';
+import { feedbackTypeDefs } from './feedback';
 
 export const typeDefs = [
   scalarTypeDefs,
@@ -44,4 +45,5 @@ export const typeDefs = [
   subscriptionsTypeDefs,
   eventsTypeDefs,
   controllerTypeDefs,
+  feedbackTypeDefs,
 ];

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -463,5 +463,16 @@ export const mutationsTypeDefs = /* GraphQL */ `
     authorizeControllerForSession(controllerId: ID!, sessionId: ID!): Boolean!
     # Send device logs to backend for forwarding to Axiom (requires controller auth)
     sendDeviceLogs(input: SendDeviceLogsInput!): SendDeviceLogsResponse!
+
+    # ============================================
+    # App Feedback Mutations (public)
+    # ============================================
+
+    """
+    Submit in-app rating + optional comment. Public — unauthenticated testers
+    can still rate. If the request has a valid auth token, the feedback row is
+    associated with the user.
+    """
+    submitAppFeedback(input: SubmitAppFeedbackInput!): Boolean!
   }
 `;

--- a/packages/shared-schema/src/types/feedback.ts
+++ b/packages/shared-schema/src/types/feedback.ts
@@ -1,5 +1,5 @@
 export type AppFeedbackPlatform = 'ios' | 'android' | 'web';
-export type AppFeedbackSource = 'prompt' | 'drawer-rate' | 'drawer-feedback';
+export type AppFeedbackSource = 'prompt' | 'drawer-feedback';
 
 export interface SubmitAppFeedbackInput {
   rating: number;

--- a/packages/shared-schema/src/types/feedback.ts
+++ b/packages/shared-schema/src/types/feedback.ts
@@ -1,0 +1,10 @@
+export type AppFeedbackPlatform = 'ios' | 'android' | 'web';
+export type AppFeedbackSource = 'prompt' | 'drawer-rate' | 'drawer-feedback';
+
+export interface SubmitAppFeedbackInput {
+  rating: number;
+  comment?: string | null;
+  platform: AppFeedbackPlatform;
+  appVersion?: string | null;
+  source: AppFeedbackSource;
+}

--- a/packages/shared-schema/src/types/index.ts
+++ b/packages/shared-schema/src/types/index.ts
@@ -19,3 +19,4 @@ export * from './events';
 export * from './new-climb-feed';
 export * from './controller';
 export * from './device-logging';
+export * from './feedback';

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -11,6 +11,7 @@ import type { HoldRenderData } from '../board-renderer/types';
 import { useWakeLock } from './use-wake-lock';
 import type { BluetoothAdapter } from '@/app/lib/ble/types';
 import { createBluetoothAdapter } from '@/app/lib/ble/adapter-factory';
+import { incrementBluetoothSends, maybeFireFeedbackPromptEvent } from '@/app/lib/feedback-prompt-db';
 
 // Module-level cache for Aurora LED placements loader to avoid repeated dynamic import overhead
 type GetLedPlacementsFn = (boardName: string, layoutId: number, sizeId: number) => Record<number, number>;
@@ -75,6 +76,7 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
         if (boardDetails.board_name === 'moonboard') {
           const bluetoothPacket = getMoonboardBluetoothPacket(frames);
           await adapterRef.current.write(bluetoothPacket, signal);
+          void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           return true;
         }
 
@@ -132,6 +134,7 @@ export function useBoardBluetooth({ boardDetails, onConnectionChange }: UseBoard
         }
 
         await adapterRef.current.write(bluetoothPacket, signal);
+        void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
         return true;
       } catch (error) {
         // Abort errors are expected during rapid swiping — don't log or show them

--- a/packages/web/app/components/feedback/__tests__/feedback-form.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/feedback-form.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { FeedbackForm } from '../feedback-form';
+
+function pickStars(n: number) {
+  fireEvent.click(screen.getByRole('option', { name: `${n} star${n > 1 ? 's' : ''}` }));
+}
+
+function getSaveButton(name: RegExp): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement;
+}
+
+describe('FeedbackForm — prompt mode', () => {
+  it('disables Save until a star is picked', () => {
+    const onSubmit = vi.fn();
+    render(<FeedbackForm mode="prompt" title="Enjoying Boardsesh?" onSubmit={onSubmit} />);
+    expect(getSaveButton(/save/i).disabled).toBe(true);
+    pickStars(5);
+    expect(getSaveButton(/save/i).disabled).toBe(false);
+  });
+
+  it('submits immediately when rating is 3 or higher', async () => {
+    const onSubmit = vi.fn();
+    render(<FeedbackForm mode="prompt" title="Enjoying Boardsesh?" onSubmit={onSubmit} />);
+    pickStars(4);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ rating: 4, comment: null });
+  });
+
+  it('transitions to the comment view when rating is below 3', async () => {
+    const onSubmit = vi.fn();
+    render(<FeedbackForm mode="prompt" title="Enjoying Boardsesh?" onSubmit={onSubmit} />);
+    pickStars(2);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/what's missing/i)).toBeTruthy();
+    expect(screen.getByPlaceholderText(/tell us what would help/i)).toBeTruthy();
+  });
+
+  it('Skip on the low-rating view still submits the rating (no comment)', async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(<FeedbackForm mode="prompt" title="Enjoying Boardsesh?" onSubmit={onSubmit} onCancel={onCancel} />);
+    pickStars(1);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ rating: 1, comment: null });
+    // Skip short-circuits to submit — onCancel is NOT called on the low-rating path.
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('submits rating + trimmed comment from the low-rating view', async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(<FeedbackForm mode="prompt" title="Enjoying Boardsesh?" onSubmit={onSubmit} onCancel={onCancel} />);
+    pickStars(2);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    });
+    fireEvent.change(screen.getByPlaceholderText(/tell us what would help/i), {
+      target: { value: '  crashes on login  ' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ rating: 2, comment: 'crashes on login' });
+  });
+});
+
+describe('FeedbackForm — drawer-feedback mode', () => {
+  it('disables Send until a rating is picked, even with a comment', () => {
+    const onSubmit = vi.fn();
+    render(<FeedbackForm mode="drawer-feedback" title="Send feedback" submitLabel="Send" onSubmit={onSubmit} />);
+    const send = getSaveButton(/^send$/i);
+    expect(send.disabled).toBe(true);
+    fireEvent.change(screen.getByPlaceholderText(/what's on your mind/i), {
+      target: { value: 'hi' },
+    });
+    // Still disabled — backend requires a rating.
+    expect(send.disabled).toBe(true);
+    pickStars(3);
+    expect(send.disabled).toBe(false);
+  });
+
+  it('submits rating and optional comment', async () => {
+    const onSubmit = vi.fn();
+    render(<FeedbackForm mode="drawer-feedback" title="Send feedback" submitLabel="Send" onSubmit={onSubmit} />);
+    pickStars(5);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ rating: 5, comment: null });
+  });
+});

--- a/packages/web/app/components/feedback/feedback-dialog.module.css
+++ b/packages/web/app/components/feedback/feedback-dialog.module.css
@@ -1,0 +1,6 @@
+.closeButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+}

--- a/packages/web/app/components/feedback/feedback-dialog.module.css
+++ b/packages/web/app/components/feedback/feedback-dialog.module.css
@@ -1,6 +1,6 @@
 .closeButton {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: var(--spacing-2);
+  right: var(--spacing-2);
   z-index: 1;
 }

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import { FeedbackForm } from './feedback-form';
+import { useSubmitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
+import type { AppFeedbackSource } from '@boardsesh/shared-schema';
+import styles from './feedback-dialog.module.css';
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onClose: () => void;
+  source: AppFeedbackSource;
+  title?: string;
+}
+
+const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
+  onClose,
+  source,
+  title = 'Send feedback',
+}) => {
+  const { mutate } = useSubmitAppFeedback();
+  const { showMessage } = useSnackbar();
+
+  const handleSubmit = (values: { rating: number | null; comment: string | null }) => {
+    if (values.rating === null && !values.comment) {
+      onClose();
+      return;
+    }
+    // Suppress the automatic banner for users who manually engaged.
+    void setFeedbackStatus('submitted');
+    mutate(
+      {
+        rating: values.rating ?? 0,
+        comment: values.comment,
+        source,
+      },
+      {
+        onSuccess: () => showMessage('Thanks — logged.', 'success'),
+        onError: () => showMessage("Couldn't send — we'll keep your feedback.", 'warning'),
+      },
+    );
+    onClose();
+  };
+
+  return (
+    <>
+      <IconButton aria-label="Close" onClick={onClose} className={styles.closeButton} size="small">
+        <CloseOutlined fontSize="small" />
+      </IconButton>
+      <DialogContent>
+        <FeedbackForm
+          mode="drawer-feedback"
+          title={title}
+          submitLabel="Send"
+          onSubmit={handleSubmit}
+          onCancel={onClose}
+        />
+      </DialogContent>
+    </>
+  );
+};
+
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, source, title }) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      {open && <FeedbackDialogBody onClose={onClose} source={source} title={title} />}
+    </Dialog>
+  );
+};

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -28,7 +28,10 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
   const { showMessage } = useSnackbar();
 
   const handleSubmit = (values: { rating: number | null; comment: string | null }) => {
-    if (values.rating === null && !values.comment) {
+    // FeedbackForm in drawer-feedback mode disables Send until a rating is
+    // picked, so rating is guaranteed non-null here. Guard anyway — the
+    // backend rejects rating < 1.
+    if (values.rating === null) {
       onClose();
       return;
     }
@@ -36,7 +39,7 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
     void setFeedbackStatus('submitted');
     mutate(
       {
-        rating: values.rating ?? 0,
+        rating: values.rating,
         comment: values.comment,
         source,
       },

--- a/packages/web/app/components/feedback/feedback-form.module.css
+++ b/packages/web/app/components/feedback/feedback-form.module.css
@@ -1,13 +1,17 @@
+/* ------------------------------------------------------------------ */
+/*  Drawer-feedback mode — spacious vertical layout inside a Dialog.  */
+/* ------------------------------------------------------------------ */
+
 .form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 4px 0;
+  gap: var(--spacing-3);
+  padding: var(--spacing-1) 0;
 }
 
 .title {
   line-height: 1.3;
-  padding-right: 32px;
+  padding-right: var(--spacing-8);
 }
 
 .rating {
@@ -16,12 +20,51 @@
 }
 
 .comment {
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
 }
 
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-1);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Prompt mode — compact banner: tiny heading + single inline row.   */
+/* ------------------------------------------------------------------ */
+
+.compactForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.compactTitle {
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--neutral-700);
+  line-height: 1.3;
+}
+
+.compactRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.compactComment {
+  margin-top: var(--spacing-1);
+}
+
+.compactActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-1);
+}
+
+.saveIconButton {
+  flex-shrink: 0;
 }

--- a/packages/web/app/components/feedback/feedback-form.module.css
+++ b/packages/web/app/components/feedback/feedback-form.module.css
@@ -1,0 +1,27 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.title {
+  line-height: 1.3;
+  padding-right: 32px;
+}
+
+.rating {
+  display: flex;
+  justify-content: center;
+}
+
+.comment {
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}

--- a/packages/web/app/components/feedback/feedback-form.tsx
+++ b/packages/web/app/components/feedback/feedback-form.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React, { useId, useState } from 'react';
+import MuiButton from '@mui/material/Button';
+import MuiTypography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import { InlineStarPicker } from '@/app/components/logbook/tick-controls';
+import styles from './feedback-form.module.css';
+
+type View = 'rating' | 'comment';
+
+interface FeedbackFormProps {
+  /**
+   * 'prompt' — automatic nudge; requires a star rating; low ratings ask for a comment.
+   * 'drawer-feedback' — manual from user drawer; rating optional, comment is the focus.
+   */
+  mode: 'prompt' | 'drawer-feedback';
+  /**
+   * Called with the captured rating and optional comment. Return false or throw
+   * to stay open; resolve (void/true) to indicate the caller has closed the form.
+   */
+  onSubmit: (values: { rating: number | null; comment: string | null }) => void | Promise<void>;
+  onCancel?: () => void;
+  title: string;
+  submitLabel?: string;
+  /** If provided, used as the id on the heading so the wrapper can aria-labelledby it. */
+  titleId?: string;
+}
+
+export const FeedbackForm: React.FC<FeedbackFormProps> = ({
+  mode,
+  onSubmit,
+  onCancel,
+  title,
+  submitLabel = 'Save',
+  titleId,
+}) => {
+  const generatedId = useId();
+  const resolvedTitleId = titleId ?? generatedId;
+  const [rating, setRating] = useState<number | null>(null);
+  const [view, setView] = useState<View>(mode === 'drawer-feedback' ? 'comment' : 'rating');
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handlePrimary = async () => {
+    if (mode === 'prompt' && view === 'rating') {
+      if (rating === null) return;
+      if (rating < 3) {
+        setView('comment');
+        return;
+      }
+    }
+    setSubmitting(true);
+    try {
+      await onSubmit({ rating, comment: comment.trim() || null });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // In prompt mode, "Skip" on the low-rating comment view still submits the
+  // rating (without a comment) so we never silently drop a star. In all other
+  // cases secondary is a plain cancel.
+  const handleSecondary = async () => {
+    if (mode === 'prompt' && view === 'comment' && rating !== null) {
+      setSubmitting(true);
+      try {
+        await onSubmit({ rating, comment: null });
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+    onCancel?.();
+  };
+
+  const canSubmit = (() => {
+    if (submitting) return false;
+    if (mode === 'prompt' && view === 'rating') return rating !== null;
+    if (mode === 'drawer-feedback') return rating !== null || comment.trim().length > 0;
+    return true;
+  })();
+
+  const showRating = view === 'rating' || mode === 'drawer-feedback';
+  const showComment = view === 'comment' || mode === 'drawer-feedback';
+
+  const heading = view === 'comment' && mode === 'prompt' ? "Sorry — what's missing?" : title;
+
+  return (
+    <div className={styles.form}>
+      <MuiTypography variant="subtitle1" component="h2" fontWeight={600} className={styles.title} id={resolvedTitleId}>
+        {heading}
+      </MuiTypography>
+
+      {showRating && (
+        <div className={styles.rating}>
+          <InlineStarPicker quality={rating} onSelect={setRating} />
+        </div>
+      )}
+
+      {showComment && (
+        <TextField
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          placeholder={mode === 'prompt' ? 'Tell us what would help' : "What's on your mind?"}
+          multiline
+          minRows={3}
+          maxRows={6}
+          fullWidth
+          size="small"
+          slotProps={{ htmlInput: { maxLength: 2000 } }}
+          className={styles.comment}
+        />
+      )}
+
+      <div className={styles.actions}>
+        {onCancel && (
+          <MuiButton onClick={handleSecondary} disabled={submitting} size="small">
+            {view === 'comment' && mode === 'prompt' ? 'Skip' : 'Cancel'}
+          </MuiButton>
+        )}
+        <MuiButton variant="contained" onClick={handlePrimary} disabled={!canSubmit} size="small">
+          {view === 'rating' && mode === 'prompt' && rating !== null && rating < 3 ? 'Next' : submitLabel}
+        </MuiButton>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/app/components/feedback/feedback-form.tsx
+++ b/packages/web/app/components/feedback/feedback-form.tsx
@@ -3,7 +3,10 @@
 import React, { useId, useState } from 'react';
 import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
+import SaveOutlined from '@mui/icons-material/SaveOutlined';
+import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined';
 import { InlineStarPicker } from '@/app/components/logbook/tick-controls';
 import styles from './feedback-form.module.css';
 
@@ -11,19 +14,14 @@ type View = 'rating' | 'comment';
 
 interface FeedbackFormProps {
   /**
-   * 'prompt' — automatic nudge; requires a star rating; low ratings ask for a comment.
+   * 'prompt' — compact, inline rating + save icon; low ratings reveal a comment.
    * 'drawer-feedback' — manual from user drawer; rating optional, comment is the focus.
    */
   mode: 'prompt' | 'drawer-feedback';
-  /**
-   * Called with the captured rating and optional comment. Return false or throw
-   * to stay open; resolve (void/true) to indicate the caller has closed the form.
-   */
   onSubmit: (values: { rating: number | null; comment: string | null }) => void | Promise<void>;
   onCancel?: () => void;
   title: string;
   submitLabel?: string;
-  /** If provided, used as the id on the heading so the wrapper can aria-labelledby it. */
   titleId?: string;
 }
 
@@ -42,8 +40,11 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
   const [comment, setComment] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  const isPromptRating = mode === 'prompt' && view === 'rating';
+  const isPromptComment = mode === 'prompt' && view === 'comment';
+
   const handlePrimary = async () => {
-    if (mode === 'prompt' && view === 'rating') {
+    if (isPromptRating) {
       if (rating === null) return;
       if (rating < 3) {
         setView('comment');
@@ -58,11 +59,10 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
     }
   };
 
-  // In prompt mode, "Skip" on the low-rating comment view still submits the
-  // rating (without a comment) so we never silently drop a star. In all other
-  // cases secondary is a plain cancel.
+  // Skip on low-rating comment view still submits the rating so we never
+  // silently drop a star.
   const handleSecondary = async () => {
-    if (mode === 'prompt' && view === 'comment' && rating !== null) {
+    if (isPromptComment && rating !== null) {
       setSubmitting(true);
       try {
         await onSubmit({ rating, comment: null });
@@ -76,15 +76,74 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
 
   const canSubmit = (() => {
     if (submitting) return false;
-    if (mode === 'prompt' && view === 'rating') return rating !== null;
-    if (mode === 'drawer-feedback') return rating !== null || comment.trim().length > 0;
+    if (isPromptRating) return rating !== null;
+    // Drawer Send-feedback always requires a rating. Backend schema enforces
+    // min=1, so sending rating=null or 0 would hard-fail.
+    if (mode === 'drawer-feedback') return rating !== null;
     return true;
   })();
 
-  const showRating = view === 'rating' || mode === 'drawer-feedback';
-  const showComment = view === 'comment' || mode === 'drawer-feedback';
+  const heading = isPromptComment ? "What's missing?" : title;
 
-  const heading = view === 'comment' && mode === 'prompt' ? "Sorry — what's missing?" : title;
+  if (mode === 'prompt') {
+    return (
+      <div className={styles.compactForm}>
+        <MuiTypography component="h2" className={styles.compactTitle} id={resolvedTitleId}>
+          {heading}
+        </MuiTypography>
+
+        {view === 'rating' && (
+          <div className={styles.compactRow}>
+            <InlineStarPicker quality={rating} onSelect={setRating} />
+            <IconButton
+              aria-label={rating !== null && rating < 3 ? 'Next' : submitLabel}
+              onClick={handlePrimary}
+              disabled={!canSubmit}
+              size="small"
+              className={styles.saveIconButton}
+            >
+              {rating !== null && rating < 3 ? (
+                <ArrowForwardOutlined fontSize="small" />
+              ) : (
+                <SaveOutlined fontSize="small" />
+              )}
+            </IconButton>
+          </div>
+        )}
+
+        {view === 'comment' && (
+          <>
+            <TextField
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              placeholder="Tell us what would help"
+              multiline
+              minRows={2}
+              maxRows={4}
+              fullWidth
+              size="small"
+              slotProps={{ htmlInput: { maxLength: 2000 } }}
+              className={styles.compactComment}
+            />
+            <div className={styles.compactActions}>
+              <MuiButton onClick={handleSecondary} disabled={submitting} size="small">
+                Skip
+              </MuiButton>
+              <IconButton
+                aria-label="Send"
+                onClick={handlePrimary}
+                disabled={!canSubmit}
+                size="small"
+                className={styles.saveIconButton}
+              >
+                <SaveOutlined fontSize="small" />
+              </IconButton>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className={styles.form}>
@@ -92,35 +151,31 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
         {heading}
       </MuiTypography>
 
-      {showRating && (
-        <div className={styles.rating}>
-          <InlineStarPicker quality={rating} onSelect={setRating} />
-        </div>
-      )}
+      <div className={styles.rating}>
+        <InlineStarPicker quality={rating} onSelect={setRating} />
+      </div>
 
-      {showComment && (
-        <TextField
-          value={comment}
-          onChange={(event) => setComment(event.target.value)}
-          placeholder={mode === 'prompt' ? 'Tell us what would help' : "What's on your mind?"}
-          multiline
-          minRows={3}
-          maxRows={6}
-          fullWidth
-          size="small"
-          slotProps={{ htmlInput: { maxLength: 2000 } }}
-          className={styles.comment}
-        />
-      )}
+      <TextField
+        value={comment}
+        onChange={(event) => setComment(event.target.value)}
+        placeholder="What's on your mind?"
+        multiline
+        minRows={3}
+        maxRows={6}
+        fullWidth
+        size="small"
+        slotProps={{ htmlInput: { maxLength: 2000 } }}
+        className={styles.comment}
+      />
 
       <div className={styles.actions}>
         {onCancel && (
           <MuiButton onClick={handleSecondary} disabled={submitting} size="small">
-            {view === 'comment' && mode === 'prompt' ? 'Skip' : 'Cancel'}
+            Cancel
           </MuiButton>
         )}
         <MuiButton variant="contained" onClick={handlePrimary} disabled={!canSubmit} size="small">
-          {view === 'rating' && mode === 'prompt' && rating !== null && rating < 3 ? 'Next' : submitLabel}
+          {submitLabel}
         </MuiButton>
       </div>
     </div>

--- a/packages/web/app/components/feedback/feedback-prompt-banner.module.css
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.module.css
@@ -1,0 +1,23 @@
+.banner {
+  position: relative;
+  margin: 0 var(--spacing-3, 12px) var(--spacing-2, 8px);
+  padding: 16px 16px 12px;
+  border-radius: 12px;
+  background-color: var(--semantic-surface);
+  border: 1px solid var(--neutral-200);
+  max-width: 480px;
+  width: auto;
+}
+
+@media (min-width: 768px) {
+  .banner {
+    margin: 0 auto var(--spacing-2, 8px);
+  }
+}
+
+.closeButton {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 1;
+}

--- a/packages/web/app/components/feedback/feedback-prompt-banner.module.css
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.module.css
@@ -1,23 +1,33 @@
 .banner {
   position: relative;
-  margin: 0 var(--spacing-3, 12px) var(--spacing-2, 8px);
-  padding: 16px 16px 12px;
-  border-radius: 12px;
+  width: auto;
+  /* Match the queue-control-bar card's side margins on mobile so the banner
+     is visually the same width. */
+  margin: 0 var(--spacing-3) var(--spacing-2);
+  /* Extra top padding reserves room for the absolute-positioned close button
+     in the top-right corner so the heading never sits under it. */
+  padding: var(--spacing-4) var(--spacing-3) var(--spacing-2);
+  border-radius: var(--border-radius-md);
   background-color: var(--semantic-surface);
   border: 1px solid var(--neutral-200);
-  max-width: 480px;
-  width: auto;
 }
 
+/* Match the queue-control-bar card's desktop max-width so the two
+   stacked pieces line up edge-to-edge. */
 @media (min-width: 768px) {
   .banner {
-    margin: 0 auto var(--spacing-2, 8px);
+    max-width: 480px;
+    margin: 0 auto var(--spacing-2);
   }
 }
 
-.closeButton {
+/* The close IconButton ignores our module padding because MUI's
+   MuiIconButton-sizeSmall rule has equal specificity but loads later.
+   Match the specificity with the parent selector so our override wins. */
+.banner .closeButton {
   position: absolute;
-  top: 6px;
-  right: 6px;
+  top: 0;
+  right: 0;
   z-index: 1;
+  padding: 4px;
 }

--- a/packages/web/app/components/feedback/feedback-prompt-banner.tsx
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.tsx
@@ -43,7 +43,7 @@ const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubm
   };
 
   return (
-    <Paper elevation={4} className={styles.banner} role="region" aria-labelledby={titleId}>
+    <Paper elevation={1} className={styles.banner} role="region" aria-labelledby={titleId}>
       <IconButton aria-label="Dismiss" onClick={onDismiss} className={styles.closeButton} size="small">
         <CloseOutlined fontSize="small" />
       </IconButton>

--- a/packages/web/app/components/feedback/feedback-prompt-banner.tsx
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useCallback, useEffect, useId, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import Fade from '@mui/material/Fade';
+import IconButton from '@mui/material/IconButton';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import { FeedbackForm } from './feedback-form';
+import { useSubmitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { requestInAppReview } from '@/app/lib/in-app-review';
+import { FEEDBACK_PROMPT_EVENT, setFeedbackStatus, shouldShowPrompt } from '@/app/lib/feedback-prompt-db';
+import styles from './feedback-prompt-banner.module.css';
+
+interface BannerBodyProps {
+  onDismiss: () => void;
+  onSubmitted: () => void;
+  titleId: string;
+}
+
+const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubmitted, titleId }) => {
+  const { mutate } = useSubmitAppFeedback();
+  const { showMessage } = useSnackbar();
+
+  const handleSubmit = (values: { rating: number | null; comment: string | null }) => {
+    if (values.rating === null) return;
+    onSubmitted();
+    if (values.rating >= 3 && isNativeApp()) {
+      void requestInAppReview();
+    }
+    mutate(
+      {
+        rating: values.rating,
+        comment: values.comment,
+        source: 'prompt',
+      },
+      {
+        onSuccess: () => showMessage('Thanks — logged.', 'success'),
+        onError: () => showMessage("Couldn't send — we'll keep your rating.", 'warning'),
+      },
+    );
+  };
+
+  return (
+    <Paper elevation={4} className={styles.banner} role="region" aria-labelledby={titleId}>
+      <IconButton aria-label="Dismiss" onClick={onDismiss} className={styles.closeButton} size="small">
+        <CloseOutlined fontSize="small" />
+      </IconButton>
+      <FeedbackForm
+        mode="prompt"
+        title="Enjoying Boardsesh?"
+        submitLabel="Save"
+        onSubmit={handleSubmit}
+        titleId={titleId}
+      />
+    </Paper>
+  );
+};
+
+export const FeedbackPromptBanner: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    void shouldShowPrompt().then((should) => {
+      if (!cancelled && should) setOpen(true);
+    });
+    const listener = () => setOpen(true);
+    window.addEventListener(FEEDBACK_PROMPT_EVENT, listener);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(FEEDBACK_PROMPT_EVENT, listener);
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    void setFeedbackStatus('dismissed');
+  }, []);
+
+  const submitted = useCallback(() => {
+    setOpen(false);
+    void setFeedbackStatus('submitted');
+  }, []);
+
+  // mountOnEnter defers the body (and its hooks) until the banner first
+  // becomes visible — important because this banner is rendered at the app
+  // root, and the body's hooks require QueryClient/Session providers that
+  // may not exist in all test harnesses.
+  return (
+    <Fade in={open} mountOnEnter unmountOnExit>
+      <div>
+        <FeedbackPromptBannerBody onDismiss={dismiss} onSubmitted={submitted} titleId={titleId} />
+      </div>
+    </Fade>
+  );
+};

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -71,6 +71,13 @@
   --spacing-12: 48px;
   --spacing-16: 64px;
 
+  /* Border radius scale (matches themeTokens.borderRadius in theme-config.ts) */
+  --border-radius-sm: 4px;
+  --border-radius-md: 8px;
+  --border-radius-lg: 12px;
+  --border-radius-xl: 16px;
+  --border-radius-full: 9999px;
+
   /* Input field backgrounds */
   --input-bg: #f9fafb;
   --input-bg-hover: #f3f4f6;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -33,6 +33,7 @@ const SeshSettingsDrawer = dynamic(() => import('../sesh-settings/sesh-settings-
   ssr: false,
 });
 import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
+import { FeedbackPromptBanner } from '../feedback/feedback-prompt-banner';
 
 interface PersistentSessionWrapperProps {
   children: React.ReactNode;
@@ -137,6 +138,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
       className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
       data-testid="bottom-bar-wrapper"
     >
+      <FeedbackPromptBanner />
       {hasActiveQueue && boardDetails && (
         <ErrorBoundary>
           <BoardProvider boardName={boardDetails.board_name}>

--- a/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
+++ b/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
@@ -5,6 +5,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { track } from '@vercel/analytics';
 import { useQueueActions, useSearchData } from '../graphql-queue';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import { incrementSearches, maybeFireFeedbackPromptEvent } from '@/app/lib/feedback-prompt-db';
 
 interface UISearchParamsContextType {
   uiSearchParams: SearchRequestPagination;
@@ -47,6 +48,7 @@ export const UISearchParamsProvider: React.FC<{ children: React.ReactNode }> = (
     if (uiSearchParams.projectsOnly) activeFilters.push('projectsOnly');
 
     if (activeFilters.length > 0) {
+      void incrementSearches().then(maybeFireFeedbackPromptEvent);
       track('Climb Search Performed', {
         searchType: 'filters',
         activeFiltersCount: activeFilters.length,

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -11,6 +11,8 @@ import LogoutOutlined from '@mui/icons-material/LogoutOutlined';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import HelpOutlineOutlined from '@mui/icons-material/HelpOutlineOutlined';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
+import StarBorderOutlined from '@mui/icons-material/StarBorderOutlined';
+import FeedbackOutlined from '@mui/icons-material/FeedbackOutlined';
 import GpsFixedOutlined from '@mui/icons-material/GpsFixedOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import SwapHorizOutlined from '@mui/icons-material/SwapHorizOutlined';
@@ -38,6 +40,10 @@ import DevUrlDialog from '../dev-url-dialog/dev-url-dialog';
 import { useDevUrl } from '@/app/lib/dev-url';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { HoldClassificationWizard } from '../hold-classification';
+import { FeedbackDialog } from '../feedback/feedback-dialog';
+import { requestInAppReview } from '@/app/lib/in-app-review';
+import { submitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
+import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
@@ -82,6 +88,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
   const [showDevUrl, setShowDevUrl] = useState(false);
   const { isAvailable: devUrlAvailable } = useDevUrl();
+  const [showFeedback, setShowFeedback] = useState(false);
 
   const { mode, toggleMode } = useColorMode();
   const isMoonboard = boardDetails?.board_name === 'moonboard';
@@ -404,6 +411,41 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemLabel}>About</span>
             </Link>
 
+            <button
+              type="button"
+              className={styles.menuItem}
+              onClick={() => {
+                handleClose();
+                void requestInAppReview();
+                void setFeedbackStatus('submitted');
+                // Record the intent in our DB too, so we can distinguish a
+                // user-initiated rate ("drawer-rate") from the automatic prompt
+                // ("prompt") and from a free-text "drawer-feedback" submission.
+                void submitAppFeedback({ rating: 5, comment: null, source: 'drawer-rate' }).catch(() => {
+                  // Best-effort: the native review sheet has already fired.
+                });
+              }}
+            >
+              <span className={styles.menuItemIcon}>
+                <StarBorderOutlined />
+              </span>
+              <span className={styles.menuItemLabel}>Rate Boardsesh</span>
+            </button>
+
+            <button
+              type="button"
+              className={styles.menuItem}
+              onClick={() => {
+                handleClose();
+                setShowFeedback(true);
+              }}
+            >
+              <span className={styles.menuItemIcon}>
+                <FeedbackOutlined />
+              </span>
+              <span className={styles.menuItemLabel}>Send feedback</span>
+            </button>
+
             {/* Logout */}
             {session?.user && (
               <>
@@ -500,6 +542,8 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
       )}
 
       {devUrlAvailable && <DevUrlDialog open={showDevUrl} onClose={() => setShowDevUrl(false)} />}
+
+      <FeedbackDialog open={showFeedback} onClose={() => setShowFeedback(false)} source="drawer-feedback" />
     </>
   );
 }

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -42,7 +42,6 @@ import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { HoldClassificationWizard } from '../hold-classification';
 import { FeedbackDialog } from '../feedback/feedback-dialog';
 import { requestInAppReview } from '@/app/lib/in-app-review';
-import { submitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
 import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
@@ -416,14 +415,14 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               className={styles.menuItem}
               onClick={() => {
                 handleClose();
+                // Trigger the native review sheet (native) or open the store
+                // URL (web). We don't write an app_feedback row here: the OS
+                // review sheet is quota-limited and doesn't report whether the
+                // user actually rated, so recording anything would be guessing.
+                // Still mark the local prompt as submitted so the automatic
+                // banner doesn't re-surface for someone who proactively rated.
                 void requestInAppReview();
                 void setFeedbackStatus('submitted');
-                // Record the intent in our DB too, so we can distinguish a
-                // user-initiated rate ("drawer-rate") from the automatic prompt
-                // ("prompt") and from a free-text "drawer-feedback" submission.
-                void submitAppFeedback({ rating: 5, comment: null, source: 'drawer-rate' }).catch(() => {
-                  // Best-effort: the native review sheet has already fired.
-                });
               }}
             >
               <span className={styles.menuItemIcon}>

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -18,6 +18,7 @@ import AndroidOutlined from '@mui/icons-material/AndroidOutlined';
 import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
 import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
+import { IOS_APP_STORE_URL, ANDROID_PLAY_STORE_URL, ANDROID_SIDELOAD_URL } from '@/app/lib/store-urls';
 import { useCountdown } from '@/app/lib/hooks/use-countdown';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
@@ -113,9 +114,6 @@ function OnboardingCard({ icon, title, description, onClick }: OnboardingCardPro
   );
 }
 
-const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
-const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
-const ANDROID_SIDELOAD_URL = 'https://github.com/boardsesh/boardsesh/releases/latest';
 const ANDROID_LAUNCH_DATE = new Date('2026-05-03T00:00:00Z');
 
 type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';

--- a/packages/web/app/hooks/use-submit-app-feedback.ts
+++ b/packages/web/app/hooks/use-submit-app-feedback.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  SUBMIT_APP_FEEDBACK,
+  type SubmitAppFeedbackMutationVariables,
+  type SubmitAppFeedbackMutationResponse,
+} from '@/app/lib/graphql/operations';
+import type { SubmitAppFeedbackInput } from '@boardsesh/shared-schema';
+import { getPlatform } from '@/app/lib/ble/capacitor-utils';
+import { getAppVersion } from '@/app/lib/app-info';
+import { useWsAuthToken } from './use-ws-auth-token';
+
+/** Fields callers provide; platform + appVersion are injected. */
+export type SubmitAppFeedbackPayload = Omit<SubmitAppFeedbackInput, 'platform' | 'appVersion'>;
+
+/**
+ * Stateless submit helper. Use this when you don't have access to a
+ * QueryClientProvider (e.g. a handler on a rarely-rendered button) and
+ * want to fire the mutation directly. Auth token is optional — when
+ * omitted, the submission is anonymous.
+ */
+export async function submitAppFeedback(payload: SubmitAppFeedbackPayload, token?: string | null): Promise<boolean> {
+  const platform = getPlatform();
+  const appVersion = await getAppVersion();
+  const client = createGraphQLHttpClient(token ?? null);
+  const variables: SubmitAppFeedbackMutationVariables = {
+    input: { ...payload, platform, appVersion },
+  };
+  const response = await client.request<SubmitAppFeedbackMutationResponse>(SUBMIT_APP_FEEDBACK, variables);
+  return response.submitAppFeedback;
+}
+
+/**
+ * Fire-and-report submission of app feedback. The mutation is public; the
+ * auth token is attached when available so the backend associates the
+ * feedback with the user. The UI should close optimistically before awaiting
+ * — an error surfaces a toast but does not reopen the prompt.
+ */
+export function useSubmitAppFeedback() {
+  const { token } = useWsAuthToken();
+
+  return useMutation({
+    mutationFn: (payload: SubmitAppFeedbackPayload): Promise<boolean> => submitAppFeedback(payload, token),
+  });
+}

--- a/packages/web/app/lib/__tests__/feedback-prompt-db.test.ts
+++ b/packages/web/app/lib/__tests__/feedback-prompt-db.test.ts
@@ -1,0 +1,98 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('../ble/capacitor-utils', () => ({
+  isNativeApp: () => true,
+}));
+
+import {
+  incrementBluetoothSends,
+  incrementSearches,
+  getFeedbackStatus,
+  setFeedbackStatus,
+  shouldShowPrompt,
+} from '../feedback-prompt-db';
+
+const DB_NAME = 'boardsesh-feedback-prompt';
+const STORE_NAME = 'feedback-prompt';
+
+beforeEach(async () => {
+  const db = await openDB(DB_NAME, 1, {
+    upgrade(upgradeDb) {
+      if (!upgradeDb.objectStoreNames.contains(STORE_NAME)) {
+        upgradeDb.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+  await db.clear(STORE_NAME);
+  db.close();
+});
+
+describe('feedback-prompt-db', () => {
+  it('starts with pending status and does not show prompt', async () => {
+    expect(await getFeedbackStatus()).toBe('pending');
+    expect(await shouldShowPrompt()).toBe(false);
+  });
+
+  it('shows prompt after 5 bluetooth sends', async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await incrementBluetoothSends();
+    }
+    expect(await shouldShowPrompt()).toBe(false);
+    await incrementBluetoothSends();
+    expect(await shouldShowPrompt()).toBe(true);
+  });
+
+  it('shows prompt after 5 searches', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await incrementSearches();
+    }
+    expect(await shouldShowPrompt()).toBe(true);
+  });
+
+  it('does not show prompt once dismissed, even after more actions', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await incrementSearches();
+    }
+    await setFeedbackStatus('dismissed');
+    expect(await shouldShowPrompt()).toBe(false);
+    for (let i = 0; i < 10; i += 1) {
+      await incrementBluetoothSends();
+    }
+    expect(await shouldShowPrompt()).toBe(false);
+  });
+
+  it('does not show prompt once submitted', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await incrementSearches();
+    }
+    await setFeedbackStatus('submitted');
+    expect(await shouldShowPrompt()).toBe(false);
+  });
+
+  it('triggers at 5 of either counter (bluetooth OR search)', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      await incrementSearches();
+    }
+    for (let i = 0; i < 4; i += 1) {
+      await incrementBluetoothSends();
+    }
+    expect(await shouldShowPrompt()).toBe(false);
+    await incrementBluetoothSends();
+    expect(await shouldShowPrompt()).toBe(true);
+  });
+});
+
+describe('shouldShowPrompt — web platform gate', () => {
+  it('never shows on web even when threshold is met', async () => {
+    vi.resetModules();
+    vi.doMock('../ble/capacitor-utils', () => ({ isNativeApp: () => false }));
+    const web = await import('../feedback-prompt-db');
+    for (let i = 0; i < 10; i += 1) {
+      await web.incrementSearches();
+    }
+    expect(await web.shouldShowPrompt()).toBe(false);
+    vi.doUnmock('../ble/capacitor-utils');
+  });
+});

--- a/packages/web/app/lib/app-info.ts
+++ b/packages/web/app/lib/app-info.ts
@@ -1,0 +1,27 @@
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+
+let cached: string | null | undefined;
+
+/**
+ * Returns a short version string for telemetry. On native this is
+ * `${version} (${build})` from `@capacitor/app` App.getInfo(). On web it
+ * returns `process.env.NEXT_PUBLIC_APP_VERSION` if present, otherwise null.
+ * Result is memoized for the life of the page.
+ */
+export async function getAppVersion(): Promise<string | null> {
+  if (cached !== undefined) return cached;
+  if (isNativeApp()) {
+    const plugin = window.Capacitor?.Plugins?.App;
+    if (plugin) {
+      try {
+        const info = await plugin.getInfo();
+        cached = `${info.version} (${info.build})`;
+        return cached;
+      } catch {
+        // Fall through
+      }
+    }
+  }
+  cached = process.env.NEXT_PUBLIC_APP_VERSION ?? null;
+  return cached;
+}

--- a/packages/web/app/lib/ble/capacitor-types.d.ts
+++ b/packages/web/app/lib/ble/capacitor-types.d.ts
@@ -32,6 +32,11 @@ interface CapacitorAppPlugin {
     eventName: 'appUrlOpen',
     listenerFunc: (event: { url: string }) => void,
   ): Promise<{ remove: () => Promise<void> }>;
+  getInfo(): Promise<{ name: string; id: string; build: string; version: string }>;
+}
+
+interface CapacitorInAppReviewPlugin {
+  requestReview(): Promise<void>;
 }
 
 interface CapacitorDevUrlPlugin {
@@ -50,6 +55,7 @@ interface CapacitorGlobal {
     Browser?: CapacitorBrowserPlugin;
     App?: CapacitorAppPlugin;
     DevUrl?: CapacitorDevUrlPlugin;
+    InAppReview?: CapacitorInAppReviewPlugin;
     LiveActivity?: {
       isAvailable(): Promise<{ available: boolean }>;
       startSession(options: Record<string, unknown>): Promise<void>;

--- a/packages/web/app/lib/feedback-prompt-db.ts
+++ b/packages/web/app/lib/feedback-prompt-db.ts
@@ -74,6 +74,9 @@ export async function setFeedbackStatus(status: FeedbackStatus): Promise<void> {
 // Auto-prompt only surfaces inside the native app, where a 5-star rating
 // actually translates to a store review. On web we rely on the manual
 // "Send feedback" entry in the user drawer.
+// Auto-prompt only surfaces inside the native app, where a 5-star rating
+// actually translates to a store review. On web we rely on the manual
+// "Send feedback" entry in the user drawer.
 export async function shouldShowPrompt(): Promise<boolean> {
   if (!isNativeApp()) return false;
   const status = await getFeedbackStatus();

--- a/packages/web/app/lib/feedback-prompt-db.ts
+++ b/packages/web/app/lib/feedback-prompt-db.ts
@@ -1,0 +1,92 @@
+import { createIndexedDBStore } from './idb-helper';
+import { isNativeApp } from './ble/capacitor-utils';
+
+export type FeedbackStatus = 'pending' | 'dismissed' | 'submitted';
+
+const STORE_NAME = 'feedback-prompt';
+const getDB = createIndexedDBStore('boardsesh-feedback-prompt', STORE_NAME);
+
+const KEY_BLUETOOTH_SENDS = 'bluetoothSends';
+const KEY_SEARCHES = 'searches';
+const KEY_STATUS = 'status';
+
+const TRIGGER_THRESHOLD = 5;
+
+async function getCount(key: string): Promise<number> {
+  try {
+    const db = await getDB();
+    if (!db) return 0;
+    const value = await db.get(STORE_NAME, key);
+    return typeof value === 'number' ? value : 0;
+  } catch (error) {
+    console.error(`Failed to read feedback counter "${key}":`, error);
+    return 0;
+  }
+}
+
+// Non-atomic get→put. Two near-simultaneous increments can collide and lose
+// one tick; at a 5-count threshold the worst case is one extra BLE send / search
+// before the prompt shows, which is not worth a transaction wrapper.
+async function incrementCount(key: string): Promise<number> {
+  try {
+    const db = await getDB();
+    if (!db) return 0;
+    const current = await db.get(STORE_NAME, key);
+    const next = (typeof current === 'number' ? current : 0) + 1;
+    await db.put(STORE_NAME, next, key);
+    return next;
+  } catch (error) {
+    console.error(`Failed to increment feedback counter "${key}":`, error);
+    return 0;
+  }
+}
+
+export async function incrementBluetoothSends(): Promise<number> {
+  return incrementCount(KEY_BLUETOOTH_SENDS);
+}
+
+export async function incrementSearches(): Promise<number> {
+  return incrementCount(KEY_SEARCHES);
+}
+
+export async function getFeedbackStatus(): Promise<FeedbackStatus> {
+  try {
+    const db = await getDB();
+    if (!db) return 'pending';
+    const value = await db.get(STORE_NAME, KEY_STATUS);
+    return value === 'dismissed' || value === 'submitted' ? value : 'pending';
+  } catch (error) {
+    console.error('Failed to read feedback status:', error);
+    return 'pending';
+  }
+}
+
+export async function setFeedbackStatus(status: FeedbackStatus): Promise<void> {
+  try {
+    const db = await getDB();
+    if (!db) return;
+    await db.put(STORE_NAME, status, KEY_STATUS);
+  } catch (error) {
+    console.error('Failed to write feedback status:', error);
+  }
+}
+
+// Auto-prompt only surfaces inside the native app, where a 5-star rating
+// actually translates to a store review. On web we rely on the manual
+// "Send feedback" entry in the user drawer.
+export async function shouldShowPrompt(): Promise<boolean> {
+  if (!isNativeApp()) return false;
+  const status = await getFeedbackStatus();
+  if (status !== 'pending') return false;
+  const [bluetoothSends, searches] = await Promise.all([getCount(KEY_BLUETOOTH_SENDS), getCount(KEY_SEARCHES)]);
+  return bluetoothSends >= TRIGGER_THRESHOLD || searches >= TRIGGER_THRESHOLD;
+}
+
+export const FEEDBACK_PROMPT_EVENT = 'boardsesh:show-feedback-prompt';
+
+export async function maybeFireFeedbackPromptEvent(): Promise<void> {
+  if (typeof window === 'undefined') return;
+  if (await shouldShowPrompt()) {
+    window.dispatchEvent(new CustomEvent(FEEDBACK_PROMPT_EVENT));
+  }
+}

--- a/packages/web/app/lib/graphql/operations/feedback.ts
+++ b/packages/web/app/lib/graphql/operations/feedback.ts
@@ -1,0 +1,16 @@
+import { gql } from 'graphql-request';
+import type { SubmitAppFeedbackInput } from '@boardsesh/shared-schema';
+
+export const SUBMIT_APP_FEEDBACK = gql`
+  mutation SubmitAppFeedback($input: SubmitAppFeedbackInput!) {
+    submitAppFeedback(input: $input)
+  }
+`;
+
+export interface SubmitAppFeedbackMutationVariables {
+  input: SubmitAppFeedbackInput;
+}
+
+export interface SubmitAppFeedbackMutationResponse {
+  submitAppFeedback: boolean;
+}

--- a/packages/web/app/lib/graphql/operations/index.ts
+++ b/packages/web/app/lib/graphql/operations/index.ts
@@ -12,3 +12,4 @@ export * from './new-climb-feed';
 export * from './sessions';
 export * from './create-session';
 export * from './climb-stats-history';
+export * from './feedback';

--- a/packages/web/app/lib/in-app-review.ts
+++ b/packages/web/app/lib/in-app-review.ts
@@ -1,11 +1,10 @@
 import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
-import { storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
+import { storeHttpsUrlForPlatform, storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
 
 /**
  * Ask the OS to display its native in-app review sheet. Falls back to the
- * platform store scheme URL (itms-apps:// / market://) so the user lands in
- * the real store app rather than an in-WebView listing page.
+ * platform store URL so the user still lands on a way to rate the app.
  *
  * Note: iOS SKStoreReviewController silently no-ops if the quota is exceeded
  * (3+ calls per 365 days) or the user opted out. The Android In-App Review
@@ -13,6 +12,7 @@ import { storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
  * behavior — callers should treat this call as fire-and-forget.
  */
 export async function requestInAppReview(): Promise<void> {
+  const platform = getPlatform();
   if (isNativeApp()) {
     const plugin = window.Capacitor?.Plugins?.InAppReview;
     if (plugin) {
@@ -20,9 +20,14 @@ export async function requestInAppReview(): Promise<void> {
         await plugin.requestReview();
         return;
       } catch {
-        // Fall through to store URL
+        // Fall through to store scheme URL — opens the real App Store /
+        // Play Store app rather than an in-WebView listing page.
       }
     }
+    openExternalUrl(storeSchemeUrlForPlatform(platform));
+    return;
   }
-  openExternalUrl(storeSchemeUrlForPlatform(getPlatform()));
+  // Web: scheme URLs (itms-apps://, market://) don't resolve in a browser.
+  // Use the https store URL instead.
+  openExternalUrl(storeHttpsUrlForPlatform(platform));
 }

--- a/packages/web/app/lib/in-app-review.ts
+++ b/packages/web/app/lib/in-app-review.ts
@@ -1,0 +1,28 @@
+import { isNativeApp, getPlatform } from '@/app/lib/ble/capacitor-utils';
+import { openExternalUrl } from '@/app/lib/open-external-url';
+import { storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
+
+/**
+ * Ask the OS to display its native in-app review sheet. Falls back to the
+ * platform store scheme URL (itms-apps:// / market://) so the user lands in
+ * the real store app rather than an in-WebView listing page.
+ *
+ * Note: iOS SKStoreReviewController silently no-ops if the quota is exceeded
+ * (3+ calls per 365 days) or the user opted out. The Android In-App Review
+ * API also no-ops when the user recently rated. Both are expected platform
+ * behavior — callers should treat this call as fire-and-forget.
+ */
+export async function requestInAppReview(): Promise<void> {
+  if (isNativeApp()) {
+    const plugin = window.Capacitor?.Plugins?.InAppReview;
+    if (plugin) {
+      try {
+        await plugin.requestReview();
+        return;
+      } catch {
+        // Fall through to store URL
+      }
+    }
+  }
+  openExternalUrl(storeSchemeUrlForPlatform(getPlatform()));
+}

--- a/packages/web/app/lib/store-urls.ts
+++ b/packages/web/app/lib/store-urls.ts
@@ -1,0 +1,23 @@
+export const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
+export const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
+export const ANDROID_SIDELOAD_URL = 'https://github.com/boardsesh/boardsesh/releases/latest';
+
+// Native scheme URLs — open the App Store / Play Store app directly and land on
+// the rate section, which https:// URLs cannot reliably do when surfaced via
+// SFSafariViewController (iOS) or a Browser-plugin in-app view.
+export const IOS_APP_STORE_SCHEME_URL = 'itms-apps://itunes.apple.com/app/id6761350784';
+export const ANDROID_PLAY_STORE_SCHEME_URL = 'market://details?id=com.boardsesh.app';
+
+export type Platform = 'ios' | 'android' | 'web';
+
+/** URL that opens the store page in a browser (shareable, web-fallback-safe). */
+export function storeHttpsUrlForPlatform(platform: Platform): string {
+  if (platform === 'android') return ANDROID_PLAY_STORE_URL;
+  return IOS_APP_STORE_URL;
+}
+
+/** URL that opens the native store app directly on device. Use inside a native app. */
+export function storeSchemeUrlForPlatform(platform: Platform): string {
+  if (platform === 'android') return ANDROID_PLAY_STORE_SCHEME_URL;
+  return IOS_APP_STORE_SCHEME_URL;
+}


### PR DESCRIPTION
## Summary
- Adds a dismissible feedback banner that appears once a native user crosses 5 Bluetooth climb-sends **or** 5 climb searches. On save, ≥ 3 stars triggers the OS in-app review sheet; < 3 stars swaps to a "what's missing" comment form.
- Adds "Rate Boardsesh" and "Send feedback" entries to the user-avatar drawer so users can rate anytime without waiting on the prompt.
- Persists ratings to a new `app_feedback` table via a public, rate-limited GraphQL mutation. Submissions include platform (`ios`/`android`/`web`) and app version so we can correlate feedback to releases.
- Uses `@capacitor-community/in-app-review@8` for the native review sheet; falls back to native store-scheme URLs (`itms-apps://`, `market://`) so users land in the real store app, not an in-WebView listing.

## Trigger state
IndexedDB (`boardsesh-feedback-prompt`) tracks `bluetoothSends`, `searches`, and a `pending | dismissed | submitted` status. The auto-banner only shows on native, and is suppressed once the user engages via any path (banner, drawer Rate, drawer Send feedback).

## Test plan
- [ ] Fresh browser profile: perform 4 climb-search submissions → no banner. 5th → banner appears above the queue bar.
- [ ] Dismiss via ×, reload → banner does not reappear. Clear IndexedDB → it re-arms.
- [ ] Repeat the trigger path via 5 successful Bluetooth climb-sends (paired board or mock adapter).
- [ ] Pick 5 stars → Save: rating `5` is inserted into `app_feedback`, banner closes immediately, thank-you toast shows.
- [ ] Pick 2 stars → Save: form swaps to "Sorry — what's missing?" → Send: rating `2` + comment inserted.
- [ ] Pick 2 stars → Save → Skip: rating `2` is still recorded with no comment (regression: earlier iterations dropped it).
- [ ] Kill network, pick 5 → banner closes optimistically, warning toast surfaces on failure, status remains `submitted` (no re-prompt).
- [ ] **Native build (Android + iOS)**: trigger banner, pick 5 → OS review sheet appears. Pick 2 → comment view, no review sheet.
- [ ] Drawer "Rate Boardsesh" on native → native review sheet; on web → correct store URL in system browser/store app (not SFSafariViewController).
- [ ] Drawer "Send feedback" → dialog with star picker + multiline comment, submits successfully.
- [ ] Web-only user (desktop) never sees the auto-banner even after 10+ searches/sends; drawer entries still work.
- [ ] `vp run db:migrate` applies `0080_concerned_prism.sql`; inserted rows visible via `vp run db:studio`.
- [ ] `vp check` + `vp run typecheck` clean.
- [ ] `vp test run` — `feedback-prompt-db`, `persistent-session-wrapper`, `user-drawer`, feedback components all green.

## Notes
- Public GraphQL mutation (unauthenticated testers can still rate); rate-limited at 10/window via `applyRateLimit`.
- Native plugin registered via `bunx cap sync` — native files (`Podfile`, `capacitor.settings.gradle`, `capacitor.build.gradle`) are part of this PR. CI / dev machines still need to run `pod install` for iOS.
- Store URLs relocated from `home-page-content.tsx` into a shared `lib/store-urls.ts` and extended with `itms-apps://` / `market://` schemes for native deep-linking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)