### PR TITLE
fix(lint): move BoardSearchMap import to top to satisfy import/first rule

### DIFF
--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-/* eslint-disable import/first -- vi.hoisted mocks must appear before imports they mock. */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, act } from '@testing-library/react';
 import React from 'react';
+import BoardSearchMap from '../board-search-map';
 
 // Shared mock state. `vi.hoisted` runs before the `vi.mock` factory below
 // (which is itself hoisted above imports), so the factory can reference it.
@@ -74,8 +74,6 @@ vi.mock('leaflet', () => {
 });
 
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
-
-import BoardSearchMap from '../board-search-map';
 
 const baseProps = {
   center: { lat: 0, lng: 0 },


### PR DESCRIPTION
vi.mock() calls are hoisted by Vitest at runtime, so the import order
in source is irrelevant for test behavior. Placing the import at the top
removes the oxlint import/first violation.

https://claude.ai/code/session_01X8MuazuqYvT5btcxvGydfc