### PR TITLE
Make warm brand text tokens readable in light mode

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -125,7 +125,9 @@
      marketing). Scoped intentionally — standard product UI keeps the
      existing neutral scale. Light-mode values are warm darks so the same
      text token reads against a light surface; the dark-mode block below
-     swaps in the warm cream that ships on dark brand surfaces. */
+     swaps in the warm cream that ships on dark brand surfaces.
+     Canonical values live in app/theme/theme-config.ts as
+     `text.brandPrimaryLight` / `text.brandMutedLight` — keep in sync. */
   --bs-text-brand-primary: #2a1f1f;
   --bs-text-brand-muted: #6b5b54;
 }
@@ -179,7 +181,8 @@ html[data-theme='dark'] {
   --overlay-dark: rgba(0, 0, 0, 0.7);
   --overlay-text: rgba(255, 255, 255, 0.85);
 
-  /* Brand surfaces are dark in dark mode — restore the warm cream pair. */
+  /* Brand surfaces are dark in dark mode — restore the warm cream pair.
+     Canonical values: `themeTokens.text.brandPrimary` / `text.brandMuted`. */
   --bs-text-brand-primary: #f4f1ea;
   --bs-text-brand-muted: #8a8780;
 }

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -123,9 +123,11 @@
 
   /* Warm text tokens for brand surfaces (landing hero, splash, OG, App Store,
      marketing). Scoped intentionally — standard product UI keeps the
-     existing neutral scale. */
-  --bs-text-brand-primary: #f4f1ea;
-  --bs-text-brand-muted: #8a8780;
+     existing neutral scale. Light-mode values are warm darks so the same
+     text token reads against a light surface; the dark-mode block below
+     swaps in the warm cream that ships on dark brand surfaces. */
+  --bs-text-brand-primary: #2a1f1f;
+  --bs-text-brand-muted: #6b5b54;
 }
 
 /* Dark mode overrides */
@@ -176,6 +178,10 @@ html[data-theme='dark'] {
   --overlay-light: rgba(0, 0, 0, 0.4);
   --overlay-dark: rgba(0, 0, 0, 0.7);
   --overlay-text: rgba(255, 255, 255, 0.85);
+
+  /* Brand surfaces are dark in dark mode — restore the warm cream pair. */
+  --bs-text-brand-primary: #f4f1ea;
+  --bs-text-brand-muted: #8a8780;
 }
 
 /* Base styles */

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -443,7 +443,11 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
               // translateY(-1px) on hover; explicitly cancel it here so
               // the brand CTA stays anchored.
               backgroundColor: '#6A1B9A',
-              color: 'var(--bs-text-brand-primary)',
+              // CTA sits on a constant purple background in both themes, so
+              // pin the label to the warm cream rather than reading the
+              // theme-aware brand text token (which flips dark in light mode
+              // and would drop contrast against the purple to ~3.6:1).
+              color: themeTokens.text.brandPrimary,
               boxShadow: '0 4px 12px rgba(106, 27, 154, 0.30)',
               '&:hover': {
                 backgroundColor: '#5C1A87',

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -29,9 +29,18 @@ export const themeTokens = {
   // Warm text colours scoped to brand surfaces (landing hero, splash,
   // OG/social, App Store screenshots, marketing emails). Standard product
   // UI keeps the cool neutral scale — do not blanket-replace neutrals.
+  //
+  // `brandPrimary` / `brandMuted` are the dark-surface (warm cream) values
+  // that ship on dark brand surfaces and on the constant-purple hero CTA.
+  // `brandPrimaryLight` / `brandMutedLight` are warm darks for the same
+  // tokens on light surfaces (the home hero in light mode). The
+  // `--bs-text-brand-*` CSS vars in `app/components/index.css` mirror this
+  // pair: light root → light values, `data-theme='dark'` → dark values.
   text: {
     brandPrimary: '#f4f1ea',
     brandMuted: '#8a8780',
+    brandPrimaryLight: '#2a1f1f',
+    brandMutedLight: '#6b5b54',
   },
 
   // Neutral palette


### PR DESCRIPTION
## Summary

- The home hero headline (\"Get on the board!\") and body copy read from `--bs-text-brand-primary` / `--bs-text-brand-muted`, which were defined once as warm cream (`#f4f1ea` / `#8a8780`). That renders cream-on-white in light mode and is unreadable.
- Split the brand text tokens by theme: light `:root` ships warm darks (`#2a1f1f` / `#6b5b54`) so the same token reads on a light surface; `html[data-theme='dark']` restores the warm cream pair for the dark brand surfaces those tokens were originally written for. Both values stay in the warm family so the brand vocabulary is consistent.
- Pin the home hero CTA label to `themeTokens.text.brandPrimary` (always cream) instead of the theme-aware var. The CTA sits on a constant V13 purple background in both modes, and the warm dark would drop contrast against the purple to ~3.6:1.

## Test plan

- [ ] Toggle the app to light mode and load `/`. The headline and body copy under the hero mark are clearly readable.
- [ ] Toggle to dark mode and reload — the warm cream is preserved.
- [ ] Both modes: \"Start climbing\" CTA label remains cream-on-purple.
- [ ] OG image still renders cream-on-dark (the server-rendered route uses `themeTokens.text.brandPrimary` directly, not the CSS var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)