### PR TITLE
Fix climb clicks in logbook and session views during party sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,8 @@ We are using next.js app router, it's important we try to use server side compon
 - While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
 - **Dark mode uses white input fields** — This is intentional for contrast. All input components (TextField, Select, Autocomplete, etc.) have white backgrounds in dark mode via `darkTokens.semantic.inputSurface`. Do not change them to dark backgrounds.
 - **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
+- **No nested ternaries** - `a ? b : c ? d : e` forces the reader to mentally re-bracket the expression. Use an `if`/`else if`/`else` block, an early return, or a small helper function. A `?:` is fine when both branches are short and unambiguous, but the moment you reach for a second `?:` inside the first, switch forms.
+- **Variable names must describe their contents** - No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `latest`, `temp`, `value`) outside of tight loops or well-known math conventions. The name should tell the next reader what's inside without forcing them to scroll back to the declaration. Prefer destructuring at the use site over a generic alias — `const { queue, currentClimb } = stateRef.current` reads better than `const s = stateRef.current` followed by `s.queue` / `s.currentClimb`.
 
 ### Copy & Microcopy
 

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -88,6 +88,17 @@ Both `PersistentSessionContext` and `QueueContext` are split into separate **Act
 
 Targeted hooks: `useQueueActions()`, `useQueueData()`, `usePersistentSessionActions()`, `usePersistentSessionState()`.
 
+### QueueBridgeProvider — root-level QueueContext
+
+`QueueBridgeProvider` (`packages/web/app/components/queue-control/queue-bridge-context.tsx`) is mounted once at the root inside `PersistentSessionWrapper` so a `QueueContext` value is always available, even off board routes (e.g. `/you/logbook`, `/session/[sessionId]`, `/playlists/...`). It has two modes:
+
+- **Injected mode** — when a board route mounts `GraphQLQueueProvider`, it injects its full context (with the GraphQL data fetcher and reducer) into the bridge. Consumers transparently see the board route's queue context.
+- **Adapter mode** — off board routes, `usePersistentSessionQueueAdapter` fronts the persistent session directly. Mutations now branch on `ps.activeSession`:
+  - **Solo / no party**: mutations go through `setLocalQueueState` (in-memory, no persistence beyond the session restore on reload).
+  - **Active party session**: mutations delegate to `ps.addQueueItem`, `ps.setCurrentClimb`, `ps.removeQueueItem`, `ps.setQueue`, `ps.mirrorCurrentClimb`, `ps.replaceQueueItem` — the same WebSocket-backed mutators `GraphQLQueueProvider` uses on board routes. `setLocalQueueState` is a no-op when `activeSession` is set, so without this delegation off-board taps would silently disappear.
+  - `setCurrentClimb` checks for an existing queue entry by `climb.uuid` first; if found it reuses that queue item via `ps.setCurrentClimb` without adding a duplicate.
+  - Items created by the adapter populate `addedBy` / `addedByUser` from `usePartyProfile` so peers see consistent attribution regardless of which surface added the climb.
+
 ## Technology Stack
 
 | Component          | Technology                        | Purpose                                                       |

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -35,6 +35,14 @@ vi.mock('../../persistent-session', () => ({
   usePersistentSessionActions: () => mockPersistentSession,
 }));
 
+let mockPartyProfile: { profile: { id: string } | null; username: string; avatarUrl?: string } = {
+  profile: null,
+  username: '',
+};
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => mockPartyProfile,
+}));
+
 vi.mock('../../graphql-queue/QueueContext', () => {
   const React = require('react');
   const ctx = React.createContext(undefined);
@@ -356,6 +364,7 @@ describe('queue-bridge-context', () => {
     vi.clearAllMocks();
     mockUuidCounter = 0;
     mockPersistentSession = createDefaultPersistentSession();
+    mockPartyProfile = { profile: null, username: '' };
   });
 
   // -----------------------------------------------------------------------
@@ -808,6 +817,76 @@ describe('queue-bridge-context', () => {
         expect(mockSetLocalQueueState).not.toHaveBeenCalled();
         expect(mockPersistentSession.mirrorCurrentClimb).toHaveBeenCalledTimes(1);
         expect((mockPersistentSession.mirrorCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(true);
+      });
+
+      it('replaceQueueItem delegates to ps.replaceQueueItem in party mode', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const { result } = renderWithPartySession([item1], item1);
+        const newClimb = createTestClimb({ uuid: 'c1-edit', name: 'Edited Climb' });
+        act(() => {
+          result.current!.replaceQueueItem('u1', newClimb);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.replaceQueueItem).toHaveBeenCalledTimes(1);
+        const call = (mockPersistentSession.replaceQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0]).toBe('u1');
+        // Preserves the slot uuid; updates the climb in place
+        expect(call[1].uuid).toBe('u1');
+        expect(call[1].climb.uuid).toBe('c1-edit');
+      });
+
+      it('setCurrentClimb reuses existing queue item instead of duplicating', async () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const { result } = renderWithPartySession([item1], item1);
+        await act(async () => {
+          // Click the same climb that's already in the queue at u1 — should
+          // NOT add a duplicate; should call setCurrentClimb on the existing item.
+          await result.current!.setCurrentClimb(climb1);
+        });
+        expect(mockPersistentSession.addQueueItem).not.toHaveBeenCalled();
+        expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
+        const call = (mockPersistentSession.setCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0].uuid).toBe('u1');
+        expect(call[0].climb.uuid).toBe('c1');
+      });
+
+      it('setCurrentClimb populates addedBy and addedByUser from party profile', async () => {
+        mockPartyProfile = {
+          profile: { id: 'user-42' },
+          username: 'climber42',
+          avatarUrl: 'https://example.com/a.png',
+        };
+        const { result } = renderWithPartySession([], null);
+        await act(async () => {
+          await result.current!.setCurrentClimb(climb1);
+        });
+        const addCall = (mockPersistentSession.addQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        const newItem = addCall[0];
+        expect(newItem.addedBy).toBe('client-abc');
+        expect(newItem.addedByUser).toEqual({
+          id: 'user-42',
+          username: 'climber42',
+          avatarUrl: 'https://example.com/a.png',
+        });
+      });
+
+      it('addToQueue populates addedBy and addedByUser from party profile', () => {
+        mockPartyProfile = {
+          profile: { id: 'user-99' },
+          username: 'climber99',
+          avatarUrl: undefined,
+        };
+        const { result } = renderWithPartySession([], null);
+        act(() => {
+          result.current!.addToQueue(climb1);
+        });
+        const call = (mockPersistentSession.addQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0].addedBy).toBe('client-abc');
+        expect(call[0].addedByUser).toEqual({
+          id: 'user-99',
+          username: 'climber99',
+          avatarUrl: undefined,
+        });
       });
     });
   });

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -43,6 +43,23 @@ vi.mock('../../party-manager/party-profile-context', () => ({
   usePartyProfile: () => mockPartyProfile,
 }));
 
