### PR TITLE
Re-enable shake-to-report with stricter tuning and opt-out

### DIFF
--- a/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
@@ -1,25 +1,40 @@
-import 'fake-indexeddb/auto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, act, waitFor } from '@testing-library/react';
 import React from 'react';
-import { openDB } from 'idb';
 import { ShakeToReportProvider } from '../shake-to-report-provider';
-import { setPreference } from '@/app/lib/user-preferences-db';
 
-// Capture the most recent callback and options passed to useShakeDetector
-// so tests can deterministically "simulate" a shake and read the enabled flag.
-type ShakeHookArgs = { onShake: () => void; enabled: boolean };
-const lastShakeHookCall: { current: ShakeHookArgs | null } = { current: null };
+type DismissedResolver = {
+  resolve: (value: boolean) => void;
+  reject: (error: unknown) => void;
+};
+
+// vi.mock factories are hoisted above module-level code, so any refs they
+// need must be created via vi.hoisted. Capturing the dismissed-preference
+// resolver here gives every test deterministic control over hydration
+// (success, opt-out, and rejection paths alike) without hitting IndexedDB.
+const { pendingGetRef, setDismissedMock, showMessageMock, shakeHookRef } = vi.hoisted(() => ({
+  pendingGetRef: { current: null as DismissedResolver | null },
+  setDismissedMock: vi.fn(),
+  showMessageMock: vi.fn(),
+  shakeHookRef: { current: null as { onShake: () => void; enabled: boolean } | null },
+}));
 
 vi.mock('@/app/hooks/use-shake-detector', () => ({
   useShakeDetector: (onShake: () => void, options: { enabled: boolean }) => {
-    lastShakeHookCall.current = { onShake, enabled: options.enabled };
+    shakeHookRef.current = { onShake, enabled: options.enabled };
   },
 }));
 
-const showMessage = vi.fn();
 vi.mock('@/app/components/providers/snackbar-provider', () => ({
-  useSnackbar: () => ({ showMessage }),
+  useSnackbar: () => ({ showMessage: showMessageMock }),
+}));
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getShakeToReportDismissed: () =>
+    new Promise<boolean>((resolve, reject) => {
+      pendingGetRef.current = { resolve, reject };
+    }),
+  setShakeToReportDismissed: setDismissedMock,
 }));
 
 // BugReportDialog pulls in React Query / form children we don't care about
@@ -29,29 +44,40 @@ type CapturedDialogProps = {
   onClose: () => void;
   secondaryAction?: { label: string; onClick: () => void };
 };
-const lastDialogProps: { current: CapturedDialogProps | null } = { current: null };
+const { dialogPropsRef } = vi.hoisted(() => ({
+  dialogPropsRef: { current: null as CapturedDialogProps | null },
+}));
 
 vi.mock('../bug-report-dialog', () => ({
   BugReportDialog: (props: CapturedDialogProps) => {
-    lastDialogProps.current = props;
+    dialogPropsRef.current = props;
     return props.open ? <div data-testid="bug-report-dialog">open</div> : null;
   },
 }));
 
