### PR TITLE
fix(create-climb): increase bottom offset so queue control bar doesn'…

### DIFF
--- a/packages/web/app/components/create-climb/create-climb-form.module.css
+++ b/packages/web/app/components/create-climb/create-climb-form.module.css
@@ -1,7 +1,7 @@
 .pageContainer {
   position: fixed;
   top: var(--safe-area-inset-top);
-  bottom: calc(120px + var(--safe-area-inset-bottom));
+  bottom: calc(180px + var(--safe-area-inset-bottom));
   left: 8px;
   right: 8px;
   display: flex;


### PR DESCRIPTION
…t hide controls

The .pageContainer reserved 120px at the bottom for the persistent bottom bar, but the bottom bar wrapper stacks the queue control bar (~60-100px) on top of the bottom tab bar (~72px), exceeding 120px. Bumping to 180px keeps the form's bottom action row (Save and friends) visible above the queue control bar.