### PR TITLE
Disable shake-to-report bug feature

### DIFF
--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -30,7 +30,6 @@ import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
 import { FeedbackPromptBanner } from '../feedback/feedback-prompt-banner';
-import { ShakeToReportProvider } from '../feedback/shake-to-report-provider';
 
 const SeshSettingsDrawer = dynamic(() => import('../sesh-settings/sesh-settings-drawer'), {
   ssr: false,
@@ -62,7 +61,6 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
                   <RootBottomBar boardConfigs={boardConfigs} />
                   <RootSessionSummaryDialog />
                   <RootSeshSettingsDrawer />
-                  <ShakeToReportProvider />
                 </ProfileHeaderShareProvider>
               </StatsFilterBridgeProvider>
             </SearchDrawerBridgeProvider>


### PR DESCRIPTION
Remove ShakeToReportProvider from the root wrapper so shaking the device
no longer triggers the bug report dialog.

https://claude.ai/code/session_01SWj8W2HQgC2e43b4o2kZSg