### PR TITLE
Drop bare boardsesh.com host from Android intent-filter

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="https" android:host="boardsesh.com" android:pathPrefix="/" />
                 <data android:scheme="https" android:host="www.boardsesh.com" android:pathPrefix="/" />
             </intent-filter>
 


### PR DESCRIPTION
## Summary
- Remove `boardsesh.com` from the AndroidManifest's autoVerify intent-filter, keeping only `www.boardsesh.com`.

## Why
`boardsesh.com` 308-redirects to `www.boardsesh.com` (which is the canonical host wired into `app/layout.tsx` and `app/sitemap.ts`). Android App Links verification does not follow redirects, so leaving the bare domain in the intent-filter caused Play Console to fail verification for the entire filter — even though the file at `https://www.boardsesh.com/.well-known/assetlinks.json` is fine.

Users hitting bare-domain links still get redirected to www and then deep-link into the app as normal.

## Test plan
- [ ] Cut a new Android build after merge
- [ ] In Play Console > Deep links, verify `www.boardsesh.com` moves to verified
- [ ] Tap an `https://www.boardsesh.com/join/...` link from another app on a device with the new build and confirm it opens directly in the app
- [ ] Tap an `https://boardsesh.com/join/...` link and confirm it follows the redirect into the app (or at least into the browser, depending on OS behaviour with redirect chains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)