### PR TITLE
ci(web): fetch base ref so vitest --changed actually finds tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,13 @@ jobs:
         with:
           name: built-packages
 
+      # actions/checkout on a pull_request event fetches only the PR merge ref,
+      # so `origin/main` isn't present locally and vitest's `--changed` silently
+      # matches zero files. Fetch the base ref explicitly so the diff works.
+      - name: Fetch base ref for vitest --changed
+        if: github.event_name == 'pull_request'
+        run: git fetch --depth=50 origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+
       - name: Run tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml` calls `vitest --changed origin/\${base_ref}` on PRs, but `actions/checkout@v6` fetches only the PR merge ref, not `origin/main`. vitest then silently matches zero files and exits with code 0, so the web test suite hasn't actually been running on PRs.
- Fix: explicitly \`git fetch\` the base ref before the test step.

You can see the broken behaviour in any recent PR's "Web Tests / test" job — the log ends with:

\`\`\`
@boardsesh/web test:run: No test files found, exiting with code 0
@boardsesh/web test:run: include: **/*.{test,spec}.?(c|m)[jt]s?(x)
@boardsesh/web test:run: exclude:  **/node_modules/**, **/dist/**, backend/**, e2e/**
\`\`\`

## Test plan

- [ ] Open this PR and confirm the Web Tests job now discovers and runs test files (should be >0 affected tests since this touches the workflow itself… but \`--changed\` only tracks source files, not CI config, so tests may still be 0 here; a follow-up PR that touches \`packages/web/app/**\` will be the real smoke test)
- [ ] On that follow-up PR, confirm tests actually run and \`junit.xml\` contains results