### PR TITLE
Beta section: PR #1738 follow-up + analytics events

### DIFF
--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -14,7 +14,12 @@ import {
   type AttachBetaLinkMutationVariables,
   type AttachBetaLinkMutationResponse,
 } from '@/app/lib/graphql/operations';
-import { isBetaVideoUrl, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@/app/lib/beta-video-url';
+import {
+  isBetaVideoUrl,
+  isInstagramUrl,
+  isTikTokUrl,
+  BETA_VIDEO_URL_VALIDATION_MESSAGE,
+} from '@/app/lib/beta-video-url';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 
 type AttachBetaLinkFormProps = {
@@ -74,11 +79,8 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['betaLinks', boardType, climbUuid] });
-      track('Beta Video Added', {
-        boardType,
-        climbUuid,
-        platform: /tiktok\.com/i.test(trimmed) ? 'TikTok' : 'Instagram',
-      });
+      const platform = isTikTokUrl(trimmed) ? 'TikTok' : isInstagramUrl(trimmed) ? 'Instagram' : 'Unknown';
+      track('Beta Video Added', { boardType, climbUuid, platform });
       showMessage('Video added to beta', 'success');
       setUrl('');
       onSuccess?.();

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { track } from '@vercel/analytics';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import {
@@ -73,6 +74,11 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['betaLinks', boardType, climbUuid] });
+      track('Beta Video Added', {
+        boardType,
+        climbUuid,
+        platform: /tiktok\.com/i.test(trimmed) ? 'TikTok' : 'Instagram',
+      });
       showMessage('Video added to beta', 'success');
       setUrl('');
       onSuccess?.();

--- a/packages/web/app/components/beta-videos/boardsesh-beta-add-button.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-add-button.tsx
@@ -19,10 +19,7 @@ const BoardseshBetaAddButton: React.FC<BoardseshBetaAddButtonProps> = ({ isAddin
   return (
     <IconButton
       size="small"
-      onClick={(event) => {
-        event.stopPropagation();
-        onToggle();
-      }}
+      onClick={onToggle}
       aria-label={isAdding ? 'Cancel adding beta video' : 'Add beta video'}
       sx={{ color: 'text.primary' }}
     >

--- a/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import AttachBetaLinkForm from './attach-beta-link-form';
 
@@ -24,6 +24,16 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
   onCancel,
   onSuccess,
 }) => {
+  // Reset add-mode in the parent whenever this panel goes away — covers the
+  // case where the user collapses the section mid-add (lazy: true unmounts
+  // the form and its draft URL state). Idempotent w.r.t. success/cancel
+  // paths, which already flip the flag.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  });
+  useEffect(() => () => onCancelRef.current(), []);
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, px: 1.5, pt: 1.5, pb: 0.5 }}>
       <AttachBetaLinkForm

--- a/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
@@ -24,15 +24,31 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
   onCancel,
   onSuccess,
 }) => {
-  // Reset add-mode in the parent whenever this panel goes away — covers the
-  // case where the user collapses the section mid-add (lazy: true unmounts
-  // the form and its draft URL state). Idempotent w.r.t. success/cancel
-  // paths, which already flip the flag.
+  // Reset add-mode in the parent only when the panel unmounts via an
+  // unhandled path (section collapse via lazy: true). When the user
+  // explicitly cancels or successfully submits, the parent already flipped
+  // isAddingBeta, so we set committedRef to suppress the cleanup and avoid
+  // a redundant setState + re-render.
   const onCancelRef = useRef(onCancel);
+  const committedRef = useRef(false);
   useEffect(() => {
     onCancelRef.current = onCancel;
   });
-  useEffect(() => () => onCancelRef.current(), []);
+  useEffect(
+    () => () => {
+      if (!committedRef.current) onCancelRef.current();
+    },
+    [],
+  );
+
+  const handleCancel = () => {
+    committedRef.current = true;
+    onCancel();
+  };
+  const handleSuccess = () => {
+    committedRef.current = true;
+    onSuccess();
+  };
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, px: 1.5, pt: 1.5, pb: 0.5 }}>
@@ -44,8 +60,8 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
         compact
         submitLabel="Add"
         showCancel
-        onCancel={onCancel}
-        onSuccess={onSuccess}
+        onCancel={handleCancel}
+        onSuccess={handleSuccess}
       />
     </Box>
   );

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import Instagram from '@mui/icons-material/Instagram';
 import { track } from '@vercel/analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
-import { isTikTokUrl } from '@/app/lib/tiktok-url';
+import { isInstagramUrl, isTikTokUrl } from '@/app/lib/beta-video-url';
 import TikTokIcon from './tiktok-icon';
 import styles from './boardsesh-beta.module.css';
 
