### PR TITLE
feat(dev-tools): ESP32 board emulator + /development debug UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,67 @@ You don't have to rebuild the Android app every time you change the web UI. The 
 
 The menu item is only visible in debug builds; release builds don't expose it. Vercel preview URLs (`https://<preview>.boardsesh.com`) work too if you'd rather not run a local server.
 
+## Testing BLE end-to-end with an ESP32
+
+The Bluetooth code path is the hardest one to validate without dragging a real climbing board into the room. To make end-to-end testing accessible to anyone, the repo ships a firmware that turns a generic ESP32 into a fake Kilter / Tension / Decoy / Touchstone / Grasshopper / MoonBoard. The phone or browser pairs with it like a real board, and every BLE write is forwarded over a WebSocket to a debug page in the web app, which decodes the payload and renders the lit-up holds — exercising the same encoder, framing, and protocol logic that runs against real hardware.
+
+Cost is roughly £5 / $5 for the ESP32. Nothing else is needed — no LEDs, no level shifter, no soldering. A generic ESP32 dev board (DevKitC, WROOM-32, WROVER-E, S3 dev kit) works fine.
+
+### One-time setup
+
+1. **Install [PlatformIO Core](https://platformio.org/install/cli)** (`pip install platformio` or VS Code extension). The dev environment is `esp32-emulator`, defined in `packages/board-controller/esp32/platformio.ini`.
+2. **Set Wi-Fi credentials.** The first build copies `packages/board-controller/esp32/.env.example` to `.env` automatically. `.env` is git-ignored, so edit it locally:
+   ```
+   EMULATOR_WIFI_SSID=your-network
+   EMULATOR_WIFI_PASS=your-password
+   ```
+   2.4 GHz networks only — the ESP32 doesn't speak 5 GHz. WPA2 is fine; WPA3 is not (yet).
+3. **Build and flash:**
+   ```bash
+   cd packages/board-controller/esp32
+   pio run -e esp32-emulator -t upload
+   ```
+   If `esptool` errors with "Unable to verify flash chip connection" (some boards lack the auto-reset circuit), hold the **BOOT** button while the upload starts.
+4. **Confirm the firmware came up.** Tail the serial log:
+   ```bash
+   pio device monitor --baud 115200
+   ```
+   You should see something like:
+   ```
+   [WiFi] Connected. IP: 192.168.20.38
+   [BLE] Advertising as: Kilter Board#751737@3
+   [WS] Listening on port 81
+   ```
+   Note the IP — the web UI needs it.
+
+### Use it from the web app
+
+1. Run `vp run dev` and open `http://localhost:3000`.
+2. Click your avatar (top-left) → **Development**. The menu entry only appears in development builds.
+3. Click the **+** tab and fill in:
+   - **IP address**: the one the firmware printed.
+   - **Board / Layout / Size / Hold sets / Angle**: same cascading dropdowns as the "Custom Board" flow. Pick whichever board you're testing.
+   - **Serial / API level**: any value; they only affect the BLE advertised name (e.g. `Tension Board#480221@3`).
+4. Save. The tab opens a WebSocket to the ESP32 and pushes your config so it re-advertises with the right protocol and name.
+5. From the phone or browser, open Boardsesh's BLE picker, pair with the advertised device, queue a climb, and send to board. The development tab decodes the BLE payload and renders the holds in real time.
+
+You can keep multiple ESP32s connected in parallel — each one gets its own tab, sockets stay open in the background, and switching the active tab doesn't drop the others.
+
+### What can it test?
+
+- Aurora API v2 and v3 framing (`Q`/`R`/`S`/`T` and `M`/`N`/`O`/`P` command bytes), single- and multi-packet sequences, position+colour encoding, and v2 power-budget scaling.
+- MoonBoard ASCII protocol (`l#S0,P35,E197#`) including chunked writes that span multiple BLE packets.
+- Reconnect/disconnect handling, stale advertising name caching, and multi-board sessions.
+
+It does **not** simulate LED hardware response timing, board-side errors, or the GATT side-channels Aurora uses for things like firmware updates — for those you still need a real board.
+
+### Troubleshooting
+
+- **Device doesn't show up in the BLE picker** after switching board type. iOS and macOS cache scan results; toggle Bluetooth off/on on the phone. The firmware already force-disconnects the central on config change, but the OS-level scanner cache is independent.
+- **No serial output** after flashing. Press the ESP32's **EN/RST** button to reset; some adapters don't auto-reset reliably.
+- **Wi-Fi never connects.** Re-check the SSID/password in `.env`. Boot logs print `[WiFi] Reason: 202 - AUTH_FAIL` on a bad password and `[WiFi] EMULATOR_WIFI_SSID empty` if the build script didn't pick up your `.env`.
+- **Flashing fails at 921600 baud.** Some WROVER-E modules can't sustain it. The emulator env already drops to 460800; if yours still fails, lower further with `upload_speed = 230400` in `platformio.ini`.
+
 ## Keeping local data up to date
 
 ### Shared Data Sync (Public Climbs)

--- a/packages/board-controller/esp32/.env.example
+++ b/packages/board-controller/esp32/.env.example
@@ -1,0 +1,6 @@
+# Wi-Fi credentials for the esp32-emulator build env.
+# Copy to .env (or let scripts/load_env.py copy it for you on first build).
+# .env is git-ignored so each contributor can keep their own credentials
+# local. The ESP32 must reach this network on 2.4 GHz; 5 GHz isn't supported.
+EMULATOR_WIFI_SSID=your-2.4ghz-ssid
+EMULATOR_WIFI_PASS=your-wifi-password

--- a/packages/board-controller/esp32/.gitignore
+++ b/packages/board-controller/esp32/.gitignore
@@ -1,0 +1,10 @@
+# PlatformIO
+.pio/
+.pioenvs/
+.piolibdeps/
+.vscode/
+.cache/
+
+# Local Wi-Fi credentials for the emulator build env.
+# .env.example is committed; contributors copy it to .env and edit locally.
+.env

--- a/packages/board-controller/esp32/platformio.ini
+++ b/packages/board-controller/esp32/platformio.ini
@@ -70,6 +70,38 @@ monitor_filters = esp32_exception_decoder
 board_build.partitions = default_8MB.csv
 board_build.filesystem = spiffs
 
+; Hardware test rig: emulates a Kilter/Tension/Decoy/Touchstone/Grasshopper or
+; MoonBoard over BLE and forwards every BLE write over a WebSocket server, so
+; the Boardsesh /development page can decode and render the climb without a
+; real board. No LEDs, no level shifter — runs on a stock ESP32 dev board.
+;
+; Wi-Fi credentials come from packages/board-controller/esp32/.env (git-ignored,
+; bootstrapped from .env.example by scripts/load_env.py on first build).
+[env:esp32-emulator]
+extends = env:esp32dev
+extra_scripts = pre:scripts/load_env.py
+; WROVER-E modules sometimes fail flash verification at the parent env's
+; 921600 baud rate. Drop to 460800 — still fast, much more reliable.
+upload_speed = 460800
+; Only compile main.cpp and the emulator/ tree. The real-controller sources
+; (LED/WS-client/BLE-client/web-config-portal) are deliberately excluded —
+; they pull in libs and have version drift with our pinned NimBLE.
+build_src_filter =
+    +<main.cpp>
+    +<emulator/>
+; EMULATOR_WIFI_SSID / EMULATOR_WIFI_PASS are injected by scripts/load_env.py
+; (it reads .env directly — `${sysenv.X}` here would expand before the script
+; runs and end up empty).
+build_flags =
+    ${env:esp32dev.build_flags}
+    -DEMULATOR_BUILD=1
+; The emulator only needs NimBLE + WebSockets + ArduinoJson; FastLED and
+; WiFiManager from the parent env are unused but harmless.
+lib_deps =
+    bblanchon/ArduinoJson@^7.0.0
+    links2004/WebSockets@^2.4.0
+    h2zero/NimBLE-Arduino@^1.4.1
+
 ; Native test environment for unit tests (runs on development machine)
 [env:native]
 platform = native

--- a/packages/board-controller/esp32/scripts/load_env.py
+++ b/packages/board-controller/esp32/scripts/load_env.py
@@ -1,0 +1,69 @@
+"""PlatformIO pre-script: inject Wi-Fi credentials from .env as build flags.
+
+Why a script instead of `${sysenv.EMULATOR_WIFI_SSID}` in platformio.ini:
+PlatformIO expands `${sysenv.X}` at config-parse time, BEFORE pre-scripts run.
+So a pre-script that loads .env into os.environ has no effect — the flags are
+already empty strings by then. Instead, this script reads .env directly and
+appends `-DEMULATOR_WIFI_SSID="..."` / `-DEMULATOR_WIFI_PASS="..."` to
+BUILD_FLAGS via env.Append, which works after parse.
+
+If .env is missing it's bootstrapped from .env.example so a fresh clone builds
+with the committed defaults (AP: scout-iot / pw: dontspyonme on Marco's build).
+Contributors edit .env locally; .env is git-ignored.
+"""
+
+import os
+import shutil
+
+Import("env")  # type: ignore  # noqa: F821 - injected by PlatformIO
+
+PROJECT_DIR = env["PROJECT_DIR"]  # type: ignore  # noqa: F821
+ENV_PATH = os.path.join(PROJECT_DIR, ".env")
+EXAMPLE_PATH = os.path.join(PROJECT_DIR, ".env.example")
+
+
+def _bootstrap_env_file() -> None:
+    if os.path.exists(ENV_PATH):
+        return
+    if os.path.exists(EXAMPLE_PATH):
+        shutil.copyfile(EXAMPLE_PATH, ENV_PATH)
+        print(f"[load_env] Created {ENV_PATH} from .env.example (edit it for your AP).")
+    else:
+        print(f"[load_env] WARNING: no {ENV_PATH} and no .env.example — emulator Wi-Fi will be empty.")
+
+
+def _read_env_file() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not os.path.exists(ENV_PATH):
+        return values
+    with open(ENV_PATH, "r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _escape_for_c_string(value: str) -> str:
+    # Backslashes first, then double-quotes — the order matters.
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+_bootstrap_env_file()
+_env = _read_env_file()
+
+# Shell environment wins so `EMULATOR_WIFI_SSID=foo pio run ...` overrides .env.
+ssid = os.environ.get("EMULATOR_WIFI_SSID", _env.get("EMULATOR_WIFI_SSID", ""))
+psk = os.environ.get("EMULATOR_WIFI_PASS", _env.get("EMULATOR_WIFI_PASS", ""))
+
+env.Append(  # type: ignore  # noqa: F821
+    BUILD_FLAGS=[
+        f'-DEMULATOR_WIFI_SSID=\\"{_escape_for_c_string(ssid)}\\"',
+        f'-DEMULATOR_WIFI_PASS=\\"{_escape_for_c_string(psk)}\\"',
+    ]
+)
+
+print(f"[load_env] EMULATOR_WIFI_SSID = {ssid!r}")
+print(f"[load_env] EMULATOR_WIFI_PASS = {'***' if psk else '(empty)'}")

--- a/packages/board-controller/esp32/src/emulator/ble_emulator.cpp
+++ b/packages/board-controller/esp32/src/emulator/ble_emulator.cpp
@@ -1,0 +1,174 @@
+#ifdef EMULATOR_BUILD
+
+#include "ble_emulator.h"
+
+#include <NimBLEDevice.h>
+
+namespace {
+
+// Aurora advertised service UUID — phone-side scan filter for
+// kilter/tension/decoy/touchstone/grasshopper looks for this.
+constexpr const char* AURORA_ADVERTISED_SERVICE = "4488b571-7806-4df6-bcff-a2897e4953ff";
+
+// Nordic UART service: where the phone writes the LED payload.
+constexpr const char* UART_SERVICE_UUID    = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
+constexpr const char* UART_WRITE_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";
+
+NimBLEServer*         gServer        = nullptr;
+NimBLEService*        gAuroraService = nullptr;
+NimBLEService*        gUartService   = nullptr;
+NimBLECharacteristic* gWriteChar     = nullptr;
+NimBLEAdvertising*    gAdvertising   = nullptr;
+
+class WriteCallbacks : public NimBLECharacteristicCallbacks {
+    void onWrite(NimBLECharacteristic* c) override {
+        std::string val = c->getValue();
+        if (val.empty()) return;
+        // Log the first few bytes so we can confirm protocol-level traffic
+        // from the serial console without needing the web UI to be working.
+        // Aurora frames begin with 0x01 (SOH); MoonBoard frames begin with 'l' (0x6C).
+        Serial.printf("[BLE] write %u bytes: ", static_cast<unsigned>(val.size()));
+        const size_t shown = val.size() < 16 ? val.size() : 16;
+        for (size_t i = 0; i < shown; ++i) Serial.printf("%02x ", static_cast<uint8_t>(val[i]));
+        if (val.size() > shown) Serial.print("...");
+        Serial.println();
+        bleEmulator.emitWrite(reinterpret_cast<const uint8_t*>(val.data()), val.size());
+    }
+};
+
+class ServerCallbacks : public NimBLEServerCallbacks {
+    void onConnect(NimBLEServer* /*s*/) override {
+        Serial.println("[BLE] Central connected");
+        bleEmulator.emitConnection(true);
+    }
+    void onDisconnect(NimBLEServer* /*s*/) override {
+        Serial.println("[BLE] Central disconnected — restarting advertising");
+        bleEmulator.emitConnection(false);
+        if (gAdvertising) gAdvertising->start();
+    }
+};
+
+WriteCallbacks  gWriteCb;
+ServerCallbacks gServerCb;
+
+}  // namespace
+
+BleEmulator bleEmulator;
+
+String BleEmulator::boardToString(EmulatedBoard b) {
+    switch (b) {
+        case EmulatedBoard::KILTER:      return "kilter";
+        case EmulatedBoard::TENSION:     return "tension";
+        case EmulatedBoard::DECOY:       return "decoy";
+        case EmulatedBoard::TOUCHSTONE:  return "touchstone";
+        case EmulatedBoard::GRASSHOPPER: return "grasshopper";
+        case EmulatedBoard::MOONBOARD:   return "moonboard";
+    }
+    return "kilter";
+}
+
+bool BleEmulator::parseBoard(const String& s, EmulatedBoard& out) {
+    String l = s;
+    l.toLowerCase();
+    if (l == "kilter")      { out = EmulatedBoard::KILTER;      return true; }
+    if (l == "tension")     { out = EmulatedBoard::TENSION;     return true; }
+    if (l == "decoy")       { out = EmulatedBoard::DECOY;       return true; }
+    if (l == "touchstone")  { out = EmulatedBoard::TOUCHSTONE;  return true; }
+    if (l == "grasshopper") { out = EmulatedBoard::GRASSHOPPER; return true; }
+    if (l == "moonboard")   { out = EmulatedBoard::MOONBOARD;   return true; }
+    return false;
+}
+
+String BleEmulator::buildLocalName(const EmulatorConfig& cfg) {
+    if (cfg.board == EmulatedBoard::MOONBOARD) {
+        return String("MoonBoard ") + (cfg.serial.length() ? cfg.serial : String("A"));
+    }
+    String prefix;
+    switch (cfg.board) {
+        case EmulatedBoard::KILTER:      prefix = "Kilter Board";      break;
+        case EmulatedBoard::TENSION:     prefix = "Tension Board";     break;
+        case EmulatedBoard::DECOY:       prefix = "Decoy Board";       break;
+        case EmulatedBoard::TOUCHSTONE:  prefix = "Touchstone Board";  break;
+        case EmulatedBoard::GRASSHOPPER: prefix = "Grasshopper Board"; break;
+        default: prefix = "Kilter Board"; break;
+    }
+    return prefix + "#" + cfg.serial + "@" + String(cfg.apiLevel);
+}
+
+bool BleEmulator::begin(const EmulatorConfig& config) {
+    currentConfig = config;
+
+    NimBLEDevice::init(buildLocalName(config).c_str());
+    NimBLEDevice::setPower(ESP_PWR_LVL_P9);
+
+    gServer = NimBLEDevice::createServer();
+    gServer->setCallbacks(&gServerCb);
+
+    gAuroraService = gServer->createService(AURORA_ADVERTISED_SERVICE);
+    gAuroraService->start();
+
+    gUartService = gServer->createService(UART_SERVICE_UUID);
+    gWriteChar = gUartService->createCharacteristic(
+        UART_WRITE_CHAR_UUID,
+        NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR);
+    gWriteChar->setCallbacks(&gWriteCb);
+    gUartService->start();
+
+    rebuildAdvertising();
+    Serial.printf("[BLE] Advertising as: %s\n", buildLocalName(config).c_str());
+    return true;
+}
+
+void BleEmulator::setConfig(const EmulatorConfig& config) {
+    currentConfig = config;
+    if (gAdvertising) gAdvertising->stop();
+
+    // While a central is connected the phone-side BLE stack keeps the cached
+    // device name from the moment it paired. Switching board type (e.g.
+    // Kilter → Tension) without dropping the connection means the phone keeps
+    // reading the old name from the GAP service and never rediscovers under
+    // the new identity. Disconnecting all peers forces a clean re-pair so the
+    // phone sees the new advertising data.
+    if (gServer) {
+        const size_t count = gServer->getConnectedCount();
+        for (size_t i = 0; i < count; ++i) {
+            NimBLEConnInfo info = gServer->getPeerInfo(i);
+            gServer->disconnect(info.getConnHandle());
+        }
+    }
+
+    NimBLEDevice::setDeviceName(buildLocalName(config).c_str());
+    rebuildAdvertising();
+    Serial.printf("[BLE] Re-advertising as: %s\n", buildLocalName(config).c_str());
+}
+
+void BleEmulator::rebuildAdvertising() {
+    gAdvertising = NimBLEDevice::getAdvertising();
+    gAdvertising->reset();
+
+    const String localName = buildLocalName(currentConfig);
+    const char* serviceUuid = currentConfig.board == EmulatedBoard::MOONBOARD
+                                  ? UART_SERVICE_UUID
+                                  : AURORA_ADVERTISED_SERVICE;
+
+    // BLE primary advertising data is capped at 31 bytes total. Aurora names
+    // ("Kilter Board#751737@3" = 21 chars → 23-byte AD field) plus a 16-byte
+    // service-UUID AD field (18 bytes) overflows. NimBLE silently drops the
+    // name when this happens — which means the phone-side MoonBoard scan
+    // filter (`namePrefix: 'MoonBoard'`) never matches and the device is
+    // invisible. Fix: keep flags + service UUID in primary adv, push the full
+    // name into the scan response packet (also 31 bytes, but on its own).
+    NimBLEAdvertisementData advData;
+    advData.setFlags(BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP);
+    advData.setCompleteServices(NimBLEUUID(serviceUuid));
+    gAdvertising->setAdvertisementData(advData);
+
+    NimBLEAdvertisementData scanResp;
+    scanResp.setName(localName.c_str());
+    gAdvertising->setScanResponseData(scanResp);
+
+    gAdvertising->setScanResponse(true);
+    gAdvertising->start();
+}
+
+#endif // EMULATOR_BUILD

--- a/packages/board-controller/esp32/src/emulator/ble_emulator.h
+++ b/packages/board-controller/esp32/src/emulator/ble_emulator.h
@@ -1,0 +1,56 @@
+#ifndef BLE_EMULATOR_H
+#define BLE_EMULATOR_H
+
+#ifdef EMULATOR_BUILD
+
+#include <Arduino.h>
+#include <functional>
+
+enum class EmulatedBoard {
+    KILTER,
+    TENSION,
+    DECOY,
+    TOUCHSTONE,
+    GRASSHOPPER,
+    MOONBOARD,
+};
+
+struct EmulatorConfig {
+    EmulatedBoard board = EmulatedBoard::KILTER;
+    String serial = "751737";
+    uint8_t apiLevel = 3;  // 2 or 3 (ignored for moonboard)
+};
+
+// Buffer is valid only for the duration of the callback — copy if needed.
+using BleWriteCallback = std::function<void(const uint8_t* data, size_t length)>;
+using BleConnectionCallback = std::function<void(bool connected)>;
+
+class BleEmulator {
+public:
+    bool begin(const EmulatorConfig& config);
+    void setConfig(const EmulatorConfig& config);
+    EmulatorConfig getConfig() const { return currentConfig; }
+
+    void setOnWrite(BleWriteCallback cb) { onWrite = std::move(cb); }
+    void setOnConnectionChange(BleConnectionCallback cb) { onConn = std::move(cb); }
+
+    // Public so file-scope NimBLE callbacks can bridge into us. Not intended
+    // for callers other than the BLE callback shims in ble_emulator.cpp.
+    void emitWrite(const uint8_t* data, size_t length) { if (onWrite) onWrite(data, length); }
+    void emitConnection(bool connected) { if (onConn) onConn(connected); }
+
+    static String boardToString(EmulatedBoard b);
+    static bool parseBoard(const String& s, EmulatedBoard& out);
+    static String buildLocalName(const EmulatorConfig& cfg);
+
+private:
+    void rebuildAdvertising();
+    EmulatorConfig currentConfig;
+    BleWriteCallback onWrite;
+    BleConnectionCallback onConn;
+};
+
+extern BleEmulator bleEmulator;
+
+#endif // EMULATOR_BUILD
+#endif // BLE_EMULATOR_H

--- a/packages/board-controller/esp32/src/emulator/emulator_main.cpp
+++ b/packages/board-controller/esp32/src/emulator/emulator_main.cpp
@@ -1,0 +1,137 @@
+#ifdef EMULATOR_BUILD
+
+#include "emulator_main.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+#include <WiFi.h>
+
+#include "ble_emulator.h"
+#include "ws_server.h"
+
+#ifndef EMULATOR_WIFI_SSID
+#define EMULATOR_WIFI_SSID ""
+#endif
+#ifndef EMULATOR_WIFI_PASS
+#define EMULATOR_WIFI_PASS ""
+#endif
+
+namespace {
+
+constexpr const char* NVS_NAMESPACE = "emul";
+Preferences gPrefs;
+
+EmulatorConfig loadConfig() {
+    EmulatorConfig cfg;
+    if (!gPrefs.begin(NVS_NAMESPACE, true)) return cfg;
+    String boardStr = gPrefs.getString("board", "kilter");
+    EmulatedBoard b;
+    if (BleEmulator::parseBoard(boardStr, b)) cfg.board = b;
+    cfg.serial   = gPrefs.getString("serial", "751737");
+    cfg.apiLevel = static_cast<uint8_t>(gPrefs.getUChar("apiLevel", 3));
+    gPrefs.end();
+    return cfg;
+}
+
+void saveConfig(const EmulatorConfig& cfg) {
+    if (!gPrefs.begin(NVS_NAMESPACE, false)) return;
+    gPrefs.putString("board", BleEmulator::boardToString(cfg.board));
+    gPrefs.putString("serial", cfg.serial);
+    gPrefs.putUChar("apiLevel", cfg.apiLevel);
+    gPrefs.end();
+}
+
+void connectWifi() {
+    const char* ssid = EMULATOR_WIFI_SSID;
+    const char* pass = EMULATOR_WIFI_PASS;
+    if (strlen(ssid) == 0) {
+        Serial.println("[WiFi] EMULATOR_WIFI_SSID empty — set it in packages/board-controller/esp32/.env");
+        return;
+    }
+    Serial.printf("[WiFi] Connecting to '%s'...\n", ssid);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid, pass);
+
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && (millis() - start) < 30000) {
+        delay(250);
+        Serial.print('.');
+    }
+    Serial.println();
+    if (WiFi.status() == WL_CONNECTED) {
+        Serial.printf("[WiFi] Connected. IP: %s\n", WiFi.localIP().toString().c_str());
+    } else {
+        Serial.println("[WiFi] Connect timed out — emulator will retry from loop().");
+    }
+}
+
+void maintainWifi() {
+    static unsigned long lastAttempt = 0;
+    if (WiFi.status() == WL_CONNECTED) return;
+    unsigned long now = millis();
+    if (now - lastAttempt < 10000) return;
+    lastAttempt = now;
+    Serial.println("[WiFi] Reconnecting...");
+    WiFi.reconnect();
+}
+
+}  // namespace
+
+// True once we've started the WS server, which we defer until Wi-Fi is up.
+// Starting the WebSocketsServer before lwIP is initialised hard-asserts in
+// tcpip_send_msg_wait_sem (Invalid mbox), so we gate it on WiFi.status().
+bool gWsStarted = false;
+
+void emulatorSetup() {
+    Serial.begin(115200);
+    delay(500);
+    Serial.println();
+    Serial.println("===============================");
+    Serial.println("  BoardSesh ESP32 EMULATOR");
+    Serial.println("===============================");
+
+    EmulatorConfig cfg = loadConfig();
+
+    connectWifi();
+
+    bleEmulator.setOnWrite([](const uint8_t* data, size_t length) {
+        if (gWsStarted) wsServer.broadcastBleWrite(data, length);
+    });
+    bleEmulator.setOnConnectionChange([](bool connected) {
+        if (gWsStarted) wsServer.broadcastBleConnection(connected);
+    });
+    bleEmulator.begin(cfg);
+
+    wsServer.setOnConfigChange([](const EmulatorConfig& newCfg) {
+        bleEmulator.setConfig(newCfg);
+        saveConfig(newCfg);
+    });
+
+    if (WiFi.status() == WL_CONNECTED) {
+        wsServer.begin(81);
+        gWsStarted = true;
+        Serial.println("===============================");
+        Serial.printf("  Ready. WS: ws://%s:81/\n", WiFi.localIP().toString().c_str());
+        Serial.printf("  BLE:    %s\n", BleEmulator::buildLocalName(cfg).c_str());
+        Serial.println("===============================");
+    } else {
+        Serial.println("===============================");
+        Serial.printf("  BLE up: %s\n", BleEmulator::buildLocalName(cfg).c_str());
+        Serial.println("  WS:    waiting for Wi-Fi…");
+        Serial.println("===============================");
+    }
+}
+
+void emulatorLoop() {
+    maintainWifi();
+    // Lazy-start the WS server the first time Wi-Fi comes up.
+    if (!gWsStarted && WiFi.status() == WL_CONNECTED) {
+        wsServer.begin(81);
+        gWsStarted = true;
+        Serial.printf("[WS] Started: ws://%s:81/\n", WiFi.localIP().toString().c_str());
+    }
+    if (gWsStarted) wsServer.loop();
+    delay(1);
+}
+
+#endif // EMULATOR_BUILD

