### PR TITLE
Fix background color inconsistency, deduplicate route mark SVG, and clean up Promise.all mixing

### DIFF
--- a/mobile/scripts/generate-assets.ts
+++ b/mobile/scripts/generate-assets.ts
@@ -6,7 +6,7 @@ const MOBILE_ROOT = path.resolve(import.meta.dirname, '..');
 const REPO_ROOT = path.resolve(MOBILE_ROOT, '..');
 const SVG_ROOT = path.join(REPO_ROOT, 'svg');
 
-const SPLASH_BG = '#0A0A0A';
+const SPLASH_BG = '#0e0e10';
 
 const APP_ICON_SVG = path.join(SVG_ROOT, 'app-icon/icon-dark-1024.svg');
 const SPLASH_LOGO_SVG = path.join(SVG_ROOT, 'mark/route-mark.svg');

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { themeTokens } from '@/app/theme/theme-config';
+import { RouteMarkContextDots, RouteMarkHolds } from './route-mark-svg';
 
 type LogoProps = {
   size?: 'sm' | 'md' | 'lg';
@@ -15,42 +16,6 @@ const sizes = {
   md: { icon: 40, fontSize: 16, gap: 8 },
   lg: { icon: 52, fontSize: 20, gap: 10 },
 };
-
-const { holdGrey, contextGrey, purple, cyan, green, orange } = themeTokens.routeMark;
-
-/** Context dots -- subtle background holds that add texture at larger sizes */
-const ContextDots = () => (
-  <>
-    <ellipse cx="10" cy="12" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-10 10 12)" />
-    <ellipse cx="52" cy="16" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(20 52 16)" />
-    <ellipse cx="14" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(25 14 50)" />
-    <ellipse cx="54" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-15 54 50)" />
-    <ellipse cx="32" cy="32" rx="3.2" ry="2.2" fill={contextGrey} transform="rotate(5 32 32)" />
-    <ellipse cx="22" cy="28" rx="3" ry="2" fill={contextGrey} transform="rotate(-25 22 28)" />
-    <ellipse cx="44" cy="36" rx="3" ry="2" fill={contextGrey} transform="rotate(14 44 36)" />
-  </>
-);
-
-/** The 4 climbing holds (start, hand, foot, finish) arranged in a diamond */
-const Holds = () => (
-  <>
-    {/* Start hold -- purple */}
-    <ellipse cx="28" cy="10" rx="4" ry="2.8" fill={holdGrey} transform="rotate(-8 28 10)" />
-    <circle cx="28" cy="10" r="9" fill="none" stroke={purple} strokeWidth="2" />
-
-    {/* Hand hold -- cyan */}
-    <ellipse cx="46" cy="26" rx="4" ry="2.8" fill={holdGrey} transform="rotate(18 46 26)" />
-    <circle cx="46" cy="26" r="9" fill="none" stroke={cyan} strokeWidth="2" />
-
-    {/* Foot hold -- green */}
-    <ellipse cx="18" cy="38" rx="3.6" ry="2.6" fill={holdGrey} transform="rotate(-22 18 38)" />
-    <circle cx="18" cy="38" r="9" fill="none" stroke={green} strokeWidth="2" />
-
-    {/* Finish hold -- orange */}
-    <ellipse cx="32" cy="54" rx="4" ry="2.8" fill={holdGrey} transform="rotate(5 32 54)" />
-    <circle cx="32" cy="54" r="9" fill="none" stroke={orange} strokeWidth="2" />
-  </>
-);
 
 const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) => {
   const { icon, fontSize, gap } = sizes[size];
@@ -74,8 +39,8 @@ const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) =>
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Boardsesh logo"
       >
-        {showContext && <ContextDots />}
-        <Holds />
+        {showContext && <RouteMarkContextDots />}
+        <RouteMarkHolds />
       </svg>
       {showText && (
         <span

--- a/packages/web/app/components/brand/route-mark-svg.tsx
+++ b/packages/web/app/components/brand/route-mark-svg.tsx
@@ -1,0 +1,39 @@
+import { themeTokens } from '@/app/theme/theme-config';
+
+const { holdGrey, contextGrey, purple, cyan, green, orange } = themeTokens.routeMark;
+
+export function RouteMarkContextDots() {
+  return (
+    <>
+      <ellipse cx="10" cy="12" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-10 10 12)" />
+      <ellipse cx="52" cy="16" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(20 52 16)" />
+      <ellipse cx="14" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(25 14 50)" />
+      <ellipse cx="54" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-15 54 50)" />
+      <ellipse cx="32" cy="32" rx="3.2" ry="2.2" fill={contextGrey} transform="rotate(5 32 32)" />
+      <ellipse cx="22" cy="28" rx="3" ry="2" fill={contextGrey} transform="rotate(-25 22 28)" />
+      <ellipse cx="44" cy="36" rx="3" ry="2" fill={contextGrey} transform="rotate(14 44 36)" />
+    </>
+  );
+}
+
+export function RouteMarkHolds() {
+  return (
+    <>
+      {/* Start hold -- purple */}
+      <ellipse cx="28" cy="10" rx="4" ry="2.8" fill={holdGrey} transform="rotate(-8 28 10)" />
+      <circle cx="28" cy="10" r="9" fill="none" stroke={purple} strokeWidth="2" />
+
+      {/* Hand hold -- cyan */}
+      <ellipse cx="46" cy="26" rx="4" ry="2.8" fill={holdGrey} transform="rotate(18 46 26)" />
+      <circle cx="46" cy="26" r="9" fill="none" stroke={cyan} strokeWidth="2" />
+
+      {/* Foot hold -- green */}
+      <ellipse cx="18" cy="38" rx="3.6" ry="2.6" fill={holdGrey} transform="rotate(-22 18 38)" />
+      <circle cx="18" cy="38" r="9" fill="none" stroke={green} strokeWidth="2" />
+
+      {/* Finish hold -- orange */}
+      <ellipse cx="32" cy="54" rx="4" ry="2.8" fill={holdGrey} transform="rotate(5 32 54)" />
+      <circle cx="32" cy="54" r="9" fill="none" stroke={orange} strokeWidth="2" />
+    </>
+  );
+}

