### PR TITLE
Validate Instagram beta links at write time

### DIFF
--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -33,7 +33,11 @@ vi.mock('../lib/beta-link-thumbnails', () => ({
   isS3Configured: vi.fn(() => false),
 }));
 
-import { validateAndEnrichBetaLinkInsert } from '../graphql/resolvers/ticks/mutations';
+import {
+  escapeLikePattern,
+  validateAndEnrichBetaLinkInsert,
+  videoUrlForTickStatus,
+} from '../graphql/resolvers/ticks/mutations';
 
 const fetchMock = vi.fn(() => {
   throw new Error('fetch should not be called for non-Instagram URLs');
@@ -72,5 +76,41 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
     expect(result).toEqual({ thumbnail: null, foreignUsername: null });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('videoUrlForTickStatus', () => {
+  it('returns the URL for flash/send', () => {
+    const url = 'https://www.instagram.com/reel/ABC123/';
+    expect(videoUrlForTickStatus('flash', url)).toBe(url);
+    expect(videoUrlForTickStatus('send', url)).toBe(url);
+  });
+
+  it('returns null for attempt status (beta only attaches on successful ascents)', () => {
+    expect(videoUrlForTickStatus('attempt', 'https://www.instagram.com/reel/ABC123/')).toBeNull();
+  });
+
+  it('returns null when no URL is provided', () => {
+    expect(videoUrlForTickStatus('send', null)).toBeNull();
+    expect(videoUrlForTickStatus('send', undefined)).toBeNull();
+    expect(videoUrlForTickStatus('flash', '')).toBeNull();
+  });
+});
+
+describe('escapeLikePattern', () => {
+  it('escapes LIKE wildcards in shortcodes', () => {
+    expect(escapeLikePattern('A_B')).toBe('A\\_B');
+    expect(escapeLikePattern('A%B')).toBe('A\\%B');
+    expect(escapeLikePattern('A_B%C_D')).toBe('A\\_B\\%C\\_D');
+  });
+
+  it('escapes backslashes before adding new escape sequences', () => {
+    expect(escapeLikePattern('A\\B')).toBe('A\\\\B');
+    expect(escapeLikePattern('A\\_B')).toBe('A\\\\\\_B');
+  });
+
+  it('passes plain alphanumerics through unchanged', () => {
+    expect(escapeLikePattern('ABC123xyz')).toBe('ABC123xyz');
+    expect(escapeLikePattern('DLM2nf9S1h6')).toBe('DLM2nf9S1h6');
   });
 });

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbSelect } = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(() => {
+    throw new Error('db.select should not be called for non-Instagram URLs');
+  }),
+}));
+
+vi.mock('../db/client', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../events', () => ({
+  publishSocialEvent: vi.fn(),
+}));
+
+vi.mock('../jobs/inferred-session-builder', () => ({
+  assignInferredSession: vi.fn(),
+}));
+
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+
+vi.mock('../lib/beta-link-thumbnails', () => ({
+  cacheInstagramThumbnail: vi.fn(),
+  isS3Configured: vi.fn(() => false),
+}));
+
+import { validateAndEnrichBetaLinkInsert } from '../graphql/resolvers/ticks/mutations';
+
+const fetchMock = vi.fn(() => {
+  throw new Error('fetch should not be called for non-Instagram URLs');
+});
+
+describe('validateAndEnrichBetaLinkInsert (gate)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    mockDbSelect.mockClear();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('skips Instagram validation for TikTok URLs', async () => {
+    const result = await validateAndEnrichBetaLinkInsert(
+      'kilter',
+      '00000000-0000-0000-0000-000000000000',
+      'https://www.tiktok.com/@user/video/12345',
+    );
+
+    expect(result).toEqual({ thumbnail: null, foreignUsername: null });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('skips Instagram validation for short-form TikTok URLs', async () => {
+    const result = await validateAndEnrichBetaLinkInsert(
+      'tension',
+      '00000000-0000-0000-0000-000000000000',
+      'https://vm.tiktok.com/abc123',
+    );
+
+    expect(result).toEqual({ thumbnail: null, foreignUsername: null });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -33,6 +33,22 @@ vi.mock('../lib/beta-link-thumbnails', () => ({
   isS3Configured: vi.fn(() => false),
 }));
 
+// Stub the rate limiter; the gate test only cares about the early-return path
+// for non-Instagram URLs, where applyRateLimit shouldn't even be reached.
+const { mockApplyRateLimit } = vi.hoisted(() => ({
+  mockApplyRateLimit: vi.fn(async () => {}),
+}));
+vi.mock('../graphql/resolvers/shared/helpers', async () => {
+  const actual = await vi.importActual<typeof import('../graphql/resolvers/shared/helpers')>(
+    '../graphql/resolvers/shared/helpers',
+  );
+  return { ...actual, applyRateLimit: mockApplyRateLimit };
+});
+
+const fakeCtx = { userId: 'test-user', isAuthenticated: true } as unknown as Parameters<
+  typeof import('../graphql/resolvers/ticks/mutations').validateAndEnrichBetaLinkInsert
+>[0];
+
 import {
   escapeLikePattern,
   validateAndEnrichBetaLinkInsert,
@@ -47,6 +63,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
   beforeEach(() => {
     fetchMock.mockClear();
     mockDbSelect.mockClear();
+    mockApplyRateLimit.mockClear();
     vi.stubGlobal('fetch', fetchMock);
   });
 
@@ -56,6 +73,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
 
   it('skips Instagram validation for TikTok URLs', async () => {
     const result = await validateAndEnrichBetaLinkInsert(
+      fakeCtx,
       'kilter',
       '00000000-0000-0000-0000-000000000000',
       'https://www.tiktok.com/@user/video/12345',
@@ -68,6 +86,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
 
   it('skips Instagram validation for short-form TikTok URLs', async () => {
     const result = await validateAndEnrichBetaLinkInsert(
+      fakeCtx,
       'tension',
       '00000000-0000-0000-0000-000000000000',
       'https://vm.tiktok.com/abc123',
@@ -76,6 +95,16 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
     expect(result).toEqual({ thumbnail: null, foreignUsername: null });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the rate limiter for non-Instagram URLs', async () => {
+    await validateAndEnrichBetaLinkInsert(
+      fakeCtx,
+      'kilter',
+      '00000000-0000-0000-0000-000000000000',
+      'https://www.tiktok.com/@user/video/12345',
+    );
+    expect(mockApplyRateLimit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -49,11 +49,8 @@ const fakeCtx = { userId: 'test-user', isAuthenticated: true } as unknown as Par
   typeof import('../graphql/resolvers/ticks/mutations').validateAndEnrichBetaLinkInsert
 >[0];
 
-import {
-  escapeLikePattern,
-  validateAndEnrichBetaLinkInsert,
-  videoUrlForTickStatus,
-} from '../graphql/resolvers/ticks/mutations';
+import { validateAndEnrichBetaLinkInsert, videoUrlForTickStatus } from '../graphql/resolvers/ticks/mutations';
+import { escapeLikePattern } from '../utils/like-pattern';
 
 const fetchMock = vi.fn(() => {
   throw new Error('fetch should not be called for non-Instagram URLs');

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -3,6 +3,7 @@ import {
   fetchInstagramPageMetadata,
   InstagramBetaValidationError,
   instagramBetaValidationInternals,
+  instagramValidationCircuitForTesting,
   validateInstagramBetaLink,
 } from '../utils/instagram-beta-validation';
 import { getInstagramMediaId } from '../lib/instagram-meta';
@@ -13,6 +14,7 @@ describe('instagram-beta-validation', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal('fetch', fetchMock);
+    instagramValidationCircuitForTesting.reset();
   });
 
   it('extracts public metadata from instagram html', async () => {
@@ -168,6 +170,64 @@ describe('instagram-beta-validation', () => {
       imageUrl: 'https://cdn.example.com/image.jpg',
       mediaId: '123456789',
     });
+  });
+
+  it('skips the ordered-token fallback when any token is too short to be distinguishing', () => {
+    // "The Project" — "the" is 3 chars. The full phrase doesn't appear as a
+    // whole-word substring in this caption, but the tokens "the" and
+    // "project" do appear separately in order. Without the min-length guard
+    // the fallback would false-positive on any English text.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: the climb after our project debrief was tough',
+        'The Project',
+      ),
+    ).toBe(false);
+    // "Power Up" — "up" is 2 chars. Same risk.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: power moves and warming up first',
+        'Power Up',
+      ),
+    ).toBe(false);
+    // But the word-bounded substring path still matches when the full phrase
+    // appears — we don't gate that path on token length.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: sent The Project today',
+        'The Project',
+      ),
+    ).toBe(true);
+  });
+
+  it('still matches multi-word names when every token is long enough', () => {
+    // "Fell From Heaven" — all tokens >= 4 chars, fallback kicks in for
+    // captions that interleave noise between the climb-name tokens.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: fell down from the great heaven yesterday',
+        'Fell From Heaven',
+      ),
+    ).toBe(true);
+  });
+
+  it('opens the circuit after enough fetch failures and stops calling out', async () => {
+    fetchMock.mockRejectedValue(new Error('TimeoutError'));
+
+    // Trip the circuit. The threshold is 10; drive it past that.
+    for (let i = 0; i < 10; i++) {
+      await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/CU-NOpdL8Kf/')).rejects.toBeInstanceOf(
+        InstagramBetaValidationError,
+      );
+    }
+    expect(instagramValidationCircuitForTesting.isOpen()).toBe(true);
+    fetchMock.mockClear();
+
+    // Once open, further calls short-circuit without hitting fetch.
+    await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/AnyOther/')).rejects.toBeInstanceOf(
+      InstagramBetaValidationError,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('matches climb names with word boundaries via containsAsWord', () => {

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchInstagramPageMetadata,
+  InstagramBetaValidationError,
+  instagramBetaValidationInternals,
+  validateInstagramBetaLink,
+} from '../utils/instagram-beta-validation';
+import { getInstagramMediaId } from '../lib/instagram-meta';
+
+const fetchMock = vi.fn();
+
+describe('instagram-beta-validation', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('extracts public metadata from instagram html', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta name="description" content="13 likes - climber on Instagram: &quot;Fell From Heaven&quot; @ 35° on the Kilter Board Homewall." />
+          <meta property="og:title" content="climber on Instagram: &quot;Fell From Heaven&quot; @ 35° on the Kilter Board Homewall." />
+          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    await expect(fetchInstagramPageMetadata('https://www.instagram.com/reel/DLM2nf9S1h6/')).resolves.toMatchObject({
+      description: expect.stringContaining('Fell From Heaven'),
+      imageUrl: 'https://cdn.example.com/image.jpg',
+      mediaId: '123456789',
+      ogTitle: expect.stringContaining('Fell From Heaven'),
+    });
+  });
+
+  it('accepts captions that mention the climb name with forgiving normalization', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta name="description" content="Had a great day. Vid #3: Cut to the Chase V10 @ 35°." />
+          <meta property="og:title" content="camgibbs on Instagram: Vid #3: Cut to the Chase V10 @ 35°" />
+          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    await expect(
+      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
+    ).resolves.toBeTruthy();
+  });
+
+  it('rejects posts that do not mention the climb name', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta name="description" content="Random climbing day montage." />
+          <meta property="og:title" content="climber on Instagram: random climbing day montage" />
+          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    await expect(
+      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
+    ).rejects.toThrow(
+      `We couldn't confirm this video is for "Cut to the Chase". Please use a public Instagram post or reel whose caption or title mentions the climb name.`,
+    );
+  });
+
+  it('rejects pages that are not previewable instagram media', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => '<html><head><title>Instagram</title></head></html>',
+    });
+
+    await expect(
+      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
+    ).rejects.toBeInstanceOf(InstagramBetaValidationError);
+  });
+
+  it('normalizes punctuation and entity differences when matching climb names', () => {
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on instagram: &quot;There, There&quot; @ 40° on the Kilter Board',
+        'There, There',
+      ),
+    ).toBe(true);
+  });
+
+  it('extracts the same media id from equivalent instagram url variants', () => {
+    expect(getInstagramMediaId('https://www.instagram.com/reel/ABC123xyz/')).toBe('ABC123xyz');
+    expect(getInstagramMediaId('https://www.instagram.com/p/ABC123xyz/?img_index=1')).toBe('ABC123xyz');
+  });
+});

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -139,6 +139,24 @@ describe('instagram-beta-validation', () => {
     expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('Random title without pattern')).toBeNull();
   });
 
