### PR TITLE
Prep AndroidManifest for Play Store submission

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -58,4 +58,17 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <!-- Don't filter the listing on tablets / Chromebooks that lack these. -->
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+
+    <!-- Required on Android 11+ to launch external apps via custom URL schemes. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="instagram" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
## Summary

Two manifest additions ahead of the first Play Store upload. No new runtime permissions.

### `<uses-feature ... required="false">` for BLE, location, and GPS

Declaring `BLUETOOTH_SCAN` / `BLUETOOTH_CONNECT` / `ACCESS_FINE_LOCATION` causes Play to infer the underlying hardware features as **required**, which filters the listing on tablets and Chromebooks that lack them. The BLE plugin's manifest already declares `bluetooth_le` as not required, but the app-level declarations make the merged manifest explicit and recover Chromebook / non-GPS-tablet installs.

### `<queries>` block for `instagram://`

`packages/web/app/lib/instagram-posting.ts:206` launches `instagram://camera` via `window.location.href`. Android 11+ package-visibility rules don't strictly block `Intent.ACTION_VIEW` on custom schemes, so this works today, but Play Console policy reviewers prefer explicit `<queries>` for external-app handoffs. Declaring it now is cheap insurance against a future review note.

## Why no `CAMERA` or motion permission on Android

The iOS PRs (#1747, #1748) added `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`, and `NSMotionUsageDescription`. Android doesn't need equivalents because:

- **Camera**: the MoonBoard import `<input accept="image/*">` does not set the `capture` attribute. Capacitor's `BridgeWebChromeClient.onShowFileChooser` only fires `ACTION_IMAGE_CAPTURE` when `fileChooserParams.isCaptureEnabled()` is true (`mobile/node_modules/@capacitor/android/.../BridgeWebChromeClient.java:282-284`), so the Android picker goes through the system photo picker — permission-less on Android 13+.
- **Motion**: Android does not gate raw accelerometer access used by `@capacitor/motion`.

## Test plan

- [ ] Build the Android app from a clean checkout (`bunx cap sync android` then Android Studio build)
- [ ] Verify the merged manifest includes all six declarations (4 `uses-feature` + `queries` block) — `app/build/intermediates/merged_manifests/.../AndroidManifest.xml`
- [ ] Sideload onto a phone, confirm BLE board pairing still works
- [ ] On the same device, trigger the "Post to Instagram" flow and confirm the `instagram://camera` deep link still opens Instagram
- [ ] Sideload onto a Chromebook (or use `adb` against a tablet without GPS) — confirm the app installs (currently this would be filtered if uploaded to Play)
- [ ] Bump `versionCode` and `versionName` in `mobile/android/app/build.gradle` before the first Play upload (currently still `1` / `1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)