--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { ImageResponse } from 'next/og';
-import { themeTokens } from '@/app/theme/theme-config';
+import { RouteMarkContextDots, RouteMarkHolds } from '@/app/components/brand/route-mark-svg';
 
 export const runtime = 'edge';
 
 export const alt = 'Boardsesh - Train smarter on your climbing board';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
-
-const { holdGrey, contextGrey, purple, cyan, green, orange } = themeTokens.routeMark;
 
 export default function Image() {
   return new ImageResponse(
@@ -26,30 +24,8 @@ export default function Image() {
     >
       {/* Route mark */}
       <svg width="120" height="120" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-        {/* Context dots */}
-        <ellipse cx="10" cy="12" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-10 10 12)" />
-        <ellipse cx="52" cy="16" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(20 52 16)" />
-        <ellipse cx="14" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(25 14 50)" />
-        <ellipse cx="54" cy="50" rx="3.6" ry="2.4" fill={contextGrey} transform="rotate(-15 54 50)" />
-        <ellipse cx="32" cy="32" rx="3.2" ry="2.2" fill={contextGrey} transform="rotate(5 32 32)" />
-        <ellipse cx="22" cy="28" rx="3" ry="2" fill={contextGrey} transform="rotate(-25 22 28)" />
-        <ellipse cx="44" cy="36" rx="3" ry="2" fill={contextGrey} transform="rotate(14 44 36)" />
-
-        {/* Start hold -- purple */}
-        <ellipse cx="28" cy="10" rx="4" ry="2.8" fill={holdGrey} transform="rotate(-8 28 10)" />
-        <circle cx="28" cy="10" r="9" fill="none" stroke={purple} strokeWidth="2" />
-
-        {/* Hand hold -- cyan */}
-        <ellipse cx="46" cy="26" rx="4" ry="2.8" fill={holdGrey} transform="rotate(18 46 26)" />
-        <circle cx="46" cy="26" r="9" fill="none" stroke={cyan} strokeWidth="2" />
-
-        {/* Foot hold -- green */}
-        <ellipse cx="18" cy="38" rx="3.6" ry="2.6" fill={holdGrey} transform="rotate(-22 18 38)" />
-        <circle cx="18" cy="38" r="9" fill="none" stroke={green} strokeWidth="2" />
-
-        {/* Finish hold -- orange */}
-        <ellipse cx="32" cy="54" rx="4" ry="2.8" fill={holdGrey} transform="rotate(5 32 54)" />
-        <circle cx="32" cy="54" r="9" fill="none" stroke={orange} strokeWidth="2" />
+        <RouteMarkContextDots />
+        <RouteMarkHolds />
       </svg>
 
       {/* Brand name */}

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -192,7 +192,7 @@ export const darkTokens = {
     selectedHover: 'rgba(175, 45, 60, 0.30)',
     selectedLight: 'rgba(175, 45, 60, 0.12)',
     selectedBorder: '#8C4A52',
-    background: '#0E0E0E',
+    background: '#0e0e10',
     surface: '#1A1A1A',
     surfaceElevated: '#282828',
     inputSurface: '#FFFFFF',

--- a/packages/web/scripts/generate-icons.ts
+++ b/packages/web/scripts/generate-icons.ts
@@ -60,18 +60,18 @@ async function main() {
   const darkSvg512 = readFileSync(DARK_ICON_512_SVG);
 
   // Generate favicon PNGs at multiple sizes for the ICO container
-  const [png16, png32, png48, ...rest] = await Promise.all([
+  const [png16, png32, png48] = await Promise.all([
     sharp(darkSvg512).resize(16, 16).png().toBuffer(),
     sharp(darkSvg512).resize(32, 32).png().toBuffer(),
     sharp(darkSvg512).resize(48, 48).png().toBuffer(),
+  ]);
 
-    // Generate app icons from dark variant
+  // Generate app icons from dark variant
+  await Promise.all([
     sharp(darkSvg1024).resize(192, 192).png().toFile(resolve(webRoot, 'public/icons/icon-192.png')),
     sharp(darkSvg1024).resize(512, 512).png().toFile(resolve(webRoot, 'public/icons/icon-512.png')),
     sharp(darkSvg1024).resize(180, 180).png().toFile(resolve(webRoot, 'public/icons/apple-touch-icon.png')),
   ]);
-
-  void rest; // sharp toFile results, unused
 
   // Generate maskable icon: render the dark icon at 410px centered on a 512px dark canvas.
   // This gives ~10% padding on each side, keeping content within the maskable safe zone.


### PR DESCRIPTION
- Unify background color to #0e0e10 across mobile splash (was #0A0A0A) and
  dark theme token (was #0E0E0E), matching layout.tsx, manifest.ts, and OG image
- Extract route mark SVG shapes into shared route-mark-svg.tsx; logo.tsx and
  opengraph-image.tsx now import RouteMarkContextDots/RouteMarkHolds instead of
  duplicating the same JSX verbatim
- Split generate-icons.ts Promise.all into two homogeneous groups (toBuffer and
  toFile separately) to remove the fragile ...rest / void rest pattern

https://claude.ai/code/session_01Tx2n4SBQ9G39QomSzdyjbY