### PR TITLE
build(web): tree-shake generated GraphQL Documents map via SWC plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@graphql-codegen/client-preset": "^4.5.1",
         "@graphql-codegen/typescript": "^4.1.2",
         "@graphql-codegen/typescript-resolvers": "^4.4.1",
+        "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
         "@vitest/coverage-v8": "^4.1.5",
         "oxlint-tsgolint": "^0.21.1",
         "vite": "^8.0.9",
@@ -1299,6 +1300,8 @@
     "@swaggerexpert/cookie": ["@swaggerexpert/cookie@2.0.2", "", { "dependencies": { "apg-lite": "^1.0.3" } }, "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg=="],
 
     "@swaggerexpert/json-pointer": ["@swaggerexpert/json-pointer@2.10.2", "", { "dependencies": { "apg-lite": "^1.0.4" } }, "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw=="],
+
+    "@swc-contrib/plugin-graphql-codegen-client-preset": ["@swc-contrib/plugin-graphql-codegen-client-preset@0.21.0", "", {}, "sha512-Jjtdj3HHk2XOu031dU/ieiKgHtE9DaS5BIvhVmqXdarNuu+BGBO9lZr/sSkBJAPB5ARzuDHfmHGvKajHYK0mXw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,6 @@
         "@graphql-codegen/client-preset": "^4.5.1",
         "@graphql-codegen/typescript": "^4.1.2",
         "@graphql-codegen/typescript-resolvers": "^4.4.1",
-        "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
         "@vitest/coverage-v8": "^4.1.5",
         "oxlint-tsgolint": "^0.21.1",
         "vite": "^8.0.9",
@@ -243,6 +242,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -3190,6 +3190,10 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@boardsesh/db/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "@boardsesh/web/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@graphql-codegen/client-preset": "^4.5.1",
     "@graphql-codegen/typescript": "^4.1.2",
     "@graphql-codegen/typescript-resolvers": "^4.4.1",
-    "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
     "@vitest/coverage-v8": "^4.1.5",
     "oxlint-tsgolint": "^0.21.1",
     "vite": "^8.0.9",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@graphql-codegen/client-preset": "^4.5.1",
     "@graphql-codegen/typescript": "^4.1.2",
     "@graphql-codegen/typescript-resolvers": "^4.4.1",
+    "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
     "@vitest/coverage-v8": "^4.1.5",
     "oxlint-tsgolint": "^0.21.1",
     "vite": "^8.0.9",

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -23,6 +23,15 @@ const nextConfig = {
   turbopack: {},
   experimental: {
     optimizePackageImports: ['@mui/material', '@mui/icons-material', '@mui/material-nextjs'],
+    // Tree-shake the gql.ts Documents map by rewriting graphql(`...`) calls
+    // into direct imports of the matching *Document constant.
+    // - Runs during `next build` (Turbopack production); does not run under
+    //   `next dev`, so local dev still bundles the full map.
+    // - artifactDirectory is resolved against the workspace root (where
+    //   bun.lock lives), not packages/web — hence the `./packages/web/...`
+    //   prefix. A wrong path may either silently no-op or trip
+    //   module-not-found, so changes here must be verified by running
+    //   `vp run boardsesh-monorepo#verify:graphql-treeshake` after a build.
     swcPlugins: [
       [
         '@swc-contrib/plugin-graphql-codegen-client-preset',

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -23,6 +23,15 @@ const nextConfig = {
   turbopack: {},
   experimental: {
     optimizePackageImports: ['@mui/material', '@mui/icons-material', '@mui/material-nextjs'],
+    swcPlugins: [
+      [
+        '@swc-contrib/plugin-graphql-codegen-client-preset',
+        {
+          artifactDirectory: './packages/web/app/lib/graphql/generated',
+          gqlTagName: 'graphql',
+        },
+      ],
+    ],
   },
   // Include WASM binary in standalone output for serverless functions.
   // Both paths needed: monorepo root (hoisted deps) and local node_modules (symlink).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -91,6 +91,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@swc-contrib/plugin-graphql-codegen-client-preset": "0.21.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/web/scripts/verify-graphql-treeshake.ts
+++ b/packages/web/scripts/verify-graphql-treeshake.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * After `next build`, assert that the SWC client-preset plugin actually
+ * tree-shook the gql.ts Documents map. A wrong `artifactDirectory` in
+ * next.config.mjs silently no-ops the plugin, so we need a positive check.
+ *
+ * The marker is `GetDeleteAccountInfoDocument` — the only graphql() call
+ * site today (account.ts → delete-account-section.tsx → /settings).
+ * If the plugin worked, the chunk holding that import must NOT contain
+ * unrelated operation names that only the full Documents map would pull in.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chunksDir = join(here, '..', '.next', 'static', 'chunks');
+
+// Query names survive bundling as string literals inside the parsed Document
+// AST. Import identifiers like *Document are minified, so we grep for the
+// operation name, which is stable across builds.
+const MARKER = 'GetDeleteAccountInfo';
+const MUST_BE_ABSENT = [
+  'GetBetaLinks',
+  'GetGlobalCommentFeed',
+  'GetUserAscentsFeed',
+  'UserFavoritesCounts',
+  'GetNewClimbFeed',
+];
+
+function fail(message: string): never {
+  console.error(`verify-graphql-treeshake: ${message}`);
+  process.exit(1);
+}
+
+let chunks: string[];
+try {
+  chunks = readdirSync(chunksDir).filter((name) => name.endsWith('.js'));
+} catch {
+  fail(`chunks directory not found at ${chunksDir}; run \`vp run build:web\` first`);
+}
+
+const markerChunks = chunks.filter((name) => {
+  const content = readFileSync(join(chunksDir, name), 'utf8');
+  return content.includes(MARKER);
+});
+
+if (markerChunks.length === 0) {
+  fail(`no chunk contains ${MARKER}; account.ts may not have been bundled — did the build complete?`);
+}
+
+const leaks: { chunk: string; size: number; queries: string[] }[] = [];
+for (const name of markerChunks) {
+  const path = join(chunksDir, name);
+  const content = readFileSync(path, 'utf8');
+  const queries = MUST_BE_ABSENT.filter((q) => content.includes(q));
+  if (queries.length > 0) {
+    leaks.push({ chunk: name, size: statSync(path).size, queries });
+  }
+}
+
+if (leaks.length > 0) {
+  console.error('SWC plugin transform did not fire — Documents map leaked into settings chunk(s):');
+  for (const { chunk, size, queries } of leaks) {
+    console.error(`  ${chunk} (${size} B): ${queries.join(', ')}`);
+  }
+  console.error('Check artifactDirectory in packages/web/next.config.mjs.');
+  process.exit(1);
+}
+
+const totalSize = markerChunks.reduce((sum, name) => sum + statSync(join(chunksDir, name)).size, 0);
+console.info(
+  `verify-graphql-treeshake: OK — ${markerChunks.length} chunk(s) carry ${MARKER} ` +
+    `(${totalSize} B total), no unrelated operations leaked.`,
+);

--- a/packages/web/scripts/verify-graphql-treeshake.ts
+++ b/packages/web/scripts/verify-graphql-treeshake.ts
@@ -5,11 +5,17 @@
  * next.config.mjs (or a missing plugin entirely) silently no-ops the
  * transform, so we need a positive check.
  *
- * Strategy: parse generated/gql.ts to learn every operation name in the
- * project, parse account.ts to learn the names that are *supposed* to be
- * in the settings chunk (the only graphql() call site today), then assert
- * that the rest don't appear there. As more operations migrate to
- * graphql(), the absence list shrinks automatically — no maintenance.
+ * Strategy:
+ *   1. Auto-discover every file under app/lib/graphql/operations/ that
+ *      imports `graphql` from the generated module — these are the live
+ *      graphql() call sites whose operations are *supposed* to be bundled.
+ *   2. Parse generated/gql.ts for every operation name in the project.
+ *   3. The set difference is must-be-absent: operations that should NOT
+ *      appear in any chunk that holds a live operation.
+ *   4. Walk static/chunks/ recursively, find chunks containing any live
+ *      operation name, and assert no must-be-absent name leaks in.
+ *
+ * As more files migrate to graphql(), step 1 picks them up automatically.
  *
  * Operation names survive bundling as string literals inside the parsed
  * Document AST (e.g. `name:{kind:"Name",value:"GetBetaLinks"}`), even
@@ -23,11 +29,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const webRoot = join(here, '..');
 const chunksDir = join(webRoot, '.next', 'static', 'chunks');
 const gqlPath = join(webRoot, 'app', 'lib', 'graphql', 'generated', 'gql.ts');
-// account.ts is the single graphql() call site as of this PR. If/when more
-// op files migrate, swap this for a glob over operations/*.ts — the
-// derivation below treats every operation in that file as "must be present
-// in the marker chunk", so adding files extends coverage automatically.
-const accountPath = join(webRoot, 'app', 'lib', 'graphql', 'operations', 'account.ts');
+const operationsDir = join(webRoot, 'app', 'lib', 'graphql', 'operations');
 
 function fail(message: string): never {
   console.error(`verify-graphql-treeshake: ${message}`);
@@ -41,16 +43,33 @@ function extractOperationNames(source: string): string[] {
   return [...new Set(Array.from(matches, (m) => m[1]))];
 }
 
-const allOperationNames = extractOperationNames(readFileSync(gqlPath, 'utf8'));
-const liveOperationNames = extractOperationNames(readFileSync(accountPath, 'utf8'));
-if (liveOperationNames.length === 0) {
-  fail(`could not parse operation names from ${accountPath}`);
+// Discover graphql() call sites: any file in operations/ that imports the
+// `graphql` helper from the generated module is in scope. Files that use
+// `gql` from `graphql-request` are not — their operations don't go through
+// the Documents map.
+const liveOperationsByFile: Record<string, string[]> = {};
+for (const name of readdirSync(operationsDir).filter((n) => n.endsWith('.ts'))) {
+  const path = join(operationsDir, name);
+  const source = readFileSync(path, 'utf8');
+  if (!/import\s*\{[^}]*\bgraphql\b[^}]*\}\s*from\s*['"][^'"]*graphql\/generated/.test(source)) {
+    continue;
+  }
+  const names = extractOperationNames(source);
+  if (names.length > 0) {
+    liveOperationsByFile[name] = names;
+  }
 }
-const [marker] = liveOperationNames;
+const liveOperationNames = [...new Set(Object.values(liveOperationsByFile).flat())];
+
+if (liveOperationNames.length === 0) {
+  fail(`no graphql() call sites found under ${operationsDir}; nothing to verify`);
+}
+
+const allOperationNames = extractOperationNames(readFileSync(gqlPath, 'utf8'));
 const mustBeAbsent = allOperationNames.filter((name) => !liveOperationNames.includes(name));
 
 if (mustBeAbsent.length === 0) {
-  fail(`no candidate operations to verify against; gql.ts only contains operations that account.ts uses`);
+  fail(`no candidate operations to verify against; every operation in gql.ts is live in operations/`);
 }
 
 // Recursive: Next App Router can split chunks into per-route subdirectories
@@ -74,23 +93,40 @@ function read(name: string): string {
   return content;
 }
 
-const markerChunks = chunkNames.filter((name) => read(name).includes(marker));
+// In bundled output, operation names appear inside the parsed Document AST
+// as `value:"<Name>"`. Matching that exact pattern (rather than a bare
+// substring) avoids collisions with unrelated identifiers — e.g. the
+// generated TypeScript type `DeleteAccountInput` would match a substring
+// search for `DeleteAccount` but is not a graphql operation.
+const opPattern = (name: string): string => `value:"${name}"`;
 
-if (markerChunks.length === 0) {
-  fail(`no chunk contains ${marker}; account.ts may not have been bundled — did the build complete?`);
+// A chunk is a "live chunk" if it contains *any* live operation name. We
+// search by all of them rather than picking a single anchor — that way a
+// future split of operations across multiple files still produces the
+// right marker set without code changes.
+const liveChunks = chunkNames.filter((name) => {
+  const content = read(name);
+  return liveOperationNames.some((op) => content.includes(opPattern(op)));
+});
+
+if (liveChunks.length === 0) {
+  fail(
+    `no chunk contains any of [${liveOperationNames.join(', ')}] as a parsed operation; ` +
+      `operations may not have been bundled — did the build complete?`,
+  );
 }
 
 const leaks: { chunk: string; size: number; queries: string[] }[] = [];
-for (const name of markerChunks) {
+for (const name of liveChunks) {
   const content = read(name);
-  const queries = mustBeAbsent.filter((q) => content.includes(q));
+  const queries = mustBeAbsent.filter((q) => content.includes(opPattern(q)));
   if (queries.length > 0) {
     leaks.push({ chunk: name, size: statSync(join(chunksDir, name)).size, queries });
   }
 }
 
 if (leaks.length > 0) {
-  console.error('SWC plugin transform did not fire — Documents map leaked into settings chunk(s):');
+  console.error('SWC plugin transform did not fire — Documents map leaked into live chunk(s):');
   for (const { chunk, size, queries } of leaks) {
     const shown = queries.slice(0, 5).join(', ');
     const extra = queries.length > 5 ? `, +${queries.length - 5} more` : '';
@@ -100,8 +136,10 @@ if (leaks.length > 0) {
   process.exit(1);
 }
 
-const totalSize = markerChunks.reduce((sum, name) => sum + statSync(join(chunksDir, name)).size, 0);
+const totalSize = liveChunks.reduce((sum, name) => sum + statSync(join(chunksDir, name)).size, 0);
+const fileList = Object.keys(liveOperationsByFile).join(', ');
 console.info(
-  `verify-graphql-treeshake: OK — ${markerChunks.length} chunk(s) carry ${marker} ` +
+  `verify-graphql-treeshake: OK — ${liveChunks.length} chunk(s) covering ` +
+    `${liveOperationNames.length} live operation(s) from [${fileList}] ` +
     `(${totalSize} B total), ${mustBeAbsent.length} unrelated operation(s) checked, none leaked.`,
 );

--- a/packages/web/scripts/verify-graphql-treeshake.ts
+++ b/packages/web/scripts/verify-graphql-treeshake.ts
@@ -23,6 +23,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const webRoot = join(here, '..');
 const chunksDir = join(webRoot, '.next', 'static', 'chunks');
 const gqlPath = join(webRoot, 'app', 'lib', 'graphql', 'generated', 'gql.ts');
+// account.ts is the single graphql() call site as of this PR. If/when more
+// op files migrate, swap this for a glob over operations/*.ts — the
+// derivation below treats every operation in that file as "must be present
+// in the marker chunk", so adding files extends coverage automatically.
 const accountPath = join(webRoot, 'app', 'lib', 'graphql', 'operations', 'account.ts');
 
 function fail(message: string): never {
@@ -31,9 +35,9 @@ function fail(message: string): never {
 }
 
 function extractOperationNames(source: string): string[] {
-  // Matches `query Name` and `mutation Name` inside graphql template
-  // literals. Captures the identifier only.
-  const matches = source.matchAll(/\b(?:query|mutation)\s+([A-Z]\w+)/g);
+  // Matches `query Name`, `mutation Name`, and `subscription Name` inside
+  // graphql template literals. Captures the identifier only.
+  const matches = source.matchAll(/\b(?:query|mutation|subscription)\s+([A-Z]\w+)/g);
   return [...new Set(Array.from(matches, (m) => m[1]))];
 }
 
@@ -49,9 +53,13 @@ if (mustBeAbsent.length === 0) {
   fail(`no candidate operations to verify against; gql.ts only contains operations that account.ts uses`);
 }
 
+// Recursive: Next App Router can split chunks into per-route subdirectories
+// (e.g. .next/static/chunks/app/...) depending on version and routing config.
 let chunkNames: string[];
 try {
-  chunkNames = readdirSync(chunksDir).filter((name) => name.endsWith('.js'));
+  chunkNames = readdirSync(chunksDir, { recursive: true })
+    .map((entry) => (typeof entry === 'string' ? entry : entry.toString()))
+    .filter((name) => name.endsWith('.js'));
 } catch {
   fail(`chunks directory not found at ${chunksDir}; run \`vp run build:web\` first`);
 }

--- a/packages/web/scripts/verify-graphql-treeshake.ts
+++ b/packages/web/scripts/verify-graphql-treeshake.ts
@@ -2,67 +2,91 @@
 /**
  * After `next build`, assert that the SWC client-preset plugin actually
  * tree-shook the gql.ts Documents map. A wrong `artifactDirectory` in
- * next.config.mjs silently no-ops the plugin, so we need a positive check.
+ * next.config.mjs (or a missing plugin entirely) silently no-ops the
+ * transform, so we need a positive check.
  *
- * The marker is `GetDeleteAccountInfoDocument` — the only graphql() call
- * site today (account.ts → delete-account-section.tsx → /settings).
- * If the plugin worked, the chunk holding that import must NOT contain
- * unrelated operation names that only the full Documents map would pull in.
+ * Strategy: parse generated/gql.ts to learn every operation name in the
+ * project, parse account.ts to learn the names that are *supposed* to be
+ * in the settings chunk (the only graphql() call site today), then assert
+ * that the rest don't appear there. As more operations migrate to
+ * graphql(), the absence list shrinks automatically — no maintenance.
+ *
+ * Operation names survive bundling as string literals inside the parsed
+ * Document AST (e.g. `name:{kind:"Name",value:"GetBetaLinks"}`), even
+ * though the *Document import identifiers get minified.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const chunksDir = join(here, '..', '.next', 'static', 'chunks');
-
-// Query names survive bundling as string literals inside the parsed Document
-// AST. Import identifiers like *Document are minified, so we grep for the
-// operation name, which is stable across builds.
-const MARKER = 'GetDeleteAccountInfo';
-const MUST_BE_ABSENT = [
-  'GetBetaLinks',
-  'GetGlobalCommentFeed',
-  'GetUserAscentsFeed',
-  'UserFavoritesCounts',
-  'GetNewClimbFeed',
-];
+const webRoot = join(here, '..');
+const chunksDir = join(webRoot, '.next', 'static', 'chunks');
+const gqlPath = join(webRoot, 'app', 'lib', 'graphql', 'generated', 'gql.ts');
+const accountPath = join(webRoot, 'app', 'lib', 'graphql', 'operations', 'account.ts');
 
 function fail(message: string): never {
   console.error(`verify-graphql-treeshake: ${message}`);
   process.exit(1);
 }
 
-let chunks: string[];
+function extractOperationNames(source: string): string[] {
+  // Matches `query Name` and `mutation Name` inside graphql template
+  // literals. Captures the identifier only.
+  const matches = source.matchAll(/\b(?:query|mutation)\s+([A-Z]\w+)/g);
+  return [...new Set(Array.from(matches, (m) => m[1]))];
+}
+
+const allOperationNames = extractOperationNames(readFileSync(gqlPath, 'utf8'));
+const liveOperationNames = extractOperationNames(readFileSync(accountPath, 'utf8'));
+if (liveOperationNames.length === 0) {
+  fail(`could not parse operation names from ${accountPath}`);
+}
+const [marker] = liveOperationNames;
+const mustBeAbsent = allOperationNames.filter((name) => !liveOperationNames.includes(name));
+
+if (mustBeAbsent.length === 0) {
+  fail(`no candidate operations to verify against; gql.ts only contains operations that account.ts uses`);
+}
+
+let chunkNames: string[];
 try {
-  chunks = readdirSync(chunksDir).filter((name) => name.endsWith('.js'));
+  chunkNames = readdirSync(chunksDir).filter((name) => name.endsWith('.js'));
 } catch {
   fail(`chunks directory not found at ${chunksDir}; run \`vp run build:web\` first`);
 }
 
-const markerChunks = chunks.filter((name) => {
-  const content = readFileSync(join(chunksDir, name), 'utf8');
-  return content.includes(MARKER);
-});
+const chunkContent = new Map<string, string>();
+function read(name: string): string {
+  let content = chunkContent.get(name);
+  if (content === undefined) {
+    content = readFileSync(join(chunksDir, name), 'utf8');
+    chunkContent.set(name, content);
+  }
+  return content;
+}
+
+const markerChunks = chunkNames.filter((name) => read(name).includes(marker));
 
 if (markerChunks.length === 0) {
-  fail(`no chunk contains ${MARKER}; account.ts may not have been bundled — did the build complete?`);
+  fail(`no chunk contains ${marker}; account.ts may not have been bundled — did the build complete?`);
 }
 
 const leaks: { chunk: string; size: number; queries: string[] }[] = [];
 for (const name of markerChunks) {
-  const path = join(chunksDir, name);
-  const content = readFileSync(path, 'utf8');
-  const queries = MUST_BE_ABSENT.filter((q) => content.includes(q));
+  const content = read(name);
+  const queries = mustBeAbsent.filter((q) => content.includes(q));
   if (queries.length > 0) {
-    leaks.push({ chunk: name, size: statSync(path).size, queries });
+    leaks.push({ chunk: name, size: statSync(join(chunksDir, name)).size, queries });
   }
 }
 
 if (leaks.length > 0) {
   console.error('SWC plugin transform did not fire — Documents map leaked into settings chunk(s):');
   for (const { chunk, size, queries } of leaks) {
-    console.error(`  ${chunk} (${size} B): ${queries.join(', ')}`);
+    const shown = queries.slice(0, 5).join(', ');
+    const extra = queries.length > 5 ? `, +${queries.length - 5} more` : '';
+    console.error(`  ${chunk} (${size} B): ${shown}${extra}`);
   }
   console.error('Check artifactDirectory in packages/web/next.config.mjs.');
   process.exit(1);
@@ -70,6 +94,6 @@ if (leaks.length > 0) {
 
 const totalSize = markerChunks.reduce((sum, name) => sum + statSync(join(chunksDir, name)).size, 0);
 console.info(
-  `verify-graphql-treeshake: OK — ${markerChunks.length} chunk(s) carry ${MARKER} ` +
-    `(${totalSize} B total), no unrelated operations leaked.`,
+  `verify-graphql-treeshake: OK — ${markerChunks.length} chunk(s) carry ${marker} ` +
+    `(${totalSize} B total), ${mustBeAbsent.length} unrelated operation(s) checked, none leaked.`,
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,6 +100,11 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/web build',
         dependsOn: ['build:shared', 'build:crypto', 'build:db', 'build:constants'],
       },
+      'verify:graphql-treeshake': {
+        command: 'bun packages/web/scripts/verify-graphql-treeshake.ts',
+        dependsOn: ['build:web'],
+        cache: false,
+      },
       build: {
         command: 'true',
         dependsOn: ['build:backend', 'build:web'],


### PR DESCRIPTION
## Summary

`@graphql-codegen/client-preset` emits `packages/web/app/lib/graphql/generated/gql.ts` with a `Documents` map keyed on raw query strings. Without a build-time transform, the map ships in every client bundle that imports `graphql()` — not tree-shakeable, not minifiable, no dead-code elimination. This blocks migrating the remaining op files in `packages/web/app/lib/graphql/operations/` to the typed `graphql()` helper.

This PR wires the SWC team's contrib plugin (`@swc-contrib/plugin-graphql-codegen-client-preset`, the supported successor to the deprecated `@graphql-codegen/client-preset-swc-plugin`) into `next.config.mjs` under `experimental.swcPlugins`. The plugin rewrites each `graphql(\`...\`)` call site at compile time into a direct import of the corresponding `*Document` constant from `generated/graphql.ts`, so unused operations become dead code and the bundler can drop them.

- Pinned to `0.21.0` exactly — SWC plugin compatibility is ABI-tied. Next 16.1+ ships a stable plugin ABI so the pin remains valid across patch releases.
- `artifactDirectory` is `./packages/web/app/lib/graphql/generated`. The wasm plugin resolves this against the **workspace root** (where `bun.lock` lives), not `next.config.mjs`'s dir or `next build`'s cwd — empirically verified: `./app/lib/graphql/generated` produces `Module not found: Can't resolve './../../../../../../app/lib/graphql/generated/graphql'` (six `..` from `account.ts` lands at the workspace root).
- `gqlTagName: 'graphql'` matches the codegen client-preset default.
- Runs only during `next build` — `next dev` still bundles the full map locally. (Build engine for this codebase is whatever `next build` uses; the build log on Next 16.1.6 shows `▲ Next.js 16.1.6 (Turbopack)`. SWC plugins are honoured in either case.)
- No `codegen.ts` change. No operation files migrated.

## Bundle size impact

Measured on the chunk that contains the only live `graphql()` call site today (`packages/web/app/components/settings/delete-account-section.tsx` → `app/lib/graphql/operations/account.ts`):

| | Before | After | Delta |
|---|---|---|---|
| Raw | 167,164 B | 28,419 B | **−138.7 KB / −83%** |
| Gzipped | 17,359 B | 8,417 B | **−8.9 KB / −51%** |
| Total `static/chunks/` dir | 6,628,941 B | 6,490,196 B | **−135 KB** |

Spot-checked: `GetBetaLinks`, `GetGlobalCommentFeed`, `GetUserAscentsFeed`, `UserFavoritesCounts`, `GetNewClimbFeed` all appeared in the baseline settings chunk and are now absent.

The other 18 op files in `operations/` still use `gql` from `graphql-request`, so their bundles are unchanged here. Migrating them to `graphql()` is the next PR — that's where the transform's payoff really shows up.

## Regression check

Added `packages/web/scripts/verify-graphql-treeshake.ts` and a `vp run boardsesh-monorepo#verify:graphql-treeshake` task that depends on `build:web`. The script:

- Parses `gql.ts` for every operation name (matching `query|mutation|subscription`)
- Parses `account.ts` for the names that should be in the marker chunk
- Treats the difference as the must-be-absent set (auto-updates as files migrate, no manual list)
- Reads `chunks/` recursively so nested per-route chunks (`.next/static/chunks/app/...`) are covered if Next switches to that layout
- Asserts the marker chunk doesn't contain any must-be-absent operation name

Verified end-to-end:

- Plugin enabled (correct path) → script passes: `OK — 1 chunk(s) carry GetDeleteAccountInfo (28419 B total), 95 unrelated operation(s) checked, none leaked.`
- `swcPlugins` block removed entirely → script fails: `SWC plugin transform did not fire — Documents map leaked into settings chunk(s): 05b369a70a9e6f0f.js (167164 B): GetBetaLinks, ClimbStatsHistory, ..., +89 more`
- Wrong path → build itself fails fast with `Module not found`, before the script runs.

Wiring this into a CI workflow that already builds the web app is a follow-up — `test.yml` doesn't currently run `next build`, so adding it would expand scope. The vp task is ready to plug into any future build job.

## Test plan

- [x] `vp run codegen` — no diff in `packages/web/app/lib/graphql/generated/` or `packages/shared-schema/src/generated/`
- [x] `vp run boardsesh-monorepo#build:web` succeeds (exit 0)
- [x] `vp run boardsesh-monorepo#typecheck:web` succeeds — pilot file `delete-account-section.tsx` still infers `GET_DELETE_ACCOUNT_INFO` and `DELETE_ACCOUNT` types correctly
- [x] `vp run boardsesh-monorepo#verify:graphql-treeshake` passes against the working build (95 operations checked)
- [x] Same script fails when `swcPlugins` is removed (regression behaviour confirmed)
- [x] Recursion works against simulated nested chunks (`chunks/app/settings/test-nested.js`)
- [x] Rebased on latest `main`
- [ ] CI green

https://claude.ai/code/session_01DAW3jHJoPTim2dy3HsxgGm