-const DB_NAME = 'boardsesh-user-preferences';
-const STORE_NAME = 'preferences';
-
-beforeEach(async () => {
-  lastShakeHookCall.current = null;
-  lastDialogProps.current = null;
-  showMessage.mockClear();
-  const db = await openDB(DB_NAME, 1, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME);
-    },
+async function resolveHydration(value: boolean) {
+  await waitFor(() => expect(pendingGetRef.current).not.toBeNull());
+  await act(async () => {
+    pendingGetRef.current!.resolve(value);
+    await Promise.resolve();
   });
-  await db.clear(STORE_NAME);
-  db.close();
+}
+
+async function rejectHydration(error: unknown) {
+  await waitFor(() => expect(pendingGetRef.current).not.toBeNull());
+  await act(async () => {
+    pendingGetRef.current!.reject(error);
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  shakeHookRef.current = null;
+  dialogPropsRef.current = null;
+  pendingGetRef.current = null;
+  showMessageMock.mockClear();
+  setDismissedMock.mockReset();
+  setDismissedMock.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -62,39 +88,47 @@ describe('ShakeToReportProvider', () => {
   it('keeps the shake detector disabled until the dismissed preference hydrates', async () => {
     render(<ShakeToReportProvider />);
     // First render — hydration has not resolved yet.
-    expect(lastShakeHookCall.current?.enabled).toBe(false);
+    expect(shakeHookRef.current?.enabled).toBe(false);
+
+    await resolveHydration(false);
+
     // Once resolution completes, detector enables for a first-time user.
-    await waitFor(() => {
-      expect(lastShakeHookCall.current?.enabled).toBe(true);
-    });
+    expect(shakeHookRef.current?.enabled).toBe(true);
   });
 
   it('leaves the shake detector disabled for a user who previously opted out', async () => {
-    await setPreference('shakeToReport:dismissed', true);
     render(<ShakeToReportProvider />);
-    // Wait long enough for hydration to complete, then confirm it stays off.
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(lastShakeHookCall.current?.enabled).toBe(false);
+    await resolveHydration(true);
+    expect(shakeHookRef.current?.enabled).toBe(false);
+  });
+
+  it('falls back to detector-on when the preference read rejects', async () => {
+    render(<ShakeToReportProvider />);
+    await rejectHydration(new Error('IndexedDB unavailable'));
+    // A failed preference lookup must not leave the detector permanently off;
+    // the user shouldn't lose the feature because storage is broken.
+    expect(shakeHookRef.current?.enabled).toBe(true);
   });
 
   it('opens the dialog when the detector fires', async () => {
     render(<ShakeToReportProvider />);
-    await waitFor(() => expect(lastShakeHookCall.current?.enabled).toBe(true));
+    await resolveHydration(false);
     act(() => {
-      lastShakeHookCall.current?.onShake();
+      shakeHookRef.current?.onShake();
     });
-    expect(lastDialogProps.current?.open).toBe(true);
+    expect(dialogPropsRef.current?.open).toBe(true);
     // Detector pauses while the dialog is open so a continuous shake can't re-trigger.
-    expect(lastShakeHookCall.current?.enabled).toBe(false);
+    expect(shakeHookRef.current?.enabled).toBe(false);
   });
 
   it('persists the opt-out, silences the detector, and fires the fallback snackbar', async () => {
     render(<ShakeToReportProvider />);
-    await waitFor(() => expect(lastShakeHookCall.current?.enabled).toBe(true));
+    await resolveHydration(false);
     act(() => {
-      lastShakeHookCall.current?.onShake();
+      shakeHookRef.current?.onShake();
     });
-    const action = lastDialogProps.current?.secondaryAction;
+
+    const action = dialogPropsRef.current?.secondaryAction;
     expect(action?.label).toBe("Don't show this again");
 
     act(() => {
@@ -102,23 +136,18 @@ describe('ShakeToReportProvider', () => {
     });
 
     // Dialog closes, detector is now permanently off for this session.
-    expect(lastDialogProps.current?.open).toBe(false);
-    expect(lastShakeHookCall.current?.enabled).toBe(false);
+    expect(dialogPropsRef.current?.open).toBe(false);
+    expect(shakeHookRef.current?.enabled).toBe(false);
+
+    // Preference write fired with true.
+    expect(setDismissedMock).toHaveBeenCalledWith(true);
 
     // Snackbar points the user at the manual fallback path.
-    expect(showMessage).toHaveBeenCalledWith(
+    expect(showMessageMock).toHaveBeenCalledWith(
       'Shake to report off. Tap your avatar up top to send feedback.',
       'info',
       undefined,
       6000,
     );
-
-    // And the preference survived into IndexedDB.
-    await waitFor(async () => {
-      const db = await openDB(DB_NAME, 1);
-      const value = await db.get(STORE_NAME, 'shakeToReport:dismissed');
-      db.close();
-      expect(value).toBe(true);
-    });
   });
 });

--- a/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
@@ -1,0 +1,125 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { openDB } from 'idb';
+
+// Capture the most recent callback and options passed to useShakeDetector
+// so tests can deterministically "simulate" a shake and read the enabled flag.
+type ShakeHookArgs = { onShake: () => void; enabled: boolean };
+const lastShakeHookCall: { current: ShakeHookArgs | null } = { current: null };
+
+vi.mock('@/app/hooks/use-shake-detector', () => ({
+  useShakeDetector: (onShake: () => void, options: { enabled: boolean }) => {
+    lastShakeHookCall.current = { onShake, enabled: options.enabled };
+  },
+}));
+
+const showMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage }),
+}));
+
+// BugReportDialog pulls in React Query / form children we don't care about
+// here — stub it down to its props so the test can drive the dismiss flow.
+type CapturedDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  secondaryAction?: { label: string; onClick: () => void };
+};
+const lastDialogProps: { current: CapturedDialogProps | null } = { current: null };
+
+vi.mock('../bug-report-dialog', () => ({
+  BugReportDialog: (props: CapturedDialogProps) => {
+    lastDialogProps.current = props;
+    return props.open ? <div data-testid="bug-report-dialog">open</div> : null;
+  },
+}));
+
+import { ShakeToReportProvider } from '../shake-to-report-provider';
+import { setPreference } from '@/app/lib/user-preferences-db';
+
+const DB_NAME = 'boardsesh-user-preferences';
+const STORE_NAME = 'preferences';
+
+beforeEach(async () => {
+  lastShakeHookCall.current = null;
+  lastDialogProps.current = null;
+  showMessage.mockClear();
+  const db = await openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME);
+    },
+  });
+  await db.clear(STORE_NAME);
+  db.close();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ShakeToReportProvider', () => {
+  it('keeps the shake detector disabled until the dismissed preference hydrates', async () => {
+    render(<ShakeToReportProvider />);
+    // First render — hydration has not resolved yet.
+    expect(lastShakeHookCall.current?.enabled).toBe(false);
+    // Once resolution completes, detector enables for a first-time user.
+    await waitFor(() => {
+      expect(lastShakeHookCall.current?.enabled).toBe(true);
+    });
+  });
+
+  it('leaves the shake detector disabled for a user who previously opted out', async () => {
+    await setPreference('shakeToReport:dismissed', true);
+    render(<ShakeToReportProvider />);
+    // Wait long enough for hydration to complete, then confirm it stays off.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(lastShakeHookCall.current?.enabled).toBe(false);
+  });
+
+  it('opens the dialog when the detector fires', async () => {
+    render(<ShakeToReportProvider />);
+    await waitFor(() => expect(lastShakeHookCall.current?.enabled).toBe(true));
+    act(() => {
+      lastShakeHookCall.current?.onShake();
+    });
+    expect(lastDialogProps.current?.open).toBe(true);
+    // Detector pauses while the dialog is open so a continuous shake can't re-trigger.
+    expect(lastShakeHookCall.current?.enabled).toBe(false);
+  });
+
+  it('persists the opt-out, silences the detector, and fires the fallback snackbar', async () => {
+    render(<ShakeToReportProvider />);
+    await waitFor(() => expect(lastShakeHookCall.current?.enabled).toBe(true));
+    act(() => {
+      lastShakeHookCall.current?.onShake();
+    });
+    const action = lastDialogProps.current?.secondaryAction;
+    expect(action?.label).toBe("Don't show this again");
+
+    act(() => {
+      action?.onClick();
+    });
+
+    // Dialog closes, detector is now permanently off for this session.
+    expect(lastDialogProps.current?.open).toBe(false);
+    expect(lastShakeHookCall.current?.enabled).toBe(false);
+
+    // Snackbar points the user at the manual fallback path.
+    expect(showMessage).toHaveBeenCalledWith(
+      'Shake to report off. Tap your avatar up top to send feedback.',
+      'info',
+      undefined,
+      6000,
+    );
+
+    // And the preference survived into IndexedDB.
+    await waitFor(async () => {
+      const db = await openDB(DB_NAME, 1);
+      const value = await db.get(STORE_NAME, 'shakeToReport:dismissed');
+      db.close();
+      expect(value).toBe(true);
+    });
+  });
+});

