### PR TITLE
fix(board-search-map): use callable function type for LMap mock to satisfy strict TypeScript

### DIFF
--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -19,7 +19,7 @@ const { mockState, resetMockState } = vi.hoisted(() => {
     invalidateSize: ReturnType<typeof vi.fn>;
     flyTo: ReturnType<typeof vi.fn>;
   };
-  const state: { handlers: Handlers; map: MockMap | null; LMap: ReturnType<typeof vi.fn> | null } = {
+  const state: { handlers: Handlers; map: MockMap | null; LMap: ((...args: unknown[]) => MockMap | null) | null } = {
     handlers: { moveend: [], once: [] },
     map: null,
     LMap: null,


### PR DESCRIPTION
`ReturnType<typeof vi.fn>` resolves to `Mock<Procedure | Constructable>`, a union
that TypeScript refuses to call directly. Narrowing the state field to an explicit
function signature removes the ambiguity without changing runtime behavior.

https://claude.ai/code/session_019CnivmRRwvy7ayZCKgdwtD