@@ -16,8 +16,10 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
   const thumbnailSrc = !thumbnailFailed ? link.thumbnail : null;
   const isTikTok = isTikTokUrl(link.link);
+  const isInstagram = !isTikTok && isInstagramUrl(link.link);
   const PlatformIcon = isTikTok ? TikTokIcon : Instagram;
-  const platformName = isTikTok ? 'TikTok' : 'Instagram';
+  const displayPlatform = isTikTok ? 'TikTok' : 'Instagram';
+  const analyticsPlatform = isTikTok ? 'TikTok' : isInstagram ? 'Instagram' : 'Unknown';
 
   return (
     <a
@@ -25,12 +27,12 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
       target="_blank"
       rel="noopener noreferrer"
       className={styles.card}
-      aria-label={`Open beta on ${platformName}${link.foreign_username ? ` by ${link.foreign_username}` : ''}`}
+      aria-label={`Open beta on ${displayPlatform}${link.foreign_username ? ` by ${link.foreign_username}` : ''}`}
       onClick={() =>
         track('Beta Video Link Clicked', {
-          platform: platformName,
+          platform: analyticsPlatform,
           climbUuid: link.climb_uuid,
-          foreignUsername: link.foreign_username ?? '',
+          ...(link.foreign_username ? { foreignUsername: link.foreign_username } : {}),
         })
       }
     >
@@ -49,7 +51,7 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
             <PlatformIcon sx={{ fontSize: 28, color: 'var(--neutral-400)' }} />
           </div>
         )}
-        <span className={styles.platformBadge} aria-label={`From ${platformName}`}>
+        <span className={styles.platformBadge} aria-label={`From ${displayPlatform}`}>
           <PlatformIcon sx={{ fontSize: 12 }} />
         </span>
         {link.foreign_username && <span className={styles.userChip}>@{link.foreign_username}</span>}

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import Instagram from '@mui/icons-material/Instagram';
+import { track } from '@vercel/analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import { isTikTokUrl } from '@/app/lib/tiktok-url';
 import TikTokIcon from './tiktok-icon';
@@ -25,6 +26,13 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
       rel="noopener noreferrer"
       className={styles.card}
       aria-label={`Open beta on ${platformName}${link.foreign_username ? ` by ${link.foreign_username}` : ''}`}
