### PR TITLE
Add NSCameraUsageDescription to fix App Store crash

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -71,6 +71,10 @@
 	<string>Boardsesh uses your location to find nearby boards to climb on and to discover nearby climbing sessions in Party Mode.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Boardsesh uses your location to find nearby boards to climb on and to discover nearby climbing sessions in Party Mode.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Boardsesh uses your camera so you can take a photo of a MoonBoard problem and import it into your library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Boardsesh reads photos you choose so you can import MoonBoard screenshots from your library.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary

- Apple's reviewer crashed build 78 (1.1) on iPad13,16 / iOS 26.3.1 with a TCC `SIGABRT`. Termination message: *"This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSCameraUsageDescription key..."*
- Thread 11 of the crash log shows `[CAMCaptureEngine enqueueCommand:]` → `[AVCaptureSession addInput:]`, i.e. the reviewer tapped "Take Photo" from the WKWebView file-picker action sheet on the MoonBoard screenshot import (`<input type="file" accept="image/*">` at `packages/web/app/components/create-climb/create-climb-form.tsx:1455` and `packages/web/app/components/moonboard-import/moonboard-bulk-import.tsx:467`).
- iOS 26 hard-aborts the process if the camera path is exercised without `NSCameraUsageDescription` declared, rather than silently denying as earlier iOS versions did.

This adds `NSCameraUsageDescription` (the load-bearing fix) and `NSPhotoLibraryUsageDescription` (preemptive, same import flow exercises it) to `mobile/ios/App/App/Info.plist`. No JS or build changes — the existing file inputs work as-is once the strings are declared.

## Test plan

- [ ] Bump `CURRENT_PROJECT_VERSION` to 79 (or next available build number) before submitting to App Store Connect
- [ ] Build the iOS app and install on a device/simulator running iOS 17+
- [ ] Open create-climb on a MoonBoard layout, tap the OCR import action — sheet opens without crashing
- [ ] Tap "Take Photo" — camera permission prompt shows the new copy, then camera view loads
- [ ] Tap "Photo Library" — picker opens (and prompt appears on iOS versions that gate it)
- [ ] Repeat for the bulk-import flow in `moonboard-bulk-import.tsx`
- [ ] Resubmit to App Store; confirm the TCC crash does not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)