+const mockShowMessage = vi.fn();
+vi.mock('../../providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+// Default: every climb passes. Tests that need to exercise the rejection
+// path override this via mockCanAddClimbToBoard.mockReturnValueOnce(...).
+type CompatResult = { ok: true } | { ok: false; reason: 'board_name' | 'layout' | 'holds_out_of_range' };
+const mockCanAddClimbToBoard = vi.fn<(climb: unknown, target: unknown) => CompatResult>(() => ({ ok: true }));
+vi.mock('@/app/lib/board-compatibility', () => ({
+  canAddClimbToBoard: (climb: unknown, target: unknown) => mockCanAddClimbToBoard(climb, target),
+}));
+
+vi.mock('../../board-lock/queue-add-error-messages', () => ({
+  queueAddErrorMessage: () => 'Climb is not compatible with this board',
+}));
+
 vi.mock('../../graphql-queue/QueueContext', () => {
   const React = require('react');
   const ctx = React.createContext(undefined);
@@ -365,6 +382,7 @@ describe('queue-bridge-context', () => {
     mockUuidCounter = 0;
     mockPersistentSession = createDefaultPersistentSession();
     mockPartyProfile = { profile: null, username: '' };
+    mockCanAddClimbToBoard.mockReturnValue({ ok: true });
   });
 
   // -----------------------------------------------------------------------
@@ -887,6 +905,94 @@ describe('queue-bridge-context', () => {
           username: 'climber99',
           avatarUrl: undefined,
         });
+      });
+
+      it('setCurrentClimbQueueItem always re-sends in party mode even when item is already current', () => {
+        // A peer might have moved the current climb away while our local
+        // optimistic state still shows item as current. Tapping should
+        // re-send the mutation so the server reconciles.
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const { result } = renderWithPartySession([item1], item1);
+        act(() => {
+          result.current!.setCurrentClimbQueueItem(item1);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
+        expect((mockPersistentSession.setCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0][0].uuid).toBe(
+          'u1',
+        );
+      });
+
+      it('setCurrentClimb logs and continues when ps.addQueueItem rejects', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+          mockPersistentSession = createDefaultPersistentSession({
+            activeSession,
+            queue: [],
+            currentClimbQueueItem: null,
+            isLocalQueueLoaded: true,
+            clientId: 'client-abc',
+            addQueueItem: vi.fn(() => Promise.reject(new Error('ws send failed'))),
+          });
+          const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueueBridgeProvider>{children}</QueueBridgeProvider>
+          );
+          const { result } = renderHook(() => useTestQueueContext(), { wrapper });
+          await act(async () => {
+            await result.current!.setCurrentClimb(climb1);
+          });
+          // Error was caught and logged; setCurrentClimb was not attempted
+          // because addQueueItem rejected first.
+          expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to set current climb:', expect.any(Error));
+          expect(mockPersistentSession.setCurrentClimb).not.toHaveBeenCalled();
+        } finally {
+          consoleErrorSpy.mockRestore();
+        }
+      });
+    });
+
+    // -------------------------------------------------------------------
+    // Validation rejection path: validateClimbForQueue surfaces a snackbar
+    // error and short-circuits the mutation.
+    // -------------------------------------------------------------------
+    describe('validation rejection', () => {
+      const bd = createTestBoardDetails();
+      const climb1 = createTestClimb({ uuid: 'c1', name: 'Climb 1' });
+
+      function renderWithLocalBoard() {
+        mockPersistentSession = createDefaultPersistentSession({
+          localQueue: [],
+          localCurrentClimbQueueItem: null,
+          localBoardDetails: bd,
+          localBoardPath: '/kilter/1/10/1,2',
+          isLocalQueueLoaded: true,
+        });
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+          <QueueBridgeProvider>{children}</QueueBridgeProvider>
+        );
+        return renderHook(() => useTestQueueContext(), { wrapper });
+      }
+
+      it('addToQueue surfaces a snackbar error and skips mutation when canAddClimbToBoard rejects', () => {
+        mockCanAddClimbToBoard.mockReturnValueOnce({ ok: false, reason: 'board_name' });
+        const { result } = renderWithLocalBoard();
+        act(() => {
+          result.current!.addToQueue(climb1);
+        });
+        expect(mockShowMessage).toHaveBeenCalledWith('Climb is not compatible with this board', 'error');
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+
+      it('setCurrentClimb returns null and skips mutation when canAddClimbToBoard rejects', async () => {
+        mockCanAddClimbToBoard.mockReturnValueOnce({ ok: false, reason: 'board_name' });
+        const { result } = renderWithLocalBoard();
+        let returned: unknown;
+        await act(async () => {
+          returned = await result.current!.setCurrentClimb(climb1);
+        });
+        expect(returned).toBeNull();
+        expect(mockShowMessage).toHaveBeenCalledWith('Climb is not compatible with this board', 'error');
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -923,7 +923,7 @@ describe('queue-bridge-context', () => {
         );
       });
 
-      it('setCurrentClimb logs and continues when ps.addQueueItem rejects', async () => {
+      it('setCurrentClimb returns null and skips setCurrentClimb when ps.addQueueItem rejects', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         try {
           mockPersistentSession = createDefaultPersistentSession({
@@ -938,13 +938,85 @@ describe('queue-bridge-context', () => {
             <QueueBridgeProvider>{children}</QueueBridgeProvider>
           );
           const { result } = renderHook(() => useTestQueueContext(), { wrapper });
+          let returnValue: ClimbQueueItem | null | undefined;
           await act(async () => {
-            await result.current!.setCurrentClimb(climb1);
+            returnValue = await result.current!.setCurrentClimb(climb1);
           });
-          // Error was caught and logged; setCurrentClimb was not attempted
-          // because addQueueItem rejected first.
-          expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to set current climb:', expect.any(Error));
+          // addQueueItem rejected, so nothing landed on the server. Return
+          // null so callers (e.g. navigateToClimb) skip downstream side
+          // effects like navigation.
+          expect(returnValue).toBeNull();
+          expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to add queue item before setting current:',
+            expect.any(Error),
+          );
           expect(mockPersistentSession.setCurrentClimb).not.toHaveBeenCalled();
+        } finally {
+          consoleErrorSpy.mockRestore();
+        }
+      });
+
+      it('setCurrentClimb returns null when ps.setCurrentClimb rejects after addQueueItem succeeds (partial failure)', async () => {
+        // Distinct from the addQueueItem-rejects case: here the item DID
+        // land in the shared queue, but activating it failed. The item is
+        // orphaned (queued but not current). Returning null lets callers
+        // skip navigation since the board never got the update.
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+          mockPersistentSession = createDefaultPersistentSession({
+            activeSession,
+            queue: [],
+            currentClimbQueueItem: null,
+            isLocalQueueLoaded: true,
+            clientId: 'client-abc',
+            addQueueItem: vi.fn(() => Promise.resolve()),
+            setCurrentClimb: vi.fn(() => Promise.reject(new Error('set-current ws send failed'))),
+          });
+          const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueueBridgeProvider>{children}</QueueBridgeProvider>
+          );
+          const { result } = renderHook(() => useTestQueueContext(), { wrapper });
+          let returnValue: ClimbQueueItem | null | undefined;
+          await act(async () => {
+            returnValue = await result.current!.setCurrentClimb(climb1);
+          });
+          expect(returnValue).toBeNull();
+          expect(mockPersistentSession.addQueueItem).toHaveBeenCalledTimes(1);
+          expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
+          expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to set current climb after queue add:',
+            expect.any(Error),
+          );
+        } finally {
+          consoleErrorSpy.mockRestore();
+        }
+      });
+
+      it('setCurrentClimb returns null when reusing an existing queue item and ps.setCurrentClimb rejects', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+          const item1 = createTestQueueItem(climb1, 'u1');
+          mockPersistentSession = createDefaultPersistentSession({
+            activeSession,
+            queue: [item1],
+            currentClimbQueueItem: null,
+            isLocalQueueLoaded: true,
+            clientId: 'client-abc',
+            setCurrentClimb: vi.fn(() => Promise.reject(new Error('set-current rejected'))),
+          });
+          const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueueBridgeProvider>{children}</QueueBridgeProvider>
+          );
+          const { result } = renderHook(() => useTestQueueContext(), { wrapper });
+          let returnValue: ClimbQueueItem | null | undefined;
+          await act(async () => {
+            // climb1 already exists in the queue as item1, so the dedupe
+            // path is taken — setCurrentClimb on the existing item.
+            returnValue = await result.current!.setCurrentClimb(climb1);
+          });
+          expect(returnValue).toBeNull();
+          expect(mockPersistentSession.addQueueItem).not.toHaveBeenCalled();
+          expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
         } finally {
           consoleErrorSpy.mockRestore();
         }

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -194,11 +194,12 @@ function createDefaultPersistentSession(overrides?: Record<string, unknown>) {
     activateSession: vi.fn(),
     setInitialQueueForSession: vi.fn(),
     subscribeToQueueEvents: vi.fn(() => vi.fn()),
-    addQueueItem: vi.fn(),
-    removeQueueItem: vi.fn(),
-    setCurrentClimb: vi.fn(),
-    setQueue: vi.fn(),
-    mirrorCurrentClimb: vi.fn(),
+    addQueueItem: vi.fn(() => Promise.resolve()),
+    removeQueueItem: vi.fn(() => Promise.resolve()),
+    setCurrentClimb: vi.fn(() => Promise.resolve()),
+    setQueue: vi.fn(() => Promise.resolve()),
+    mirrorCurrentClimb: vi.fn(() => Promise.resolve()),
+    replaceQueueItem: vi.fn(() => Promise.resolve()),
     triggerResync: vi.fn(),
     ...overrides,
   };
@@ -671,6 +672,142 @@ describe('queue-bridge-context', () => {
           void result.current!.setCurrentClimb(climb);
         });
         expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+      });
+    });
+
+    // -------------------------------------------------------------------
+    // Party-mode operations: with an active party session, the adapter must
+    // delegate mutations to the persistent session's WebSocket-backed API
+    // instead of setLocalQueueState (which no-ops in party mode).
+    // -------------------------------------------------------------------
+    describe('adapter party-mode operations', () => {
+      const bd = createTestBoardDetails();
+      const climb1 = createTestClimb({ uuid: 'c1', name: 'Climb 1' });
+      const climb2 = createTestClimb({ uuid: 'c2', name: 'Climb 2' });
+      const activeSession = {
+        sessionId: 'party-1',
+        boardPath: '/kilter/1/10/1,2/40/list',
+        boardDetails: bd,
+        parsedParams: {
+          board_name: 'kilter' as const,
+          layout_id: 1,
+          size_id: 10,
+          set_ids: [1, 2],
+          angle: 40 as Angle,
+        },
+      };
+
+      function renderWithPartySession(
+        queue: ClimbQueueItem[],
+        current: ClimbQueueItem | null,
+        psOverrides?: Record<string, unknown>,
+      ) {
+        mockPersistentSession = createDefaultPersistentSession({
+          activeSession,
+          queue,
+          currentClimbQueueItem: current,
+          isLocalQueueLoaded: true,
+          clientId: 'client-abc',
+          ...psOverrides,
+        });
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+          <QueueBridgeProvider>{children}</QueueBridgeProvider>
+        );
+        return renderHook(() => useTestQueueContext(), { wrapper });
+      }
+
+      it('setCurrentClimb delegates to ps.addQueueItem and ps.setCurrentClimb in party mode', async () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const { result } = renderWithPartySession([item1], item1);
+        await act(async () => {
+          await result.current!.setCurrentClimb(climb2);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.addQueueItem).toHaveBeenCalledTimes(1);
+        const addCall = (mockPersistentSession.addQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(addCall[0].climb.uuid).toBe('c2');
+        // Position is currentIndex + 1 = 1 (current at index 0, insert after)
+        expect(addCall[1]).toBe(1);
+        expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
+        const setCurrentCall = (mockPersistentSession.setCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(setCurrentCall[0].climb.uuid).toBe('c2');
+        // shouldAddToQueue is false (we already added)
+        expect(setCurrentCall[1]).toBe(false);
+        // correlationId derived from clientId
+        expect(setCurrentCall[2]).toMatch(/^client-abc-/);
+      });
+
+      it('setCurrentClimb passes undefined position when no current is set', async () => {
+        const { result } = renderWithPartySession([], null);
+        await act(async () => {
+          await result.current!.setCurrentClimb(climb1);
+        });
+        expect(mockPersistentSession.addQueueItem).toHaveBeenCalledTimes(1);
+        const addCall = (mockPersistentSession.addQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(addCall[1]).toBeUndefined();
+      });
+
+      it('setCurrentClimbQueueItem delegates to ps.setCurrentClimb in party mode', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const item2 = createTestQueueItem(climb2, 'u2');
+        const { result } = renderWithPartySession([item1, item2], item1);
+        act(() => {
+          result.current!.setCurrentClimbQueueItem(item2);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.setCurrentClimb).toHaveBeenCalledTimes(1);
+        const call = (mockPersistentSession.setCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0].uuid).toBe('u2');
+        // shouldAddToQueue uses item.suggested
+        expect(call[1]).toBe(false);
+      });
+
+      it('addToQueue delegates to ps.addQueueItem in party mode', () => {
+        const { result } = renderWithPartySession([], null);
+        act(() => {
+          result.current!.addToQueue(climb1);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.addQueueItem).toHaveBeenCalledTimes(1);
+        const call = (mockPersistentSession.addQueueItem as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0].climb.uuid).toBe('c1');
+      });
+
+      it('removeFromQueue delegates to ps.removeQueueItem in party mode', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const { result } = renderWithPartySession([item1], item1);
+        act(() => {
+          result.current!.removeFromQueue(item1);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.removeQueueItem).toHaveBeenCalledTimes(1);
+        expect((mockPersistentSession.removeQueueItem as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('u1');
+      });
+
+      it('setQueue delegates to ps.setQueue in party mode', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const item2 = createTestQueueItem(climb2, 'u2');
+        const { result } = renderWithPartySession([item1], item1);
+        act(() => {
+          result.current!.setQueue([item1, item2]);
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.setQueue).toHaveBeenCalledTimes(1);
+        const call = (mockPersistentSession.setQueue as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[0]).toHaveLength(2);
+        expect(call[1].uuid).toBe('u1');
+      });
+
+      it('mirrorClimb delegates to ps.mirrorCurrentClimb in party mode', () => {
+        const climb = createTestClimb({ uuid: 'c1', mirrored: false });
+        const item = createTestQueueItem(climb, 'u1');
+        const { result } = renderWithPartySession([item], item);
+        act(() => {
+          result.current!.mirrorClimb();
+        });
+        expect(mockSetLocalQueueState).not.toHaveBeenCalled();
+        expect(mockPersistentSession.mirrorCurrentClimb).toHaveBeenCalledTimes(1);
+        expect((mockPersistentSession.mirrorCurrentClimb as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(true);
       });
     });
   });

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -179,11 +179,11 @@ function usePersistentSessionQueueAdapter(): {
   // current party profile so off-board mutations (logbook, session view)
   // carry the same attribution as items created from the board route.
   const buildQueueItem = useCallback((climb: Climb): ClimbQueueItem => {
-    const r = latestRef.current;
+    const latest = latestRef.current;
     return {
       climb,
-      addedBy: r.ps.clientId ?? null,
-      addedByUser: r.currentUserInfo,
+      addedBy: latest.ps.clientId ?? null,
+      addedByUser: latest.currentUserInfo,
       uuid: uuidv4(),
       suggested: false,
     };
@@ -194,151 +194,147 @@ function usePersistentSessionQueueAdapter(): {
   // compatible. Message formatting lives in `queue-add-error-messages`
   // so the board-route and root-level entry points speak the same copy.
   const validateClimbForQueue = useCallback((climb: Climb): boolean => {
-    const r = latestRef.current;
-    const target = r.ps.activeSession?.boardDetails ?? r.boardDetails;
+    const latest = latestRef.current;
+    const target = latest.ps.activeSession?.boardDetails ?? latest.boardDetails;
     if (!target) return true;
     const result = canAddClimbToBoard(climb, target);
     if (result.ok) return true;
-    r.showMessage(queueAddErrorMessage(climb, target, result), 'error');
+    latest.showMessage(queueAddErrorMessage(climb, target, result), 'error');
     return false;
   }, []);
 
   const getNextClimbQueueItem = useCallback((): ClimbQueueItem | null => {
-    const r = latestRef.current;
-    const idx = r.queue.findIndex(({ uuid }) => uuid === r.currentClimbQueueItem?.uuid);
-    return idx >= 0 && idx < r.queue.length - 1 ? r.queue[idx + 1] : null;
+    const latest = latestRef.current;
+    const idx = latest.queue.findIndex(({ uuid }) => uuid === latest.currentClimbQueueItem?.uuid);
+    return idx >= 0 && idx < latest.queue.length - 1 ? latest.queue[idx + 1] : null;
   }, []);
 
   const getPreviousClimbQueueItem = useCallback((): ClimbQueueItem | null => {
-    const r = latestRef.current;
-    const idx = r.queue.findIndex(({ uuid }) => uuid === r.currentClimbQueueItem?.uuid);
-    return idx > 0 ? r.queue[idx - 1] : null;
+    const latest = latestRef.current;
+    const idx = latest.queue.findIndex(({ uuid }) => uuid === latest.currentClimbQueueItem?.uuid);
+    return idx > 0 ? latest.queue[idx - 1] : null;
   }, []);
 
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
-    const r = latestRef.current;
-    const alreadyInQueue = r.queue.some((q) => q.uuid === item.uuid);
-    if (r.ps.activeSession) {
+    const latest = latestRef.current;
+    const alreadyInQueue = latest.queue.some((q) => q.uuid === item.uuid);
+    if (latest.ps.activeSession) {
       // Don't bail on the "already current" optimistic state in party mode —
       // a peer may have moved the current climb away and our local view
       // hasn't caught up yet. Always re-send so the server reconciles.
-      const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
-      r.ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
+      const correlationId = latest.ps.clientId ? `${latest.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+      latest.ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
         console.error('Failed to set current climb queue item:', err);
       });
       return;
     }
-    if (alreadyInQueue && r.currentClimbQueueItem?.uuid === item.uuid) return;
-    if (!r.boardDetails) return;
-    const newQueue = alreadyInQueue ? r.queue : [...r.queue, item];
-    r.ps.setLocalQueueState(newQueue, item, r.baseBoardPath, r.boardDetails);
+    if (alreadyInQueue && latest.currentClimbQueueItem?.uuid === item.uuid) return;
+    if (!latest.boardDetails) return;
+    const newQueue = alreadyInQueue ? latest.queue : [...latest.queue, item];
+    latest.ps.setLocalQueueState(newQueue, item, latest.baseBoardPath, latest.boardDetails);
   }, []);
 
   const addToQueue = useCallback(
     (climb: Climb) => {
-      const r = latestRef.current;
+      const latest = latestRef.current;
       if (!validateClimbForQueue(climb)) return;
       const newItem = buildQueueItem(climb);
-      if (r.ps.activeSession) {
-        r.ps.addQueueItem(newItem).catch((err: unknown) => {
+      if (latest.ps.activeSession) {
+        latest.ps.addQueueItem(newItem).catch((err: unknown) => {
           console.error('Failed to add queue item:', err);
         });
         return;
       }
-      if (!r.boardDetails) {
+      if (!latest.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
         const seed = deriveSeedStateFromClimb(climb);
         if (!seed) return;
-        r.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        latest.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
         return;
       }
-      const newQueue = [...r.queue, newItem];
-      const current = r.currentClimbQueueItem ?? newItem;
-      r.ps.setLocalQueueState(newQueue, current, r.baseBoardPath, r.boardDetails);
+      const newQueue = [...latest.queue, newItem];
+      const current = latest.currentClimbQueueItem ?? newItem;
+      latest.ps.setLocalQueueState(newQueue, current, latest.baseBoardPath, latest.boardDetails);
     },
     [validateClimbForQueue, buildQueueItem],
   );
 
   const removeFromQueue = useCallback((item: ClimbQueueItem) => {
-    const r = latestRef.current;
-    if (r.ps.activeSession) {
-      r.ps.removeQueueItem(item.uuid).catch((err: unknown) => {
+    const latest = latestRef.current;
+    if (latest.ps.activeSession) {
+      latest.ps.removeQueueItem(item.uuid).catch((err: unknown) => {
         console.error('Failed to remove queue item:', err);
       });
       return;
     }
-    if (!r.boardDetails) return;
-    const newQueue = r.queue.filter((q) => q.uuid !== item.uuid);
-    const newCurrent = r.currentClimbQueueItem?.uuid === item.uuid ? (newQueue[0] ?? null) : r.currentClimbQueueItem;
-    r.ps.setLocalQueueState(newQueue, newCurrent, r.baseBoardPath, r.boardDetails);
+    if (!latest.boardDetails) return;
+    const newQueue = latest.queue.filter((q) => q.uuid !== item.uuid);
+    const newCurrent = latest.currentClimbQueueItem?.uuid === item.uuid ? (newQueue[0] ?? null) : latest.currentClimbQueueItem;
+    latest.ps.setLocalQueueState(newQueue, newCurrent, latest.baseBoardPath, latest.boardDetails);
   }, []);
 
   const setQueue = useCallback((newQueue: ClimbQueueItem[]) => {
-    const r = latestRef.current;
-    if (r.ps.activeSession) {
-      const newCurrent =
-        newQueue.length === 0
-          ? null
-          : r.currentClimbQueueItem && newQueue.some((q) => q.uuid === r.currentClimbQueueItem!.uuid)
-            ? r.currentClimbQueueItem
-            : newQueue[0];
-      r.ps.setQueue(newQueue, newCurrent).catch((err: unknown) => {
+    const latest = latestRef.current;
+    // Pick the new current climb: keep the existing one if it survived the
+    // queue update, otherwise fall back to the first item (or null when empty).
+    const pickCurrent = (): ClimbQueueItem | null => {
+      if (newQueue.length === 0) return null;
+      const current = latest.currentClimbQueueItem;
+      if (current && newQueue.some((q) => q.uuid === current.uuid)) return current;
+      return newQueue[0];
+    };
+    if (latest.ps.activeSession) {
+      latest.ps.setQueue(newQueue, pickCurrent()).catch((err: unknown) => {
         console.error('Failed to set queue:', err);
       });
       return;
     }
-    if (!r.boardDetails) return;
-    const newCurrent =
-      newQueue.length === 0
-        ? null
-        : r.currentClimbQueueItem && newQueue.some((q) => q.uuid === r.currentClimbQueueItem!.uuid)
-          ? r.currentClimbQueueItem
-          : newQueue[0];
-    r.ps.setLocalQueueState(newQueue, newCurrent, r.baseBoardPath, r.boardDetails);
+    if (!latest.boardDetails) return;
+    latest.ps.setLocalQueueState(newQueue, pickCurrent(), latest.baseBoardPath, latest.boardDetails);
   }, []);
 
   const mirrorClimb = useCallback(() => {
-    const r = latestRef.current;
-    if (!r.currentClimbQueueItem?.climb) return;
-    const mirrored = !r.currentClimbQueueItem.climb.mirrored;
-    if (r.ps.activeSession) {
-      r.ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
+    const latest = latestRef.current;
+    if (!latest.currentClimbQueueItem?.climb) return;
+    const mirrored = !latest.currentClimbQueueItem.climb.mirrored;
+    if (latest.ps.activeSession) {
+      latest.ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
         console.error('Failed to mirror current climb:', err);
       });
       return;
     }
-    if (!r.boardDetails) return;
+    if (!latest.boardDetails) return;
     const updatedItem: ClimbQueueItem = {
-      ...r.currentClimbQueueItem,
-      climb: { ...r.currentClimbQueueItem.climb, mirrored },
+      ...latest.currentClimbQueueItem,
+      climb: { ...latest.currentClimbQueueItem.climb, mirrored },
     };
-    const newQueue = r.queue.map((q) => (q.uuid === updatedItem.uuid ? updatedItem : q));
-    r.ps.setLocalQueueState(newQueue, updatedItem, r.baseBoardPath, r.boardDetails);
+    const newQueue = latest.queue.map((q) => (q.uuid === updatedItem.uuid ? updatedItem : q));
+    latest.ps.setLocalQueueState(newQueue, updatedItem, latest.baseBoardPath, latest.boardDetails);
   }, []);
 
   const setCurrentClimb = useCallback(
     async (climb: Climb): Promise<ClimbQueueItem | null> => {
-      const r = latestRef.current;
+      const latest = latestRef.current;
       if (!validateClimbForQueue(climb)) return null;
-      if (r.ps.activeSession) {
-        const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+      if (latest.ps.activeSession) {
+        const correlationId = latest.ps.clientId ? `${latest.ps.clientId}-${++correlationCounterRef.current}` : undefined;
         // If the climb is already in the queue, reuse the existing item
         // instead of adding a duplicate. This mirrors the natural behavior
         // expected by users tapping a logbook/session-view climb that's
         // already queued from another peer or earlier in the sesh.
-        const existing = r.queue.find((q) => q.climb?.uuid === climb.uuid);
+        const existing = latest.queue.find((q) => q.climb?.uuid === climb.uuid);
         if (existing) {
           try {
-            await r.ps.setCurrentClimb(existing, false, correlationId);
+            await latest.ps.setCurrentClimb(existing, false, correlationId);
           } catch (err: unknown) {
             console.error('Failed to set current climb:', err);
           }
           return existing;
         }
         const newItem = buildQueueItem(climb);
-        const currentIdx = r.currentClimbQueueItem
-          ? r.queue.findIndex((q) => q.uuid === r.currentClimbQueueItem!.uuid)
+        const currentIdx = latest.currentClimbQueueItem
+          ? latest.queue.findIndex((q) => q.uuid === latest.currentClimbQueueItem!.uuid)
           : -1;
         const position = currentIdx === -1 ? undefined : currentIdx + 1;
         try {
@@ -346,32 +342,32 @@ function usePersistentSessionQueueAdapter(): {
           // FIFO ordering, so the server processes the add before the
           // setCurrentClimb that references it. This mirrors
           // GraphQLQueueProvider.setCurrentClimb.
-          await r.ps.addQueueItem(newItem, position);
-          await r.ps.setCurrentClimb(newItem, false, correlationId);
+          await latest.ps.addQueueItem(newItem, position);
+          await latest.ps.setCurrentClimb(newItem, false, correlationId);
         } catch (err: unknown) {
           console.error('Failed to set current climb:', err);
         }
         return newItem;
       }
       const newItem = buildQueueItem(climb);
-      if (!r.boardDetails) {
+      if (!latest.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
         const seed = deriveSeedStateFromClimb(climb);
         if (!seed) return null;
-        r.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        latest.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
         return newItem;
       }
-      const currentIdx = r.currentClimbQueueItem
-        ? r.queue.findIndex((q) => q.uuid === r.currentClimbQueueItem!.uuid)
+      const currentIdx = latest.currentClimbQueueItem
+        ? latest.queue.findIndex((q) => q.uuid === latest.currentClimbQueueItem!.uuid)
         : -1;
-      const newQueue = [...r.queue];
+      const newQueue = [...latest.queue];
       if (currentIdx >= 0) {
         newQueue.splice(currentIdx + 1, 0, newItem);
       } else {
         newQueue.push(newItem);
       }
-      r.ps.setLocalQueueState(newQueue, newItem, r.baseBoardPath, r.boardDetails);
+      latest.ps.setLocalQueueState(newQueue, newItem, latest.baseBoardPath, latest.boardDetails);
       return newItem;
     },
     [validateClimbForQueue, buildQueueItem],
@@ -382,23 +378,23 @@ function usePersistentSessionQueueAdapter(): {
   // with a new climb while preserving the queue-item uuid and existing
   // addedBy attribution.
   const replaceQueueItem = useCallback((queueItemUuid: string, climb: Climb) => {
-    const r = latestRef.current;
-    const existing = r.queue.find((q) => q.uuid === queueItemUuid);
+    const latest = latestRef.current;
+    const existing = latest.queue.find((q) => q.uuid === queueItemUuid);
     if (!existing) return;
     const updated: ClimbQueueItem = {
       ...existing,
       climb,
     };
-    if (r.ps.activeSession) {
-      r.ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
+    if (latest.ps.activeSession) {
+      latest.ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
         console.error('Failed to replace queue item:', err);
       });
       return;
     }
-    if (!r.boardDetails) return;
-    const newQueue = r.queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
-    const nextCurrent = r.currentClimbQueueItem?.uuid === queueItemUuid ? updated : r.currentClimbQueueItem;
-    r.ps.setLocalQueueState(newQueue, nextCurrent, r.baseBoardPath, r.boardDetails);
+    if (!latest.boardDetails) return;
+    const newQueue = latest.queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
+    const nextCurrent = latest.currentClimbQueueItem?.uuid === queueItemUuid ? updated : latest.currentClimbQueueItem;
+    latest.ps.setLocalQueueState(newQueue, nextCurrent, latest.baseBoardPath, latest.boardDetails);
   }, []);
 
   // No-op functions for fields not used by the bottom bar

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -179,11 +179,11 @@ function usePersistentSessionQueueAdapter(): {
   // current party profile so off-board mutations (logbook, session view)
   // carry the same attribution as items created from the board route.
   const buildQueueItem = useCallback((climb: Climb): ClimbQueueItem => {
-    const latest = latestRef.current;
+    const { ps, currentUserInfo: user } = latestRef.current;
     return {
       climb,
-      addedBy: latest.ps.clientId ?? null,
-      addedByUser: latest.currentUserInfo,
+      addedBy: ps.clientId ?? null,
+      addedByUser: user,
       uuid: uuidv4(),
       suggested: false,
     };
@@ -194,180 +194,173 @@ function usePersistentSessionQueueAdapter(): {
   // compatible. Message formatting lives in `queue-add-error-messages`
   // so the board-route and root-level entry points speak the same copy.
   const validateClimbForQueue = useCallback((climb: Climb): boolean => {
-    const latest = latestRef.current;
-    const target = latest.ps.activeSession?.boardDetails ?? latest.boardDetails;
+    const { ps, boardDetails, showMessage } = latestRef.current;
+    const target = ps.activeSession?.boardDetails ?? boardDetails;
     if (!target) return true;
     const result = canAddClimbToBoard(climb, target);
     if (result.ok) return true;
-    latest.showMessage(queueAddErrorMessage(climb, target, result), 'error');
+    showMessage(queueAddErrorMessage(climb, target, result), 'error');
     return false;
   }, []);
 
   const getNextClimbQueueItem = useCallback((): ClimbQueueItem | null => {
-    const latest = latestRef.current;
-    const idx = latest.queue.findIndex(({ uuid }) => uuid === latest.currentClimbQueueItem?.uuid);
-    return idx >= 0 && idx < latest.queue.length - 1 ? latest.queue[idx + 1] : null;
+    const { queue, currentClimbQueueItem: current } = latestRef.current;
+    const idx = queue.findIndex(({ uuid }) => uuid === current?.uuid);
+    return idx >= 0 && idx < queue.length - 1 ? queue[idx + 1] : null;
   }, []);
 
   const getPreviousClimbQueueItem = useCallback((): ClimbQueueItem | null => {
-    const latest = latestRef.current;
-    const idx = latest.queue.findIndex(({ uuid }) => uuid === latest.currentClimbQueueItem?.uuid);
-    return idx > 0 ? latest.queue[idx - 1] : null;
+    const { queue, currentClimbQueueItem: current } = latestRef.current;
+    const idx = queue.findIndex(({ uuid }) => uuid === current?.uuid);
+    return idx > 0 ? queue[idx - 1] : null;
   }, []);
 
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
-    const latest = latestRef.current;
-    const alreadyInQueue = latest.queue.some((q) => q.uuid === item.uuid);
-    if (latest.ps.activeSession) {
+    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
+    const alreadyInQueue = queue.some((q) => q.uuid === item.uuid);
+    if (ps.activeSession) {
       // Don't bail on the "already current" optimistic state in party mode —
       // a peer may have moved the current climb away and our local view
       // hasn't caught up yet. Always re-send so the server reconciles.
-      const correlationId = latest.ps.clientId ? `${latest.ps.clientId}-${++correlationCounterRef.current}` : undefined;
-      latest.ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
+      const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
+      ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
         console.error('Failed to set current climb queue item:', err);
       });
       return;
     }
-    if (alreadyInQueue && latest.currentClimbQueueItem?.uuid === item.uuid) return;
-    if (!latest.boardDetails) return;
-    const newQueue = alreadyInQueue ? latest.queue : [...latest.queue, item];
-    latest.ps.setLocalQueueState(newQueue, item, latest.baseBoardPath, latest.boardDetails);
+    if (alreadyInQueue && current?.uuid === item.uuid) return;
+    if (!boardDetails) return;
+    const newQueue = alreadyInQueue ? queue : [...queue, item];
+    ps.setLocalQueueState(newQueue, item, baseBoardPath, boardDetails);
   }, []);
 
   const addToQueue = useCallback(
     (climb: Climb) => {
-      const latest = latestRef.current;
+      const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
       if (!validateClimbForQueue(climb)) return;
       const newItem = buildQueueItem(climb);
-      if (latest.ps.activeSession) {
-        latest.ps.addQueueItem(newItem).catch((err: unknown) => {
+      if (ps.activeSession) {
+        ps.addQueueItem(newItem).catch((err: unknown) => {
           console.error('Failed to add queue item:', err);
         });
         return;
       }
-      if (!latest.boardDetails) {
+      if (!boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
         const seed = deriveSeedStateFromClimb(climb);
         if (!seed) return;
-        latest.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
         return;
       }
-      const newQueue = [...latest.queue, newItem];
-      const current = latest.currentClimbQueueItem ?? newItem;
-      latest.ps.setLocalQueueState(newQueue, current, latest.baseBoardPath, latest.boardDetails);
+      ps.setLocalQueueState([...queue, newItem], current ?? newItem, baseBoardPath, boardDetails);
     },
     [validateClimbForQueue, buildQueueItem],
   );
 
   const removeFromQueue = useCallback((item: ClimbQueueItem) => {
-    const latest = latestRef.current;
-    if (latest.ps.activeSession) {
-      latest.ps.removeQueueItem(item.uuid).catch((err: unknown) => {
+    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
+    if (ps.activeSession) {
+      ps.removeQueueItem(item.uuid).catch((err: unknown) => {
         console.error('Failed to remove queue item:', err);
       });
       return;
     }
-    if (!latest.boardDetails) return;
-    const newQueue = latest.queue.filter((q) => q.uuid !== item.uuid);
-    const newCurrent = latest.currentClimbQueueItem?.uuid === item.uuid ? (newQueue[0] ?? null) : latest.currentClimbQueueItem;
-    latest.ps.setLocalQueueState(newQueue, newCurrent, latest.baseBoardPath, latest.boardDetails);
+    if (!boardDetails) return;
+    const newQueue = queue.filter((q) => q.uuid !== item.uuid);
+    const newCurrent = current?.uuid === item.uuid ? (newQueue[0] ?? null) : current;
+    ps.setLocalQueueState(newQueue, newCurrent, baseBoardPath, boardDetails);
   }, []);
 
   const setQueue = useCallback((newQueue: ClimbQueueItem[]) => {
-    const latest = latestRef.current;
+    const { currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
     // Pick the new current climb: keep the existing one if it survived the
     // queue update, otherwise fall back to the first item (or null when empty).
     const pickCurrent = (): ClimbQueueItem | null => {
       if (newQueue.length === 0) return null;
-      const current = latest.currentClimbQueueItem;
       if (current && newQueue.some((q) => q.uuid === current.uuid)) return current;
       return newQueue[0];
     };
-    if (latest.ps.activeSession) {
-      latest.ps.setQueue(newQueue, pickCurrent()).catch((err: unknown) => {
+    if (ps.activeSession) {
+      ps.setQueue(newQueue, pickCurrent()).catch((err: unknown) => {
         console.error('Failed to set queue:', err);
       });
       return;
     }
-    if (!latest.boardDetails) return;
-    latest.ps.setLocalQueueState(newQueue, pickCurrent(), latest.baseBoardPath, latest.boardDetails);
+    if (!boardDetails) return;
+    ps.setLocalQueueState(newQueue, pickCurrent(), baseBoardPath, boardDetails);
   }, []);
 
   const mirrorClimb = useCallback(() => {
-    const latest = latestRef.current;
-    if (!latest.currentClimbQueueItem?.climb) return;
-    const mirrored = !latest.currentClimbQueueItem.climb.mirrored;
-    if (latest.ps.activeSession) {
-      latest.ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
+    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
+    if (!current?.climb) return;
+    const mirrored = !current.climb.mirrored;
+    if (ps.activeSession) {
+      ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
         console.error('Failed to mirror current climb:', err);
       });
       return;
     }
-    if (!latest.boardDetails) return;
+    if (!boardDetails) return;
     const updatedItem: ClimbQueueItem = {
-      ...latest.currentClimbQueueItem,
-      climb: { ...latest.currentClimbQueueItem.climb, mirrored },
+      ...current,
+      climb: { ...current.climb, mirrored },
     };
-    const newQueue = latest.queue.map((q) => (q.uuid === updatedItem.uuid ? updatedItem : q));
-    latest.ps.setLocalQueueState(newQueue, updatedItem, latest.baseBoardPath, latest.boardDetails);
+    const newQueue = queue.map((q) => (q.uuid === updatedItem.uuid ? updatedItem : q));
+    ps.setLocalQueueState(newQueue, updatedItem, baseBoardPath, boardDetails);
   }, []);
 
   const setCurrentClimb = useCallback(
     async (climb: Climb): Promise<ClimbQueueItem | null> => {
-      const latest = latestRef.current;
+      const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
       if (!validateClimbForQueue(climb)) return null;
-      if (latest.ps.activeSession) {
-        const correlationId = latest.ps.clientId ? `${latest.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+      if (ps.activeSession) {
+        const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
         // If the climb is already in the queue, reuse the existing item
         // instead of adding a duplicate. This mirrors the natural behavior
         // expected by users tapping a logbook/session-view climb that's
         // already queued from another peer or earlier in the sesh.
-        const existing = latest.queue.find((q) => q.climb?.uuid === climb.uuid);
+        const existing = queue.find((q) => q.climb?.uuid === climb.uuid);
         if (existing) {
           try {
-            await latest.ps.setCurrentClimb(existing, false, correlationId);
+            await ps.setCurrentClimb(existing, false, correlationId);
           } catch (err: unknown) {
             console.error('Failed to set current climb:', err);
           }
           return existing;
         }
         const newItem = buildQueueItem(climb);
-        const currentIdx = latest.currentClimbQueueItem
-          ? latest.queue.findIndex((q) => q.uuid === latest.currentClimbQueueItem!.uuid)
-          : -1;
+        const currentIdx = current ? queue.findIndex((q) => q.uuid === current.uuid) : -1;
         const position = currentIdx === -1 ? undefined : currentIdx + 1;
         try {
           // Sequential awaits over a single graphql-ws connection preserve
           // FIFO ordering, so the server processes the add before the
           // setCurrentClimb that references it. This mirrors
           // GraphQLQueueProvider.setCurrentClimb.
-          await latest.ps.addQueueItem(newItem, position);
-          await latest.ps.setCurrentClimb(newItem, false, correlationId);
+          await ps.addQueueItem(newItem, position);
+          await ps.setCurrentClimb(newItem, false, correlationId);
         } catch (err: unknown) {
           console.error('Failed to set current climb:', err);
         }
         return newItem;
       }
       const newItem = buildQueueItem(climb);
-      if (!latest.boardDetails) {
+      if (!boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
         const seed = deriveSeedStateFromClimb(climb);
         if (!seed) return null;
-        latest.ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
+        ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
         return newItem;
       }
-      const currentIdx = latest.currentClimbQueueItem
-        ? latest.queue.findIndex((q) => q.uuid === latest.currentClimbQueueItem!.uuid)
-        : -1;
-      const newQueue = [...latest.queue];
+      const currentIdx = current ? queue.findIndex((q) => q.uuid === current.uuid) : -1;
+      const newQueue = [...queue];
       if (currentIdx >= 0) {
         newQueue.splice(currentIdx + 1, 0, newItem);
       } else {
         newQueue.push(newItem);
       }
-      latest.ps.setLocalQueueState(newQueue, newItem, latest.baseBoardPath, latest.boardDetails);
+      ps.setLocalQueueState(newQueue, newItem, baseBoardPath, boardDetails);
       return newItem;
     },
     [validateClimbForQueue, buildQueueItem],
@@ -378,23 +371,20 @@ function usePersistentSessionQueueAdapter(): {
   // with a new climb while preserving the queue-item uuid and existing
   // addedBy attribution.
   const replaceQueueItem = useCallback((queueItemUuid: string, climb: Climb) => {
-    const latest = latestRef.current;
-    const existing = latest.queue.find((q) => q.uuid === queueItemUuid);
+    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
+    const existing = queue.find((q) => q.uuid === queueItemUuid);
     if (!existing) return;
-    const updated: ClimbQueueItem = {
-      ...existing,
-      climb,
-    };
-    if (latest.ps.activeSession) {
-      latest.ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
+    const updated: ClimbQueueItem = { ...existing, climb };
+    if (ps.activeSession) {
+      ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
         console.error('Failed to replace queue item:', err);
       });
       return;
     }
-    if (!latest.boardDetails) return;
-    const newQueue = latest.queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
-    const nextCurrent = latest.currentClimbQueueItem?.uuid === queueItemUuid ? updated : latest.currentClimbQueueItem;
-    latest.ps.setLocalQueueState(newQueue, nextCurrent, latest.baseBoardPath, latest.boardDetails);
+    if (!boardDetails) return;
+    const newQueue = queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
+    const nextCurrent = current?.uuid === queueItemUuid ? updated : current;
+    ps.setLocalQueueState(newQueue, nextCurrent, baseBoardPath, boardDetails);
   }, []);
 
   // No-op functions for fields not used by the bottom bar

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -26,9 +26,10 @@ import {
 } from '../graphql-queue/QueueContext';
 import type { CurrentClimbDataType, QueueListDataType, SearchDataType, SessionDataType } from '../graphql-queue/types';
 import { usePersistentSession } from '../persistent-session';
+import { usePartyProfile } from '../party-manager/party-profile-context';
 import { getBaseBoardPath, DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { BoardDetails, Angle, Climb, SearchRequestPagination } from '@/app/lib/types';
-import type { ClimbQueueItem } from './types';
+import type { ClimbQueueItem, QueueItemUser } from './types';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
@@ -110,6 +111,14 @@ function usePersistentSessionQueueAdapter(): {
 } {
   const ps = usePersistentSession();
   const { showMessage } = useSnackbar();
+  const { profile, username, avatarUrl } = usePartyProfile();
+
+  // Mirror GraphQLQueueProvider's currentUserInfo so queue items created off
+  // board routes carry the same "who added this" attribution.
+  const currentUserInfo: QueueItemUser | undefined = useMemo(() => {
+    if (!profile?.id) return undefined;
+    return { id: profile.id, username: username || '', avatarUrl };
+  }, [profile?.id, username, avatarUrl]);
 
   const isParty = !!ps.activeSession;
   const queue = isParty ? ps.queue : ps.localQueue;
@@ -149,6 +158,7 @@ function usePersistentSessionQueueAdapter(): {
     baseBoardPath,
     ps,
     showMessage,
+    currentUserInfo,
   });
   latestRef.current = {
     queue,
@@ -157,12 +167,27 @@ function usePersistentSessionQueueAdapter(): {
     baseBoardPath,
     ps,
     showMessage,
+    currentUserInfo,
   };
 
   // Counter for correlation IDs sent with party-mode SET_CURRENT_CLIMB
   // mutations so the persistent session's pending-update tracker can
   // match local optimistic state with server confirmations.
   const correlationCounterRef = useRef(0);
+
+  // Build a queue item from a climb, populating addedBy/addedByUser from the
+  // current party profile so off-board mutations (logbook, session view)
+  // carry the same attribution as items created from the board route.
+  const buildQueueItem = useCallback((climb: Climb): ClimbQueueItem => {
+    const r = latestRef.current;
+    return {
+      climb,
+      addedBy: r.ps.clientId ?? null,
+      addedByUser: r.currentUserInfo,
+      uuid: uuidv4(),
+      suggested: false,
+    };
+  }, []);
 
   // Validates a climb against the locked board (session) or the current
   // adapter board. Shows a Snackbar error and returns false if not
@@ -210,12 +235,7 @@ function usePersistentSessionQueueAdapter(): {
     (climb: Climb) => {
       const r = latestRef.current;
       if (!validateClimbForQueue(climb)) return;
-      const newItem: ClimbQueueItem = {
-        climb,
-        addedBy: null,
-        uuid: uuidv4(),
-        suggested: false,
-      };
+      const newItem = buildQueueItem(climb);
       if (r.ps.activeSession) {
         r.ps.addQueueItem(newItem).catch((err: unknown) => {
           console.error('Failed to add queue item:', err);
@@ -234,7 +254,7 @@ function usePersistentSessionQueueAdapter(): {
       const current = r.currentClimbQueueItem ?? newItem;
       r.ps.setLocalQueueState(newQueue, current, r.baseBoardPath, r.boardDetails);
     },
-    [validateClimbForQueue],
+    [validateClimbForQueue, buildQueueItem],
   );
 
   const removeFromQueue = useCallback((item: ClimbQueueItem) => {
@@ -298,19 +318,31 @@ function usePersistentSessionQueueAdapter(): {
     async (climb: Climb): Promise<ClimbQueueItem | null> => {
       const r = latestRef.current;
       if (!validateClimbForQueue(climb)) return null;
-      const newItem: ClimbQueueItem = {
-        climb,
-        addedBy: null,
-        uuid: uuidv4(),
-        suggested: false,
-      };
       if (r.ps.activeSession) {
+        const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+        // If the climb is already in the queue, reuse the existing item
+        // instead of adding a duplicate. This mirrors the natural behavior
+        // expected by users tapping a logbook/session-view climb that's
+        // already queued from another peer or earlier in the sesh.
+        const existing = r.queue.find((q) => q.climb?.uuid === climb.uuid);
+        if (existing) {
+          try {
+            await r.ps.setCurrentClimb(existing, false, correlationId);
+          } catch (err: unknown) {
+            console.error('Failed to set current climb:', err);
+          }
+          return existing;
+        }
+        const newItem = buildQueueItem(climb);
         const currentIdx = r.currentClimbQueueItem
           ? r.queue.findIndex((q) => q.uuid === r.currentClimbQueueItem!.uuid)
           : -1;
         const position = currentIdx === -1 ? undefined : currentIdx + 1;
-        const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
         try {
+          // Sequential awaits over a single graphql-ws connection preserve
+          // FIFO ordering, so the server processes the add before the
+          // setCurrentClimb that references it. This mirrors
+          // GraphQLQueueProvider.setCurrentClimb.
           await r.ps.addQueueItem(newItem, position);
           await r.ps.setCurrentClimb(newItem, false, correlationId);
         } catch (err: unknown) {
@@ -318,6 +350,7 @@ function usePersistentSessionQueueAdapter(): {
         }
         return newItem;
       }
+      const newItem = buildQueueItem(climb);
       if (!r.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
@@ -338,7 +371,7 @@ function usePersistentSessionQueueAdapter(): {
       r.ps.setLocalQueueState(newQueue, newItem, r.baseBoardPath, r.boardDetails);
       return newItem;
     },
-    [validateClimbForQueue],
+    [validateClimbForQueue, buildQueueItem],
   );
 
   // Bridge-mode replace: in party mode, delegate to the persistent session's

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -324,25 +324,39 @@ function usePersistentSessionQueueAdapter(): {
         if (existing) {
           try {
             await ps.setCurrentClimb(existing, false, correlationId);
+            return existing;
           } catch (err: unknown) {
             console.error('Failed to set current climb:', err);
+            return null;
           }
-          return existing;
         }
         const newItem = buildQueueItem(climb);
         const currentIdx = current ? queue.findIndex((q) => q.uuid === current.uuid) : -1;
         const position = currentIdx === -1 ? undefined : currentIdx + 1;
+        // Split the awaits so a partial failure is observable: addQueueItem
+        // adds the item to the shared queue, then setCurrentClimb activates
+        // it. If addQueueItem fails, nothing landed on the server. If
+        // setCurrentClimb fails after addQueueItem succeeded, the item is
+        // queued but not active — return null so the caller (e.g.
+        // SessionDetailContent.navigateToClimb) doesn't navigate to a climb
+        // the board never actually got told to display.
+        try {
+          await ps.addQueueItem(newItem, position);
+        } catch (err: unknown) {
+          console.error('Failed to add queue item before setting current:', err);
+          return null;
+        }
         try {
           // Sequential awaits over a single graphql-ws connection preserve
           // FIFO ordering, so the server processes the add before the
           // setCurrentClimb that references it. This mirrors
           // GraphQLQueueProvider.setCurrentClimb.
-          await ps.addQueueItem(newItem, position);
           await ps.setCurrentClimb(newItem, false, correlationId);
+          return newItem;
         } catch (err: unknown) {
-          console.error('Failed to set current climb:', err);
+          console.error('Failed to set current climb after queue add:', err);
+          return null;
         }
-        return newItem;
       }
       const newItem = buildQueueItem(climb);
       if (!boardDetails) {

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -218,14 +218,17 @@ function usePersistentSessionQueueAdapter(): {
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
     const r = latestRef.current;
     const alreadyInQueue = r.queue.some((q) => q.uuid === item.uuid);
-    if (alreadyInQueue && r.currentClimbQueueItem?.uuid === item.uuid) return;
     if (r.ps.activeSession) {
+      // Don't bail on the "already current" optimistic state in party mode —
+      // a peer may have moved the current climb away and our local view
+      // hasn't caught up yet. Always re-send so the server reconciles.
       const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
       r.ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
         console.error('Failed to set current climb queue item:', err);
       });
       return;
     }
+    if (alreadyInQueue && r.currentClimbQueueItem?.uuid === item.uuid) return;
     if (!r.boardDetails) return;
     const newQueue = alreadyInQueue ? r.queue : [...r.queue, item];
     r.ps.setLocalQueueState(newQueue, item, r.baseBoardPath, r.boardDetails);
@@ -742,7 +745,11 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
 
   // Renamed locals so jsx-handler-names sees on*-prefixed identifiers being
   // passed to the on*-prefixed props on LiveActivityBridge below.
-  const onSetCurrentClimb = adapter.context.setCurrentClimbQueueItem;
+  // Use effectiveActions.setCurrentClimbQueueItem so widget taps route through
+  // the injected GraphQLQueueProvider when on a board route. The adapter's
+  // version writes to local state (no-op in party mode) and would silently
+  // drop widget navigation during an active sesh.
+  const onSetCurrentClimb = effectiveActions.setCurrentClimbQueueItem;
   const onWidgetNavigate = effectiveActions.dispatchWidgetNavigation;
 
   return (
@@ -756,13 +763,16 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
                   <QueueListContext.Provider value={effectiveQueueList}>
                     <SearchContext.Provider value={effectiveSearch}>
                       <SessionContext.Provider value={effectiveSession}>
-                        {/* Sync queue state to iOS Live Activity (code-split, no-op on non-iOS) */}
+                        {/* Sync queue state to iOS Live Activity (code-split, no-op on non-iOS).
+                            Use effectiveData/effectiveBoardDetails so the Live Activity reflects
+                            the live party queue while on a board route (injected mode), not the
+                            adapter's local view (which is a no-op in party mode). */}
                         <LiveActivityBridge
-                          queue={adapter.context.queue}
-                          currentClimbQueueItem={adapter.context.currentClimbQueueItem}
-                          boardDetails={adapter.boardDetails}
-                          sessionId={adapter.context.sessionId}
-                          isSessionActive={adapter.context.isSessionActive}
+                          queue={effectiveData.queue}
+                          currentClimbQueueItem={effectiveData.currentClimbQueueItem}
+                          boardDetails={effectiveBoardDetails}
+                          sessionId={effectiveData.sessionId}
+                          isSessionActive={effectiveData.isSessionActive}
                           onSetCurrentClimb={onSetCurrentClimb}
                           onWidgetNavigate={onWidgetNavigate}
                         />

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -159,6 +159,11 @@ function usePersistentSessionQueueAdapter(): {
     showMessage,
   };
 
+  // Counter for correlation IDs sent with party-mode SET_CURRENT_CLIMB
+  // mutations so the persistent session's pending-update tracker can
+  // match local optimistic state with server confirmations.
+  const correlationCounterRef = useRef(0);
+
   // Validates a climb against the locked board (session) or the current
   // adapter board. Shows a Snackbar error and returns false if not
   // compatible. Message formatting lives in `queue-add-error-messages`
@@ -187,9 +192,16 @@ function usePersistentSessionQueueAdapter(): {
 
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
     const r = latestRef.current;
-    if (!r.boardDetails) return;
     const alreadyInQueue = r.queue.some((q) => q.uuid === item.uuid);
     if (alreadyInQueue && r.currentClimbQueueItem?.uuid === item.uuid) return;
+    if (r.ps.activeSession) {
+      const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+      r.ps.setCurrentClimb(item, item.suggested, correlationId).catch((err: unknown) => {
+        console.error('Failed to set current climb queue item:', err);
+      });
+      return;
+    }
+    if (!r.boardDetails) return;
     const newQueue = alreadyInQueue ? r.queue : [...r.queue, item];
     r.ps.setLocalQueueState(newQueue, item, r.baseBoardPath, r.boardDetails);
   }, []);
@@ -204,6 +216,12 @@ function usePersistentSessionQueueAdapter(): {
         uuid: uuidv4(),
         suggested: false,
       };
+      if (r.ps.activeSession) {
+        r.ps.addQueueItem(newItem).catch((err: unknown) => {
+          console.error('Failed to add queue item:', err);
+        });
+        return;
+      }
       if (!r.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
@@ -221,6 +239,12 @@ function usePersistentSessionQueueAdapter(): {
 
   const removeFromQueue = useCallback((item: ClimbQueueItem) => {
     const r = latestRef.current;
+    if (r.ps.activeSession) {
+      r.ps.removeQueueItem(item.uuid).catch((err: unknown) => {
+        console.error('Failed to remove queue item:', err);
+      });
+      return;
+    }
     if (!r.boardDetails) return;
     const newQueue = r.queue.filter((q) => q.uuid !== item.uuid);
     const newCurrent = r.currentClimbQueueItem?.uuid === item.uuid ? (newQueue[0] ?? null) : r.currentClimbQueueItem;
@@ -229,6 +253,18 @@ function usePersistentSessionQueueAdapter(): {
 
   const setQueue = useCallback((newQueue: ClimbQueueItem[]) => {
     const r = latestRef.current;
+    if (r.ps.activeSession) {
+      const newCurrent =
+        newQueue.length === 0
+          ? null
+          : r.currentClimbQueueItem && newQueue.some((q) => q.uuid === r.currentClimbQueueItem!.uuid)
+            ? r.currentClimbQueueItem
+            : newQueue[0];
+      r.ps.setQueue(newQueue, newCurrent).catch((err: unknown) => {
+        console.error('Failed to set queue:', err);
+      });
+      return;
+    }
     if (!r.boardDetails) return;
     const newCurrent =
       newQueue.length === 0
@@ -241,8 +277,15 @@ function usePersistentSessionQueueAdapter(): {
 
   const mirrorClimb = useCallback(() => {
     const r = latestRef.current;
-    if (!r.currentClimbQueueItem?.climb || !r.boardDetails) return;
+    if (!r.currentClimbQueueItem?.climb) return;
     const mirrored = !r.currentClimbQueueItem.climb.mirrored;
+    if (r.ps.activeSession) {
+      r.ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
+        console.error('Failed to mirror current climb:', err);
+      });
+      return;
+    }
+    if (!r.boardDetails) return;
     const updatedItem: ClimbQueueItem = {
       ...r.currentClimbQueueItem,
       climb: { ...r.currentClimbQueueItem.climb, mirrored },
@@ -261,6 +304,20 @@ function usePersistentSessionQueueAdapter(): {
         uuid: uuidv4(),
         suggested: false,
       };
+      if (r.ps.activeSession) {
+        const currentIdx = r.currentClimbQueueItem
+          ? r.queue.findIndex((q) => q.uuid === r.currentClimbQueueItem!.uuid)
+          : -1;
+        const position = currentIdx === -1 ? undefined : currentIdx + 1;
+        const correlationId = r.ps.clientId ? `${r.ps.clientId}-${++correlationCounterRef.current}` : undefined;
+        try {
+          await r.ps.addQueueItem(newItem, position);
+          await r.ps.setCurrentClimb(newItem, false, correlationId);
+        } catch (err: unknown) {
+          console.error('Failed to set current climb:', err);
+        }
+        return newItem;
+      }
       if (!r.boardDetails) {
         // Cold-start path: no active board yet. Seed local state from the
         // climb's own board config so the queue bar begins showing.
@@ -284,18 +341,25 @@ function usePersistentSessionQueueAdapter(): {
     [validateClimbForQueue],
   );
 
-  // Bridge-mode replace: mirrors the local-state update with a new climb while
-  // preserving the queue-item uuid and existing addedBy attribution. The
-  // bridge context has no network path, so this is a pure local mutation.
+  // Bridge-mode replace: in party mode, delegate to the persistent session's
+  // WebSocket-backed replaceQueueItem; otherwise mirror the local-state update
+  // with a new climb while preserving the queue-item uuid and existing
+  // addedBy attribution.
   const replaceQueueItem = useCallback((queueItemUuid: string, climb: Climb) => {
     const r = latestRef.current;
-    if (!r.boardDetails) return;
     const existing = r.queue.find((q) => q.uuid === queueItemUuid);
     if (!existing) return;
     const updated: ClimbQueueItem = {
       ...existing,
       climb,
     };
+    if (r.ps.activeSession) {
+      r.ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
+        console.error('Failed to replace queue item:', err);
+      });
+      return;
+    }
+    if (!r.boardDetails) return;
     const newQueue = r.queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
     const nextCurrent = r.currentClimbQueueItem?.uuid === queueItemUuid ? updated : r.currentClimbQueueItem;
     r.ps.setLocalQueueState(newQueue, nextCurrent, r.baseBoardPath, r.boardDetails);

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -411,11 +411,15 @@ export default function SessionDetailContent({
   // Set the climb as current (so it's sent to the board / shared with the
   // party session) and, when not embedded in a drawer, navigate to its detail
   // page. Embedded mode skips navigation so the drawer stays open.
+  // setCurrentClimb returns null when board-compatibility validation fails
+  // (a snackbar is already surfaced). In that case, skip navigation too — the
+  // user shouldn't land on a climb page for a climb the board rejected.
   const navigateToClimb = useCallback(
     async (climb: Climb) => {
       try {
         if (queueActions) {
-          await queueActions.setCurrentClimb(climb);
+          const result = await queueActions.setCurrentClimb(climb);
+          if (result === null) return;
         }
         if (embedded) return;
         const bt = climb.boardType;

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -57,6 +57,7 @@ import { generateSessionName } from '@/app/lib/session-utils';
 import { ConfirmPopover } from '@/app/components/ui/confirm-popover';
 import { useDeleteTick } from '@/app/hooks/use-delete-tick';
 import SaveToHealthKitButton from '@/app/components/healthkit/save-to-healthkit-button';
+import { useOptionalQueueActions } from '@/app/components/graphql-queue';
 
 type SessionDetailContentProps = {
   session: SessionDetail | null;
@@ -291,6 +292,7 @@ export default function SessionDetailContent({
   const router = useRouter();
   const deleteTick = useDeleteTick();
   const { showMessage } = useSnackbar();
+  const queueActions = useOptionalQueueActions();
 
   const {
     session: hookSession,
@@ -406,10 +408,16 @@ export default function SessionDetailContent({
     climbUuids,
   });
 
-  // Navigate to climb detail page using client-side routing
+  // Set the climb as current (so it's sent to the board / shared with the
+  // party session) and, when not embedded in a drawer, navigate to its detail
+  // page. Embedded mode skips navigation so the drawer stays open.
   const navigateToClimb = useCallback(
     async (climb: Climb) => {
       try {
+        if (queueActions) {
+          await queueActions.setCurrentClimb(climb);
+        }
+        if (embedded) return;
         const bt = climb.boardType;
         if (!bt) return;
         const params = new URLSearchParams({ boardType: bt, climbUuid: climb.uuid });
@@ -421,7 +429,7 @@ export default function SessionDetailContent({
         console.error('Failed to navigate to climb:', error);
       }
     },
-    [router],
+    [queueActions, embedded, router],
   );
 
   const handleShare = useCallback(async () => {

--- a/packages/web/app/session/__tests__/session-detail-content.test.tsx
+++ b/packages/web/app/session/__tests__/session-detail-content.test.tsx
@@ -828,5 +828,19 @@ describe('SessionDetailContent', () => {
       await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1'));
       expect(mockSetCurrentClimb).not.toHaveBeenCalled();
     });
+
+    it('skips navigation when setCurrentClimb rejects validation (returns null)', async () => {
+      // setCurrentClimb resolves to null when validateClimbForQueue fires the
+      // snackbar — the user shouldn't land on a climb page the board can't take.
+      mockSetCurrentClimb.mockResolvedValueOnce(null);
+      mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
+      render(<SessionDetailContent session={makeSession()} />);
+      fireEvent.click(screen.getByTestId('climb-item'));
+      await waitFor(() => expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1));
+      // Give any pending microtasks a chance to flush
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web/app/session/__tests__/session-detail-content.test.tsx
+++ b/packages/web/app/session/__tests__/session-detail-content.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { SessionDetail } from '@boardsesh/shared-schema';
@@ -9,8 +9,9 @@ vi.mock('next/link', () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));
 
+const mockRouterPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 vi.mock('next-auth/react', () => ({
@@ -99,13 +100,20 @@ vi.mock('@/app/components/collapsible-section/collapsible-section', () => ({
     title,
     children,
     defaultExpanded,
+    sections,
   }: {
-    title: string;
-    children: React.ReactNode;
+    title?: string;
+    children?: React.ReactNode;
     defaultExpanded?: boolean;
+    sections?: Array<{ key: string; label: string; content: React.ReactNode }>;
   }) => (
     <div data-testid="collapsible-section" data-title={title} data-expanded={defaultExpanded}>
       {children}
+      {sections?.map((s) => (
+        <div key={s.key} data-testid={`section-${s.key}`}>
+          {s.content}
+        </div>
+      ))}
     </div>
   ),
 }));
@@ -199,20 +207,34 @@ vi.mock('@/app/components/board-page/climbs-list', () => ({
     upsizedClimbs?: unknown;
     isFetching?: boolean;
     hasMore?: boolean;
-    onClimbSelect?: unknown;
+    onClimbSelect?: (climb: { uuid: string; name: string }) => void;
     onLoadMore?: unknown;
     hideEndMessage?: boolean;
     showBottomSpacer?: boolean;
   }) => (
     <div data-testid="climbs-list">
       {props.climbs.map((climb) => (
-        <div key={climb.uuid} data-testid="climb-item" data-climb-name={climb.name}>
+        <div
+          key={climb.uuid}
+          data-testid="climb-item"
+          data-climb-name={climb.name}
+          onClick={() => props.onClimbSelect?.(climb)}
+        >
           {climb.name}
           {props.renderItemExtra?.(climb)}
         </div>
       ))}
     </div>
   ),
+}));
+
+// Mock graphql-queue to expose a controllable useOptionalQueueActions for the
+// click-handler tests below. The default export returns null (no provider),
+// matching production behavior on /session/[sessionId] standalone pages.
+const mockSetCurrentClimb = vi.fn();
+let mockQueueActions: { setCurrentClimb: typeof mockSetCurrentClimb } | null = null;
+vi.mock('@/app/components/graphql-queue', () => ({
+  useOptionalQueueActions: () => mockQueueActions,
 }));
 
 vi.mock('@/app/components/climb-actions/favorites-batch-context', () => ({
@@ -754,5 +776,64 @@ describe('SessionDetailContent', () => {
     });
     render(<SessionDetailContent session={session} />);
     expect(screen.getByText('Great beta!')).toBeTruthy();
+  });
+
+  describe('climb click handler', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      mockSetCurrentClimb.mockReset();
+      mockRouterPush.mockReset();
+      mockQueueActions = null;
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ url: '/kilter/1/10/1/40/view/climb-1' }),
+        }),
+      ) as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('calls setCurrentClimb when clicking a climb with a queue context', async () => {
+      mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
+      render(<SessionDetailContent session={makeSession()} />);
+      fireEvent.click(screen.getByTestId('climb-item'));
+      // Wait a microtask for the async click handler to run
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1);
+      expect(mockSetCurrentClimb.mock.calls[0][0].uuid).toBe('climb-1');
+    });
+
+    it('navigates after setting current climb when not embedded', async () => {
+      mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
+      render(<SessionDetailContent session={makeSession()} />);
+      fireEvent.click(screen.getByTestId('climb-item'));
+      // Wait for async handler (setCurrentClimb -> fetch -> push)
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1');
+    });
+
+    it('skips navigation in embedded mode but still sets current climb', async () => {
+      mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
+      render(<SessionDetailContent session={makeSession()} embedded />);
+      fireEvent.click(screen.getByTestId('climb-item'));
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1);
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('still navigates when no queue context is available (legacy fallback)', async () => {
+      mockQueueActions = null;
+      render(<SessionDetailContent session={makeSession()} />);
+      fireEvent.click(screen.getByTestId('climb-item'));
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(mockSetCurrentClimb).not.toHaveBeenCalled();
+      expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1');
+    });
   });
 });

--- a/packages/web/app/session/__tests__/session-detail-content.test.tsx
+++ b/packages/web/app/session/__tests__/session-detail-content.test.tsx
@@ -837,8 +837,12 @@ describe('SessionDetailContent', () => {
       render(<SessionDetailContent session={makeSession()} />);
       fireEvent.click(screen.getByTestId('climb-item'));
       await waitFor(() => expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1));
-      // Give any pending microtasks a chance to flush
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for the click handler's awaited promise to actually resolve, then
+      // drain one more microtask so the synchronous code following the await
+      // (the `if (result === null) return` early-out) has run. Deterministic —
+      // no real timers involved.
+      await mockSetCurrentClimb.mock.results[0]!.value;
+      await Promise.resolve();
       expect(global.fetch).not.toHaveBeenCalled();
       expect(mockRouterPush).not.toHaveBeenCalled();
     });

--- a/packages/web/app/session/__tests__/session-detail-content.test.tsx
+++ b/packages/web/app/session/__tests__/session-detail-content.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { SessionDetail } from '@boardsesh/shared-schema';
 import SessionDetailContent from '../[sessionId]/session-detail-content';
@@ -801,10 +801,7 @@ describe('SessionDetailContent', () => {
       mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
       render(<SessionDetailContent session={makeSession()} />);
       fireEvent.click(screen.getByTestId('climb-item'));
-      // Wait a microtask for the async click handler to run
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1));
       expect(mockSetCurrentClimb.mock.calls[0][0].uuid).toBe('climb-1');
     });
 
@@ -812,17 +809,14 @@ describe('SessionDetailContent', () => {
       mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
       render(<SessionDetailContent session={makeSession()} />);
       fireEvent.click(screen.getByTestId('climb-item'));
-      // Wait for async handler (setCurrentClimb -> fetch -> push)
-      for (let i = 0; i < 5; i++) await Promise.resolve();
-      expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1');
+      await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1'));
     });
 
     it('skips navigation in embedded mode but still sets current climb', async () => {
       mockQueueActions = { setCurrentClimb: mockSetCurrentClimb };
       render(<SessionDetailContent session={makeSession()} embedded />);
       fireEvent.click(screen.getByTestId('climb-item'));
-      for (let i = 0; i < 5; i++) await Promise.resolve();
-      expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1));
       expect(mockRouterPush).not.toHaveBeenCalled();
       expect(global.fetch).not.toHaveBeenCalled();
     });
@@ -831,9 +825,8 @@ describe('SessionDetailContent', () => {
       mockQueueActions = null;
       render(<SessionDetailContent session={makeSession()} />);
       fireEvent.click(screen.getByTestId('climb-item'));
-      for (let i = 0; i < 5; i++) await Promise.resolve();
+      await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1'));
       expect(mockSetCurrentClimb).not.toHaveBeenCalled();
-      expect(mockRouterPush).toHaveBeenCalledWith('/kilter/1/10/1/40/view/climb-1');
     });
   });
 });


### PR DESCRIPTION
## Summary

In the logbook (`/you/logbook`) and session-detail (`/session/[sessionId]`) views — including the embedded view in the `SeshSettingsDrawer` — tapping a climb only set it active when no party session was running. Once a sesh was active, the same tap silently did nothing and the user had to find the climb again via search to put it on the board.

Two gaps caused this:

- `usePersistentSessionQueueAdapter` (the QueueContext fallback used off board routes) routed every mutation through `setLocalQueueState`, which is a no-op when `activeSession` is set (`use-queue-storage.ts:82`). The adapter never delegated to the persistent session's WebSocket-backed mutators that already exist on `ps`.
- `SessionDetailContent.navigateToClimb` only called `router.push`. Outside a party that landed the user on the climb's URL and the URL-driven board page made it active as a side effect; inside a party the session's `currentClimbQueueItem` is decoupled from the URL, so navigation alone changed nothing.

This PR teaches the bridge adapter to mirror `GraphQLQueueProvider` in party mode (`addQueueItem` + `setCurrentClimb` + `removeQueueItem` + `setQueue` + `mirrorCurrentClimb` + `replaceQueueItem`) and updates the session-view click handler to call `setCurrentClimb` via `useOptionalQueueActions`, skipping navigation in embedded mode so the drawer stays open.

## Test plan

- [x] `vp lint` — 0 errors
- [x] `vp run typecheck:web` — passes
- [x] `vp test run --project web` — 3749/3749 pass (37 in `queue-bridge-context.test.tsx`, 32 in `session-detail-content.test.tsx`)
- [ ] Solo: tap a climb in `/you/logbook` and in `/session/[sessionId]` → climb becomes current, board reflects it
- [ ] In a party sesh: tap a climb in the embedded session view in `SeshSettingsDrawer` → climb becomes current via WebSocket; second tab sees the change
- [ ] In a party sesh: tap a climb in `/you/logbook` → same as above

https://claude.ai/code/session_01AtKxfov9p8NDUxivnrggSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtKxfov9p8NDUxivnrggSL)_