### PR TITLE
Scope ascent badge to current angle

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -97,3 +97,71 @@ void describe('createClimbFilters: projectsOnly', () => {
     assert.equal(f.climbStatsConditions.length, 0);
   });
 });
+
+void describe('createClimbFilters: personal progress filters are scoped to the current angle', () => {
+  // Locks in the angle-scoping contract — a send at one angle must not leak
+  // into hide/show filters at a different angle. Each filter renders a
+  // (NOT) EXISTS subquery against boardsesh_ticks that must restrict by
+  // the `angle` column.
+  const userId = 'user-abc';
+  const angleParams: BoardRouteParams = { ...params, angle: 50 };
+
+  function progressSql(searchParams: ClimbSearchParams): string {
+    const f = createClimbFilters(angleParams, searchParams, userId);
+    return f.personalProgressConditions.map(sqlToString).join(' && ');
+  }
+
+  void it('emits exactly one progress condition per active filter', () => {
+    const f = createClimbFilters(angleParams, { hideCompleted: true }, userId);
+    assert.equal(f.personalProgressConditions.length, 1);
+  });
+
+  void it('hideCompleted is a NOT EXISTS subquery scoped to the angle column', () => {
+    const sql = progressSql({ hideCompleted: true });
+    assert.match(sql, /NOT EXISTS/);
+    assert.match(sql, /angle\s*=/);
+    // Sanity: targets completions (flash/send), not attempts.
+    assert.match(sql, /'flash'.*'send'/);
+    assert.doesNotMatch(sql, /'attempt'/);
+  });
+
+  void it('hideAttempted is a NOT EXISTS subquery scoped to the angle column', () => {
+    const sql = progressSql({ hideAttempted: true });
+    assert.match(sql, /NOT EXISTS/);
+    assert.match(sql, /angle\s*=/);
+    assert.match(sql, /'attempt'/);
+  });
+
+  void it('showOnlyCompleted is a positive EXISTS subquery scoped to the angle column', () => {
+    const sql = progressSql({ showOnlyCompleted: true });
+    assert.match(sql, /EXISTS/);
+    assert.doesNotMatch(sql, /NOT EXISTS/);
+    assert.match(sql, /angle\s*=/);
+    assert.match(sql, /'flash'.*'send'/);
+  });
+
+  void it('showOnlyAttempted is a positive EXISTS subquery scoped to the angle column', () => {
+    const sql = progressSql({ showOnlyAttempted: true });
+    assert.match(sql, /EXISTS/);
+    assert.doesNotMatch(sql, /NOT EXISTS/);
+    assert.match(sql, /angle\s*=/);
+    assert.match(sql, /'attempt'/);
+  });
+
+  void it('skips personal progress conditions entirely when no userId is supplied', () => {
+    const f = createClimbFilters(angleParams, { hideCompleted: true });
+    assert.equal(f.personalProgressConditions.length, 0);
+  });
+
+  void it('per-climb userAscents/userAttempts selectors are scoped to the angle column', () => {
+    const f = createClimbFilters(angleParams, baseSearch, userId);
+    const selects = f.getUserLogbookSelects();
+    const ascentsSql = sqlToString(selects.userAscents as unknown as SQL);
+    const attemptsSql = sqlToString(selects.userAttempts as unknown as SQL);
+    assert.match(ascentsSql, /angle\s*=/);
+    assert.match(attemptsSql, /angle\s*=/);
+    // And the status sets must still match the semantic of each selector.
+    assert.match(ascentsSql, /'flash'.*'send'/);
+    assert.match(attemptsSql, /'attempt'/);
+  });
+});

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -24,7 +24,7 @@ const baseSearch: ClimbSearchParams = {};
  *   - nested SQL fragments with their own queryChunks
  *   - param markers ({ value: <runtime val> })
  */