+      onClick={() =>
+        track('Beta Video Link Clicked', {
+          platform: platformName,
+          climbUuid: link.climb_uuid,
+          foreignUsername: link.foreign_username ?? '',
+        })
+      }
     >
       <div className={styles.thumbnailWrapper}>
         {thumbnailSrc ? (

--- a/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
@@ -4,42 +4,14 @@ import React from 'react';
 import Skeleton from '@mui/material/Skeleton';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import BoardseshBetaCard from './boardsesh-beta-card';
-import BoardseshBetaAddPanel from './boardsesh-beta-add-panel';
 import styles from './boardsesh-beta.module.css';
 
-type BoardseshBetaSectionProps = {
-  boardType: string;
-  climbUuid: string;
-  angle: number;
+type BoardseshBetaListProps = {
   links: BetaLink[];
   isLoading: boolean;
-  isAdding: boolean;
-  onCancelAdd: () => void;
-  onAddSuccess: () => void;
 };
 
-const BoardseshBetaSection: React.FC<BoardseshBetaSectionProps> = ({
-  boardType,
-  climbUuid,
-  angle,
-  links,
-  isLoading,
-  isAdding,
-  onCancelAdd,
-  onAddSuccess,
-}) => {
-  if (isAdding) {
-    return (
-      <BoardseshBetaAddPanel
-        boardType={boardType}
-        climbUuid={climbUuid}
-        angle={angle}
-        onCancel={onCancelAdd}
-        onSuccess={onAddSuccess}
-      />
-    );
-  }
-
+const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading }) => {
   return (
     <div className={styles.section}>
       <div className={styles.scrollContainer}>
@@ -64,4 +36,4 @@ const BoardseshBetaSection: React.FC<BoardseshBetaSectionProps> = ({
   );
 };
 
-export default BoardseshBetaSection;
+export default BoardseshBetaList;

--- a/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import React from 'react';
-import { renderHook } from '@testing-library/react';
+import React, { act } from 'react';
+import { renderHook, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useBuildClimbDetailSections } from '../build-climb-detail-sections';
 import type { Climb } from '@/app/lib/types';
@@ -10,9 +10,11 @@ import type { Climb } from '@/app/lib/types';
 // Mocks
 // ---------------------------------------------------------------------------
 
-// Mock next/navigation
+// Mock next/navigation. Tests can mutate `mockSearchParams` to vary the
+// resolved query string per case.
+let mockSearchParams = new URLSearchParams();
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
 }));
 
 // Mock child components to avoid pulling in their dependency trees
@@ -29,12 +31,29 @@ vi.mock('@/app/components/social/climb-social-section', () => ({
 vi.mock('@/app/components/charts/climb-analytics', () => ({
   default: () => null,
 }));
-vi.mock('@/app/components/beta-videos/boardsesh-beta-section', () => ({
+vi.mock('@/app/components/beta-videos/boardsesh-beta-list', () => ({
+  default: () => <div data-testid="beta-list" />,
+}));
+vi.mock('@/app/components/beta-videos/boardsesh-beta-add-panel', () => ({
+  default: () => <div data-testid="beta-add-panel" />,
+}));
+vi.mock('@/app/components/beta-videos/boardsesh-beta-add-button', () => ({
   default: () => null,
 }));
+
+// Mutable mock payload for the betaLinks GraphQL query.
+let mockBetaLinks: Array<{
+  climbUuid: string;
+  link: string;
+  foreignUsername: string | null;
+  angle: number | null;
+  thumbnail: string | null;
+  isListed: boolean;
+  createdAt: string;
+}> = [];
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({
-    request: async () => ({ betaLinks: [] }),
+    request: async () => ({ betaLinks: mockBetaLinks }),
   }),
 }));
 
@@ -98,6 +117,8 @@ const BASE_PROPS = {
 describe('useBuildClimbDetailSections', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockBetaLinks = [];
   });
 
   it('returns 5 sections when enabled (default)', () => {
@@ -149,5 +170,102 @@ describe('useBuildClimbDetailSections', () => {
 
     const beta = result.current.find((s) => s.key === 'beta');
     expect(beta?.defaultActive).toBe(true);
+  });
+
+  it('beta is NOT default-active when proposalUuid is set (community wins)', () => {
+    mockSearchParams = new URLSearchParams('proposalUuid=abc');
+    const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
+      wrapper: createWrapper(),
+    });
+
+    const beta = result.current.find((s) => s.key === 'beta');
+    const community = result.current.find((s) => s.key === 'community');
+    expect(beta?.defaultActive).toBe(false);
+    expect(community?.defaultActive).toBe(true);
+  });
+
+  it('getSummary returns the deduped video count once betaLinks loads', async () => {
+    mockBetaLinks = [
+      {
+        climbUuid: MOCK_CLIMB.uuid,
+        link: 'https://www.instagram.com/reel/aaa/',
+        foreignUsername: 'a',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-01',
+      },
+      {
+        climbUuid: MOCK_CLIMB.uuid,
+        link: 'https://www.instagram.com/reel/bbb/',
+        foreignUsername: 'b',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-02',
+      },
+      {
+        climbUuid: MOCK_CLIMB.uuid,
+        link: 'https://www.tiktok.com/@user/video/123',
+        foreignUsername: 'c',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-03',
+      },
+    ];
+
+    const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      const beta = result.current.find((s) => s.key === 'beta');
+      expect(beta?.getSummary?.()).toEqual(['3 videos']);
+    });
+  });
+
+  it('getSummary uses singular form for one video', async () => {
+    mockBetaLinks = [
+      {
+        climbUuid: MOCK_CLIMB.uuid,
+        link: 'https://www.instagram.com/reel/aaa/',
+        foreignUsername: 'a',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-01',
+      },
+    ];
+
+    const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      const beta = result.current.find((s) => s.key === 'beta');
+      expect(beta?.getSummary?.()).toEqual(['1 video']);
+    });
+  });
+
+  it('beta content swaps from list to add panel when the action toggle fires', () => {
+    const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
+      wrapper: createWrapper(),
+    });
+
+    const initialBeta = result.current.find((s) => s.key === 'beta')!;
+    const { rerender } = render(<>{initialBeta.content}</>);
+    expect(screen.queryByTestId('beta-list')).not.toBeNull();
+    expect(screen.queryByTestId('beta-add-panel')).toBeNull();
+
+    const action = initialBeta.action as React.ReactElement<{ onToggle: () => void }>;
+    act(() => {
+      action.props.onToggle();
+    });
+
+    const nextBeta = result.current.find((s) => s.key === 'beta')!;
+    rerender(<>{nextBeta.content}</>);
+    expect(screen.queryByTestId('beta-add-panel')).not.toBeNull();
+    expect(screen.queryByTestId('beta-list')).toBeNull();
   });
 });

