### PR TITLE
Remove hydration state check from ClimbsList component

### DIFF
--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -334,8 +334,6 @@ const ClimbsList = ({
   const visibleClimbs = useMemo(() => climbs.slice(0, visibleCount), [climbs, visibleCount]);
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
-  const [hydrated, setHydrated] = useState(false);
-  useEffect(() => setHydrated(true), []);
 
   const onClimbSelectRef = useRef(onClimbSelect);
   onClimbSelectRef.current = onClimbSelect;
@@ -645,7 +643,6 @@ const ClimbsList = ({
                           fetchPriority={index === 0 ? 'high' : undefined}
                           onSelect={() => handleClimbClickByIndex(index)}
                           onThumbnailClick={() => handleClimbThumbnailClickByIndex(index)}
-                          disableSwipe={!hydrated}
                           unsupported={unsupportedClimbs?.has(climb.uuid)}
                           needsBiggerBoard={upsizedClimbs?.has(climb.uuid)}
                           onNeedsBiggerBoard={handleNeedsBiggerBoard}


### PR DESCRIPTION
## Summary
Removed the hydration state management from the ClimbsList component, eliminating the need to conditionally disable swipe functionality based on whether the component has been hydrated on the client.

## Key Changes
- Removed `hydrated` state variable and its initialization effect
- Removed the `disableSwipe={!hydrated}` prop from the ClimbCard component, allowing swipe to be enabled by default

## Implementation Details
The hydration check was previously used to prevent swipe interactions during server-side rendering or initial hydration. By removing this check, the component now allows swipe functionality immediately without waiting for client-side hydration to complete. This simplifies the component logic and improves the user experience by enabling interactions sooner.

https://claude.ai/code/session_018BF1cHFYG57ESrqgkx49uh