### PR TITLE
Serve Android assetlinks fingerprints by default

### DIFF
--- a/packages/web/app/.well-known/assetlinks.json/route.ts
+++ b/packages/web/app/.well-known/assetlinks.json/route.ts
@@ -1,4 +1,7 @@
-const DEFAULT_CERT_FINGERPRINTS: string[] = [];
+const DEFAULT_CERT_FINGERPRINTS: string[] = [
+  '54:4A:D4:37:19:27:8F:D2:35:BB:21:49:B2:EC:DA:19:AA:68:EF:99:82:AC:91:75:19:52:9A:D7:8D:12:7E:4D',
+  'F4:CC:2A:4D:4B:88:02:75:B0:B8:E1:7E:77:E6:C3:6E:23:DB:80:F1:98:1F:1C:42:4E:F8:8C:D5:E0:33:7D:65',
+];
 
 function getCertFingerprints(): string[] {
   const configuredFingerprints = process.env.ANDROID_APP_LINK_CERT_FINGERPRINTS;
@@ -16,7 +19,7 @@ function getCertFingerprints(): string[] {
 export function GET(): Response {
   const assetLinks = [
     {
-      relation: ['delegate_permission/common.handle_all_urls'],
+      relation: ['delegate_permission/common.handle_all_urls', 'delegate_permission/common.get_login_creds'],
       target: {
         namespace: 'android_app',
         package_name: 'com.boardsesh.app',


### PR DESCRIPTION
## Summary
- Bake the two public SHA-256 cert fingerprints (Play upload + signing) into the `/.well-known/assetlinks.json` route so domain verification works without requiring `ANDROID_APP_LINK_CERT_FINGERPRINTS` to be set in Vercel.
- Add `delegate_permission/common.get_login_creds` to the relation array alongside `handle_all_urls`, matching the snippet Play Console generates.

## Why
Play Console reported both `boardsesh.com` and `www.boardsesh.com` as failed for deep link verification. The route handler was serving an empty `sha256_cert_fingerprints` array because the env var was never configured, so Google had no way to verify ownership and `/join/.*` (and every other path) opened in the browser instead of the app.

## Test plan
- [ ] After deploy, `curl https://boardsesh.com/.well-known/assetlinks.json` returns 200 with both fingerprints
- [ ] Same for `https://www.boardsesh.com/.well-known/assetlinks.json` (no redirect; if www redirects to bare, Play verification will still fail and we'll need to either serve content on www or drop www from the AndroidManifest intent-filter)
- [ ] In Play Console > Deep links, click "Turn on credential sharing" again and confirm both domains move to verified
- [ ] Push a new Android build and confirm `/join/...` URLs open the app directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)