### PR TITLE
Add NSMotionUsageDescription for shake-to-report

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -75,6 +75,8 @@
 	<string>Boardsesh uses your camera so you can take a photo of a MoonBoard problem and import it into your library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Boardsesh reads photos you choose so you can import MoonBoard screenshots from your library.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Boardsesh uses device motion so you can shake your phone to send feedback.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary

Defensive follow-up to #1747. The shake-to-report feature uses the Capacitor Motion plugin in the native shell (`packages/web/app/hooks/use-shake-detector.ts:75` calls `motion.addListener('accel', ...)` when `isNativeApp()` is true), which reads the iOS accelerometer through `CMMotionManager`.

Strictly speaking, raw `CMMotionManager` accelerometer access doesn't trigger TCC today (only `CMPedometer` / fitness APIs do), so this isn't fixing a known crash. But Apple has steadily tightened motion-data privacy over the last few iOS releases, and we just got bitten by the same class of issue with `NSCameraUsageDescription` — adding the string is cheap insurance against a future runtime abort or App Store rejection.

## Audit context

While investigating the camera crash, I scanned the rest of the repo for similar gaps. Everything else was clean:
- No `getUserMedia`, no `accept="audio/*"` / `accept="video/*"` inputs (no mic path)
- No `SpeechRecognition`
- No `EventKit` / `Contacts` / `Photos` / `HomeKit` / `MediaPlayer` Swift imports (only `HealthKit`, already covered)
- Party Mode uses standard `URLSessionWebSocketTask` to a known host — no Bonjour / mDNS, so no `NSLocalNetworkUsageDescription` needed
- No `Notification.requestPermission` / `UNUserNotificationCenter` usage
- AndroidManifest only declares `BLUETOOTH_*`, `*_LOCATION`, `INTERNET`, `ACCESS_NETWORK_STATE` — all already mapped on iOS

`NSMotionUsageDescription` was the one remaining lurker.

## Test plan

- [ ] Build the iOS app and install on device or simulator
- [ ] Open the app in the native shell, trigger the shake-to-report flow (shake the device while on any screen)
- [ ] On first run, confirm the new prompt appears with the expected copy and that accepting it lets the shake gesture fire
- [ ] On subsequent runs, confirm shake detection continues working without re-prompting
- [ ] Resubmit; confirm no new TCC-related rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)