### PR TITLE
fix(dev-tools): review feedback from #1760

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,8 @@ Cost is roughly £5 / $5 for the ESP32. Nothing else is needed — no LEDs, no l
 
 ### Use it from the web app
 
+> **The debug page only works from `http://localhost:3000`.** It opens a plain `ws://<esp32-ip>:81` socket, and browsers block plain WebSockets from HTTPS origins as mixed content. Vercel preview URLs and any other `https://` origin will load the page but the sockets will silently fail. Use a local dev server.
+
 1. Run `vp run dev` and open `http://localhost:3000`.
 2. Click your avatar (top-left) → **Development**. The menu entry only appears in development builds.
 3. Click the **+** tab and fill in:

--- a/packages/board-controller/esp32/src/emulator/ws_server.cpp
+++ b/packages/board-controller/esp32/src/emulator/ws_server.cpp
@@ -7,7 +7,10 @@
 
 namespace {
 
-WebSocketsServer gWs(81);
+// Allocated lazily in EmulatorWsServer::begin() so the caller's `port` arg
+// actually applies. The library's WebSocketsServer takes the port at
+// construction, so a file-scope instance would lock us to a hard-coded port.
+WebSocketsServer* gWs = nullptr;
 
 constexpr const char* FW_VERSION = "0.1.0";
 
@@ -37,7 +40,7 @@ String configToHelloJson(const EmulatorConfig& cfg) {
 void onWsEvent(uint8_t clientId, WStype_t type, uint8_t* payload, size_t length) {
     switch (type) {
         case WStype_CONNECTED: {
-            IPAddress ip = gWs.remoteIP(clientId);
+            IPAddress ip = gWs->remoteIP(clientId);
             Serial.printf("[WS] #%u connected from %s\n", clientId, ip.toString().c_str());
             wsServer.handleClientConnected(clientId);
             break;
@@ -62,15 +65,21 @@ void onWsEvent(uint8_t clientId, WStype_t type, uint8_t* payload, size_t length)
 EmulatorWsServer wsServer;
 
 bool EmulatorWsServer::begin(uint16_t port) {
-    (void)port;  // hard-coded to 81 in the ctor of WebSocketsServer above.
-    gWs.begin();
-    gWs.onEvent(onWsEvent);
-    Serial.println("[WS] Listening on port 81");
+    if (gWs != nullptr) {
+        // Idempotent — calling begin() twice with a different port isn't
+        // supported by the underlying library, so just keep the first.
+        Serial.println("[WS] begin() called twice — keeping existing server");
+        return true;
+    }
+    gWs = new WebSocketsServer(port);
+    gWs->begin();
+    gWs->onEvent(onWsEvent);
+    Serial.printf("[WS] Listening on port %u\n", static_cast<unsigned>(port));
     return true;
 }
 
 void EmulatorWsServer::loop() {
-    gWs.loop();
+    if (gWs) gWs->loop();
 }
 
 void EmulatorWsServer::broadcastBleWrite(const uint8_t* data, size_t length) {
@@ -80,7 +89,7 @@ void EmulatorWsServer::broadcastBleWrite(const uint8_t* data, size_t length) {
     doc["hex"]  = bytesToHex(data, length);
     String out;
     serializeJson(doc, out);
-    gWs.broadcastTXT(out);
+    if (gWs) gWs->broadcastTXT(out);
 }
 
 void EmulatorWsServer::broadcastBleConnection(bool connected) {
@@ -88,17 +97,17 @@ void EmulatorWsServer::broadcastBleConnection(bool connected) {
     doc["type"] = connected ? "ble-connected" : "ble-disconnected";
     String out;
     serializeJson(doc, out);
-    gWs.broadcastTXT(out);
+    if (gWs) gWs->broadcastTXT(out);
 }
 
 void EmulatorWsServer::broadcastHello(const EmulatorConfig& cfg) {
     String out = configToHelloJson(cfg);
-    gWs.broadcastTXT(out);
+    if (gWs) gWs->broadcastTXT(out);
 }
 
 void EmulatorWsServer::handleClientConnected(uint8_t clientId) {
     String hello = configToHelloJson(bleEmulator.getConfig());
-    gWs.sendTXT(clientId, hello);
+    if (gWs) gWs->sendTXT(clientId, hello);
 }
 
 void EmulatorWsServer::handleClientMessage(uint8_t clientId, const String& payload) {
@@ -111,7 +120,7 @@ void EmulatorWsServer::handleClientMessage(uint8_t clientId, const String& paylo
     const char* type = doc["type"] | "";
 
     if (strcmp(type, "ping") == 0) {
-        gWs.sendTXT(clientId, "{\"type\":\"pong\"}");
+        if (gWs) gWs->sendTXT(clientId, "{\"type\":\"pong\"}");
         return;
     }
 
@@ -124,7 +133,7 @@ void EmulatorWsServer::handleClientMessage(uint8_t clientId, const String& paylo
         if (strlen(board) > 0) {
             EmulatedBoard b;
             if (!BleEmulator::parseBoard(String(board), b)) {
-                gWs.sendTXT(clientId, "{\"type\":\"error\",\"message\":\"unknown board\"}");
+                if (gWs) gWs->sendTXT(clientId, "{\"type\":\"error\",\"message\":\"unknown board\"}");
                 return;
             }
             cfg.board = b;
@@ -144,7 +153,7 @@ void EmulatorWsServer::handleClientMessage(uint8_t clientId, const String& paylo
         ack["config"]["apiLevel"] = cfg.apiLevel;
         String out;
         serializeJson(ack, out);
-        gWs.broadcastTXT(out);
+        if (gWs) gWs->broadcastTXT(out);
         return;
     }
 

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -35,6 +35,7 @@ import {
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
 import BuildOutlined from '@mui/icons-material/BuildOutlined';
+import DeveloperBoardOutlined from '@mui/icons-material/DeveloperBoardOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import DevUrlDialog from '../dev-url-dialog/dev-url-dialog';
 import { useDevUrl } from '@/app/lib/dev-url';
@@ -337,7 +338,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               {process.env.NODE_ENV === 'development' && (
                 <Link href="/development" className={styles.menuItem} onClick={handleClose}>
                   <span className={styles.menuItemIcon}>
-                    <BuildOutlined />
+                    <DeveloperBoardOutlined />
                   </span>
                   <span className={styles.menuItemLabel}>Development</span>
                 </Link>

--- a/packages/web/app/development/components/esp32-tab.tsx
+++ b/packages/web/app/development/components/esp32-tab.tsx
@@ -181,9 +181,14 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
       </Box>
 
       {latest && (
-        <Box sx={{ fontFamily: 'monospace', fontSize: 12, opacity: 0.7, wordBreak: 'break-all' }}>
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+          sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+        >
           frames: {latest.framesString || '(empty)'}
-        </Box>
+        </Typography>
       )}
     </Box>
   );

--- a/packages/web/app/development/components/payload-decoder.ts
+++ b/packages/web/app/development/components/payload-decoder.ts
@@ -8,7 +8,7 @@
 // snapshot when a single-frame (T/P) or multi-frame (R…Q…S / N…M…O) sequence
 // completes.
 
-import { buildFramesString, getReverseLedPlacements } from '@boardsesh/board-constants/led-placements';
+import { buildFramesString } from '@boardsesh/board-constants/led-placements';
 import type { BoardName } from '@boardsesh/shared-schema';
 
 import { MOONBOARD_GRID } from '@/app/lib/moonboard-config';
@@ -339,6 +339,3 @@ export function decodeOnce(bytes: Uint8Array, config: DecoderConfig): DecodedFra
   const frames = decoder.push(bytes);
   return frames[0] ?? null;
 }
-
-// Re-export reverse placements helper for callers building UI tooltips.
-export { getReverseLedPlacements };

--- a/packages/web/app/development/development-content.tsx
+++ b/packages/web/app/development/development-content.tsx
@@ -20,20 +20,9 @@ type DevelopmentContentProps = {
   boardConfigs: BoardConfigData;
 };
 
+// The dev-mode guard lives in page.tsx (notFound() server-side) so production
+// requests never reach this client component. We don't repeat it here.
 export default function DevelopmentContent({ boardConfigs }: DevelopmentContentProps) {
-  // Hard guard so a production build never accidentally renders the dev UI.
-  if (process.env.NODE_ENV !== 'development') {
-    return (
-      <Box sx={{ p: 4 }}>
-        <Typography variant="h6">Development tools are disabled in production builds.</Typography>
-      </Box>
-    );
-  }
-
-  return <DevelopmentInner boardConfigs={boardConfigs} />;
-}
-
-function DevelopmentInner({ boardConfigs }: DevelopmentContentProps) {
   const [connections, setConnections] = useState<Esp32Connection[]>([]);
   const [active, setActive] = useState<string>(ADD_TAB);
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/packages/web/app/development/page.tsx
+++ b/packages/web/app/development/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { notFound } from 'next/navigation';
 
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getAllBoardConfigs } from '@/app/lib/server-board-configs';
@@ -12,6 +13,14 @@ export const metadata = createNoIndexMetadata({
 });
 
 export default async function DevelopmentPage() {
+  // Hard server-side guard: in production builds we never want to load the
+  // dev tooling at all. Calling notFound() here also skips the
+  // getAllBoardConfigs() fetch below, so we don't pay the work-cost on every
+  // production request.
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
   // Same data the user-drawer's "Custom Board" flow loads — drives the
   // cascading Board → Layout → Size → Sets → Angle dropdowns in AddEsp32Dialog.
   const boardConfigs = await getAllBoardConfigs();


### PR DESCRIPTION
## Summary

Six small follow-ups from the review of #1760:

1. **`ws_server.cpp` honours the `port` arg.** The `WebSocketsServer` was constructed at file scope with port 81 hard-coded, so `begin(9000)` silently used 81. Allocated lazily inside `begin()` now.
2. **Dev-mode guard moved to the server.** `page.tsx` calls `notFound()` in production so we skip the `getAllBoardConfigs()` fetch entirely. Removed the now-redundant client-side guard from `development-content.tsx`.
3. **Dead re-export gone.** `getReverseLedPlacements` had no callers in this repo — removed the import and re-export from `payload-decoder.ts`.
4. **Distinct icon for the Development menu entry.** Switched from `BuildOutlined` (still used by Dev URL) to `DeveloperBoardOutlined`.
5. **Typography token instead of pixel fontSize.** `esp32-tab.tsx` frames footer is now `Typography variant="caption" color="text.secondary"` per `CLAUDE.md`.
6. **Mixed-content note in CONTRIBUTING.md.** Calls out that `ws://` is blocked from HTTPS origins, so the debug page only works from `http://localhost:3000`. Vercel previews silently fail otherwise.

## Test plan

- [x] `vp run typecheck:web` — passes.
- [x] `vp check` — 0 errors.
- [x] `vp test run --reporter=agent --project web packages/web/app/development` — 9/9 pass.
- [x] `pio run -e esp32-emulator` — builds clean.
- [ ] Manual: confirm `/development` returns 404 in a `NODE_ENV=production` build.
- [ ] Manual: re-flash, confirm serial log prints the actual configured port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)