### PR TITLE
Fix malformed thumbnail path fallthrough and add TikTok circuit-breaker test

### DIFF
--- a/packages/backend/src/__tests__/instagram-meta.test.ts
+++ b/packages/backend/src/__tests__/instagram-meta.test.ts
@@ -60,6 +60,7 @@ describe('fetchInstagramMeta', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -206,8 +207,6 @@ describe('fetchInstagramMeta', () => {
     dateSpy.mockReturnValue(start + INSTAGRAM_META_TTL_MS + 1);
     await fetchInstagramMeta(SAMPLE_URL);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    dateSpy.mockRestore();
   });
 
   it('opens the circuit after a burst of transient errors and short-circuits subsequent calls', async () => {
@@ -249,7 +248,5 @@ describe('fetchInstagramMeta', () => {
     expect(recovered.status).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(11);
 
-    dateSpy.mockRestore();
-    warnSpy.mockRestore();
   });
 });

--- a/packages/backend/src/__tests__/integration.test.ts
+++ b/packages/backend/src/__tests__/integration.test.ts
@@ -828,4 +828,21 @@ describe('Daemon Integration Tests', () => {
       expect(result.session.users).toHaveLength(1); // Only client2 remains
     });
   });
+
+  describe('HTTP path handling', () => {
+    it('returns 400 for /static/beta-link-thumbnails/ with no platform segment', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/static/beta-link-thumbnails/`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for /static/beta-link-thumbnails/<platform> with no filename', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/static/beta-link-thumbnails/instagram`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for /static/beta-link-thumbnails/ with empty platform segment', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/static/beta-link-thumbnails//filename.jpg`);
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/packages/backend/src/__tests__/tiktok-meta.test.ts
+++ b/packages/backend/src/__tests__/tiktok-meta.test.ts
@@ -71,6 +71,7 @@ describe('fetchTikTokMeta', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -230,8 +231,6 @@ describe('fetchTikTokMeta', () => {
     dateSpy.mockReturnValue(start + TIKTOK_META_TTL_MS + 1);
     await fetchTikTokMeta(LONG_URL);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    dateSpy.mockRestore();
   });
 
   it('opens the circuit after a burst of transient errors and short-circuits subsequent calls', async () => {
@@ -267,7 +266,5 @@ describe('fetchTikTokMeta', () => {
     expect(recovered.status).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(11);
 
-    dateSpy.mockRestore();
-    warnSpy.mockRestore();
   });
 });

--- a/packages/backend/src/__tests__/tiktok-meta.test.ts
+++ b/packages/backend/src/__tests__/tiktok-meta.test.ts
@@ -233,4 +233,41 @@ describe('fetchTikTokMeta', () => {
 
     dateSpy.mockRestore();
   });
+
+  it('opens the circuit after a burst of transient errors and short-circuits subsequent calls', async () => {
+    const transientResponse = { ok: false, status: 503, json: () => Promise.resolve({}) };
+    const fetchMock = vi.fn().mockResolvedValue(transientResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dateSpy = vi.spyOn(Date, 'now');
+    dateSpy.mockReturnValue(0);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    for (let i = 0; i < 10; i++) {
+      const url = `https://www.tiktok.com/@user/video/${String(i).padStart(19, '0')}`;
+      const result = await fetchTikTokMeta(url);
+      expect(result).toEqual({ status: 'transient_error' });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+
+    // Eleventh URL: breaker is open, no fetch call is made.
+    const blocked = await fetchTikTokMeta('https://www.tiktok.com/@user/video/9999999999999999999');
+    expect(blocked).toEqual({ status: 'transient_error' });
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+
+    // Jump past the 5-minute cooldown and confirm the breaker closes.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(JSON.parse(oembedBody())),
+    });
+    dateSpy.mockReturnValue(5 * 60 * 1000 + 1);
+    const recovered = await fetchTikTokMeta(LONG_URL);
+    expect(recovered.status).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+
+    dateSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -118,6 +118,9 @@ export async function startServer(): Promise<ServerResources> {
             return;
           }
         }
+        res.writeHead(400);
+        res.end();
+        return;
       }
 
       // Sync cron endpoint (triggered by external cron service)


### PR DESCRIPTION
## Summary

- **`packages/backend/src/server.ts`**: Malformed requests to `/static/beta-link-thumbnails/` that match the prefix but lack a valid `platform/filename` structure (e.g. `/static/beta-link-thumbnails/` or `/static/beta-link-thumbnails/instagram`) now return **400** instead of silently falling through to the catch-all 404 handler.
- **`packages/backend/src/__tests__/tiktok-meta.test.ts`**: Adds a burst-to-open-and-recover circuit-breaker integration test, symmetric with the existing test in `instagram-meta.test.ts`. Verifies that 10 consecutive transient errors trip the breaker, the 11th call is short-circuited without a network request, and the breaker closes after the 5-minute cooldown.

## Test plan

- [ ] `vp test --project backend` — all tiktok-meta tests pass including the new circuit-breaker test
- [ ] `vp run typecheck:backend` — no type errors

https://claude.ai/code/session_01SfpxCAMqqvxh5zq7rhAqbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfpxCAMqqvxh5zq7rhAqbf)_