--- a/packages/board-controller/esp32/src/emulator/emulator_main.h
+++ b/packages/board-controller/esp32/src/emulator/emulator_main.h
@@ -1,0 +1,10 @@
+#ifndef EMULATOR_MAIN_H
+#define EMULATOR_MAIN_H
+
+#ifdef EMULATOR_BUILD
+
+void emulatorSetup();
+void emulatorLoop();
+
+#endif // EMULATOR_BUILD
+#endif // EMULATOR_MAIN_H

--- a/packages/board-controller/esp32/src/emulator/ws_server.cpp
+++ b/packages/board-controller/esp32/src/emulator/ws_server.cpp
@@ -1,0 +1,154 @@
+#ifdef EMULATOR_BUILD
+
+#include "ws_server.h"
+
+#include <ArduinoJson.h>
+#include <WebSocketsServer.h>
+
+namespace {
+
+WebSocketsServer gWs(81);
+
+constexpr const char* FW_VERSION = "0.1.0";
+
+String bytesToHex(const uint8_t* data, size_t length) {
+    static const char hex[] = "0123456789abcdef";
+    String out;
+    out.reserve(length * 2);
+    for (size_t i = 0; i < length; ++i) {
+        out += hex[(data[i] >> 4) & 0xF];
+        out += hex[data[i] & 0xF];
+    }
+    return out;
+}
+
+String configToHelloJson(const EmulatorConfig& cfg) {
+    JsonDocument doc;
+    doc["type"]      = "hello";
+    doc["fwVersion"] = FW_VERSION;
+    doc["board"]     = BleEmulator::boardToString(cfg.board);
+    doc["serial"]    = cfg.serial;
+    doc["apiLevel"]  = cfg.apiLevel;
+    String out;
+    serializeJson(doc, out);
+    return out;
+}
+
+void onWsEvent(uint8_t clientId, WStype_t type, uint8_t* payload, size_t length) {
+    switch (type) {
+        case WStype_CONNECTED: {
+            IPAddress ip = gWs.remoteIP(clientId);
+            Serial.printf("[WS] #%u connected from %s\n", clientId, ip.toString().c_str());
+            wsServer.handleClientConnected(clientId);
+            break;
+        }
+        case WStype_DISCONNECTED:
+            Serial.printf("[WS] #%u disconnected\n", clientId);
+            break;
+        case WStype_TEXT: {
+            String msg;
+            msg.reserve(length);
+            for (size_t i = 0; i < length; ++i) msg += static_cast<char>(payload[i]);
+            wsServer.handleClientMessage(clientId, msg);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+}  // namespace
+
+EmulatorWsServer wsServer;
+
+bool EmulatorWsServer::begin(uint16_t port) {
+    (void)port;  // hard-coded to 81 in the ctor of WebSocketsServer above.
+    gWs.begin();
+    gWs.onEvent(onWsEvent);
+    Serial.println("[WS] Listening on port 81");
+    return true;
+}
+
+void EmulatorWsServer::loop() {
+    gWs.loop();
+}
+
+void EmulatorWsServer::broadcastBleWrite(const uint8_t* data, size_t length) {
+    JsonDocument doc;
+    doc["type"] = "ble-write";
+    doc["ts"]   = static_cast<uint32_t>(millis());
+    doc["hex"]  = bytesToHex(data, length);
+    String out;
+    serializeJson(doc, out);
+    gWs.broadcastTXT(out);
+}
+
+void EmulatorWsServer::broadcastBleConnection(bool connected) {
+    JsonDocument doc;
+    doc["type"] = connected ? "ble-connected" : "ble-disconnected";
+    String out;
+    serializeJson(doc, out);
+    gWs.broadcastTXT(out);
+}
+
+void EmulatorWsServer::broadcastHello(const EmulatorConfig& cfg) {
+    String out = configToHelloJson(cfg);
+    gWs.broadcastTXT(out);
+}
+
+void EmulatorWsServer::handleClientConnected(uint8_t clientId) {
+    String hello = configToHelloJson(bleEmulator.getConfig());
+    gWs.sendTXT(clientId, hello);
+}
+
+void EmulatorWsServer::handleClientMessage(uint8_t clientId, const String& payload) {
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, payload);
+    if (err) {
+        Serial.printf("[WS] Bad JSON from #%u: %s\n", clientId, err.c_str());
+        return;
+    }
+    const char* type = doc["type"] | "";
+
+    if (strcmp(type, "ping") == 0) {
+        gWs.sendTXT(clientId, "{\"type\":\"pong\"}");
+        return;
+    }
+
+    if (strcmp(type, "set-config") == 0) {
+        EmulatorConfig cfg = bleEmulator.getConfig();
+        const char* board    = doc["board"]    | "";
+        const char* serial   = doc["serial"]   | "";
+        int         apiLevel = doc["apiLevel"] | static_cast<int>(cfg.apiLevel);
+
+        if (strlen(board) > 0) {
+            EmulatedBoard b;
+            if (!BleEmulator::parseBoard(String(board), b)) {
+                gWs.sendTXT(clientId, "{\"type\":\"error\",\"message\":\"unknown board\"}");
+                return;
+            }
+            cfg.board = b;
+        }
+        if (strlen(serial) > 0) cfg.serial = String(serial);
+        if (apiLevel == 2 || apiLevel == 3) cfg.apiLevel = static_cast<uint8_t>(apiLevel);
+
+        if (onConfig) onConfig(cfg);
+
+        // Echo the active config back to all clients.
+        broadcastHello(cfg);
+
+        JsonDocument ack;
+        ack["type"]              = "config-ack";
+        ack["config"]["board"]   = BleEmulator::boardToString(cfg.board);
+        ack["config"]["serial"]  = cfg.serial;
+        ack["config"]["apiLevel"] = cfg.apiLevel;
+        String out;
+        serializeJson(ack, out);
+        gWs.broadcastTXT(out);
+        return;
+    }
+
+    Serial.printf("[WS] Unknown message type from #%u: %s\n", clientId, type);
+}
+
+#endif // EMULATOR_BUILD

--- a/packages/board-controller/esp32/src/emulator/ws_server.h
+++ b/packages/board-controller/esp32/src/emulator/ws_server.h
@@ -1,0 +1,42 @@
+#ifndef EMULATOR_WS_SERVER_H
+#define EMULATOR_WS_SERVER_H
+
+#ifdef EMULATOR_BUILD
+
+#include <Arduino.h>
+#include <functional>
+
+#include "ble_emulator.h"
+
+// Callback when the web client requests a configuration change.
+using ConfigChangeCallback = std::function<void(const EmulatorConfig& cfg)>;
+
+class EmulatorWsServer {
+public:
+    bool begin(uint16_t port);
+    void loop();
+
+    // Broadcast a raw BLE write payload (in hex) to every connected client.
+    void broadcastBleWrite(const uint8_t* data, size_t length);
+
+    // Broadcast BLE central connection status.
+    void broadcastBleConnection(bool connected);
+
+    // Broadcast a fresh hello (used after re-config so clients display
+    // current state). Includes the current config.
+    void broadcastHello(const EmulatorConfig& cfg);
+
+    void setOnConfigChange(ConfigChangeCallback cb) { onConfig = std::move(cb); }
+
+    // Internal — called by the file-scope WS callback in ws_server.cpp.
+    void handleClientMessage(uint8_t clientId, const String& payload);
+    void handleClientConnected(uint8_t clientId);
+
+private:
+    ConfigChangeCallback onConfig;
+};
+
+extern EmulatorWsServer wsServer;
+
+#endif // EMULATOR_BUILD
+#endif // EMULATOR_WS_SERVER_H

--- a/packages/board-controller/esp32/src/main.cpp
+++ b/packages/board-controller/esp32/src/main.cpp
@@ -19,6 +19,17 @@
  */
 
 #include <Arduino.h>
+
+#ifdef EMULATOR_BUILD
+// Hardware test rig build: skip the real LED/WiFi/WebSocket-client stack and
+// run a BLE-emulator + local WebSocket-server instead. See src/emulator/.
+#include "emulator/emulator_main.h"
+
+void setup() { emulatorSetup(); }
+void loop()  { emulatorLoop(); }
+
+#else  // EMULATOR_BUILD
+
 #include "config/config_manager.h"
 #include "wifi/wifi_manager.h"
 #include "led/led_controller.h"
@@ -190,3 +201,6 @@ void onWebSocketLedUpdate(const LedCommand* commands, int count) {
         ledController.blink(255, 0, 0, 2, 100);
     }
 }
+
+#endif  // EMULATOR_BUILD
+

--- a/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+
+import type { BoardName } from '@/app/lib/types';
+import { SUPPORTED_BOARDS, ANGLES } from '@/app/lib/board-data';
+
+export type BoardConfigSelectsProps = {
+  selectedBoard: BoardName | undefined;
+  selectedLayout: number | undefined;
+  selectedSize: number | undefined;
+  selectedSets: number[];
+  selectedAngle: number;
+  layouts: Array<{ id: number; name: string }>;
+  sizes: Array<{ id: number; name: string; description?: string }>;
+  sets: Array<{ id: number; name: string }>;
+  onBoardChange: (board: BoardName) => void;
+  onLayoutChange: (layoutId: number) => void;
+  onSizeChange: (sizeId: number) => void;
+  onSetsChange: (setIds: number[]) => void;
+  onAngleChange: (angle: number) => void;
+};
+
+export default function BoardConfigSelects({
+  selectedBoard,
+  selectedLayout,
+  selectedSize,
+  selectedSets,
+  selectedAngle,
+  layouts,
+  sizes,
+  sets,
+  onBoardChange,
+  onLayoutChange,
+  onSizeChange,
+  onSetsChange,
+  onAngleChange,
+}: BoardConfigSelectsProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+      <FormControl fullWidth size="small">
+        <InputLabel>Board</InputLabel>
+        <MuiSelect
+          value={selectedBoard || ''}
+          label="Board"
+          onChange={(e: SelectChangeEvent) => onBoardChange(e.target.value as BoardName)}
+        >
+          {SUPPORTED_BOARDS.map((board) => (
+            <MenuItem key={board} value={board}>
+              {board.charAt(0).toUpperCase() + board.slice(1)}
+            </MenuItem>
+          ))}
+        </MuiSelect>
+      </FormControl>
+
+      <FormControl fullWidth size="small">
+        <InputLabel>Layout</InputLabel>
+        <MuiSelect
+          value={selectedLayout ?? ''}
+          label="Layout"
+          onChange={(e: SelectChangeEvent<number | string>) => onLayoutChange(e.target.value as number)}
+          disabled={!selectedBoard}
+        >
+          {layouts.map(({ id, name }) => (
+            <MenuItem key={id} value={id}>
+              {name}
+            </MenuItem>
+          ))}
+        </MuiSelect>
+      </FormControl>
+
+      {selectedBoard !== 'moonboard' && (
+        <FormControl fullWidth size="small">
+          <InputLabel>Size</InputLabel>
+          <MuiSelect
+            value={selectedSize ?? ''}
+            label="Size"
+            onChange={(e: SelectChangeEvent<number | string>) => onSizeChange(e.target.value as number)}
+            disabled={!selectedLayout}
+          >
+            {sizes.map(({ id, name, description }) => (
+              <MenuItem key={id} value={id}>{`${name} ${description}`}</MenuItem>
+            ))}
+          </MuiSelect>
+        </FormControl>
+      )}
+
+      <FormControl fullWidth size="small">
+        <InputLabel>Hold Sets</InputLabel>
+        <MuiSelect<number[]>
+          multiple
+          value={selectedSets}
+          label="Hold Sets"
+          onChange={(e) => onSetsChange(e.target.value as number[])}
+          disabled={!selectedSize}
+        >
+          {sets.map(({ id, name }) => (
+            <MenuItem key={id} value={id}>
+              {name}
+            </MenuItem>
+          ))}
+        </MuiSelect>
+      </FormControl>
+
+      <FormControl fullWidth size="small">
+        <InputLabel>Angle</InputLabel>
+        <MuiSelect
+          value={selectedAngle}
+          label="Angle"
+          onChange={(e: SelectChangeEvent<number>) => onAngleChange(e.target.value)}
+          disabled={!selectedBoard}
+        >
+          {selectedBoard &&
+            ANGLES[selectedBoard].map((angle) => (
+              <MenuItem key={angle} value={angle}>
+                {angle}
+              </MenuItem>
+            ))}
+        </MuiSelect>
+      </FormControl>
+    </Box>
+  );
+}

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -3,10 +3,6 @@
 import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
 import CircularProgress from '@mui/material/CircularProgress';
 import CollapsibleSection, {
   type CollapsibleSectionConfig,
@@ -16,130 +12,15 @@ import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import { BOARD_NAME_PREFIX_REGEX, getDefaultSizeForLayout } from '@/app/lib/board-constants';
-import { SUPPORTED_BOARDS, ANGLES } from '@/app/lib/board-data';
+import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import { constructClimbListWithSlugs, constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import { type StoredBoardConfig, saveBoardConfig } from '@/app/lib/saved-boards-db';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
 
+import BoardConfigSelects from './board-config-selects';
+
 const CreateBoardForm = lazy(() => import('../board-entity/create-board-form'));
-
-type BoardConfigSelectsProps = {
-  selectedBoard: BoardName | undefined;
-  selectedLayout: number | undefined;
-  selectedSize: number | undefined;
-  selectedSets: number[];
-  selectedAngle: number;
-  layouts: Array<{ id: number; name: string }>;
-  sizes: Array<{ id: number; name: string; description?: string }>;
-  sets: Array<{ id: number; name: string }>;
-  onBoardChange: (board: BoardName) => void;
-  onLayoutChange: (layoutId: number) => void;
-  onSizeChange: (sizeId: number) => void;
-  onSetsChange: (setIds: number[]) => void;
-  onAngleChange: (angle: number) => void;
-};
-
-function BoardConfigSelects({
-  selectedBoard,
-  selectedLayout,
-  selectedSize,
-  selectedSets,
-  selectedAngle,
-  layouts,
-  sizes,
-  sets,
-  onBoardChange,
-  onLayoutChange,
-  onSizeChange,
-  onSetsChange,
-  onAngleChange,
-}: BoardConfigSelectsProps) {
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-      <FormControl fullWidth size="small">
-        <InputLabel>Board</InputLabel>
-        <MuiSelect
-          value={selectedBoard || ''}
-          label="Board"
-          onChange={(e: SelectChangeEvent) => onBoardChange(e.target.value as BoardName)}
-        >
-          {SUPPORTED_BOARDS.map((board) => (
-            <MenuItem key={board} value={board}>
-              {board.charAt(0).toUpperCase() + board.slice(1)}
-            </MenuItem>
-          ))}
-        </MuiSelect>
-      </FormControl>
-
-      <FormControl fullWidth size="small">
-        <InputLabel>Layout</InputLabel>
-        <MuiSelect
-          value={selectedLayout ?? ''}
-          label="Layout"
-          onChange={(e: SelectChangeEvent<number | string>) => onLayoutChange(e.target.value as number)}
-          disabled={!selectedBoard}
-        >
-          {layouts.map(({ id, name }) => (
-            <MenuItem key={id} value={id}>
-              {name}
-            </MenuItem>
-          ))}
-        </MuiSelect>
-      </FormControl>
-
-      {selectedBoard !== 'moonboard' && (
-        <FormControl fullWidth size="small">
-          <InputLabel>Size</InputLabel>
-          <MuiSelect
-            value={selectedSize ?? ''}
-            label="Size"
-            onChange={(e: SelectChangeEvent<number | string>) => onSizeChange(e.target.value as number)}
-            disabled={!selectedLayout}
-          >
-            {sizes.map(({ id, name, description }) => (
-              <MenuItem key={id} value={id}>{`${name} ${description}`}</MenuItem>
-            ))}
-          </MuiSelect>
-        </FormControl>
-      )}
-
-      <FormControl fullWidth size="small">
-        <InputLabel>Hold Sets</InputLabel>
-        <MuiSelect<number[]>
-          multiple
-          value={selectedSets}
-          label="Hold Sets"
-          onChange={(e) => onSetsChange(e.target.value as number[])}
-          disabled={!selectedSize}
-        >
-          {sets.map(({ id, name }) => (
-            <MenuItem key={id} value={id}>
-              {name}
-            </MenuItem>
-          ))}
-        </MuiSelect>
-      </FormControl>
-
-      <FormControl fullWidth size="small">
-        <InputLabel>Angle</InputLabel>
-        <MuiSelect
-          value={selectedAngle}
-          label="Angle"
-          onChange={(e: SelectChangeEvent<number>) => onAngleChange(e.target.value)}
-          disabled={!selectedBoard}
-        >
-          {selectedBoard &&
-            ANGLES[selectedBoard].map((angle) => (
-              <MenuItem key={angle} value={angle}>
-                {angle}
-              </MenuItem>
-            ))}
-        </MuiSelect>
-      </FormControl>
-    </Box>
-  );
-}
 
 type BoardSelectorDrawerProps = {
   open: boolean;

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -334,6 +334,15 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 </button>
               )}
 
