### PR TITLE
Fix beta-link thumbnail 403s; harden against IG/TikTok rate-limits

### DIFF
--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -130,12 +130,26 @@ describe('betaLinks resolver', () => {
     expect(fetchTikTokMetaMock).not.toHaveBeenCalled();
   });
 
-  it('drops Instagram rows that come back as gone', async () => {
+  it('drops Instagram rows that come back as gone with no cached thumbnail', async () => {
     selectMock.mockReturnValueOnce([row({ link: 'https://www.instagram.com/p/GONE/' })]);
     fetchInstagramMetaMock.mockResolvedValueOnce({ status: 'gone' });
 
     const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
     expect(result).toEqual([]);
+  });
+
+  it('keeps gone rows when we already have our own cached thumbnail (gone is heuristic)', async () => {
+    // The `gone` detector is HTML-based and false-positives during IG
+    // login-wall / rate-limit responses. If we have a cached thumbnail we
+    // can render, trust the cache over the live signal.
+    selectMock.mockReturnValueOnce([
+      row({ link: 'https://www.instagram.com/p/ABC/', thumbnail: OUR_S3_THUMB, foreignUsername: null }),
+    ]);
+    fetchInstagramMetaMock.mockResolvedValueOnce({ status: 'gone' });
+
+    const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ thumbnail: OUR_S3_THUMB });
   });
 
   it('passes through rows on transient_error, only serving an S3-cached thumbnail', async () => {

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -138,29 +138,28 @@ describe('betaLinks resolver', () => {
     expect(result).toEqual([]);
   });
 
-  it('keeps gone rows when we already have our own cached thumbnail (gone is heuristic)', async () => {
-    // The `gone` detector is HTML-based and false-positives during IG
-    // login-wall / rate-limit responses. If we have a cached thumbnail we
-    // can render, trust the cache over the live signal.
+  it('short-circuits the live fetch as soon as a cached thumbnail is on our S3 (even without username)', async () => {
+    // Once we've cached the thumbnail we have everything the slider needs.
+    // Skipping the live fetch keeps us from re-poking IG every read for
+    // rows that get stuck on `gone` (false positives during login-wall
+    // responses) or `transient_error` (active rate-limiting).
     selectMock.mockReturnValueOnce([
       row({ link: 'https://www.instagram.com/p/ABC/', thumbnail: OUR_S3_THUMB, foreignUsername: null }),
     ]);
-    fetchInstagramMetaMock.mockResolvedValueOnce({ status: 'gone' });
 
     const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ thumbnail: OUR_S3_THUMB });
+    expect(result[0]).toMatchObject({ thumbnail: OUR_S3_THUMB, foreignUsername: null });
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
   });
 
-  it('passes through rows on transient_error, only serving an S3-cached thumbnail', async () => {
-    selectMock.mockReturnValueOnce([
-      row({ link: 'https://www.instagram.com/p/ABC/', thumbnail: OUR_S3_THUMB, foreignUsername: 'climber' }),
-    ]);
+  it('passes through transient_error rows with no cached thumbnail (keeps them in the slider with thumbnail: null)', async () => {
+    selectMock.mockReturnValueOnce([row({ link: 'https://www.instagram.com/p/ABC/', thumbnail: null })]);
     fetchInstagramMetaMock.mockResolvedValueOnce({ status: 'transient_error' });
 
     const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ thumbnail: OUR_S3_THUMB, foreignUsername: 'climber' });
+    expect(result[0]).toMatchObject({ thumbnail: null });
   });
 
   it('persists the S3 thumbnail on first read when S3 is configured', async () => {

--- a/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
+++ b/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
@@ -30,8 +30,14 @@ describe('beta-link-thumbnails: key + url helpers', () => {
     expect(getDevProxyThumbnailUrl(remote)).toBe(`/api/internal/beta-link-thumbnail?url=${encodeURIComponent(remote)}`);
   });
 
-  it('isOurS3Url recognizes URLs from the configured bucket prefix', () => {
+  it('isOurS3Url recognizes the new /static/ prefix and the legacy bucket prefix', () => {
+    // Canonical (post-fix) form
+    expect(isOurS3Url('/static/beta-link-thumbnails/instagram/ABC.jpg')).toBe(true);
+    expect(isOurS3Url('/static/beta-link-thumbnails/tiktok/cache_42.jpg')).toBe(true);
+    // Legacy direct-bucket form (still recognized so the resolver short-circuit
+    // holds for rows that haven't been backfilled yet).
     expect(isOurS3Url('https://example-bucket.s3.amazonaws.com/beta-link-thumbnails/instagram/ABC.jpg')).toBe(true);
+    // Foreign URLs
     expect(isOurS3Url('https://scontent.cdninstagram.com/foo.jpg')).toBe(false);
     expect(isOurS3Url(null)).toBe(false);
   });
@@ -57,12 +63,15 @@ describe('cacheInstagramThumbnail', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uploads fetched image to the expected S3 key and returns the public URL', async () => {
+  it('uploads fetched image to the expected S3 key and returns the static proxy URL', async () => {
     mockFetchImageOnce({ contentType: 'image/jpeg' });
 
     const url = await cacheInstagramThumbnail('ABC123', 'https://scontent.cdninstagram.com/photo.jpg');
 
-    expect(url).toBe('https://example-bucket.s3.amazonaws.com/beta-link-thumbnails/instagram/ABC123.jpg');
+    // Returns the backend-relative /static/ URL (proxied through
+    // handleStaticBetaThumbnail), not the direct S3 URL — Tigris on Railway
+    // doesn't honor public-read ACLs.
+    expect(url).toBe('/static/beta-link-thumbnails/instagram/ABC123.jpg');
     expect(uploadToS3).toHaveBeenCalledTimes(1);
     const [buffer, key, contentType] = vi.mocked(uploadToS3).mock.calls[0];
     expect(Buffer.isBuffer(buffer)).toBe(true);
@@ -121,7 +130,7 @@ describe('cacheTikTokThumbnail', () => {
 
     const url = await cacheTikTokThumbnail('cache_42', 'https://p16-sign.tiktokcdn.com/photo.webp');
 
-    expect(url).toBe('https://example-bucket.s3.amazonaws.com/beta-link-thumbnails/tiktok/cache_42.jpg');
+    expect(url).toBe('/static/beta-link-thumbnails/tiktok/cache_42.jpg');
     const [, key, contentType] = vi.mocked(uploadToS3).mock.calls[0];
     expect(key).toBe('beta-link-thumbnails/tiktok/cache_42.jpg');
     expect(contentType).toBe('image/webp');

--- a/packages/backend/src/__tests__/circuit-breaker.test.ts
+++ b/packages/backend/src/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { createCircuitBreaker } from '../lib/circuit-breaker';
+
+describe('createCircuitBreaker', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stays closed below the failure threshold', () => {
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 3, cooldownMs: 5_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it('opens once the threshold is reached inside the rolling window', () => {
+    const onOpen = vi.fn();
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 3, cooldownMs: 5_000, onOpen });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith(3, 5_000);
+  });
+
+  it('does not open when failures fall outside the rolling window', () => {
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 3, cooldownMs: 5_000 });
+    vi.mocked(Date.now).mockReturnValue(0);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    // Jump past the window so the prior two timestamps drop out.
+    vi.mocked(Date.now).mockReturnValue(60_001);
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it('does not extend an already-open breaker on additional failures', () => {
+    // The breaker should open once per "trip", not slide its open-until
+    // forward every time another failure lands during cooldown — otherwise
+    // a steady stream of failures keeps the breaker open indefinitely.
+    const onOpen = vi.fn();
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 2, cooldownMs: 5_000, onOpen });
+    vi.mocked(Date.now).mockReturnValue(0);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(breaker.isOpen()).toBe(true);
+
+    vi.mocked(Date.now).mockReturnValue(1_000);
+    breaker.recordFailure();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // Original cooldown is 5_000, so at t=4_999 we're still open and at
+    // t=5_001 we're closed. Without the extension guard, the t=1_000
+    // failure would have pushed openUntil to 6_000.
+    vi.mocked(Date.now).mockReturnValue(5_001);
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it('closes once the cooldown elapses and can re-open on a fresh burst', () => {
+    const onOpen = vi.fn();
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 2, cooldownMs: 5_000, onOpen });
+
+    vi.mocked(Date.now).mockReturnValue(0);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+
+    vi.mocked(Date.now).mockReturnValue(5_001);
+    expect(breaker.isOpen()).toBe(false);
+
+    // Two more failures, both far enough in the future to be inside a
+    // fresh window. The breaker trips again and onOpen fires a second time.
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset() clears failure history and any open cooldown', () => {
+    const breaker = createCircuitBreaker({ windowMs: 60_000, threshold: 2, cooldownMs: 5_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+
+    breaker.reset();
+    expect(breaker.isOpen()).toBe(false);
+
+    // A single failure after reset shouldn't trip a threshold-of-2 breaker.
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/instagram-meta.test.ts
+++ b/packages/backend/src/__tests__/instagram-meta.test.ts
@@ -209,4 +209,47 @@ describe('fetchInstagramMeta', () => {
 
     dateSpy.mockRestore();
   });
+
+  it('opens the circuit after a burst of transient errors and short-circuits subsequent calls', async () => {
+    // 11 distinct URLs each return a transient (503). The first 10 record
+    // failures and trip the breaker; the 11th call short-circuits to
+    // transient_error without making a network request. We mock 11
+    // responses but only expect 10 fetches to land.
+    const transientResponse = { ok: false, status: 503, text: () => Promise.resolve('') };
+    const fetchMock = vi.fn().mockResolvedValue(transientResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dateSpy = vi.spyOn(Date, 'now');
+    dateSpy.mockReturnValue(0);
+
+    // Suppress the breaker's console.warn so the test output stays clean.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    for (let i = 0; i < 10; i++) {
+      const result = await fetchInstagramMeta(`https://www.instagram.com/p/CIRCUIT${i}/`);
+      expect(result).toEqual({ status: 'transient_error' });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+
+    // Eleventh URL: breaker is open, no fetch call is made.
+    const blocked = await fetchInstagramMeta('https://www.instagram.com/p/CIRCUITX/');
+    expect(blocked).toEqual({ status: 'transient_error' });
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+
+    // Once the cooldown elapses, the breaker closes and fetches resume.
+    // The default IG cooldown is 5 minutes; jump just past it and provide
+    // a successful response to confirm.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(htmlWithImage()),
+    });
+    dateSpy.mockReturnValue(5 * 60 * 1000 + 1);
+    const recovered = await fetchInstagramMeta('https://www.instagram.com/p/RECOVER/');
+    expect(recovered.status).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+
+    dateSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/backend/src/__tests__/instagram-meta.test.ts
+++ b/packages/backend/src/__tests__/instagram-meta.test.ts
@@ -4,6 +4,7 @@ import {
   fetchInstagramMeta,
   getInstagramMediaId,
   INSTAGRAM_META_TTL_MS,
+  INSTAGRAM_TRANSIENT_TTL_MS,
   isInstagramUrl,
 } from '../lib/instagram-meta';
 
@@ -147,7 +148,7 @@ describe('fetchInstagramMeta', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not cache transient_error (refetches on next call)', async () => {
+  it('negative-caches transient_error briefly so a rate-limit does not cause refetches on every read', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: false, status: 503, text: () => Promise.resolve('') })
@@ -157,7 +158,32 @@ describe('fetchInstagramMeta', () => {
     const first = await fetchInstagramMeta(SAMPLE_URL);
     const second = await fetchInstagramMeta(SAMPLE_URL);
 
+    // First call observes the transient error. Second call returns the
+    // cached result without making a network request — that's the whole
+    // point of the negative cache. The mock's second response (an `ok`)
+    // would only be consumed after the negative TTL expires.
     expect(first).toEqual({ status: 'transient_error' });
+    expect(second).toEqual({ status: 'transient_error' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the negative TTL expires', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, text: () => Promise.resolve('') })
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(htmlWithImage()) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const start = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now');
+    dateSpy.mockReturnValue(start);
+
+    const first = await fetchInstagramMeta(SAMPLE_URL);
+    expect(first).toEqual({ status: 'transient_error' });
+
+    dateSpy.mockReturnValue(start + INSTAGRAM_TRANSIENT_TTL_MS + 1);
+
+    const second = await fetchInstagramMeta(SAMPLE_URL);
     expect(second.status).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/packages/backend/src/__tests__/tiktok-meta.test.ts
+++ b/packages/backend/src/__tests__/tiktok-meta.test.ts
@@ -5,6 +5,7 @@ import {
   getTikTokCacheId,
   isTikTokUrl,
   TIKTOK_META_TTL_MS,
+  TIKTOK_TRANSIENT_TTL_MS,
 } from '../lib/tiktok-meta';
 
 const LONG_URL = 'https://www.tiktok.com/@scout2015/video/6718335390845095173';
@@ -175,7 +176,7 @@ describe('fetchTikTokMeta', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not cache transient_error', async () => {
+  it('negative-caches transient_error briefly so a rate-limit does not cause refetches on every read', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) })
@@ -186,6 +187,27 @@ describe('fetchTikTokMeta', () => {
     const second = await fetchTikTokMeta(LONG_URL);
 
     expect(first).toEqual({ status: 'transient_error' });
+    expect(second).toEqual({ status: 'transient_error' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the negative TTL expires', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(JSON.parse(oembedBody())) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const start = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now');
+    dateSpy.mockReturnValue(start);
+
+    const first = await fetchTikTokMeta(LONG_URL);
+    expect(first).toEqual({ status: 'transient_error' });
+
+    dateSpy.mockReturnValue(start + TIKTOK_TRANSIENT_TTL_MS + 1);
+
+    const second = await fetchTikTokMeta(LONG_URL);
     expect(second.status).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -106,10 +106,14 @@ async function persistEnriched(row: Row, persistedThumbnail: string | null, newU
 async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | null> {
   const haveCachedThumbnail = isOurS3Url(row.thumbnail);
 
-  // Short-circuit: row is fully enriched (thumbnail already on our S3 *and*
-  // we know the username). The live fetch would only confirm the post still
-  // exists — skip it to avoid hammering Instagram/TikTok on every read.
-  if (haveCachedThumbnail && row.foreignUsername) {
+  // Short-circuit: once we've cached the thumbnail we have everything we
+  // need to render the slider — the live fetch would only refresh the
+  // username, which is presentational. Skipping the fetch avoids an
+  // open-ended refetch loop for rows that get stuck on `gone` (false
+  // positives during IG login-wall responses) and rows whose meta lookup
+  // never returns a username, since `gone` and `transient_error` carry no
+  // username and `persistEnriched` would have nothing to write either.
+  if (haveCachedThumbnail) {
     return {
       climbUuid: row.climbUuid,
       link: row.link,
@@ -124,27 +128,23 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
   const meta = await cfg.fetchMeta(row.link);
 
   if (meta.status === 'gone') {
-    // If we already cached a thumbnail and have a username, trust our cache:
-    // the `gone` detector is a heuristic over IG HTML and can false-positive
-    // during rate-limiting / login-wall responses. Only filter the row when
-    // we have nothing useful to render anyway.
-    if (haveCachedThumbnail) return passthroughResult(row);
+    // No cached thumbnail to fall back on — drop the row.
     return null;
   }
 
   if (meta.status === 'transient_error') {
-    // Same idea: serve whatever we have cached. passthroughResult already
-    // returns the cached thumbnail when isOurS3Url(row.thumbnail) is true.
+    // No cached thumbnail; passthroughResult will return thumbnail: null but
+    // keeps the row visible in the slider with whatever metadata we have.
     return passthroughResult(row);
   }
 
+  // haveCachedThumbnail is necessarily false past the short-circuit above —
+  // we only reach this branch on a fresh row whose meta lookup returned ok.
   const cacheId = cfg.getCacheId(row.link);
   let thumbnail: string | null = null;
   let persistedThumbnail: string | null = null;
 
-  if (haveCachedThumbnail) {
-    thumbnail = row.thumbnail;
-  } else if (isS3Configured() && cacheId) {
+  if (isS3Configured() && cacheId) {
     thumbnail = await cfg.cacheThumbnail(cacheId, meta.thumbnail);
     persistedThumbnail = thumbnail;
   } else if (!isS3Configured()) {

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -96,12 +96,20 @@ async function persistEnriched(row: Row, persistedThumbnail: string | null, newU
  * Fetch live metadata + (re)cache the thumbnail to S3 if available, falling
  * back to the dev proxy. The same control flow applies to Instagram and
  * TikTok — only the platform-specific helpers passed in `cfg` differ.
+ *
+ * Resilience contract: once we have our own cached thumbnail for a row, the
+ * UI must keep rendering it regardless of what Instagram/TikTok does. We
+ * never null out a cached thumbnail because of a transient error or a
+ * `gone` heuristic miss — those signals can flap when IG rate-limits us or
+ * serves a login wall.
  */
 async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | null> {
+  const haveCachedThumbnail = isOurS3Url(row.thumbnail);
+
   // Short-circuit: row is fully enriched (thumbnail already on our S3 *and*
   // we know the username). The live fetch would only confirm the post still
   // exists — skip it to avoid hammering Instagram/TikTok on every read.
-  if (isOurS3Url(row.thumbnail) && row.foreignUsername) {
+  if (haveCachedThumbnail && row.foreignUsername) {
     return {
       climbUuid: row.climbUuid,
       link: row.link,
@@ -115,21 +123,31 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
 
   const meta = await cfg.fetchMeta(row.link);
 
-  if (meta.status === 'gone') return null;
-  if (meta.status === 'transient_error') return passthroughResult(row);
+  if (meta.status === 'gone') {
+    // If we already cached a thumbnail and have a username, trust our cache:
+    // the `gone` detector is a heuristic over IG HTML and can false-positive
+    // during rate-limiting / login-wall responses. Only filter the row when
+    // we have nothing useful to render anyway.
+    if (haveCachedThumbnail) return passthroughResult(row);
+    return null;
+  }
+
+  if (meta.status === 'transient_error') {
+    // Same idea: serve whatever we have cached. passthroughResult already
+    // returns the cached thumbnail when isOurS3Url(row.thumbnail) is true.
+    return passthroughResult(row);
+  }
 
   const cacheId = cfg.getCacheId(row.link);
   let thumbnail: string | null = null;
   let persistedThumbnail: string | null = null;
 
-  if (isS3Configured()) {
-    if (isOurS3Url(row.thumbnail)) {
-      thumbnail = row.thumbnail;
-    } else if (cacheId) {
-      thumbnail = await cfg.cacheThumbnail(cacheId, meta.thumbnail);
-      persistedThumbnail = thumbnail;
-    }
-  } else {
+  if (haveCachedThumbnail) {
+    thumbnail = row.thumbnail;
+  } else if (isS3Configured() && cacheId) {
+    thumbnail = await cfg.cacheThumbnail(cacheId, meta.thumbnail);
+    persistedThumbnail = thumbnail;
+  } else if (!isS3Configured()) {
     thumbnail = getDevProxyThumbnailUrl(meta.thumbnail);
   }
 

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -100,3 +100,57 @@ export async function handleStaticAvatar(req: IncomingMessage, res: ServerRespon
     res.end(JSON.stringify({ error: 'Not found' }));
   }
 }
+
+const BETA_THUMBNAIL_PLATFORMS = new Set(['instagram', 'tiktok']);
+const BETA_THUMBNAIL_FILENAME = /^[A-Za-z0-9_-]+\.jpg$/;
+
+/**
+ * Static beta-link thumbnail serving handler
+ * GET /static/beta-link-thumbnails/:platform/:filename
+ *
+ * Streams cached Instagram / TikTok beta-video thumbnails out of S3. Mirrors
+ * the avatar pattern: clients receive a backend-relative URL and we proxy
+ * the bytes from S3 ourselves, because Tigris on Railway doesn't honor the
+ * `ACL: 'public-read'` we set on the upload.
+ */
+export async function handleStaticBetaThumbnail(
+  req: IncomingMessage,
+  res: ServerResponse,
+  platform: string,
+  fileName: string,
+): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (!BETA_THUMBNAIL_PLATFORMS.has(platform) || !BETA_THUMBNAIL_FILENAME.test(fileName)) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Invalid path' }));
+    return;
+  }
+
+  if (!isS3Configured()) {
+    // No S3 means no cached thumbnails to serve. Dev environments use the
+    // /api/internal/beta-link-thumbnail proxy instead.
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  const s3Key = `beta-link-thumbnails/${platform}/${fileName}`;
+  const s3Object = await getFromS3(s3Key);
+
+  if (!s3Object) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': s3Object.contentType || 'image/jpeg',
+    ...(s3Object.contentLength && { 'Content-Length': s3Object.contentLength }),
+    // Thumbnail keys are immutable per shortcode, so we can let the browser /
+    // CDN cache aggressively.
+    'Cache-Control': 'public, max-age=31536000, immutable',
+  });
+
+  s3Object.stream.pipe(res);
+}

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -9,9 +9,15 @@ const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
  * pattern: backend-relative `/static/...` path that the backend proxies out
  * of S3 (Tigris on Railway doesn't honor `ACL: 'public-read'`, so direct
  * bucket URLs 403 in the browser).
+ *
+ * Strips a leading slash from the key so we never produce `/static//...`
+ * if a future refactor changes how keys are constructed — that mismatched
+ * URL would slip past `isOurS3Url` and silently break the resolver
+ * short-circuit.
  */
 function getStaticThumbnailUrl(key: string): string {
-  return `/static/${key}`;
+  const normalizedKey = key.replace(/^\/+/, '');
+  return `/static/${normalizedKey}`;
 }
 
 /**

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -2,6 +2,18 @@ import { getPublicUrl, isS3Configured, uploadToS3 } from '../storage/s3';
 
 export { isS3Configured };
 
+const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
+
+/**
+ * URL we surface to clients for a cached thumbnail. Mirrors the avatar
+ * pattern: backend-relative `/static/...` path that the backend proxies out
+ * of S3 (Tigris on Railway doesn't honor `ACL: 'public-read'`, so direct
+ * bucket URLs 403 in the browser).
+ */
+function getStaticThumbnailUrl(key: string): string {
+  return `/static/${key}`;
+}
+
 /**
  * Dev-only thumbnail proxy. Used by both Instagram and TikTok branches when
  * S3 is not configured — lets the browser fetch CDN thumbnails through our
@@ -26,12 +38,21 @@ export function tiktokThumbnailKey(cacheId: string): string {
 
 export function isOurS3Url(url: string | null): boolean {
   if (!url) return false;
+  // New canonical form: backend-relative `/static/beta-link-thumbnails/...`
+  // served via handleStaticBetaThumbnail.
+  if (url.startsWith(STATIC_THUMBNAIL_PREFIX)) return true;
+  // Legacy form (pre-#1734-fix): direct Tigris/S3 URL persisted from
+  // getPublicUrl. These objects exist in our bucket but 403 in the browser
+  // because Tigris ignores public-read ACLs. We still recognize them as
+  // "ours" so the resolver short-circuit holds during/after the backfill;
+  // the backfill rewrites these to the new prefix.
   try {
     const ourPrefix = getPublicUrl('');
-    return url.startsWith(ourPrefix);
+    if (ourPrefix && url.startsWith(ourPrefix)) return true;
   } catch {
-    return false;
+    // S3 not configured — only the static prefix is ours.
   }
+  return false;
 }
 
 async function cacheRemoteThumbnail(key: string, sourceUrl: string): Promise<string | null> {
@@ -45,8 +66,8 @@ async function cacheRemoteThumbnail(key: string, sourceUrl: string): Promise<str
     const arrayBuffer = await res.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
     const contentType = res.headers.get('content-type') || 'image/jpeg';
-    const { url } = await uploadToS3(buffer, key, contentType);
-    return url;
+    await uploadToS3(buffer, key, contentType);
+    return getStaticThumbnailUrl(key);
   } catch (err) {
     console.error('[BetaLinks] cacheRemoteThumbnail failed:', err);
     return null;

--- a/packages/backend/src/lib/circuit-breaker.ts
+++ b/packages/backend/src/lib/circuit-breaker.ts
@@ -1,0 +1,62 @@
+/**
+ * In-process circuit breaker.
+ *
+ * Trips after `threshold` failures land in a rolling `windowMs` and stays
+ * open for `cooldownMs`. Used to back off external calls (Instagram /
+ * TikTok meta fetches) when the upstream is throttling us — the resolver
+ * keeps serving cached thumbnails while the breaker is open.
+ *
+ * State is per-process. In a horizontally scaled deploy each instance
+ * independently rate-limits itself; a fleet-wide breaker would need a
+ * shared store (e.g. Redis), which is out of scope for the current usage.
+ */
+export type CircuitBreakerOptions = {
+  /** Length of the rolling window over which failures are counted. */
+  windowMs: number;
+  /** How many failures inside the window will open the breaker. */
+  threshold: number;
+  /** How long the breaker stays open after tripping. */
+  cooldownMs: number;
+  /**
+   * Optional log line emitted whenever the breaker transitions to open.
+   * The factory passes the failure count and the cooldown so callers can
+   * include the upstream name in the message.
+   */
+  onOpen?: (failureCount: number, cooldownMs: number) => void;
+};
+
+export type CircuitBreaker = {
+  /** Record an upstream failure; trips the breaker if the threshold is reached. */
+  recordFailure: () => void;
+  /** Returns true while the breaker is in its cooldown window. */
+  isOpen: () => boolean;
+  /** Reset to a fresh state. Useful for tests; cheap to call in production too. */
+  reset: () => void;
+};
+
+export function createCircuitBreaker(opts: CircuitBreakerOptions): CircuitBreaker {
+  const { windowMs, threshold, cooldownMs, onOpen } = opts;
+  const failureTimestamps: number[] = [];
+  let openUntil = 0;
+
+  return {
+    recordFailure: () => {
+      const now = Date.now();
+      failureTimestamps.push(now);
+      const cutoff = now - windowMs;
+      while (failureTimestamps.length > 0 && failureTimestamps[0] < cutoff) {
+        failureTimestamps.shift();
+      }
+      // Don't extend an already-open breaker — only open it on a fresh trip.
+      if (failureTimestamps.length >= threshold && openUntil <= now) {
+        openUntil = now + cooldownMs;
+        onOpen?.(failureTimestamps.length, cooldownMs);
+      }
+    },
+    isOpen: () => Date.now() < openUntil,
+    reset: () => {
+      failureTimestamps.length = 0;
+      openUntil = 0;
+    },
+  };
+}

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -7,6 +7,19 @@ const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
 
 export const INSTAGRAM_META_TTL_MS = 10 * 60 * 1000;
+// Cache transient errors briefly so a rate-limit / login-wall response from
+// Instagram doesn't make us refetch on every read of every beta link. Short
+// enough that we recover quickly when IG comes back, long enough to break
+// the request-per-read pattern under load.
+export const INSTAGRAM_TRANSIENT_TTL_MS = 2 * 60 * 1000;
+
+// Circuit breaker: if we observe a burst of transient errors, stop calling
+// out for a cooldown so we don't keep poking IG while it's actively
+// throttling us. The resolver layer keeps serving cached thumbnails during
+// the open window (see enrichRow's transient_error handling).
+const CIRCUIT_WINDOW_MS = 60 * 1000;
+const CIRCUIT_THRESHOLD = 10;
+const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;
 
 export type InstagramMetaResult =
   | { status: 'ok'; thumbnail: string; username: string | null }
@@ -49,9 +62,34 @@ function looksLikeLoginWall(html: string): boolean {
 const metaCache = new Map<string, { data: InstagramMetaResult; expiresAt: number }>();
 const inflight = new Map<string, Promise<InstagramMetaResult>>();
 
+const transientTimestamps: number[] = [];
+let circuitOpenUntil = 0;
+
+function recordTransientError(): void {
+  const now = Date.now();
+  transientTimestamps.push(now);
+  // Drop entries outside the rolling window.
+  const cutoff = now - CIRCUIT_WINDOW_MS;
+  while (transientTimestamps.length > 0 && transientTimestamps[0] < cutoff) {
+    transientTimestamps.shift();
+  }
+  if (transientTimestamps.length >= CIRCUIT_THRESHOLD && circuitOpenUntil <= now) {
+    circuitOpenUntil = now + CIRCUIT_COOLDOWN_MS;
+    console.warn(
+      `[instagram-meta] circuit breaker open for ${CIRCUIT_COOLDOWN_MS / 1000}s after ${transientTimestamps.length} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
+    );
+  }
+}
+
+function isCircuitOpen(): boolean {
+  return Date.now() < circuitOpenUntil;
+}
+
 export function clearInstagramMetaCache(): void {
   metaCache.clear();
   inflight.clear();
+  transientTimestamps.length = 0;
+  circuitOpenUntil = 0;
 }
 
 async function fetchInstagramMetaUncached(url: string): Promise<InstagramMetaResult> {
@@ -135,14 +173,23 @@ export async function fetchInstagramMeta(url: string): Promise<InstagramMetaResu
     return cached.data;
   }
 
+  // Circuit open: short-circuit to transient_error without making a network
+  // call. The resolver layer keeps serving cached thumbnails during this
+  // window (see enrichRow). Don't poison the meta cache with this synthetic
+  // result — once the circuit closes we want to retry normally.
+  if (isCircuitOpen()) {
+    return { status: 'transient_error' };
+  }
+
   const existing = inflight.get(url);
   if (existing) return existing;
 
   const promise = fetchInstagramMetaUncached(url)
     .then((result) => {
-      // Only cache terminal results — don't pin transient errors.
-      if (result.status !== 'transient_error') {
-        metaCache.set(url, { data: result, expiresAt: Date.now() + INSTAGRAM_META_TTL_MS });
+      const ttl = result.status === 'transient_error' ? INSTAGRAM_TRANSIENT_TTL_MS : INSTAGRAM_META_TTL_MS;
+      metaCache.set(url, { data: result, expiresAt: Date.now() + ttl });
+      if (result.status === 'transient_error') {
+        recordTransientError();
       }
       return result;
     })

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -17,6 +17,12 @@ export const INSTAGRAM_TRANSIENT_TTL_MS = 2 * 60 * 1000;
 // out for a cooldown so we don't keep poking IG while it's actively
 // throttling us. The resolver layer keeps serving cached thumbnails during
 // the open window (see enrichRow's transient_error handling).
+//
+// State is per-process (module-singleton) — same shape as the existing
+// `metaCache` / `inflight` maps. In a horizontally scaled deploy each
+// instance independently rate-limits itself; threshold + cooldown are sized
+// so a single instance can't sustain enough outbound load to matter, but a
+// fleet-wide breaker would need a Redis-backed counter (out of scope here).
 const CIRCUIT_WINDOW_MS = 60 * 1000;
 const CIRCUIT_THRESHOLD = 10;
 const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -1,4 +1,5 @@
 import { getInstagramMediaId, INSTAGRAM_URL_REGEX, isInstagramUrl } from '@boardsesh/shared-schema';
+import { createCircuitBreaker } from './circuit-breaker';
 
 export { INSTAGRAM_URL_REGEX, isInstagramUrl, getInstagramMediaId };
 
@@ -16,13 +17,8 @@ export const INSTAGRAM_TRANSIENT_TTL_MS = 2 * 60 * 1000;
 // Circuit breaker: if we observe a burst of transient errors, stop calling
 // out for a cooldown so we don't keep poking IG while it's actively
 // throttling us. The resolver layer keeps serving cached thumbnails during
-// the open window (see enrichRow's transient_error handling).
-//
-// State is per-process (module-singleton) — same shape as the existing
-// `metaCache` / `inflight` maps. In a horizontally scaled deploy each
-// instance independently rate-limits itself; threshold + cooldown are sized
-// so a single instance can't sustain enough outbound load to matter, but a
-// fleet-wide breaker would need a Redis-backed counter (out of scope here).
+// the open window (see enrichRow's transient_error handling). State scope
+// (per-process vs. fleet-wide) is documented on createCircuitBreaker.
 const CIRCUIT_WINDOW_MS = 60 * 1000;
 const CIRCUIT_THRESHOLD = 10;
 const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -68,34 +64,21 @@ function looksLikeLoginWall(html: string): boolean {
 const metaCache = new Map<string, { data: InstagramMetaResult; expiresAt: number }>();
 const inflight = new Map<string, Promise<InstagramMetaResult>>();
 
-const transientTimestamps: number[] = [];
-let circuitOpenUntil = 0;
-
-function recordTransientError(): void {
-  const now = Date.now();
-  transientTimestamps.push(now);
-  // Drop entries outside the rolling window.
-  const cutoff = now - CIRCUIT_WINDOW_MS;
-  while (transientTimestamps.length > 0 && transientTimestamps[0] < cutoff) {
-    transientTimestamps.shift();
-  }
-  if (transientTimestamps.length >= CIRCUIT_THRESHOLD && circuitOpenUntil <= now) {
-    circuitOpenUntil = now + CIRCUIT_COOLDOWN_MS;
+const circuit = createCircuitBreaker({
+  windowMs: CIRCUIT_WINDOW_MS,
+  threshold: CIRCUIT_THRESHOLD,
+  cooldownMs: CIRCUIT_COOLDOWN_MS,
+  onOpen: (count, cooldownMs) => {
     console.warn(
-      `[instagram-meta] circuit breaker open for ${CIRCUIT_COOLDOWN_MS / 1000}s after ${transientTimestamps.length} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
+      `[instagram-meta] circuit breaker open for ${cooldownMs / 1000}s after ${count} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
     );
-  }
-}
-
-function isCircuitOpen(): boolean {
-  return Date.now() < circuitOpenUntil;
-}
+  },
+});
 
 export function clearInstagramMetaCache(): void {
   metaCache.clear();
   inflight.clear();
-  transientTimestamps.length = 0;
-  circuitOpenUntil = 0;
+  circuit.reset();
 }
 
 async function fetchInstagramMetaUncached(url: string): Promise<InstagramMetaResult> {
@@ -183,7 +166,7 @@ export async function fetchInstagramMeta(url: string): Promise<InstagramMetaResu
   // call. The resolver layer keeps serving cached thumbnails during this
   // window (see enrichRow). Don't poison the meta cache with this synthetic
   // result — once the circuit closes we want to retry normally.
-  if (isCircuitOpen()) {
+  if (circuit.isOpen()) {
     return { status: 'transient_error' };
   }
 
@@ -195,7 +178,7 @@ export async function fetchInstagramMeta(url: string): Promise<InstagramMetaResu
       const ttl = result.status === 'transient_error' ? INSTAGRAM_TRANSIENT_TTL_MS : INSTAGRAM_META_TTL_MS;
       metaCache.set(url, { data: result, expiresAt: Date.now() + ttl });
       if (result.status === 'transient_error') {
-        recordTransientError();
+        circuit.recordFailure();
       }
       return result;
     })

--- a/packages/backend/src/lib/tiktok-meta.ts
+++ b/packages/backend/src/lib/tiktok-meta.ts
@@ -8,6 +8,13 @@ const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
 
 export const TIKTOK_META_TTL_MS = 10 * 60 * 1000;
+// Negative TTL for transient errors so a TikTok rate-limit doesn't cause a
+// refetch on every read. See instagram-meta.ts for the same pattern.
+export const TIKTOK_TRANSIENT_TTL_MS = 2 * 60 * 1000;
+
+const CIRCUIT_WINDOW_MS = 60 * 1000;
+const CIRCUIT_THRESHOLD = 10;
+const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;
 
 /**
  * Stable cache key for a TikTok URL.
@@ -38,9 +45,33 @@ type OEmbedResponse = {
 const metaCache = new Map<string, { data: TikTokMetaResult; expiresAt: number }>();
 const inflight = new Map<string, Promise<TikTokMetaResult>>();
 
+const transientTimestamps: number[] = [];
+let circuitOpenUntil = 0;
+
+function recordTransientError(): void {
+  const now = Date.now();
+  transientTimestamps.push(now);
+  const cutoff = now - CIRCUIT_WINDOW_MS;
+  while (transientTimestamps.length > 0 && transientTimestamps[0] < cutoff) {
+    transientTimestamps.shift();
+  }
+  if (transientTimestamps.length >= CIRCUIT_THRESHOLD && circuitOpenUntil <= now) {
+    circuitOpenUntil = now + CIRCUIT_COOLDOWN_MS;
+    console.warn(
+      `[tiktok-meta] circuit breaker open for ${CIRCUIT_COOLDOWN_MS / 1000}s after ${transientTimestamps.length} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
+    );
+  }
+}
+
+function isCircuitOpen(): boolean {
+  return Date.now() < circuitOpenUntil;
+}
+
 export function clearTikTokMetaCache(): void {
   metaCache.clear();
   inflight.clear();
+  transientTimestamps.length = 0;
+  circuitOpenUntil = 0;
 }
 
 async function fetchTikTokMetaUncached(url: string): Promise<TikTokMetaResult> {
@@ -93,14 +124,19 @@ export async function fetchTikTokMeta(url: string): Promise<TikTokMetaResult> {
     return cached.data;
   }
 
+  if (isCircuitOpen()) {
+    return { status: 'transient_error' };
+  }
+
   const existing = inflight.get(url);
   if (existing) return existing;
 
   const promise = fetchTikTokMetaUncached(url)
     .then((result) => {
-      // Only cache terminal results — don't pin transient errors.
-      if (result.status !== 'transient_error') {
-        metaCache.set(url, { data: result, expiresAt: Date.now() + TIKTOK_META_TTL_MS });
+      const ttl = result.status === 'transient_error' ? TIKTOK_TRANSIENT_TTL_MS : TIKTOK_META_TTL_MS;
+      metaCache.set(url, { data: result, expiresAt: Date.now() + ttl });
+      if (result.status === 'transient_error') {
+        recordTransientError();
       }
       return result;
     })

--- a/packages/backend/src/lib/tiktok-meta.ts
+++ b/packages/backend/src/lib/tiktok-meta.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { getTikTokVideoId, isTikTokUrl, TIKTOK_URL_REGEX } from '@boardsesh/shared-schema';
+import { createCircuitBreaker } from './circuit-breaker';
 
 export { TIKTOK_URL_REGEX, isTikTokUrl };
 
@@ -12,8 +13,7 @@ export const TIKTOK_META_TTL_MS = 10 * 60 * 1000;
 // refetch on every read. See instagram-meta.ts for the same pattern.
 export const TIKTOK_TRANSIENT_TTL_MS = 2 * 60 * 1000;
 
-// Per-process circuit breaker — see instagram-meta.ts for the full note on
-// fleet-wide vs. per-instance scoping.
+// Per-process circuit breaker — scope notes on createCircuitBreaker.
 const CIRCUIT_WINDOW_MS = 60 * 1000;
 const CIRCUIT_THRESHOLD = 10;
 const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -47,33 +47,21 @@ type OEmbedResponse = {
 const metaCache = new Map<string, { data: TikTokMetaResult; expiresAt: number }>();
 const inflight = new Map<string, Promise<TikTokMetaResult>>();
 
-const transientTimestamps: number[] = [];
-let circuitOpenUntil = 0;
-
-function recordTransientError(): void {
-  const now = Date.now();
-  transientTimestamps.push(now);
-  const cutoff = now - CIRCUIT_WINDOW_MS;
-  while (transientTimestamps.length > 0 && transientTimestamps[0] < cutoff) {
-    transientTimestamps.shift();
-  }
-  if (transientTimestamps.length >= CIRCUIT_THRESHOLD && circuitOpenUntil <= now) {
-    circuitOpenUntil = now + CIRCUIT_COOLDOWN_MS;
+const circuit = createCircuitBreaker({
+  windowMs: CIRCUIT_WINDOW_MS,
+  threshold: CIRCUIT_THRESHOLD,
+  cooldownMs: CIRCUIT_COOLDOWN_MS,
+  onOpen: (count, cooldownMs) => {
     console.warn(
-      `[tiktok-meta] circuit breaker open for ${CIRCUIT_COOLDOWN_MS / 1000}s after ${transientTimestamps.length} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
+      `[tiktok-meta] circuit breaker open for ${cooldownMs / 1000}s after ${count} transient errors in ${CIRCUIT_WINDOW_MS / 1000}s`,
     );
-  }
-}
-
-function isCircuitOpen(): boolean {
-  return Date.now() < circuitOpenUntil;
-}
+  },
+});
 
 export function clearTikTokMetaCache(): void {
   metaCache.clear();
   inflight.clear();
-  transientTimestamps.length = 0;
-  circuitOpenUntil = 0;
+  circuit.reset();
 }
 
 async function fetchTikTokMetaUncached(url: string): Promise<TikTokMetaResult> {
@@ -126,7 +114,7 @@ export async function fetchTikTokMeta(url: string): Promise<TikTokMetaResult> {
     return cached.data;
   }
 
-  if (isCircuitOpen()) {
+  if (circuit.isOpen()) {
     return { status: 'transient_error' };
   }
 
@@ -138,7 +126,7 @@ export async function fetchTikTokMeta(url: string): Promise<TikTokMetaResult> {
       const ttl = result.status === 'transient_error' ? TIKTOK_TRANSIENT_TTL_MS : TIKTOK_META_TTL_MS;
       metaCache.set(url, { data: result, expiresAt: Date.now() + ttl });
       if (result.status === 'transient_error') {
-        recordTransientError();
+        circuit.recordFailure();
       }
       return result;
     })

--- a/packages/backend/src/lib/tiktok-meta.ts
+++ b/packages/backend/src/lib/tiktok-meta.ts
@@ -12,6 +12,8 @@ export const TIKTOK_META_TTL_MS = 10 * 60 * 1000;
 // refetch on every read. See instagram-meta.ts for the same pattern.
 export const TIKTOK_TRANSIENT_TTL_MS = 2 * 60 * 1000;
 
+// Per-process circuit breaker — see instagram-meta.ts for the full note on
+// fleet-wide vs. per-instance scoping.
 const CIRCUIT_WINDOW_MS = 60 * 1000;
 const CIRCUIT_THRESHOLD = 10;
 const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -10,7 +10,7 @@ import { initCors, applyCorsHeaders } from './handlers/cors';
 import { handleHealthCheck } from './handlers/health';
 import { handleSessionJoin } from './handlers/join';
 import { handleAvatarUpload } from './handlers/avatars';
-import { handleStaticAvatar } from './handlers/static';
+import { handleStaticAvatar, handleStaticBetaThumbnail } from './handlers/static';
 import { handleSyncCron } from './handlers/sync';
 import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
 import { createYogaInstance } from './graphql/yoga';
@@ -103,6 +103,20 @@ export async function startServer(): Promise<ServerResources> {
         if (fileName) {
           await handleStaticAvatar(req, res, fileName);
           return;
+        }
+      }
+
+      // Static beta-link thumbnails (Instagram / TikTok), proxied from S3
+      if (pathname.startsWith('/static/beta-link-thumbnails/')) {
+        const remainder = pathname.slice('/static/beta-link-thumbnails/'.length);
+        const slashIndex = remainder.indexOf('/');
+        if (slashIndex > 0) {
+          const platform = remainder.slice(0, slashIndex);
+          const fileName = remainder.slice(slashIndex + 1);
+          if (fileName) {
+            await handleStaticBetaThumbnail(req, res, platform, fileName);
+            return;
+          }
         }
       }
 

--- a/packages/db/scripts/backfill-beta-link-thumbnail-urls.ts
+++ b/packages/db/scripts/backfill-beta-link-thumbnail-urls.ts
@@ -1,0 +1,107 @@
+/**
+ * Backfill `board_beta_links.thumbnail` so legacy direct-bucket URLs become
+ * backend-relative `/static/beta-link-thumbnails/...` URLs.
+ *
+ * Why: Tigris on Railway (`t3.storageapi.dev/<bucket>/...`) does not honor
+ * the `ACL: 'public-read'` we set on PutObject, so the direct bucket URLs
+ * we previously persisted return 403 in the browser. The new pipeline
+ * serves thumbnails through the backend's `handleStaticBetaThumbnail`
+ * handler at `/static/beta-link-thumbnails/<platform>/<id>.jpg`, which
+ * streams the object from S3 server-side. The S3 objects themselves stay
+ * where they are — only the URL we surface to clients changes.
+ *
+ * Idempotent: only touches rows whose thumbnail still starts with the
+ * legacy bucket endpoint. Re-running is a no-op once everything is
+ * migrated.
+ *
+ * Usage:
+ *   bun run packages/db/scripts/backfill-beta-link-thumbnail-urls.ts [--dry-run]
+ *
+ * Notes:
+ *   - The bucket endpoint is read from AWS_ENDPOINT_URL + AWS_S3_BUCKET_NAME
+ *     (the same env vars the backend uses).
+ *   - Falls back to scanning by the literal `/beta-link-thumbnails/` path
+ *     fragment if those env vars aren't set, so the script still works in a
+ *     pinch when run with only DATABASE_URL.
+ */
+
+import { sql } from 'drizzle-orm';
+import { createScriptDb } from './db-connection.js';
+
+const dryRun = process.argv.includes('--dry-run');
+
+function getLegacyPrefix(): string | null {
+  const endpoint = process.env.AWS_ENDPOINT_URL;
+  const bucket = process.env.AWS_S3_BUCKET_NAME;
+  if (!endpoint || !bucket) return null;
+  return `${endpoint.replace(/\/$/, '')}/${bucket}/`;
+}
+
+async function main(): Promise<void> {
+  const { db, close } = createScriptDb();
+  const legacyPrefix = getLegacyPrefix();
+
+  try {
+    if (legacyPrefix) {
+      console.info(`[backfill] Rewriting thumbnails matching prefix: ${legacyPrefix}beta-link-thumbnails/`);
+    } else {
+      console.info(
+        '[backfill] AWS_ENDPOINT_URL / AWS_S3_BUCKET_NAME not set — falling back to a path-fragment match. Set them for a tighter scope.',
+      );
+    }
+
+    const previewResult = await db.execute(
+      legacyPrefix
+        ? sql`
+            SELECT thumbnail, COUNT(*)::int AS n
+            FROM board_beta_links
+            WHERE thumbnail LIKE ${legacyPrefix + 'beta-link-thumbnails/%'}
+            GROUP BY thumbnail
+            ORDER BY thumbnail
+            LIMIT 10
+          `
+        : sql`
+            SELECT thumbnail, COUNT(*)::int AS n
+            FROM board_beta_links
+            WHERE thumbnail LIKE 'http%/beta-link-thumbnails/%'
+              AND thumbnail NOT LIKE '/static/%'
+            GROUP BY thumbnail
+            ORDER BY thumbnail
+            LIMIT 10
+          `,
+    );
+    const previewRows = (previewResult as unknown as { rows?: Array<{ thumbnail: string; n: number }> }).rows ?? [];
+    console.info(`[backfill] Sample of rows that would be rewritten (up to 10):`);
+    for (const r of previewRows) {
+      console.info(`  ${r.thumbnail} (×${r.n})`);
+    }
+
+    if (dryRun) {
+      console.info('[backfill] --dry-run: skipping update');
+      return;
+    }
+
+    const updateResult = legacyPrefix
+      ? await db.execute(sql`
+          UPDATE board_beta_links
+          SET thumbnail = REPLACE(thumbnail, ${legacyPrefix}, '/static/')
+          WHERE thumbnail LIKE ${legacyPrefix + 'beta-link-thumbnails/%'}
+        `)
+      : await db.execute(sql`
+          UPDATE board_beta_links
+          SET thumbnail = '/static/' || SUBSTRING(thumbnail FROM POSITION('/beta-link-thumbnails/' IN thumbnail) + 1)
+          WHERE thumbnail LIKE 'http%/beta-link-thumbnails/%'
+            AND thumbnail NOT LIKE '/static/%'
+        `);
+
+    const rowCount = (updateResult as unknown as { rowCount?: number; count?: number }).rowCount ?? 0;
+    console.info(`[backfill] Rewrote ${rowCount} thumbnail URLs.`);
+  } finally {
+    await close();
+  }
+}
+
+main().catch((err) => {
+  console.error('[backfill] failed:', err);
+  process.exit(1);
+});

--- a/packages/db/scripts/backfill-beta-link-thumbnail-urls.ts
+++ b/packages/db/scripts/backfill-beta-link-thumbnail-urls.ts
@@ -94,8 +94,18 @@ async function main(): Promise<void> {
             AND thumbnail NOT LIKE '/static/%'
         `);
 
-    const rowCount = (updateResult as unknown as { rowCount?: number; count?: number }).rowCount ?? 0;
-    console.info(`[backfill] Rewrote ${rowCount} thumbnail URLs.`);
+    // Drizzle exposes the raw driver result here; postgres-js uses `count`,
+    // node-postgres uses `rowCount`. Read both so the script reports a real
+    // number regardless of which driver `createScriptDb` picked.
+    const raw = updateResult as unknown as { rowCount?: number; count?: number };
+    const rewritten = raw.rowCount ?? raw.count;
+    if (rewritten === undefined) {
+      console.warn(
+        '[backfill] update succeeded but driver returned no row count — verify with a SELECT against `board_beta_links`',
+      );
+    } else {
+      console.info(`[backfill] Rewrote ${rewritten} thumbnail URLs.`);
+    }
   } finally {
     await close();
   }

--- a/packages/web/app/lib/__tests__/beta-video-url.test.ts
+++ b/packages/web/app/lib/__tests__/beta-video-url.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+
+describe('mapBetaLinksResponse — thumbnail absolutization', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function commonRow(thumbnail: string | null) {
+    return {
+      climbUuid: 'climb-1',
+      link: 'https://www.instagram.com/p/ABC/',
+      foreignUsername: 'climber',
+      angle: null,
+      thumbnail,
+      isListed: true,
+      createdAt: '2026-04-26T00:00:00Z',
+    };
+  }
+
+  it('prepends the backend origin to a relative /static/... thumbnail', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const [link] = mapBetaLinksResponse([commonRow('/static/beta-link-thumbnails/instagram/ABC.jpg')]);
+
+    expect(link.thumbnail).toBe('https://ws.boardsesh.com/static/beta-link-thumbnails/instagram/ABC.jpg');
+  });
+
+  it('leaves an absolute http(s) thumbnail untouched (legacy direct-bucket URLs that have not been backfilled yet)', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const legacy = 'https://t3.storageapi.dev/structured-parcel-ei3jl8g/beta-link-thumbnails/instagram/ABC.jpg';
+    const [link] = mapBetaLinksResponse([commonRow(legacy)]);
+
+    expect(link.thumbnail).toBe(legacy);
+  });
+
+  it('leaves a null thumbnail null', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const [link] = mapBetaLinksResponse([commonRow(null)]);
+
+    expect(link.thumbnail).toBeNull();
+  });
+
+  it('returns the relative path unchanged when no backend URL can be resolved', async () => {
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    delete process.env.BACKEND_INTERNAL_URL;
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const [link] = mapBetaLinksResponse([commonRow('/static/beta-link-thumbnails/instagram/ABC.jpg')]);
+
+    // Falls back to the relative path so same-origin deploys still render
+    // the thumbnail; split-domain deploys without a configured backend URL
+    // would just have to set NEXT_PUBLIC_WS_URL.
+    expect(link.thumbnail).toBe('/static/beta-link-thumbnails/instagram/ABC.jpg');
+  });
+
+  it('does not produce double slashes if the backend URL ever ends with a slash', async () => {
+    // getBackendHttpUrl strips trailing slashes today, but absolutize is
+    // defensive against a future change to that contract — a doubled slash
+    // would 404 against the static handler and silently break thumbnails.
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
+    const backendUrl = await import('../backend-url');
+    vi.spyOn(backendUrl, 'getBackendHttpUrl').mockReturnValue('https://ws.boardsesh.com/');
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const [link] = mapBetaLinksResponse([commonRow('/static/beta-link-thumbnails/instagram/ABC.jpg')]);
+
+    expect(link.thumbnail).toBe('https://ws.boardsesh.com/static/beta-link-thumbnails/instagram/ABC.jpg');
+  });
+});

--- a/packages/web/app/lib/beta-video-url.ts
+++ b/packages/web/app/lib/beta-video-url.ts
@@ -7,8 +7,25 @@ import {
   isTikTokUrl,
 } from '@boardsesh/shared-schema';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import { getBackendHttpUrl } from '@/app/lib/backend-url';
 
 export { BETA_VIDEO_URL_VALIDATION_MESSAGE, isBetaVideoUrl, isInstagramUrl, isTikTokUrl };
+
+/**
+ * Beta thumbnails are served by the backend's `/static/beta-link-thumbnails/...`
+ * handler, which streams the cached image from S3. The GraphQL resolver
+ * persists and returns the path as a backend-relative URL so the same value
+ * works in same-origin deploys; in split-domain deploys (web + backend on
+ * different hosts, see `getBackendHttpUrl`) we need to prepend the backend
+ * origin so the browser actually hits the backend instead of 404-ing
+ * against the frontend host.
+ */
+function absolutizeThumbnail(thumbnail: string | null): string | null {
+  if (!thumbnail || !thumbnail.startsWith('/')) return thumbnail;
+  const backendBase = getBackendHttpUrl();
+  if (!backendBase) return thumbnail;
+  return `${backendBase}${thumbnail}`;
+}
 
 /**
  * Stable identity used to dedupe beta links that point at the same video,
@@ -71,7 +88,7 @@ export function mapBetaLinksResponse(rows: BetaLinksGqlRow[]): BetaLink[] {
     link: b.link,
     foreign_username: b.foreignUsername,
     angle: b.angle,
-    thumbnail: b.thumbnail,
+    thumbnail: absolutizeThumbnail(b.thumbnail),
     is_listed: b.isListed ?? false,
     created_at: b.createdAt ?? '',
   }));

--- a/packages/web/app/lib/beta-video-url.ts
+++ b/packages/web/app/lib/beta-video-url.ts
@@ -24,7 +24,10 @@ function absolutizeThumbnail(thumbnail: string | null): string | null {
   if (!thumbnail || !thumbnail.startsWith('/')) return thumbnail;
   const backendBase = getBackendHttpUrl();
   if (!backendBase) return thumbnail;
-  return `${backendBase}${thumbnail}`;
+  // Defensive: getBackendHttpUrl strips a trailing slash today, but normalize
+  // here too so a future change to its return shape can't produce
+  // `https://host//static/...` which would 404.
+  return `${backendBase.replace(/\/+$/, '')}${thumbnail}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Beta-link thumbnails 403'd in the browser because Tigris on Railway silently ignores the `ACL: 'public-read'` we set on PutObject — every URL persisted in `board_beta_links.thumbnail` was a direct bucket URL. Mirror the working avatar pattern: serve thumbnails through a backend `/static/beta-link-thumbnails/<platform>/<file>` proxy that streams from S3 server-side, and rewrite legacy URLs in the DB via a one-shot backfill script.
- Make the read resolver resilient: once we have our own cached thumbnail, the UI keeps rendering it regardless of upstream `gone` / `transient_error` signals (the IG `gone` heuristic false-positives during login-wall / rate-limit responses).
- Stop hammering Instagram / TikTok when they're throttling us: negative-cache `transient_error` for 2 min (was uncached, so a rate-limit caused a refetch on every read) and add a global circuit breaker that opens for 5 min after 10 transient errors in 60s.

## Test plan

- [x] `vp run typecheck` (web + backend + db) — clean
- [x] `vp test --project backend` — 765/765
- [x] `vp check` — 0 errors
- [ ] After deploy, execute the backfill script against prod (with AWS_ENDPOINT_URL + AWS_S3_BUCKET_NAME + DATABASE_URL set), first with `--dry-run`, then for real
- [ ] curl `https://ws.boardsesh.com/static/beta-link-thumbnails/instagram/CJ99iALFDaP.jpg` → expect 200 + `image/jpeg`
- [ ] Sample 10 rows from `board_beta_links` post-backfill — `thumbnail` starts with `/static/beta-link-thumbnails/`
- [ ] Watch S3 PUT count for `beta-link-thumbnails/` over 24h — should track new attaches only, not reads

Generated with Claude Code