--- a/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { render, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { openDB } from 'idb';
+import { ShakeToReportProvider } from '../shake-to-report-provider';
+import { setPreference } from '@/app/lib/user-preferences-db';
 
 // Capture the most recent callback and options passed to useShakeDetector
 // so tests can deterministically "simulate" a shake and read the enabled flag.
@@ -35,9 +37,6 @@ vi.mock('../bug-report-dialog', () => ({
     return props.open ? <div data-testid="bug-report-dialog">open</div> : null;
   },
 }));
-
-import { ShakeToReportProvider } from '../shake-to-report-provider';
-import { setPreference } from '@/app/lib/user-preferences-db';
 
 const DB_NAME = 'boardsesh-user-preferences';
 const STORE_NAME = 'preferences';

--- a/packages/web/app/components/feedback/bug-report-dialog.tsx
+++ b/packages/web/app/components/feedback/bug-report-dialog.tsx
@@ -2,15 +2,17 @@
 
 import React from 'react';
 import type { AppFeedbackSource } from '@boardsesh/shared-schema';
-import { FeedbackDialog } from './feedback-dialog';
+import { FeedbackDialog, type FeedbackDialogSecondaryAction } from './feedback-dialog';
 
 type BugReportDialogProps = {
   open: boolean;
   onClose: () => void;
   /** 'shake-bug' for the motion trigger, 'drawer-bug' for the drawer button. */
   source: Extract<AppFeedbackSource, 'shake-bug' | 'drawer-bug'>;
+  /** Muted action shown below the form — shake variant uses this for "Don't show this again". */
+  secondaryAction?: FeedbackDialogSecondaryAction;
 };
 
