### PR TITLE
fix(board-search-map): guard Leaflet access after unmount

### DIFF
--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+/* eslint-disable import/first -- vi.hoisted mocks must appear before imports they mock. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+
+// Shared mock state. `vi.hoisted` runs before the `vi.mock` factory below
+// (which is itself hoisted above imports), so the factory can reference it.
+const { mockState, resetMockState } = vi.hoisted(() => {
+  type Handlers = { moveend: Array<() => void>; once: Array<() => void> };
+  type MockMap = {
+    setView: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    getCenter: ReturnType<typeof vi.fn>;
+    getZoom: ReturnType<typeof vi.fn>;
+    invalidateSize: ReturnType<typeof vi.fn>;
+    flyTo: ReturnType<typeof vi.fn>;
+  };
+  const state: { handlers: Handlers; map: MockMap | null; LMap: ReturnType<typeof vi.fn> | null } = {
+    handlers: { moveend: [], once: [] },
+    map: null,
+    LMap: null,
+  };
+
+  function buildMockMap(): MockMap {
+    const m: Partial<MockMap> = {};
+    m.setView = vi.fn(() => m as MockMap);
+    m.on = vi.fn((event: string, fn: () => void) => {
+      if (event === 'moveend') state.handlers.moveend.push(fn);
+      return m as MockMap;
+    });
+    m.off = vi.fn(() => {
+      state.handlers.moveend = [];
+      return m as MockMap;
+    });
+    m.once = vi.fn((event: string, fn: () => void) => {
+      if (event === 'moveend') state.handlers.once.push(fn);
+      return m as MockMap;
+    });
+    m.remove = vi.fn();
+    m.getCenter = vi.fn(() => ({ lat: 1, lng: 2 }));
+    m.getZoom = vi.fn(() => 12);
+    m.invalidateSize = vi.fn();
+    m.flyTo = vi.fn();
+    return m as MockMap;
+  }
+
+  return {
+    mockState: state,
+    resetMockState: () => {
+      state.handlers.moveend = [];
+      state.handlers.once = [];
+      state.map = buildMockMap();
+      state.LMap = vi.fn(() => state.map);
+    },
+  };
+});
+
+vi.mock('leaflet', () => {
+  const L = {
+    map: (...args: unknown[]) => mockState.LMap!(...args),
+    tileLayer: vi.fn(() => ({ addTo: vi.fn() })),
+    layerGroup: vi.fn(() => {
+      const layer = { addTo: vi.fn(() => layer), removeLayer: vi.fn() };
+      return layer;
+    }),
+    divIcon: vi.fn(() => ({})),
+    marker: vi.fn(() => ({ on: vi.fn(), addTo: vi.fn(), setIcon: vi.fn() })),
+  };
+  return { default: L, ...L };
+});
+
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+
+import BoardSearchMap from '../board-search-map';
+
+const baseProps = {
+  center: { lat: 0, lng: 0 },
+  zoom: 2,
+  boards: [],
+  selectedBoardUuid: null,
+  userCoords: null,
+  requestPermission: vi.fn(),
+  onBoardClick: vi.fn(),
+};
+
+describe('BoardSearchMap lifecycle', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Reproduces the production crash: during cleanup, Leaflet's internal
+  // teardown emits a `moveend`. Without our fix, that re-runs fireViewport,
+  // schedules a fresh setTimeout, and 250ms later calls getCenter() on a
+  // destroyed _mapPane. The fix is twofold:
+  //   1. `map.off('moveend')` runs BEFORE `map.remove()` so teardown events
+  //      can no longer reach fireViewport.
+  //   2. The setTimeout body checks cancelledRef as a belt-and-braces guard.
+  it('does not call map.getCenter() if Leaflet emits moveend during teardown', async () => {
+    vi.useFakeTimers();
+    const onViewportChange = vi.fn();
+
+    const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
+
+    // Simulate Leaflet's internal teardown emitting moveend during remove().
+    mockState.map!.remove.mockImplementation(() => {
+      mockState.handlers.moveend.forEach((fn: () => void) => fn());
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    // Cleanup must detach moveend BEFORE removing the map. With this order,
+    // remove()'s teardown emission finds no handlers and schedules nothing.
+    expect(mockState.map!.off).toHaveBeenCalledWith('moveend');
+    const offOrder = mockState.map!.off.mock.invocationCallOrder.at(-1)!;
+    const removeOrder = mockState.map!.remove.mock.invocationCallOrder.at(-1)!;
+    expect(offOrder).toBeLessThan(removeOrder);
+
+    mockState.map!.getCenter.mockClear();
+
+    // Advance well past the debounce. If a stale setTimeout slipped through,
+    // it would fire here and the cancelledRef guard catches it.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockState.map!.getCenter).not.toHaveBeenCalled();
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  // Even if a moveend slips through before unmount and schedules a debounced
+  // viewport timer, the cleanup's clearTimeout and the cancelledRef guard
+  // ensure the callback is a no-op against the destroyed map.
+  it('does not fire the debounced viewport callback against a destroyed map', async () => {
+    vi.useFakeTimers();
+    const onViewportChange = vi.fn();
+
+    const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      mockState.handlers.moveend.forEach((fn: () => void) => fn());
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    mockState.map!.getCenter.mockClear();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockState.map!.getCenter).not.toHaveBeenCalled();
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  // Per-invocation `cancelled` guard: if the component unmounts before the
+  // dynamic Leaflet import resolves, the import callback must bail out
+  // without creating a map. A shared ref would be reset by a subsequent
+  // mount and the stale callback would then create a second map on the
+  // (now reused) container.
+  it('does not initialize a Leaflet map when unmounted before the import resolves', async () => {
+    const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={vi.fn()} />);
+
+    // Synchronously unmount BEFORE letting microtasks flush.
+    unmount();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockState.LMap).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -79,6 +79,12 @@ export default function BoardSearchMap({
     const container = containerRef.current;
     if (!container) return;
 
+    // Per-invocation cancellation for the async Leaflet import. Must stay a
+    // local `let` (not a ref): under React Strict Mode the effect runs twice,
+    // and the first run's Promise.all callback must see its own `cancelled`
+    // — a shared ref would be reset to false by the second mount and the
+    // stale callback would create a second map on the same container.
+    let cancelled = false;
     cancelledRef.current = false;
     let resizeObserver: ResizeObserver | null = null;
 
@@ -91,7 +97,7 @@ export default function BoardSearchMap({
     // and attribution render unstyled.
     // @ts-expect-error — CSS dynamic import handled by Next.js bundler
     void Promise.all([import('leaflet'), import('leaflet/dist/leaflet.css')]).then(([L]) => {
-      if (cancelledRef.current || !containerRef.current) return;
+      if (cancelled || !containerRef.current) return;
 
       const map = L.map(containerRef.current, {
         zoomControl: true,
@@ -150,6 +156,7 @@ export default function BoardSearchMap({
     });
 
     return () => {
+      cancelled = true;
       cancelledRef.current = true;
       if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
       if (resizeObserver) {

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -61,6 +61,10 @@ export default function BoardSearchMap({
   const centerRef = useRef(center);
   const zoomRef = useRef(zoom);
   const selectedBoardUuidRef = useRef(selectedBoardUuid);
+  // Tracks whether the init effect has torn down. Guards deferred Leaflet
+  // access (debounced setTimeout, one-shot moveend) from firing after
+  // map.remove() — reading a destroyed map's _mapPane throws.
+  const cancelledRef = useRef(false);
   const [mapReady, setMapReady] = useState(false);
   const [pendingMyLocation, setPendingMyLocation] = useState(false);
 
@@ -75,7 +79,7 @@ export default function BoardSearchMap({
     const container = containerRef.current;
     if (!container) return;
 
-    let cancelled = false;
+    cancelledRef.current = false;
     let resizeObserver: ResizeObserver | null = null;
 
     const markersByUuid = markersByUuidRef.current;
@@ -87,7 +91,7 @@ export default function BoardSearchMap({
     // and attribution render unstyled.
     // @ts-expect-error — CSS dynamic import handled by Next.js bundler
     void Promise.all([import('leaflet'), import('leaflet/dist/leaflet.css')]).then(([L]) => {
-      if (cancelled || !containerRef.current) return;
+      if (cancelledRef.current || !containerRef.current) return;
 
       const map = L.map(containerRef.current, {
         zoomControl: true,
@@ -113,6 +117,11 @@ export default function BoardSearchMap({
         }
         if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
         viewportTimerRef.current = setTimeout(() => {
+          // A moveend can re-arm this timer mid-cleanup (e.g. from flyTo's
+          // tail animation or from invalidateSize during teardown). Bail out
+          // if the map has been removed — getCenter() would throw on a
+          // destroyed _mapPane.
+          if (cancelledRef.current || mapRef.current !== map) return;
           const c = map.getCenter();
           onViewportChangeRef.current({
             lat: Math.round(c.lat * 1000000) / 1000000,
@@ -141,13 +150,16 @@ export default function BoardSearchMap({
     });
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
       if (resizeObserver) {
         resizeObserver.disconnect();
         resizeObserver = null;
       }
       if (mapRef.current) {
+        // Detach moveend before remove() so teardown-time events can't
+        // re-arm fireViewport's setTimeout.
+        mapRef.current.off('moveend');
         mapRef.current.remove();
         mapRef.current = null;
         markersLayerRef.current = null;
@@ -267,6 +279,7 @@ export default function BoardSearchMap({
     // FIFO ordering — if that ever changes, fireViewport must not clear the flag
     // before the once() handler has read it.
     map.once('moveend', () => {
+      if (cancelledRef.current || mapRef.current !== map) return;
       const c = map.getCenter();
       onViewportChangeRef.current({
         lat: Math.round(c.lat * 1000000) / 1000000,


### PR DESCRIPTION
A debounced moveend handler re-arming during teardown left an orphaned
setTimeout that called map.getCenter() on a destroyed map, throwing
`Cannot read properties of undefined (reading '_leaflet_pos')`. The
one-shot moveend handler in flyToUserCoords had the same shape. Track
unmount with a ref and bail out of deferred callbacks; detach moveend
before map.remove() so teardown can't re-arm the debounce.

https://claude.ai/code/session_01UAWCXuszkP7ZQarfkMqixE