+  it('accepts a public post that mentions the climb name even when og:image is missing', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta name="description" content="Cut to the Chase V10 from yesterday's session." />
+          <meta property="og:title" content="camgibbs on Instagram: Cut to the Chase V10" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    await expect(
+      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
+    ).resolves.toMatchObject({ imageUrl: null, mediaId: '123456789' });
+  });
+
   it('returns the parsed username on the metadata', async () => {
     fetchMock.mockResolvedValue({
       headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -211,6 +211,23 @@ describe('instagram-beta-validation', () => {
     ).toBe(true);
   });
 
+  it('does not match fallback tokens that appear inside larger words', () => {
+    // "Fell From Heaven" — "fell" should not match inside "befell".
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'the storm that befell us from on high seemed heaven sent',
+        'Fell From Heaven',
+      ),
+    ).toBe(false);
+  });
+
+  it('indexOfWord requires whole-word matches', () => {
+    expect(instagramBetaValidationInternals.indexOfWord('the storm befell us', 'fell', 0)).toBe(-1);
+    expect(instagramBetaValidationInternals.indexOfWord('we fell hard today', 'fell', 0)).toBe(3);
+    expect(instagramBetaValidationInternals.indexOfWord('fell at the start', 'fell', 0)).toBe(0);
+    expect(instagramBetaValidationInternals.indexOfWord('one then fell', 'fell', 0)).toBe(9);
+  });
+
   it('opens the circuit after enough fetch failures and stops calling out', async () => {
     fetchMock.mockRejectedValue(new Error('TimeoutError'));
 

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -102,4 +102,58 @@ describe('instagram-beta-validation', () => {
     expect(getInstagramMediaId('https://www.instagram.com/reel/ABC123xyz/')).toBe('ABC123xyz');
     expect(getInstagramMediaId('https://www.instagram.com/p/ABC123xyz/?img_index=1')).toBe('ABC123xyz');
   });
+
+  it('wraps fetch failures in InstagramBetaValidationError', async () => {
+    fetchMock.mockRejectedValue(new Error('TimeoutError: signal timed out'));
+
+    await expect(
+      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
+    ).rejects.toBeInstanceOf(InstagramBetaValidationError);
+  });
+
+  it('matches climb names in non-Latin scripts after Unicode-aware normalization', () => {
+    // Cyrillic — would have been wiped to empty by [^a-z0-9].
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: Покатушки @ 40° on the Kilter Board',
+        'Покатушки',
+      ),
+    ).toBe(true);
+    // CJK — shouldn't survive lowercase but should survive the filter.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: 攀岩 @ 40° on the Kilter Board',
+        '攀岩',
+      ),
+    ).toBe(true);
+  });
+
+  it('parses username from Instagram og:title patterns', () => {
+    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('camgibbs on Instagram: "Cut to the Chase"')).toBe(
+      'camgibbs',
+    );
+    expect(
+      instagramBetaValidationInternals.parseUsernameFromOgTitle('@cam.gibbs on Instagram in Boulder, CO: ...'),
+    ).toBe('cam.gibbs');
+    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle(null)).toBeNull();
+    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('Random title without pattern')).toBeNull();
+  });
+
+  it('returns the parsed username on the metadata', async () => {
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta property="og:title" content="camgibbs on Instagram: Cut to the Chase V10" />
+          <meta name="description" content="Cut to the Chase V10" />
+          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    const metadata = await validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase');
+    expect(metadata.username).toBe('camgibbs');
+  });
 });

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -128,6 +128,57 @@ describe('instagram-beta-validation', () => {
     ).toBe(true);
   });
 
+  it('rejects single-word climb names that only appear inside other words', () => {
+    // "Gravity" climb shouldn't validate against a post that just mentions
+    // "antigravity" — that's the false-positive the ordered-token fallback
+    // used to allow.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: antigravity training session',
+        'Gravity',
+      ),
+    ).toBe(false);
+    // But the same short name still matches when it appears as a whole word.
+    expect(
+      instagramBetaValidationInternals.containsNormalizedClimbName(
+        'climber on Instagram: sent Gravity today!',
+        'Gravity',
+      ),
+    ).toBe(true);
+  });
+
+  it('parses og:image even when og:title comes first with a long caption', async () => {
+    // Regression guard: parseMetaContent's attrRegex used to be a /g regex
+    // shared across iterations. After the long og:title tag exhausted the
+    // regex's lastIndex, the shorter og:image tag could be silently skipped.
+    fetchMock.mockResolvedValue({
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      ok: true,
+      text: async () => `
+        <html><head>
+          <meta property="og:title" content="${'a'.repeat(500)} on Instagram: Cut to the Chase V10 ${'b'.repeat(500)}" />
+          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
+          <meta name="description" content="Cut to the Chase V10" />
+          <meta property="al:ios:url" content="instagram://media?id=123456789" />
+        </head></html>
+      `,
+    });
+
+    await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toMatchObject({
+      imageUrl: 'https://cdn.example.com/image.jpg',
+      mediaId: '123456789',
+    });
+  });
+
+  it('matches climb names with word boundaries via containsAsWord', () => {
+    expect(instagramBetaValidationInternals.containsAsWord('sent gravity today', 'gravity')).toBe(true);
+    expect(instagramBetaValidationInternals.containsAsWord('gravity is the project', 'gravity')).toBe(true);
+    expect(instagramBetaValidationInternals.containsAsWord('the project is gravity', 'gravity')).toBe(true);
+    expect(instagramBetaValidationInternals.containsAsWord('gravity', 'gravity')).toBe(true);
+    expect(instagramBetaValidationInternals.containsAsWord('antigravity training', 'gravity')).toBe(false);
+    expect(instagramBetaValidationInternals.containsAsWord('gravityfall demo', 'gravity')).toBe(false);
+  });
+
   it('parses username from Instagram og:title patterns', () => {
     expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('camgibbs on Instagram: "Cut to the Chase"')).toBe(
       'camgibbs',

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -121,6 +121,14 @@ async function enrichInstagramBetaInsert(metadata: InstagramPageMetadata): Promi
     return { thumbnail: null, foreignUsername };
   }
 
+  // Note: this S3 write happens before the boardseshTicks/boardBetaLinks
+  // insert in saveTick. If that subsequent transaction rolls back (bad
+  // sessionId, DB hiccup, dup conflict that we don't surface), the S3
+  // object is orphaned. Acceptable trade-off: the cache key is the IG
+  // media ID, so any future attach for the same post idempotently reuses
+  // the existing object — orphans aren't duplicated, they just sit at a
+  // few KB each indexed by media ID. If this becomes meaningful a
+  // periodic GC keyed on `boardBetaLinks.thumbnail` could sweep them.
   const cached = await cacheInstagramThumbnail(mediaId, metadata.imageUrl);
   return { thumbnail: cached, foreignUsername };
 }

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -11,6 +11,85 @@ import { resolveBoardFromPath } from '../social/boards';
 import { publishSocialEvent } from '../../../events';
 import { assignInferredSession } from '../../../jobs/inferred-session-builder';
 import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publisher';
