### PR TITLE
feat(feedback): drawer — collapse "Send feedback" into "Rate Boardses…

### DIFF
--- a/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+
+// The dialog pulls in a React Query hook, a snackbar provider, and an
+// IndexedDB-backed db module. Stub them out so these tests focus on the
+// onSubmitted chaining contract and don't depend on a full app shell.
+vi.mock('@/app/hooks/use-submit-app-feedback', () => ({
+  useSubmitAppFeedback: vi.fn(),
+}));
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+vi.mock('@/app/lib/feedback-prompt-db', () => ({
+  setFeedbackStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { FeedbackDialog } from '../feedback-dialog';
+import { useSubmitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
+
+type MutationOptions = { onSuccess?: () => void; onError?: (err: Error) => void };
+type Mutate = (payload: unknown, options?: MutationOptions) => void;
+
+const mockedUseSubmitAppFeedback = vi.mocked(useSubmitAppFeedback);
+
+function pickStars(n: number) {
+  fireEvent.click(screen.getByRole('option', { name: `${n} star${n > 1 ? 's' : ''}` }));
+}
+
+function setupMutate(behavior: 'success' | 'error' | 'noop') {
+  const mutate: Mutate = vi.fn((_payload, options) => {
+    if (behavior === 'success') options?.onSuccess?.();
+    if (behavior === 'error') options?.onError?.(new Error('simulated failure'));
+  });
+  mockedUseSubmitAppFeedback.mockReturnValue({ mutate } as never);
+  return mutate;
+}
+
+describe('FeedbackDialog — onSubmitted chaining', () => {
+  beforeEach(() => {
+    mockedUseSubmitAppFeedback.mockReset();
+  });
+
+  it('fires onSubmitted with the submitted values AFTER the mutation succeeds', async () => {
+    setupMutate('success');
+    const onSubmitted = vi.fn();
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-feedback" onSubmitted={onSubmitted} />);
+    pickStars(5);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(onSubmitted).toHaveBeenCalledTimes(1);
+    expect(onSubmitted).toHaveBeenCalledWith({ rating: 5, comment: null });
+  });
+
+  it('does NOT fire onSubmitted when the mutation errors', async () => {
+    setupMutate('error');
+    const onSubmitted = vi.fn();
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-feedback" onSubmitted={onSubmitted} />);
+    pickStars(5);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    // The user sees the "Couldn't send" snackbar — asking them to publicly
+    // review the app on top of that failure would be user-hostile.
+    expect(onSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire onSubmitted when the user cancels', async () => {
+    setupMutate('noop');
+    const onSubmitted = vi.fn();
+    const onClose = vi.fn();
+    render(<FeedbackDialog open onClose={onClose} source="drawer-feedback" onSubmitted={onSubmitted} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire onSubmitted when the user hits the Close (X) icon', async () => {
+    setupMutate('noop');
+    const onSubmitted = vi.fn();
+    const onClose = vi.fn();
+    render(<FeedbackDialog open onClose={onClose} source="drawer-feedback" onSubmitted={onSubmitted} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('fires onSubmitted with rating=null for a successful bug submission', async () => {
+    const mutate = setupMutate('success');
+    const onSubmitted = vi.fn();
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-bug" mode="bug" onSubmitted={onSubmitted} />);
+    fireEvent.change(screen.getByPlaceholderText(/what were you doing/i), {
+      target: { value: 'crashed when submitting' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /send bug report/i }));
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(onSubmitted).toHaveBeenCalledWith({ rating: null, comment: 'crashed when submitting' });
+  });
+});

--- a/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
@@ -17,11 +17,13 @@ vi.mock('@/app/lib/feedback-prompt-db', () => ({
 
 import { FeedbackDialog } from '../feedback-dialog';
 import { useSubmitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
+import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
 
 type MutationOptions = { onSuccess?: () => void; onError?: (err: Error) => void };
 type Mutate = (payload: unknown, options?: MutationOptions) => void;
 
 const mockedUseSubmitAppFeedback = vi.mocked(useSubmitAppFeedback);
+const mockedSetFeedbackStatus = vi.mocked(setFeedbackStatus);
 
 function pickStars(n: number) {
   fireEvent.click(screen.getByRole('option', { name: `${n} star${n > 1 ? 's' : ''}` }));
@@ -39,6 +41,7 @@ function setupMutate(behavior: 'success' | 'error' | 'noop') {
 describe('FeedbackDialog — onSubmitted chaining', () => {
   beforeEach(() => {
     mockedUseSubmitAppFeedback.mockReset();
+    mockedSetFeedbackStatus.mockClear();
   });
 
   it('fires onSubmitted with the submitted values AFTER the mutation succeeds', async () => {
@@ -51,6 +54,45 @@ describe('FeedbackDialog — onSubmitted chaining', () => {
     });
     expect(onSubmitted).toHaveBeenCalledTimes(1);
     expect(onSubmitted).toHaveBeenCalledWith({ rating: 5, comment: null });
+  });
+
+  it('calls onClose on successful submission — guarantees no stacking when a caller chains another dialog in onSubmitted', async () => {
+    setupMutate('success');
+    const onClose = vi.fn();
+    render(<FeedbackDialog open onClose={onClose} source="drawer-feedback" onSubmitted={vi.fn()} />);
+    pickStars(5);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('marks the auto-banner status as "submitted" when the user rates via the drawer', async () => {
+    setupMutate('success');
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-feedback" onSubmitted={vi.fn()} />);
+    pickStars(4);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(mockedSetFeedbackStatus).toHaveBeenCalledWith('submitted');
+  });
+
+  it("does NOT mark the auto-banner status on a bug submission — bugs aren't a rating", async () => {
+    setupMutate('success');
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-bug" mode="bug" onSubmitted={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/what were you doing/i), {
+      target: { value: 'crashed when submitting' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /send bug report/i }));
+    });
+    expect(mockedSetFeedbackStatus).not.toHaveBeenCalled();
+  });
+
+  it('uses "Rate Boardsesh" as the default title when no title is passed', () => {
+    setupMutate('noop');
+    render(<FeedbackDialog open onClose={vi.fn()} source="drawer-feedback" />);
+    expect(screen.getByText('Rate Boardsesh')).toBeTruthy();
   });
 
   it('does NOT fire onSubmitted when the mutation errors', async () => {

--- a/packages/web/app/components/feedback/__tests__/store-review-prompt-dialog.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/store-review-prompt-dialog.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/app/lib/in-app-review', () => ({
+  requestInAppReview: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { StoreReviewPromptDialog } from '../store-review-prompt-dialog';
+import { requestInAppReview } from '@/app/lib/in-app-review';
+
+const mockedRequestInAppReview = vi.mocked(requestInAppReview);
+
+describe('StoreReviewPromptDialog', () => {
+  beforeEach(() => {
+    mockedRequestInAppReview.mockClear();
+  });
+
+  it('calls requestInAppReview and closes when the user clicks "Leave a review"', () => {
+    const onClose = vi.fn();
+    render(<StoreReviewPromptDialog open onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /leave a review/i }));
+    expect(mockedRequestInAppReview).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes WITHOUT calling requestInAppReview when the user clicks "Not now"', () => {
+    const onClose = vi.fn();
+    render(<StoreReviewPromptDialog open onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(mockedRequestInAppReview).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when open=false', () => {
+    render(<StoreReviewPromptDialog open={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /leave a review/i })).toBeNull();
+  });
+});

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -70,12 +70,18 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
         source,
       },
       {
-        onSuccess: () => showMessage(isBug ? 'Bug logged — thanks.' : 'Thanks — logged.', 'success'),
+        onSuccess: () => {
+          showMessage(isBug ? 'Bug logged — thanks.' : 'Thanks — logged.', 'success');
+          // Fire chained follow-ups (e.g. "also leave a store review?") only
+          // on successful submission. Otherwise we'd be prompting the user to
+          // publicly review the app right after telling them their feedback
+          // didn't save.
+          onSubmitted?.(values);
+        },
         onError: () => showMessage("Couldn't send — we'll keep your feedback.", 'warning'),
       },
     );
     onClose();
-    onSubmitted?.(values);
   };
 
   return (

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -14,12 +14,24 @@ import styles from './feedback-dialog.module.css';
 
 export type FeedbackDialogMode = 'rating' | 'bug';
 
+export interface FeedbackSubmission {
+  rating: number | null;
+  comment: string | null;
+}
+
 interface FeedbackDialogProps {
   open: boolean;
   onClose: () => void;
   source: AppFeedbackSource;
   title?: string;
   mode?: FeedbackDialogMode;
+  /**
+   * Fires after the user's submission is accepted by the form and the mutation
+   * has been kicked off (fire-and-forget). Used by callers that want to chain
+   * a follow-up step — e.g. the drawer asking about an App Store review after
+   * a rating submission. Not invoked when the form is cancelled/closed.
+   */
+  onSubmitted?: (submission: FeedbackSubmission) => void;
 }
 
 const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
@@ -27,13 +39,14 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
   source,
   title,
   mode = 'rating',
+  onSubmitted,
 }) => {
   const { mutate } = useSubmitAppFeedback();
   const { showMessage } = useSnackbar();
   const isBug = mode === 'bug';
-  const resolvedTitle = title ?? (isBug ? 'Report a bug' : 'Send feedback');
+  const resolvedTitle = title ?? (isBug ? 'Report a bug' : 'Rate Boardsesh');
 
-  const handleSubmit = (values: { rating: number | null; comment: string | null }) => {
+  const handleSubmit = (values: FeedbackSubmission) => {
     if (isBug) {
       // Bug-mode form guarantees comment length via canSubmit.
       if (!values.comment) {
@@ -62,6 +75,7 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
       },
     );
     onClose();
+    onSubmitted?.(values);
   };
 
   return (
@@ -82,10 +96,12 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
   );
 };
 
-export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, source, title, mode }) => {
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, source, title, mode, onSubmitted }) => {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      {open && <FeedbackDialogBody onClose={onClose} source={source} title={title} mode={mode} />}
+      {open && (
+        <FeedbackDialogBody onClose={onClose} source={source} title={title} mode={mode} onSubmitted={onSubmitted} />
+      )}
     </Dialog>
   );
 };

--- a/packages/web/app/components/feedback/store-review-prompt-dialog.tsx
+++ b/packages/web/app/components/feedback/store-review-prompt-dialog.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+import { requestInAppReview } from '@/app/lib/in-app-review';
+
+interface StoreReviewPromptDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Chained follow-up after an in-app star rating. Asks the user if they'd also
+ * leave a review on the App Store / Play Store (or open the web store listing
+ * on browsers). Shown only for high ratings so we don't steer unhappy users
+ * to publicly 1-star the app — gating lives in the caller.
+ */
+export const StoreReviewPromptDialog: React.FC<StoreReviewPromptDialogProps> = ({ open, onClose }) => {
+  const handleReview = () => {
+    void requestInAppReview();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Help others find Boardsesh</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Thanks for the rating. Would you also leave a quick review on your app store? It&apos;s the single best thing
+          you can do to help other climbers find us.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Not now</Button>
+        <Button variant="contained" onClick={handleReview}>
+          Leave a review
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -541,8 +541,11 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
         open={showRating}
         onClose={() => setShowRating(false)}
         source="drawer-feedback"
-        title="Rate Boardsesh"
         onSubmitted={({ rating }) => {
+          // Defensive: the dialog body always calls onClose in its submit
+          // path, but closing explicitly here too guarantees no stacking if
+          // that ever changes. Idempotent — React coalesces the setState.
+          setShowRating(false);
           // Only chain into the App Store prompt on a clearly positive rating —
           // asking a user who just gave us 2 stars to publicly review us is
           // how you end up with 2-star public reviews. The in-app prompt banner

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -12,7 +12,6 @@ import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import HelpOutlineOutlined from '@mui/icons-material/HelpOutlineOutlined';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import StarBorderOutlined from '@mui/icons-material/StarBorderOutlined';
-import FeedbackOutlined from '@mui/icons-material/FeedbackOutlined';
 import BugReportOutlined from '@mui/icons-material/BugReportOutlined';
 import GpsFixedOutlined from '@mui/icons-material/GpsFixedOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
@@ -43,8 +42,7 @@ import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { HoldClassificationWizard } from '../hold-classification';
 import { FeedbackDialog } from '../feedback/feedback-dialog';
 import { BugReportDialog } from '../feedback/bug-report-dialog';
-import { requestInAppReview } from '@/app/lib/in-app-review';
-import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
+import { StoreReviewPromptDialog } from '../feedback/store-review-prompt-dialog';
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
@@ -89,8 +87,9 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
   const [showDevUrl, setShowDevUrl] = useState(false);
   const { isAvailable: devUrlAvailable } = useDevUrl();
-  const [showFeedback, setShowFeedback] = useState(false);
+  const [showRating, setShowRating] = useState(false);
   const [showBugReport, setShowBugReport] = useState(false);
+  const [showStoreReviewPrompt, setShowStoreReviewPrompt] = useState(false);
 
   const { mode, toggleMode } = useColorMode();
   const isMoonboard = boardDetails?.board_name === 'moonboard';
@@ -418,34 +417,13 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               className={styles.menuItem}
               onClick={() => {
                 handleClose();
-                // Trigger the native review sheet (native) or open the store
-                // URL (web). We don't write an app_feedback row here: the OS
-                // review sheet is quota-limited and doesn't report whether the
-                // user actually rated, so recording anything would be guessing.
-                // Still mark the local prompt as submitted so the automatic
-                // banner doesn't re-surface for someone who proactively rated.
-                void requestInAppReview();
-                void setFeedbackStatus('submitted');
+                setShowRating(true);
               }}
             >
               <span className={styles.menuItemIcon}>
                 <StarBorderOutlined />
               </span>
               <span className={styles.menuItemLabel}>Rate Boardsesh</span>
-            </button>
-
-            <button
-              type="button"
-              className={styles.menuItem}
-              onClick={() => {
-                handleClose();
-                setShowFeedback(true);
-              }}
-            >
-              <span className={styles.menuItemIcon}>
-                <FeedbackOutlined />
-              </span>
-              <span className={styles.menuItemLabel}>Send feedback</span>
             </button>
 
             <button
@@ -559,8 +537,23 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
 
       {devUrlAvailable && <DevUrlDialog open={showDevUrl} onClose={() => setShowDevUrl(false)} />}
 
-      <FeedbackDialog open={showFeedback} onClose={() => setShowFeedback(false)} source="drawer-feedback" />
+      <FeedbackDialog
+        open={showRating}
+        onClose={() => setShowRating(false)}
+        source="drawer-feedback"
+        title="Rate Boardsesh"
+        onSubmitted={({ rating }) => {
+          // Only chain into the App Store prompt on a clearly positive rating —
+          // asking a user who just gave us 2 stars to publicly review us is
+          // how you end up with 2-star public reviews. The in-app prompt banner
+          // already applies the same gating (≥3) for native in-app review.
+          if (rating !== null && rating >= 4) {
+            setShowStoreReviewPrompt(true);
+          }
+        }}
+      />
       <BugReportDialog open={showBugReport} onClose={() => setShowBugReport(false)} source="drawer-bug" />
+      <StoreReviewPromptDialog open={showStoreReviewPrompt} onClose={() => setShowStoreReviewPrompt(false)} />
     </>
   );
 }


### PR DESCRIPTION
…h", chain to App Store prompt

Previously the drawer had two side-by-side entry points that did nearly the same thing: "Rate Boardsesh" (opened the OS in-app-review sheet directly) and "Send feedback" (opened the star-rating modal). Users had no way to tell which was which, and a rating submitted via the modal never nudged them toward a public store review.

Now:
- "Rate Boardsesh" opens the star-rating modal (was "Send feedback"'s behavior). Source stays `drawer-feedback` so the existing enum and Discord payload are unchanged.
- After a submission with rating ≥ 4, we chain into a follow-up dialog ("Would you also leave a quick review on your app store?") that calls requestInAppReview() on "Yes" — which itself already handles the native in-app sheet vs web store URL fallback.
- Gating at ≥ 4 intentionally avoids steering unhappy users to publicly 1-star the app; the automatic feedback-prompt-banner uses the same philosophy (≥ 3 + isNativeApp before prompting the OS sheet).
- "Send feedback" button removed. "Report a bug" unchanged.

Implementation:
- feedback-dialog.tsx: new optional `onSubmitted` callback that fires after the mutation is kicked off (fire-and-forget, not awaited on success). Exports FeedbackSubmission for the payload type.
- store-review-prompt-dialog.tsx: new thin MUI Dialog with Not-now / Leave-a-review actions; delegates the actual review call to the existing requestInAppReview().
- user-drawer.tsx: drops the "Send feedback" button + its FeedbackOutlined import; state var renamed showFeedback → showRating; title on the rating dialog now says "Rate Boardsesh"; drops now-unused requestInAppReview / setFeedbackStatus imports (the dialog body handles setFeedbackStatus internally on submit).