### PR TITLE
fix(search): guard searchParamsToUrlParams against undefined numeric fields

### DIFF
--- a/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { BoardDetails, SearchRequestPagination } from '@/app/lib/types';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+
+const mockUpdateFilters = vi.fn();
+let mockUISearchParams: SearchRequestPagination = { ...DEFAULT_SEARCH_PARAMS };
+
+vi.mock('@/app/components/queue-control/ui-searchparams-provider', () => ({
+  useUISearchParams: () => ({
+    uiSearchParams: mockUISearchParams,
+    updateFilters: mockUpdateFilters,
+  }),
+}));
+
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ isAuthenticated: false }),
+}));
+
+vi.mock('@/app/components/providers/auth-modal-provider', () => ({
+  useAuthModal: () => ({ openAuthModal: vi.fn() }),
+}));
+
+vi.mock('../search-climb-name-input', () => ({
+  default: () => null,
+}));
+
+vi.mock('../setter-name-select', () => ({
+  default: () => null,
+}));
+
+vi.mock('../climb-hold-search-form', () => ({
+  default: () => null,
+}));
+
+vi.mock('../search-summary-utils', () => ({
+  getQualityPanelSummary: () => '',
+  getStatusPanelSummary: () => '',
+  getUserPanelSummary: () => '',
+  getHoldsPanelSummary: () => '',
+}));
+
+import AccordionSearchForm from '../accordion-search-form';
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 1,
+  set_ids: [],
+  size_name: '12 x 12',
+} as unknown as BoardDetails;
+
+describe('AccordionSearchForm — numeric handlers never emit undefined', () => {
+  beforeEach(() => {
+    mockUpdateFilters.mockClear();
+    mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS };
+  });
+
+  // Regression for Sentry issues 7434008446 / 7435688419 / 7439815956:
+  // clearing a numeric input previously dispatched `undefined`, which then
+  // crashed `searchParamsToUrlParams` in mobile Safari. The handlers must emit
+  // 0 (the DEFAULT_SEARCH_PARAMS sentinel) instead.
+  const findNumericInputs = () =>
+    screen
+      .getAllByPlaceholderText('Any')
+      .filter((el): el is HTMLInputElement => (el as HTMLInputElement).type === 'number');
+
+  it('Min Ascents emits 0 when cleared', () => {
+    mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS, minAscents: 5 };
+    render(<AccordionSearchForm boardDetails={boardDetails} />);
+    // Source order: [0]=Min Ascents, [1]=Min Rating.
+    const minAscents = findNumericInputs()[0];
+    expect(minAscents.value).toBe('5');
+
+    fireEvent.change(minAscents, { target: { value: '' } });
+    const lastCall = mockUpdateFilters.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual({ minAscents: 0 });
+    expect(lastCall?.minAscents).not.toBeUndefined();
+  });
+
+  it('Min Rating emits 0 when cleared', () => {
+    mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS, minRating: 2.5 };
+    render(<AccordionSearchForm boardDetails={boardDetails} />);
+    const minRating = findNumericInputs()[1];
+    expect(minRating.value).toBe('2.5');
+
+    fireEvent.change(minRating, { target: { value: '' } });
+    const lastCall = mockUpdateFilters.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual({ minRating: 0 });
+    expect(lastCall?.minRating).not.toBeUndefined();
+  });
+
+  it('Min Ascents emits the typed number verbatim', () => {
+    render(<AccordionSearchForm boardDetails={boardDetails} />);
+    const minAscents = findNumericInputs()[0];
+    fireEvent.change(minAscents, { target: { value: '12' } });
+    expect(mockUpdateFilters.mock.calls.at(-1)?.[0]).toEqual({ minAscents: 12 });
+  });
+});

--- a/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
@@ -77,6 +77,76 @@ describe('recent-searches-storage', () => {
     });
   });
 