--- a/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import React, { act } from 'react';
-import { renderHook, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderHook, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useBuildClimbDetailSections } from '../build-climb-detail-sections';
 import type { Climb } from '@/app/lib/types';
@@ -37,8 +37,15 @@ vi.mock('@/app/components/beta-videos/boardsesh-beta-list', () => ({
 vi.mock('@/app/components/beta-videos/boardsesh-beta-add-panel', () => ({
   default: () => <div data-testid="beta-add-panel" />,
 }));
+// Render the add-button as a real <button> wired to its onToggle prop so
+// integration tests can drive add-mode via fireEvent.click rather than
+// reaching into React element props.
 vi.mock('@/app/components/beta-videos/boardsesh-beta-add-button', () => ({
-  default: () => null,
+  default: ({ onToggle }: { isAdding: boolean; onToggle: () => void }) => (
+    <button type="button" data-testid="beta-add-toggle" onClick={onToggle}>
+      toggle
+    </button>
+  ),
 }));
 
 // Mutable mock payload for the betaLinks GraphQL query.
@@ -248,24 +255,33 @@ describe('useBuildClimbDetailSections', () => {
     });
   });
 
-  it('beta content swaps from list to add panel when the action toggle fires', () => {
+  it('beta content swaps from list to add panel when the user clicks the toggle button', () => {
     const { result } = renderHook(() => useBuildClimbDetailSections(BASE_PROPS), {
       wrapper: createWrapper(),
     });
 
-    const initialBeta = result.current.find((s) => s.key === 'beta')!;
-    const { rerender } = render(<>{initialBeta.content}</>);
+    const renderBeta = () => {
+      const beta = result.current.find((s) => s.key === 'beta')!;
+      return (
+        <>
+          {beta.action}
+          {beta.content}
+        </>
+      );
+    };
+
+    const { rerender } = render(renderBeta());
     expect(screen.queryByTestId('beta-list')).not.toBeNull();
     expect(screen.queryByTestId('beta-add-panel')).toBeNull();
 
-    const action = initialBeta.action as React.ReactElement<{ onToggle: () => void }>;
-    act(() => {
-      action.props.onToggle();
-    });
-
-    const nextBeta = result.current.find((s) => s.key === 'beta')!;
-    rerender(<>{nextBeta.content}</>);
+    fireEvent.click(screen.getByTestId('beta-add-toggle'));
+    rerender(renderBeta());
     expect(screen.queryByTestId('beta-add-panel')).not.toBeNull();
     expect(screen.queryByTestId('beta-list')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('beta-add-toggle'));
+    rerender(renderBeta());
+    expect(screen.queryByTestId('beta-list')).not.toBeNull();
+    expect(screen.queryByTestId('beta-add-panel')).toBeNull();
   });
 });

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -10,7 +10,8 @@ import { LogbookSection, useLogbookSummary } from '@/app/components/logbook/logb
 import { CrewLogbookView } from '@/app/components/logbook/crew-logbook-view';
 import ClimbSocialSection from '@/app/components/social/climb-social-section';
 import ClimbAnalytics from '@/app/components/charts/climb-analytics';
-import BoardseshBetaSection from '@/app/components/beta-videos/boardsesh-beta-section';
+import BoardseshBetaList from '@/app/components/beta-videos/boardsesh-beta-list';
+import BoardseshBetaAddPanel from '@/app/components/beta-videos/boardsesh-beta-add-panel';
 import BoardseshBetaAddButton from '@/app/components/beta-videos/boardsesh-beta-add-button';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
@@ -18,14 +19,14 @@ import { dedupeBetaLinks, mapBetaLinksResponse } from '@/app/lib/beta-video-url'
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import type { Climb } from '@/app/lib/types';
 
-const BETA_LABEL = (
+const betaLabel = (
   <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
     <VideocamOutlined sx={{ fontSize: 16 }} />
     Beta
   </Box>
 );
 
-const BETA_TITLE = (
+const betaTitle = (
   <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
     <VideocamOutlined sx={{ fontSize: 22 }} />
     Beta
@@ -92,8 +93,8 @@ export function useBuildClimbDetailSections({
   return [
     {
       key: 'beta',
-      label: BETA_LABEL,
-      title: BETA_TITLE,
+      label: betaLabel,
+      title: betaTitle,
       defaultSummary: 'No videos yet',
       getSummary: () => (betaCount > 0 ? [`${betaCount} video${betaCount !== 1 ? 's' : ''}`] : []),
       defaultActive: !highlightProposalUuid,
@@ -101,16 +102,19 @@ export function useBuildClimbDetailSections({
       lazy: true,
       action: <BoardseshBetaAddButton isAdding={isAddingBeta} onToggle={() => setIsAddingBeta((v) => !v)} />,
       content: (
-        <BoardseshBetaSection
-          boardType={boardType}
-          climbUuid={climbUuid}
-          angle={angle}
-          links={dedupedBetaLinks}
-          isLoading={betaLinksLoading}
-          isAdding={isAddingBeta}
-          onCancelAdd={() => setIsAddingBeta(false)}
-          onAddSuccess={() => setIsAddingBeta(false)}
-        />
+        <Box aria-live="polite">
+          {isAddingBeta ? (
+            <BoardseshBetaAddPanel
+              boardType={boardType}
+              climbUuid={climbUuid}
+              angle={angle}
+              onCancel={() => setIsAddingBeta(false)}
+              onSuccess={() => setIsAddingBeta(false)}
+            />
+          ) : (
+            <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} />
+          )}
+        </Box>
       ),
     },
     {

--- a/packages/web/app/components/collapsible-section/__tests__/collapsible-section.test.tsx
+++ b/packages/web/app/components/collapsible-section/__tests__/collapsible-section.test.tsx
@@ -60,6 +60,19 @@ describe('CollapsibleSection', () => {
       render(<CollapsibleSection sections={sections} />);
       expect(screen.getByText('Recent activity')).toBeDefined();
     });
+
+    it('honours defaultActive when sections arrive on a later render', () => {
+      // Simulates the play-drawer deferred-mount path: parent first renders
+      // with no sections, then the climb-detail hook returns the real list
+      // a tick later.
+      const { rerender } = render(<CollapsibleSection sections={[]} />);
+      expect(screen.queryByText('Recent activity')).toBeNull();
+
+      const sections = makeSections();
+      sections[1].defaultActive = true;
+      rerender(<CollapsibleSection sections={sections} />);
+      expect(screen.getByText('Recent activity')).toBeDefined();
+    });
   });
 
   describe('controlled mode (forcedActiveKey)', () => {

--- a/packages/web/app/lib/beta-video-url.ts
+++ b/packages/web/app/lib/beta-video-url.ts
@@ -72,7 +72,7 @@ export function dedupeBetaLinks(betaLinks: BetaLink[]): BetaLink[] {
 
 /**
  * Maps the GraphQL `betaLinks` response into the `BetaLink` shape used by
- * the rest of the web app. Used by both `BoardseshBetaSection` and the IG
+ * the rest of the web app. Used by both `BoardseshBetaList` and the IG
  * post dialog.
  */
 type BetaLinksGqlRow = {


### PR DESCRIPTION
## Summary
- Reset `isAddingBeta` on add-panel unmount so collapsing the section mid-add doesn't strand the user in add mode with an empty form on re-expand (the only user-affecting issue from the #1738 review).
- Split `BoardseshBetaSection` into a pure `BoardseshBetaList`; the hook now routes between list and add panel directly. Drops 8 props of pass-through dead weight.
- `aria-live="polite"` around the beta content so screen readers announce the list ↔ add-form swap.
- Drop the duplicated `stopPropagation` in `BoardseshBetaAddButton` — `CollapsibleSection`'s `headerAction` wrapper already guards bubbling.
- Rename `BETA_LABEL` / `BETA_TITLE` → `betaLabel` / `betaTitle`.
- Vercel analytics: `Beta Video Link Clicked` (on the card anchor) and `Beta Video Added` (in the mutation `onSuccess`).

Closes the prioritized review items from #1738. Pre-existing formatting issues on `instagram-meta.test.ts`, `tiktok-meta.test.ts`, and `board-search-map.test.tsx` are out of scope here (verified on clean `origin/main`).

## Test plan
- [x] `vp run typecheck:web` passes
- [x] `vp test run --project web` — 3722/3722 pass, including:
  - `defaultActive` is false for beta when `proposalUuid` is set
  - `getSummary` returns `'1 video'` / `'N videos'` once betaLinks loads
  - beta content swaps to add panel when the action's `onToggle` fires
  - `CollapsibleSection` honours `defaultActive` when sections arrive on a later render (deferred-mount lock-in)
- [ ] Manual smoke: open a climb detail drawer, expand Beta, click `+`, paste a URL, **collapse the section before submitting**, re-expand → should be back on the list (clean form on next `+`)
- [ ] Manual a11y: with VoiceOver/NVDA, the list↔form swap should be announced
- [ ] Verify the two new events show up in Vercel analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)