### PR TITLE
fix: resolve icon.svg via import.meta.url for standalone container

### DIFF
--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ImageResponse } from 'next/og';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const runtime = 'nodejs';
 
@@ -9,7 +9,8 @@ export const alt = 'Boardsesh - Train smarter on your climbing board';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-const iconSvg = readFileSync(join(process.cwd(), 'app', 'icon.svg'));
+// new URL + import.meta.url lets @vercel/nft trace and include icon.svg in standalone output
+const iconSvg = readFileSync(fileURLToPath(new URL('./icon.svg', import.meta.url)));
 const iconDataUrl = `data:image/svg+xml;base64,${iconSvg.toString('base64')}`;
 
 export default function Image() {


### PR DESCRIPTION
## Summary

- `readFileSync(join(process.cwd(), 'app', 'icon.svg'))` hard-coded a cwd-relative path that resolves to `/app/app/icon.svg` in the Docker standalone container (WORKDIR `/app`, server entry at `packages/web/server.js`), causing ENOENT at import time and 500s on `/opengraph-image` and `/twitter-image`.
- Replaced with `readFileSync(fileURLToPath(new URL('./icon.svg', import.meta.url)))`, the pattern `@vercel/nft` (Next.js file tracer) recognises for asset tracing — the file is copied into the standalone output alongside the route module and resolves correctly on every deploy target (dev, Vercel, standalone Docker).

## Test plan

- [ ] Verify `/opengraph-image` and `/twitter-image` return 200 in the standalone Docker container
- [ ] Verify the existing `opengraph-image.test.tsx` test suite still passes

https://claude.ai/code/session_01Qyscd7o14dS8My4YrZfCni

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyscd7o14dS8My4YrZfCni)_