### PR TITLE
Add preview mode for climbs (#1779)

### DIFF
--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -162,13 +162,24 @@ vi.mock('@/app/hooks/use-drawer-drag-resize', () => ({
 vi.mock('@/app/theme/theme-config', () => ({
   themeTokens: {
     spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 16: 64 },
-    colors: { error: '#B8524C', primary: '#8C4A52', success: '#6B9080' },
+    colors: { error: '#B8524C', primary: '#8C4A52', success: '#6B9080', info: '#4A6F8A' },
     neutral: { 200: '#E5E7EB', 400: '#9CA3AF', 500: '#6B7280', 600: '#4B5563' },
     typography: {
       fontSize: { xs: 12, sm: 14, xl: 20, '2xl': 24 },
       fontWeight: { normal: 400, semibold: 600, bold: 700 },
     },
   },
+}));
+
+const mockSetPreviewClimb = vi.fn();
+vi.mock('../../queue-control/preview-climb-context', () => ({
+  usePreviewClimb: () => ({ previewClimb: null, setPreviewClimb: mockSetPreviewClimb }),
+}));
+
+const mockDispatchOpenPlayDrawer = vi.fn();
+vi.mock('../../queue-control/play-drawer-event', () => ({
+  dispatchOpenPlayDrawer: () => mockDispatchOpenPlayDrawer(),
+  PLAY_DRAWER_EVENT: 'boardsesh:open-play-drawer',
 }));
 
 // Default props that every ClimbListItem render needs
@@ -224,6 +235,8 @@ describe('ClimbListItem', () => {
     mockDoubleTapFavorite.dismissHeart = vi.fn();
     mockDoubleTapFavorite.isFavorited = false;
     mockDoubleTapFavorite.toggleFavorite = vi.fn();
+    mockSetPreviewClimb.mockReset();
+    mockDispatchOpenPlayDrawer.mockReset();
   });
 
   describe('basic rendering', () => {
@@ -697,7 +710,24 @@ describe('ClimbListItem', () => {
       expect(addToQueue).toHaveBeenCalledWith(climb);
     });
 
-    it('calls onOpenPlaylistSelector on swipe-right', () => {
+    it('opens preview drawer on short swipe-right', () => {
+      const climb = makeClimb();
+      render(
+        <ClimbListItem
+          pathname={defaultPathname}
+          isDark={defaultIsDark}
+          climb={climb}
+          boardDetails={makeBoardDetails()}
+        />,
+      );
+
+      const swipeRightHandler = capturedSwipeOptions?.onSwipeRight as () => void;
+      swipeRightHandler();
+      expect(mockSetPreviewClimb).toHaveBeenCalledWith(climb);
+      expect(mockDispatchOpenPlayDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onOpenPlaylistSelector on long swipe-right', () => {
       const onOpenPlaylistSelector = vi.fn();
       const climb = makeClimb();
       render(
@@ -710,27 +740,9 @@ describe('ClimbListItem', () => {
         />,
       );
 
-      const swipeRightHandler = capturedSwipeOptions?.onSwipeRight as () => void;
-      swipeRightHandler();
-      expect(onOpenPlaylistSelector).toHaveBeenCalledWith(climb);
-    });
-
-    it('calls onOpenActions on long swipe-right', () => {
-      const onOpenActions = vi.fn();
-      const climb = makeClimb();
-      render(
-        <ClimbListItem
-          pathname={defaultPathname}
-          isDark={defaultIsDark}
-          climb={climb}
-          boardDetails={makeBoardDetails()}
-          onOpenActions={onOpenActions}
-        />,
-      );
-
       const swipeRightLongHandler = capturedSwipeOptions?.onSwipeRightLong as () => void;
       swipeRightLongHandler();
-      expect(onOpenActions).toHaveBeenCalledWith(climb);
+      expect(onOpenPlaylistSelector).toHaveBeenCalledWith(climb);
     });
   });
 });

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -7,8 +7,11 @@ import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
+import VisibilityOutlined from '@mui/icons-material/VisibilityOutlined';
 import { track } from '@vercel/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
+import { usePreviewClimb } from '../queue-control/preview-climb-context';
+import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
 import ClimbThumbnail from './climb-thumbnail';
 import ClimbTitle, { type ClimbTitleProps } from './climb-title';
 import DrawerClimbHeader from './drawer-climb-header';
@@ -66,16 +69,17 @@ const rightSwipeActionLayerBaseStyle: React.CSSProperties = {
   willChange: 'opacity',
 };
 
-// Static initial styles for action layers — opacity updated via direct DOM manipulation during swipe
+// Static initial styles for action layers — opacity updated via direct DOM manipulation during swipe.
+// Short → swipe = preview (slate info color); long → swipe = add to playlist (primary).
 const shortSwipeLayerInitialStyle: React.CSSProperties = {
   ...swipeActionLayerBaseStyle,
-  backgroundColor: themeTokens.colors.primary,
+  backgroundColor: themeTokens.colors.info,
   opacity: 0,
 };
 
 const longSwipeLayerInitialStyle: React.CSSProperties = {
   ...swipeActionLayerBaseStyle,
-  backgroundColor: themeTokens.neutral[600],
+  backgroundColor: themeTokens.colors.primary,
   opacity: 0,
 };
 
@@ -257,6 +261,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     // When `selectedOverride` or `disableSelection` is provided, ignore the store value.
     const storeSelected = useIsClimbSelected(climb.uuid);
     const selected = selectedOverride ?? (disableSelection ? false : storeSelected);
+    const { setPreviewClimb } = usePreviewClimb();
     // Check if we're inside a BoardProvider — needed for inline tick bar
     const boardProvider = useOptionalBoardProvider();
     // When parent provides both drawer callbacks or a custom menuSlot, skip local drawers entirely.
@@ -293,8 +298,18 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
       track('Add to Queue', { source: 'swipe' });
     }, [climb]);
 
-    // Swipe right short (left action): open playlist selector
+    // Swipe right short (left action): preview the climb in the play drawer
+    // without sending it to the board. The play drawer reads `previewClimb`
+    // from PreviewClimbContext and renders preview-mode UI.
     const handleDefaultSwipeRight = useCallback(() => {
+      setPreviewClimb(climb);
+      dispatchOpenPlayDrawer();
+      track('Climb Preview Opened', { source: 'swipe' });
+    }, [climb, setPreviewClimb]);
+
+    // Swipe right long (left action): open the playlist selector (the
+    // ellipsis actions menu is still reachable via the ⋯ button).
+    const handleDefaultSwipeRightLong = useCallback(() => {
       if (onOpenPlaylistSelector) {
         onOpenPlaylistSelector(climb);
       } else {
@@ -302,16 +317,6 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
         setIsPlaylistSelectorOpen(true);
       }
     }, [onOpenPlaylistSelector, climb]);
-
-    // Swipe right long (left action): open actions menu
-    const handleDefaultSwipeRightLong = useCallback(() => {
-      if (onOpenActions) {
-        onOpenActions(climb);
-      } else {
-        setIsPlaylistSelectorOpen(false);
-        setIsActionsOpen(true);
-      }
-    }, [onOpenActions, climb]);
 
     // Override handler for right swipe action (e.g., tick in queue)
     const handleOverrideSwipeLeft = useCallback(() => {
@@ -548,13 +553,13 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
         <div style={containerStyle}>
           {!disableSwipe && (
             <>
-              {/* Left action (revealed on swipe right) */}
+              {/* Left action (revealed on swipe right): short = preview, long = add to playlist */}
               <div ref={leftActionCombinedRef} style={defaultLeftActionStyle}>
                 <div ref={shortSwipeLayerRef} style={shortSwipeLayerInitialStyle}>
-                  <LocalOfferOutlined style={iconStyle} />
+                  <VisibilityOutlined style={iconStyle} />
                 </div>
                 <div ref={longSwipeLayerRef} style={longSwipeLayerInitialStyle}>
-                  <MoreHorizOutlined style={iconStyle} />
+                  <LocalOfferOutlined style={iconStyle} />
                 </div>
               </div>
 

--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -10,6 +10,13 @@
   border-bottom: 1px solid var(--neutral-100);
 }
 
+.onBoardPillRow {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  padding: 8px 12px 0;
+}
+
 .boardSectionWrapper {
   flex: 1;
   min-height: 0;

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -13,6 +13,7 @@ import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
 import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
@@ -39,6 +40,9 @@ import { QuickTickBar, type QuickTickBarHandle } from '../logbook/quick-tick-bar
 import { hasPriorHistoryForClimb } from '@/app/hooks/use-tick-save';
 import type { ActiveDrawer } from '../queue-control/queue-control-bar';
 import { PLAY_DRAWER_EVENT } from '../queue-control/play-drawer-event';
+import { usePreviewClimb } from '../queue-control/preview-climb-context';
+import MuiButton from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import {
   TOUR_CLOSE_PLAY_QUEUE_EVENT,
   TOUR_OPEN_PLAY_QUEUE_EVENT,
@@ -102,6 +106,11 @@ type PlayViewActionBarProps = {
   onOpenActions: () => void;
   onOpenQueue: () => void;
   angleSelector?: React.ReactNode;
+  /** When true, renders the preview variant: hides prev/next/queue and shows
+   *  a primary "Send to board" CTA. */
+  isPreview?: boolean;
+  onSendToBoard?: () => void;
+  sendDisabled?: boolean;
 };
 
 export const PlayViewActionBar = React.memo(function PlayViewActionBar({
@@ -118,12 +127,17 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   onOpenActions,
   onOpenQueue,
   angleSelector,
+  isPreview = false,
+  onSendToBoard,
+  sendDisabled,
 }: PlayViewActionBarProps) {
   return (
     <div className={styles.actionBar}>
-      <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
-        <SkipPreviousOutlined />
-      </IconButton>
+      {!isPreview && (
+        <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
+          <SkipPreviousOutlined />
+        </IconButton>
+      )}
       {supportsMirroring && (
         <IconButton
           color={isMirrored ? 'primary' : 'default'}
@@ -150,23 +164,43 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
       <IconButton onClick={onOpenActions} aria-label="Climb actions">
         <MoreHorizOutlined />
       </IconButton>
-      <MuiBadge
-        badgeContent={remainingQueueCount}
-        max={99}
-        sx={{
-          '& .MuiBadge-badge': {
+      {isPreview ? (
+        <MuiButton
+          variant="contained"
+          startIcon={<LightbulbOutlined />}
+          onClick={onSendToBoard}
+          disabled={sendDisabled || !onSendToBoard}
+          sx={{
+            flex: 1,
             backgroundColor: themeTokens.colors.primary,
             color: 'common.white',
-          },
-        }}
-      >
-        <IconButton onClick={onOpenQueue} aria-label="Open queue">
-          <FormatListBulletedOutlined />
-        </IconButton>
-      </MuiBadge>
-      <IconButton disabled={!canSwipeNext} onClick={onNextClick}>
-        <SkipNextOutlined />
-      </IconButton>
+            textTransform: 'none',
+            '&:hover': { backgroundColor: themeTokens.colors.primaryHover },
+          }}
+        >
+          Send to board
+        </MuiButton>
+      ) : (
+        <>
+          <MuiBadge
+            badgeContent={remainingQueueCount}
+            max={99}
+            sx={{
+              '& .MuiBadge-badge': {
+                backgroundColor: themeTokens.colors.primary,
+                color: 'common.white',
+              },
+            }}
+          >
+            <IconButton onClick={onOpenQueue} aria-label="Open queue">
+              <FormatListBulletedOutlined />
+            </IconButton>
+          </MuiBadge>
+          <IconButton disabled={!canSwipeNext} onClick={onNextClick}>
+            <SkipNextOutlined />
+          </IconButton>
+        </>
+      )}
     </div>
   );
 });
@@ -465,10 +499,17 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
   const { currentClimb, currentClimbQueueItem } = isOpen ? currentClimbData : deferredCurrentClimb;
   const { queue } = isOpen ? queueListData : deferredQueue;
   const { viewOnlyMode } = isOpen ? sessionData : deferredSession;
-  const { mirrorClimb, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem } = useQueueActions();
+  const { mirrorClimb, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem, setCurrentClimb } =
+    useQueueActions();
+
+  const { previewClimb, setPreviewClimb } = usePreviewClimb();
+  const isPreviewMode = previewClimb !== null;
+  const displayedClimb = previewClimb ?? currentClimb;
+  const showOnBoardPill =
+    isPreviewMode && currentClimbQueueItem?.climb && currentClimbQueueItem.climb.uuid !== previewClimb?.uuid;
 
   const { handleDoubleTap, showHeart, dismissHeart, isFavorited, toggleFavorite } = useDoubleTapFavorite({
-    climbUuid: currentClimb?.uuid ?? '',
+    climbUuid: displayedClimb?.uuid ?? '',
   });
 
   const currentQueueIndex = currentClimbQueueItem
@@ -501,17 +542,41 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
     if (isActionsOpen || isQueueOpen || isPlaylistSelectorOpen) return;
     setDrawerOpen(false);
     setActiveDrawer('none');
+    setPreviewClimb(null);
     if (window.location.hash === '#playing') {
       window.history.back();
     }
-  }, [setActiveDrawer, isActionsOpen, isQueueOpen, isPlaylistSelectorOpen]);
+  }, [setActiveDrawer, isActionsOpen, isQueueOpen, isPlaylistSelectorOpen, setPreviewClimb]);
+
+  // Promote the previewed climb onto the board: reuse an existing queue item
+  // when the climb is already queued, otherwise create one. setCurrentClimb
+  // both inserts the item and makes it current, which the BluetoothAutoSender
+  // picks up to light the wall.
+  const handleSendPreviewToBoard = useCallback(async () => {
+    if (!previewClimb || viewOnlyMode) return;
+    const existing = queue.find((item) => item.climb.uuid === previewClimb.uuid);
+    if (existing) {
+      setCurrentClimbQueueItem(existing);
+    } else {
+      await setCurrentClimb(previewClimb);
+    }
+    setPreviewClimb(null);
+    track('Climb Sent From Preview', { climbUuid: previewClimb.uuid });
+  }, [previewClimb, viewOnlyMode, queue, setCurrentClimbQueueItem, setCurrentClimb, setPreviewClimb]);
+
+  // "On board: <name>" pill — flips the drawer back to on-board mode by
+  // clearing the preview state. The drawer re-renders against
+  // currentClimbQueueItem without closing/reopening.
+  const handleJumpToOnBoard = useCallback(() => {
+    setPreviewClimb(null);
+  }, [setPreviewClimb]);
 
   // Compute ascent info for tick FAB badge
   const currentAngle = typeof angle === 'string' ? parseInt(angle, 10) : angle;
   const filteredLogbook = useMemo(() => {
-    if (!logbook || !currentClimb) return [];
-    return logbook.filter((asc) => asc.climb_uuid === currentClimb.uuid && Number(asc.angle) === currentAngle);
-  }, [logbook, currentClimb, currentAngle]);
+    if (!logbook || !displayedClimb) return [];
+    return logbook.filter((asc) => asc.climb_uuid === displayedClimb.uuid && Number(asc.angle) === currentAngle);
+  }, [logbook, displayedClimb, currentAngle]);
 
   const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
   const ascentCount = filteredLogbook.length;
@@ -547,10 +612,10 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
     setIsTickBarActive(false);
   }, []);
 
-  // Reset tick bar when the climb changes so it doesn't stay open for the wrong climb
+  // Reset tick bar when the displayed climb changes so it doesn't stay open for the wrong climb
   useEffect(() => {
     setIsTickBarActive(false);
-  }, [currentClimb?.uuid]);
+  }, [displayedClimb?.uuid]);
 
   const handleTickBarError = useCallback(() => {
     showMessage("Couldn't save your tick — it's saved as a draft", 'error');
@@ -580,7 +645,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
     setIsQueueOpen(true);
   }, []);
 
-  const isMirrored = !!currentClimb?.mirrored;
+  const isMirrored = !!displayedClimb?.mirrored;
 
   // Go to queue from actions drawer
   const handleGoToQueueFromActions = useCallback(() => {
@@ -659,8 +724,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
       setIsQueueOpen(false);
       setIsActionsOpen(false);
       setIsTickBarActive(false);
+      setPreviewClimb(null);
     }
-  }, [isOpen]);
+  }, [isOpen, setPreviewClimb]);
 
   useEffect(() => {
     if (isOpen) {
@@ -686,20 +752,20 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
     if (open) setSectionsEverEnabled(true);
   }, []);
 
-  const currentFrames = currentClimb?.frames;
-  const currentMirrored = currentClimb?.mirrored;
+  const displayedFrames = displayedClimb?.frames;
+  const displayedMirrored = displayedClimb?.mirrored;
   useEffect(() => {
-    if (currentClimb) {
+    if (displayedClimb) {
       renderBoard({
         boardDetails,
-        frames: currentClimb.frames,
-        mirrored: !!currentClimb.mirrored,
+        frames: displayedClimb.frames,
+        mirrored: !!displayedClimb.mirrored,
       }).catch((e: unknown) => {
         if (process.env.NODE_ENV === 'development') console.info('Pre-warm render failed:', e);
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
-  }, [currentFrames, currentMirrored, boardDetails]);
+  }, [displayedFrames, displayedMirrored, boardDetails]);
 
   const handleBoardPullClose = useCallback(() => {
     setDrawerOpen(false);
@@ -745,36 +811,71 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
   }, [boardPull]);
 
   const aboveFold = useMemo(() => {
-    if (!currentClimb) return null;
+    if (!displayedClimb) return null;
     return (
       <>
-        {/* Header: Grade | Name */}
+        {/* Preview-mode "On board: <name>" pill — single tap returns to the
+            on-board climb without closing the drawer. */}
+        {showOnBoardPill && currentClimbQueueItem?.climb && (
+          <div className={styles.onBoardPillRow}>
+            <Chip
+              icon={<LightbulbOutlined sx={{ fontSize: 16 }} />}
+              label={`On board: ${currentClimbQueueItem.climb.name}`}
+              onClick={handleJumpToOnBoard}
+              size="small"
+              sx={{
+                maxWidth: '100%',
+                backgroundColor: themeTokens.colors.primary,
+                color: 'common.white',
+                '& .MuiChip-icon': { color: 'common.white' },
+                '& .MuiChip-label': {
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                },
+              }}
+            />
+          </div>
+        )}
+
+        {/* Header: Grade | Name (with optional "Preview" eyebrow) */}
         <div className={styles.headerSection}>
-          <ClimbDetailHeader climb={currentClimb} />
+          {isPreviewMode && (
+            <div
+              style={{
+                fontSize: themeTokens.typography.fontSize.xs,
+                fontWeight: 600,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: 'var(--neutral-500)',
+                marginBottom: themeTokens.spacing[1],
+              }}
+            >
+              Preview
+            </div>
+          )}
+          <ClimbDetailHeader climb={displayedClimb} />
         </div>
 
         {/* Board renderer with card-swipe and floating Tick FAB */}
         <div className={styles.boardSectionWrapper}>
-          {currentClimb && (
-            <SwipeBoardCarousel
-              boardDetails={boardDetails}
-              currentClimb={currentClimb}
-              nextClimb={nextItem?.climb}
-              previousClimb={prevItem?.climb}
-              onSwipeNext={handleSwipeNext}
-              onSwipePrevious={handleSwipePrevious}
-              canSwipeNext={canSwipeNext}
-              canSwipePrevious={canSwipePrevious}
-              className={styles.boardSection}
-              boardContainerClassName={styles.swipeCardContainer}
-              fillContainer
-              onDoubleTap={handleDoubleTap}
-              showZoomHint
-              isDrawerOpen={isOpen}
-              onZoomChange={setIsBoardZoomed}
-              overlay={<HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} />}
-            />
-          )}
+          <SwipeBoardCarousel
+            boardDetails={boardDetails}
+            currentClimb={displayedClimb}
+            nextClimb={isPreviewMode ? undefined : nextItem?.climb}
+            previousClimb={isPreviewMode ? undefined : prevItem?.climb}
+            onSwipeNext={handleSwipeNext}
+            onSwipePrevious={handleSwipePrevious}
+            canSwipeNext={!isPreviewMode && canSwipeNext}
+            canSwipePrevious={!isPreviewMode && canSwipePrevious}
+            className={styles.boardSection}
+            boardContainerClassName={styles.swipeCardContainer}
+            fillContainer
+            onDoubleTap={handleDoubleTap}
+            showZoomHint
+            isDrawerOpen={isOpen}
+            onZoomChange={setIsBoardZoomed}
+            overlay={<HeartAnimationOverlay visible={showHeart} onAnimationEnd={dismissHeart} />}
+          />
 
           {/* Floating Tick FAB - hides when tick bar is active */}
           {isOpen && (
@@ -801,10 +902,10 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
           )}
 
           {/* Floating tick bar — overlays bottom of board section, no reflow */}
-          {isOpen && currentClimb && (
+          {isOpen && (
             <PlayViewTickBar
               isTickBarActive={isTickBarActive}
-              currentClimb={currentClimb}
+              currentClimb={displayedClimb}
               angle={angle}
               boardDetails={boardDetails}
               onClose={handleTickBarClose}
@@ -813,11 +914,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
           )}
         </div>
 
-        {/* Action bar */}
+        {/* Action bar — preview mode swaps prev/next + queue badge for a
+            primary "Send to board" button. Mirror, favorite, share, and
+            angle controls stay so the user can prep before sending. */}
         {isOpen && (
           <PlayViewActionBar
-            canSwipePrevious={canSwipePrevious}
-            canSwipeNext={canSwipeNext}
+            canSwipePrevious={!isPreviewMode && canSwipePrevious}
+            canSwipeNext={!isPreviewMode && canSwipeNext}
             isMirrored={isMirrored}
             supportsMirroring={!!boardDetails.supportsMirroring}
             isFavorited={isFavorited}
@@ -828,12 +931,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
             onToggleFavorite={toggleFavorite}
             onOpenActions={handleOpenActionsMenu}
             onOpenQueue={handleOpenQueueDrawer}
+            isPreview={isPreviewMode}
+            onSendToBoard={handleSendPreviewToBoard}
+            sendDisabled={viewOnlyMode}
             angleSelector={
               <AngleSelector
                 boardName={boardDetails.board_name}
                 boardDetails={boardDetails}
                 currentAngle={currentAngle}
-                currentClimb={currentClimb}
+                currentClimb={displayedClimb}
                 isAngleAdjustable
               />
             }
@@ -842,7 +948,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
       </>
     );
   }, [
-    currentClimb,
+    displayedClimb,
     boardDetails,
     currentAngle,
     nextItem,
@@ -871,6 +977,12 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
     angle,
     handleTickBarClose,
     handleTickBarError,
+    isPreviewMode,
+    showOnBoardPill,
+    currentClimbQueueItem?.climb,
+    handleJumpToOnBoard,
+    handleSendPreviewToBoard,
+    viewOnlyMode,
   ]);
 
   return (
@@ -914,9 +1026,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
             onTouchMove={handleBoardTouchMove}
             onTouchEnd={handleBoardTouchEnd}
           >
-            {currentClimb ? (
+            {displayedClimb ? (
               <PlayDrawerContent
-                climb={currentClimb}
+                climb={displayedClimb}
                 boardType={boardDetails.board_name}
                 angle={currentAngle}
                 sectionsEnabled={sectionsEverEnabled && isOpen}
@@ -928,15 +1040,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
           </div>
 
           {/* Climb actions drawer */}
-          {isOpen && currentClimb && isActionsOpen && (
+          {isOpen && displayedClimb && isActionsOpen && (
             <SwipeableDrawer
               placement="bottom"
               title={
-                currentClimb ? (
-                  <div data-swipe-blocked="" {...actionsDragHandlers} className={drawerCss.dragHeaderWrapper}>
-                    <DrawerClimbHeader climb={currentClimb} boardDetails={boardDetails} />
-                  </div>
-                ) : undefined
+                <div data-swipe-blocked="" {...actionsDragHandlers} className={drawerCss.dragHeaderWrapper}>
+                  <DrawerClimbHeader climb={displayedClimb} boardDetails={boardDetails} />
+                </div>
               }
               height="60%"
               paperRef={actionsPaperRef}
@@ -953,7 +1063,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
               }}
             >
               <ClimbActions
-                climb={currentClimb}
+                climb={displayedClimb}
                 boardDetails={boardDetails}
                 angle={currentAngle}
                 currentPathname={pathname}
@@ -969,9 +1079,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
           )}
 
           {/* Playlist selector drawer */}
-          {isOpen && currentClimb && isPlaylistSelectorOpen && (
+          {isOpen && displayedClimb && isPlaylistSelectorOpen && (
             <SwipeableDrawer
-              title={<DrawerClimbHeader climb={currentClimb} boardDetails={boardDetails} />}
+              title={<DrawerClimbHeader climb={displayedClimb} boardDetails={boardDetails} />}
               placement="bottom"
               open={isPlaylistSelectorOpen}
               onClose={handleClosePlaylist}
@@ -988,7 +1098,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
               }}
             >
               <PlaylistSelectionContent
-                climbUuid={currentClimb.uuid}
+                climbUuid={displayedClimb.uuid}
                 boardDetails={boardDetails}
                 angle={currentAngle}
                 onDone={handleClosePlaylist}

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { PartyProfileProvider } from '../party-manager/party-profile-context';
 import { PersistentSessionProvider, usePersistentSession } from '../persistent-session';
 import { QueueBridgeProvider, useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
+import { PreviewClimbProvider } from '../queue-control/preview-climb-context';
 import { useCurrentClimb, useQueueList } from '../graphql-queue';
 import QueueControlBar from '../queue-control/queue-control-bar';
 import QueueControlBarShell from '../queue-control/queue-control-bar-shell';
@@ -52,19 +53,21 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
     <PartyProfileProvider>
       <PersistentSessionProvider>
         <QueueBridgeProvider>
-          <BoardSwitchConfirmProvider>
-            <SearchDrawerBridgeProvider>
-              <StatsFilterBridgeProvider>
-                <ProfileHeaderShareProvider>
-                  <GlobalHeader boardConfigs={boardConfigs} />
-                  {children}
-                  <RootBottomBar boardConfigs={boardConfigs} />
-                  <RootSessionSummaryDialog />
-                  <RootSeshSettingsDrawer />
-                </ProfileHeaderShareProvider>
-              </StatsFilterBridgeProvider>
-            </SearchDrawerBridgeProvider>
-          </BoardSwitchConfirmProvider>
+          <PreviewClimbProvider>
+            <BoardSwitchConfirmProvider>
+              <SearchDrawerBridgeProvider>
+                <StatsFilterBridgeProvider>
+                  <ProfileHeaderShareProvider>
+                    <GlobalHeader boardConfigs={boardConfigs} />
+                    {children}
+                    <RootBottomBar boardConfigs={boardConfigs} />
+                    <RootSessionSummaryDialog />
+                    <RootSeshSettingsDrawer />
+                  </ProfileHeaderShareProvider>
+                </StatsFilterBridgeProvider>
+              </SearchDrawerBridgeProvider>
+            </BoardSwitchConfirmProvider>
+          </PreviewClimbProvider>
         </QueueBridgeProvider>
       </PersistentSessionProvider>
     </PartyProfileProvider>

--- a/packages/web/app/components/queue-control/preview-climb-context.tsx
+++ b/packages/web/app/components/queue-control/preview-climb-context.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { Climb } from '@/app/lib/types';
+
+type PreviewClimbContextValue = {
+  previewClimb: Climb | null;
+  setPreviewClimb: (climb: Climb | null) => void;
+};
+
+const NOOP_VALUE: PreviewClimbContextValue = {
+  previewClimb: null,
+  setPreviewClimb: () => {},
+};
+
+const PreviewClimbContext = createContext<PreviewClimbContextValue>(NOOP_VALUE);
+
+export function PreviewClimbProvider({ children }: { children: React.ReactNode }) {
+  const [previewClimb, setPreviewClimbState] = useState<Climb | null>(null);
+
+  const setPreviewClimb = useCallback((climb: Climb | null) => {
+    setPreviewClimbState(climb);
+  }, []);
+
+  const value = useMemo<PreviewClimbContextValue>(
+    () => ({ previewClimb, setPreviewClimb }),
+    [previewClimb, setPreviewClimb],
+  );
+
+  return <PreviewClimbContext.Provider value={value}>{children}</PreviewClimbContext.Provider>;
+}
+
+export function usePreviewClimb(): PreviewClimbContextValue {
+  return useContext(PreviewClimbContext);
+}


### PR DESCRIPTION
Closes #1779.

## Why

Analytics show users still default to the Aurora-app pattern: pick a climb, look at it, swipe inside the viewer to navigate. Boardsesh's queue is being adopted slowly, and the gap is that there's no way to *peek* at a climb. Every viewing moment is also a board-illumination moment because `currentClimbQueueItem` and "what's lit" are the same state.

This change adds a preview mode that lets you peek at any climb in the play drawer without sending it to the board. From preview you can promote with one tap.

## Decisions (sparred with @marcodejongh)

- **Tap stays as set active.** Don't break the dominant 1-tap workflow.
- **Preview entry**: short → swipe on a climb row.
- **Add-to-playlist** moves to long → swipe (replaces the now-redundant ellipsis swipe; the ⋯ button still opens the full actions menu).
- **Send from preview** lights the board, adds the climb to the queue, and promotes it to `currentClimbQueueItem`. The drawer transitions in-place to on-board mode.
- **Mode differentiation**: `Preview` eyebrow + a tappable `On board: <name>` pill at the top, prev/next replaced by a primary `Send to board` button. No board dimming.
- **Jump back to the on-board climb**: tap the pill — the drawer flips back to on-board mode without close/reopen and without a back button.

## Final swipe map

| Gesture | Action |
|---|---|
| Tap row | Set active (existing) |
| Short ← swipe | Add to queue (unchanged) |
| Long ← swipe | unused (reserved) |
| Short → swipe | **Preview** (new) |
| Long → swipe | Add to playlist (was ellipsis) |
| ⋯ button | Full actions menu (unchanged) |

## Implementation

- **`preview-climb-context.tsx`** (new): tiny `PreviewClimbProvider` exposing `previewClimb` + `setPreviewClimb`. Mounted inside `QueueBridgeProvider` in `persistent-session-wrapper.tsx`.
- **`climb-list-item.tsx`**: short → swipe now calls `setPreviewClimb(climb)` + `dispatchOpenPlayDrawer()`. Long → swipe takes over the playlist selector. Peek icons swap to `VisibilityOutlined` / `LocalOfferOutlined`. Long-swipe layer recolored to primary so the playlist swipe keeps a meaningful color.
- **`play-view-drawer.tsx`**: derives `displayedClimb = previewClimb ?? currentClimb`, threads it through every render path. Auto-sender is unchanged — it still watches only `currentClimbQueueItem`, so previewing never lights the board. The drawer renders an "On board: <name>" pill + a primary "Send to board" CTA in preview mode. Promotion uses the existing `setCurrentClimbQueueItem` (when the climb is already in the queue) or `setCurrentClimb` (when it isn't), then clears the preview state. Preview is cleared on every drawer close path.
- **Tests**: updated swipe-direction tests in `climb-list-item.test.tsx`. All 3827 web tests pass.

## Test plan

- [ ] Tap a climb row → drawer opens, LEDs light, climb is in queue (regression).
- [ ] Short → swipe → drawer opens in preview mode, no LEDs, climb NOT in queue. `Preview` eyebrow visible. No prev/next. `Send to board` button visible.
- [ ] Press `Send to board` → LEDs light, drawer flips header + reveals prev/next, climb appears in queue and becomes current.
- [ ] Preview climb B with climb A on the board → `On board: A` pill is visible. Tap pill → drawer flips to on-board mode for A. No close/reopen. LEDs unchanged.
- [ ] Preview a climb when nothing is on the board → no pill.
- [ ] Long → swipe → playlist selector opens.
- [ ] ⋯ button → full actions menu.
- [ ] Party non-leader → preview works; `Send to board` is disabled.
- [ ] Bluetooth disconnected → `Send to board` behaves like today's auto-send (prompts connect / queues for next connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjWLKeF3CbeBMRtYwvRrtW)_