### PR TITLE
chore(tests): tighten schema-drift CI and clean up test infra smells

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -61,19 +61,29 @@ jobs:
         with:
           fetch-depth: 50
 
-      # Flag (don't block) when shared Drizzle schema changes land without a
-      # parallel edit to the hand-maintained test DDL in schema-sql.ts. Keeps
-      # the two from silently drifting apart.
+      # Block when shared Drizzle schema changes land without a parallel edit
+      # to the hand-maintained test DDL in schema-sql.ts. Runs on PRs and on
+      # direct pushes to main so drift can't sneak in either way. If a schema
+      # change genuinely doesn't affect the backend test DDL, touch
+      # schema-sql.ts (e.g. update the header comment) to record the decision.
       - name: Check for test schema drift
-        if: github.event_name == 'pull_request'
         run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
-          git fetch --no-tags --depth=50 origin "$BASE" || true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
+            git fetch --no-tags --depth=50 origin "$BASE" || true
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              BASE="HEAD~1"
+            fi
+          fi
           changed=$(git diff --name-only "$BASE" "$HEAD" || true)
           if echo "$changed" | grep -qE '^packages/db/src/schema/'; then
             if ! echo "$changed" | grep -qE '^packages/backend/src/__tests__/schema-sql\.ts$'; then
-              echo "::warning title=Test schema may be stale::packages/db/src/schema/ changed but packages/backend/src/__tests__/schema-sql.ts was not. If your change added/removed columns the backend tests care about, mirror it there too."
+              echo "::error title=Test schema is stale::packages/db/src/schema/ changed but packages/backend/src/__tests__/schema-sql.ts was not. Mirror the change there, or touch schema-sql.ts to record that this schema change does not affect backend tests."
+              exit 1
             fi
           fi
 