-export const BugReportDialog: React.FC<BugReportDialogProps> = ({ open, onClose, source }) => {
-  return <FeedbackDialog open={open} onClose={onClose} source={source} mode="bug" />;
+export const BugReportDialog: React.FC<BugReportDialogProps> = ({ open, onClose, source, secondaryAction }) => {
+  return <FeedbackDialog open={open} onClose={onClose} source={source} mode="bug" secondaryAction={secondaryAction} />;
 };

--- a/packages/web/app/components/feedback/feedback-dialog.module.css
+++ b/packages/web/app/components/feedback/feedback-dialog.module.css
@@ -10,3 +10,9 @@
   right: var(--spacing-2);
   z-index: 1;
 }
+
+.secondaryAction {
+  display: flex;
+  justify-content: center;
+  padding: 0 var(--spacing-3) var(--spacing-3);
+}

--- a/packages/web/app/components/feedback/feedback-dialog.module.css
+++ b/packages/web/app/components/feedback/feedback-dialog.module.css
@@ -10,9 +10,3 @@
   right: var(--spacing-2);
   z-index: 1;
 }
-
-.secondaryAction {
-  display: flex;
-  justify-content: center;
-  padding: 0 var(--spacing-3) var(--spacing-3);
-}

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
@@ -19,6 +20,11 @@ export type FeedbackSubmission = {
   comment: string | null;
 };
 