+import { getInstagramMediaId, isInstagramUrl } from '../../../lib/instagram-meta';
+import {
+  InstagramBetaValidationError,
+  validateInstagramBetaLink,
+  type InstagramPageMetadata,
+} from '../../../utils/instagram-beta-validation';
+import { cacheInstagramThumbnail, isS3Configured } from '../../../lib/beta-link-thumbnails';
+
+async function getClimbNameForBetaValidation(boardType: string, climbUuid: string): Promise<string> {
+  const [climb] = await db
+    .select({ name: dbSchema.boardClimbs.name })
+    .from(dbSchema.boardClimbs)
+    .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, climbUuid)))
+    .limit(1);
+
+  const climbName = climb?.name?.trim();
+  if (!climbName) {
+    throw new InstagramBetaValidationError("We couldn't verify this Instagram link for the selected climb.");
+  }
+  return climbName;
+}
+
+async function ensureInstagramShortcodeIsNotAlreadyLinked(
+  boardType: string,
+  selectedClimbUuid: string,
+  instagramUrl: string,
+): Promise<void> {
+  const incomingShortcode = getInstagramMediaId(instagramUrl);
+  if (!incomingShortcode) return;
+
+  const existingLinks = await db
+    .select({
+      climbName: dbSchema.boardClimbs.name,
+      climbUuid: dbSchema.boardBetaLinks.climbUuid,
+      link: dbSchema.boardBetaLinks.link,
+    })
+    .from(dbSchema.boardBetaLinks)
+    .innerJoin(
+      dbSchema.boardClimbs,
+      and(
+        eq(dbSchema.boardClimbs.boardType, dbSchema.boardBetaLinks.boardType),
+        eq(dbSchema.boardClimbs.uuid, dbSchema.boardBetaLinks.climbUuid),
+      ),
+    )
+    .where(eq(dbSchema.boardBetaLinks.boardType, boardType));
+
+  for (const entry of existingLinks) {
+    if (getInstagramMediaId(entry.link) !== incomingShortcode) continue;
+
+    if (entry.climbUuid === selectedClimbUuid) {
+      throw new InstagramBetaValidationError(
+        'We already have this Instagram video linked for this climb. Try a different post or reel.',
+      );
+    }
+
+    throw new InstagramBetaValidationError(
+      `This Instagram post is already attached to "${entry.climbName}". Multi-climb slideshows are hard to navigate — please post a separate reel for this climb and share that one instead.`,
+    );
+  }
+}
+
+type EnrichedBetaInsert = {
+  thumbnail: string | null;
+  foreignUsername: string | null;
+};
+
+async function enrichInstagramBetaInsert(metadata: InstagramPageMetadata): Promise<EnrichedBetaInsert> {
+  if (!isS3Configured() || !metadata.imageUrl) {
+    return { thumbnail: null, foreignUsername: null };
+  }
+
+  const mediaId = metadata.mediaId;
+  if (!mediaId) {
+    return { thumbnail: null, foreignUsername: null };
+  }
+
+  const cached = await cacheInstagramThumbnail(mediaId, metadata.imageUrl);
+  return { thumbnail: cached, foreignUsername: null };
+}
 
 export const tickMutations = {
   /**
@@ -104,6 +183,26 @@ export const tickMutations = {
       );
     }
 
+    // Run write-time Instagram validation before opening the transaction so a
+    // bad video URL doesn't leave a half-state. Zod already validated the
+    // surface shape; this confirms the post is actually public, mentions the
+    // climb name, and isn't already attached to another climb. TikTok / other
+    // platforms skip the deep validation — only the regex check applies.
+    const shouldAttachBeta =
+      validatedInput.videoUrl && (validatedInput.status === 'flash' || validatedInput.status === 'send');
+    let enrichedInsert: EnrichedBetaInsert = { thumbnail: null, foreignUsername: null };
+
+    if (shouldAttachBeta && validatedInput.videoUrl && isInstagramUrl(validatedInput.videoUrl)) {
+      const climbName = await getClimbNameForBetaValidation(validatedInput.boardType, validatedInput.climbUuid);
+      await ensureInstagramShortcodeIsNotAlreadyLinked(
+        validatedInput.boardType,
+        validatedInput.climbUuid,
+        validatedInput.videoUrl,
+      );
+      const metadata = await validateInstagramBetaLink(validatedInput.videoUrl, climbName);
+      enrichedInsert = await enrichInstagramBetaInsert(metadata);
+    }
+
     // Insert into database
     const [tick] = await db.transaction(async (tx) => {
       const [createdTick] = await tx
@@ -138,12 +237,9 @@ export const tickMutations = {
         await tx.update(sessions).set({ lastActivity: new Date() }).where(eq(sessions.id, validatedInput.sessionId));
       }
 
-      // Attach the Instagram URL as community beta for this climb if the
-      // user provided one on a successful ascent. Zod already validated the
-      // URL format; the (boardType, climbUuid, link) PK makes re-submission
-      // idempotent.
-      const shouldAttachBeta =
-        validatedInput.videoUrl && (validatedInput.status === 'flash' || validatedInput.status === 'send');
+      // Attach the video URL as community beta for this climb if the user
+      // provided one on a successful ascent. The (boardType, climbUuid, link)
+      // PK makes re-submission idempotent.
       if (shouldAttachBeta) {
         await tx
           .insert(dbSchema.boardBetaLinks)
@@ -153,6 +249,8 @@ export const tickMutations = {
             link: validatedInput.videoUrl!,
             angle: validatedInput.angle,
             isListed: true,
+            thumbnail: enrichedInsert.thumbnail,
+            foreignUsername: enrichedInsert.foreignUsername,
             createdAt: now,
           })
           .onConflictDoNothing();
@@ -218,6 +316,15 @@ export const tickMutations = {
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
     const now = new Date().toISOString();
 
+    let enrichedInsert: EnrichedBetaInsert = { thumbnail: null, foreignUsername: null };
+
+    if (isInstagramUrl(validated.link)) {
+      const climbName = await getClimbNameForBetaValidation(validated.boardType, validated.climbUuid);
+      await ensureInstagramShortcodeIsNotAlreadyLinked(validated.boardType, validated.climbUuid, validated.link);
+      const metadata = await validateInstagramBetaLink(validated.link, climbName);
+      enrichedInsert = await enrichInstagramBetaInsert(metadata);
+    }
+
     await db
       .insert(dbSchema.boardBetaLinks)
       .values({
@@ -226,6 +333,8 @@ export const tickMutations = {
         link: validated.link,
         angle: validated.angle ?? null,
         isListed: true,
+        thumbnail: enrichedInsert.thumbnail,
+        foreignUsername: enrichedInsert.foreignUsername,
         createdAt: now,
       })
       .onConflictDoNothing();

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, like } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -41,6 +41,11 @@ async function ensureInstagramShortcodeIsNotAlreadyLinked(
   const incomingShortcode = getInstagramMediaId(instagramUrl);
   if (!incomingShortcode) return;
 
+  // Narrow at the DB level — the shortcode appears as `/p/<id>/`, `/reel/<id>/`,
+  // or `/tv/<id>/` in the link. A LIKE prefilter avoids loading every beta
+  // link for the board on every write. Drizzle parameterizes the value, and
+  // we re-verify with `getInstagramMediaId` below so any false positives
+  // (e.g. shortcodes appearing in non-canonical positions) are filtered out.
   const existingLinks = await db
     .select({
       climbName: dbSchema.boardClimbs.name,
@@ -55,7 +60,12 @@ async function ensureInstagramShortcodeIsNotAlreadyLinked(
         eq(dbSchema.boardClimbs.uuid, dbSchema.boardBetaLinks.climbUuid),
       ),
     )
-    .where(eq(dbSchema.boardBetaLinks.boardType, boardType));
+    .where(
+      and(
+        eq(dbSchema.boardBetaLinks.boardType, boardType),
+        like(dbSchema.boardBetaLinks.link, `%${incomingShortcode}%`),
+      ),
+    );
 
   for (const entry of existingLinks) {
     if (getInstagramMediaId(entry.link) !== incomingShortcode) continue;
@@ -78,17 +88,38 @@ type EnrichedBetaInsert = {
 };
 
 async function enrichInstagramBetaInsert(metadata: InstagramPageMetadata): Promise<EnrichedBetaInsert> {
+  const foreignUsername = metadata.username;
+
   if (!isS3Configured() || !metadata.imageUrl) {
-    return { thumbnail: null, foreignUsername: null };
+    return { thumbnail: null, foreignUsername };
   }
 
   const mediaId = metadata.mediaId;
   if (!mediaId) {
-    return { thumbnail: null, foreignUsername: null };
+    return { thumbnail: null, foreignUsername };
   }
 
   const cached = await cacheInstagramThumbnail(mediaId, metadata.imageUrl);
-  return { thumbnail: cached, foreignUsername: null };
+  return { thumbnail: cached, foreignUsername };
+}
+
+// Single gated entrypoint for write-time beta-link validation. Non-Instagram
+// URLs (TikTok and other zod-allowed platforms) skip the deep checks and
+// return null thumbnail/username — the read-time `betaLinks` resolver will
+// enrich them lazily. Exported for testing.
+export async function validateAndEnrichBetaLinkInsert(
+  boardType: string,
+  climbUuid: string,
+  url: string,
+): Promise<EnrichedBetaInsert> {
+  if (!isInstagramUrl(url)) {
+    return { thumbnail: null, foreignUsername: null };
+  }
+
+  const climbName = await getClimbNameForBetaValidation(boardType, climbUuid);
+  await ensureInstagramShortcodeIsNotAlreadyLinked(boardType, climbUuid, url);
+  const metadata = await validateInstagramBetaLink(url, climbName);
+  return enrichInstagramBetaInsert(metadata);
 }
 
 export const tickMutations = {
@@ -185,22 +216,19 @@ export const tickMutations = {
 
     // Run write-time Instagram validation before opening the transaction so a
     // bad video URL doesn't leave a half-state. Zod already validated the
-    // surface shape; this confirms the post is actually public, mentions the
-    // climb name, and isn't already attached to another climb. TikTok / other
-    // platforms skip the deep validation — only the regex check applies.
+    // surface shape; the helper confirms the post is actually public, mentions
+    // the climb name, and isn't already attached to another climb. TikTok and
+    // other supported platforms skip the deep validation.
     const shouldAttachBeta =
       validatedInput.videoUrl && (validatedInput.status === 'flash' || validatedInput.status === 'send');
     let enrichedInsert: EnrichedBetaInsert = { thumbnail: null, foreignUsername: null };
 
-    if (shouldAttachBeta && validatedInput.videoUrl && isInstagramUrl(validatedInput.videoUrl)) {
-      const climbName = await getClimbNameForBetaValidation(validatedInput.boardType, validatedInput.climbUuid);
-      await ensureInstagramShortcodeIsNotAlreadyLinked(
+    if (shouldAttachBeta && validatedInput.videoUrl) {
+      enrichedInsert = await validateAndEnrichBetaLinkInsert(
         validatedInput.boardType,
         validatedInput.climbUuid,
         validatedInput.videoUrl,
       );
-      const metadata = await validateInstagramBetaLink(validatedInput.videoUrl, climbName);
-      enrichedInsert = await enrichInstagramBetaInsert(metadata);
     }
 
     // Insert into database
@@ -316,14 +344,11 @@ export const tickMutations = {
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
     const now = new Date().toISOString();
 
-    let enrichedInsert: EnrichedBetaInsert = { thumbnail: null, foreignUsername: null };
-
-    if (isInstagramUrl(validated.link)) {
-      const climbName = await getClimbNameForBetaValidation(validated.boardType, validated.climbUuid);
-      await ensureInstagramShortcodeIsNotAlreadyLinked(validated.boardType, validated.climbUuid, validated.link);
-      const metadata = await validateInstagramBetaLink(validated.link, climbName);
-      enrichedInsert = await enrichInstagramBetaInsert(metadata);
-    }
+    const enrichedInsert = await validateAndEnrichBetaLinkInsert(
+      validated.boardType,
+      validated.climbUuid,
+      validated.link,
+    );
 
     await db
       .insert(dbSchema.boardBetaLinks)

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,10 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import { eq, and, inArray, like } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
 import { applyRateLimit, requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
+import { escapeLikePattern } from '../../../utils/like-pattern';
 import { getConsensusDifficultyName } from '../shared/sql-expressions';
 import { SaveTickInputSchema, UpdateTickInputSchema, AttachBetaLinkInputSchema } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
@@ -31,14 +33,6 @@ async function getClimbNameForBetaValidation(boardType: string, climbUuid: strin
     throw new InstagramBetaValidationError("We couldn't verify this Instagram link for the selected climb.");
   }
   return climbName;
-}
-
-// Escape `\`, `_`, and `%` so Instagram shortcodes containing underscores
-// (which are LIKE single-char wildcards) don't expand the prefilter to
-// unrelated rows. Backslash is escaped first so we don't double-escape the
-// inserts we add for `_` / `%`.
-export function escapeLikePattern(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/[_%]/g, (m) => `\\${m}`);
 }
 
 // Beta links are only attached on successful ascents (flash / send), never on
@@ -373,11 +367,12 @@ export const tickMutations = {
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
     const now = new Date().toISOString();
 
-    // Validation happens before the transaction — it's an outbound HTTP fetch
-    // we don't want to hold a DB connection open for. The insert itself is
-    // wrapped so a constraint failure or connection drop after a successful
-    // validation surfaces an explicit error rather than landing the user on
-    // the generic "couldn't add video" toast.
+    // Validation runs first — it's an outbound HTTP fetch we don't want to
+    // hold a DB connection open for. The insert is a single statement; no
+    // need to wrap it in a transaction. The catch surfaces an explicit error
+    // for the rare case where the insert fails (constraint, connection drop)
+    // after validation already passed, so the user doesn't see the generic
+    // "couldn't add video" toast.
     const enrichedInsert = await validateAndEnrichBetaLinkInsert(
       ctx,
       validated.boardType,
@@ -386,24 +381,24 @@ export const tickMutations = {
     );
 
     try {
-      await db.transaction(async (tx) => {
-        await tx
-          .insert(dbSchema.boardBetaLinks)
-          .values({
-            boardType: validated.boardType,
-            climbUuid: validated.climbUuid,
-            link: validated.link,
-            angle: validated.angle ?? null,
-            isListed: true,
-            thumbnail: enrichedInsert.thumbnail,
-            foreignUsername: enrichedInsert.foreignUsername,
-            createdAt: now,
-          })
-          .onConflictDoNothing();
-      });
+      await db
+        .insert(dbSchema.boardBetaLinks)
+        .values({
+          boardType: validated.boardType,
+          climbUuid: validated.climbUuid,
+          link: validated.link,
+          angle: validated.angle ?? null,
+          isListed: true,
+          thumbnail: enrichedInsert.thumbnail,
+          foreignUsername: enrichedInsert.foreignUsername,
+          createdAt: now,
+        })
+        .onConflictDoNothing();
     } catch (err) {
       console.error('[attachBetaLink] insert failed after validation passed:', err);
-      throw new Error("Couldn't save the beta link. Please try again.");
+      throw new GraphQLError("Couldn't save the beta link. Please try again.", {
+        extensions: { code: 'BETA_LINK_INSERT_FAILED' },
+      });
     }
 
     return true;

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -4,7 +4,7 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
-import { requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
+import { applyRateLimit, requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
 import { getConsensusDifficultyName } from '../shared/sql-expressions';
 import { SaveTickInputSchema, UpdateTickInputSchema, AttachBetaLinkInputSchema } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
@@ -134,8 +134,11 @@ async function enrichInstagramBetaInsert(metadata: InstagramPageMetadata): Promi
 // Single gated entrypoint for write-time beta-link validation. Non-Instagram
 // URLs (TikTok and other zod-allowed platforms) skip the deep checks and
 // return null thumbnail/username — the read-time `betaLinks` resolver will
-// enrich them lazily. Exported for testing.
+// enrich them lazily. The `ctx` is used to apply per-user rate limiting on
+// the outbound IG fetch (only when we'd actually hit the network).
+// Exported for testing.
 export async function validateAndEnrichBetaLinkInsert(
+  ctx: ConnectionContext,
   boardType: string,
   climbUuid: string,
   url: string,
@@ -143,6 +146,11 @@ export async function validateAndEnrichBetaLinkInsert(
   if (!isInstagramUrl(url)) {
     return { thumbnail: null, foreignUsername: null };
   }
+
+  // Cap outbound IG fetches per user. 30/min is far above legitimate use
+  // (you don't attach beta videos that fast manually) but stops a tight
+  // loop from getting our IP rate-limited or blocked by Instagram.
+  await applyRateLimit(ctx, 30, 'instagram-beta-validation');
 
   const climbName = await getClimbNameForBetaValidation(boardType, climbUuid);
   await ensureInstagramShortcodeIsNotAlreadyLinked(boardType, climbUuid, url);
@@ -249,7 +257,7 @@ export const tickMutations = {
     // other supported platforms skip the deep validation.
     const attachedVideoUrl = videoUrlForTickStatus(validatedInput.status, validatedInput.videoUrl);
     const enrichedInsert: EnrichedBetaInsert = attachedVideoUrl
-      ? await validateAndEnrichBetaLinkInsert(validatedInput.boardType, validatedInput.climbUuid, attachedVideoUrl)
+      ? await validateAndEnrichBetaLinkInsert(ctx, validatedInput.boardType, validatedInput.climbUuid, attachedVideoUrl)
       : { thumbnail: null, foreignUsername: null };
 
     // Insert into database
@@ -365,25 +373,38 @@ export const tickMutations = {
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
     const now = new Date().toISOString();
 
+    // Validation happens before the transaction — it's an outbound HTTP fetch
+    // we don't want to hold a DB connection open for. The insert itself is
+    // wrapped so a constraint failure or connection drop after a successful
+    // validation surfaces an explicit error rather than landing the user on
+    // the generic "couldn't add video" toast.
     const enrichedInsert = await validateAndEnrichBetaLinkInsert(
+      ctx,
       validated.boardType,
       validated.climbUuid,
       validated.link,
     );
 
-    await db
-      .insert(dbSchema.boardBetaLinks)
-      .values({
-        boardType: validated.boardType,
-        climbUuid: validated.climbUuid,
-        link: validated.link,
-        angle: validated.angle ?? null,
-        isListed: true,
-        thumbnail: enrichedInsert.thumbnail,
-        foreignUsername: enrichedInsert.foreignUsername,
-        createdAt: now,
-      })
-      .onConflictDoNothing();
+    try {
+      await db.transaction(async (tx) => {
+        await tx
+          .insert(dbSchema.boardBetaLinks)
+          .values({
+            boardType: validated.boardType,
+            climbUuid: validated.climbUuid,
+            link: validated.link,
+            angle: validated.angle ?? null,
+            isListed: true,
+            thumbnail: enrichedInsert.thumbnail,
+            foreignUsername: enrichedInsert.foreignUsername,
+            createdAt: now,
+          })
+          .onConflictDoNothing();
+      });
+    } catch (err) {
+      console.error('[attachBetaLink] insert failed after validation passed:', err);
+      throw new Error("Couldn't save the beta link. Please try again.");
+    }
 
     return true;
   },

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -33,6 +33,26 @@ async function getClimbNameForBetaValidation(boardType: string, climbUuid: strin
   return climbName;
 }
 
+// Escape `\`, `_`, and `%` so Instagram shortcodes containing underscores
+// (which are LIKE single-char wildcards) don't expand the prefilter to
+// unrelated rows. Backslash is escaped first so we don't double-escape the
+// inserts we add for `_` / `%`.
+export function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/[_%]/g, (m) => `\\${m}`);
+}
+
+// Beta links are only attached on successful ascents (flash / send), never on
+// `attempt`. Returns the URL to attach, or null if the tick shouldn't carry
+// one. Exported so the rule can be unit-tested without integration setup.
+export function videoUrlForTickStatus(
+  status: 'flash' | 'send' | 'attempt',
+  videoUrl: string | null | undefined,
+): string | null {
+  if (!videoUrl) return null;
+  if (status !== 'flash' && status !== 'send') return null;
+  return videoUrl;
+}
+
 async function ensureInstagramShortcodeIsNotAlreadyLinked(
   boardType: string,
   selectedClimbUuid: string,
@@ -43,9 +63,17 @@ async function ensureInstagramShortcodeIsNotAlreadyLinked(
 
   // Narrow at the DB level — the shortcode appears as `/p/<id>/`, `/reel/<id>/`,
   // or `/tv/<id>/` in the link. A LIKE prefilter avoids loading every beta
-  // link for the board on every write. Drizzle parameterizes the value, and
-  // we re-verify with `getInstagramMediaId` below so any false positives
-  // (e.g. shortcodes appearing in non-canonical positions) are filtered out.
+  // link for the board on every write. Drizzle parameterizes the value;
+  // escapeLikePattern handles `_` / `%` since shortcodes can contain
+  // underscores (which would otherwise act as wildcards). The post-fetch
+  // `getInstagramMediaId(entry.link)` re-check still filters any false
+  // positives (e.g. shortcodes appearing in non-canonical positions).
+  //
+  // Race: two concurrent attaches of the same shortcode can both pass this
+  // check. The (boardType, climbUuid, link) PK + onConflictDoNothing makes
+  // the loser a silent no-op rather than a duplicate row. The loser misses
+  // the friendly "already linked" message — acceptable for a beta-link
+  // feature; an advisory lock would be overkill.
   const existingLinks = await db
     .select({
       climbName: dbSchema.boardClimbs.name,
@@ -63,7 +91,7 @@ async function ensureInstagramShortcodeIsNotAlreadyLinked(
     .where(
       and(
         eq(dbSchema.boardBetaLinks.boardType, boardType),
-        like(dbSchema.boardBetaLinks.link, `%${incomingShortcode}%`),
+        like(dbSchema.boardBetaLinks.link, `%${escapeLikePattern(incomingShortcode)}%`),
       ),
     );
 
@@ -219,17 +247,10 @@ export const tickMutations = {
     // surface shape; the helper confirms the post is actually public, mentions
     // the climb name, and isn't already attached to another climb. TikTok and
     // other supported platforms skip the deep validation.
-    const shouldAttachBeta =
-      validatedInput.videoUrl && (validatedInput.status === 'flash' || validatedInput.status === 'send');
-    let enrichedInsert: EnrichedBetaInsert = { thumbnail: null, foreignUsername: null };
-
-    if (shouldAttachBeta && validatedInput.videoUrl) {
-      enrichedInsert = await validateAndEnrichBetaLinkInsert(
-        validatedInput.boardType,
-        validatedInput.climbUuid,
-        validatedInput.videoUrl,
-      );
-    }
+    const attachedVideoUrl = videoUrlForTickStatus(validatedInput.status, validatedInput.videoUrl);
+    const enrichedInsert: EnrichedBetaInsert = attachedVideoUrl
+      ? await validateAndEnrichBetaLinkInsert(validatedInput.boardType, validatedInput.climbUuid, attachedVideoUrl)
+      : { thumbnail: null, foreignUsername: null };
 
     // Insert into database
     const [tick] = await db.transaction(async (tx) => {
@@ -268,13 +289,13 @@ export const tickMutations = {
       // Attach the video URL as community beta for this climb if the user
       // provided one on a successful ascent. The (boardType, climbUuid, link)
       // PK makes re-submission idempotent.
-      if (shouldAttachBeta) {
+      if (attachedVideoUrl) {
         await tx
           .insert(dbSchema.boardBetaLinks)
           .values({
             boardType: validatedInput.boardType,
             climbUuid: validatedInput.climbUuid,
-            link: validatedInput.videoUrl!,
+            link: attachedVideoUrl,
             angle: validatedInput.angle,
             isListed: true,
             thumbnail: enrichedInsert.thumbnail,

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -11,6 +11,7 @@ import {
   consensusGradeJoinCondition,
 } from '../shared/sql-expressions';
 import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas';
+import { escapeLikePattern } from '../../../utils/like-pattern';
 
 export const tickQueries = {
   /**
@@ -306,10 +307,6 @@ export const tickQueries = {
         ),
       )
       .leftJoin(consensusGradeTable, consensusGradeJoinCondition);
-
-    // Escape LIKE wildcards so user input is treated as a literal substring,
-    // not a SQL pattern (e.g. typing "100%" should match the literal string).
-    const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (char) => `\\${char}`);
 
     // Full conditions including climb name filter (requires JOIN)
     const allConditions = [

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import { getInstagramMediaId } from '../lib/instagram-meta';
 import { createCircuitBreaker } from '../lib/circuit-breaker';
 
@@ -45,9 +46,15 @@ export const instagramValidationCircuitForTesting = validationCircuit;
 const GENERIC_VALIDATION_ERROR =
   "We couldn't verify this Instagram link. Make sure it's a public post or reel that Boardsesh can preview, and that the caption or title mentions the climb name.";
 
-export class InstagramBetaValidationError extends Error {
+// Extends GraphQLError so the user-facing message survives Yoga's
+// `maskedErrors: true` in production. Plain Error subclasses are replaced
+// with the generic "Unexpected error." string before reaching the client,
+// which would surface as the fallback "Couldn't add video. Try again."
+// toast instead of our specific guidance ("post must mention the climb",
+// "already linked to <other climb>", etc.).
+export class InstagramBetaValidationError extends GraphQLError {
   constructor(message: string) {
-    super(message);
+    super(message, { extensions: { code: 'INSTAGRAM_BETA_VALIDATION' } });
     this.name = 'InstagramBetaValidationError';
   }
 }
@@ -94,6 +101,24 @@ function containsAsWord(haystack: string, needle: string): boolean {
   return haystack.includes(` ${needle} `);
 }
 
+// Word-bounded indexOf for the ordered-token fallback. Returns the start
+// index of `needle` if it appears as a whole word at or after `fromIndex`,
+// otherwise -1. Necessary because plain indexOf would match "fell" inside
+// "befell".
+function indexOfWord(haystack: string, needle: string, fromIndex: number): number {
+  let cursor = fromIndex;
+  while (cursor <= haystack.length) {
+    const idx = haystack.indexOf(needle, cursor);
+    if (idx === -1) return -1;
+    const before = idx === 0 ? ' ' : haystack[idx - 1];
+    const afterIdx = idx + needle.length;
+    const after = afterIdx >= haystack.length ? ' ' : haystack[afterIdx];
+    if (before === ' ' && after === ' ') return idx;
+    cursor = idx + 1;
+  }
+  return -1;
+}
+
 // Minimum length per token before we'll allow the ordered-token fallback to
 // fire. Short tokens like "the", "to", "for", "up" appear in nearly every
 // English Instagram caption, so a climb name like "The Project" or "Power
@@ -120,7 +145,7 @@ function containsNormalizedClimbName(haystack: string, climbName: string): boole
 
   let cursor = 0;
   for (const token of tokens) {
-    const nextIndex = normalizedHaystack.indexOf(token, cursor);
+    const nextIndex = indexOfWord(normalizedHaystack, token, cursor);
     if (nextIndex === -1) return false;
     cursor = nextIndex + token.length;
   }
@@ -252,6 +277,7 @@ export const instagramBetaValidationInternals = {
   containsAsWord,
   containsNormalizedClimbName,
   decodeHtmlEntities,
+  indexOfWord,
   normalizeText,
   parseMetaContent,
   parseUsernameFromOgTitle,

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -30,6 +30,7 @@ export interface InstagramPageMetadata {
   imageUrl: string | null;
   mediaId: string | null;
   ogTitle: string | null;
+  username: string | null;
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -40,11 +41,16 @@ function decodeHtmlEntities(value: string): string {
 }
 
 function normalizeText(value: string): string {
+  // Strip combining marks (NFKD splits accented chars into base + mark, then
+  // we drop the marks). Replace anything that isn't a Unicode letter or
+  // number with a single space so non-Latin climb names (Cyrillic, CJK, etc.)
+  // survive normalization. Lowercase last because some scripts have
+  // case-folding rules but most don't — applying to the whole string is fine.
   return decodeHtmlEntities(value)
     .normalize('NFKD')
-    .replace(new RegExp('[\\u0300-\\u036f]', 'g'), '')
+    .replace(/\p{M}+/gu, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
     .trim()
     .replace(/\s+/g, ' ');
 }
@@ -70,14 +76,15 @@ function containsNormalizedClimbName(haystack: string, climbName: string): boole
 
 function parseMetaContent(html: string, target: string): string | null {
   const metaTagRegex = /<meta\b[^>]*>/gi;
-  const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*"([^"]*)"/g;
+  // Match double-quoted, single-quoted, or unquoted attribute values.
+  const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
   const normalizedTarget = target.toLowerCase();
 
   for (const metaTag of html.match(metaTagRegex) ?? []) {
     const attrs: Record<string, string> = {};
     let match: RegExpExecArray | null;
     while ((match = attrRegex.exec(metaTag)) !== null) {
-      attrs[match[1].toLowerCase()] = match[2];
+      attrs[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? '';
     }
 
     if (attrs.property?.toLowerCase() === normalizedTarget || attrs.name?.toLowerCase() === normalizedTarget) {
@@ -88,12 +95,29 @@ function parseMetaContent(html: string, target: string): string | null {
   return null;
 }
 
+// Instagram's og:title is consistently "<username> on Instagram: <caption…>"
+// (with an optional leading "@"). Pull the username out so the caller can
+// persist it eagerly when the row is inserted.
+function parseUsernameFromOgTitle(ogTitle: string | null): string | null {
+  if (!ogTitle) return null;
+  const match = ogTitle.match(/^@?([\w.]+)\s+on\s+Instagram\b/i);
+  return match?.[1] ?? null;
+}
+
 export async function fetchInstagramPageMetadata(url: string): Promise<InstagramPageMetadata> {
-  const response = await fetch(url, {
-    headers: INSTAGRAM_FETCH_HEADERS,
-    redirect: 'follow',
-    signal: AbortSignal.timeout(8000),
-  });
+  // Wrap the network leg in a try/catch so timeouts (AbortSignal.timeout),
+  // DNS failures, and connection resets surface as InstagramBetaValidationError
+  // instead of leaking raw runtime errors to the resolver.
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: INSTAGRAM_FETCH_HEADERS,
+      redirect: 'follow',
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
 
   if (!response.ok) {
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
@@ -104,7 +128,13 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
-  const html = await response.text();
+  let html: string;
+  try {
+    html = await response.text();
+  } catch {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
   const description = parseMetaContent(html, 'description') ?? parseMetaContent(html, 'og:description');
   const ogTitle = parseMetaContent(html, 'og:title') ?? parseMetaContent(html, 'twitter:title');
   const imageUrl = parseMetaContent(html, 'og:image') ?? parseMetaContent(html, 'twitter:image');
@@ -119,6 +149,7 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
     imageUrl,
     mediaId: mediaIdFromAppUrl ?? getInstagramMediaId(url),
     ogTitle,
+    username: parseUsernameFromOgTitle(ogTitle),
   };
 }
 
@@ -144,4 +175,5 @@ export const instagramBetaValidationInternals = {
   decodeHtmlEntities,
   normalizeText,
   parseMetaContent,
+  parseUsernameFromOgTitle,
 };

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -1,4 +1,5 @@
 import { getInstagramMediaId } from '../lib/instagram-meta';
+import { createCircuitBreaker } from '../lib/circuit-breaker';
 
 const HTML_ENTITY_MAP: Record<string, string> = {
   amp: '&',
@@ -9,11 +10,37 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   quot: '"',
 };
 
+// Hardcoding a desktop User-Agent to scrape Instagram's og:* tags is fragile
+// and at the edge of Meta's ToS — IG has historically responded with a
+// login-wall HTML to unrecognized clients, in which case the validator
+// rejects with the generic error. The circuit breaker below limits the
+// blast radius if/when that starts happening at scale; the rate limiter at
+// the resolver layer caps per-user abuse. If validation acceptance rates
+// drop, revisit by switching to oEmbed + Graph API or removing this
+// write-time check entirely (1736's read-time live check still filters
+// `gone` posts).
 const INSTAGRAM_FETCH_HEADERS = {
   'accept-language': 'en-US,en;q=0.9',
   'user-agent':
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
 };
+
+// Per-process circuit breaker for the canonical-post fetch. If we observe a
+// burst of failures (timeouts, non-200, non-HTML, login-wall), stop calling
+// out for `cooldownMs` so we don't keep poking IG while it's actively
+// rejecting us. While the breaker is open the validator throws the generic
+// error immediately — users see "we couldn't verify this Instagram link"
+// instead of waiting for a guaranteed-failing fetch.
+const validationCircuit = createCircuitBreaker({
+  windowMs: 60 * 1000,
+  threshold: 10,
+  cooldownMs: 5 * 60 * 1000,
+  onOpen: (failures, cooldownMs) => {
+    console.warn(`[InstagramBetaValidation] circuit OPEN: ${failures} failures in window, cooldown ${cooldownMs}ms`);
+  },
+});
+
+export const instagramValidationCircuitForTesting = validationCircuit;
 
 const GENERIC_VALIDATION_ERROR =
   "We couldn't verify this Instagram link. Make sure it's a public post or reel that Boardsesh can preview, and that the caption or title mentions the climb name.";
@@ -67,6 +94,14 @@ function containsAsWord(haystack: string, needle: string): boolean {
   return haystack.includes(` ${needle} `);
 }
 
+// Minimum length per token before we'll allow the ordered-token fallback to
+// fire. Short tokens like "the", "to", "for", "up" appear in nearly every
+// English Instagram caption, so a climb name like "The Project" or "Power
+// Up" would otherwise produce false positives on unrelated posts. Four
+// characters keeps "fell", "from", "cut", etc. out of the fallback while
+// still allowing genuinely distinguishing words.
+const MIN_TOKEN_LENGTH_FOR_FALLBACK = 4;
+
 function containsNormalizedClimbName(haystack: string, climbName: string): boolean {
   const normalizedHaystack = normalizeText(haystack);
   const normalizedClimbName = normalizeText(climbName);
@@ -75,11 +110,13 @@ function containsNormalizedClimbName(haystack: string, climbName: string): boole
   if (containsAsWord(normalizedHaystack, normalizedClimbName)) return true;
 
   // Ordered-token fallback handles multi-word names with intervening noise
-  // (e.g. "Fell From Heaven" matching "fell down from the heaven"). Skip it
-  // for single-token names — they rely solely on the word-bounded substring
-  // check above to avoid false positives on common short words.
+  // (e.g. "Fell From Heaven" matching "fell down from the heaven"). Only
+  // fire it when every token is long enough to be meaningfully
+  // distinguishing — otherwise common-word climb names would match almost
+  // any English caption.
   const tokens = normalizedClimbName.split(' ').filter(Boolean);
   if (tokens.length < 2) return false;
+  if (tokens.some((t) => t.length < MIN_TOKEN_LENGTH_FOR_FALLBACK)) return false;
 
   let cursor = 0;
   for (const token of tokens) {
@@ -123,6 +160,13 @@ function parseUsernameFromOgTitle(ogTitle: string | null): string | null {
 }
 
 export async function fetchInstagramPageMetadata(url: string): Promise<InstagramPageMetadata> {
+  // Short-circuit when the breaker is open — IG is failing us in bulk, so
+  // there's no point spending the client's request budget on a likely-doomed
+  // fetch. Don't record this as a circuit failure (it isn't a fresh signal).
+  if (validationCircuit.isOpen()) {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
   // Wrap the network leg in a try/catch so timeouts (AbortSignal.timeout),
   // DNS failures, and connection resets surface as InstagramBetaValidationError
   // instead of leaking raw runtime errors to the resolver.
@@ -138,15 +182,18 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
       signal: AbortSignal.timeout(4000),
     });
   } catch {
+    validationCircuit.recordFailure();
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
   if (!response.ok) {
+    validationCircuit.recordFailure();
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
   const contentType = response.headers.get('content-type') ?? '';
   if (!contentType.includes('text/html')) {
+    validationCircuit.recordFailure();
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
@@ -154,6 +201,7 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
   try {
     html = await response.text();
   } catch {
+    validationCircuit.recordFailure();
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
@@ -163,6 +211,10 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
   const mediaIdFromAppUrl = parseMetaContent(html, 'al:ios:url')?.match(/instagram:\/\/media\?id=(\d+)/)?.[1] ?? null;
 
   if (!description && !ogTitle) {
+    // 200 OK with no og data usually means IG served a login-wall page.
+    // Treat it as a transient failure for breaker purposes so a sustained
+    // wall response trips the cooldown.
+    validationCircuit.recordFailure();
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -156,7 +156,11 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
 export async function validateInstagramBetaLink(url: string, climbName: string): Promise<InstagramPageMetadata> {
   const metadata = await fetchInstagramPageMetadata(url);
 
-  if (!metadata.imageUrl || !metadata.mediaId) {
+  // mediaId is the canonical identity for the post (used for dedup + S3 cache
+  // key), so without it we can't safely persist. imageUrl is just enrichment —
+  // a public post with a caption mentioning the climb name should pass even
+  // if og:image happens to be missing.
+  if (!metadata.mediaId) {
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -55,15 +55,31 @@ function normalizeText(value: string): string {
     .replace(/\s+/g, ' ');
 }
 
+// Word-bounded substring: `needle` must appear with whitespace or string
+// edges on both sides in the (already-normalized) haystack. This prevents a
+// climb name like "Gravity" from matching unrelated text that happens to
+// contain the substring (e.g. "antigravity").
+function containsAsWord(haystack: string, needle: string): boolean {
+  if (!haystack || !needle) return false;
+  if (haystack === needle) return true;
+  if (haystack.startsWith(`${needle} `)) return true;
+  if (haystack.endsWith(` ${needle}`)) return true;
+  return haystack.includes(` ${needle} `);
+}
+
 function containsNormalizedClimbName(haystack: string, climbName: string): boolean {
   const normalizedHaystack = normalizeText(haystack);
   const normalizedClimbName = normalizeText(climbName);
 
   if (!normalizedHaystack || !normalizedClimbName) return false;
-  if (normalizedHaystack.includes(normalizedClimbName)) return true;
+  if (containsAsWord(normalizedHaystack, normalizedClimbName)) return true;
 
+  // Ordered-token fallback handles multi-word names with intervening noise
+  // (e.g. "Fell From Heaven" matching "fell down from the heaven"). Skip it
+  // for single-token names — they rely solely on the word-bounded substring
+  // check above to avoid false positives on common short words.
   const tokens = normalizedClimbName.split(' ').filter(Boolean);
-  if (tokens.length === 0) return false;
+  if (tokens.length < 2) return false;
 
   let cursor = 0;
   for (const token of tokens) {
@@ -76,11 +92,13 @@ function containsNormalizedClimbName(haystack: string, climbName: string): boole
 
 function parseMetaContent(html: string, target: string): string | null {
   const metaTagRegex = /<meta\b[^>]*>/gi;
-  // Match double-quoted, single-quoted, or unquoted attribute values.
-  const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
   const normalizedTarget = target.toLowerCase();
 
   for (const metaTag of html.match(metaTagRegex) ?? []) {
+    // Construct attrRegex inside the loop so its `/g` `lastIndex` state
+    // can't carry over between iterations and silently skip a shorter
+    // tag's attributes after a longer one.
+    const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
     const attrs: Record<string, string> = {};
     let match: RegExpExecArray | null;
     while ((match = attrRegex.exec(metaTag)) !== null) {
@@ -113,7 +131,11 @@ export async function fetchInstagramPageMetadata(url: string): Promise<Instagram
     response = await fetch(url, {
       headers: INSTAGRAM_FETCH_HEADERS,
       redirect: 'follow',
-      signal: AbortSignal.timeout(8000),
+      // Keep the timeout tight so the GraphQL mutation doesn't hang the
+      // client when Instagram is slow or rate-limited. A healthy fetch
+      // returns in well under a second; the user can retry on transient
+      // failures.
+      signal: AbortSignal.timeout(4000),
     });
   } catch {
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
@@ -175,6 +197,7 @@ export async function validateInstagramBetaLink(url: string, climbName: string):
 }
 
 export const instagramBetaValidationInternals = {
+  containsAsWord,
   containsNormalizedClimbName,
   decodeHtmlEntities,
   normalizeText,

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -32,6 +32,14 @@ const INSTAGRAM_FETCH_HEADERS = {
 // rejecting us. While the breaker is open the validator throws the generic
 // error immediately — users see "we couldn't verify this Instagram link"
 // instead of waiting for a guaranteed-failing fetch.
+//
+// Known limitation: state is per-process. In a multi-pod deploy each
+// instance tracks its own failures, so one pod tripping the breaker
+// doesn't stop another from continuing to hit Instagram. The per-user
+// rate limit at the resolver layer is the cluster-wide protection;
+// this breaker is best-effort per-instance back-off. If this becomes
+// a problem (e.g. fleet-wide IP block from IG) the failure window
+// could move to Redis using the same key pattern as redis-rate-limiter.
 const validationCircuit = createCircuitBreaker({
   windowMs: 60 * 1000,
   threshold: 10,

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -1,0 +1,147 @@
+import { getInstagramMediaId } from '../lib/instagram-meta';
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"',
+};
+
+const INSTAGRAM_FETCH_HEADERS = {
+  'accept-language': 'en-US,en;q=0.9',
+  'user-agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+};
+
+const GENERIC_VALIDATION_ERROR =
+  "We couldn't verify this Instagram link. Make sure it's a public post or reel that Boardsesh can preview, and that the caption or title mentions the climb name.";
+
+export class InstagramBetaValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InstagramBetaValidationError';
+  }
+}
+
+export interface InstagramPageMetadata {
+  description: string | null;
+  imageUrl: string | null;
+  mediaId: string | null;
+  ogTitle: string | null;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&([a-z]+);/gi, (_, entity) => HTML_ENTITY_MAP[entity.toLowerCase()] ?? `&${entity};`);
+}
+
+function normalizeText(value: string): string {
+  return decodeHtmlEntities(value)
+    .normalize('NFKD')
+    .replace(new RegExp('[\\u0300-\\u036f]', 'g'), '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function containsNormalizedClimbName(haystack: string, climbName: string): boolean {
+  const normalizedHaystack = normalizeText(haystack);
+  const normalizedClimbName = normalizeText(climbName);
+
+  if (!normalizedHaystack || !normalizedClimbName) return false;
+  if (normalizedHaystack.includes(normalizedClimbName)) return true;
+
+  const tokens = normalizedClimbName.split(' ').filter(Boolean);
+  if (tokens.length === 0) return false;
+
+  let cursor = 0;
+  for (const token of tokens) {
+    const nextIndex = normalizedHaystack.indexOf(token, cursor);
+    if (nextIndex === -1) return false;
+    cursor = nextIndex + token.length;
+  }
+  return true;
+}
+
+function parseMetaContent(html: string, target: string): string | null {
+  const metaTagRegex = /<meta\b[^>]*>/gi;
+  const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*"([^"]*)"/g;
+  const normalizedTarget = target.toLowerCase();
+
+  for (const metaTag of html.match(metaTagRegex) ?? []) {
+    const attrs: Record<string, string> = {};
+    let match: RegExpExecArray | null;
+    while ((match = attrRegex.exec(metaTag)) !== null) {
+      attrs[match[1].toLowerCase()] = match[2];
+    }
+
+    if (attrs.property?.toLowerCase() === normalizedTarget || attrs.name?.toLowerCase() === normalizedTarget) {
+      return attrs.content ? decodeHtmlEntities(attrs.content) : null;
+    }
+  }
+
+  return null;
+}
+
+export async function fetchInstagramPageMetadata(url: string): Promise<InstagramPageMetadata> {
+  const response = await fetch(url, {
+    headers: INSTAGRAM_FETCH_HEADERS,
+    redirect: 'follow',
+    signal: AbortSignal.timeout(8000),
+  });
+
+  if (!response.ok) {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('text/html')) {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
+  const html = await response.text();
+  const description = parseMetaContent(html, 'description') ?? parseMetaContent(html, 'og:description');
+  const ogTitle = parseMetaContent(html, 'og:title') ?? parseMetaContent(html, 'twitter:title');
+  const imageUrl = parseMetaContent(html, 'og:image') ?? parseMetaContent(html, 'twitter:image');
+  const mediaIdFromAppUrl = parseMetaContent(html, 'al:ios:url')?.match(/instagram:\/\/media\?id=(\d+)/)?.[1] ?? null;
+
+  if (!description && !ogTitle) {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
+  return {
+    description,
+    imageUrl,
+    mediaId: mediaIdFromAppUrl ?? getInstagramMediaId(url),
+    ogTitle,
+  };
+}
+
+export async function validateInstagramBetaLink(url: string, climbName: string): Promise<InstagramPageMetadata> {
+  const metadata = await fetchInstagramPageMetadata(url);
+
+  if (!metadata.imageUrl || !metadata.mediaId) {
+    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  }
+
+  const searchableText = [metadata.ogTitle, metadata.description].filter(Boolean).join(' ');
+  if (!containsNormalizedClimbName(searchableText, climbName)) {
+    throw new InstagramBetaValidationError(
+      `We couldn't confirm this video is for "${climbName}". Please use a public Instagram post or reel whose caption or title mentions the climb name.`,
+    );
+  }
+
+  return metadata;
+}
+
+export const instagramBetaValidationInternals = {
+  containsNormalizedClimbName,
+  decodeHtmlEntities,
+  normalizeText,
+  parseMetaContent,
+};

--- a/packages/backend/src/utils/like-pattern.ts
+++ b/packages/backend/src/utils/like-pattern.ts
@@ -1,0 +1,10 @@
+// Escape `\`, `_`, and `%` so user input interpolated into a SQL `LIKE` /
+// `ILIKE` pattern is treated as a literal substring. Without this, a `_`
+// in (for example) an Instagram shortcode or a `%` in a search term would
+// act as a wildcard and broaden the match.
+//
+// Backslash is escaped first so the inserts we add for `_` / `%` aren't
+// double-escaped on the next pass.
+export function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/[_%]/g, (m) => `\\${m}`);
+}

--- a/packages/web/app/components/beta-videos/__tests__/extract-graphql-error-message.test.ts
+++ b/packages/web/app/components/beta-videos/__tests__/extract-graphql-error-message.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { extractGraphQLErrorMessage } from '../attach-beta-link-form';
+
+describe('extractGraphQLErrorMessage', () => {
+  it('returns the first error message from a graphql-request ClientError shape', () => {
+    const error = Object.assign(new Error('GraphQL Error'), {
+      response: {
+        errors: [{ message: 'This Instagram post is already attached to "Cut to the Chase".' }],
+      },
+    });
+    expect(extractGraphQLErrorMessage(error)).toBe('This Instagram post is already attached to "Cut to the Chase".');
+  });
+
+  it('picks the first error when multiple are returned', () => {
+    const error = {
+      response: {
+        errors: [{ message: 'first message' }, { message: 'second message' }],
+      },
+    };
+    expect(extractGraphQLErrorMessage(error)).toBe('first message');
+  });
+
+  it('returns null for plain Error instances (no response field)', () => {
+    expect(extractGraphQLErrorMessage(new Error('network down'))).toBeNull();
+  });
+
+  it('returns null when response is missing or not an object', () => {
+    expect(extractGraphQLErrorMessage({ response: null })).toBeNull();
+    expect(extractGraphQLErrorMessage({ response: 'oops' })).toBeNull();
+    expect(extractGraphQLErrorMessage({})).toBeNull();
+  });
+
+  it('returns null when response.errors is missing or not an array', () => {
+    expect(extractGraphQLErrorMessage({ response: {} })).toBeNull();
+    expect(extractGraphQLErrorMessage({ response: { errors: null } })).toBeNull();
+    expect(extractGraphQLErrorMessage({ response: { errors: 'not-an-array' } })).toBeNull();
+  });
+
+  it('returns null when errors array is empty', () => {
+    expect(extractGraphQLErrorMessage({ response: { errors: [] } })).toBeNull();
+  });
+
+  it('returns null when the first error has no message field', () => {
+    expect(extractGraphQLErrorMessage({ response: { errors: [{ code: 'X' }] } })).toBeNull();
+    expect(extractGraphQLErrorMessage({ response: { errors: [null] } })).toBeNull();
+  });
+
+  it('returns null when message exists but is not a non-empty string', () => {
+    expect(extractGraphQLErrorMessage({ response: { errors: [{ message: '' }] } })).toBeNull();
+    expect(extractGraphQLErrorMessage({ response: { errors: [{ message: 42 }] } })).toBeNull();
+  });
+
+  it('returns null for primitive/null/undefined inputs', () => {
+    expect(extractGraphQLErrorMessage(null)).toBeNull();
+    expect(extractGraphQLErrorMessage(undefined)).toBeNull();
+    expect(extractGraphQLErrorMessage('string error')).toBeNull();
+    expect(extractGraphQLErrorMessage(42)).toBeNull();
+  });
+});

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -38,7 +38,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   angle,
   resetTrigger,
   submitLabel = 'Share beta',
-  helperText = 'Paste an Instagram or TikTok link so others can see your beta.',
+  helperText,
   onSuccess,
   onCancel,
   showCancel = false,
@@ -77,8 +77,19 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       setUrl('');
       onSuccess?.();
     },
-    onError: () => {
-      showMessage('Couldn’t add video. Try again.', 'error');
+    onError: (error) => {
+      let message = 'Couldn’t add video. Try again.';
+      if (error instanceof Error) {
+        if ('response' in error && typeof error.response === 'object' && error.response !== null) {
+          const response = error.response as { errors?: Array<{ message: string }> };
+          if (response.errors?.length) {
+            message = response.errors[0].message;
+          }
+        } else if (error.message) {
+          message = error.message;
+        }
+      }
+      showMessage(message, 'error');
     },
   });
 
@@ -94,7 +105,13 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         error={!!validationError}
-        helperText={validationError ?? helperText}
+        helperText={
+          validationError ??
+          helperText ??
+          (climbName
+            ? `Paste a public Instagram reel or post that mentions ${climbName}, or a TikTok URL.`
+            : 'Paste a public Instagram reel/post or TikTok URL so others can see your beta.')
+        }
         onKeyDown={(e) => {
           if (e.key === 'Enter' && canSubmit) {
             e.preventDefault();

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -21,7 +21,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 // (zod errors, InstagramBetaValidationError, our explicit throws). Anything
 // else — fetch failures, library bugs, `error.message` — is opaque and we
 // fall back to the generic toast so we never leak internal strings.
-function extractGraphQLErrorMessage(error: unknown): string | null {
+export function extractGraphQLErrorMessage(error: unknown): string | null {
   if (!error || typeof error !== 'object') return null;
   if (!('response' in error)) return null;
   const response = (error as { response?: unknown }).response;

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -16,6 +16,24 @@ import {
 import { isBetaVideoUrl, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@/app/lib/beta-video-url';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 
+// graphql-request throws ClientError-shaped errors with a `response.errors[]`
+// array. We trust those messages because they come from our own resolvers
+// (zod errors, InstagramBetaValidationError, our explicit throws). Anything
+// else — fetch failures, library bugs, `error.message` — is opaque and we
+// fall back to the generic toast so we never leak internal strings.
+function extractGraphQLErrorMessage(error: unknown): string | null {
+  if (!error || typeof error !== 'object') return null;
+  if (!('response' in error)) return null;
+  const response = (error as { response?: unknown }).response;
+  if (!response || typeof response !== 'object' || !('errors' in response)) return null;
+  const errors = (response as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return null;
+  const first = errors[0];
+  if (!first || typeof first !== 'object' || !('message' in first)) return null;
+  const message = (first as { message?: unknown }).message;
+  return typeof message === 'string' && message.length > 0 ? message : null;
+}
+
 type AttachBetaLinkFormProps = {
   boardType: string;
   climbUuid: string;
@@ -78,18 +96,13 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       onSuccess?.();
     },
     onError: (error) => {
-      let message = 'Couldn’t add video. Try again.';
-      if (error instanceof Error) {
-        if ('response' in error && typeof error.response === 'object' && error.response !== null) {
-          const response = error.response as { errors?: Array<{ message: string }> };
-          if (response.errors?.length) {
-            message = response.errors[0].message;
-          }
-        } else if (error.message) {
-          message = error.message;
-        }
-      }
-      showMessage(message, 'error');
+      // Surface the GraphQL resolver's user-facing error message (the validator
+      // throws InstagramBetaValidationError with a message we want users to
+      // see). Don't fall back to error.message — for non-GraphQL failures
+      // (network, library internals, type assertions) that field can carry
+      // raw stack traces or implementation strings that shouldn't be shown.
+      const serverMessage = extractGraphQLErrorMessage(error);
+      showMessage(serverMessage ?? 'Couldn’t add video. Try again.', 'error');
     },
   });
 


### PR DESCRIPTION
## Summary

Stacks on #1716. Adds server-side validation when a user attaches an Instagram URL via `attachBetaLink` or `saveTick(videoUrl)`. Ported from #1607, adapted for 1716's pipeline.

The mutation now rejects the write if:

- the post isn't publicly previewable (not 200 + HTML, no og tags)
- the caption / `og:title` doesn't mention the climb name (forgiving normalized fuzzy match)
- the same Instagram shortcode is already attached to the same climb
- the same Instagram shortcode is already attached to a different climb — users get a message asking them to post a separate reel per climb instead. Existing cross-climb duplicates are grandfathered (only new writes are blocked).

TikTok and other platforms still skip the deep validation — only the zod regex check applies. 1716's read-time `betaLinks` resolver (which filters `gone` posts) keeps doing its job for legacy rows.

## Eager thumbnail caching

While the validator already fetches the post page, reuse the parsed `og:image` to eagerly call `cacheInstagramThumbnail()` and persist the S3 URL into the new `boardBetaLinks` row. The just-attached user doesn't pay a cold-fetch on first read. In dev with no S3 configured, `thumbnail` stays null and the existing dev proxy fallback in the read resolver handles it.

## UX

The attach form's `onError` now surfaces the GraphQL error message so users see *"This Instagram post is already attached to &lt;other climb&gt;..."* instead of the generic *"Couldn't add video. Try again."* toast.

## What was dropped from #1607 (superseded by 1716)

- `is_accessible` / `checked_at` columns + migration `0083_gorgeous_daredevil`
- `beta-link-revalidation.ts` background revalidation lib
- `backfill-beta-link-accessibility.ts` script
- REST `/api/v1/.../beta/...` route + `climb-detail-data.server.ts` changes

1716's read-time live check covers this gap.

## Files

**Added**
- `packages/backend/src/utils/instagram-beta-validation.ts` — validator, fetcher, `InstagramBetaValidationError`
- `packages/backend/src/__tests__/instagram-beta-validation.test.ts` — 6 tests

**Modified**
- `packages/backend/src/graphql/resolvers/ticks/mutations.ts` — adds `getClimbNameForBetaValidation`, `ensureInstagramShortcodeIsNotAlreadyLinked`, `enrichInstagramBetaInsert` helpers; wires validation into both mutations
- `packages/web/app/components/beta-videos/attach-beta-link-form.tsx` — surface server error in onError snackbar; helper text now mentions the climb name

## Test plan

- [ ] Attach a public Instagram reel whose caption mentions the climb → succeeds, row gets a thumbnail (S3 if configured)
- [ ] Attach a public Instagram reel whose caption does NOT mention the climb → server rejects, real error message shown in snackbar
- [ ] Attach a private/deleted Instagram URL → generic "we couldn't verify this Instagram link" error
- [ ] Attach the same Instagram URL twice to the same climb → "already linked for this climb"
- [ ] Attach the same Instagram URL to a second climb → blocked, message asks for a separate reel
- [ ] Attach a TikTok URL → passes through (no deep validation)
- [ ] Save a tick with a valid `videoUrl` on flash/send where caption matches → tick + beta link both saved
- [ ] Save a tick with a bogus `videoUrl` → mutation fails, no tick row inserted
- [ ] In dev (no S3) → first read populates the dev proxy URL via `getDevProxyThumbnailUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)