### PR TITLE
feat(android): native bottom tab bar mirroring iOS

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "androidx.webkit:webkit:$androidxWebkitVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -1,5 +1,6 @@
 package com.boardsesh.app;
 
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -11,6 +12,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
 import android.text.TextUtils;
+import android.view.ViewGroup;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -19,8 +21,11 @@ import android.webkit.WebView;
 
 import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.boardsesh.app.plugins.DevUrlPlugin;
+import com.boardsesh.app.plugins.NativeTabBarPlugin;
+import com.boardsesh.app.tabs.TabContainerController;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
@@ -30,9 +35,13 @@ public class MainActivity extends BridgeActivity {
     private static final String DEV_RESET_SCHEME = "boardsesh-dev";
     private final OfflineFallbackStateMachine fallbackState = new OfflineFallbackStateMachine();
 
+    @Nullable
+    private TabContainerController tabContainerController;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DevUrlPlugin.class);
+        registerPlugin(NativeTabBarPlugin.class);
 
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
@@ -50,11 +59,56 @@ public class MainActivity extends BridgeActivity {
         settings.setCacheMode(WebSettings.LOAD_DEFAULT);
         webView.setWebViewClient(new OfflineAwareBridgeWebViewClient(bridge));
 
+        ViewGroup tabContainer = findViewById(R.id.tab_container);
+        ViewGroup tabBarHost = findViewById(R.id.native_tab_bar_host);
+        if (tabContainer != null && tabBarHost != null) {
+            tabContainerController = new TabContainerController(
+                this,
+                tabContainer,
+                tabBarHost,
+                webView,
+                resolveServerUrl()
+            );
+        }
+
         // Cold-start deep link: Capacitor's default load() points the WebView at
         // server.url and discards the launch intent's path, so /join/{id} (and
         // any other App Link) never lands. Mirror SceneDelegate.swift on iOS by
         // forwarding the intent URL into the WebView ourselves.
         loadDeepLinkIfPresent(getIntent(), webView);
+    }
+
+    @Nullable
+    public TabContainerController getTabContainerController() {
+        return tabContainerController;
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        if (tabContainerController == null) return;
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+            tabContainerController.handleMemoryWarning();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (tabContainerController != null) {
+            tabContainerController.destroy();
+            tabContainerController = null;
+        }
+        super.onDestroy();
+    }
+
+    private String resolveServerUrl() {
+        if (bridge != null && bridge.getConfig() != null) {
+            String configured = bridge.getConfig().getServerUrl();
+            if (configured != null && !configured.isEmpty()) {
+                return configured;
+            }
+        }
+        return DevUrlPlugin.DEFAULT_URL;
     }
 
     @Override
@@ -95,7 +149,16 @@ public class MainActivity extends BridgeActivity {
         if (BuildConfig.DEBUG && DevUrlPrefs.getOverrideUrl(this) != null) {
             return;
         }
-        webView.loadUrl(data.toString());
+        if (tabContainerController != null) {
+            // Route the deep link to whichever tab owns the path so /feed/x lands in
+            // the feed tab, /you/x in the you tab, etc. — mirrors SceneDelegate.swift.
+            String path = data.getPath();
+            String tab = TabContainerController.tabForPath(path);
+            String targetTab = "create".equals(tab) ? "climbs" : tab;
+            tabContainerController.navigateToTab(targetTab, data.toString());
+        } else {
+            webView.loadUrl(data.toString());
+        }
     }
 
     @Override

