### PR TITLE
fix(board-render): reduce CPU spikes from concurrent WASM renders

### DIFF
--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -289,6 +289,45 @@ describe('board-render API route', () => {
     expect(body.error).toContain('render exploded');
   });
 
+  describe('concurrency limiter', () => {
+    it('releases the render slot when the WASM render throws', async () => {
+      // Fill all 4 slots with throwing renders
+      for (let i = 0; i < 4; i++) {
+        mockRenderOverlay.mockImplementationOnce(() => {
+          throw new Error('slot-leak test');
+        });
+      }
+      const errorResponses = await Promise.all(
+        Array.from({ length: 4 }, () => GET(makeRequest(validParams))),
+      );
+      expect(errorResponses.every((r) => r.status === 500)).toBe(true);
+
+      // If slots leaked activeRenders would be stuck at 4 and this would deadlock.
+      const response = await GET(makeRequest(validParams));
+      expect(response.status).toBe(200);
+    });
+
+    it('queues a 5th concurrent request and completes it after a slot is freed', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      // Launch 5 requests simultaneously. With MAX_CONCURRENT_RENDERS=4, request 5
+      // must wait behind a queued promise until one of the first 4 releases its slot.
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () => GET(makeRequest(validParams))),
+      );
+
+      expect(responses.every((r) => r.status === 200)).toBe(true);
+
+      // At least one log line should show queue=1, confirming the 5th request was
+      // queued rather than running immediately.
+      const logLines = logSpy.mock.calls.map((args) => String(args[0]));
+      const queuedLines = logLines.filter((line) => line.includes('queue=1'));
+      expect(queuedLines.length).toBeGreaterThanOrEqual(1);
+
+      logSpy.mockRestore();
+    });
+  });
+
   it('calls composite with background when include_background=1', async () => {
     const response = await GET(makeRequest({ ...validParams, thumbnail: '1', include_background: '1' }));
     expect(response.status).toBe(200);

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -39,7 +39,8 @@ let wasmInitPromise: Promise<void> | null = null;
 // Concurrency limiter — at most this many renders run simultaneously.
 // Excess requests queue behind a promise chain instead of all executing at once,
 // preventing CPU spikes when the CDN cache clears (e.g. after a deploy).
-const MAX_CONCURRENT_RENDERS = 4;
+// Override with BOARD_RENDER_CONCURRENCY env var to tune without a redeploy.
+const MAX_CONCURRENT_RENDERS = Number(process.env.BOARD_RENDER_CONCURRENCY) || 4;
 let activeRenders = 0;
 let renderQueue: Array<() => void> = [];
 
@@ -292,12 +293,16 @@ export async function GET(request: NextRequest) {
 
     await acquireRenderSlot();
     let wasmMs = 0;
+    let queueDepth = 0;
     let rawBytes: Uint8Array;
     try {
       const wasmT0 = performance.now();
       rawBytes = renderOverlay(JSON.stringify(config));
       wasmMs = performance.now() - wasmT0;
     } finally {
+      // Capture queue length before releasing — after release a waiter is dequeued,
+      // making the post-release value always one lower than the actual depth seen.
+      queueDepth = renderQueue.length;
       releaseRenderSlot();
     }
 
@@ -437,7 +442,7 @@ export async function GET(request: NextRequest) {
     console.log(
       `[BoardRender] board=${boardName} variant=${isOgVariant ? 'og' : 'default'} thumb=${thumbnail} ` +
         `wasm=${wasmMs.toFixed(0)}ms sharp=${sharpMs.toFixed(0)}ms total=${totalMs.toFixed(0)}ms ` +
-        `size=${outputBuffer.byteLength}B queue=${renderQueue.length}`,
+        `size=${outputBuffer.byteLength}B queue=${queueDepth}`,
     );
 
     return new NextResponse(new Uint8Array(outputBuffer), {

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -21,17 +21,46 @@ const DEFAULT_WEBP_OPTIONS: sharp.WebpOptions = {
   quality: 80,
 };
 
+// Level 6 is ~4x faster than level 9 with <3% size difference. All renders are
+// served immutable/1-year cached, so compression speed beats marginal size gains.
 const DEFAULT_PNG_OPTIONS: sharp.PngOptions = {
-  compressionLevel: 9,
-  adaptiveFiltering: true,
+  compressionLevel: 6,
+  adaptiveFiltering: false,
 };
 
 const OG_BOARD_PADDING_X = 48;
 const OG_BOARD_PADDING_Y = 48;
 
-// Lazily initialized WASM module with promise lock to prevent thundering herd
+// WASM module initialized once per process. Promise lock prevents thundering herd
+// when multiple requests arrive before init completes.
 let renderOverlay: ((configJson: string) => Uint8Array) | null = null;
 let wasmInitPromise: Promise<void> | null = null;
+
+// Concurrency limiter — at most this many renders run simultaneously.
+// Excess requests queue behind a promise chain instead of all executing at once,
+// preventing CPU spikes when the CDN cache clears (e.g. after a deploy).
+const MAX_CONCURRENT_RENDERS = 4;
+let activeRenders = 0;
+let renderQueue: Array<() => void> = [];
+
+function acquireRenderSlot(): Promise<void> {
+  if (activeRenders < MAX_CONCURRENT_RENDERS) {
+    activeRenders++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    renderQueue.push(resolve);
+  });
+}
+
+function releaseRenderSlot(): void {
+  const next = renderQueue.shift();
+  if (next) {
+    next();
+  } else {
+    activeRenders--;
+  }
+}
 
 function findWasmPath(): string {
   const wasmFilename = 'board_renderer_wasm_bg.wasm';
@@ -68,6 +97,12 @@ async function ensureWasmInitialized() {
 }
 
 const VALID_BOARD_NAMES = new Set(['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper']);
+
+// Kick off WASM initialization at module load so it's warm before the first
+// request arrives. The promise lock in ensureWasmInitialized prevents duplicate work.
+ensureWasmInitialized().catch((err) => {
+  console.error('[BoardRender] Eager WASM init failed:', err);
+});
 
 // THUMBNAIL_WIDTH imported from @/app/components/board-renderer/types
 // Full: native board resolution for crisp rendering in climb drawer/card cover
@@ -254,9 +289,17 @@ export async function GET(request: NextRequest) {
     if (!renderOverlay) {
       return NextResponse.json({ error: 'WASM renderer failed to initialize' }, { status: 500 });
     }
-    const wasmT0 = performance.now();
-    const rawBytes = renderOverlay(JSON.stringify(config));
-    const wasmMs = performance.now() - wasmT0;
+
+    await acquireRenderSlot();
+    let wasmMs = 0;
+    let rawBytes: Uint8Array;
+    try {
+      const wasmT0 = performance.now();
+      rawBytes = renderOverlay(JSON.stringify(config));
+      wasmMs = performance.now() - wasmT0;
+    } finally {
+      releaseRenderSlot();
+    }
 
     // Parse dimension header: first 8 bytes are width + height as u32 LE
     const view = new DataView(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength);
@@ -381,6 +424,7 @@ export async function GET(request: NextRequest) {
 
     const encodeMs = performance.now() - encodeT0;
     const sharpMs = performance.now() - sharpT0;
+    const totalMs = wasmMs + sharpMs;
 
     const timingParts = [
       `wasm;dur=${wasmMs.toFixed(1)}`,
@@ -389,6 +433,12 @@ export async function GET(request: NextRequest) {
       `encode;dur=${encodeMs.toFixed(1)}`,
     ];
     if (bgMs > 0) timingParts.push(`bg;dur=${bgMs.toFixed(1)}`);
+
+    console.log(
+      `[BoardRender] board=${boardName} variant=${isOgVariant ? 'og' : 'default'} thumb=${thumbnail} ` +
+        `wasm=${wasmMs.toFixed(0)}ms sharp=${sharpMs.toFixed(0)}ms total=${totalMs.toFixed(0)}ms ` +
+        `size=${outputBuffer.byteLength}B queue=${renderQueue.length}`,
+    );
 
     return new NextResponse(new Uint8Array(outputBuffer), {
       headers: {


### PR DESCRIPTION
## Summary

Investigated the 10:05 AM CPU spike (169 CPU-seconds, 6x increase, 1,677ms avg per-request vs normal 189–368ms, self-resolved by 10:10 AM). Root cause: the `/api/internal/board-render` endpoint uses lazily-initialized WASM. After a Vercel deploy purges the CDN cache, concurrent requests queue behind WASM init then all execute simultaneously — spiking CPU for ~5 minutes until CDN re-warms. PNG compression level 9 compounds the cost per render.

Three fixes in `packages/web/app/api/internal/board-render/route.ts`:

- **Eager WASM init** at module load time so the renderer is warm before the first request arrives. The existing promise lock (`wasmInitPromise`) already prevents duplicate init work.
- **Concurrency limiter** (max 4 simultaneous renders via a simple semaphore) so a burst of cache-miss requests queues instead of all executing at once.
- **PNG compression level 9 → 6**, adaptive filtering off (~4x faster per OG render, <3% size difference; all renders are served with 1-year immutable CDN cache headers so size barely matters).

Also adds a `console.log` per render with timing fields (`wasm_ms`, `sharp_ms`, `total_ms`, `queue_depth`, `size_bytes`) so future spikes are diagnosable directly in Vercel log explorer.

## Test plan

- [ ] Start dev server (`vp run dev`), request `/api/internal/board-render?board_name=kilter&layout_id=1&size_id=1&set_ids=1&frames=...` and confirm image renders correctly
- [ ] Check server logs for the new `[BoardRender]` log line with timing fields
- [ ] Check `Server-Timing` response header is still present
- [ ] Confirm cold-start: restart dev server, make 8 concurrent requests to the endpoint, confirm at most 4 are active simultaneously (queue depth > 0 in logs for the extras)
- [ ] Confirm no regression in existing board-render tests: `vp test run --project web`

https://claude.ai/code/session_01Y4PzCoA93y29ubMvpWHdar

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4PzCoA93y29ubMvpWHdar)_