### PR TITLE
fix(board-search-map): narrow map.off to specific handler; add at-destination test

### DIFF
--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, act, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
-import BoardSearchMap from '../board-search-map';
+import BoardSearchMap, { FLY_TO_ZOOM } from '../board-search-map';
 
 // Shared mock state. `vi.hoisted` runs before the `vi.mock` factory below
 // (which is itself hoisted above imports), so the factory can reference it.
@@ -79,6 +79,7 @@ vi.mock('leaflet', () => {
 
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
 
+
 const baseProps = {
   center: { lat: 0, lng: 0 },
   zoom: 2,
@@ -111,12 +112,9 @@ describe('BoardSearchMap lifecycle', () => {
 
     const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
     });
-
-    expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
 
     // Simulate Leaflet's internal teardown emitting moveend during remove().
     mockState.map!.remove.mockImplementation(() => {
@@ -155,9 +153,8 @@ describe('BoardSearchMap lifecycle', () => {
 
     const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
     });
 
     act(() => {
@@ -183,24 +180,20 @@ describe('BoardSearchMap lifecycle', () => {
   // handler would never fire. The guard detects this and calls onViewportChange
   // immediately instead of relying on a moveend that will never come.
   it('calls onViewportChange immediately when map is already at user location', async () => {
-    const FLY_TO_ZOOM = 13;
     mockState.map!.getCenter.mockReturnValue({ lat: 37.5, lng: -122.1 });
     mockState.map!.getZoom.mockReturnValue(FLY_TO_ZOOM);
 
     const onViewportChange = vi.fn();
     const userCoords = { latitude: 37.5, longitude: -122.1 };
 
-    const { getByRole } = render(
+    const { findByRole } = render(
       <BoardSearchMap {...baseProps} userCoords={userCoords} onViewportChange={onViewportChange} />,
     );
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    const button = await findByRole('button', { name: /my location/i });
 
     act(() => {
-      fireEvent.click(getByRole('button', { name: /my location/i }));
+      fireEvent.click(button);
     });
 
     expect(mockState.map!.flyTo).not.toHaveBeenCalled();

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, act, fireEvent } from '@testing-library/react';
 import React from 'react';
-import BoardSearchMap, { FLY_TO_ZOOM } from '../board-search-map';
+import BoardSearchMap from '../board-search-map';
 
 // Shared mock state. `vi.hoisted` runs before the `vi.mock` factory below
 // (which is itself hoisted above imports), so the factory can reference it.
@@ -191,6 +191,11 @@ describe('BoardSearchMap lifecycle', () => {
   // handler would never fire. The guard detects this and calls onViewportChange
   // immediately instead of relying on a moveend that will never come.
   it('calls onViewportChange immediately when map is already at user location', async () => {
+    // 13 matches the component's internal FLY_TO_ZOOM. Not exported — that
+    // would couple the public API to test infrastructure. If the component
+    // changes the zoom, this test fails: flyTo fires and the not.toHaveBeenCalled
+    // assertion below catches it.
+    const FLY_TO_ZOOM = 13;
     mockState.map!.getCenter.mockReturnValue({ lat: 37.5, lng: -122.1 });
     mockState.map!.getZoom.mockReturnValue(FLY_TO_ZOOM);
 
@@ -203,9 +208,7 @@ describe('BoardSearchMap lifecycle', () => {
 
     const button = await findByRole('button', { name: /my location/i });
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     expect(mockState.map!.flyTo).not.toHaveBeenCalled();
     expect(mockState.map!.once).not.toHaveBeenCalled();

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import BoardSearchMap from '../board-search-map';
 
@@ -32,8 +32,12 @@ const { mockState, resetMockState } = vi.hoisted(() => {
       if (event === 'moveend') state.handlers.moveend.push(fn);
       return m as MockMap;
     });
-    m.off = vi.fn(() => {
-      state.handlers.moveend = [];
+    m.off = vi.fn((event: string, fn?: () => void) => {
+      if (event === 'moveend') {
+        state.handlers.moveend = fn
+          ? state.handlers.moveend.filter((h) => h !== fn)
+          : [];
+      }
       return m as MockMap;
     });
     m.once = vi.fn((event: string, fn: () => void) => {
@@ -125,7 +129,7 @@ describe('BoardSearchMap lifecycle', () => {
 
     // Cleanup must detach moveend BEFORE removing the map. With this order,
     // remove()'s teardown emission finds no handlers and schedules nothing.
-    expect(mockState.map!.off).toHaveBeenCalledWith('moveend');
+    expect(mockState.map!.off).toHaveBeenCalledWith('moveend', expect.any(Function));
     const offOrder = mockState.map!.off.mock.invocationCallOrder.at(-1)!;
     const removeOrder = mockState.map!.remove.mock.invocationCallOrder.at(-1)!;
     expect(offOrder).toBeLessThan(removeOrder);
@@ -172,6 +176,36 @@ describe('BoardSearchMap lifecycle', () => {
 
     expect(mockState.map!.getCenter).not.toHaveBeenCalled();
     expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  // At-destination guard: if the map is already at the user's location and
+  // zoom level, flyTo would be a no-op and never emit moveend, so the once()
+  // handler would never fire. The guard detects this and calls onViewportChange
+  // immediately instead of relying on a moveend that will never come.
+  it('calls onViewportChange immediately when map is already at user location', async () => {
+    const FLY_TO_ZOOM = 13;
+    mockState.map!.getCenter.mockReturnValue({ lat: 37.5, lng: -122.1 });
+    mockState.map!.getZoom.mockReturnValue(FLY_TO_ZOOM);
+
+    const onViewportChange = vi.fn();
+    const userCoords = { latitude: 37.5, longitude: -122.1 };
+
+    const { getByRole } = render(
+      <BoardSearchMap {...baseProps} userCoords={userCoords} onViewportChange={onViewportChange} />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      fireEvent.click(getByRole('button', { name: /my location/i }));
+    });
+
+    expect(mockState.map!.flyTo).not.toHaveBeenCalled();
+    expect(mockState.map!.once).not.toHaveBeenCalled();
+    expect(onViewportChange).toHaveBeenCalledWith({ lat: 37.5, lng: -122.1, zoom: FLY_TO_ZOOM });
   });
 
   // Per-invocation `cancelled` guard: if the component unmounts before the

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, act, fireEvent, waitFor } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import BoardSearchMap, { FLY_TO_ZOOM } from '../board-search-map';
 
@@ -112,9 +112,16 @@ describe('BoardSearchMap lifecycle', () => {
 
     const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
 
-    await waitFor(() => {
-      expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
+    // Flush the async Leaflet import. waitFor can't be used here because its
+    // setInterval retry mechanism is frozen by vi.useFakeTimers(). Promise
+    // microtasks are unaffected by fake timers, so two ticks suffice: one for
+    // Promise.all to coalesce, one for the .then() to run. The explicit expect
+    // makes failure loud if the flush depth ever needs to change.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
     });
+    expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
 
     // Simulate Leaflet's internal teardown emitting moveend during remove().
     mockState.map!.remove.mockImplementation(() => {
@@ -153,9 +160,13 @@ describe('BoardSearchMap lifecycle', () => {
 
     const { unmount } = render(<BoardSearchMap {...baseProps} onViewportChange={onViewportChange} />);
 
-    await waitFor(() => {
-      expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
+    // Same flush approach as the teardown test above: fake timers freeze
+    // waitFor's setInterval, so we flush microtasks manually instead.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
     });
+    expect(mockState.handlers.moveend.length).toBeGreaterThan(0);
 
     act(() => {
       mockState.handlers.moveend.forEach((fn: () => void) => fn());

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -13,6 +13,7 @@ import markerStyles from './board-search-map.module.css';
 const VIEWPORT_DEBOUNCE_MS = 250;
 const MARKER_SIZE = 16;
 const MARKER_SIZE_SELECTED = 22;
+export const FLY_TO_ZOOM = 13;
 
 type BoardSearchMapProps = {
   center: { lat: number; lng: number };
@@ -170,8 +171,11 @@ export default function BoardSearchMap({
         // on Leaflet treating undefined the same as an omitted argument.
         if (fireViewportRef.current) {
           mapRef.current.off('moveend', fireViewportRef.current);
-        } else {
-          mapRef.current.off('moveend');
+        } else if (process.env.NODE_ENV !== 'production') {
+          throw new Error(
+            'BoardSearchMap: fireViewportRef.current is null while mapRef.current is set. ' +
+              'Both are assigned in the same .then() block — if this fires, they were decoupled.',
+          );
         }
         fireViewportRef.current = null;
         mapRef.current.remove();
@@ -267,7 +271,6 @@ export default function BoardSearchMap({
     // and locationResolved would stay false for the session. Report the current
     // viewport immediately and bail out instead.
     const current = map.getCenter();
-    const FLY_TO_ZOOM = 13;
     if (
       Math.abs(current.lat - coords.latitude) < 0.0001 &&
       Math.abs(current.lng - coords.longitude) < 0.0001 &&

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -65,6 +65,7 @@ export default function BoardSearchMap({
   // access (debounced setTimeout, one-shot moveend) from firing after
   // map.remove() — reading a destroyed map's _mapPane throws.
   const cancelledRef = useRef(false);
+  const fireViewportRef = useRef<(() => void) | null>(null);
   const [mapReady, setMapReady] = useState(false);
   const [pendingMyLocation, setPendingMyLocation] = useState(false);
 
@@ -139,6 +140,7 @@ export default function BoardSearchMap({
       // 'zoomend' before 'moveend'; a second handler on 'zoomend' would clear
       // programmaticMoveRef prematurely, letting the 'moveend' fireViewport and
       // the once('moveend') callback both fire, producing two updates per flyTo.
+      fireViewportRef.current = fireViewport;
       map.on('moveend', fireViewport);
 
       // Observe container size so we can correct Leaflet's internal size whenever
@@ -161,9 +163,11 @@ export default function BoardSearchMap({
         resizeObserver = null;
       }
       if (mapRef.current) {
-        // Detach moveend before remove() so teardown-time events can't
-        // re-arm fireViewport's setTimeout.
-        mapRef.current.off('moveend');
+        // Detach only our handler before remove() so teardown-time events
+        // can't re-arm fireViewport's setTimeout. Pass undefined when the
+        // ref is unset (shouldn't happen) to fall back to clearing all.
+        mapRef.current.off('moveend', fireViewportRef.current ?? undefined);
+        fireViewportRef.current = null;
         mapRef.current.remove();
         mapRef.current = null;
         markersLayerRef.current = null;

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -164,9 +164,15 @@ export default function BoardSearchMap({
       }
       if (mapRef.current) {
         // Detach only our handler before remove() so teardown-time events
-        // can't re-arm fireViewport's setTimeout. Pass undefined when the
-        // ref is unset (shouldn't happen) to fall back to clearing all.
-        mapRef.current.off('moveend', fireViewportRef.current ?? undefined);
+        // can't re-arm fireViewport's setTimeout. fireViewportRef is always
+        // set when mapRef is set (both assigned in the same .then()), but the
+        // else branch makes the fallback intent explicit rather than relying
+        // on Leaflet treating undefined the same as an omitted argument.
+        if (fireViewportRef.current) {
+          mapRef.current.off('moveend', fireViewportRef.current);
+        } else {
+          mapRef.current.off('moveend');
+        }
         fireViewportRef.current = null;
         mapRef.current.remove();
         mapRef.current = null;

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -13,8 +13,7 @@ import markerStyles from './board-search-map.module.css';
 const VIEWPORT_DEBOUNCE_MS = 250;
 const MARKER_SIZE = 16;
 const MARKER_SIZE_SELECTED = 22;
-export const FLY_TO_ZOOM = 13;
-
+const FLY_TO_ZOOM = 13;
 type BoardSearchMapProps = {
   center: { lat: number; lng: number };
   zoom: number;
@@ -164,18 +163,22 @@ export default function BoardSearchMap({
         resizeObserver = null;
       }
       if (mapRef.current) {
-        // Detach only our handler before remove() so teardown-time events
-        // can't re-arm fireViewport's setTimeout. fireViewportRef is always
-        // set when mapRef is set (both assigned in the same .then()), but the
-        // else branch makes the fallback intent explicit rather than relying
-        // on Leaflet treating undefined the same as an omitted argument.
+        // Detach our specific handler before remove() so teardown-time events
+        // can't re-arm fireViewport's setTimeout. fireViewportRef is always set
+        // when mapRef is set (both assigned in the same .then() block). If that
+        // invariant is ever broken by a future refactor, fall back to broad
+        // removal and log in dev so it surfaces without breaking teardown.
         if (fireViewportRef.current) {
           mapRef.current.off('moveend', fireViewportRef.current);
-        } else if (process.env.NODE_ENV !== 'production') {
-          throw new Error(
-            'BoardSearchMap: fireViewportRef.current is null while mapRef.current is set. ' +
-              'Both are assigned in the same .then() block — if this fires, they were decoupled.',
-          );
+        } else {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error(
+              'BoardSearchMap: fireViewportRef.current is null while mapRef.current is set; ' +
+                'falling back to broad map.off("moveend"). Both refs should be set in the ' +
+                'same .then() block — if this fires, they were decoupled.',
+            );
+          }
+          mapRef.current.off('moveend');
         }
         fireViewportRef.current = null;
         mapRef.current.remove();


### PR DESCRIPTION
Replace broad map.off('moveend') in cleanup with off('moveend', fireViewportRef)
so only our listener is removed rather than all moveend handlers including any
Leaflet-internal ones. Store the handler reference in a ref so the cleanup
closure can access it.

Add test covering the flyToUserCoords at-destination guard: when the map is
already at the target position and zoom, flyTo would be a no-op and moveend
would never fire, so the guard calls onViewportChange immediately instead.

https://claude.ai/code/session_015N2jHaFJYPsxzLdTgVBysG