+  describe('sanitization of corrupt persisted entries', () => {
+    it('should replace undefined numeric fields with defaults on read', async () => {
+      // Seed IndexedDB with the exact corrupt shape that crashed iOS Safari:
+      // numeric filter fields stored as `undefined`. (Object.assign keeps the
+      // property present-with-undefined-value, which is what JSON parsing of
+      // older entries produced when the form wrote `|| undefined`.)
+      const corruptEntry: RecentSearch = {
+        id: 'corrupt-1',
+        label: 'Corrupt search',
+        filters: {
+          minGrade: undefined,
+          maxGrade: undefined,
+          minAscents: undefined,
+          minRating: undefined,
+          gradeAccuracy: undefined,
+          name: 'climb',
+        } as Partial<import('@/app/lib/types').SearchRequestPagination>,
+        timestamp: Date.now(),
+      };
+      const db = await openDB(DB_NAME, 1);
+      await db.put(STORE_NAME, [corruptEntry], 'recent');
+      db.close();
+
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].filters.minGrade).toBe(0);
+      expect(results[0].filters.maxGrade).toBe(0);
+      expect(results[0].filters.minAscents).toBe(0);
+      expect(results[0].filters.minRating).toBe(0);
+      expect(results[0].filters.gradeAccuracy).toBe(0);
+      expect(results[0].filters.name).toBe('climb');
+    });
+
+    it('should write the sanitized version back to IndexedDB', async () => {
+      const corruptEntry: RecentSearch = {
+        id: 'corrupt-1',
+        label: 'Corrupt search',
+        filters: { minGrade: undefined, maxGrade: 5 } as Partial<
+          import('@/app/lib/types').SearchRequestPagination
+        >,
+        timestamp: Date.now(),
+      };
+      const db = await openDB(DB_NAME, 1);
+      await db.put(STORE_NAME, [corruptEntry], 'recent');
+      db.close();
+
+      // First read sanitizes and writes back.
+      await getRecentSearches();
+
+      // Read directly from IndexedDB to confirm the corrupt undefined is gone.
+      const db2 = await openDB(DB_NAME, 1);
+      const stored = (await db2.get(STORE_NAME, 'recent')) as RecentSearch[];
+      db2.close();
+      expect(stored[0].filters.minGrade).toBe(0);
+      expect(stored[0].filters.maxGrade).toBe(5);
+    });
+
+    it('should sanitize undefined numeric fields on write', async () => {
+      await addRecentSearch('From form', {
+        minAscents: undefined,
+        minGrade: 7,
+      } as Partial<import('@/app/lib/types').SearchRequestPagination>);
+
+      const results = await getRecentSearches();
+      expect(results).toHaveLength(1);
+      expect(results[0].filters.minAscents).toBe(0);
+      expect(results[0].filters.minGrade).toBe(7);
+    });
+  });
+
   describe('localStorage migration', () => {
     it('should migrate recent searches from localStorage on first read', async () => {
       const legacyData: RecentSearch[] = [

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -194,6 +194,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
               <TextField
                 type="number"
                 slotProps={{ htmlInput: { min: 1 } }}
+                // 0 is the "no filter" sentinel (DEFAULT_SEARCH_PARAMS.minAscents),
+                // so render it as the empty placeholder rather than a literal "0".
                 value={uiSearchParams.minAscents || ''}
                 onChange={(e) => updateFilters({ minAscents: Number(e.target.value) || 0 })}
                 className={styles.fullWidth}
@@ -206,6 +208,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
               <TextField
                 type="number"
                 slotProps={{ htmlInput: { min: 1.0, max: 3.0, step: 0.1 } }}
+                // 0 is the "no filter" sentinel (DEFAULT_SEARCH_PARAMS.minRating),
+                // so render it as the empty placeholder rather than a literal "0".
                 value={uiSearchParams.minRating || ''}
                 onChange={(e) => updateFilters({ minRating: Number(e.target.value) || 0 })}
                 className={styles.fullWidth}

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -76,7 +76,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
         <div className={styles.gradeRow}>
           <MuiSelect
             value={uiSearchParams.minGrade || 0}
-            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', e.target.value || undefined)}
+            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('min', Number(e.target.value) || 0)}
             className={styles.fullWidth}
             size="small"
             displayEmpty
@@ -91,7 +91,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
           </MuiSelect>
           <MuiSelect
             value={uiSearchParams.maxGrade || 0}
-            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', e.target.value || undefined)}
+            onChange={(e: SelectChangeEvent<number>) => handleGradeChange('max', Number(e.target.value) || 0)}
             className={styles.fullWidth}
             size="small"
             displayEmpty
@@ -194,8 +194,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
               <TextField
                 type="number"
                 slotProps={{ htmlInput: { min: 1 } }}
-                value={uiSearchParams.minAscents ?? ''}
-                onChange={(e) => updateFilters({ minAscents: Number(e.target.value) || undefined })}
+                value={uiSearchParams.minAscents || ''}
+                onChange={(e) => updateFilters({ minAscents: Number(e.target.value) || 0 })}
                 className={styles.fullWidth}
                 placeholder="Any"
                 size="small"
@@ -206,8 +206,8 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
               <TextField
                 type="number"
                 slotProps={{ htmlInput: { min: 1.0, max: 3.0, step: 0.1 } }}
-                value={uiSearchParams.minRating ?? ''}
-                onChange={(e) => updateFilters({ minRating: Number(e.target.value) || undefined })}
+                value={uiSearchParams.minRating || ''}
+                onChange={(e) => updateFilters({ minRating: Number(e.target.value) || 0 })}
                 className={styles.fullWidth}
                 placeholder="Any"
                 size="small"
@@ -219,7 +219,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
             <span className={styles.fieldLabel}>Grade Accuracy</span>
             <MuiSelect
               value={uiSearchParams.gradeAccuracy ?? 0}
-              onChange={(e) => updateFilters({ gradeAccuracy: e.target.value || undefined })}
+              onChange={(e) => updateFilters({ gradeAccuracy: Number(e.target.value) || 0 })}
               className={styles.fullWidth}
               size="small"
               MenuProps={{ disableScrollLock: true }}

--- a/packages/web/app/components/search-drawer/recent-searches-storage.ts
+++ b/packages/web/app/components/search-drawer/recent-searches-storage.ts
@@ -1,5 +1,6 @@
 import { type IDBPDatabase, openDB } from 'idb';
 import type { SearchRequestPagination } from '@/app/lib/types';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 
 export type RecentSearch = {
   id: string;
@@ -15,6 +16,31 @@ const STORE_NAME = 'searches';
 const STORE_KEY = 'recent';
 const MAX_ITEMS = 10;
 const LEGACY_STORAGE_KEY = 'boardsesh_recent_searches';
+
+// Numeric filter fields that the form historically wrote as `undefined` and
+// that searchParamsToUrlParams used to crash on. Cleaned up on read.
+const NUMERIC_FILTER_FIELDS = ['minGrade', 'maxGrade', 'minAscents', 'minRating', 'gradeAccuracy'] as const;
+
+/**
+ * Replace `undefined` numeric fields with their defaults. Older entries
+ * persisted by the search drawer can contain `undefined` for these fields,
+ * which violates the SearchRequestPagination type and crashed serialization
+ * on iOS (see Sentry issues 7434008446 / 7435688419 / 7439815956).
+ */
+function sanitizeFilters(filters: Partial<SearchRequestPagination>): {
+  filters: Partial<SearchRequestPagination>;
+  changed: boolean;
+} {
+  let changed = false;
+  const cleaned: Partial<SearchRequestPagination> = { ...filters };
+  for (const field of NUMERIC_FILTER_FIELDS) {
+    if (field in cleaned && cleaned[field] === undefined) {
+      cleaned[field] = DEFAULT_SEARCH_PARAMS[field];
+      changed = true;
+    }
+  }
+  return { filters: cleaned, changed };
+}
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -45,13 +71,28 @@ export async function getRecentSearches(): Promise<RecentSearch[]> {
   try {
     const db = await initDB();
     if (!db) return [];
-    const data = await db.get(STORE_NAME, STORE_KEY);
-    if (data) return data as RecentSearch[];
+    const data = (await db.get(STORE_NAME, STORE_KEY)) as RecentSearch[] | undefined;
+    if (data) {
+      let anyChanged = false;
+      const cleaned = data.map((entry) => {
+        const { filters, changed } = sanitizeFilters(entry.filters);
+        if (changed) anyChanged = true;
+        return changed ? { ...entry, filters } : entry;
+      });
+      // One-time write-back so the corrupt undefined values stop coming back on every read.
+      if (anyChanged) {
+        await db.put(STORE_NAME, cleaned, STORE_KEY);
+      }
+      return cleaned;
+    }
 
     // Attempt one-time migration from localStorage
     const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
     if (legacy) {
-      const parsed = JSON.parse(legacy) as RecentSearch[];
+      const parsed = (JSON.parse(legacy) as RecentSearch[]).map((entry) => ({
+        ...entry,
+        filters: sanitizeFilters(entry.filters).filters,
+      }));
       await db.put(STORE_NAME, parsed, STORE_KEY);
       localStorage.removeItem(LEGACY_STORAGE_KEY);
       return parsed;
@@ -67,8 +108,9 @@ export async function getRecentSearches(): Promise<RecentSearch[]> {
 export async function addRecentSearch(label: string, filters: Partial<SearchRequestPagination>): Promise<void> {
   if (typeof window === 'undefined') return;
   try {
+    const sanitized = sanitizeFilters(filters).filters;
     const existing = await getRecentSearches();
-    const filterKey = getFilterKey(filters);
+    const filterKey = getFilterKey(sanitized);
 
     // Remove duplicate if exists
     const deduplicated = existing.filter((s) => getFilterKey(s.filters) !== filterKey);
@@ -76,7 +118,7 @@ export async function addRecentSearch(label: string, filters: Partial<SearchRequ
     const newEntry: RecentSearch = {
       id: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
       label,
-      filters,
+      filters: sanitized,
       timestamp: Date.now(),
     };
 

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -140,6 +140,49 @@ describe('searchParamsToUrlParams', () => {
 
     expect(result.toString()).toBe('maxGrade=5');
   });
+
+  it('should treat undefined numeric fields as defaults without throwing', () => {
+    // Regression: a recent-search pill tap on iOS Safari was crashing because
+    // IndexedDB-persisted filters contained `undefined` for minGrade/maxGrade/
+    // minAscents/minRating/gradeAccuracy, and the serializer called .toString()
+    // on them. The boundary must coalesce undefined to the default.
+    const corrupt = {
+      ...DEFAULT_SEARCH_PARAMS,
+      minGrade: undefined,
+      maxGrade: undefined,
+      minAscents: undefined,
+      minRating: undefined,
+      gradeAccuracy: undefined,
+    } as unknown as SearchRequestPagination;
+
+    const result = searchParamsToUrlParams(corrupt);
+    expect(result.toString()).toBe('');
+  });
+
+  it('should treat undefined non-numeric fields as defaults without throwing', () => {
+    const corrupt = {
+      ...DEFAULT_SEARCH_PARAMS,
+      sortBy: undefined,
+      sortOrder: undefined,
+      name: undefined,
+      onlyClassics: undefined,
+      onlyTallClimbs: undefined,
+      settername: undefined,
+      setternameSuggestion: undefined,
+      holdsFilter: undefined,
+      hideAttempted: undefined,
+      hideCompleted: undefined,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: undefined,
+      onlyDrafts: undefined,
+      projectsOnly: undefined,
+      page: undefined,
+      pageSize: undefined,
+    } as unknown as SearchRequestPagination;
+
+    const result = searchParamsToUrlParams(corrupt);
+    expect(result.toString()).toBe('');
+  });
 });
 
 describe('parsedRouteSearchParamsToSearchParams', () => {

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -66,29 +66,32 @@ export function parseBoardRouteParams<T extends BoardRouteParameters>(
   return parsedParams as T extends BoardRouteParametersWithUuid ? never : ParsedBoardRouteParameters;
 }
 
-export const searchParamsToUrlParams = ({
-  gradeAccuracy,
-  maxGrade,
-  minGrade,
-  minAscents,
-  minRating,
-  sortBy,
-  sortOrder,
-  name,
-  onlyClassics,
-  onlyTallClimbs,
-  settername,
-  setternameSuggestion,
-  holdsFilter,
-  hideAttempted,
-  hideCompleted,
-  showOnlyAttempted,
-  showOnlyCompleted,
-  onlyDrafts,
-  projectsOnly,
-  page,
-  pageSize,
-}: SearchRequestPagination): URLSearchParams => {
+export const searchParamsToUrlParams = (input: SearchRequestPagination): URLSearchParams => {
+  // Coalesce any missing/undefined fields to their defaults. Stored recent searches
+  // (IndexedDB) and partial filter updates can leak undefined values into this path,
+  // which would otherwise crash on `.toString()`.
+  const gradeAccuracy = input.gradeAccuracy ?? DEFAULT_SEARCH_PARAMS.gradeAccuracy;
+  const maxGrade = input.maxGrade ?? DEFAULT_SEARCH_PARAMS.maxGrade;
+  const minGrade = input.minGrade ?? DEFAULT_SEARCH_PARAMS.minGrade;
+  const minAscents = input.minAscents ?? DEFAULT_SEARCH_PARAMS.minAscents;
+  const minRating = input.minRating ?? DEFAULT_SEARCH_PARAMS.minRating;
+  const sortBy = input.sortBy ?? DEFAULT_SEARCH_PARAMS.sortBy;
+  const sortOrder = input.sortOrder ?? DEFAULT_SEARCH_PARAMS.sortOrder;
+  const name = input.name ?? DEFAULT_SEARCH_PARAMS.name;
+  const onlyClassics = input.onlyClassics ?? DEFAULT_SEARCH_PARAMS.onlyClassics;
+  const onlyTallClimbs = input.onlyTallClimbs ?? DEFAULT_SEARCH_PARAMS.onlyTallClimbs;
+  const settername = input.settername ?? DEFAULT_SEARCH_PARAMS.settername;
+  const setternameSuggestion = input.setternameSuggestion ?? DEFAULT_SEARCH_PARAMS.setternameSuggestion;
+  const holdsFilter = input.holdsFilter ?? DEFAULT_SEARCH_PARAMS.holdsFilter;
+  const hideAttempted = input.hideAttempted ?? DEFAULT_SEARCH_PARAMS.hideAttempted;
+  const hideCompleted = input.hideCompleted ?? DEFAULT_SEARCH_PARAMS.hideCompleted;
+  const showOnlyAttempted = input.showOnlyAttempted ?? DEFAULT_SEARCH_PARAMS.showOnlyAttempted;
+  const showOnlyCompleted = input.showOnlyCompleted ?? DEFAULT_SEARCH_PARAMS.showOnlyCompleted;
+  const onlyDrafts = input.onlyDrafts ?? DEFAULT_SEARCH_PARAMS.onlyDrafts;
+  const projectsOnly = input.projectsOnly ?? DEFAULT_SEARCH_PARAMS.projectsOnly;
+  const page = input.page ?? DEFAULT_SEARCH_PARAMS.page;
+  const pageSize = input.pageSize ?? DEFAULT_SEARCH_PARAMS.pageSize;
+
   const params: Record<string, string> = {};
 
   // Only add parameters that differ from defaults


### PR DESCRIPTION
Form handlers in accordion-search-form passed `|| undefined` for numeric
filter fields (minAscents, minRating, gradeAccuracy, minGrade, maxGrade),
violating the `number` type on SearchRequestPagination. Those undefined
values propagated through the spread in updateFilters, got persisted via
addRecentSearch into IndexedDB, and crashed mobile Safari the next time a
recent-search pill serialized the filter to the URL (`.toString()` on
undefined).

Normalize every field in searchParamsToUrlParams against DEFAULT_SEARCH_PARAMS
so already-corrupt IndexedDB entries stop throwing, and change the form
handlers to emit `0` (the existing "no filter" sentinel) so the runtime
matches the declared types going forward.