### PR TITLE
Sort ticks explicitly and clarify session-detail caching

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -501,7 +501,7 @@ sequenceDiagram
 | `SessionEnded`        | Session is ended explicitly or by cleanup   | `reason`, `newPath`                                                                                                                                               |
 | `SessionStatsUpdated` | A tick is saved for an active party session | `totalSends`, `totalFlashes`, `totalAttempts`, `tickCount`, `participants`, `gradeDistribution`, `boardTypes`, `hardestGrade`, `durationMinutes`, `goal`, `ticks` |
 
-`SessionStatsUpdated` payloads now include full `ticks` rows so clients can update charts and climbs/attempt lists without issuing an extra session detail refetch.
+`SessionStatsUpdated` payloads include full `ticks` rows so clients can update charts and climbs/attempt lists without issuing an extra session detail refetch. On the client, `useEventProcessor` patches the `SESSION_DETAIL_QUERY_KEY(sessionId)` React Query cache entry directly with the new stats and ticks — there is no separate `liveSessionStats` merge layer, so any component subscribed via `useSessionDetail` re-renders from the updated cache automatically.
 
 ---
 

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -191,6 +191,56 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     expect(cached!.firstTickAt).toBe('2026-04-30T09:00:00Z');
   });
 
+  it('derives firstTickAt/lastTickAt regardless of incoming tick order', () => {
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    // Ticks arrive ascending — opposite of the documented newest-first contract.
+    const ticks = [
+      createTick('2026-04-30T09:00:00Z'),
+      createTick('2026-04-30T09:30:00Z'),
+      createTick('2026-04-30T10:00:00Z'),
+    ];
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.lastTickAt).toBe('2026-04-30T10:00:00Z');
+    expect(cached!.firstTickAt).toBe('2026-04-30T09:00:00Z');
+    // Cached ticks are normalized to newest-first.
+    expect(cached!.ticks.map((tick) => tick.climbedAt)).toEqual([
+      '2026-04-30T10:00:00Z',
+      '2026-04-30T09:30:00Z',
+      '2026-04-30T09:00:00Z',
+    ]);
+  });
+
+  it('handles mixed-timezone climbedAt strings via epoch comparison', () => {
+    queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    // 14:30+05:30 == 09:00Z; 12:00Z is later; 11:00Z is earliest in absolute time.
+    const ticks = [
+      createTick('2026-04-30T11:00:00Z'),
+      createTick('2026-04-30T14:30:00+05:30'),
+      createTick('2026-04-30T12:00:00Z'),
+    ];
+
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.lastTickAt).toBe('2026-04-30T12:00:00Z');
+    expect(cached!.firstTickAt).toBe('2026-04-30T14:30:00+05:30');
+  });
+
   it('preserves prev firstTickAt/lastTickAt when merging with no ticks', () => {
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 

--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -3,6 +3,7 @@ import { openDB } from 'idb';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { getPreference, setPreference, removePreference } from '@/app/lib/user-preferences-db';
 import type { BoardDetails } from '@/app/lib/types';
 import { PersistentSessionProvider, usePersistentSession } from '../persistent-session-context';
@@ -80,8 +81,16 @@ function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails
   } as BoardDetails;
 }
 
-function wrapper({ children }: { children: React.ReactNode }) {
-  return <PersistentSessionProvider>{children}</PersistentSessionProvider>;
+function createWrapper() {
+  // Fresh QueryClient per test so cached session-detail entries don't leak
+  // across cases. PersistentSessionProvider's useEventProcessor calls
+  // useQueryClient(), so the provider must be in scope.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <PersistentSessionProvider>{children}</PersistentSessionProvider>
+    </QueryClientProvider>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +158,7 @@ describe('Active session persistence', () => {
 
 describe('PersistentSessionProvider auto-restore on mount', () => {
   it('sets isLocalQueueLoaded=true when no stored data exists', async () => {
-    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(result.current.isLocalQueueLoaded).toBe(true);
@@ -177,7 +186,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
 
     await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
 
-    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(result.current.isLocalQueueLoaded).toBe(true);
@@ -190,7 +199,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
   });
 
   it('activateSession persists to IndexedDB', async () => {
-    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(result.current.isLocalQueueLoaded).toBe(true);
@@ -236,7 +245,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     };
     await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
 
-    const { result } = renderHook(() => usePersistentSession(), { wrapper });
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(result.current.activeSession).toEqual(sessionInfo);

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -182,8 +182,9 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
         queryClient.setQueryData<SessionDetail | null>(queryKey, (prev) => {
           if (!prev) return prev;
 
-          // ticks are ordered newest-first (descending by climbedAt)
-          const ticks = event.ticks;
+          // Sort newest-first explicitly so firstTickAt/lastTickAt don't depend
+          // on the server's arrival order.
+          const ticks = [...event.ticks].sort((a, b) => b.climbedAt.localeCompare(a.climbedAt));
           const firstTickAt = ticks.length > 0
             ? ticks[ticks.length - 1].climbedAt
             : prev.firstTickAt;

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -183,8 +183,11 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           if (!prev) return prev;
 
           // Sort newest-first explicitly so firstTickAt/lastTickAt don't depend
-          // on the server's arrival order.
-          const ticks = [...event.ticks].sort((a, b) => b.climbedAt.localeCompare(a.climbedAt));
+          // on the server's arrival order. Compare epoch millis so mixed
+          // timezone offsets (e.g. `+05:30` vs `Z`) still sort correctly.
+          const ticks = [...event.ticks].sort(
+            (a, b) => new Date(b.climbedAt).getTime() - new Date(a.climbedAt).getTime(),
+          );
           const firstTickAt = ticks.length > 0
             ? ticks[ticks.length - 1].climbedAt
             : prev.firstTickAt;

--- a/packages/web/app/hooks/use-session-detail.ts
+++ b/packages/web/app/hooks/use-session-detail.ts
@@ -39,6 +39,8 @@ export function useSessionDetail({ sessionId, initialData, enabled = true }: Use
     },
     enabled: enabled && !!sessionId && isAuthenticated && !!token,
     staleTime: 30_000,
+    // Live updates arrive via SessionStatsUpdated cache patches, so a
+    // window-focus refetch would only race the WS feed and reintroduce flicker.
     refetchOnWindowFocus: false,
     ...(initialData
       ? {


### PR DESCRIPTION
## Summary

Addresses three review comments on the React Query session-detail flow:

- **`use-event-processor.ts`** — `firstTickAt`/`lastTickAt` previously assumed the server delivered `event.ticks` newest-first. The contract was implicit and the tests only locked in the expected output, not the boundary. Now the array is sorted descending by `climbedAt` before deriving the bookend timestamps, so a server-side sort change can't silently swap them.
- **`docs/websocket-implementation.md`** — Updated the `SessionStatsUpdated` blurb to describe the current behavior: clients patch the `SESSION_DETAIL_QUERY_KEY(sessionId)` React Query cache directly, replacing the old `liveSessionStats` merge layer.
- **`use-session-detail.ts`** — Added a short comment explaining why `refetchOnWindowFocus: false` is set on the shared hook (live updates arrive via the WS cache patch, so a focus refetch only races the feed).

## Test plan

- [ ] `vp test run` — existing `event-processor-session-cache.test.ts` cases still pass (input is already newest-first, so the explicit sort is a no-op for them).
- [ ] `vp run typecheck:web`
- [ ] `vp check`

https://claude.ai/code/session_01MH7BiC9DprtwedQFtaPE4d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH7BiC9DprtwedQFtaPE4d)_