### PR TITLE
fix(ble): post-merge review fixes for record-serial flow

### DIFF
--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -360,6 +360,8 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     Look up boards by controller serial numbers.
     Searches all boards (including unlisted/non-public).
+    Capped at 20 serials per request — exceeding this throws a validation
+    error rather than silently truncating, so callers must cap on their end.
     """
     boardsBySerialNumbers(serialNumbers: [String!]!): [UserBoard!]!
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -12,6 +12,8 @@ const {
   mockGetMoonboardBluetoothPacket,
   mockGetLedPlacements,
   mockShowMessage,
+  mockParseSerialNumber,
+  mockFetch,
 } = vi.hoisted(() => {
   const mockAdapter = {
     isAvailable: vi.fn(),
@@ -48,6 +50,8 @@ const {
       () => ({ 4131: 39 }),
     ),
     mockShowMessage: vi.fn(),
+    mockParseSerialNumber: vi.fn<(name: string) => string | undefined>(() => undefined),
+    mockFetch: vi.fn<typeof fetch>(() => Promise.resolve(new Response(null, { status: 204 }))),
   };
 });
 
@@ -59,7 +63,7 @@ vi.mock('@/app/lib/ble/adapter-factory', () => ({
 vi.mock('../bluetooth-aurora', () => ({
   getAuroraBluetoothPacket: mockGetAuroraBluetoothPacket,
   parseApiLevel: vi.fn(() => 3),
-  parseSerialNumber: vi.fn(() => undefined),
+  parseSerialNumber: mockParseSerialNumber,
 }));
 
 vi.mock('../bluetooth-moonboard', () => ({
@@ -115,6 +119,9 @@ describe('useBoardBluetooth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetFactoryCache();
+    mockParseSerialNumber.mockReturnValue(undefined);
+    mockFetch.mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', mockFetch);
     mockCreateBluetoothAdapter.mockResolvedValue(mockAdapter);
     mockAdapter.isAvailable.mockResolvedValue(true);
     mockAdapter.requestAndConnect.mockResolvedValue({
@@ -337,5 +344,49 @@ describe('useBoardBluetooth', () => {
       'error',
     );
     expect(mockAdapter.write).not.toHaveBeenCalledWith(new Uint8Array([1, 2, 3]), undefined);
+  });
+
+  // Traditional `[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...` routes
+  // don't carry a boardUuid — the recorded serial mapping should reflect that
+  // (the API row gets a NULL board_uuid). The /b/{slug}/... case sends a UUID.
+  it('records traditional-route serial with no boardUuid when prop is omitted', async () => {
+    mockParseSerialNumber.mockReturnValueOnce('AB1234');
+    const traditionalRouteDetails = {
+      ...mockBoardDetails,
+      set_ids: [1, 2],
+    } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardDetails: traditionalRouteDetails }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const recordCall = mockFetch.mock.calls.find(([url]) => url === '/api/internal/board-serials');
+    expect(recordCall).toBeDefined();
+    const body = JSON.parse((recordCall![1] as RequestInit).body as string);
+    expect(body.serialNumber).toBe('AB1234');
+    expect(body.boardUuid).toBeUndefined();
+  });
+
+  it('records saved-board serial with boardUuid when prop is provided', async () => {
+    mockParseSerialNumber.mockReturnValueOnce('CD5678');
+    const savedBoardDetails = {
+      ...mockBoardDetails,
+      set_ids: [1, 2],
+    } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardDetails: savedBoardDetails, boardUuid: 'board-uuid-xyz' }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const recordCall = mockFetch.mock.calls.find(([url]) => url === '/api/internal/board-serials');
+    expect(recordCall).toBeDefined();
+    const body = JSON.parse((recordCall![1] as RequestInit).body as string);
+    expect(body.boardUuid).toBe('board-uuid-xyz');
   });
 });

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -134,10 +134,11 @@ export function BluetoothProvider({
   // `/b/{slug}/{angle}/...` routes carry `[angle]` as a dynamic segment.
   // Read it here instead of taking it as a prop so the provider isn't
   // coupled to the route shape at the call site — only the mismatch
-  // dialog's "switch URL" builder needs it.
+  // dialog's "switch URL" builder needs it. Stays `null` when absent so
+  // the switch handler can warn instead of routing the user to angle 0.
   const params = useParams<{ angle?: string }>();
-  const parsedAngle = Number(params?.angle);
-  const routeAngle = Number.isFinite(parsedAngle) ? parsedAngle : 0;
+  const parsedAngle = params?.angle != null ? Number(params.angle) : Number.NaN;
+  const routeAngle: number | null = Number.isFinite(parsedAngle) ? parsedAngle : null;
 
   const [isBluetoothSupported, setIsBluetoothSupported] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
@@ -365,6 +366,13 @@ export function BluetoothProvider({
 
   const handleMismatchSwitch = useCallback(() => {
     if (!mismatch) return;
+    if (routeAngle == null) {
+      // Provider mounted on a route that doesn't carry an [angle] segment.
+      // Silently building a URL at angle 0 would yank the user to a fake
+      // angle they never picked — surface the issue and let them choose.
+      showMessage("Couldn't switch — open a climb at a specific angle first.", 'warning');
+      return;
+    }
     const target = buildSwitchUrl(mismatch.config, routeAngle);
     if (!target) {
       // Couldn't resolve a switch URL (unknown layout/size, missing slug data).

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -67,6 +67,10 @@ function recordBoardSerial(serialNumber: string, boardDetails: BoardDetails, boa
   // read, but keeping the stored value canonical means recorded entries
   // produced by different routes are byte-equal.
   const setIds = [...new Set(boardDetails.set_ids)].sort((a, b) => a - b).join(',');
+  // Empty set_ids would serialise to "" and the route's Zod schema rejects
+  // empty strings — the POST 400s and the `.catch` swallows it silently, so
+  // the serial would never get recorded. Skip the call deliberately instead.
+  if (!setIds) return;
   void fetch('/api/internal/board-serials', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Follow-up to the just-merged "record BLE serials" change addressing four review notes:

1. **`routeAngle` no longer silently defaults to `0`** (`bluetooth-context.tsx`)
   When the route doesn't carry an `[angle]` segment, `routeAngle` stays `null`. The mismatch dialog's "Switch to correct config" path now shows a snackbar warning instead of yanking the user to angle 0.

2. **Empty `set_ids` skips the record-serial POST** (`use-board-bluetooth.ts`)
   `set_ids: []` was joining to `""`, which the route's Zod schema rejects — the 400 was swallowed by `.catch(() => {})`, leaving the serial unrecorded. Added an early `if (!setIds) return;` guard with a comment explaining why.

3. **GraphQL docstring documents the 20-serial cap** (`shared-schema/queries.ts`)
   `boardsBySerialNumbers` now throws (via `SerialNumberLookupSchema.max(20)`) instead of silently truncating. Updated the schema docstring so future callers know to cap on their end before they hit an opaque error.

4. **Test coverage for traditional-route recording** (`use-board-bluetooth.test.ts`)
   Added two paired tests: one asserts `boardUuid` is omitted from the POST body when the hook is used without a `boardUuid` prop (traditional `[board_name]/...` route), and one confirms the UUID is forwarded when the hook is mounted under `/b/{slug}/...`. Required hoisting `parseSerialNumber` and `fetch` mocks into `vi.hoisted()`.

## Test plan

- [ ] `vp run typecheck:web` passes
- [ ] `vp run typecheck:shared` passes
- [ ] `vp test --project web` passes, including the two new `useBoardBluetooth` cases
- [ ] Manually verify the mismatch dialog on a route without an `[angle]` segment surfaces the warning instead of routing to `/.../0/...`

https://claude.ai/code/session_01UoHqXyW22k4UVpFdSsnAm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoHqXyW22k4UVpFdSsnAm6)_