### PR TITLE
Enable oxlint no-nested-ternary rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,6 +9,7 @@
     "no-unused-vars": "error",
     "import/no-cycle": "error",
     "prefer-const": "error",
+    "no-nested-ternary": "error",
     "no-template-curly-in-string": "error",
     "eqeqeq": ["error", "smart"],
     "no-console": ["error", { "allow": ["warn", "error", "info"] }],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,6 @@ We are using next.js app router, it's important we try to use server side compon
 - While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
 - **Dark mode uses white input fields** — This is intentional for contrast. All input components (TextField, Select, Autocomplete, etc.) have white backgrounds in dark mode via `darkTokens.semantic.inputSurface`. Do not change them to dark backgrounds.
 - **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
-- **No nested ternaries** - `a ? b : c ? d : e` forces the reader to mentally re-bracket the expression. Use an `if`/`else if`/`else` block, an early return, or a small helper function. A `?:` is fine when both branches are short and unambiguous, but the moment you reach for a second `?:` inside the first, switch forms.
 - **Variable names must describe their contents** - No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `latest`, `temp`, `value`) outside of tight loops or well-known math conventions. The name should tell the next reader what's inside without forcing them to scroll back to the declaration. Prefer destructuring at the use site over a generic alias — `const { queue, currentClimb } = stateRef.current` reads better than `const s = stateRef.current` followed by `s.queue` / `s.currentClimb`.
 
 ### Copy & Microcopy


### PR DESCRIPTION
## Summary

- Adds `"no-nested-ternary": "error"` to the root `.oxlintrc.json`. The codebase already complies (0 violations on `vp lint`), so this just locks in the existing rule.
- Removes the corresponding "No nested ternaries" entry from `CLAUDE.md` since the linter now enforces it — no need for a human-only guideline.

## Other lintable CLAUDE.md rules considered (not enabled here)

While auditing CLAUDE.md, two other guidelines map cleanly to oxlint rules but would require code changes or `eslint-disable` comments to enable cleanly:

- **`no-restricted-globals` for `localStorage` / `sessionStorage`** — CLAUDE.md says these are forbidden except in one-time migration code. There are ~10 legitimate uses (migration code in `*-db.ts` files, e2e flags, tests) that would need disable comments.
- **`no-restricted-imports` for the raw Neon `sql` client from `@/app/lib/db/db`** — CLAUDE.md says "never use the raw Neon `sql` client for new code." A handful of pre-existing imports (`api/v1/angles/...`, `api/og/profile/...`, `lib/data/queries.ts`, `lib/seo/dynamic-og-data.ts`) would need to either migrate to Drizzle or get disable comments.

Happy to enable those in follow-ups if desired.

## Test plan

- [x] `vp lint` passes with 0 errors (109 pre-existing warnings unchanged)
- [x] Verified the rule fires on a synthetic nested ternary
- [x] Confirmed the rule appears under `oxlint --rules` as `eslint/no-nested-ternary`


---
_Generated by [Claude Code](https://claude.ai/code/session_01F9CY7133srXb4yZ6khgbnh)_