--- a/mobile/android/app/src/main/java/com/boardsesh/app/plugins/NativeTabBarPlugin.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/plugins/NativeTabBarPlugin.java
@@ -24,6 +24,8 @@ public class NativeTabBarPlugin extends Plugin {
 
     private static final String TAG = "NativeTabBarPlugin";
 
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
     @PluginMethod
     public void setActiveTab(PluginCall call) {
         String tab = call.getString("tab", "home");
@@ -86,6 +88,6 @@ public class NativeTabBarPlugin extends Plugin {
     }
 
     private void runOnUi(Runnable runnable) {
-        new Handler(Looper.getMainLooper()).post(runnable);
+        mainHandler.post(runnable);
     }
 }

--- a/mobile/android/app/src/main/java/com/boardsesh/app/plugins/NativeTabBarPlugin.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/plugins/NativeTabBarPlugin.java
@@ -1,0 +1,91 @@
+package com.boardsesh.app.plugins;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.boardsesh.app.MainActivity;
+import com.boardsesh.app.tabs.TabContainerController;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Bridges JavaScript to the native tab bar held by {@link MainActivity}'s
+ * {@link TabContainerController}. Mirrors {@code NativeTabBarPlugin.swift}:
+ * exposes {@code setActiveTab}, {@code setBarsHidden},
+ * {@code setNotificationBadge}, and {@code navigateTab} on
+ * {@code window.Capacitor.Plugins.NativeTabBar}.
+ */
+@CapacitorPlugin(name = "NativeTabBar")
+public class NativeTabBarPlugin extends Plugin {
+
+    private static final String TAG = "NativeTabBarPlugin";
+
+    @PluginMethod
+    public void setActiveTab(PluginCall call) {
+        String tab = call.getString("tab", "home");
+        runOnUi(() -> {
+            TabContainerController controller = controller();
+            if (controller != null && controller.getTabBarView() != null) {
+                controller.getTabBarView().setActiveTab(tab);
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod
+    public void setBarsHidden(PluginCall call) {
+        boolean hidden = Boolean.TRUE.equals(call.getBoolean("hidden", false));
+        runOnUi(() -> {
+            TabContainerController controller = controller();
+            if (controller != null && controller.getTabBarView() != null) {
+                controller.getTabBarView().setBarsHidden(hidden);
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod
+    public void setNotificationBadge(PluginCall call) {
+        Integer count = call.getInt("count", 0);
+        int safeCount = count == null ? 0 : count;
+        runOnUi(() -> {
+            TabContainerController controller = controller();
+            if (controller != null && controller.getTabBarView() != null) {
+                controller.getTabBarView().setNotificationBadge(safeCount);
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod
+    public void navigateTab(PluginCall call) {
+        String tab = call.getString("tab", "home");
+        String url = call.getString("url", "/");
+        runOnUi(() -> {
+            TabContainerController controller = controller();
+            if (controller == null) {
+                call.reject("TabContainerController not available");
+                return;
+            }
+            controller.navigateToTab(tab, url);
+            call.resolve();
+        });
+    }
+
+    private TabContainerController controller() {
+        Activity activity = getActivity();
+        if (activity instanceof MainActivity) {
+            return ((MainActivity) activity).getTabContainerController();
+        }
+        Log.w(TAG, "Host activity is not MainActivity; no controller available");
+        return null;
+    }
+
+    private void runOnUi(Runnable runnable) {
+        new Handler(Looper.getMainLooper()).post(runnable);
+    }
+}

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/NativeTabBarView.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/NativeTabBarView.java
@@ -1,0 +1,258 @@
+package com.boardsesh.app.tabs;
+
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewPropertyAnimator;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.boardsesh.app.R;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Native bottom tab bar mirroring the iOS NativeTabBarView. Renders six tabs
+ * (Home / Climb / Discover / Feed / Create / You) on a translucent dark
+ * surface, with an active-tab tint, slide hide/show animation, and an
+ * unread-notification badge on the You tab.
+ */
+public class NativeTabBarView extends FrameLayout {
+
+    public static final int CONTENT_HEIGHT_DP = 49;
+
+    // Colors mirror NativeTabBarView.swift constants.
+    private static final int ACTIVE_COLOR = 0xFF8C4A52;
+    private static final int INACTIVE_COLOR = 0xFF9CA3AF;
+    private static final int BADGE_COLOR = 0xFFEF4444;
+    private static final int BAR_BACKGROUND = 0xE60A0A0A;
+
+    private static final long HIDE_ANIMATION_DURATION_MS = 300L;
+
+    private static final TabDef[] TABS = new TabDef[]{
+        new TabDef("home",    R.drawable.ic_tab_home,    "Home"),
+        new TabDef("climbs",  R.drawable.ic_tab_climbs,  "Climb"),
+        new TabDef("library", R.drawable.ic_tab_library, "Discover"),
+        new TabDef("feed",    R.drawable.ic_tab_feed,    "Feed"),
+        new TabDef("create",  R.drawable.ic_tab_create,  "Create"),
+        new TabDef("you",     R.drawable.ic_tab_you,     "You"),
+    };
+
+    public interface OnTabTappedListener {
+        void onTabTapped(@NonNull String tabKey);
+    }
+
+    private final Map<String, ImageView> tabIcons = new LinkedHashMap<>();
+    private final Map<String, TextView> tabLabels = new LinkedHashMap<>();
+    private TextView notificationBadge;
+    private String activeTabKey = "home";
+    @Nullable
+    private OnTabTappedListener tabTappedListener;
+    private boolean lastHiddenState = false;
+
+    public NativeTabBarView(@NonNull Context context) {
+        super(context);
+        setupView();
+    }
+
+    public NativeTabBarView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        setupView();
+    }
+
+    public NativeTabBarView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setupView();
+    }
+
+    public void setOnTabTappedListener(@Nullable OnTabTappedListener listener) {
+        this.tabTappedListener = listener;
+    }
+
+    public void setActiveTab(@NonNull String tabKey) {
+        activeTabKey = tabKey;
+        updateButtonAppearances();
+    }
+
+    /**
+     * Slide the bar off-screen (down) when {@code hidden} is true. Idempotent:
+     * repeat calls with the same value are no-ops, so rapid drawer
+     * open/close events don't queue redundant animations.
+     */
+    public void setBarsHidden(boolean hidden) {
+        setBarsHidden(hidden, true);
+    }
+
+    public void setBarsHidden(boolean hidden, boolean animated) {
+        if (hidden == lastHiddenState) return;
+        lastHiddenState = hidden;
+
+        float targetTranslationY = hidden ? getHeight() : 0f;
+        ViewPropertyAnimator animator = animate()
+            .translationY(targetTranslationY)
+            .setDuration(animated ? HIDE_ANIMATION_DURATION_MS : 0L);
+        animator.start();
+    }
+
+    public void setNotificationBadge(int count) {
+        if (notificationBadge == null) return;
+        if (count <= 0) {
+            notificationBadge.setVisibility(GONE);
+            return;
+        }
+        notificationBadge.setVisibility(VISIBLE);
+        notificationBadge.setText(count > 99 ? "99+" : String.valueOf(count));
+    }
+
+    private void setupView() {
+        setBackgroundColor(BAR_BACKGROUND);
+
+        LinearLayout row = new LinearLayout(getContext());
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setWeightSum(TABS.length);
+        FrameLayout.LayoutParams rowParams = new FrameLayout.LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            dp(CONTENT_HEIGHT_DP)
+        );
+        rowParams.gravity = Gravity.TOP;
+        addView(row, rowParams);
+
+        for (TabDef tab : TABS) {
+            row.addView(buildTabButton(tab));
+        }
+
+        updateButtonAppearances();
+    }
+
+    private View buildTabButton(@NonNull TabDef tab) {
+        FrameLayout container = new FrameLayout(getContext());
+        LinearLayout.LayoutParams containerParams = new LinearLayout.LayoutParams(
+            0,
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            1f
+        );
+        container.setLayoutParams(containerParams);
+        container.setClickable(true);
+        container.setFocusable(true);
+        container.setContentDescription(tab.label);
+        container.setOnClickListener(v -> {
+            if (tabTappedListener != null) {
+                tabTappedListener.onTabTapped(tab.tabKey);
+            }
+        });
+
+        LinearLayout column = new LinearLayout(getContext());
+        column.setOrientation(LinearLayout.VERTICAL);
+        column.setGravity(Gravity.CENTER);
+        FrameLayout.LayoutParams columnParams = new FrameLayout.LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT
+        );
+        container.addView(column, columnParams);
+
+        ImageView icon = new ImageView(getContext());
+        icon.setImageResource(tab.iconRes);
+        icon.setColorFilter(INACTIVE_COLOR, PorterDuff.Mode.SRC_IN);
+        LinearLayout.LayoutParams iconParams = new LinearLayout.LayoutParams(
+            dp(22),
+            dp(22)
+        );
+        column.addView(icon, iconParams);
+
+        TextView label = new TextView(getContext());
+        label.setText(tab.label);
+        label.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10f);
+        label.setTextColor(INACTIVE_COLOR);
+        label.setIncludeFontPadding(false);
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        labelParams.topMargin = dp(2);
+        column.addView(label, labelParams);
+
+        tabIcons.put(tab.tabKey, icon);
+        tabLabels.put(tab.tabKey, label);
+
+        if ("you".equals(tab.tabKey)) {
+            notificationBadge = buildNotificationBadge();
+            container.addView(notificationBadge);
+        }
+
+        return container;
+    }
+
+    private TextView buildNotificationBadge() {
+        TextView badge = new TextView(getContext());
+        badge.setBackground(buildBadgeBackground());
+        badge.setTextColor(Color.WHITE);
+        badge.setTextSize(TypedValue.COMPLEX_UNIT_SP, 9f);
+        badge.setGravity(Gravity.CENTER);
+        badge.setPadding(dp(4), 0, dp(4), 0);
+        badge.setIncludeFontPadding(false);
+        badge.setVisibility(GONE);
+
+        FrameLayout.LayoutParams badgeParams = new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            dp(14)
+        );
+        badgeParams.gravity = Gravity.TOP | Gravity.CENTER_HORIZONTAL;
+        badgeParams.topMargin = dp(4);
+        badgeParams.leftMargin = dp(8);
+        badge.setLayoutParams(badgeParams);
+        badge.setMinWidth(dp(14));
+        return badge;
+    }
+
+    private android.graphics.drawable.GradientDrawable buildBadgeBackground() {
+        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
+        bg.setShape(android.graphics.drawable.GradientDrawable.RECTANGLE);
+        bg.setColor(BADGE_COLOR);
+        bg.setCornerRadius(dp(7));
+        return bg;
+    }
+
+    private void updateButtonAppearances() {
+        for (TabDef tab : TABS) {
+            boolean isActive = tab.tabKey.equals(activeTabKey);
+            int color = isActive ? ACTIVE_COLOR : INACTIVE_COLOR;
+            ImageView icon = tabIcons.get(tab.tabKey);
+            TextView label = tabLabels.get(tab.tabKey);
+            if (icon != null) icon.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+            if (label != null) label.setTextColor(color);
+        }
+    }
+
+    private int dp(int dp) {
+        return (int) TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            dp,
+            getResources().getDisplayMetrics()
+        );
+    }
+
+    private static final class TabDef {
+        final String tabKey;
+        @DrawableRes
+        final int iconRes;
+        final String label;
+
+        TabDef(String tabKey, @DrawableRes int iconRes, String label) {
+            this.tabKey = tabKey;
+            this.iconRes = iconRes;
+            this.label = label;
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/NativeTabBarView.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/NativeTabBarView.java
@@ -1,14 +1,12 @@
 package com.boardsesh.app.tabs;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
-import android.view.ViewPropertyAnimator;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -17,6 +15,7 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.widget.ImageViewCompat;
 
 import com.boardsesh.app.R;
 
@@ -99,11 +98,22 @@ public class NativeTabBarView extends FrameLayout {
         if (hidden == lastHiddenState) return;
         lastHiddenState = hidden;
 
+        // Defer if we haven't been measured yet — otherwise getHeight() returns
+        // 0, the translation is a no-op, and the idempotency guard would block
+        // a future re-attempt at the same state.
+        if (hidden && getHeight() == 0) {
+            post(() -> {
+                lastHiddenState = !hidden;
+                setBarsHidden(hidden, animated);
+            });
+            return;
+        }
+
         float targetTranslationY = hidden ? getHeight() : 0f;
-        ViewPropertyAnimator animator = animate()
+        animate()
             .translationY(targetTranslationY)
-            .setDuration(animated ? HIDE_ANIMATION_DURATION_MS : 0L);
-        animator.start();
+            .setDuration(animated ? HIDE_ANIMATION_DURATION_MS : 0L)
+            .start();
     }
 
     public void setNotificationBadge(int count) {
@@ -164,7 +174,7 @@ public class NativeTabBarView extends FrameLayout {
 
         ImageView icon = new ImageView(getContext());
         icon.setImageResource(tab.iconRes);
-        icon.setColorFilter(INACTIVE_COLOR, PorterDuff.Mode.SRC_IN);
+        ImageViewCompat.setImageTintList(icon, ColorStateList.valueOf(INACTIVE_COLOR));
         LinearLayout.LayoutParams iconParams = new LinearLayout.LayoutParams(
             dp(22),
             dp(22)
@@ -230,7 +240,7 @@ public class NativeTabBarView extends FrameLayout {
             int color = isActive ? ACTIVE_COLOR : INACTIVE_COLOR;
             ImageView icon = tabIcons.get(tab.tabKey);
             TextView label = tabLabels.get(tab.tabKey);
-            if (icon != null) icon.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+            if (icon != null) ImageViewCompat.setImageTintList(icon, ColorStateList.valueOf(color));
             if (label != null) label.setTextColor(color);
         }
     }

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/SatelliteBridge.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/SatelliteBridge.java
@@ -1,0 +1,404 @@
+package com.boardsesh.app.tabs;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.webkit.WebViewCompat;
+import androidx.webkit.WebViewFeature;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages a single non-Capacitor WebView in the multi-webview tab
+ * architecture. Mirrors {@code SatelliteBridge.swift}: injects a JavaScript
+ * shim at document start that emulates {@code window.Capacitor} (so the web
+ * app's {@code isNativeApp()} detection works), and routes plugin calls from
+ * JS back to the {@link TabContainerController} via a callback.
+ */
+public final class SatelliteBridge {
+
+    private static final String TAG = "SatelliteBridge";
+
+    /** Callback invoked when the satellite webview makes a NativeTabBar plugin call. */
+    public interface TabBarAction {
+        void onTabBarCall(@NonNull String methodName, @NonNull JSONObject options);
+    }
+
+    /** Callback invoked once when the webview finishes its first navigation. */
+    public interface OnFirstLoadComplete {
+        void onFirstLoadComplete();
+    }
+
+    private final String tabKey;
+    private final Context context;
+    private final Set<String> allowedOriginRules;
+
+    @Nullable
+    private WebView webView;
+    @Nullable
+    private TabBarAction tabBarAction;
+    @Nullable
+    private OnFirstLoadComplete firstLoadCompleteListener;
+    private boolean hasCompletedFirstLoad = false;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    /**
+     * @param tabKey          tab identifier (injected as {@code window.__BOARDSESH_TAB__})
+     * @param allowedOrigins  origin patterns the document-start script is allowed to run on
+     *                        (e.g. {@code https://www.boardsesh.com}).
+     */
+    public SatelliteBridge(@NonNull Context context, @NonNull String tabKey, @NonNull Set<String> allowedOrigins) {
+        this.context = context;
+        this.tabKey = tabKey;
+        this.allowedOriginRules = new HashSet<>(allowedOrigins);
+    }
+
+    public void setOnTabBarAction(@Nullable TabBarAction action) {
+        this.tabBarAction = action;
+    }
+
+    public void setOnFirstLoadCompleteListener(@Nullable OnFirstLoadComplete listener) {
+        this.firstLoadCompleteListener = listener;
+    }
+
+    /** Reset first-load tracking so the listener can fire again after an unload/reload cycle. */
+    public void resetLoadState() {
+        hasCompletedFirstLoad = false;
+    }
+
+    @NonNull
+    @SuppressLint("SetJavaScriptEnabled")
+    public WebView createWebView() {
+        WebView wv = new WebView(context);
+        webView = wv;
+
+        WebSettings settings = wv.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setMediaPlaybackRequiresUserGesture(false);
+        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
+        settings.setCacheMode(WebSettings.LOAD_DEFAULT);
+        settings.setSupportMultipleWindows(false);
+        settings.setLoadWithOverviewMode(true);
+        settings.setUseWideViewPort(true);
+        settings.setDatabaseEnabled(true);
+
+        wv.setBackgroundColor(Color.parseColor("#0A0A0A"));
+        wv.addJavascriptInterface(new JsBridge(), "bridge");
+
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            WebViewCompat.addDocumentStartJavaScript(wv, buildJsShim(), allowedOriginRules);
+        } else {
+            Log.w(TAG, "DOCUMENT_START_SCRIPT unsupported on this device — Capacitor shim will not inject");
+        }
+
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                super.onPageFinished(view, url);
+                if (hasCompletedFirstLoad) return;
+                hasCompletedFirstLoad = true;
+                OnFirstLoadComplete listener = firstLoadCompleteListener;
+                if (listener != null) {
+                    listener.onFirstLoadComplete();
+                }
+            }
+        });
+
+        return wv;
+    }
+
+    @Nullable
+    public WebView getWebView() {
+        return webView;
+    }
+
+    public void detach() {
+        WebView wv = webView;
+        if (wv != null) {
+            wv.removeJavascriptInterface("bridge");
+        }
+        webView = null;
+        tabBarAction = null;
+        firstLoadCompleteListener = null;
+    }
+
+    /**
+     * Evaluates JavaScript in the satellite webview on the main thread. Used by
+     * the tab container to dispatch {@code boardsesh:native-tab-tapped} and
+     * {@code boardsesh:navigate} events into the page.
+     */
+    public void evaluateJs(@NonNull String js) {
+        mainHandler.post(() -> {
+            WebView wv = webView;
+            if (wv != null) {
+                wv.evaluateJavascript(js, null);
+            }
+        });
+    }
+
+    private void resolveCallback(@NonNull String callbackId, boolean success, @NonNull JSONObject data) {
+        String json;
+        try {
+            json = data.toString();
+        } catch (Exception e) {
+            json = success ? "{}" : "{\"error\":\"serialization failed\"}";
+        }
+        String safeCallbackId = jsEscape(callbackId);
+        String js = "window.__capacitorCallback('" + safeCallbackId + "'," + success + "," + json + ");";
+        evaluateJs(js);
+    }
+
+    /**
+     * JS-side bridge invoked via {@code window.bridge.postMessage(jsonString)}.
+     * Called on a binder thread, so we hop to the main thread before touching
+     * the webview or invoking listener callbacks that may mutate UI state.
+     */
+    private final class JsBridge {
+        @JavascriptInterface
+        public void postMessage(@Nullable String json) {
+            if (json == null) return;
+            mainHandler.post(() -> handleBridgeMessage(json));
+        }
+    }
+
+    private void handleBridgeMessage(@NonNull String json) {
+        JSONObject body;
+        try {
+            body = new JSONObject(json);
+        } catch (JSONException e) {
+            Log.w(TAG, "Bridge message is not valid JSON: " + e.getMessage());
+            return;
+        }
+
+        String pluginId = body.optString("pluginId", "");
+        String methodName = body.optString("methodName", "");
+        String callbackId = body.optString("callbackId", "");
+        JSONObject options = body.optJSONObject("options");
+        if (options == null) options = new JSONObject();
+
+        if (pluginId.isEmpty() || methodName.isEmpty() || callbackId.isEmpty()) {
+            Log.w(TAG, "Bridge message missing required fields (pluginId/methodName/callbackId)");
+            return;
+        }
+
+        if ("NativeTabBar".equals(pluginId)) {
+            TabBarAction action = tabBarAction;
+            if (action != null) {
+                action.onTabBarCall(methodName, options);
+            }
+            resolveCallback(callbackId, true, new JSONObject());
+            return;
+        }
+
+        Log.w(TAG, "Unknown pluginId from " + tabKey + ": " + pluginId);
+        JSONObject error = new JSONObject();
+        try {
+            error.put("error", "Unknown plugin: " + pluginId);
+        } catch (JSONException ignored) {
+            // toString fallback in resolveCallback handles it
+        }
+        resolveCallback(callbackId, false, error);
+    }
+
+    /**
+     * Builds the JavaScript shim injected at document-start. Mirrors the IIFE
+     * in {@code SatelliteBridge.swift#buildJSShim}: creates {@code window.Capacitor},
+     * registers a {@code NativeTabBar} plugin stub that posts to the native bridge,
+     * sets {@code __BOARDSESH_TAB__}, and patches {@code history.pushState} /
+     * {@code replaceState} so cross-tab navigations are redirected to a native
+     * tab switch instead of an in-page navigation.
+     *
+     * The {@code NativeWebSocket} stub from iOS is intentionally omitted — Android
+     * does not have a native WS plugin yet, and each WebView opens its own WS to
+     * the GraphQL backend.
+     */
+    private String buildJsShim() {
+        String safeTabKey = jsEscape(tabKey);
+        return "(function() {\n"
+            + "    'use strict';\n"
+            + "\n"
+            + "    var pendingCallbacks = {};\n"
+            + "    var callbackCounter = 0;\n"
+            + "\n"
+            + "    window.__capacitorCallback = function(callbackId, success, data) {\n"
+            + "        var entry = pendingCallbacks[callbackId];\n"
+            + "        if (!entry) return;\n"
+            + "        delete pendingCallbacks[callbackId];\n"
+            + "        if (success) {\n"
+            + "            entry.resolve(data || {});\n"
+            + "        } else {\n"
+            + "            entry.reject(data || { error: 'unknown error' });\n"
+            + "        }\n"
+            + "    };\n"
+            + "\n"
+            + "    function postBridgeMessage(pluginId, methodName, options) {\n"
+            + "        return new Promise(function(resolve, reject) {\n"
+            + "            var callbackId = 'cb_' + (++callbackCounter) + '_' + Date.now();\n"
+            + "            pendingCallbacks[callbackId] = { resolve: resolve, reject: reject };\n"
+            + "            try {\n"
+            + "                window.bridge.postMessage(JSON.stringify({\n"
+            + "                    pluginId: pluginId,\n"
+            + "                    methodName: methodName,\n"
+            + "                    callbackId: callbackId,\n"
+            + "                    options: options || {}\n"
+            + "                }));\n"
+            + "            } catch (e) {\n"
+            + "                delete pendingCallbacks[callbackId];\n"
+            + "                reject({ error: String(e) });\n"
+            + "            }\n"
+            + "        });\n"
+            + "    }\n"
+            + "\n"
+            + "    window.__satelliteListeners = {};\n"
+            + "    function addPluginListener(pluginId, eventName, callback) {\n"
+            + "        var key = pluginId + ':' + eventName;\n"
+            + "        if (!window.__satelliteListeners[key]) {\n"
+            + "            window.__satelliteListeners[key] = [];\n"
+            + "        }\n"
+            + "        window.__satelliteListeners[key].push(callback);\n"
+            + "        return Promise.resolve({\n"
+            + "            remove: function() {\n"
+            + "                var arr = window.__satelliteListeners[key];\n"
+            + "                if (!arr) return;\n"
+            + "                var idx = arr.indexOf(callback);\n"
+            + "                if (idx !== -1) arr.splice(idx, 1);\n"
+            + "            }\n"
+            + "        });\n"
+            + "    }\n"
+            + "\n"
+            + "    var NativeTabBar = {\n"
+            + "        setActiveTab: function(opts) { return postBridgeMessage('NativeTabBar', 'setActiveTab', opts); },\n"
+            + "        setBarsHidden: function(opts) { return postBridgeMessage('NativeTabBar', 'setBarsHidden', opts); },\n"
+            + "        setNotificationBadge: function(opts) { return postBridgeMessage('NativeTabBar', 'setNotificationBadge', opts); },\n"
+            + "        navigateTab: function(opts) { return postBridgeMessage('NativeTabBar', 'navigateTab', opts); },\n"
+            + "        addListener: function(eventName, callback) { return addPluginListener('NativeTabBar', eventName, callback); }\n"
+            + "    };\n"
+            + "\n"
+            + "    var CAPBrowser = {\n"
+            + "        open: function(opts) {\n"
+            + "            if (opts && opts.url) { window.open(opts.url, '_blank'); }\n"
+            + "            return Promise.resolve();\n"
+            + "        },\n"
+            + "        close: function() { return Promise.resolve(); },\n"
+            + "        addListener: function(eventName, callback) { return addPluginListener('CAPBrowser', eventName, callback); }\n"
+            + "    };\n"
+            + "\n"
+            + "    var LiveActivity = {\n"
+            + "        isAvailable: function() { return Promise.resolve({ available: false }); },\n"
+            + "        startSession: function() { return Promise.resolve(); },\n"
+            + "        endSession: function() { return Promise.resolve(); },\n"
+            + "        updateActivity: function() { return Promise.resolve(); },\n"
+            + "        updateActivityClimb: function() { return Promise.resolve(); },\n"
+            + "        addListener: function(eventName, callback) { return addPluginListener('LiveActivity', eventName, callback); }\n"
+            + "    };\n"
+            + "\n"
+            + "    window.Capacitor = {\n"
+            + "        isNativePlatform: function() { return true; },\n"
+            + "        getPlatform: function() { return 'android'; },\n"
+            + "        Plugins: {\n"
+            + "            NativeTabBar: NativeTabBar,\n"
+            + "            CAPBrowserPlugin: CAPBrowser,\n"
+            + "            LiveActivity: LiveActivity\n"
+            + "        }\n"
+            + "    };\n"
+            + "\n"
+            + "    window.__BOARDSESH_TAB__ = '" + safeTabKey + "';\n"
+            + "\n"
+            + "    var currentTab = '" + safeTabKey + "';\n"
+            + "\n"
+            + "    function getTabForPath(path) {\n"
+            + "        if (path === '/') return 'home';\n"
+            + "        if (path.match(/\\/create$/)) return 'create';\n"
+            + "        if (path.indexOf('/feed') === 0) return 'feed';\n"
+            + "        if (path.indexOf('/you') === 0) return 'you';\n"
+            + "        if (path.indexOf('/playlists') === 0) return 'library';\n"
+            + "        return 'climbs';\n"
+            + "    }\n"
+            + "\n"
+            + "    function extractPath(url) {\n"
+            + "        if (!url) return null;\n"
+            + "        try {\n"
+            + "            if (url.indexOf('://') !== -1) { return new URL(url).pathname; }\n"
+            + "            return url.split('?')[0].split('#')[0];\n"
+            + "        } catch(e) { return null; }\n"
+            + "    }\n"
+            + "\n"
+            + "    var _origPushState = history.pushState;\n"
+            + "    var _origReplaceState = history.replaceState;\n"
+            + "\n"
+            + "    history.pushState = function(state, title, url) {\n"
+            + "        var path = extractPath(url);\n"
+            + "        if (path) {\n"
+            + "            var targetTab = getTabForPath(path);\n"
+            + "            if (targetTab !== currentTab && targetTab !== 'create') {\n"
+            + "                var fullUrl = url;\n"
+            + "                if (url && url.indexOf('://') === -1) {\n"
+            + "                    fullUrl = window.location.origin + (url.charAt(0) === '/' ? '' : '/') + url;\n"
+            + "                }\n"
+            + "                postBridgeMessage('NativeTabBar', 'navigateTab', { tab: targetTab, url: fullUrl || url });\n"
+            + "                return;\n"
+            + "            }\n"
+            + "        }\n"
+            + "        return _origPushState.apply(this, arguments);\n"
+            + "    };\n"
+            + "\n"
+            + "    history.replaceState = function(state, title, url) {\n"
+            + "        var path = extractPath(url);\n"
+            + "        if (path) {\n"
+            + "            var targetTab = getTabForPath(path);\n"
+            + "            if (targetTab !== currentTab && targetTab !== 'create') {\n"
+            + "                var fullUrl = url;\n"
+            + "                if (url && url.indexOf('://') === -1) {\n"
+            + "                    fullUrl = window.location.origin + (url.charAt(0) === '/' ? '' : '/') + url;\n"
+            + "                }\n"
+            + "                postBridgeMessage('NativeTabBar', 'navigateTab', { tab: targetTab, url: fullUrl || url });\n"
+            + "                return;\n"
+            + "            }\n"
+            + "        }\n"
+            + "        return _origReplaceState.apply(this, arguments);\n"
+            + "    };\n"
+            + "})();\n";
+    }
+
+    /**
+     * Escapes a string so it can be safely placed inside a single-quoted
+     * JavaScript string literal. Mirrors {@code WebSocketBroadcaster.escapeForJavaScript}
+     * on the iOS side.
+     */
+    @NonNull
+    public static String jsEscape(@NonNull String value) {
+        StringBuilder out = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\': out.append("\\\\"); break;
+                case '\'': out.append("\\'"); break;
+                case '"':  out.append("\\\""); break;
+                case '\n': out.append("\\n"); break;
+                case '\r': out.append("\\r"); break;
+                case '\t': out.append("\\t"); break;
+                case ' ': out.append("\\u2028"); break;
+                case ' ': out.append("\\u2029"); break;
+                case '\0': out.append("\\0"); break;
+                default: out.append(c);
+            }
+        }
+        return out.toString();
+    }
+}

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/SatelliteBridge.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/SatelliteBridge.java
@@ -393,8 +393,6 @@ public final class SatelliteBridge {
                 case '\n': out.append("\\n"); break;
                 case '\r': out.append("\\r"); break;
                 case '\t': out.append("\\t"); break;
-                case ' ': out.append("\\u2028"); break;
-                case ' ': out.append("\\u2029"); break;
                 case '\0': out.append("\\0"); break;
                 default: out.append(c);
             }

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/TabContainerController.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/TabContainerController.java
@@ -242,6 +242,15 @@ public final class TabContainerController {
     public void destroy() {
         for (Map.Entry<String, SatelliteBridge> entry : satelliteBridges.entrySet()) {
             entry.getValue().detach();
+            // Satellites are app-owned WebViews; release native resources
+            // explicitly. The Capacitor (climbs) WebView is framework-owned, so
+            // we leave it alone.
+            WebView wv = tabWebViews.remove(entry.getKey());
+            if (wv != null) {
+                ViewGroup parent = (ViewGroup) wv.getParent();
+                if (parent != null) parent.removeView(wv);
+                wv.destroy();
+            }
         }
         satelliteBridges.clear();
     }
@@ -424,6 +433,7 @@ public final class TabContainerController {
 
     // -- Satellite plugin call routing --------------------------------------
 
+    @MainThread
     private void handleSatelliteTabBarAction(
         @NonNull String tabKey,
         @NonNull String methodName,

--- a/mobile/android/app/src/main/java/com/boardsesh/app/tabs/TabContainerController.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/tabs/TabContainerController.java
@@ -1,0 +1,455 @@
+package com.boardsesh.app.tabs;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.widget.FrameLayout;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Orchestrates the native bottom-tab-bar experience: owns one WebView per
+ * tab (the Capacitor bridge for "climbs", four satellite WebViews for the
+ * rest), the {@link NativeTabBarView}, and all of the show/hide, lazy-load,
+ * cross-tab navigation, and memory-pressure logic.
+ *
+ * <p>Mirror of {@code MultiWebViewController.swift}. The "create" tab has
+ * no dedicated webview — taps fire a {@code boardsesh:native-tab-tapped}
+ * event into the active webview and let the web layer handle the action.
+ */
+public final class TabContainerController {
+
+    private static final String TAG = "TabContainerController";
+
+    private static final List<String> TAB_ORDER =
+        Collections.unmodifiableList(Arrays.asList("home", "climbs", "library", "feed", "you"));
+
+    private static final Map<String, String> TAB_INITIAL_PATHS;
+    static {
+        Map<String, String> paths = new HashMap<>();
+        paths.put("home", "/");
+        paths.put("climbs", "/");
+        paths.put("library", "/playlists");
+        paths.put("feed", "/feed");
+        paths.put("you", "/you");
+        TAB_INITIAL_PATHS = Collections.unmodifiableMap(paths);
+    }
+
+    /** Loading priority after the active tab finishes loading. Climbs is excluded — Capacitor self-loads. */
+    private static final List<String> DEFERRED_LOAD_ORDER =
+        Collections.unmodifiableList(Arrays.asList("feed", "library", "you"));
+
+    private static final long DEFERRED_LOAD_STAGGER_MS = 500L;
+
+    private final Activity activity;
+    private final ViewGroup tabContainer;
+    private final WebView climbsWebView;
+    private final ViewGroup tabBarHost;
+    private final String serverUrl;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    private final Map<String, WebView> tabWebViews = new HashMap<>();
+    private final Map<String, SatelliteBridge> satelliteBridges = new HashMap<>();
+    private final Set<String> loadedTabs = new HashSet<>();
+    private final Map<String, String> pendingNavigationUrls = new HashMap<>();
+
+    private NativeTabBarView tabBarView;
+    private String activeTab = "home";
+    private int lastInjectedTabBarHeightPx = 0;
+    private boolean hasDeferredLoadsStarted = false;
+    @Nullable
+    private Uri pendingUniversalLink;
+
+    /**
+     * @param activity        host activity (for context + layout inflation)
+     * @param tabContainer    the FrameLayout where satellite WebViews are added; the
+     *                        Capacitor (climbs) WebView is already a child of it.
+     * @param tabBarHost      the FrameLayout where the {@link NativeTabBarView} is mounted.
+     * @param climbsWebView   the Capacitor bridge's WebView (treated as the climbs tab).
+     * @param serverUrl       base server URL (e.g. {@code https://www.boardsesh.com}).
+     */
+    public TabContainerController(
+        @NonNull Activity activity,
+        @NonNull ViewGroup tabContainer,
+        @NonNull ViewGroup tabBarHost,
+        @NonNull WebView climbsWebView,
+        @NonNull String serverUrl
+    ) {
+        this.activity = activity;
+        this.tabContainer = tabContainer;
+        this.tabBarHost = tabBarHost;
+        this.climbsWebView = climbsWebView;
+        this.serverUrl = stripTrailingSlash(serverUrl);
+
+        tabWebViews.put("climbs", climbsWebView);
+        // Capacitor begins loading from server.url as soon as the activity is up,
+        // so treat the climbs tab as already loaded.
+        loadedTabs.add("climbs");
+
+        setupSatelliteWebViews();
+        setupTabBar();
+        applyInsets();
+
+        // Default tab is home. Climbs starts hidden.
+        climbsWebView.setVisibility(View.GONE);
+        loadTab("home");
+    }
+
+    public String getActiveTab() {
+        return activeTab;
+    }
+
+    public NativeTabBarView getTabBarView() {
+        return tabBarView;
+    }
+
+    /**
+     * Maps a URL pathname to the corresponding tab key. Stays byte-for-byte
+     * in sync with {@code packages/web/app/lib/tab-routing.ts#getActiveTab}
+     * and {@code MultiWebViewController.tabForPath} on iOS.
+     */
+    @NonNull
+    public static String tabForPath(@Nullable String path) {
+        if (path == null || path.isEmpty()) return "climbs";
+        if ("/".equals(path)) return "home";
+        if (path.endsWith("/create")) return "create";
+        if (path.startsWith("/feed")) return "feed";
+        if (path.startsWith("/you")) return "you";
+        if (path.startsWith("/playlists")) return "library";
+        return "climbs";
+    }
+
+    /** Stash a universal link URL received before the controller was ready. */
+    public void setPendingUniversalLink(@Nullable Uri uri) {
+        this.pendingUniversalLink = uri;
+    }
+
+    public void loadPendingUniversalLink() {
+        Uri uri = pendingUniversalLink;
+        if (uri == null) return;
+        pendingUniversalLink = null;
+
+        String path = uri.getPath();
+        String tab = tabForPath(path);
+        String targetTab = "create".equals(tab) ? "climbs" : tab;
+        navigateToTab(targetTab, uri.toString());
+    }
+
+    @MainThread
+    public void handleTabTap(@NonNull String tab) {
+        if ("create".equals(tab)) {
+            // Create has no dedicated webview — fire the event into the active tab.
+            dispatchTabTappedEvent(tab, activeTab);
+            return;
+        }
+        if (tab.equals(activeTab)) {
+            // Same-tab tap: scroll-to-top semantics, dispatch event without switching.
+            dispatchTabTappedEvent(tab, activeTab);
+            return;
+        }
+        switchToTab(tab);
+        dispatchTabTappedEvent(tab, tab);
+    }
+
+    @MainThread
+    public void switchToTab(@NonNull String tab) {
+        if (tab.equals(activeTab)) return;
+        if (!TAB_ORDER.contains(tab)) {
+            Log.w(TAG, "Attempted to switch to unknown tab: " + tab);
+            return;
+        }
+
+        hideWebView(activeTab);
+        showWebView(tab);
+
+        activeTab = tab;
+        tabBarView.setActiveTab(tab);
+        loadTab(tab);
+
+        // Keep the tab bar above whichever webview just became visible.
+        tabBarHost.bringToFront();
+    }
+
+    /**
+     * Switch to the given tab (if different from current) and navigate it to
+     * {@code url}. Mirrors {@code MultiWebViewController.navigateToTab}: if the
+     * target webview is already loaded, a {@code boardsesh:navigate} event is
+     * dispatched (preserves React state); otherwise the URL is queued and used
+     * as the initial load URL.
+     */
+    @MainThread
+    public void navigateToTab(@NonNull String tab, @NonNull String url) {
+        String targetTab = "create".equals(tab) ? activeTab : tab;
+
+        if (!targetTab.equals(activeTab)) {
+            switchToTab(targetTab);
+        }
+
+        WebView wv = tabWebViews.get(targetTab);
+        if (wv == null) {
+            Log.e(TAG, "No webview for tab " + targetTab + " — cannot navigate to " + url);
+            return;
+        }
+
+        if (loadedTabs.contains(targetTab)) {
+            String escaped = SatelliteBridge.jsEscape(url);
+            String js = "window.dispatchEvent(new CustomEvent('boardsesh:navigate',{detail:{url:\"" + escaped + "\"}}));";
+            wv.evaluateJavascript(js, null);
+        } else {
+            pendingNavigationUrls.put(targetTab, url);
+            loadTab(targetTab);
+        }
+    }
+
+    /** Trim non-active satellite webviews on memory pressure. */
+    @MainThread
+    public void handleMemoryWarning() {
+        Log.w(TAG, "Memory warning — unloading non-visible satellite webviews");
+        for (String tab : TAB_ORDER) {
+            if (tab.equals(activeTab) || "climbs".equals(tab)) continue;
+            if (!loadedTabs.contains(tab)) continue;
+            WebView wv = tabWebViews.get(tab);
+            if (wv == null) continue;
+
+            wv.loadUrl("about:blank");
+            loadedTabs.remove(tab);
+            SatelliteBridge bridge = satelliteBridges.get(tab);
+            if (bridge != null) bridge.resetLoadState();
+        }
+    }
+
+    public void destroy() {
+        for (Map.Entry<String, SatelliteBridge> entry : satelliteBridges.entrySet()) {
+            entry.getValue().detach();
+        }
+        satelliteBridges.clear();
+    }
+
+    // -- Setup ---------------------------------------------------------------
+
+    private void setupSatelliteWebViews() {
+        Set<String> allowedOrigins = buildAllowedOrigins();
+        for (String tabKey : TAB_ORDER) {
+            if ("climbs".equals(tabKey)) continue;
+
+            SatelliteBridge bridge = new SatelliteBridge(activity, tabKey, allowedOrigins);
+            bridge.setOnTabBarAction((methodName, options) ->
+                handleSatelliteTabBarAction(tabKey, methodName, options));
+            bridge.setOnFirstLoadCompleteListener(() -> {
+                triggerDeferredLoadsIfNeeded();
+                injectTabBarHeightIntoWebView(tabKey);
+            });
+
+            WebView wv = bridge.createWebView();
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            );
+            tabContainer.addView(wv, params);
+            wv.setVisibility("home".equals(tabKey) ? View.VISIBLE : View.GONE);
+
+            tabWebViews.put(tabKey, wv);
+            satelliteBridges.put(tabKey, bridge);
+        }
+    }
+
+    private void setupTabBar() {
+        tabBarView = new NativeTabBarView(activity);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        tabBarHost.addView(tabBarView, params);
+        tabBarView.setOnTabTappedListener(this::handleTabTap);
+        tabBarView.setActiveTab(activeTab);
+    }
+
+    private void applyInsets() {
+        // EdgeToEdge is enabled in MainActivity — we own the bottom inset here so
+        // the tab bar visually sits above the gesture/nav area while content
+        // continues to extend behind it.
+        //
+        // The listener is attached to the activity's content root because some
+        // ViewGroups (CoordinatorLayout in particular) consume insets and won't
+        // dispatch them to a deeper child like tabBarHost.
+        View root = activity.findViewById(android.R.id.content);
+        if (root != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
+                Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                tabBarHost.setPadding(0, 0, 0, bars.bottom);
+                tabBarHost.post(this::injectTabBarHeightIntoAllWebViews);
+                return insets;
+            });
+            ViewCompat.requestApplyInsets(root);
+        }
+        tabBarHost.addOnLayoutChangeListener((v, l, t, r, b, ol, ot, or, ob) ->
+            injectTabBarHeightIntoAllWebViews());
+    }
+
+    @NonNull
+    private Set<String> buildAllowedOrigins() {
+        Set<String> origins = new LinkedHashSet<>();
+        Uri serverUri = Uri.parse(serverUrl);
+        String scheme = serverUri.getScheme();
+        String host = serverUri.getHost();
+        if (scheme != null && host != null) {
+            origins.add(scheme + "://" + host);
+        }
+        // Explicit fallbacks. Production wildcard for *.boardsesh.com so the
+        // shim attaches on www / staging / preview hosts; the configured dev
+        // URL above already covers the active dev tunnel host on debug builds.
+        origins.add("https://*.boardsesh.com");
+        origins.add("https://boardsesh.com");
+        return origins;
+    }
+
+    // -- Visibility ----------------------------------------------------------
+
+    private void hideWebView(@NonNull String tab) {
+        WebView wv = tabWebViews.get(tab);
+        if (wv != null) wv.setVisibility(View.GONE);
+    }
+
+    private void showWebView(@NonNull String tab) {
+        WebView wv = tabWebViews.get(tab);
+        if (wv != null) wv.setVisibility(View.VISIBLE);
+    }
+
+    // -- Loading -------------------------------------------------------------
+
+    @MainThread
+    public void loadTab(@NonNull String tab) {
+        if (loadedTabs.contains(tab)) return;
+        loadedTabs.add(tab);
+
+        if ("climbs".equals(tab)) {
+            triggerDeferredLoadsIfNeeded();
+            return;
+        }
+
+        WebView wv = tabWebViews.get(tab);
+        if (wv == null) {
+            Log.e(TAG, "No webview for tab " + tab + " — cannot load");
+            return;
+        }
+
+        String pendingUrl = pendingNavigationUrls.remove(tab);
+        String path = pendingUrl != null ? pendingUrl : TAB_INITIAL_PATHS.get(tab);
+        if (path == null) path = "/";
+
+        String fullUrl;
+        if (path.startsWith("http://") || path.startsWith("https://")) {
+            fullUrl = path;
+        } else {
+            fullUrl = serverUrl + path;
+        }
+
+        wv.loadUrl(fullUrl);
+    }
+
+    private void triggerDeferredLoadsIfNeeded() {
+        if (hasDeferredLoadsStarted) return;
+        hasDeferredLoadsStarted = true;
+
+        int delayIndex = 1;
+        for (String tab : DEFERRED_LOAD_ORDER) {
+            if (loadedTabs.contains(tab)) continue;
+            long delay = DEFERRED_LOAD_STAGGER_MS * delayIndex;
+            mainHandler.postDelayed(() -> loadTab(tab), delay);
+            delayIndex++;
+        }
+    }
+
+    // -- CSS variable injection ---------------------------------------------
+
+    private void injectTabBarHeightIntoAllWebViews() {
+        int heightPx = tabBarHost.getHeight();
+        if (heightPx <= 0) return;
+        if (heightPx == lastInjectedTabBarHeightPx) return;
+        lastInjectedTabBarHeightPx = heightPx;
+        for (String tab : TAB_ORDER) {
+            injectTabBarHeightIntoWebView(tab);
+        }
+    }
+
+    private void injectTabBarHeightIntoWebView(@NonNull String tab) {
+        int heightPx = tabBarHost.getHeight();
+        if (heightPx <= 0) return;
+        if (!loadedTabs.contains(tab)) return;
+        WebView wv = tabWebViews.get(tab);
+        if (wv == null) return;
+
+        // Convert px back to CSS px (which equals 1dp at the device's css scale of 1).
+        // WebView's CSS-px = device-independent-px in API >= 19, so divide by density.
+        float density = activity.getResources().getDisplayMetrics().density;
+        if (density <= 0f) density = 1f;
+        int cssPx = Math.round(heightPx / density);
+
+        String js = "document.documentElement.style.setProperty('--native-tab-bar-height','"
+            + cssPx + "px');";
+        wv.evaluateJavascript(js, null);
+    }
+
+    // -- Event dispatching ---------------------------------------------------
+
+    private void dispatchTabTappedEvent(@NonNull String tappedTab, @NonNull String targetTab) {
+        WebView wv = tabWebViews.get(targetTab);
+        if (wv == null) return;
+        String escaped = SatelliteBridge.jsEscape(tappedTab);
+        String js = "window.dispatchEvent(new CustomEvent('boardsesh:native-tab-tapped',{detail:{tab:'"
+            + escaped + "'}}));";
+        wv.evaluateJavascript(js, null);
+    }
+
+    // -- Satellite plugin call routing --------------------------------------
+
+    private void handleSatelliteTabBarAction(
+        @NonNull String tabKey,
+        @NonNull String methodName,
+        @NonNull JSONObject options
+    ) {
+        switch (methodName) {
+            case "setActiveTab":
+                tabBarView.setActiveTab(options.optString("tab", "home"));
+                break;
+            case "setBarsHidden":
+                tabBarView.setBarsHidden(options.optBoolean("hidden", false));
+                break;
+            case "setNotificationBadge":
+                tabBarView.setNotificationBadge(options.optInt("count", 0));
+                break;
+            case "navigateTab":
+                navigateToTab(options.optString("tab", "home"), options.optString("url", "/"));
+                break;
+            default:
+                Log.w(TAG, "Unhandled satellite tab bar call: " + methodName + " from " + tabKey);
+        }
+    }
+
+    @NonNull
+    private static String stripTrailingSlash(@NonNull String url) {
+        if (url.endsWith("/")) return url.substring(0, url.length() - 1);
+        return url;
+    }
+}

--- a/mobile/android/app/src/main/res/drawable/ic_tab_climbs.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_climbs.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_tab_create.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_create.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_tab_feed.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_feed.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11.99,18.54l-7.37,-5.73L3,14.07l9,7 9,-7 -1.63,-1.27 -7.38,5.74zM12,16l7.36,-5.73L21,9l-9,-7 -9,7 1.63,1.27L12,16z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_tab_home.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_home.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_tab_library.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_library.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.63,5.84C17.27,5.33 16.67,5 16,5L5,5.01C3.9,5.01 3,5.9 3,7v10c0,1.1 0.9,1.99 2,1.99L16,19c0.67,0 1.27,-0.33 1.63,-0.84L22,12l-4.37,-6.16z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_tab_you.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_tab_you.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
+</vector>

--- a/mobile/android/app/src/main/res/layout/bridge_layout_main.xml
+++ b/mobile/android/app/src/main/res/layout/bridge_layout_main.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Overrides @capacitor/android's default bridge_layout_main.xml.
+
+  Capacitor's BridgeActivity calls setContentView(R.layout.bridge_layout_main),
+  which resolves to whichever copy is most-specific. Because this file lives in
+  the app module's res/layout, it shadows the library copy.
+
+  We wrap the CapacitorWebView in tab_container so TabContainerController can
+  attach four satellite WebViews as siblings, and we add native_tab_bar_host
+  for the NativeTabBarView. The Capacitor WebView KEEPS its id ("@+id/webview")
+  and class (CapacitorWebView) so the bridge wires up unchanged.
+-->
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <FrameLayout
+        android:id="@+id/tab_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.getcapacitor.CapacitorWebView
+            android:id="@+id/webview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/native_tab_bar_host"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/mobile/android/app/src/main/res/layout/capacitor_bridge_layout_main.xml
+++ b/mobile/android/app/src/main/res/layout/capacitor_bridge_layout_main.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Overrides @capacitor/android's default bridge_layout_main.xml.
+  Overrides @capacitor/android's default capacitor_bridge_layout_main.xml.
 
-  Capacitor's BridgeActivity calls setContentView(R.layout.bridge_layout_main),
+  Capacitor's BridgeActivity calls setContentView(R.layout.capacitor_bridge_layout_main),
   which resolves to whichever copy is most-specific. Because this file lives in
   the app module's res/layout, it shadows the library copy.
 

--- a/mobile/android/app/src/test/java/com/boardsesh/app/tabs/TabContainerControllerTest.java
+++ b/mobile/android/app/src/test/java/com/boardsesh/app/tabs/TabContainerControllerTest.java
@@ -1,0 +1,55 @@
+package com.boardsesh.app.tabs;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Parity check for {@link TabContainerController#tabForPath(String)}. The
+ * mapping must stay identical to {@code packages/web/app/lib/tab-routing.ts}
+ * and {@code MultiWebViewController.tabForPath} on iOS — drift causes a deep
+ * link or cross-tab navigation to land in the wrong tab.
+ */
+public class TabContainerControllerTest {
+
+    @Test
+    public void rootPath_mapsToHome() {
+        assertEquals("home", TabContainerController.tabForPath("/"));
+    }
+
+    @Test
+    public void createSuffix_mapsToCreate() {
+        assertEquals("create", TabContainerController.tabForPath("/create"));
+        assertEquals("create", TabContainerController.tabForPath("/kilter/create"));
+    }
+
+    @Test
+    public void feedPrefix_mapsToFeed() {
+        assertEquals("feed", TabContainerController.tabForPath("/feed"));
+        assertEquals("feed", TabContainerController.tabForPath("/feed/some-user"));
+    }
+
+    @Test
+    public void youPrefix_mapsToYou() {
+        assertEquals("you", TabContainerController.tabForPath("/you"));
+        assertEquals("you", TabContainerController.tabForPath("/you/settings"));
+    }
+
+    @Test
+    public void playlistsPrefix_mapsToLibrary() {
+        assertEquals("library", TabContainerController.tabForPath("/playlists"));
+        assertEquals("library", TabContainerController.tabForPath("/playlists/123"));
+    }
+
+    @Test
+    public void otherPaths_mapToClimbs() {
+        assertEquals("climbs", TabContainerController.tabForPath("/kilter/1/2/3/40"));
+        assertEquals("climbs", TabContainerController.tabForPath("/tension"));
+    }
+
+    @Test
+    public void emptyOrNullPath_mapsToClimbs() {
+        assertEquals("climbs", TabContainerController.tabForPath(null));
+        assertEquals("climbs", TabContainerController.tabForPath(""));
+    }
+}


### PR DESCRIPTION
## Summary

Ports the iOS multi-WebView native tab bar architecture to Android. The web layer was already platform-agnostic — `getNativeTabBarPlugin()`, `useTabRouter`, `addNativeOverlay`, `tab-routing.ts`, and the conditional rendering inside `bottom-tab-bar.tsx` already detect `Capacitor.getPlatform() === 'android'` and call `window.Capacitor.Plugins.NativeTabBar.*`. They just needed an Android plugin and tab container to call into.

`BridgeActivity` now hosts the climbs Capacitor `WebView` plus four satellite `WebView`s (home, library, feed, you) inside a `tab_container` `FrameLayout`, with a custom `NativeTabBarView` mounted in `native_tab_bar_host`. A new `NativeTabBar` Capacitor plugin exposes `setActiveTab`, `setBarsHidden`, `setNotificationBadge`, and `navigateTab`. Satellite WebViews inject a JS shim at document start (via `WebViewCompat.addDocumentStartJavaScript`) that emulates `window.Capacitor`, registers the `NativeTabBar` stub, and patches `history.pushState` / `replaceState` so cross-tab navigations fire a native tab switch instead of an in-page navigation.

Mirrors `MultiWebViewController.swift` + `NativeTabBarView.swift` + `NativeTabBarPlugin.swift` + `SatelliteBridge.swift`.

- New: `NativeTabBarView.java`, `TabContainerController.java`, `SatelliteBridge.java`, `NativeTabBarPlugin.java`, six tab-icon vector drawables, `bridge_layout_main.xml` overriding the `@capacitor/android` default, JUnit parity test for `tabForPath`.
- Modified: `MainActivity.java` registers the new plugin, builds the controller, routes deep links into the right tab, and unloads non-active satellites in `onTrimMemory`. `app/build.gradle` adds `androidx.webkit`.
- Out of scope (will follow): native WebSocket plugin to share one connection across tabs (each WebView opens its own WS for now), and frosted-glass blur on the bar (using a translucent dark surface as a placeholder).

## Test plan

- [ ] `./gradlew :app:assembleDebug` builds without errors
- [ ] `./gradlew :app:test` passes, including `TabContainerControllerTest` (parity with `tab-routing.ts`)
- [ ] App launches on a debug device, lands on home tab, native bar renders with 6 tabs
- [ ] Tapping each of Home/Climb/Discover/Feed/You swaps the WebView and updates the active indicator; the MUI `BottomNavigation` does NOT render
- [ ] Tapping Create from any tab fires the create action without switching tabs
- [ ] Tapping the active tab again triggers scroll-to-top in the page
- [ ] Opening the board-selector / playlist / custom-board drawer slides the bar down; closing slides it back up
- [ ] Unread notification count surfaces as a red badge on the You tab (with `99+` cap)
- [ ] In-app cross-tab links (e.g. clicking a `/feed/...` link from home) switch tabs and load the URL
- [ ] Deep link cold start: `adb shell am start -a android.intent.action.VIEW -d "https://www.boardsesh.com/feed/x"` lands on the feed tab
- [ ] Deep link warm start: same command while app is foregrounded routes to the right tab
- [ ] `adb shell am send-trim-memory <pkg> RUNNING_CRITICAL` unloads non-active satellites; revisiting them reloads
- [ ] Older Play Store builds (no plugin) still fall back to MUI `BottomNavigation` — backwards-compatible

https://claude.ai/code/session_014AezQPRQpbHSNM3y62BvDR

---
_Generated by [Claude Code](https://claude.ai/code/session_014AezQPRQpbHSNM3y62BvDR)_