### PR TITLE
fix(observability): symbolicate iOS Chrome stack overflows on home page

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -1,4 +1,7 @@
 {
+  "stackOverflowTrap": {
+    "message": "Something looped on this page. We logged it — try reloading."
+  },
   "languageSwitcher": {
     "ariaLabelWithCurrent": "Language: {{language}}"
   },

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -1,4 +1,7 @@
 {
+  "stackOverflowTrap": {
+    "message": "Algo entró en bucle en esta página. Lo registramos — prueba a recargar."
+  },
   "languageSwitcher": {
     "ariaLabelWithCurrent": "Idioma: {{language}}"
   },

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -1,4 +1,7 @@
 {
+  "stackOverflowTrap": {
+    "message": "Quelque chose a bouclé sur cette page. Nous l'avons enregistré — essaie de recharger."
+  },
   "languageSwitcher": {
     "ariaLabelWithCurrent": "Langue : {{language}}"
   },

--- a/packages/web/app/components/providers/__tests__/global-error-trap.test.tsx
+++ b/packages/web/app/components/providers/__tests__/global-error-trap.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, act } from '@testing-library/react';
+import { render, act, cleanup } from '@testing-library/react';
 import React from 'react';
 import { GlobalErrorTrap } from '../global-error-trap';
 import { SnackbarProvider } from '../snackbar-provider';
@@ -8,6 +8,14 @@ const captureExceptionMock = vi.fn();
 
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === 'stackOverflowTrap.message' ? 'Something looped on this page. We logged it — try reloading.' : key,
+    i18n: { language: 'en-US' },
+  }),
 }));
 
 function dispatchErrorEvent(error: unknown, overrides: Partial<ErrorEventInit> = {}) {
@@ -28,8 +36,10 @@ describe('GlobalErrorTrap', () => {
   });
 
   afterEach(() => {
-    // Clean up any leftover snackbar nodes between tests.
-    document.body.innerHTML = '';
+    // Unmount via React so the GlobalErrorTrap `useEffect` cleanup runs and
+    // removes its window `error` listener between tests (a raw innerHTML reset
+    // would leak listeners across cases).
+    cleanup();
   });
 
   it('captures RangeError stack overflow with extra context', () => {

--- a/packages/web/app/components/providers/__tests__/global-error-trap.test.tsx
+++ b/packages/web/app/components/providers/__tests__/global-error-trap.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { GlobalErrorTrap } from '../global-error-trap';
+import { SnackbarProvider } from '../snackbar-provider';
+
+const captureExceptionMock = vi.fn();
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+function dispatchErrorEvent(error: unknown, overrides: Partial<ErrorEventInit> = {}) {
+  const event = new ErrorEvent('error', {
+    error,
+    message: error instanceof Error ? error.message : String(error),
+    filename: 'https://www.boardsesh.com/_next/static/chunks/app.js',
+    lineno: 38,
+    colno: 1,
+    ...overrides,
+  });
+  window.dispatchEvent(event);
+}
+
+describe('GlobalErrorTrap', () => {
+  beforeEach(() => {
+    captureExceptionMock.mockReset();
+  });
+
+  afterEach(() => {
+    // Clean up any leftover snackbar nodes between tests.
+    document.body.innerHTML = '';
+  });
+
+  it('captures RangeError stack overflow with extra context', () => {
+    render(
+      <SnackbarProvider>
+        <GlobalErrorTrap />
+      </SnackbarProvider>,
+    );
+
+    const err = new RangeError('Maximum call stack size exceeded.');
+    act(() => {
+      dispatchErrorEvent(err);
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [capturedErr, captureContext] = captureExceptionMock.mock.calls[0] as [
+      unknown,
+      { tags: Record<string, string>; extra: Record<string, unknown> },
+    ];
+    expect(capturedErr).toBe(err);
+    expect(captureContext.tags).toEqual({ kind: 'stack-overflow-trap' });
+    expect(captureContext.extra.lineno).toBe(38);
+    expect(captureContext.extra.filename).toBe('https://www.boardsesh.com/_next/static/chunks/app.js');
+  });
+
+  it('shows a snackbar when a stack overflow is captured', () => {
+    const { baseElement } = render(
+      <SnackbarProvider>
+        <GlobalErrorTrap />
+      </SnackbarProvider>,
+    );
+
+    act(() => {
+      dispatchErrorEvent(new RangeError('Maximum call stack size exceeded.'));
+    });
+
+    expect(baseElement.textContent).toContain('Something looped');
+  });
+
+  it('ignores unrelated errors', () => {
+    render(
+      <SnackbarProvider>
+        <GlobalErrorTrap />
+      </SnackbarProvider>,
+    );
+
+    act(() => {
+      dispatchErrorEvent(new TypeError('Cannot read property foo of undefined'));
+      dispatchErrorEvent(new RangeError('Invalid array length'));
+      dispatchErrorEvent('not even an error');
+    });
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('removes its window listener on unmount', () => {
+    const { unmount } = render(
+      <SnackbarProvider>
+        <GlobalErrorTrap />
+      </SnackbarProvider>,
+    );
+
+    unmount();
+
+    act(() => {
+      dispatchErrorEvent(new RangeError('Maximum call stack size exceeded.'));
+    });
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/providers/global-error-trap.tsx
+++ b/packages/web/app/components/providers/global-error-trap.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/nextjs';
 import { useSnackbar } from './snackbar-provider';
 
@@ -25,12 +26,18 @@ const STACK_OVERFLOW_MESSAGE = 'Maximum call stack';
  */
 export function GlobalErrorTrap() {
   const { showMessage } = useSnackbar();
+  const { t } = useTranslation('common');
 
   useEffect(() => {
     const handler = (event: ErrorEvent) => {
       const err = event.error;
       if (!(err instanceof RangeError)) return;
       if (!err.message?.includes(STACK_OVERFLOW_MESSAGE)) return;
+
+      // Suppress the browser's default error logging for this event. We
+      // re-capture below with enriched context, so the bare auto-captured
+      // frame is redundant noise.
+      event.preventDefault();
 
       Sentry.captureException(err, {
         tags: { kind: 'stack-overflow-trap' },
@@ -43,12 +50,12 @@ export function GlobalErrorTrap() {
         },
       });
 
-      showMessage('Something looped on this page. We logged it — try reloading.', 'warning', undefined, 6000);
+      showMessage(t('stackOverflowTrap.message'), 'warning', undefined, 6000);
     };
 
     window.addEventListener('error', handler);
     return () => window.removeEventListener('error', handler);
-  }, [showMessage]);
+  }, [showMessage, t]);
 
   return null;
 }

--- a/packages/web/app/components/providers/global-error-trap.tsx
+++ b/packages/web/app/components/providers/global-error-trap.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { useSnackbar } from './snackbar-provider';
+
+const STACK_OVERFLOW_MESSAGE = 'Maximum call stack';
+
+/**
+ * Last-resort handler for unhandled stack-overflow errors thrown outside of
+ * React's render cycle (RAF callbacks, microtasks, async event listeners,
+ * etc.). React error boundaries — including `app/global-error.tsx` — can't
+ * catch these; they reach the browser as `window.onerror` and Sentry tags
+ * them with `mechanism: auto.browser.global_handlers.onerror`.
+ *
+ * This component:
+ * 1. Re-captures the error to Sentry with extra browser context, since the
+ *    default `onerror` capture path tends to lose frames on iOS WebKit.
+ * 2. Surfaces a snackbar so the user sees something actionable instead of
+ *    the page silently freezing or going blank.
+ *
+ * This is a guard rail, not a fix — it makes recurring iOS Chrome
+ * `RangeError: Maximum call stack size exceeded` reports less invisible
+ * while we wait for symbolicated stacks to identify the recursion.
+ */
+export function GlobalErrorTrap() {
+  const { showMessage } = useSnackbar();
+
+  useEffect(() => {
+    const handler = (event: ErrorEvent) => {
+      const err = event.error;
+      if (!(err instanceof RangeError)) return;
+      if (!err.message?.includes(STACK_OVERFLOW_MESSAGE)) return;
+
+      Sentry.captureException(err, {
+        tags: { kind: 'stack-overflow-trap' },
+        extra: {
+          url: typeof location !== 'undefined' ? location.href : null,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+          filename: event.filename,
+          lineno: event.lineno,
+          colno: event.colno,
+        },
+      });
+
+      showMessage('Something looped on this page. We logged it — try reloading.', 'warning', undefined, 6000);
+    };
+
+    window.addEventListener('error', handler);
+    return () => window.removeEventListener('error', handler);
+  }, [showMessage]);
+
+  return null;
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -8,6 +8,7 @@ import SessionProviderWrapper from './components/providers/session-provider';
 import QueryClientProvider from './components/providers/query-client-provider';
 import PersistentSessionWrapper from './components/providers/persistent-session-wrapper';
 import { SnackbarProvider } from './components/providers/snackbar-provider';
+import { GlobalErrorTrap } from './components/providers/global-error-trap';
 import { AuthModalProvider } from './components/providers/auth-modal-provider';
 import { NotificationSubscriptionManager } from './components/providers/notification-subscription-manager';
 import I18nProvider from './components/providers/i18n-provider';
@@ -97,6 +98,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 >
                   <SnackbarProvider>
                     <NativeDeepLinkListener />
+                    <GlobalErrorTrap />
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>
                         <PersistentSessionWrapper boardConfigs={boardConfigs}>

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -20,6 +20,22 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
 
+  // Capture more breadcrumbs leading up to an error. Defaults to 50, which is
+  // not enough to see the chain of fetches preceding a stack overflow on the
+  // home page (multiple SWR/GraphQL queries fire in parallel on mount).
+  maxBreadcrumbs: 100,
+
+  integrations: [
+    // Records fetch/XHR/navigation breadcrumbs without sampling traces. We
+    // explicitly opt out of performance traces (tracesSampleRate is unset) —
+    // the integration is here purely for the breadcrumb side effects, which
+    // are what tell us "what was happening before the error".
+    Sentry.browserTracingIntegration(),
+    // Forward console.error to Sentry as breadcrumbs so async errors swallowed
+    // by .catch(console.error) still leave a trail.
+    Sentry.captureConsoleIntegration({ levels: ['error'] }),
+  ],
+
   // Filter out errors from browser extensions and third-party scripts
   beforeSend(event, hint) {
     const error = hint.originalException;

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -25,6 +25,12 @@ Sentry.init({
   // home page (multiple SWR/GraphQL queries fire in parallel on mount).
   maxBreadcrumbs: 100,
 
+  // Scope `sentry-trace`/`baggage` propagation headers (injected by
+  // browserTracingIntegration) to our own origin. Without this they'd ride
+  // along on every outgoing request, including Aurora proxy and third-party
+  // endpoints that don't expect them.
+  tracePropagationTargets: ['boardsesh.com'],
+
   integrations: [
     // Records fetch/XHR/navigation breadcrumbs without sampling traces. We
     // explicitly opt out of performance traces (tracesSampleRate is unset) —

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -7,6 +7,11 @@ const withVercelToolbar = createWithVercelToolbar();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // Required for Sentry to symbolicate stack traces from production iOS/Android
+  // browsers — without this, client bundles ship without `.map` files and
+  // window.onerror reports degrade to single minified frames like
+  // "Unknown function in undefined [Line 38]".
+  productionBrowserSourceMaps: true,
   typescript: {
     // ignoreBuildErrors: true,
   },


### PR DESCRIPTION
Sentry issue #942 reports a recurring `RangeError: Maximum call stack size
exceeded` on the home page from Chrome Mobile iOS. The stack trace is a
single un-symbolicated frame ("Unknown function in undefined [Line 38]")
because `productionBrowserSourceMaps` was off, so the Sentry plugin had
nothing to upload, and the error escapes React via `window.onerror` so
`global-error.tsx` never runs.

- next.config.mjs: enable `productionBrowserSourceMaps` so client bundles
  ship `.map` files for the Sentry plugin to upload.
- instrumentation-client.ts: add `browserTracingIntegration` (for fetch/XHR
  breadcrumbs) and `captureConsoleIntegration` (for console.error trail);
  raise `maxBreadcrumbs` to 100 so the parallel home-page fetches all fit.
- global-error-trap.tsx (new): re-captures unhandled stack overflows with
  extra browser context and shows a snackbar instead of a silent freeze.

Doesn't fix the underlying recursion — it makes the next occurrence
debuggable and the user-visible symptom less dire.

https://claude.ai/code/session_01JimwdLeNjq2aXCGBbNwrXf