### PR TITLE
test: add isUnlisted coverage and remove redundant base variable

### DIFF
--- a/packages/backend/src/__tests__/boards-serial-privacy.test.ts
+++ b/packages/backend/src/__tests__/boards-serial-privacy.test.ts
@@ -128,6 +128,30 @@ describe('boardsBySerialNumbers privacy', () => {
       expect(board.locationName).toBeNull();
     });
 
+    it('strips name, description, and locationName from unlisted boards', async () => {
+      const unlistedBoard = makeDbBoard({
+        isPublic: false,
+        isUnlisted: true,
+        name: 'Hidden Wall',
+        description: 'Not discoverable',
+        locationName: 'Secret Location',
+      });
+      setupDbSelect([unlistedBoard]);
+
+      const results = await socialBoardQueries.boardsBySerialNumbers(
+        null,
+        { serialNumbers: ['SERIAL001'] },
+        makeUnauthCtx(),
+      );
+
+      expect(results).toHaveLength(1);
+      const board = results[0];
+      expect(board.name).toBe('kilter');
+      expect(board.description).toBeNull();
+      expect(board.locationName).toBeNull();
+      expect(board.isUnlisted).toBe(true);
+    });
+
     it('includes name, description, and locationName for public boards', async () => {
       const publicBoard = makeDbBoard({
         isPublic: true,

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -668,7 +668,7 @@ export const socialBoardQueries = {
     // Public boards include UGC fields; non-public boards get config only.
     if (!ctx.isAuthenticated) {
       return boards.map((board) => {
-        const base = {
+        return {
           uuid: board.uuid,
           slug: board.slug,
           ownerId: '',
@@ -705,8 +705,6 @@ export const socialBoardQueries = {
           distanceMeters: null,
           serialNumber: board.serialNumber ?? null,
         };
-
-        return base;
       });
     }
 


### PR DESCRIPTION
Adds explicit test asserting unlisted boards (isPublic: false, isUnlisted: true)
have their name/description/locationName stripped for unauthenticated callers,
matching the same gating behaviour as fully private boards.

Also inlines the redundant `const base = {...}; return base;` pattern in the
boardsBySerialNumbers unauthenticated map to a direct `return {...}`.

https://claude.ai/code/session_01UVufyHVDUFBihwcHNXp55Y