### PR TITLE
Fix logbook "X ago" being off by the user's UTC offset

### DIFF
--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -15,10 +15,8 @@ import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
 import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import utc from 'dayjs/plugin/utc';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { formatTickRelativeTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_USER_GROUPED_ASCENTS_FEED,
@@ -34,10 +32,6 @@ import { useDeleteTick } from '@/app/hooks/use-delete-tick';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
-
-dayjs.extend(relativeTime);
-dayjs.extend(utc);
-dayjs.extend(relativeTime);
 
 type AscentsFeedProps = {
   userId: string;
@@ -108,7 +102,7 @@ const TickItemRow: React.FC<{
   onDelete: (uuid: string) => void;
   isDeleting: boolean;
 }> = ({ item, onDelete, isDeleting }) => {
-  const timeAgo = dayjs(item.climbedAt).utc(true).fromNow();
+  const timeAgo = formatTickRelativeTime(item.climbedAt);
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
       <Chip
@@ -146,9 +140,9 @@ const GroupedFeedItem: React.FC<{
   isDeleting?: boolean;
 }> = ({ group, isOwnProfile = false, onDeleteTick, isDeleting = false }) => {
   const latestItem = group.items.reduce((latest, item) =>
-    new Date(item.climbedAt) > new Date(latest.climbedAt) ? item : latest,
+    tickTimeMs(item.climbedAt) > tickTimeMs(latest.climbedAt) ? item : latest,
   );
-  const timeAgo = dayjs(latestItem.climbedAt).utc(true).fromNow();
+  const timeAgo = formatTickRelativeTime(latestItem.climbedAt);
   const boardDisplay = getLayoutDisplayName(group.boardType, group.layoutId);
   const statusSummary = getGroupStatusSummary(group);
   const hasSuccess = group.flashCount > 0 || group.sendCount > 0;

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -16,8 +16,7 @@ import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import Link from 'next/link';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
+import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
 import type { FollowingAscentFeedItem } from '@boardsesh/shared-schema';
 import AscentThumbnail from './ascent-thumbnail';
 import VoteButton from '@/app/components/social/vote-button';
@@ -25,8 +24,6 @@ import CommentSection from '@/app/components/social/comment-section';
 import ClimbIcons from '@/app/components/climb-card/climb-icons';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './ascents-feed.module.css';
-
-dayjs.extend(relativeTime);
 
 // Layout name mapping (shared with ascents-feed.tsx)
 const layoutNames: Record<string, string> = {
@@ -68,7 +65,7 @@ type SocialFeedItemProps = {
 
 const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = false }) => {
   const [commentsOpen, setCommentsOpen] = useState(false);
-  const timeAgo = dayjs(item.climbedAt).fromNow();
+  const timeAgo = formatTickRelativeTime(item.climbedAt);
   const statusDisplay = getStatusDisplay(item.status);
   const boardDisplay = getLayoutDisplayName(item.boardType, item.layoutId ?? null);
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -24,9 +24,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import utc from 'dayjs/plugin/utc';
+import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
 import { track } from '@vercel/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
@@ -61,8 +59,6 @@ const AttachBetaLinkDialog = dynamic(() => import('@/app/components/beta-videos/
   ssr: false,
 });
 
-dayjs.extend(relativeTime);
-dayjs.extend(utc);
 
 // Layout name mapping
 const layoutNames: Record<string, string> = {
@@ -500,7 +496,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     // Subtitle: "2h ago . 40deg . Kilter Original"
     const subtitle = useMemo(() => {
       const parts: string[] = [];
-      parts.push(dayjs(item.climbedAt).utc(true).fromNow());
+      parts.push(formatTickRelativeTime(item.climbedAt));
       parts.push(`${item.angle}\u00B0`);
       if (showBoardType) {
         parts.push(getLayoutDisplayName(item.boardType, item.layoutId));

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -59,7 +59,6 @@ const AttachBetaLinkDialog = dynamic(() => import('@/app/components/beta-videos/
   ssr: false,
 });
 
-
 // Layout name mapping
 const layoutNames: Record<string, string> = {
   'kilter-1': 'Kilter Original',

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -26,6 +26,7 @@ import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
 import { track } from '@vercel/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
@@ -61,6 +62,7 @@ const AttachBetaLinkDialog = dynamic(() => import('@/app/components/beta-videos/
 });
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 // Layout name mapping
 const layoutNames: Record<string, string> = {
@@ -498,7 +500,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     // Subtitle: "2h ago . 40deg . Kilter Original"
     const subtitle = useMemo(() => {
       const parts: string[] = [];
-      parts.push(dayjs(item.climbedAt).fromNow());
+      parts.push(dayjs(item.climbedAt).utc(true).fromNow());
       parts.push(`${item.angle}\u00B0`);
       if (showBoardType) {
         parts.push(getLayoutDisplayName(item.boardType, item.layoutId));

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -12,11 +12,11 @@ import Rating from '@mui/material/Rating';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
-import dayjs from 'dayjs';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '@/app/components/ascent-status/ascent-status-utils';
 import VoteButton from '@/app/components/social/vote-button';
 import FeedCommentButton from '@/app/components/social/feed-comment-button';
+import { formatTickAbsoluteTime } from '@/app/lib/format-tick-time';
 
 export type LogbookEntryUser = {
   userId: string;
@@ -95,7 +95,7 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
         <Stack spacing={1} sx={{ width: '100%' }}>
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
             <Typography variant="body2" component="span" fontWeight={600}>
-              {dayjs(entry.climbedAt).format('MMM D, YYYY h:mm A')}
+              {formatTickAbsoluteTime(entry.climbedAt, 'MMM D, YYYY h:mm A')}
             </Typography>
             {showAngleAndStatus && (
               <>

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -6,7 +6,7 @@ import BookOutlined from '@mui/icons-material/BookOutlined';
 import { LogbookView } from './logbook-view';
 import type { Climb } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import dayjs from 'dayjs';
+import { formatTickAbsoluteTime } from '@/app/lib/format-tick-time';
 
 type LogbookSectionProps = {
   climb: Climb;
@@ -32,7 +32,7 @@ export function useLogbookSummary(climbUuid: string): LogbookSummary | null {
 
     const totalAttempts = climbAscents.reduce((sum, ascent) => sum + (ascent.tries || 1), 0);
 
-    const sessionDates = new Set(climbAscents.map((ascent) => dayjs(ascent.climbed_at).format('YYYY-MM-DD')));
+    const sessionDates = new Set(climbAscents.map((ascent) => formatTickAbsoluteTime(ascent.climbed_at, 'YYYY-MM-DD')));
     const sessionCount = sessionDates.size;
 
     const successfulAscents = climbAscents.filter((a) => a.is_ascent).length;

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
-import dayjs from 'dayjs';
+import { tickTimeMs } from '@/app/lib/format-tick-time';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import type { Climb } from '@/app/lib/types';
 import { VoteSummaryProvider } from '@/app/components/social/vote-summary-context';
@@ -33,7 +33,7 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
     () =>
       logbook
         .filter((ascent) => ascent.climb_uuid === currentClimb.uuid)
-        .sort((a, b) => dayjs(b.climbed_at).valueOf() - dayjs(a.climbed_at).valueOf()),
+        .sort((a, b) => tickTimeMs(b.climbed_at) - tickTimeMs(a.climbed_at)),
     [logbook, currentClimb.uuid],
   );
 

--- a/packages/web/app/components/play-view/play-view-comments.tsx
+++ b/packages/web/app/components/play-view/play-view-comments.tsx
@@ -8,7 +8,7 @@ import Rating from '@mui/material/Rating';
 import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { themeTokens } from '@/app/theme/theme-config';
-import dayjs from 'dayjs';
+import { formatTickAbsoluteTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '@/app/components/ascent-status/ascent-status-utils';
 
@@ -29,7 +29,7 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
     () =>
       logbook
         .filter((entry) => entry.climb_uuid === climbUuid)
-        .sort((a, b) => dayjs(b.climbed_at).valueOf() - dayjs(a.climbed_at).valueOf()),
+        .sort((a, b) => tickTimeMs(b.climbed_at) - tickTimeMs(a.climbed_at)),
     [logbook, climbUuid],
   );
 
@@ -91,7 +91,7 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
                     color="text.secondary"
                     sx={{ fontSize: themeTokens.typography.fontSize.xs }}
                   >
-                    {dayjs(ascent.climbed_at).format('MMM D, YYYY')}
+                    {formatTickAbsoluteTime(ascent.climbed_at, 'MMM D, YYYY')}
                   </Typography>
                   <Chip
                     label={getAscentChipLabel(ascentStatus)}

--- a/packages/web/app/lib/__tests__/format-tick-time.test.ts
+++ b/packages/web/app/lib/__tests__/format-tick-time.test.ts
@@ -51,12 +51,21 @@ describe('parseTickTime', () => {
 });
 
 describe('formatTickAbsoluteTime', () => {
-  it('renders the absolute moment in the viewer-local clock', () => {
-    // The output displays the local-clock equivalent of the UTC moment, so we
-    // assert against the same helper applied to the Z-suffixed form rather
-    // than a literal — that keeps the test host-TZ independent.
-    expect(formatTickAbsoluteTime(NAIVE, 'YYYY-MM-DD HH:mm')).toBe(
-      formatTickAbsoluteTime(Z_FORM, 'YYYY-MM-DD HH:mm'),
-    );
+  it('parses naive strings as UTC, not local time', () => {
+    // The output is the local-clock equivalent of the UTC moment; rendering
+    // it with a `Z` offset token and parsing back via `Date` recovers the
+    // absolute ms regardless of host TZ. If the helper ever parsed NAIVE in
+    // local time, the recovered ms would be off by the host offset.
+    const formatted = formatTickAbsoluteTime(NAIVE, 'YYYY-MM-DDTHH:mm:ss.SSSZ');
+    expect(new Date(formatted).getTime()).toBe(ABSOLUTE_MS);
+  });
+});
+
+describe('helper guards', () => {
+  it('throws when given an empty string instead of silently using "now"', () => {
+    expect(() => formatTickRelativeTime('')).toThrow(TypeError);
+    expect(() => parseTickTime('')).toThrow(TypeError);
+    expect(() => tickTimeMs('')).toThrow(TypeError);
+    expect(() => formatTickAbsoluteTime('', 'X')).toThrow(TypeError);
   });
 });

--- a/packages/web/app/lib/__tests__/format-tick-time.test.ts
+++ b/packages/web/app/lib/__tests__/format-tick-time.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
+import {
+  formatTickAbsoluteTime,
+  formatTickRelativeTime,
+  parseTickTime,
+  tickTimeMs,
+} from '@/app/lib/format-tick-time';
+
+const NAIVE = '2026-04-27 05:39:13.000';
+const Z_FORM = '2026-04-27T05:39:13.000Z';
+const ABSOLUTE_MS = Date.UTC(2026, 3, 27, 5, 39, 13, 0);
 
 describe('formatTickRelativeTime', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    // 60 seconds after the seeded climbed_at strings below, in UTC absolute terms.
     vi.setSystemTime(new Date('2026-04-27T05:40:13.000Z'));
   });
 
@@ -13,23 +21,42 @@ describe('formatTickRelativeTime', () => {
   });
 
   it('treats Drizzle naive timestamp strings as UTC absolute moments', () => {
-    // The shape Drizzle returns from boardsesh_ticks.climbed_at — no Z, no offset.
-    expect(formatTickRelativeTime('2026-04-27 05:39:13.000')).toBe('a minute ago');
+    expect(formatTickRelativeTime(NAIVE)).toBe('a minute ago');
   });
 
   it('agrees with the equivalent Z-suffixed ISO string', () => {
-    expect(formatTickRelativeTime('2026-04-27 05:39:13.000')).toBe(
-      formatTickRelativeTime('2026-04-27T05:39:13.000Z'),
-    );
+    // If the helper ever drops `dayjs.utc(...)`, this fails on any non-UTC host
+    // because dayjs parses the naive form in local time but the Z form in UTC.
+    expect(formatTickRelativeTime(NAIVE)).toBe(formatTickRelativeTime(Z_FORM));
+  });
+});
+
+describe('tickTimeMs', () => {
+  it('returns the same epoch ms for naive and Z-suffixed strings', () => {
+    expect(tickTimeMs(NAIVE)).toBe(ABSOLUTE_MS);
+    expect(tickTimeMs(NAIVE)).toBe(tickTimeMs(Z_FORM));
   });
 
-  it('produces the same output regardless of how the host parses the naive string', () => {
-    // The naive form parsed via dayjs.utc must land on the same absolute moment as
-    // the explicit UTC ISO form. If the helper ever drops `dayjs.utc(...)`, this
-    // assertion fails on any non-UTC host because dayjs would parse the naive
-    // string in local time instead.
-    const naive = '2026-04-27 05:39:13.000';
-    const explicit = '2026-04-27T05:39:13.000Z';
-    expect(formatTickRelativeTime(naive)).toBe(formatTickRelativeTime(explicit));
+  it('orders ticks by absolute moment', () => {
+    const earlier = '2026-04-27 05:00:00.000';
+    const later = '2026-04-27 06:00:00.000';
+    expect(tickTimeMs(later) - tickTimeMs(earlier)).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('parseTickTime', () => {
+  it('lands on the same epoch ms as a Z-suffixed parse', () => {
+    expect(parseTickTime(NAIVE).valueOf()).toBe(ABSOLUTE_MS);
+  });
+});
+
+describe('formatTickAbsoluteTime', () => {
+  it('renders the absolute moment in the viewer-local clock', () => {
+    // The output displays the local-clock equivalent of the UTC moment, so we
+    // assert against the same helper applied to the Z-suffixed form rather
+    // than a literal — that keeps the test host-TZ independent.
+    expect(formatTickAbsoluteTime(NAIVE, 'YYYY-MM-DD HH:mm')).toBe(
+      formatTickAbsoluteTime(Z_FORM, 'YYYY-MM-DD HH:mm'),
+    );
   });
 });

--- a/packages/web/app/lib/__tests__/format-tick-time.test.ts
+++ b/packages/web/app/lib/__tests__/format-tick-time.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
+
+describe('formatTickRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 60 seconds after the seeded climbed_at strings below, in UTC absolute terms.
+    vi.setSystemTime(new Date('2026-04-27T05:40:13.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('treats Drizzle naive timestamp strings as UTC absolute moments', () => {
+    // The shape Drizzle returns from boardsesh_ticks.climbed_at — no Z, no offset.
+    expect(formatTickRelativeTime('2026-04-27 05:39:13.000')).toBe('a minute ago');
+  });
+
+  it('agrees with the equivalent Z-suffixed ISO string', () => {
+    expect(formatTickRelativeTime('2026-04-27 05:39:13.000')).toBe(
+      formatTickRelativeTime('2026-04-27T05:39:13.000Z'),
+    );
+  });
+
+  it('produces the same output regardless of how the host parses the naive string', () => {
+    // The naive form parsed via dayjs.utc must land on the same absolute moment as
+    // the explicit UTC ISO form. If the helper ever drops `dayjs.utc(...)`, this
+    // assertion fails on any non-UTC host because dayjs would parse the naive
+    // string in local time instead.
+    const naive = '2026-04-27 05:39:13.000';
+    const explicit = '2026-04-27T05:39:13.000Z';
+    expect(formatTickRelativeTime(naive)).toBe(formatTickRelativeTime(explicit));
+  });
+});

--- a/packages/web/app/lib/format-tick-time.ts
+++ b/packages/web/app/lib/format-tick-time.ts
@@ -1,11 +1,19 @@
 import dayjs, { type Dayjs } from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
 
-dayjs.extend(isoWeek);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
+
+function requireString(climbedAt: string): string {
+  // dayjs.utc(undefined) silently returns "now", which would corrupt sorts and
+  // bucket bounds. The signatures already require `string`, but we guard at
+  // runtime so a stray `?.` or future caller can't bypass the type system.
+  if (!climbedAt) {
+    throw new TypeError('format-tick-time helpers require a non-empty timestamp string');
+  }
+  return climbedAt;
+}
 
 // `boardsesh_ticks.climbed_at` (and `created_at` / `updated_at`) are naive
 // `timestamp` columns. Drizzle returns them as strings with no `Z` suffix,
@@ -14,11 +22,11 @@ dayjs.extend(utc);
 // before any rendering, sorting, or bucketing.
 
 export function parseTickTime(climbedAt: string): Dayjs {
-  return dayjs.utc(climbedAt).local();
+  return dayjs.utc(requireString(climbedAt)).local();
 }
 
 export function formatTickRelativeTime(climbedAt: string): string {
-  return dayjs.utc(climbedAt).fromNow();
+  return dayjs.utc(requireString(climbedAt)).fromNow();
 }
 
 export function formatTickAbsoluteTime(climbedAt: string, format: string): string {
@@ -26,5 +34,5 @@ export function formatTickAbsoluteTime(climbedAt: string, format: string): strin
 }
 
 export function tickTimeMs(climbedAt: string): number {
-  return dayjs.utc(climbedAt).valueOf();
+  return dayjs.utc(requireString(climbedAt)).valueOf();
 }

--- a/packages/web/app/lib/format-tick-time.ts
+++ b/packages/web/app/lib/format-tick-time.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(relativeTime);
+dayjs.extend(utc);
+
+// `boardsesh_ticks.climbed_at` is a naive `timestamp` column, so Drizzle
+// returns it as a string with no `Z` suffix. Parse it through `dayjs.utc`
+// to recover the absolute moment, otherwise non-UTC viewers see the time
+// shifted by their local offset.
+export function formatTickRelativeTime(climbedAt: string): string {
+  return dayjs.utc(climbedAt).fromNow();
+}

--- a/packages/web/app/lib/format-tick-time.ts
+++ b/packages/web/app/lib/format-tick-time.ts
@@ -1,14 +1,30 @@
-import dayjs from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
 
+dayjs.extend(isoWeek);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
-// `boardsesh_ticks.climbed_at` is a naive `timestamp` column, so Drizzle
-// returns it as a string with no `Z` suffix. Parse it through `dayjs.utc`
-// to recover the absolute moment, otherwise non-UTC viewers see the time
-// shifted by their local offset.
+// `boardsesh_ticks.climbed_at` (and `created_at` / `updated_at`) are naive
+// `timestamp` columns. Drizzle returns them as strings with no `Z` suffix,
+// so any `dayjs(<naiveString>)` call would parse them as browser-local time.
+// These helpers parse through `dayjs.utc(...)` to recover the absolute moment
+// before any rendering, sorting, or bucketing.
+
+export function parseTickTime(climbedAt: string): Dayjs {
+  return dayjs.utc(climbedAt).local();
+}
+
 export function formatTickRelativeTime(climbedAt: string): string {
   return dayjs.utc(climbedAt).fromNow();
+}
+
+export function formatTickAbsoluteTime(climbedAt: string, format: string): string {
+  return parseTickTime(climbedAt).format(format);
+}
+
+export function tickTimeMs(climbedAt: string): number {
+  return dayjs.utc(climbedAt).valueOf();
 }

--- a/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { parseTickTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import type { GetUserProfileStatsQueryResponse } from '@/app/lib/graphql/operations';
 import type { CssBarChartBar, GroupedBar } from '@/app/components/charts/css-bar-chart';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -23,7 +23,6 @@ import {
 const FLASH_COLOR = `${themeTokens.colors.success}99`; // 60% opacity hex
 const REDPOINT_COLOR = `${themeTokens.colors.error}99`;
 
-dayjs.extend(isoWeek);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 
@@ -38,13 +37,13 @@ export function filterLogbookByTimeframe(
   const now = dayjs();
   switch (timeframe) {
     case 'today':
-      return logbook.filter((entry) => dayjs(entry.climbed_at).isSame(now, 'day'));
+      return logbook.filter((entry) => parseTickTime(entry.climbed_at).isSame(now, 'day'));
     case 'lastWeek':
-      return logbook.filter((entry) => dayjs(entry.climbed_at).isAfter(now.subtract(1, 'week')));
+      return logbook.filter((entry) => parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'week')));
     case 'lastMonth':
-      return logbook.filter((entry) => dayjs(entry.climbed_at).isAfter(now.subtract(1, 'month')));
+      return logbook.filter((entry) => parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'month')));
     case 'lastYear':
-      return logbook.filter((entry) => dayjs(entry.climbed_at).isAfter(now.subtract(1, 'year')));
+      return logbook.filter((entry) => parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'year')));
     case 'custom':
       return logbook.filter((entry) => {
         // Compare date strings only (YYYY-MM-DD) to avoid timezone issues.
@@ -73,13 +72,13 @@ function filterByUnifiedTimeframe(
   return entries.filter((entry) => {
     switch (timeframe) {
       case 'today':
-        return dayjs(entry.climbed_at).isSame(now, 'day');
+        return parseTickTime(entry.climbed_at).isSame(now, 'day');
       case 'lastWeek':
-        return dayjs(entry.climbed_at).isAfter(now.subtract(1, 'week'));
+        return parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'week'));
       case 'lastMonth':
-        return dayjs(entry.climbed_at).isAfter(now.subtract(1, 'month'));
+        return parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'month'));
       case 'lastYear':
-        return dayjs(entry.climbed_at).isAfter(now.subtract(1, 'year'));
+        return parseTickTime(entry.climbed_at).isAfter(now.subtract(1, 'year'));
       case 'custom': {
         const dateStr = entry.climbed_at.slice(0, 10);
         return (!fromDate || dateStr >= fromDate) && (!toDate || dateStr <= toDate);
@@ -193,7 +192,7 @@ export function buildWeeklyBars(
   const entries =
     fromDate || toDate
       ? filteredLogbook.filter((entry) => {
-          const d = dayjs(entry.climbed_at);
+          const d = parseTickTime(entry.climbed_at);
           if (fromDate && d.isBefore(dayjs(fromDate), 'day')) return false;
           if (toDate && d.isAfter(dayjs(toDate), 'day')) return false;
           return true;
@@ -204,8 +203,8 @@ export function buildWeeklyBars(
 
   const DEFAULT_MAX_WEEKS = 52;
   const allWeekKeys: string[] = [];
-  const first = dayjs(entries[entries.length - 1]?.climbed_at).startOf('isoWeek');
-  const last = dayjs(entries[0]?.climbed_at).endOf('isoWeek');
+  const first = parseTickTime(entries[entries.length - 1]?.climbed_at).startOf('isoWeek');
+  const last = parseTickTime(entries[0]?.climbed_at).endOf('isoWeek');
   let current = first;
   while (current.isBefore(last) || current.isSame(last)) {
     allWeekKeys.push(`${current.isoWeekYear()}-W${current.isoWeek()}`);
@@ -218,7 +217,7 @@ export function buildWeeklyBars(
     if (entry.difficulty === null) return;
     const grade = mapping[entry.difficulty];
     if (!grade) return;
-    const d = dayjs(entry.climbed_at);
+    const d = parseTickTime(entry.climbed_at);
     const weekKey = `${d.isoWeekYear()}-W${d.isoWeek()}`;
     if (!weeklyData[weekKey]) weeklyData[weekKey] = {};
     weeklyData[weekKey][grade] = (weeklyData[weekKey][grade] || 0) + 1;
@@ -377,12 +376,12 @@ export function buildVPointsTimeline(
 
   // Collect all entries to find the overall time range
   const allEntries = activeLayouts.flatMap((lk) => entriesByLayout[lk]);
-  const sorted = [...allEntries].sort((a, b) => new Date(a.climbed_at).getTime() - new Date(b.climbed_at).getTime());
+  const sorted = [...allEntries].sort((a, b) => tickTimeMs(a.climbed_at) - tickTimeMs(b.climbed_at));
 
   // Build full week key range
   const allWeekKeys: string[] = [];
-  const first = dayjs(sorted[0].climbed_at).startOf('isoWeek');
-  const last = dayjs(sorted[sorted.length - 1].climbed_at).endOf('isoWeek');
+  const first = parseTickTime(sorted[0].climbed_at).startOf('isoWeek');
+  const last = parseTickTime(sorted[sorted.length - 1].climbed_at).endOf('isoWeek');
   let current = first;
   while (current.isBefore(last) || current.isSame(last, 'day')) {
     allWeekKeys.push(`${current.isoWeekYear()}-W${current.isoWeek()}`);
@@ -404,7 +403,7 @@ export function buildVPointsTimeline(
       if (entry.difficulty === null) continue;
       const grade = difficultyMapping[entry.difficulty];
       if (!grade) continue;
-      const d = dayjs(entry.climbed_at);
+      const d = parseTickTime(entry.climbed_at);
       const wk = `${d.isoWeekYear()}-W${d.isoWeek()}`;
       weekPoints[wk] = (weekPoints[wk] || 0) + vGradeToPoints(grade);
     }

--- a/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { parseTickTime, tickTimeMs } from '@/app/lib/format-tick-time';
@@ -23,6 +24,7 @@ import {
 const FLASH_COLOR = `${themeTokens.colors.success}99`; // 60% opacity hex
 const REDPOINT_COLOR = `${themeTokens.colors.error}99`;
 
+dayjs.extend(isoWeek);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 
@@ -203,8 +205,9 @@ export function buildWeeklyBars(
 
   const DEFAULT_MAX_WEEKS = 52;
   const allWeekKeys: string[] = [];
-  const first = parseTickTime(entries[entries.length - 1]?.climbed_at).startOf('isoWeek');
-  const last = parseTickTime(entries[0]?.climbed_at).endOf('isoWeek');
+  // Safe to drop the optional chain: `entries.length === 0` is handled above.
+  const first = parseTickTime(entries[entries.length - 1].climbed_at).startOf('isoWeek');
+  const last = parseTickTime(entries[0].climbed_at).endOf('isoWeek');
   let current = first;
   while (current.isBefore(last) || current.isSame(last)) {
     allWeekKeys.push(`${current.isoWeekYear()}-W${current.isoWeek()}`);


### PR DESCRIPTION
## Summary

- `boardsesh_ticks.{climbed_at,created_at,updated_at}` are naive `timestamp` columns (no tz). Drizzle returns them as strings without a `Z` suffix, so any `dayjs(<naiveString>)` call parses them as **browser-local time**. For a user in CEST (UTC+2), a tick written seconds ago showed up on `/you/logbook` as "2 hours ago" — same shape on the other tick-display surfaces.
- New helper module `packages/web/app/lib/format-tick-time.ts` exposes `formatTickRelativeTime`, `formatTickAbsoluteTime`, `parseTickTime`, and `tickTimeMs`. All four go through `dayjs.utc(...)` so the absolute moment is recovered before any rendering, sorting, or bucketing.
- Every web call site that took a `boardsesh_ticks` timestamp was migrated to one of the helpers. The duplicate `dayjs.extend(relativeTime)` line in `ascents-feed.tsx` was cleaned up while we were there. Plugin extension is now centralized in the helper module — the migrated files no longer extend `utc`/`relativeTime`/`isoWeek` themselves.

Reported by user `dd5d1e4b-6cc5-42be-9622-0223abaf2d74` (Germany / CEST). Verified read-only against prod: their most recent tick rows store correct UTC wall-clock; the bug was purely client-side render.

## Sites migrated

- `packages/web/app/components/library/logbook-feed-item.tsx` — `/you/logbook` row subtitle (the original report).
- `packages/web/app/components/activity-feed/ascents-feed.tsx` — relative time + latest-item picker.
- `packages/web/app/components/activity-feed/social-feed-item.tsx` — relative time on followed climbers' feed.
- `packages/web/app/components/logbook/logbook-entry-card.tsx` — climb-detail absolute timestamp.
- `packages/web/app/components/logbook/logbook-view.tsx` — sort by `climbed_at`.
- `packages/web/app/components/logbook/logbook-section.tsx` — session-day bucketing.
- `packages/web/app/components/play-view/play-view-comments.tsx` — sort + absolute format.
- `packages/web/app/profile/[user_id]/utils/chart-data-builders.ts` — timeframe filters and isoWeek bucketing for the profile charts.

## Out of scope

- `dayjs(item.createdAt).fromNow()` call sites in the social/comment/new-climb feeds. Those source columns are `timestamp` with `mode: 'date'` (the Drizzle default), so the resolver gets a JS `Date` and GraphQL serializes it as a `Z`-suffixed ISO string — `dayjs(...)` parses correctly without any helper.
- `packages/web/app/lib/api-wrappers/aurora/{saveAttempt,saveAscent}.ts` format `climbed_at` for an external API call (Aurora), not for display. Different concern; needs its own audit of what Aurora expects on the wire.
- Migrating `boardsesh_ticks.climbed_at` / `created_at` / `updated_at` from `timestamp` to `timestamp with time zone` at the schema level. That's the right long-term fix and would let us drop `dayjs.utc(...)` workarounds entirely, but it's a drizzle migration over a large prod table and needs a careful re-validation pass over every reader and writer. Worth a separate ticket.

## Test plan

- [x] `vp test run --project web` clean (3711 tests pass).
- [x] `vp lint` clean on all modified files.
- [ ] Local `vp run dev`, log in as the seed test user, insert a tick with `climbed_at = NOW() AT TIME ZONE 'UTC'` via Drizzle Studio, load `/you/logbook` and `/profile/<user>` — confirm row reads "a few seconds ago" and the profile charts bucket today.
- [ ] Switch the OS / browser timezone to `Europe/Berlin` (or `TZ=Europe/Berlin` for the dev server) and reload — every surface that shows tick time must read "a few seconds ago", not "2 hours ago".

🤖 Generated with [Claude Code](https://claude.com/claude-code)