--- a/packages/backend/src/__tests__/global-setup.ts
+++ b/packages/backend/src/__tests__/global-setup.ts
@@ -85,5 +85,15 @@ async function dropStaleWorkerDatabases(): Promise<void> {
 export default async function globalSetup() {
   await ensureInfra();
   if (process.env.SKIP_TEST_INFRA === '1') return;
-  await dropStaleWorkerDatabases();
+  try {
+    await dropStaleWorkerDatabases();
+  } catch (error) {
+    const masked = baseConnectionString.replace(/\/\/[^@]+@/, '//***@');
+    console.error(
+      `[test-infra] Failed to clean up stale worker databases via ${masked}. ` +
+        `Check that DATABASE_URL points to a reachable postgres admin DB with valid credentials.\n` +
+        `Original error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    throw error;
+  }
 }

--- a/packages/backend/src/__tests__/worker-db.ts
+++ b/packages/backend/src/__tests__/worker-db.ts
@@ -33,16 +33,19 @@ function buildWorkerDatabaseUrl(): string {
   return raw.replace(/\/[^/]+$/, `/${name}`);
 }
 
-// Module-load side effect: redirect DATABASE_URL to the worker's dedicated DB
-// BEFORE any ESM import can materialise `db/client`'s cached connection against
-// the template DB. Import worker-db.ts first in setupFiles.
+// Resolve once at module init using the original DATABASE_URL, then redirect
+// DATABASE_URL to it BEFORE any ESM import can materialise `db/client`'s
+// cached connection against the template DB. Import worker-db.ts first in
+// setupFiles.
+const WORKER_DATABASE_URL = buildWorkerDatabaseUrl();
+
 if (!process.env.__BOARDSESH_WORKER_DB_INITIALIZED__) {
-  process.env.DATABASE_URL = buildWorkerDatabaseUrl();
+  process.env.DATABASE_URL = WORKER_DATABASE_URL;
   process.env.__BOARDSESH_WORKER_DB_INITIALIZED__ = '1';
 }
 
 export function getWorkerDatabaseUrl(): string {
-  return buildWorkerDatabaseUrl();
+  return WORKER_DATABASE_URL;
 }
 
 let setupPromise: Promise<void> | null = null;

--- a/packages/moonboard-ocr/src/__tests__/helpers/test-utils.ts
+++ b/packages/moonboard-ocr/src/__tests__/helpers/test-utils.ts
@@ -2,9 +2,35 @@
  * Shared test utilities for validating parser results.
  */
 
-import { expect } from 'vite-plus/test';
+import { expect, beforeAll, afterAll } from 'vite-plus/test';
+import { createScheduler, createWorker } from 'tesseract.js';
 import type { ParseResult } from '../../types';
 import type { ExpectedClimbResult } from '../fixtures/expected-results';
+
+type Scheduler = Awaited<ReturnType<typeof createScheduler>>;
+
+/**
+ * Register beforeAll/afterAll hooks that spin up a tesseract scheduler with
+ * `workerCount` workers and tear it down after the surrounding describe.
+ * Returns an accessor; the scheduler isn't constructed until beforeAll runs.
+ */
+export function useTesseractScheduler(workerCount = 4): { current: () => Scheduler } {
+  let scheduler: Scheduler | undefined;
+  beforeAll(async () => {
+    scheduler = createScheduler();
+    const workers = await Promise.all(Array.from({ length: workerCount }, () => createWorker('eng')));
+    for (const w of workers) scheduler.addWorker(w);
+  }, 60_000);
+  afterAll(async () => {
+    if (scheduler) await scheduler.terminate();
+  });
+  return {
+    current: () => {
+      if (!scheduler) throw new Error('useTesseractScheduler: accessed before beforeAll ran');
+      return scheduler;
+    },
+  };
+}
 
 export type ValidationOptions = {
   /** Whether to validate OCR fields (name, setter, grades) */

--- a/packages/moonboard-ocr/src/__tests__/parser.canvas.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/parser.canvas.test.ts
@@ -9,38 +9,24 @@
  * different image processing pipelines. Hold detection should be consistent.
  */
 
-import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
+import { describe, it } from 'vite-plus/test';
 import path from 'path';
-import { createScheduler, createWorker } from 'tesseract.js';
 import { NodeCanvasImageProcessor } from './helpers/node-canvas-processor';
 import { parseWithProcessor } from '../parser';
 import { EXPECTED_RESULTS } from './fixtures/expected-results';
-import { validateParseResult } from './helpers/test-utils';
+import { useTesseractScheduler, validateParseResult } from './helpers/test-utils';
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
-type Scheduler = Awaited<ReturnType<typeof createScheduler>>;
-
 describe('MoonBoard OCR Parser (Canvas Implementation)', () => {
-  let scheduler: Scheduler;
-
-  beforeAll(async () => {
-    scheduler = createScheduler();
-    const workerCount = 4;
-    const workers = await Promise.all(Array.from({ length: workerCount }, () => createWorker('eng')));
-    for (const w of workers) scheduler.addWorker(w);
-  }, 60_000);
-
-  afterAll(async () => {
-    await scheduler.terminate();
-  });
+  const scheduler = useTesseractScheduler();
 
   for (const expected of EXPECTED_RESULTS) {
     describe(expected.fixture, () => {
       it.concurrent('should extract correct climb data', async () => {
         const processor = new NodeCanvasImageProcessor();
         await processor.load(path.join(FIXTURES_DIR, expected.fixture));
-        const result = await parseWithProcessor(processor, { scheduler });
+        const result = await parseWithProcessor(processor, { scheduler: scheduler.current() });
 
         validateParseResult(result, expected, {
           validateOcr: true,

--- a/packages/moonboard-ocr/src/__tests__/parser.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/parser.test.ts
@@ -5,39 +5,25 @@
  * Uses shared expected results from fixtures/expected-results.ts.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { describe, it, expect } from 'vite-plus/test';
 import path from 'path';
-import { createScheduler, createWorker } from 'tesseract.js';
 import { SharpImageProcessor } from '../image-processor/sharp-processor';
 import { parseWithProcessor } from '../parser-core';
 import { parseScreenshot } from '../parser';
 import { EXPECTED_RESULTS } from './fixtures/expected-results';
-import { validateParseResult } from './helpers/test-utils';
+import { useTesseractScheduler, validateParseResult } from './helpers/test-utils';
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
-type Scheduler = Awaited<ReturnType<typeof createScheduler>>;
-
 describe('MoonBoard OCR Parser (Sharp Implementation)', () => {
-  let scheduler: Scheduler;
-
-  beforeAll(async () => {
-    scheduler = createScheduler();
-    const workerCount = 4;
-    const workers = await Promise.all(Array.from({ length: workerCount }, () => createWorker('eng')));
-    for (const w of workers) scheduler.addWorker(w);
-  }, 60_000);
-
-  afterAll(async () => {
-    await scheduler.terminate();
-  });
+  const scheduler = useTesseractScheduler();
 
   for (const expected of EXPECTED_RESULTS) {
     describe(expected.fixture, () => {
       it.concurrent('should extract correct climb data', async () => {
         const processor = new SharpImageProcessor();
         await processor.load(path.join(FIXTURES_DIR, expected.fixture));
-        const result = await parseWithProcessor(processor, { scheduler });
+        const result = await parseWithProcessor(processor, { scheduler: scheduler.current() });
 
         validateParseResult(result, expected, {
           validateOcr: true,
@@ -52,7 +38,7 @@ describe('MoonBoard OCR Parser (Sharp Implementation)', () => {
   // this one-off check guards the thin file-path API that callers actually use.
   it('parseScreenshot wires a Sharp processor end-to-end', async () => {
     const expected = EXPECTED_RESULTS[0];
-    const result = await parseScreenshot(path.join(FIXTURES_DIR, expected.fixture), { scheduler });
+    const result = await parseScreenshot(path.join(FIXTURES_DIR, expected.fixture), { scheduler: scheduler.current() });
     expect(result.success).toBe(true);
     expect(result.climb).toBeDefined();
     expect(result.climb!.sourceFile).toBe(expected.fixture);


### PR DESCRIPTION
- Make the schema-sql.ts drift check blocking and run on direct pushes to main, not just PRs. The previous warning-only PR-only check let drift accumulate silently.
- Extract the duplicated tesseract scheduler beforeAll/afterAll from parser.test.ts and parser.canvas.test.ts into a shared `useTesseractScheduler` helper in test-utils.
- Cache the worker DATABASE_URL once at module init in worker-db.ts so getWorkerDatabaseUrl() stops re-deriving it on every call.
- Wrap dropStaleWorkerDatabases() in global-setup.ts with a try/catch that prints the (masked) admin URL and a hint when the admin connection fails, instead of dumping a raw postgres stack trace.