-function sqlToString(fragment: SQL): string {
+function sqlToString<T>(fragment: SQL<T>): string {
   const chunks = (fragment as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
   return chunks
     .map((chunk) => {
@@ -156,8 +156,8 @@ void describe('createClimbFilters: personal progress filters are scoped to the c
   void it('per-climb userAscents/userAttempts selectors are scoped to the angle column', () => {
     const f = createClimbFilters(angleParams, baseSearch, userId);
     const selects = f.getUserLogbookSelects();
-    const ascentsSql = sqlToString(selects.userAscents as unknown as SQL);
-    const attemptsSql = sqlToString(selects.userAttempts as unknown as SQL);
+    const ascentsSql = sqlToString(selects.userAscents);
+    const attemptsSql = sqlToString(selects.userAttempts);
     assert.match(ascentsSql, /angle\s*=/);
     assert.match(attemptsSql, /angle\s*=/);
     // And the status sets must still match the semantic of each selector.

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -161,7 +161,11 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
             titleFontSize={themeTokens.typography.fontSize['2xl']}
             rightAddon={
               displayClimb && (
-                <AscentStatus climbUuid={displayClimb.uuid} fontSize={themeTokens.typography.fontSize['2xl']} />
+                <AscentStatus
+                  climbUuid={displayClimb.uuid}
+                  angle={angle}
+                  fontSize={themeTokens.typography.fontSize['2xl']}
+                />
               )
             }
             isNoMatch={!!displayClimb?.is_no_match}

--- a/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
@@ -56,20 +56,20 @@ function createBoardContextValue({
   };
 }
 
-function renderWithBoardContext(contextValue: BoardContextType) {
+function renderWithBoardContext(contextValue: BoardContextType, angle = 40) {
   return render(
     <BoardContext.Provider value={contextValue}>
-      <AscentStatus climbUuid="climb-1" />
+      <AscentStatus climbUuid="climb-1" angle={angle} />
     </BoardContext.Provider>,
   );
 }
 
-function AscentStatusHarness() {
+function AscentStatusHarness({ angle = 40 }: { angle?: number } = {}) {
   const { logbook } = useLogbook('kilter', ['climb-1']);
 
   return (
     <BoardContext.Provider value={createBoardContextValue({ logbook })}>
-      <AscentStatus climbUuid="climb-1" />
+      <AscentStatus climbUuid="climb-1" angle={angle} />
     </BoardContext.Provider>
   );
 }
@@ -92,8 +92,82 @@ describe('AscentStatus', () => {
   });
 
   it('renders nothing when the climb has no logbook entries', () => {
-    const { container } = render(<AscentStatus climbUuid="climb-1" />);
+    const { container } = render(<AscentStatus climbUuid="climb-1" angle={40} />);
     expect(container.innerHTML).toBe('');
+  });
+
+  it('hides the badge when the only ticks are at a different angle than the current view', () => {
+    renderWithBoardContext(
+      createBoardContextValue({
+        boardName: 'kilter',
+        logbook: [
+          {
+            uuid: '1',
+            climb_uuid: 'climb-1',
+            angle: 30,
+            is_mirror: false,
+            tries: 1,
+            quality: null,
+            difficulty: null,
+            comment: '',
+            climbed_at: '2025-01-01T00:00:00.000Z',
+            is_ascent: true,
+            status: 'send',
+            upvotes: 0,
+            downvotes: 0,
+            commentCount: 0,
+          },
+        ],
+      }),
+      50,
+    );
+
+    expect(screen.queryByTestId('ascent-badge')).toBeNull();
+  });
+
+  it('shows the badge only for ticks at the current angle', () => {
+    renderWithBoardContext(
+      createBoardContextValue({
+        boardName: 'kilter',
+        logbook: [
+          {
+            uuid: '1',
+            climb_uuid: 'climb-1',
+            angle: 30,
+            is_mirror: false,
+            tries: 1,
+            quality: null,
+            difficulty: null,
+            comment: '',
+            climbed_at: '2025-01-01T00:00:00.000Z',
+            is_ascent: true,
+            status: 'flash',
+            upvotes: 0,
+            downvotes: 0,
+            commentCount: 0,
+          },
+          {
+            uuid: '2',
+            climb_uuid: 'climb-1',
+            angle: 50,
+            is_mirror: false,
+            tries: 4,
+            quality: null,
+            difficulty: null,
+            comment: '',
+            climbed_at: '2025-01-02T00:00:00.000Z',
+            is_ascent: false,
+            status: 'attempt',
+            upvotes: 0,
+            downvotes: 0,
+            commentCount: 0,
+          },
+        ],
+      }),
+      50,
+    );
+
+    expect(screen.getByTestId('ascent-badge').getAttribute('data-status')).toBe('attempt');
   });
 
   it('prefers flash over send and attempt for the same climb', () => {

--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -15,6 +15,9 @@ const EMPTY_LOGBOOK: LogbookEntry[] = [];
 
 type AscentStatusProps = {
   climbUuid: ClimbUuid;
+  /** Currently selected board angle. Badges only reflect ticks logged at this angle
+   *  so a send at 30° doesn't display when the user is viewing the climb at 50°. */
+  angle: number;
   fontSize?: number;
   /** Class for the badge wrapper (e.g. positioning on a thumbnail).
    *  For mirroring boards this is applied to each individual badge. */
@@ -35,14 +38,14 @@ function getHighestStatus(entries: LogbookEntry[]): AscentStatusValue | null {
   );
 }
 
-export const AscentStatus = ({ climbUuid, fontSize, className, mirroredClassName }: AscentStatusProps) => {
+export const AscentStatus = ({ climbUuid, angle, fontSize, className, mirroredClassName }: AscentStatusProps) => {
   const boardProvider = useOptionalBoardProvider();
   const logbook = boardProvider?.logbook ?? EMPTY_LOGBOOK;
   const boardName = boardProvider?.boardName ?? 'kilter';
 
   const ascentsForClimb = useMemo(
-    () => logbook.filter((ascent) => ascent.climb_uuid === climbUuid),
-    [logbook, climbUuid],
+    () => logbook.filter((ascent) => ascent.climb_uuid === climbUuid && Number(ascent.angle) === angle),
+    [logbook, climbUuid, angle],
   );
 
   const overallStatus = useMemo(() => getHighestStatus(ascentsForClimb), [ascentsForClimb]);

--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -44,7 +44,7 @@ export const AscentStatus = ({ climbUuid, angle, fontSize, className, mirroredCl
   const boardName = boardProvider?.boardName ?? 'kilter';
 
   const ascentsForClimb = useMemo(
-    () => logbook.filter((ascent) => ascent.climb_uuid === climbUuid && Number(ascent.angle) === angle),
+    () => logbook.filter((ascent) => ascent.climb_uuid === climbUuid && ascent.angle === angle),
     [logbook, climbUuid, angle],
   );
 

--- a/packages/web/app/components/climb-card/climb-card-cover.tsx
+++ b/packages/web/app/components/climb-card/climb-card-cover.tsx
@@ -70,6 +70,7 @@ const ClimbCardCover = ({
       {climb && (
         <AscentStatus
           climbUuid={climb.uuid}
+          angle={climb.angle}
           fontSize={12}
           className={styles.badge}
           mirroredClassName={styles.badgeMirrored}

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -613,6 +613,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
                 )}
                 <AscentStatus
                   climbUuid={climb.uuid}
+                  angle={climb.angle}
                   fontSize={12}
                   className={ascentStyles.badge}
                   mirroredClassName={ascentStyles.badgeMirrored}


### PR DESCRIPTION
## Summary

User report: after sending a climb at 30°, switching the board to 50° and using the "hide completed" filter "still hides the climb"; even when it doesn't, there's no way to tell if the send was at the current angle.

Investigation showed two things:

- **The `hideCompleted` / `hideAttempted` / `showOnlyCompleted` / `showOnlyAttempted` SQL filters already restrict by `boardsesh_ticks.angle = params.angle`** (see `packages/db/src/queries/climbs/create-climb-filters.ts:184-237`). All search paths (SSR, GraphQL backend, count) flow through that file, ingestion preserves angle, and caches that bypass on `userId` keep the angle in their key. So the SQL behaviour is correct.
- **The "sent / flash / attempted" badge on climb cards was angle-blind.** `AscentStatus` filtered the logbook by `climb_uuid` only, so a 30° send still showed the green badge at 50°. Sibling components (`tick-action`, `tick-button`, `play-view-drawer`) already filter by `Number(asc.angle) === angle` — `AscentStatus` was the outlier.

This PR fixes the badge and locks in the angle-scoping contract on the SQL side with a regression test.

- `AscentStatus` now takes a required `angle` prop and filters logbook entries by `climb_uuid && Number(angle) === angle`.
- All three call sites (`climb-card-cover`, `climb-list-item`, `play-view-client`) now pass the current angle (`climb.angle` or the route's `angle`).
- New `createClimbFilters` tests assert each progress filter renders a `(NOT) EXISTS` subquery referencing the `angle` column, and that the per-climb `userAscents` / `userAttempts` selectors are angle-scoped too.

## Test plan

- [x] `vp run typecheck:web` (passes)
- [x] `vp run typecheck:db` (passes)
- [x] `vp test run --project web -t AscentStatus` — 16 passed including two new "different angle" cases
- [x] `tsx --test packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts` — 13 passed including 7 new angle-scoping cases
- [x] `vp check` — exits 0 (pre-existing format issues in 4 unrelated files, none touched by this PR)
- [x] Manual: as `test@boardsesh.com`, log a flash at 30°, switch to 50°, confirm the badge disappears, hide-completed leaves the climb in results, and switching back to 30° restores the badge and hides the climb.

https://claude.ai/code/session_01K8qpmP5CsWajjNRuS4JJS3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8qpmP5CsWajjNRuS4JJS3)_