+export type FeedbackDialogSecondaryAction = {
+  label: string;
+  onClick: () => void;
+};
+
 type FeedbackDialogProps = {
   open: boolean;
   onClose: () => void;
@@ -32,6 +38,11 @@ type FeedbackDialogProps = {
    * a rating submission. Not invoked when the form is cancelled/closed.
    */
   onSubmitted?: (submission: FeedbackSubmission) => void;
+  /**
+   * Optional muted action rendered below the form. Used by the shake-triggered
+   * variant to expose a "Don't show this again" escape hatch.
+   */
+  secondaryAction?: FeedbackDialogSecondaryAction;
 };
 
 const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
@@ -40,6 +51,7 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
   title,
   mode = 'rating',
   onSubmitted,
+  secondaryAction,
 }) => {
   const { mutate } = useSubmitAppFeedback();
   const { showMessage } = useSnackbar();
@@ -98,15 +110,37 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
           onCancel={onClose}
         />
       </DialogContent>
+      {secondaryAction && (
+        <div className={styles.secondaryAction}>
+          <Button variant="text" size="small" color="inherit" onClick={secondaryAction.onClick}>
+            {secondaryAction.label}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };
 
-export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, source, title, mode, onSubmitted }) => {
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({
+  open,
+  onClose,
+  source,
+  title,
+  mode,
+  onSubmitted,
+  secondaryAction,
+}) => {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       {open && (
-        <FeedbackDialogBody onClose={onClose} source={source} title={title} mode={mode} onSubmitted={onSubmitted} />
+        <FeedbackDialogBody
+          onClose={onClose}
+          source={source}
+          title={title}
+          mode={mode}
+          onSubmitted={onSubmitted}
+          secondaryAction={secondaryAction}
+        />
       )}
     </Dialog>
   );

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
@@ -111,11 +112,11 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
         />
       </DialogContent>
       {secondaryAction && (
-        <div className={styles.secondaryAction}>
+        <DialogActions sx={{ justifyContent: 'center' }}>
           <Button variant="text" size="small" color="inherit" onClick={() => secondaryAction.onClick()}>
             {secondaryAction.label}
           </Button>
-        </div>
+        </DialogActions>
       )}
     </div>
   );

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -112,7 +112,7 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
       </DialogContent>
       {secondaryAction && (
         <div className={styles.secondaryAction}>
-          <Button variant="text" size="small" color="inherit" onClick={secondaryAction.onClick}>
+          <Button variant="text" size="small" color="inherit" onClick={() => secondaryAction.onClick()}>
             {secondaryAction.label}
           </Button>
         </div>

--- a/packages/web/app/components/feedback/shake-to-report-provider.tsx
+++ b/packages/web/app/components/feedback/shake-to-report-provider.tsx
@@ -1,20 +1,53 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useShakeDetector } from '@/app/hooks/use-shake-detector';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { getShakeToReportDismissed, setShakeToReportDismissed } from '@/app/lib/user-preferences-db';
 import { BugReportDialog } from './bug-report-dialog';
 
 /**
  * Mounts an accelerometer listener at app root and opens the bug-report
  * dialog on a strong shake. Listener is paused while the dialog is open so
  * a continuous shake doesn't re-trigger.
+ *
+ * The dialog exposes a "Don't show this again" escape hatch — if the user
+ * picks it we persist the choice to IndexedDB and detach the detector for
+ * good. The manual drawer entry is unaffected.
  */
 export const ShakeToReportProvider: React.FC = () => {
   const [open, setOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
+  const { showMessage } = useSnackbar();
+
+  useEffect(() => {
+    let cancelled = false;
+    void getShakeToReportDismissed().then((value) => {
+      if (!cancelled) setDismissed(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const handleShake = useCallback(() => setOpen(true), []);
   const handleClose = useCallback(() => setOpen(false), []);
 
-  useShakeDetector(handleShake, { enabled: !open });
+  const handleDontShowAgain = useCallback(() => {
+    setDismissed(true);
+    setOpen(false);
+    void setShakeToReportDismissed(true);
+    showMessage('Shake to report off. Tap your avatar up top to send feedback.', 'info', undefined, 6000);
+  }, [showMessage]);
 
-  return <BugReportDialog open={open} onClose={handleClose} source="shake-bug" />;
+  useShakeDetector(handleShake, { enabled: !open && !dismissed });
+
+  return (
+    <BugReportDialog
+      open={open}
+      onClose={handleClose}
+      source="shake-bug"
+      secondaryAction={{ label: "Don't show this again", onClick: handleDontShowAgain }}
+    />
+  );
 };

--- a/packages/web/app/components/feedback/shake-to-report-provider.tsx
+++ b/packages/web/app/components/feedback/shake-to-report-provider.tsx
@@ -17,7 +17,13 @@ import { BugReportDialog } from './bug-report-dialog';
  */
 export const ShakeToReportProvider: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const [dismissed, setDismissed] = useState(true);
+  // null = hydration pending. We keep the detector detached until IndexedDB
+  // resolves: defaulting to "not dismissed" would let a previously opted-out
+  // user see the dialog fire if they happen to shake during the ~100-300ms
+  // hydration window, silently overriding their explicit opt-out. First-time
+  // users lose the same window of shake availability, which is an acceptable
+  // trade — they're not likely to shake the phone in the first 300ms of load.
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
   const { showMessage } = useSnackbar();
 
   useEffect(() => {
@@ -40,7 +46,7 @@ export const ShakeToReportProvider: React.FC = () => {
     showMessage('Shake to report off. Tap your avatar up top to send feedback.', 'info', undefined, 6000);
   }, [showMessage]);
 
-  useShakeDetector(handleShake, { enabled: !open && !dismissed });
+  useShakeDetector(handleShake, { enabled: !open && dismissed === false });
 
   return (
     <BugReportDialog

--- a/packages/web/app/components/feedback/shake-to-report-provider.tsx
+++ b/packages/web/app/components/feedback/shake-to-report-provider.tsx
@@ -28,9 +28,17 @@ export const ShakeToReportProvider: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false;
-    void getShakeToReportDismissed().then((value) => {
-      if (!cancelled) setDismissed(value);
-    });
+    getShakeToReportDismissed()
+      .then((value) => {
+        if (!cancelled) setDismissed(value);
+      })
+      .catch(() => {
+        // IndexedDB can fail in private browsing or when the storage quota is
+        // exhausted. Fall back to "not dismissed" so the feature is still
+        // available — a broken opt-out is less bad than a silently dead
+        // detector the user can never re-enable via the normal path.
+        if (!cancelled) setDismissed(false);
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -30,6 +30,7 @@ import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
 import { FeedbackPromptBanner } from '../feedback/feedback-prompt-banner';
+import { ShakeToReportProvider } from '../feedback/shake-to-report-provider';
 
 const SeshSettingsDrawer = dynamic(() => import('../sesh-settings/sesh-settings-drawer'), {
   ssr: false,
@@ -61,6 +62,7 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
                   <RootBottomBar boardConfigs={boardConfigs} />
                   <RootSessionSummaryDialog />
                   <RootSeshSettingsDrawer />
+                  <ShakeToReportProvider />
                 </ProfileHeaderShareProvider>
               </StatsFilterBridgeProvider>
             </SearchDrawerBridgeProvider>

--- a/packages/web/app/hooks/__tests__/detect-shake.test.ts
+++ b/packages/web/app/hooks/__tests__/detect-shake.test.ts
@@ -85,25 +85,29 @@ describe('detectShake', () => {
   });
 
   describe('DEFAULT_SHAKE_OPTIONS (tuned to reduce false positives)', () => {
-    it('ignores a strong single bump (13 m/s²) below the 14 m/s² threshold', () => {
-      const step = detectShake(13, 100, initialShakeState());
+    it('ignores a single jolt just below the threshold', () => {
+      const step = detectShake(DEFAULT_SHAKE_OPTIONS.threshold - 1, 100, initialShakeState());
       expect(step.fired).toBe(false);
       expect(step.state.joltTimestamps).toEqual([]);
     });
 
-    it('does not fire on two jolts — a single bump-and-recover', () => {
+    it('does not fire when only requiredJolts-1 jolts occur', () => {
       let state = initialShakeState();
-      state = detectShake(20, 0, state).state;
-      const step = detectShake(20, 300, state);
-      expect(step.fired).toBe(false);
-      expect(step.state.joltTimestamps).toEqual([0, 300]);
+      for (let i = 0; i < DEFAULT_SHAKE_OPTIONS.requiredJolts - 1; i += 1) {
+        const step = detectShake(DEFAULT_SHAKE_OPTIONS.threshold + 5, i * 200, state);
+        expect(step.fired).toBe(false);
+        state = step.state;
+      }
+      expect(state.joltTimestamps.length).toBe(DEFAULT_SHAKE_OPTIONS.requiredJolts - 1);
     });
 
-    it('fires on three jolts inside the window — a deliberate shake', () => {
+    it('fires once requiredJolts jolts land inside windowMs', () => {
       let state = initialShakeState();
-      state = detectShake(20, 0, state).state;
-      state = detectShake(20, 200, state).state;
-      const step = detectShake(20, 400, state);
+      let step = { fired: false, state } as ReturnType<typeof detectShake>;
+      for (let i = 0; i < DEFAULT_SHAKE_OPTIONS.requiredJolts; i += 1) {
+        step = detectShake(DEFAULT_SHAKE_OPTIONS.threshold + 5, i * 200, state);
+        state = step.state;
+      }
       expect(step.fired).toBe(true);
     });
   });

--- a/packages/web/app/hooks/__tests__/detect-shake.test.ts
+++ b/packages/web/app/hooks/__tests__/detect-shake.test.ts
@@ -83,4 +83,28 @@ describe('detectShake', () => {
     expect(step.fired).toBe(false);
     expect(step.state.joltTimestamps).toEqual([]);
   });
+
+  describe('DEFAULT_SHAKE_OPTIONS (tuned to reduce false positives)', () => {
+    it('ignores a strong single bump (13 m/s²) below the 14 m/s² threshold', () => {
+      const step = detectShake(13, 100, initialShakeState());
+      expect(step.fired).toBe(false);
+      expect(step.state.joltTimestamps).toEqual([]);
+    });
+
+    it('does not fire on two jolts — a single bump-and-recover', () => {
+      let state = initialShakeState();
+      state = detectShake(20, 0, state).state;
+      const step = detectShake(20, 300, state);
+      expect(step.fired).toBe(false);
+      expect(step.state.joltTimestamps).toEqual([0, 300]);
+    });
+
+    it('fires on three jolts inside the window — a deliberate shake', () => {
+      let state = initialShakeState();
+      state = detectShake(20, 0, state).state;
+      state = detectShake(20, 200, state).state;
+      const step = detectShake(20, 400, state);
+      expect(step.fired).toBe(true);
+    });
+  });
 });

--- a/packages/web/app/hooks/detect-shake.ts
+++ b/packages/web/app/hooks/detect-shake.ts
@@ -33,8 +33,12 @@ export const DEFAULT_SHAKE_OPTIONS: ShakeOptions = {
   threshold: 14,
   /** Jolts older than this (ms) are pruned from the rolling window. */
   windowMs: 1000,
-  /** After firing, suppress further fires for this duration (ms). */
-  cooldownMs: 3000,
+  /**
+   * After firing, suppress further fires for this duration (ms). 30s gives
+   * the user time to close the dialog and put the phone down without an
+   * immediate re-trigger from incidental motion.
+   */
+  cooldownMs: 30_000,
   /**
    * Three jolts inside the window means two direction reversals — the
    * signature of a human shaking an object, not a phone being picked up

--- a/packages/web/app/hooks/detect-shake.ts
+++ b/packages/web/app/hooks/detect-shake.ts
@@ -25,18 +25,22 @@ export type ShakeOptions = {
 export const DEFAULT_SHAKE_OPTIONS: ShakeOptions = {
   /**
    * User-acceleration magnitude (m/s², excluding gravity) that counts as a
-   * "jolt". 12 comfortably catches a purposeful shake on most phones and
-   * ignores normal handling, walking, and pocketing. Tune upward if we see
-   * false positives in the wild; the old 15 was too strict — real shakes
-   * often peak around 12–25 depending on grip and device.
+   * "jolt". A deliberate shake peaks around 15–25 m/s²; a single hard bump
+   * (setting the phone down, the pad slapping the wall) can cross 12 but
+   * rarely reaches 14. Paired with requiredJolts=3 this keeps incidental
+   * handling from firing the report dialog.
    */
-  threshold: 12,
+  threshold: 14,
   /** Jolts older than this (ms) are pruned from the rolling window. */
   windowMs: 1000,
   /** After firing, suppress further fires for this duration (ms). */
   cooldownMs: 3000,
-  /** Two direction reversals inside the window is enough to mean "shake". */
-  requiredJolts: 2,
+  /**
+   * Three jolts inside the window means two direction reversals — the
+   * signature of a human shaking an object, not a phone being picked up
+   * or jostled in a pocket.
+   */
+  requiredJolts: 3,
 };
 
 export const initialShakeState = (): ShakeState => ({ joltTimestamps: [], lastFireAt: null });

--- a/packages/web/app/lib/__tests__/user-preferences-db.test.ts
+++ b/packages/web/app/lib/__tests__/user-preferences-db.test.ts
@@ -1,7 +1,13 @@
 import 'fake-indexeddb/auto';
 import { openDB } from 'idb';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { getPreference, setPreference, removePreference } from '../user-preferences-db';
+import {
+  getPreference,
+  setPreference,
+  removePreference,
+  getShakeToReportDismissed,
+  setShakeToReportDismissed,
+} from '../user-preferences-db';
 import { DEFAULT_LOGBOOK_PREFERENCES } from '../logbook-preferences';
 
 const DB_NAME = 'boardsesh-user-preferences';
@@ -158,6 +164,29 @@ describe('user-preferences-db', () => {
       // Second read should return from IndexedDB (localStorage is already cleared)
       const result = await getPreference<string>('climbListViewMode');
       expect(result).toBe('grid');
+    });
+  });
+
+  describe('shakeToReport:dismissed', () => {
+    it('defaults to false when the preference has never been set', async () => {
+      await expect(getShakeToReportDismissed()).resolves.toBe(false);
+    });
+
+    it('round-trips true through IndexedDB', async () => {
+      await setShakeToReportDismissed(true);
+      await expect(getShakeToReportDismissed()).resolves.toBe(true);
+    });
+
+    it('can be cleared by writing false', async () => {
+      await setShakeToReportDismissed(true);
+      await setShakeToReportDismissed(false);
+      await expect(getShakeToReportDismissed()).resolves.toBe(false);
+    });
+
+    it('coerces non-true stored values to false (defensive)', async () => {
+      // Simulate a legacy or corrupted value that isn't strictly boolean true.
+      await setPreference('shakeToReport:dismissed', 'yes' as unknown as boolean);
+      await expect(getShakeToReportDismissed()).resolves.toBe(false);
     });
   });
 

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -11,6 +11,7 @@ export type UserPreferenceKeyMap = {
   'swipeHint:queueBarSeen': boolean;
   'swipeHint:logbookSeen': boolean;
   tickBarExpanded: boolean;
+  'shakeToReport:dismissed': boolean;
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration
@@ -100,6 +101,22 @@ export const setAlwaysTickInApp = async (enabled: boolean): Promise<void> => {
 export type { GradeDisplayFormat } from './grade-colors';
 // Re-export so existing consumers don't break.
 // The canonical definition lives in grade-colors.ts.
+
+/**
+ * Get the "shake to report bug" dismissed preference.
+ * When true, the shake detector stays detached for that user.
+ */
+export const getShakeToReportDismissed = async (): Promise<boolean> => {
+  const value = await getPreference<boolean>('shakeToReport:dismissed');
+  return value === true;
+};
+
+/**
+ * Persist the user's decision to disable shake-to-report.
+ */
+export const setShakeToReportDismissed = async (dismissed: boolean): Promise<void> => {
+  await setPreference('shakeToReport:dismissed', dismissed);
+};
 
 /**
  * Get the grade display format preference.


### PR DESCRIPTION
- Raise DEFAULT_SHAKE_OPTIONS threshold (12 -> 14 m/s^2) and requiredJolts
  (2 -> 3) so a single bump or pocket jostle no longer fires the dialog;
  only a sustained deliberate shake does.
- Add a "Don't show this again" escape hatch to the shake-triggered bug
  report dialog. Tapping it persists shakeToReport:dismissed=true to
  IndexedDB via the existing user-preferences store and confirms with a
  snackbar pointing the user at the avatar menu for manual reports.
- Re-mount ShakeToReportProvider in the persistent session wrapper
  (previously removed in 8625b249 when the feature was too sensitive).
- Add a generic secondaryAction prop to FeedbackDialog / BugReportDialog
  so callers can surface a muted action below the form without changing
  the form's own API.

https://claude.ai/code/session_01ZU39hb3WCfz3dK5iuxKCdq