+              {process.env.NODE_ENV === 'development' && (
+                <Link href="/development" className={styles.menuItem} onClick={handleClose}>
+                  <span className={styles.menuItemIcon}>
+                    <BuildOutlined />
+                  </span>
+                  <span className={styles.menuItemLabel}>Development</span>
+                </Link>
+              )}
+
               {boardDetails && !isMoonboard && (
                 <button
                   type="button"

--- a/packages/web/app/development/__tests__/payload-decoder.test.ts
+++ b/packages/web/app/development/__tests__/payload-decoder.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+
+import { getAuroraBluetoothPacket } from '@/app/components/board-bluetooth-control/bluetooth-aurora';
+import { getMoonboardBluetoothPacket } from '@/app/components/board-bluetooth-control/bluetooth-moonboard';
+import { splitMessages } from '@/app/components/board-bluetooth-control/bluetooth-shared';
+import { getLedPlacements } from '@boardsesh/board-constants/led-placements';
+
+import { decodeOnce, PayloadDecoder } from '../components/payload-decoder';
+
+// Match the existing bluetooth-aurora test setup: stub out the moonboard
+// runtime flag so the encoder import doesn't reach into Next.js plumbing.
+vi.mock('@/app/lib/moonboard-config', async () => {
+  const actual = await vi.importActual<typeof import('@/app/lib/moonboard-config')>('@/app/lib/moonboard-config');
+  return { ...actual, MOONBOARD_ENABLED: false };
+});
+
+const KILTER_LAYOUT = 1;
+const KILTER_SIZE = 10;
+
+function fromHex(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) out[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  return out;
+}
+
+describe('PayloadDecoder — Aurora v3 single frame', () => {
+  it('round-trips a small Kilter climb back to the original frames string', () => {
+    const placements = getLedPlacements('kilter', KILTER_LAYOUT, KILTER_SIZE);
+    const frames = 'p1379r44p1395r44p1447r45p1464r45';
+    const { packet } = getAuroraBluetoothPacket(frames, placements, 'kilter', 3);
+    expect(packet.length).toBeGreaterThan(0);
+
+    const decoded = decodeOnce(packet, { board: 'kilter', layoutId: KILTER_LAYOUT, sizeId: KILTER_SIZE });
+    expect(decoded).not.toBeNull();
+    expect(decoded!.board).toBe('kilter');
+    if (decoded!.board === 'moonboard') throw new Error('expected aurora frame');
+    expect(decoded!.apiLevel).toBe(3);
+    expect(decoded!.framesString).toBe(frames);
+  });
+
+  it('accepts the validated 12x12 captured payload and recovers the source frames', () => {
+    // Same fixture used in bluetooth-packet.test.ts — keeps the decoder
+    // honest against bytes from the real Aurora app, not just our encoder.
+    const captured = fromHex('010dbb02544400e3dc01e30000f42100f403');
+    const decoded = decodeOnce(captured, { board: 'kilter', layoutId: KILTER_LAYOUT, sizeId: KILTER_SIZE });
+    if (!decoded || decoded.board === 'moonboard') throw new Error('expected aurora frame');
+    expect(decoded.framesString).toBe('p1379r44p1395r44p1447r45p1464r45');
+  });
+});
+
+describe('PayloadDecoder — Aurora v3 multi-frame', () => {
+  it('reassembles 200 LEDs split across R/Q/S frames into one decoded snapshot', () => {
+    // Build a synthetic placement map that directly maps placementIds 0..199
+    // to LED positions 0..199 — keeps the test focused on multi-frame
+    // accumulation, not on real-board geometry.
+    const placements: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 200; i++) {
+      placements[i] = i;
+      frames += `p${i}r42`;
+    }
+    const { packet } = getAuroraBluetoothPacket(frames, placements, 'kilter', 3);
+    // Sanity: the encoder should have produced multiple framed messages.
+    expect(packet.length).toBeGreaterThan(254);
+
+    // Feed in 20-byte BLE-sized chunks the way a real phone would write.
+    const decoder = new PayloadDecoder({ board: 'kilter', layoutId: KILTER_LAYOUT, sizeId: KILTER_SIZE });
+    // Use a placement map override: monkey-patch reverse lookup by passing a
+    // matching layout/size — for this synthetic test we instead just assert
+    // the LED positions we recovered match what we sent.
+    let collected: ReturnType<typeof decoder.push> = [];
+    for (const chunk of splitMessages(packet)) {
+      const out = decoder.push(chunk);
+      if (out.length > 0) collected = out;
+    }
+    expect(collected).toHaveLength(1);
+    const result = collected[0];
+    if (result.board === 'moonboard') throw new Error('expected aurora frame');
+    expect(result.leds).toHaveLength(200);
+    const positions = result.leds.map((l) => l.position).sort((a, b) => a - b);
+    expect(positions).toEqual(Array.from({ length: 200 }, (_, i) => i));
+  });
+});
+
+describe('PayloadDecoder — Aurora v2', () => {
+  it('round-trips a Tension v2 climb (with v2 power scaling)', () => {
+    // Use a small synthetic placement map so the v2 power scale stays at 1.0.
+    const placements: Record<number, number> = { 1: 10, 2: 256, 3: 500 };
+    const frames = 'p1r1p2r1p3r1';
+    const { packet } = getAuroraBluetoothPacket(frames, placements, 'tension', 2);
+
+    const decoder = new PayloadDecoder({ board: 'tension', layoutId: 0, sizeId: 0 });
+    const out = decoder.push(packet);
+    expect(out).toHaveLength(1);
+    if (out[0].board === 'moonboard') throw new Error('expected aurora frame');
+    expect(out[0].apiLevel).toBe(2);
+    expect(out[0].leds.map((l) => l.position).sort((a, b) => a - b)).toEqual([10, 256, 500]);
+  });
+});
+
+describe('PayloadDecoder — MoonBoard ASCII', () => {
+  it('decodes a single-shot MoonBoard payload back to the original frames', () => {
+    const frames = 'p1r42p2r43p198r44';
+    const packet = getMoonboardBluetoothPacket(frames);
+    const decoded = decodeOnce(packet, { board: 'moonboard', layoutId: 0, sizeId: 0 });
+    if (!decoded || decoded.board !== 'moonboard') throw new Error('expected moonboard frame');
+    // MoonBoard reverse-mapping is sort-stable on holdId, so the round-tripped
+    // string should match exactly.
+    expect(decoded.framesString).toBe(frames);
+  });
+
+  it('handles an empty MoonBoard payload (no holds lit)', () => {
+    const packet = new TextEncoder().encode('l##');
+    const decoded = decodeOnce(packet, { board: 'moonboard', layoutId: 0, sizeId: 0 });
+    if (!decoded || decoded.board !== 'moonboard') throw new Error('expected moonboard frame');
+    expect(decoded.leds).toHaveLength(0);
+    expect(decoded.framesString).toBe('');
+  });
+
+  it('reassembles MoonBoard payloads split across multiple BLE writes', () => {
+    // The phone splits any payload > 20 bytes into 20-byte BLE chunks via
+    // splitMessages, including MoonBoard. A climb with several holds easily
+    // exceeds that. Drive a payload through the decoder one BLE-sized slice
+    // at a time and assert we get exactly one frame at the end.
+    const frames = 'p1r42p2r43p10r43p20r43p50r43p100r43p150r43p198r44';
+    const packet = getMoonboardBluetoothPacket(frames);
+    expect(packet.length).toBeGreaterThan(20);
+
+    const decoder = new PayloadDecoder({ board: 'moonboard', layoutId: 0, sizeId: 0 });
+    let collected: ReturnType<typeof decoder.push> = [];
+    for (const chunk of splitMessages(packet)) {
+      const out = decoder.push(chunk);
+      if (out.length > 0) collected = collected.concat(out);
+    }
+    expect(collected).toHaveLength(1);
+    if (collected[0].board !== 'moonboard') throw new Error('expected moonboard frame');
+    expect(collected[0].framesString).toBe(frames);
+  });
+});
+
+describe('PayloadDecoder — resilience', () => {
+  it('drops noise bytes before SOH instead of breaking the stream', () => {
+    const placements = getLedPlacements('kilter', KILTER_LAYOUT, KILTER_SIZE);
+    const frames = 'p1379r44';
+    const { packet } = getAuroraBluetoothPacket(frames, placements, 'kilter', 3);
+
+    const noisy = new Uint8Array([0xff, 0xfe, ...packet]);
+    const decoder = new PayloadDecoder({ board: 'kilter', layoutId: KILTER_LAYOUT, sizeId: KILTER_SIZE });
+    const out = decoder.push(noisy);
+    expect(out).toHaveLength(1);
+    if (out[0].board === 'moonboard') throw new Error('expected aurora frame');
+    expect(out[0].framesString).toBe(frames);
+  });
+
+  it('does not emit until a partial frame is completed by a follow-up chunk', () => {
+    const placements = getLedPlacements('kilter', KILTER_LAYOUT, KILTER_SIZE);
+    const frames = 'p1379r44p1395r44';
+    const { packet } = getAuroraBluetoothPacket(frames, placements, 'kilter', 3);
+    const decoder = new PayloadDecoder({ board: 'kilter', layoutId: KILTER_LAYOUT, sizeId: KILTER_SIZE });
+    // Cut the packet roughly in half — no frame should emit yet.
+    const half = Math.floor(packet.length / 2);
+    expect(decoder.push(packet.subarray(0, half))).toHaveLength(0);
+    const rest = decoder.push(packet.subarray(half));
+    expect(rest).toHaveLength(1);
+    if (rest[0].board === 'moonboard') throw new Error('expected aurora frame');
+    expect(rest[0].framesString).toBe(frames);
+  });
+});

--- a/packages/web/app/development/components/add-esp32-dialog.tsx
+++ b/packages/web/app/development/components/add-esp32-dialog.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+
+import BoardConfigSelects from '@/app/components/board-selector-drawer/board-config-selects';
+import { getDefaultSizeForLayout } from '@/app/lib/board-constants';
+import type { BoardConfigData } from '@/app/lib/server-board-configs';
+import type { BoardName } from '@/app/lib/types';
+import type { Esp32Connection } from '@/app/lib/user-preferences-db';
+
+type AddEsp32DialogProps = {
+  open: boolean;
+  boardConfigs: BoardConfigData;
+  initial?: Esp32Connection;
+  onClose: () => void;
+  onSubmit: (conn: Esp32Connection) => void;
+};
+
+const DEFAULTS: Esp32Connection = {
+  id: '',
+  label: 'Desk ESP32',
+  ip: '192.168.1.100',
+  board: 'kilter',
+  serial: '751737',
+  apiLevel: 3,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: [1, 20],
+  angle: 40,
+};
+
+export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, onSubmit }: AddEsp32DialogProps) {
+  const [form, setForm] = useState<Esp32Connection>(initial ?? DEFAULTS);
+
+  useEffect(() => {
+    setForm(initial ?? DEFAULTS);
+  }, [initial, open]);
+
+  const isEdit = Boolean(initial);
+
+  // Mirror the cascade logic from BoardSelectorDrawer (board → layout → default
+  // size → all sets) so the user only has to pick a board to get a working
+  // config. Without this the form ships with stale numeric defaults that don't
+  // match a freshly-picked board.
+  const layouts = useMemo(() => boardConfigs.layouts[form.board] ?? [], [boardConfigs.layouts, form.board]);
+  const sizes = useMemo(
+    () => boardConfigs.sizes[`${form.board}-${form.layoutId}`] ?? [],
+    [boardConfigs.sizes, form.board, form.layoutId],
+  );
+  const sets = useMemo(
+    () => boardConfigs.sets[`${form.board}-${form.layoutId}-${form.sizeId}`] ?? [],
+    [boardConfigs.sets, form.board, form.layoutId, form.sizeId],
+  );
+
+  const handleBoardChange = (board: BoardName): void => {
+    const nextLayouts = boardConfigs.layouts[board] ?? [];
+    const nextLayoutId = nextLayouts[0]?.id ?? 0;
+    const defaultSize = nextLayoutId ? getDefaultSizeForLayout(board, nextLayoutId) : null;
+    const nextSizes = nextLayoutId ? (boardConfigs.sizes[`${board}-${nextLayoutId}`] ?? []) : [];
+    const nextSizeId = defaultSize ?? nextSizes[0]?.id ?? 0;
+    const nextSets = nextSizeId ? (boardConfigs.sets[`${board}-${nextLayoutId}-${nextSizeId}`] ?? []) : [];
+    setForm((f) => ({
+      ...f,
+      board,
+      layoutId: nextLayoutId,
+      sizeId: nextSizeId,
+      setIds: nextSets.map((s) => s.id),
+    }));
+  };
+
+  const handleLayoutChange = (layoutId: number): void => {
+    const defaultSize = getDefaultSizeForLayout(form.board, layoutId);
+    const nextSizes = boardConfigs.sizes[`${form.board}-${layoutId}`] ?? [];
+    const nextSizeId = defaultSize ?? nextSizes[0]?.id ?? 0;
+    const nextSets = nextSizeId ? (boardConfigs.sets[`${form.board}-${layoutId}-${nextSizeId}`] ?? []) : [];
+    setForm((f) => ({ ...f, layoutId, sizeId: nextSizeId, setIds: nextSets.map((s) => s.id) }));
+  };
+
+  const handleSizeChange = (sizeId: number): void => {
+    const nextSets = boardConfigs.sets[`${form.board}-${form.layoutId}-${sizeId}`] ?? [];
+    setForm((f) => ({ ...f, sizeId, setIds: nextSets.map((s) => s.id) }));
+  };
+
+  const handleSubmit = (): void => {
+    const id =
+      form.id || (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));
+    onSubmit({
+      ...form,
+      id,
+      // Strip any scheme/path the user might have pasted.
+      ip: form.ip.replace(/^wss?:\/\//, '').replace(/[/:].*$/, ''),
+    });
+  };
+
+  const isComplete =
+    form.label.trim().length > 0 &&
+    form.ip.trim().length > 0 &&
+    form.layoutId > 0 &&
+    (form.board === 'moonboard' || form.sizeId > 0) &&
+    form.setIds.length > 0;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{isEdit ? 'Edit ESP32' : 'Add ESP32'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Label"
+            value={form.label}
+            onChange={(e) => setForm({ ...form, label: e.target.value })}
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label="IP address"
+            value={form.ip}
+            onChange={(e) => setForm({ ...form, ip: e.target.value })}
+            placeholder="192.168.1.100"
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label="Serial"
+            value={form.serial}
+            onChange={(e) => setForm({ ...form, serial: e.target.value })}
+            helperText="Used in the BLE advertised name (e.g. Kilter Board#751737@3)"
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label="API level"
+            value={form.apiLevel}
+            onChange={(e) => setForm({ ...form, apiLevel: e.target.value === '2' ? 2 : 3 })}
+            select
+            fullWidth
+            size="small"
+            disabled={form.board === 'moonboard'}
+            helperText={form.board === 'moonboard' ? 'Ignored for MoonBoard.' : '2 = legacy, 3 = current'}
+          >
+            <MenuItem value={3}>3</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+          </TextField>
+
+          <BoardConfigSelects
+            selectedBoard={form.board}
+            selectedLayout={form.layoutId || undefined}
+            selectedSize={form.sizeId || undefined}
+            selectedSets={form.setIds}
+            selectedAngle={form.angle}
+            layouts={layouts}
+            sizes={sizes}
+            sets={sets}
+            onBoardChange={handleBoardChange}
+            onLayoutChange={handleLayoutChange}
+            onSizeChange={handleSizeChange}
+            onSetsChange={(setIds) => setForm((f) => ({ ...f, setIds }))}
+            onAngleChange={(angle) => setForm((f) => ({ ...f, angle }))}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={!isComplete}>
+          {isEdit ? 'Save' : 'Add'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/development/components/esp32-tab.tsx
+++ b/packages/web/app/development/components/esp32-tab.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import EditOutlined from '@mui/icons-material/EditOutlined';
+import DeleteOutline from '@mui/icons-material/DeleteOutline';
+import RefreshOutlined from '@mui/icons-material/RefreshOutlined';
+
+import BoardRenderer from '@/app/components/board-renderer/board-renderer';
+import { getBoardDetails } from '@/app/lib/board-constants';
+import { getMoonBoardDetails } from '@/app/lib/moonboard-config';
+import { convertLitUpHoldsStringToMap } from '@boardsesh/board-constants/hold-states';
+import type { BoardDetails } from '@/app/lib/types';
+import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
+import type { Esp32Connection } from '@/app/lib/user-preferences-db';
+
+import { PayloadDecoder, type DecodedFrame } from './payload-decoder';
+import { useEsp32Socket } from './use-esp32-socket';
+
+type Esp32TabProps = {
+  connection: Esp32Connection;
+  active: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
+};
+
+function statusColor(status: string): 'default' | 'success' | 'warning' | 'error' {
+  if (status === 'connected') return 'success';
+  if (status === 'connecting' || status === 'reconnecting') return 'warning';
+  if (status === 'error') return 'error';
+  return 'default';
+}
+
+export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32TabProps) {
+  // The decoder is stateful (multi-frame Aurora payloads), so we keep one per
+  // tab and reset it when the configured board geometry changes.
+  const decoderRef = useRef<PayloadDecoder>(
+    new PayloadDecoder({
+      board: connection.board,
+      layoutId: connection.layoutId,
+      sizeId: connection.sizeId,
+    }),
+  );
+
+  useEffect(() => {
+    decoderRef.current.setConfig({
+      board: connection.board,
+      layoutId: connection.layoutId,
+      sizeId: connection.sizeId,
+    });
+    decoderRef.current.reset();
+  }, [connection.board, connection.layoutId, connection.sizeId]);
+
+  const [latest, setLatest] = useState<DecodedFrame | null>(null);
+  const [latestAt, setLatestAt] = useState<number | null>(null);
+
+  const handleBleWrite = (hex: string): void => {
+    const bytes = hexToBytes(hex);
+    const frames = decoderRef.current.push(bytes);
+    if (frames.length > 0) {
+      setLatest(frames[frames.length - 1]);
+      setLatestAt(Date.now());
+    }
+  };
+
+  const socket = useEsp32Socket({ ip: connection.ip, onBleWrite: handleBleWrite });
+
+  // Push current config to ESP32 once connected so it advertises the right
+  // name even if it booted with a stale NVS-saved config.
+  useEffect(() => {
+    if (socket.status === 'connected') {
+      socket.sendConfig({
+        board: connection.board,
+        serial: connection.serial,
+        apiLevel: connection.apiLevel,
+      });
+    }
+    // socket.sendConfig is stable (useCallback in the hook); only push on connect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [socket.status, connection.board, connection.serial, connection.apiLevel]);
+
+  const boardDetails: BoardDetails | null = useMemo(() => {
+    try {
+      if (connection.board === 'moonboard') {
+        return getMoonBoardDetails({
+          layout_id: connection.layoutId,
+          set_ids: connection.setIds,
+        }) as unknown as BoardDetails;
+      }
+      return getBoardDetails({
+        board_name: connection.board,
+        layout_id: connection.layoutId,
+        size_id: connection.sizeId,
+        set_ids: connection.setIds,
+      });
+    } catch (e) {
+      console.error('[development] Failed to build board details', e);
+      return null;
+    }
+  }, [connection.board, connection.layoutId, connection.sizeId, connection.setIds]);
+
+  const litUpHoldsMap: LitUpHoldsMap | undefined = useMemo(() => {
+    if (!latest) return undefined;
+    if (latest.framesString.length === 0) return {};
+    const map = convertLitUpHoldsStringToMap(latest.framesString, connection.board);
+    return map[0] ?? {};
+  }, [latest, connection.board]);
+
+  return (
+    <Box
+      role="tabpanel"
+      sx={{
+        display: active ? 'flex' : 'none',
+        flexDirection: 'column',
+        gap: 2,
+        p: 2,
+        height: '100%',
+        overflow: 'auto',
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+        <Chip label={`WS: ${socket.status}`} color={statusColor(socket.status)} size="small" />
+        <Chip
+          label={socket.bleConnected ? 'Phone connected' : 'Phone idle'}
+          color={socket.bleConnected ? 'success' : 'default'}
+          size="small"
+        />
+        {socket.hello && (
+          <Chip
+            label={`${socket.hello.board} #${socket.hello.serial} @${socket.hello.apiLevel}`}
+            size="small"
+            variant="outlined"
+          />
+        )}
+        <Box flexGrow={1} />
+        <Tooltip title="Reconnect">
+          <IconButton size="small" onClick={socket.reconnect}>
+            <RefreshOutlined fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Edit">
+          <IconButton size="small" onClick={onEdit}>
+            <EditOutlined fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Remove">
+          <IconButton size="small" onClick={onRemove}>
+            <DeleteOutline fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+
+      {socket.errorMessage && (
+        <Typography variant="caption" color="error">
+          {socket.errorMessage}
+        </Typography>
+      )}
+
+      <Stack direction="row" spacing={2} alignItems="baseline" flexWrap="wrap">
+        <Typography variant="body2" color="text.secondary">
+          ws://{connection.ip}:81/
+        </Typography>
+        {latestAt && (
+          <Typography variant="caption" color="text.secondary">
+            last frame: {new Date(latestAt).toLocaleTimeString()}
+          </Typography>
+        )}
+      </Stack>
+
+      <Box sx={{ flex: 1, minHeight: 0, display: 'flex', justifyContent: 'center' }}>
+        {boardDetails ? (
+          <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={false} fillHeight />
+        ) : (
+          <Typography color="error">Could not load board details for this configuration.</Typography>
+        )}
+      </Box>
+
+      {latest && (
+        <Box sx={{ fontFamily: 'monospace', fontSize: 12, opacity: 0.7, wordBreak: 'break-all' }}>
+          frames: {latest.framesString || '(empty)'}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(Math.floor(hex.length / 2));
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/packages/web/app/development/components/payload-decoder.ts
+++ b/packages/web/app/development/components/payload-decoder.ts
@@ -1,0 +1,344 @@
+// Decode raw BLE writes that the ESP32 emulator forwards back to the dev UI.
+// Inverts what packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
+// (Aurora v2/v3) and bluetooth-moonboard.ts encode, so the same fixtures used to
+// validate the encoder also validate this decoder via round-trip tests.
+//
+// Aurora frames arrive as ≤20-byte BLE chunks because the phone splits with
+// `splitMessages` before writing; we accumulate bytes and emit a complete LED
+// snapshot when a single-frame (T/P) or multi-frame (R…Q…S / N…M…O) sequence
+// completes.
+
+import { buildFramesString, getReverseLedPlacements } from '@boardsesh/board-constants/led-placements';
+import type { BoardName } from '@boardsesh/shared-schema';
+
+import { MOONBOARD_GRID } from '@/app/lib/moonboard-config';
+
+// Aurora command bytes (must match bluetooth-aurora.ts).
+const V3_PACKET_MIDDLE = 0x51; // 'Q' 81
+const V3_PACKET_FIRST = 0x52; // 'R' 82
+const V3_PACKET_LAST = 0x53; // 'S' 83
+const V3_PACKET_ONLY = 0x54; // 'T' 84
+
+const V2_PACKET_MIDDLE = 0x4d; // 'M' 77
+const V2_PACKET_FIRST = 0x4e; // 'N' 78
+const V2_PACKET_LAST = 0x4f; // 'O' 79
+const V2_PACKET_ONLY = 0x50; // 'P' 80
+
+const FRAME_SOH = 0x01;
+const FRAME_STX = 0x02;
+const FRAME_ETX = 0x03;
+
+export type DecodedLed = {
+  position: number;
+  /** RGB triplet recovered from the colour byte (0–255 each). */
+  r: number;
+  g: number;
+  b: number;
+};
+
+export type DecodedAuroraFrame = {
+  board: BoardName;
+  apiLevel: 2 | 3;
+  leds: DecodedLed[];
+  /** Frames string suitable for `convertLitUpHoldsStringToMap`. Empty if no LED maps. */
+  framesString: string;
+};
+
+export type DecodedMoonboardFrame = {
+  board: 'moonboard';
+  leds: Array<{ holdId: number; roleCode: number }>;
+  framesString: string;
+};
+
+export type DecodedFrame = DecodedAuroraFrame | DecodedMoonboardFrame;
+
+// ---- Aurora colour byte → 8-bit RGB ----
+
+// v3 colour byte: RRRGGGBB. We expand each channel back to a representative
+// 8-bit value by replicating the high bits, which lets `colorToRoleCode` (in
+// led-placements.ts) classify it via its >127 thresholds.
+function expandV3Color(byte: number): { r: number; g: number; b: number } {
+  const r3 = (byte >> 5) & 0b111;
+  const g3 = (byte >> 2) & 0b111;
+  const b2 = byte & 0b11;
+  return {
+    r: (r3 << 5) | (r3 << 2) | (r3 >> 1),
+    g: (g3 << 5) | (g3 << 2) | (g3 >> 1),
+    b: (b2 << 6) | (b2 << 4) | (b2 << 2) | b2,
+  };
+}
+
+// v2 colour byte: (R<<6) | (G<<4) | (B<<2) | posHi[1:0].
+function expandV2Color(byte: number): { r: number; g: number; b: number } {
+  const r2 = (byte >> 6) & 0b11;
+  const g2 = (byte >> 4) & 0b11;
+  const b2 = (byte >> 2) & 0b11;
+  return {
+    r: (r2 << 6) | (r2 << 4) | (r2 << 2) | r2,
+    g: (g2 << 6) | (g2 << 4) | (g2 << 2) | g2,
+    b: (b2 << 6) | (b2 << 4) | (b2 << 2) | b2,
+  };
+}
+
+// ---- Aurora frame parsing ----
+
+type ParsedFrame = {
+  command: number;
+  // payload = command byte + LED data
+  payload: Uint8Array;
+  /** Total bytes consumed from the input buffer (header + payload + ETX). */
+  consumed: number;
+};
+
+// Parse a single framed message starting at offset 0 of `bytes`. Returns null
+// if the buffer doesn't contain a complete, valid frame yet.
+function parseFrame(bytes: Uint8Array): ParsedFrame | null {
+  if (bytes.length < 5) return null;
+  if (bytes[0] !== FRAME_SOH) return null;
+  const length = bytes[1];
+  // Frame layout: SOH(1) LEN(1) CHK(1) STX(1) PAYLOAD(length) ETX(1) = length + 5
+  if (bytes.length < length + 5) return null;
+  if (bytes[3] !== FRAME_STX) return null;
+  if (bytes[length + 4] !== FRAME_ETX) return null;
+  const payload = bytes.subarray(4, 4 + length);
+  return { command: payload[0], payload, consumed: length + 5 };
+}
+
+function decodeLedDataV3(ledBytes: Uint8Array): DecodedLed[] {
+  const leds: DecodedLed[] = [];
+  for (let i = 0; i + 2 < ledBytes.length; i += 3) {
+    const position = ledBytes[i] | (ledBytes[i + 1] << 8);
+    const colour = expandV3Color(ledBytes[i + 2]);
+    leds.push({ position, ...colour });
+  }
+  return leds;
+}
+
+function decodeLedDataV2(ledBytes: Uint8Array): DecodedLed[] {
+  const leds: DecodedLed[] = [];
+  for (let i = 0; i + 1 < ledBytes.length; i += 2) {
+    const posLo = ledBytes[i];
+    const byte2 = ledBytes[i + 1];
+    const posHi = byte2 & 0b11;
+    const position = posLo | (posHi << 8);
+    const colour = expandV2Color(byte2);
+    leds.push({ position, ...colour });
+  }
+  return leds;
+}
+
+// ---- MoonBoard ASCII payload ----
+
+// Reverse of `getMoonboardSerialPosition`: serial position → 1-based holdId.
+function moonboardSerialToHoldId(serialPosition: number): number | null {
+  const { numColumns, numRows } = MOONBOARD_GRID;
+  const colIndex = Math.floor(serialPosition / numRows);
+  if (colIndex < 0 || colIndex >= numColumns) return null;
+  const rawRow = serialPosition - colIndex * numRows;
+  const rowIndex = colIndex % 2 === 0 ? rawRow : numRows - 1 - rawRow;
+  if (rowIndex < 0 || rowIndex >= numRows) return null;
+  return rowIndex * numColumns + colIndex + 1;
+}
+
+const MOONBOARD_LETTER_TO_ROLE: Record<string, number> = {
+  S: 42, // STARTING
+  P: 43, // HAND
+  E: 44, // FINISH
+};
+
+// Parse an already-fully-buffered MoonBoard payload of the form `l#…#`.
+function parseCompleteMoonboardAscii(text: string): DecodedMoonboardFrame | null {
+  const match = text.match(/^l#([^#]*)#$/);
+  if (!match) return null;
+  const inner = match[1];
+  const leds: DecodedMoonboardFrame['leds'] = [];
+  if (inner.length > 0) {
+    for (const entry of inner.split(',')) {
+      const letter = entry[0];
+      const roleCode = MOONBOARD_LETTER_TO_ROLE[letter];
+      if (!roleCode) continue;
+      const serial = Number(entry.slice(1));
+      if (!Number.isFinite(serial)) continue;
+      const holdId = moonboardSerialToHoldId(serial);
+      if (holdId == null) continue;
+      leds.push({ holdId, roleCode });
+    }
+  }
+  leds.sort((a, b) => a.holdId - b.holdId);
+  const framesString = leds.map((l) => `p${l.holdId}r${l.roleCode}`).join('');
+  return { board: 'moonboard', leds, framesString };
+}
+
+// ---- Stateful accumulator ----
+
+export type DecoderConfig = {
+  board: BoardName;
+  layoutId: number;
+  sizeId: number;
+};
+
+export class PayloadDecoder {
+  private buffer: number[] = [];
+  private pendingLeds: DecodedLed[] = [];
+  private pendingApiLevel: 2 | 3 = 3;
+  private inMultiFrame = false;
+  // MoonBoard payloads also get split into 20-byte BLE chunks (the phone calls
+  // splitMessages too), so we accumulate ASCII bytes until we see the closing
+  // '#' that terminates the `l#…#` frame.
+  private mbBuffer = '';
+
+  constructor(private config: DecoderConfig) {}
+
+  setConfig(config: DecoderConfig): void {
+    this.config = config;
+  }
+
+  reset(): void {
+    this.buffer = [];
+    this.pendingLeds = [];
+    this.inMultiFrame = false;
+    this.mbBuffer = '';
+  }
+
+  /**
+   * Push a chunk of raw BLE bytes (as forwarded by the ESP32). Returns one or
+   * more decoded frames if the chunk completes any. Both Aurora and MoonBoard
+   * payloads can span multiple BLE writes — we buffer until a complete frame
+   * is recoverable.
+   */
+  push(chunk: Uint8Array): DecodedFrame[] {
+    if (this.config.board === 'moonboard') {
+      return this.pushMoonboardChunk(chunk);
+    }
+
+    // Aurora: accumulate, then drain complete frames.
+    for (let i = 0; i < chunk.length; i++) this.buffer.push(chunk[i]);
+    return this.drainAuroraFrames();
+  }
+
+  private pushMoonboardChunk(chunk: Uint8Array): DecodedFrame[] {
+    let text: string;
+    try {
+      text = new TextDecoder('ascii').decode(chunk);
+    } catch {
+      return [];
+    }
+    this.mbBuffer += text;
+
+    const out: DecodedFrame[] = [];
+    // Drain every complete `l#…#` frame currently in the buffer. There may be
+    // more than one if the phone bursts climbs back-to-back.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const start = this.mbBuffer.indexOf('l#');
+      if (start === -1) {
+        // No frame start in view — drop accumulated noise so we don't grow
+        // unbounded on a stream of garbage.
+        if (this.mbBuffer.length > 1024) this.mbBuffer = '';
+        break;
+      }
+      // The closing `#` is the second `#` (the first one is in `l#`).
+      const closing = this.mbBuffer.indexOf('#', start + 2);
+      if (closing === -1) {
+        // Frame still incomplete — keep what we have starting at the prefix.
+        if (start > 0) this.mbBuffer = this.mbBuffer.slice(start);
+        break;
+      }
+      const frameText = this.mbBuffer.slice(start, closing + 1);
+      this.mbBuffer = this.mbBuffer.slice(closing + 1);
+      const decoded = parseCompleteMoonboardAscii(frameText);
+      if (decoded) out.push(decoded);
+    }
+    return out;
+  }
+
+  private drainAuroraFrames(): DecodedFrame[] {
+    const out: DecodedFrame[] = [];
+    while (this.buffer.length > 0) {
+      // Resync: drop bytes until we land on SOH.
+      while (this.buffer.length > 0 && this.buffer[0] !== FRAME_SOH) {
+        this.buffer.shift();
+      }
+      const view = Uint8Array.from(this.buffer);
+      const parsed = parseFrame(view);
+      if (!parsed) return out;
+
+      this.buffer.splice(0, parsed.consumed);
+      const ledBytes = parsed.payload.subarray(1);
+
+      let leds: DecodedLed[];
+      let apiLevel: 2 | 3;
+
+      switch (parsed.command) {
+        case V3_PACKET_ONLY:
+        case V3_PACKET_FIRST:
+        case V3_PACKET_MIDDLE:
+        case V3_PACKET_LAST:
+          leds = decodeLedDataV3(ledBytes);
+          apiLevel = 3;
+          break;
+        case V2_PACKET_ONLY:
+        case V2_PACKET_FIRST:
+        case V2_PACKET_MIDDLE:
+        case V2_PACKET_LAST:
+          leds = decodeLedDataV2(ledBytes);
+          apiLevel = 2;
+          break;
+        default:
+          // Unknown command — skip the frame and keep draining.
+          continue;
+      }
+
+      const isOnly = parsed.command === V3_PACKET_ONLY || parsed.command === V2_PACKET_ONLY;
+      const isFirst = parsed.command === V3_PACKET_FIRST || parsed.command === V2_PACKET_FIRST;
+      const isLast = parsed.command === V3_PACKET_LAST || parsed.command === V2_PACKET_LAST;
+
+      if (isOnly) {
+        out.push(this.buildAuroraFrame(leds, apiLevel));
+        this.pendingLeds = [];
+        this.inMultiFrame = false;
+        continue;
+      }
+
+      if (isFirst) {
+        this.pendingLeds = leds;
+        this.pendingApiLevel = apiLevel;
+        this.inMultiFrame = true;
+        continue;
+      }
+
+      if (this.inMultiFrame) {
+        this.pendingLeds.push(...leds);
+        if (isLast) {
+          out.push(this.buildAuroraFrame(this.pendingLeds, this.pendingApiLevel));
+          this.pendingLeds = [];
+          this.inMultiFrame = false;
+        }
+      }
+    }
+    return out;
+  }
+
+  private buildAuroraFrame(leds: DecodedLed[], apiLevel: 2 | 3): DecodedAuroraFrame {
+    // Look up placementId for each LED position via the board geometry. Holds
+    // we can't map are dropped (with a warning inside buildFramesString).
+    const framesString = buildFramesString(
+      leds.map((l) => ({ position: l.position, r: l.r, g: l.g, b: l.b })),
+      this.config.board,
+      this.config.layoutId,
+      this.config.sizeId,
+    );
+    return { board: this.config.board, apiLevel, leds, framesString };
+  }
+}
+
+// Convenience: decode a single complete payload (e.g. from a unit test where
+// the whole packet arrives in one buffer). Useful for round-trip tests.
+export function decodeOnce(bytes: Uint8Array, config: DecoderConfig): DecodedFrame | null {
+  const decoder = new PayloadDecoder(config);
+  const frames = decoder.push(bytes);
+  return frames[0] ?? null;
+}
+
+// Re-export reverse placements helper for callers building UI tooltips.
+export { getReverseLedPlacements };

--- a/packages/web/app/development/components/use-esp32-socket.ts
+++ b/packages/web/app/development/components/use-esp32-socket.ts
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+export type Esp32SocketStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error';
+
+export type Esp32Hello = {
+  type: 'hello';
+  fwVersion: string;
+  board: string;
+  serial: string;
+  apiLevel: number;
+};
+
+export type Esp32BleWrite = { type: 'ble-write'; ts: number; hex: string };
+export type Esp32BleConn = { type: 'ble-connected' | 'ble-disconnected' };
+export type Esp32ConfigAck = { type: 'config-ack'; config: { board: string; serial: string; apiLevel: number } };
+export type Esp32ErrorMsg = { type: 'error'; message: string };
+
+export type Esp32Message = Esp32Hello | Esp32BleWrite | Esp32BleConn | Esp32ConfigAck | Esp32ErrorMsg;
+
+export type Esp32Config = {
+  board: string;
+  serial: string;
+  apiLevel: 2 | 3;
+};
+
+export type Esp32SocketState = {
+  status: Esp32SocketStatus;
+  hello: Esp32Hello | null;
+  bleConnected: boolean;
+  /** Last error message (transport or server-emitted). */
+  errorMessage: string | null;
+};
+
+export type Esp32SocketHandle = Esp32SocketState & {
+  /** Send a config update to the ESP32 (re-advertises BLE with new name). */
+  sendConfig: (cfg: Esp32Config) => void;
+  /** Manually trigger a reconnect — useful when the user changes IP. */
+  reconnect: () => void;
+};
+
+type UseEsp32SocketOpts = {
+  ip: string;
+  onBleWrite?: (hex: string) => void;
+};
+
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 5_000;
+
+// Hosts a single WebSocket connection to one ESP32 emulator on ws://<ip>:81/.
+// Auto-reconnects with backoff and surfaces hello/config-ack/ble events.
+export function useEsp32Socket({ ip, onBleWrite }: UseEsp32SocketOpts): Esp32SocketHandle {
+  const [state, setState] = useState<Esp32SocketState>({
+    status: 'idle',
+    hello: null,
+    bleConnected: false,
+    errorMessage: null,
+  });
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectDelayRef = useRef<number>(RECONNECT_MIN_MS);
+  const onBleWriteRef = useRef(onBleWrite);
+  // Keep the latest callback without forcing reconnects when the parent
+  // re-creates the function each render.
+  onBleWriteRef.current = onBleWrite;
+
+  const closeQuietly = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws) return;
+    wsRef.current = null;
+    try {
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      ws.onopen = null;
+      ws.close();
+    } catch {
+      // Already closed — fine.
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (!ip) {
+      setState((s) => ({ ...s, status: 'idle', errorMessage: null }));
+      return;
+    }
+
+    closeQuietly();
+    setState((s) => ({ ...s, status: s.status === 'idle' ? 'connecting' : 'reconnecting' }));
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(`ws://${ip}:81/`);
+    } catch (e) {
+      setState((s) => ({ ...s, status: 'error', errorMessage: e instanceof Error ? e.message : 'invalid url' }));
+      return;
+    }
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      reconnectDelayRef.current = RECONNECT_MIN_MS;
+      setState((s) => ({ ...s, status: 'connected', errorMessage: null }));
+    };
+
+    ws.onmessage = (ev) => {
+      let msg: Esp32Message;
+      try {
+        msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '') as Esp32Message;
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case 'hello':
+          setState((s) => ({ ...s, hello: msg }));
+          break;
+        case 'ble-write':
+          onBleWriteRef.current?.(msg.hex);
+          break;
+        case 'ble-connected':
+          setState((s) => ({ ...s, bleConnected: true }));
+          break;
+        case 'ble-disconnected':
+          setState((s) => ({ ...s, bleConnected: false }));
+          break;
+        case 'config-ack':
+          // hello broadcast follows config-ack from the firmware, so no extra
+          // handling needed here — it's mostly a debugging echo.
+          break;
+        case 'error':
+          setState((s) => ({ ...s, errorMessage: msg.message }));
+          break;
+        default:
+          break;
+      }
+    };
+
+    ws.onerror = () => {
+      setState((s) => ({ ...s, status: 'error', errorMessage: 'websocket error' }));
+    };
+
+    ws.onclose = () => {
+      wsRef.current = null;
+      setState((s) => ({ ...s, status: 'reconnecting', bleConnected: false }));
+      const delay = reconnectDelayRef.current;
+      reconnectDelayRef.current = Math.min(delay * 2, RECONNECT_MAX_MS);
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+  }, [ip, closeQuietly]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      closeQuietly();
+    };
+    // Reconnect whenever the target IP changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ip]);
+
+  const sendConfig = useCallback((cfg: Esp32Config) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ type: 'set-config', ...cfg }));
+  }, []);
+
+  const reconnect = useCallback(() => {
+    reconnectDelayRef.current = RECONNECT_MIN_MS;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    connect();
+  }, [connect]);
+
+  return { ...state, sendConfig, reconnect };
+}

--- a/packages/web/app/development/development-content.tsx
+++ b/packages/web/app/development/development-content.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Box from '@mui/material/Box';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Typography from '@mui/material/Typography';
+import AddOutlined from '@mui/icons-material/AddOutlined';
+
+import { getPreference, setPreference, type Esp32Connection } from '@/app/lib/user-preferences-db';
+import type { BoardConfigData } from '@/app/lib/server-board-configs';
+import { themeTokens } from '@/app/theme/theme-config';
+
+import AddEsp32Dialog from './components/add-esp32-dialog';
+import Esp32Tab from './components/esp32-tab';
+
+const ADD_TAB = 'ADD';
+
+type DevelopmentContentProps = {
+  boardConfigs: BoardConfigData;
+};
+
+export default function DevelopmentContent({ boardConfigs }: DevelopmentContentProps) {
+  // Hard guard so a production build never accidentally renders the dev UI.
+  if (process.env.NODE_ENV !== 'development') {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="h6">Development tools are disabled in production builds.</Typography>
+      </Box>
+    );
+  }
+
+  return <DevelopmentInner boardConfigs={boardConfigs} />;
+}
+
+function DevelopmentInner({ boardConfigs }: DevelopmentContentProps) {
+  const [connections, setConnections] = useState<Esp32Connection[]>([]);
+  const [active, setActive] = useState<string>(ADD_TAB);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Load persisted connections on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void getPreference<Esp32Connection[]>('esp32Connections').then((list) => {
+      if (cancelled) return;
+      const safe = Array.isArray(list) ? list : [];
+      setConnections(safe);
+      setActive(safe.length > 0 ? safe[0].id : ADD_TAB);
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist any change.
+  useEffect(() => {
+    if (!loaded) return;
+    void setPreference('esp32Connections', connections);
+  }, [connections, loaded]);
+
+  const handleTabChange = (_: React.SyntheticEvent, value: string): void => {
+    if (value === ADD_TAB) {
+      openAddDialog();
+      return;
+    }
+    setActive(value);
+  };
+
+  // The "+" tab needs its own onClick because MUI's Tabs onChange does not fire
+  // when the clicked value already equals `value` — which happens whenever the
+  // connections list is empty (ADD_TAB is the only/active tab).
+  const openAddDialog = (): void => {
+    setEditingId(null);
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = (conn: Esp32Connection): void => {
+    setConnections((prev) => {
+      const idx = prev.findIndex((c) => c.id === conn.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = conn;
+        return next;
+      }
+      return [...prev, conn];
+    });
+    setActive(conn.id);
+    setDialogOpen(false);
+    setEditingId(null);
+  };
+
+  const handleEdit = (id: string): void => {
+    setEditingId(id);
+    setDialogOpen(true);
+  };
+
+  const handleRemove = (id: string): void => {
+    setConnections((prev) => {
+      const next = prev.filter((c) => c.id !== id);
+      if (active === id) setActive(next[0]?.id ?? ADD_TAB);
+      return next;
+    });
+  };
+
+  const editingConnection = editingId ? connections.find((c) => c.id === editingId) : undefined;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        // Both the global header and the bottom tab bar are `position: fixed`,
+        // so we carve out vertical space for both. --global-header-height +
+        // themeTokens.layout.bottomNavSpacer (which already includes the iOS
+        // safe-area inset) match the rest of the app's full-height pages.
+        marginTop: 'var(--global-header-height)',
+        height: `calc(100vh - var(--global-header-height) - ${themeTokens.layout.bottomNavSpacer})`,
+      }}
+    >
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
+        <Tabs
+          value={connections.some((c) => c.id === active) || active === ADD_TAB ? active : ADD_TAB}
+          onChange={handleTabChange}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          {connections.map((conn) => (
+            <Tab key={conn.id} value={conn.id} label={conn.label || conn.ip} sx={{ textTransform: 'none' }} />
+          ))}
+          <Tab value={ADD_TAB} icon={<AddOutlined />} aria-label="Add ESP32" onClick={openAddDialog} />
+        </Tabs>
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        {connections.length === 0 ? (
+          <Box sx={{ p: 4 }}>
+            <Typography variant="h6" gutterBottom>
+              No ESP32 emulators yet
+            </Typography>
+            <Typography color="text.secondary">
+              Click the <strong>+</strong> tab to add one. Flash the firmware from
+              <code> packages/board-controller/esp32/ </code> with <code>pio run -e esp32-emulator -t upload</code> and
+              enter the IP it logs at boot.
+            </Typography>
+          </Box>
+        ) : (
+          // All tabs are mounted in parallel — only the active one is visible.
+          // This keeps every WebSocket open in the background so payloads still
+          // arrive when you switch back. (Standard `TabPanel` unmounts.)
+          connections.map((conn) => (
+            <Esp32Tab
+              key={conn.id}
+              connection={conn}
+              active={active === conn.id}
+              onEdit={() => handleEdit(conn.id)}
+              onRemove={() => handleRemove(conn.id)}
+            />
+          ))
+        )}
+      </Box>
+
+      <AddEsp32Dialog
+        open={dialogOpen}
+        boardConfigs={boardConfigs}
+        initial={editingConnection}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditingId(null);
+        }}
+        onSubmit={handleSubmit}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/development/page.tsx
+++ b/packages/web/app/development/page.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
+
+import DevelopmentContent from './development-content';
+
+export const metadata = createNoIndexMetadata({
+  title: 'Development',
+  description: 'Boardsesh hardware test rig debugger (development build only).',
+  path: '/development',
+});
+
+export default async function DevelopmentPage() {
+  // Same data the user-drawer's "Custom Board" flow loads — drives the
+  // cascading Board → Layout → Size → Sets → Angle dropdowns in AddEsp32Dialog.
+  const boardConfigs = await getAllBoardConfigs();
+  return <DevelopmentContent boardConfigs={boardConfigs} />;
+}

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -1,8 +1,24 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+
 import { createIndexedDBStore, migrateFromLocalStorage } from './idb-helper';
 import type { LogbookPreferences } from './logbook-preferences';
 import type { GradeDisplayFormat } from './grade-colors';
 
 const STORE_NAME = 'preferences';
+
+// Persisted ESP32 emulator connections for the dev-only /development page.
+export type Esp32Connection = {
+  id: string;
+  label: string;
+  ip: string;
+  board: BoardName;
+  serial: string;
+  apiLevel: 2 | 3;
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+  angle: number;
+};
 
 export type UserPreferenceKeyMap = {
   libraryTab: 'playlists' | 'logbook';
@@ -12,6 +28,7 @@ export type UserPreferenceKeyMap = {
   'swipeHint:logbookSeen': boolean;
   tickBarExpanded: boolean;
   'shakeToReport:dismissed': boolean;
+  esp32Connections: Esp32Connection[];
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration


### PR DESCRIPTION
## Summary

- Adds an ESP32 firmware (`packages/board-controller/esp32/`, env `esp32-emulator`) that turns a generic ~$5 dev board into a fake Kilter / Tension / Decoy / Touchstone / Grasshopper / MoonBoard. It accepts BLE writes from the phone or browser and forwards every raw payload over a WebSocket on port 81.
- Adds a dev-only `/development` page (avatar → **Development**) with one tab per connected ESP32 plus a `+` tab for adding more. Each tab decodes the Aurora v2/v3 framing or MoonBoard ASCII back into hold IDs and renders the climb in the existing `BoardRenderer`, exercising the same encoder/framing/protocol logic that runs against real hardware.
- Extracts `BoardConfigSelects` from `board-selector-drawer.tsx` so the add/edit dialog reuses the same cascading **Board → Layout → Size → Sets → Angle** dropdowns as the "Custom Board" flow.
- Documents the whole flow in `CONTRIBUTING.md` under **"Testing BLE end-to-end with an ESP32"** — hardware, setup, daily use, capabilities, troubleshooting.

## Why

The Bluetooth code path is the hardest one to validate without dragging a real climbing board into the room. Lowering that barrier to ~$5 of off-the-shelf hardware should help contributors land BLE changes confidently and reproduce protocol bugs we can't otherwise inspect locally.

## Test plan

- [x] `vp run typecheck:web` — passes.
- [x] `vp check` — 0 errors.
- [x] `vp test run --reporter=agent --project web` — 3808/3808 pass (incl. new `payload-decoder.test.ts` round-trips for v2 single, v3 single, v3 multi-packet R/Q/S, MoonBoard single + chunked, noise resilience).
- [x] `pio run -e esp32-emulator` — builds clean on ESP32-WROVER-E (also tested with ESP32-D0WD-V3).
- [x] Manual E2E: phone pairs with `Kilter Board#751737@3`, queues a climb, holds render in the dev tab.
- [x] Manual E2E: switch to Tension — firmware re-advertises as `Tension Board#…@3`, phone reconnects, Tension role-code colours render correctly.
- [x] Manual E2E: switch to MoonBoard — firmware re-advertises with `MoonBoard {serial}` prefix and UART service UUID, MoonBoard ASCII payloads decode onto the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)