### PR TITLE
Enforce CLAUDE.md style rules through oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,10 +9,33 @@
     "no-unused-vars": "error",
     "import/no-cycle": "error",
     "prefer-const": "error",
-    "no-nested-ternary": "error",
     "no-template-curly-in-string": "error",
     "eqeqeq": ["error", "smart"],
     "no-console": ["error", { "allow": ["warn", "error", "info"] }],
+    "no-nested-ternary": "error",
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "localStorage",
+        "message": "Use IndexedDB via packages/web/app/lib/user-preferences-db.ts or a domain-specific *-db.ts module instead. localStorage is only allowed in one-time migration code, and must be marked with // oxlint-disable-next-line no-restricted-globals."
+      },
+      {
+        "name": "sessionStorage",
+        "message": "Use IndexedDB via packages/web/app/lib/user-preferences-db.ts or a domain-specific *-db.ts module instead."
+      }
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@/app/lib/db/db",
+            "importNames": ["sql"],
+            "message": "Use Drizzle's getDb() or dbz from @/app/lib/db/db instead of the raw Neon sql client. New code must go through the Drizzle query builder."
+          }
+        ]
+      }
+    ],
     "typescript/no-explicit-any": ["deny", { "fixToUnknown": true }],
     "typescript/return-await": "error",
     "typescript/await-thenable": "error",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,9 @@ We are using next.js app router, it's important we try to use server side compon
 - For rendering avoid JavaScript breakpoint detection & Grid.useBreakpoint()
 - While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
 - **Dark mode uses white input fields** — This is intentional for contrast. All input components (TextField, Select, Autocomplete, etc.) have white backgrounds in dark mode via `darkTokens.semantic.inputSurface`. Do not change them to dark backgrounds.
-- **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
 - **Variable names must describe their contents** - No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `latest`, `temp`, `value`) outside of tight loops or well-known math conventions. The name should tell the next reader what's inside without forcing them to scroll back to the declaration. Prefer destructuring at the use site over a generic alias — `const { queue, currentClimb } = stateRef.current` reads better than `const s = stateRef.current` followed by `s.queue` / `s.currentClimb`.
+
+A handful of these style rules are enforced as oxlint errors so they fail `vp check`. See `.oxlintrc.json` for the exact rule names and config; the current lint-enforced set includes `typescript/no-explicit-any` (no `any`), `no-nested-ternary`, `no-restricted-globals` (no `localStorage` / `sessionStorage`), and `no-restricted-imports` (no raw Neon `sql` client from `@/app/lib/db/db`).
 
 ### Copy & Microcopy
 
@@ -346,19 +347,18 @@ Bad examples:
 
 **Always use Drizzle ORM query builder** (`db.select()`, `db.insert()`, `db.update()`, `db.delete()`) for database operations. Only fall back to raw SQL (`sql` template literals from `drizzle-orm`) when the query genuinely cannot be expressed with the query builder (complex JOINs with type casts, window functions, CTEs, EXISTS subqueries, complex aggregations).
 
-- **Never use the raw Neon `sql` client** (`import { sql } from '@/app/lib/db/db'`) for new code. Use Drizzle's `db` instance instead (`getDb()` or `dbz`), which provides type safety and schema validation.
+- Importing `sql` from `@/app/lib/db/db` (the raw Neon HTTP client) is blocked by lint (`no-restricted-imports`). Use Drizzle's `db` instance instead (`getDb()` or `dbz`).
 - When raw SQL is necessary, use `db.execute(sql`...`)` with Drizzle's `sql` from `drizzle-orm` — not the Neon HTTP client directly.
 - Both are safe from SQL injection (parameterized), but Drizzle gives you type safety and schema awareness.
 
 ### Client-Side Storage: IndexedDB Only
 
-**Never use `localStorage` or `sessionStorage`**. All client-side persistence must use IndexedDB via the `idb` package.
+All client-side persistence must use IndexedDB via the `idb` package. Bare `localStorage` and `sessionStorage` references are blocked by lint (`no-restricted-globals`); the only legitimate uses are one-time migration code that reads old data and deletes it (mark those sites with `// oxlint-disable-next-line no-restricted-globals`).
 
 - **Simple key-value preferences** (e.g., view mode, party mode): Use the shared utility at `packages/web/app/lib/user-preferences-db.ts` which provides `getPreference<T>(key)`, `setPreference(key, value)`, and `removePreference(key)`.
 - **Domain-specific data** (e.g., recent searches, session history, onboarding status): Create a dedicated `*-db.ts` file in `packages/web/app/lib/` following the established pattern (lazy `dbPromise` init, SSR guard, try-catch error handling). See `tab-navigation-db.ts` or `onboarding-db.ts` for examples.
 - All IndexedDB access must be guarded with `typeof window === 'undefined'` checks for SSR compatibility.
 - When migrating a value from `localStorage` to IndexedDB, include one-time migration logic that reads the old key, writes to IndexedDB, and deletes the localStorage key. See `user-preferences-db.ts` (`getPreference` fallback), `recent-searches-storage.ts`, and `party-profile-db.ts` for examples.
-- The only acceptable `localStorage` references are in one-time migration code that reads old data and deletes it.
 
 ### State Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,7 +353,7 @@ Bad examples:
 
 ### Client-Side Storage: IndexedDB Only
 
-All client-side persistence must use IndexedDB via the `idb` package. Bare `localStorage` and `sessionStorage` references are blocked by lint (`no-restricted-globals`); the only legitimate uses are one-time migration code that reads old data and deletes it (mark those sites with `// oxlint-disable-next-line no-restricted-globals`).
+All client-side persistence must use IndexedDB via the `idb` package. Bare `localStorage` and `sessionStorage` references are blocked by lint (`no-restricted-globals`); the only legitimate uses are one-time migration code that reads old data and deletes it, plus a couple of e2e test affordances that need synchronous reads at render time. Mark those sites with `// oxlint-disable-next-line no-restricted-globals` and a short reason. Do not bypass the rule by writing `window.localStorage` / `window.sessionStorage` — write the bare global and disable the rule explicitly so the exception is greppable.
 
 - **Simple key-value preferences** (e.g., view mode, party mode): Use the shared utility at `packages/web/app/lib/user-preferences-db.ts` which provides `getPreference<T>(key)`, `setPreference(key, value)`, and `removePreference(key)`.
 - **Domain-specific data** (e.g., recent searches, session history, onboarding status): Create a dedicated `*-db.ts` file in `packages/web/app/lib/` following the established pattern (lazy `dbPromise` init, SSR guard, try-catch error handling). See `tab-navigation-db.ts` or `onboarding-db.ts` for examples.

--- a/packages/aurora-sync/src/cli/index.ts
+++ b/packages/aurora-sync/src/cli/index.ts
@@ -164,7 +164,12 @@ program
         console.info('No credentials found.');
       } else {
         credentials.forEach((cred) => {
-          const status = cred.syncStatus === 'active' ? '✓' : cred.syncStatus === 'error' ? '✗' : '○';
+          let status = '○';
+          if (cred.syncStatus === 'active') {
+            status = '✓';
+          } else if (cred.syncStatus === 'error') {
+            status = '✗';
+          }
           const lastSync = cred.lastSyncAt ? new Date(cred.lastSyncAt).toISOString() : 'never';
           console.info(`${status} ${cred.userId} (${cred.boardType})`);
           console.info(`    Aurora ID: ${cred.auroraUserId}`);

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -588,12 +588,16 @@ export async function syncUserData(
       } catch (error) {
         await client.query('ROLLBACK');
         // Extract meaningful error message from PostgreSQL/Drizzle errors
-        const errorMessage =
-          error instanceof Error
-            ? error.message.includes('violates foreign key constraint')
-              ? `FK constraint violation: ${error.message.split('violates foreign key constraint')[1]?.split('"')[1] || 'unknown'}`
-              : error.message.slice(0, 2000)
-            : String(error).slice(0, 2000);
+        let errorMessage: string;
+        if (error instanceof Error) {
+          if (error.message.includes('violates foreign key constraint')) {
+            errorMessage = `FK constraint violation: ${error.message.split('violates foreign key constraint')[1]?.split('"')[1] || 'unknown'}`;
+          } else {
+            errorMessage = error.message.slice(0, 2000);
+          }
+        } else {
+          errorMessage = String(error).slice(0, 2000);
+        }
         log(`Database error: ${errorMessage}`);
         throw new Error(`Database error: ${errorMessage}`);
       } finally {

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -314,12 +314,14 @@ export const climbMutations = {
 
     // Decide the next draft/publish state. We only honor a transition from
     // draft → published; a publish → draft attempt is silently ignored.
-    const nextIsDraft =
-      validated.isDraft === undefined
-        ? (existing.isDraft ?? false)
-        : currentlyDraft && validated.isDraft === false
-          ? false
-          : (existing.isDraft ?? false);
+    let nextIsDraft: boolean;
+    if (validated.isDraft === undefined) {
+      nextIsDraft = existing.isDraft ?? false;
+    } else if (currentlyDraft && validated.isDraft === false) {
+      nextIsDraft = false;
+    } else {
+      nextIsDraft = existing.isDraft ?? false;
+    }
 
     const transitioningToPublished = currentlyDraft && validated.isDraft === false;
     const now = new Date().toISOString();

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -155,12 +155,14 @@ export async function applyRateLimit(ctx: ConnectionContext, limit?: number, ope
   // Tier 1: Synchronous in-memory rate limiting (fast path, per-instance)
   // Use userId for authenticated users, clientIp for anonymous HTTP requests,
   // or connectionId as fallback (WebSocket connections)
-  const key =
-    ctx.isAuthenticated && ctx.userId
-      ? `${ctx.userId}:${operation}`
-      : ctx.clientIp
-        ? `ip:${ctx.clientIp}:${operation}`
-        : ctx.connectionId;
+  let key: string;
+  if (ctx.isAuthenticated && ctx.userId) {
+    key = `${ctx.userId}:${operation}`;
+  } else if (ctx.clientIp) {
+    key = `ip:${ctx.clientIp}:${operation}`;
+  } else {
+    key = ctx.connectionId;
+  }
   checkRateLimit(key, maxRequests);
 
   // Tier 2: Distributed Redis rate limiting (authenticated users only)

--- a/packages/backend/src/graphql/resolvers/social/notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/notifications.ts
@@ -23,6 +23,12 @@ type NotificationRow = {
   commentBody: string | null;
 };
 
+function truncateCommentBody(commentBody: string | null): string | undefined {
+  if (!commentBody) return undefined;
+  if (commentBody.length > 100) return commentBody.slice(0, 100) + '...';
+  return commentBody;
+}
+
 function mapNotificationRow(row: NotificationRow) {
   return {
     uuid: row.uuid,
@@ -32,11 +38,7 @@ function mapNotificationRow(row: NotificationRow) {
     actorAvatarUrl: row.actorAvatarUrl || row.actorImage || undefined,
     entityType: row.entityType,
     entityId: row.entityId,
-    commentBody: row.commentBody
-      ? row.commentBody.length > 100
-        ? row.commentBody.slice(0, 100) + '...'
-        : row.commentBody
-      : undefined,
+    commentBody: truncateCommentBody(row.commentBody),
     climbName: undefined,
     climbUuid: undefined,
     boardType: undefined,
@@ -200,11 +202,7 @@ export const socialNotificationQueries = {
         entityId: row.entityId,
         actorCount: Number(row.actorCount),
         actors,
-        commentBody: row.commentBody
-          ? row.commentBody.length > 100
-            ? row.commentBody.slice(0, 100) + '...'
-            : row.commentBody
-          : undefined,
+        commentBody: truncateCommentBody(row.commentBody),
         climbName: undefined as string | undefined,
         climbUuid: undefined as string | undefined,
         boardType: undefined as string | undefined,

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -228,8 +228,13 @@ export const tickQueries = {
     const fromDate = validatedInput.fromDate;
     const toDate = validatedInput.toDate;
     const legacyStatus = validatedInput.status;
-    const statusMode =
-      validatedInput.statusMode ?? (legacyStatus === 'attempt' ? 'attempt' : legacyStatus ? 'send' : 'both');
+    let inferredStatusMode = 'both';
+    if (legacyStatus === 'attempt') {
+      inferredStatusMode = 'attempt';
+    } else if (legacyStatus) {
+      inferredStatusMode = 'send';
+    }
+    const statusMode = validatedInput.statusMode ?? inferredStatusMode;
     const flashOnly = validatedInput.flashOnly ?? legacyStatus === 'flash';
 
     const resolvedBenchmarkExpr = sql<boolean>`CASE
@@ -367,23 +372,27 @@ export const tickQueries = {
       }
     };
 
-    const resolvedPrimarySort =
-      sortBy === 'recent'
-        ? { field: 'date', direction: sortOrder }
-        : sortBy === 'hardest'
-          ? { field: 'consensusGrade', direction: 'desc' }
-          : sortBy === 'easiest'
-            ? { field: 'loggedGrade', direction: 'asc' }
-            : sortBy === 'mostAttempts'
-              ? { field: 'attemptCount', direction: 'desc' }
-              : { field: sortBy, direction: sortOrder };
+    let resolvedPrimarySort: { field: string; direction: string };
+    if (sortBy === 'recent') {
+      resolvedPrimarySort = { field: 'date', direction: sortOrder };
+    } else if (sortBy === 'hardest') {
+      resolvedPrimarySort = { field: 'consensusGrade', direction: 'desc' };
+    } else if (sortBy === 'easiest') {
+      resolvedPrimarySort = { field: 'loggedGrade', direction: 'asc' };
+    } else if (sortBy === 'mostAttempts') {
+      resolvedPrimarySort = { field: 'attemptCount', direction: 'desc' };
+    } else {
+      resolvedPrimarySort = { field: sortBy, direction: sortOrder };
+    }
 
-    const resolvedSecondarySort =
-      sortBy === 'hardest'
-        ? { field: 'loggedGrade', direction: 'desc' }
-        : secondarySortBy
-          ? { field: secondarySortBy, direction: secondarySortOrder }
-          : null;
+    let resolvedSecondarySort: { field: string; direction: string } | null;
+    if (sortBy === 'hardest') {
+      resolvedSecondarySort = { field: 'loggedGrade', direction: 'desc' };
+    } else if (secondarySortBy) {
+      resolvedSecondarySort = { field: secondarySortBy, direction: secondarySortOrder };
+    } else {
+      resolvedSecondarySort = null;
+    }
 
     const orderClauses = [
       buildOrderClause(resolvedPrimarySort.field, resolvedPrimarySort.direction),

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -126,13 +126,15 @@ async function fetchInstagramMetaUncached(url: string): Promise<InstagramMetaRes
     const ogImageRaw = html.match(/property=["']og:image["']\s+content=["']([^"']+)["']/i)?.[1] ?? null;
     const displayUrlRaw = html.match(/"display_url"\s*:\s*"([^"]+)"/)?.[1] ?? null;
     const thumbnailSrcRaw = html.match(/"thumbnail_src"\s*:\s*"([^"]+)"/)?.[1] ?? null;
-    thumbnail = ogImageRaw
-      ? decodeHtmlEntities(ogImageRaw)
-      : displayUrlRaw
-        ? decodeJsonString(displayUrlRaw)
-        : thumbnailSrcRaw
-          ? decodeJsonString(thumbnailSrcRaw)
-          : null;
+    if (ogImageRaw) {
+      thumbnail = decodeHtmlEntities(ogImageRaw);
+    } else if (displayUrlRaw) {
+      thumbnail = decodeJsonString(displayUrlRaw);
+    } else if (thumbnailSrcRaw) {
+      thumbnail = decodeJsonString(thumbnailSrcRaw);
+    } else {
+      thumbnail = null;
+    }
   }
 
   if (!thumbnail) {

--- a/packages/backend/src/services/discord.ts
+++ b/packages/backend/src/services/discord.ts
@@ -46,13 +46,16 @@ function formatBoard(payload: FeedbackDiscordPayload): string | null {
 export function buildWebhookBody(payload: FeedbackDiscordPayload): Record<string, unknown> {
   const isBug = BUG_SOURCES.has(payload.source);
   const title = isBug ? '🐞 Bug report' : `⭐ Rating: ${payload.rating ?? '?'}/5`;
-  const color = isBug
-    ? COLOR_RED
-    : payload.rating !== null && payload.rating >= 4
-      ? COLOR_GREEN
-      : payload.rating !== null && payload.rating >= 3
-        ? COLOR_YELLOW
-        : COLOR_RED;
+  let color: number;
+  if (isBug) {
+    color = COLOR_RED;
+  } else if (payload.rating !== null && payload.rating >= 4) {
+    color = COLOR_GREEN;
+  } else if (payload.rating !== null && payload.rating >= 3) {
+    color = COLOR_YELLOW;
+  } else {
+    color = COLOR_RED;
+  }
 
   const fields: Array<{ name: string; value: string; inline?: boolean }> = [
     { name: 'Platform', value: payload.platform, inline: true },
@@ -65,11 +68,12 @@ export function buildWebhookBody(payload: FeedbackDiscordPayload): Record<string
 
   const ctx = payload.context;
   if (ctx?.climbName || ctx?.climbUuid) {
-    const climbValue = ctx.climbName
-      ? ctx.difficulty
-        ? `${ctx.climbName} (${ctx.difficulty})`
-        : ctx.climbName
-      : (ctx.climbUuid ?? '');
+    let climbValue: string;
+    if (ctx.climbName) {
+      climbValue = ctx.difficulty ? `${ctx.climbName} (${ctx.difficulty})` : ctx.climbName;
+    } else {
+      climbValue = ctx.climbUuid ?? '';
+    }
     fields.push({ name: 'Climb', value: climbValue, inline: false });
   }
   if (ctx?.sessionId) {

--- a/packages/db/scripts/fixtures/comment-templates.ts
+++ b/packages/db/scripts/fixtures/comment-templates.ts
@@ -1561,8 +1561,12 @@ export const SALTY_THREADS: ThreadTemplate[] = [
 // =============================================================================
 
 export function pickTickComment(status: TickStatus): string {
-  const pool =
-    status === 'flash' ? FLASH_TICK_COMMENTS : status === 'send' ? SEND_TICK_COMMENTS : ATTEMPT_TICK_COMMENTS;
+  let pool = ATTEMPT_TICK_COMMENTS;
+  if (status === 'flash') {
+    pool = FLASH_TICK_COMMENTS;
+  } else if (status === 'send') {
+    pool = SEND_TICK_COMMENTS;
+  }
 
   // 70% status-specific, 30% general
   const useGeneral = Math.random() < 0.3;

--- a/packages/db/scripts/fixtures/deterministic-social.ts
+++ b/packages/db/scripts/fixtures/deterministic-social.ts
@@ -208,6 +208,12 @@ function buildFixtureTicks(): FixtureTick[] {
     for (let i = 0; i < 10; i++) {
       const gi = ti * 10 + i;
       const userNum = ((gi + 3) % 12) + 1;
+      let attemptCount = 8;
+      if (cfg.status === 'flash') {
+        attemptCount = 1;
+      } else if (cfg.status === 'send') {
+        attemptCount = 3;
+      }
       ticks.push({
         uuid: `fx-tick-${cfg.short}-${String(i + 1).padStart(2, '0')}`,
         userId: uid(userNum),
@@ -215,7 +221,7 @@ function buildFixtureTicks(): FixtureTick[] {
         angle: ANGLES[gi % 6],
         isMirror: false,
         status: cfg.status,
-        attemptCount: cfg.status === 'flash' ? 1 : cfg.status === 'send' ? 3 : 8,
+        attemptCount,
         quality: cfg.status !== 'attempt' ? 4 : null,
         comment: '',
         globalIndex: gi,

--- a/packages/db/scripts/seed-social.ts
+++ b/packages/db/scripts/seed-social.ts
@@ -599,23 +599,37 @@ async function seedSocialData() {
           } else if (gradeRank > 0.7) {
             // Project grades: fewer flashes, more attempts
             const roll = faker.number.float({ min: 0, max: 1 });
-            status = roll < 0.05 ? 'flash' : roll < 0.55 ? 'send' : 'attempt';
-            attemptCount =
-              status === 'flash'
-                ? 1
-                : status === 'send'
-                  ? faker.number.int({ min: 3, max: 20 })
-                  : faker.number.int({ min: 1, max: 10 });
+            if (roll < 0.05) {
+              status = 'flash';
+            } else if (roll < 0.55) {
+              status = 'send';
+            } else {
+              status = 'attempt';
+            }
+            if (status === 'flash') {
+              attemptCount = 1;
+            } else if (status === 'send') {
+              attemptCount = faker.number.int({ min: 3, max: 20 });
+            } else {
+              attemptCount = faker.number.int({ min: 1, max: 10 });
+            }
           } else {
             // Comfort zone: good mix of flashes and sends
             const roll = faker.number.float({ min: 0, max: 1 });
-            status = roll < 0.25 ? 'flash' : roll < 0.85 ? 'send' : 'attempt';
-            attemptCount =
-              status === 'flash'
-                ? 1
-                : status === 'send'
-                  ? faker.number.int({ min: 2, max: 8 })
-                  : faker.number.int({ min: 1, max: 5 });
+            if (roll < 0.25) {
+              status = 'flash';
+            } else if (roll < 0.85) {
+              status = 'send';
+            } else {
+              status = 'attempt';
+            }
+            if (status === 'flash') {
+              attemptCount = 1;
+            } else if (status === 'send') {
+              attemptCount = faker.number.int({ min: 2, max: 8 });
+            } else {
+              attemptCount = faker.number.int({ min: 1, max: 5 });
+            }
           }
 
           const quality = status !== 'attempt' ? faker.number.int({ min: 1, max: 5 }) : null;
@@ -679,8 +693,14 @@ async function seedSocialData() {
 
           // Weighted status: flash 20%, send 50%, attempt 30%
           const statusRoll = faker.number.float({ min: 0, max: 1 });
-          const status =
-            statusRoll < 0.2 ? ('flash' as const) : statusRoll < 0.7 ? ('send' as const) : ('attempt' as const);
+          let status: 'flash' | 'send' | 'attempt';
+          if (statusRoll < 0.2) {
+            status = 'flash';
+          } else if (statusRoll < 0.7) {
+            status = 'send';
+          } else {
+            status = 'attempt';
+          }
 
           // Each tick in the session is 10-30 minutes after the previous
           const minutesIntoSession = j * faker.number.int({ min: 10, max: 30 });
@@ -688,12 +708,14 @@ async function seedSocialData() {
 
           const difficulty = status !== 'attempt' ? faker.helpers.arrayElement(grades) : null;
           const quality = status !== 'attempt' ? faker.number.int({ min: 1, max: 5 }) : null;
-          const attemptCount =
-            status === 'flash'
-              ? 1
-              : status === 'send'
-                ? faker.number.int({ min: 2, max: 15 })
-                : faker.number.int({ min: 1, max: 5 });
+          let attemptCount: number;
+          if (status === 'flash') {
+            attemptCount = 1;
+          } else if (status === 'send') {
+            attemptCount = faker.number.int({ min: 2, max: 15 });
+          } else {
+            attemptCount = faker.number.int({ min: 1, max: 5 });
+          }
 
           const comment = faker.datatype.boolean(0.3) ? pickTickComment(status) : '';
 
@@ -877,20 +899,28 @@ async function seedSocialData() {
         for (let ti = 0; ti < ticksForUser; ti++) {
           const climb = faker.helpers.arrayElement(climbs);
           const statusRoll = faker.number.float({ min: 0, max: 1 });
-          const status =
-            statusRoll < 0.2 ? ('flash' as const) : statusRoll < 0.7 ? ('send' as const) : ('attempt' as const);
+          let status: 'flash' | 'send' | 'attempt';
+          if (statusRoll < 0.2) {
+            status = 'flash';
+          } else if (statusRoll < 0.7) {
+            status = 'send';
+          } else {
+            status = 'attempt';
+          }
 
           const minutesIntoSession = ti * faker.number.int({ min: 8, max: 20 });
           const climbedAt = new Date(sessionBaseTime + minutesIntoSession * 60 * 1000);
 
           const difficulty = status !== 'attempt' ? faker.helpers.arrayElement(grades) : null;
           const quality = status !== 'attempt' ? faker.number.int({ min: 1, max: 5 }) : null;
-          const attemptCount =
-            status === 'flash'
-              ? 1
-              : status === 'send'
-                ? faker.number.int({ min: 2, max: 10 })
-                : faker.number.int({ min: 1, max: 5 });
+          let attemptCount: number;
+          if (status === 'flash') {
+            attemptCount = 1;
+          } else if (status === 'send') {
+            attemptCount = faker.number.int({ min: 2, max: 10 });
+          } else {
+            attemptCount = faker.number.int({ min: 1, max: 5 });
+          }
 
           await db
             .insert(boardseshTicks)

--- a/packages/web/app/__tests__/page-seo-metadata.test.ts
+++ b/packages/web/app/__tests__/page-seo-metadata.test.ts
@@ -24,13 +24,19 @@ function getOpenGraphImageUrl(image: string | URL | { url: string | URL } | unde
   return typeof image.url === 'string' ? image.url : image.url.toString();
 }
 
+function toOpenGraphImageList<T>(images: T | T[] | undefined): T[] {
+  if (Array.isArray(images)) {
+    return images;
+  }
+  if (images) {
+    return [images];
+  }
+  return [];
+}
+
 describe('page metadata exports', () => {
   it('gives static marketing pages a canonical URL and default social image', () => {
-    const aboutImages = Array.isArray(aboutPage.metadata.openGraph?.images)
-      ? aboutPage.metadata.openGraph.images
-      : aboutPage.metadata.openGraph?.images
-        ? [aboutPage.metadata.openGraph.images]
-        : [];
+    const aboutImages = toOpenGraphImageList(aboutPage.metadata.openGraph?.images);
     const aboutImageUrl = getOpenGraphImageUrl(aboutImages[0]);
 
     expect(aboutPage.metadata.title).toBe('About | Boardsesh');

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -214,11 +214,12 @@ export async function GET(request: NextRequest) {
           (OG_IMAGE_HEIGHT - OG_BOARD_PADDING_Y * 2) / boardDetails.boardHeight,
         )
       : null;
-    const outputWidth = isOgVariant
-      ? Math.max(1, Math.round(boardDetails.boardWidth * (ogScale || 1)))
-      : thumbnail
-        ? THUMBNAIL_WIDTH
-        : boardDetails.boardWidth;
+    const computeOutputWidth = () => {
+      if (isOgVariant) return Math.max(1, Math.round(boardDetails.boardWidth * (ogScale || 1)));
+      if (thumbnail) return THUMBNAIL_WIDTH;
+      return boardDetails.boardWidth;
+    };
+    const outputWidth = computeOutputWidth();
 
     // Build hold state map for this board
     const holdStateMap: Record<number, { color: string; renderStyle?: string }> = {};
@@ -366,9 +367,12 @@ export async function GET(request: NextRequest) {
         .toBuffer();
       outputContentType = 'image/png';
     } else if (outputBuffer === null && imageBuffer && format === 'webp') {
-      outputBuffer = await sharp(imageBuffer)
-        .webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : didCompositeBackground ? DEFAULT_WEBP_OPTIONS : { lossless: true })
-        .toBuffer();
+      const getWebpOptions = () => {
+        if (thumbnail) return THUMBNAIL_WEBP_OPTIONS;
+        if (didCompositeBackground) return DEFAULT_WEBP_OPTIONS;
+        return { lossless: true };
+      };
+      outputBuffer = await sharp(imageBuffer).webp(getWebpOptions()).toBuffer();
       outputContentType = 'image/webp';
     } else if (outputBuffer === null && imageBuffer) {
       outputBuffer = imageBuffer;

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import type { NextRequest } from 'next/server';
+// oxlint-disable-next-line no-restricted-imports -- legacy raw Neon sql usage; migrate to drizzle
 import { sql } from '@/app/lib/db/db';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';

--- a/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
+++ b/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-restricted-imports -- legacy raw Neon sql usage; migrate to drizzle
 import { sql } from '@/app/lib/db/db';
 import { NextResponse } from 'next/server';
 

--- a/packages/web/app/components/activity-feed/activity-feed.tsx
+++ b/packages/web/app/components/activity-feed/activity-feed.tsx
@@ -99,6 +99,23 @@ export default function ActivityFeed({
     );
   }
 
+  let emptyStateContent: React.ReactNode = null;
+  if (isAuthenticated) {
+    emptyStateContent = (
+      <EmptyState icon={<PersonSearchOutlined fontSize="inherit" />} description="Follow some climbers to fill this up">
+        {onFindClimbers && (
+          <MuiButton variant="contained" onClick={onFindClimbers}>
+            Find Climbers
+          </MuiButton>
+        )}
+      </EmptyState>
+    );
+  } else {
+    emptyStateContent = (
+      <EmptyState icon={<PublicOutlined fontSize="inherit" />} description="No recent activity yet" />
+    );
+  }
+
   return (
     <Box data-testid="activity-feed" sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       {!isAuthenticated && (
@@ -127,20 +144,7 @@ export default function ActivityFeed({
       )}
 
       {!error && sessions.length === 0 ? (
-        isAuthenticated ? (
-          <EmptyState
-            icon={<PersonSearchOutlined fontSize="inherit" />}
-            description="Follow some climbers to fill this up"
-          >
-            {onFindClimbers && (
-              <MuiButton variant="contained" onClick={onFindClimbers}>
-                Find Climbers
-              </MuiButton>
-            )}
-          </EmptyState>
-        ) : (
-          <EmptyState icon={<PublicOutlined fontSize="inherit" />} description="No recent activity yet" />
-        )
+        emptyStateContent
       ) : (
         <VoteSummaryProvider entityType="session" entityIds={sessionIds}>
           {sessions.map((session) => (

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -97,7 +97,12 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['betaLinks', boardType, climbUuid] });
-      const platform = isTikTokUrl(trimmed) ? 'TikTok' : isInstagramUrl(trimmed) ? 'Instagram' : 'Unknown';
+      let platform: 'TikTok' | 'Instagram' | 'Unknown' = 'Unknown';
+      if (isTikTokUrl(trimmed)) {
+        platform = 'TikTok';
+      } else if (isInstagramUrl(trimmed)) {
+        platform = 'Instagram';
+      }
       track('Beta Video Added', { boardType, climbUuid, platform });
       showMessage('Video added to beta', 'success');
       setUrl('');

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -19,7 +19,12 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
   const isInstagram = !isTikTok && isInstagramUrl(link.link);
   const PlatformIcon = isTikTok ? TikTokIcon : Instagram;
   const displayPlatform = isTikTok ? 'TikTok' : 'Instagram';
-  const analyticsPlatform = isTikTok ? 'TikTok' : isInstagram ? 'Instagram' : 'Unknown';
+  let analyticsPlatform: 'TikTok' | 'Instagram' | 'Unknown' = 'Unknown';
+  if (isTikTok) {
+    analyticsPlatform = 'TikTok';
+  } else if (isInstagram) {
+    analyticsPlatform = 'Instagram';
+  }
 
   return (
     <a

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -157,7 +157,8 @@ export function BluetoothProvider({
   const [demoResolvedBoards, setDemoResolvedBoards] = useState<Map<string, ResolvedBoardEntry> | null>(null);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (window.sessionStorage.getItem('boardsesh:e2e-bluetooth-picker') !== '1') return;
+    // oxlint-disable-next-line no-restricted-globals -- e2e flag must be read synchronously during render
+    if (sessionStorage.getItem('boardsesh:e2e-bluetooth-picker') !== '1') return;
 
     // Real boards (and where available, real serials) sourced from
     // production user_boards.json so the picker shows authentic-looking

--- a/packages/web/app/components/board-entity/board-leaderboard.tsx
+++ b/packages/web/app/components/board-entity/board-leaderboard.tsx
@@ -109,15 +109,17 @@ export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
         ))}
       </Box>
 
-      {isLoading ? (
+      {isLoading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress size={28} />
         </Box>
-      ) : !leaderboard || leaderboard.entries.length === 0 ? (
+      )}
+      {!isLoading && (!leaderboard || leaderboard.entries.length === 0) && (
         <MuiTypography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
           No activity yet for this period.
         </MuiTypography>
-      ) : (
+      )}
+      {!isLoading && leaderboard && leaderboard.entries.length > 0 && (
         <>
           <TableContainer>
             <Table size="small">

--- a/packages/web/app/components/board-entity/map-location-picker.tsx
+++ b/packages/web/app/components/board-entity/map-location-picker.tsx
@@ -83,11 +83,12 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
       if (!containerRef.current) return;
 
       const hasCoords = latitude != null && longitude != null;
-      const center: [number, number] = hasCoords
-        ? [latitude, longitude]
-        : userCoords
-          ? [userCoords.latitude, userCoords.longitude]
-          : [40, -95];
+      let center: [number, number] = [40, -95];
+      if (hasCoords) {
+        center = [latitude, longitude];
+      } else if (userCoords) {
+        center = [userCoords.latitude, userCoords.longitude];
+      }
       const zoom = hasCoords || userCoords ? 14 : 3;
 
       const map = L.map(containerRef.current, {

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -233,6 +233,12 @@ const ClimbsListSkeleton = ({ aspectRatio, viewMode }: { aspectRatio: number; vi
   ));
 };
 
+const getOnboardingIdProps = (index: number): { id?: string } => {
+  if (index === 0) return { id: 'onboarding-climb-card' };
+  if (index === 1) return { id: 'onboarding-climb-card-2' };
+  return {};
+};
+
 type GridClimbItemProps = {
   climb: Climb;
   index: number;
@@ -265,7 +271,7 @@ const GridClimbItem = React.memo(function GridClimbItem({
   }, [onClimbClickByIndex, index, needsBiggerBoard, onNeedsBiggerBoard]);
   return (
     <>
-      <div {...(index === 0 ? { id: 'onboarding-climb-card' } : index === 1 ? { id: 'onboarding-climb-card-2' } : {})}>
+      <div {...getOnboardingIdProps(index)}>
         <ClimbCard
           climb={climb}
           boardDetails={boardDetails}
@@ -620,11 +626,7 @@ const ClimbsList = ({
                         key={virtualItem.key}
                         ref={virtualizer.measureElement}
                         data-index={virtualItem.index}
-                        {...(index === 0
-                          ? { id: 'onboarding-climb-card' }
-                          : index === 1
-                            ? { id: 'onboarding-climb-card-2' }
-                            : {})}
+                        {...getOnboardingIdProps(index)}
                         style={{
                           position: 'absolute',
                           top: 0,

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -56,6 +56,26 @@ export const ShareBoardButton = () => {
     }
   };
 
+  let lightbulbIcon: React.ReactNode;
+  if (isConnecting || btLoading) {
+    lightbulbIcon = <CircularProgress size={16} />;
+  } else if (isBoardConnected) {
+    lightbulbIcon = (
+      <Lightbulb
+        sx={{
+          color: themeTokens.colors.warning,
+          '@keyframes connectedGlow': {
+            '0%': { filter: `drop-shadow(0 0 2px ${themeTokens.colors.warning}99)` },
+            '100%': { filter: `drop-shadow(0 0 6px ${themeTokens.colors.warning})` },
+          },
+          animation: 'connectedGlow 1.5s ease-in-out infinite alternate',
+        }}
+      />
+    );
+  } else {
+    lightbulbIcon = <LightbulbOutlined />;
+  }
+
   return (
     <>
       <IconButton
@@ -63,22 +83,7 @@ export const ShareBoardButton = () => {
         onClick={handleLightbulbClick}
         color={isSessionActive ? 'primary' : 'default'}
       >
-        {isConnecting || btLoading ? (
-          <CircularProgress size={16} />
-        ) : isBoardConnected ? (
-          <Lightbulb
-            sx={{
-              color: themeTokens.colors.warning,
-              '@keyframes connectedGlow': {
-                '0%': { filter: `drop-shadow(0 0 2px ${themeTokens.colors.warning}99)` },
-                '100%': { filter: `drop-shadow(0 0 6px ${themeTokens.colors.warning})` },
-              },
-              animation: 'connectedGlow 1.5s ease-in-out infinite alternate',
-            }}
-          />
-        ) : (
-          <LightbulbOutlined />
-        )}
+        {lightbulbIcon}
       </IconButton>
 
       <Dialog open={unsupportedOpen} onClose={() => setUnsupportedOpen(false)}>

--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -56,7 +56,12 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
     if (!canvas) return;
 
     let cancelled = false;
-    const context: RenderContext = thumbnail ? 'thumbnail' : contain ? 'full-board' : 'card';
+    let context: RenderContext = 'card';
+    if (thumbnail) {
+      context = 'thumbnail';
+    } else if (contain) {
+      context = 'full-board';
+    }
 
     renderBoard({ boardDetails, frames, mirrored, thumbnail, cropTop })
       .then((bitmap) => {

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -65,7 +65,12 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
 
   const imgStyle = contain || thumbnail ? layerContainStyle : layerStyle;
 
-  const renderContext: RenderContext = thumbnail ? 'thumbnail' : contain ? 'full-board' : 'card';
+  let renderContext: RenderContext = 'card';
+  if (thumbnail) {
+    renderContext = 'thumbnail';
+  } else if (contain) {
+    renderContext = 'full-board';
+  }
 
   const handleOverlayError = useCallback(() => {
     trackRenderError(renderContext, 'wasm');

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -235,11 +235,12 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
             flexShrink: 0,
           }}
         >
-          {showSpinner ? (
+          {showSpinner && (
             <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
               <CircularProgress size={20} />
             </Box>
-          ) : boards.length === 0 ? (
+          )}
+          {!showSpinner && boards.length === 0 && (
             <Box sx={{ py: 3, textAlign: 'center', px: 2 }}>
               <Typography variant="body2" color="text.secondary">
                 {query.trim().length >= 2
@@ -247,7 +248,8 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                   : 'No boards in this area. Pan or zoom out to find more.'}
               </Typography>
             </Box>
-          ) : (
+          )}
+          {!showSpinner && boards.length > 0 && (
             <Box
               ref={carouselRef}
               onScroll={handleCarouselScroll}

--- a/packages/web/app/components/charts/css-bar-chart.tsx
+++ b/packages/web/app/components/charts/css-bar-chart.tsx
@@ -87,7 +87,10 @@ export const CssBarChart = React.memo(function CssBarChart({
     return <div role="img" aria-label={ariaLabel} />;
   }
 
-  const bottomMargin = showLegend ? (angledLabels ? 40 : 24) : 4;
+  let bottomMargin = 4;
+  if (showLegend) {
+    bottomMargin = angledLabels ? 40 : 24;
+  }
 
   return (
     <Box

--- a/packages/web/app/components/climb-actions/__tests__/go-to-queue-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/go-to-queue-action.test.tsx
@@ -60,10 +60,18 @@ vi.mock('../../graphql-queue', () => ({
  */
 const mockBuildActionResult = vi.fn();
 vi.mock('../action-view-renderer', () => ({
-  computeActionDisplay: (_viewMode: string, size = 'default', _showLabel?: boolean) => ({
-    shouldShowLabel: true,
-    iconSize: size === 'small' ? 14 : size === 'large' ? 20 : 16,
-  }),
+  computeActionDisplay: (_viewMode: string, size = 'default', _showLabel?: boolean) => {
+    let iconSize = 16;
+    if (size === 'small') {
+      iconSize = 14;
+    } else if (size === 'large') {
+      iconSize = 20;
+    }
+    return {
+      shouldShowLabel: true,
+      iconSize,
+    };
+  },
   buildActionResult: (args: Record<string, unknown>) => {
     mockBuildActionResult(args);
     const onClick = args.onClick as (e?: React.MouseEvent) => void;

--- a/packages/web/app/components/climb-actions/action-view-renderer.tsx
+++ b/packages/web/app/components/climb-actions/action-view-renderer.tsx
@@ -20,9 +20,15 @@ export function computeActionDisplay(
   size: ClimbActionSize = 'default',
   showLabel?: boolean,
 ) {
+  let iconSize = 16;
+  if (size === 'small') {
+    iconSize = 14;
+  } else if (size === 'large') {
+    iconSize = 20;
+  }
   return {
     shouldShowLabel: showLabel ?? (viewMode === 'button' || viewMode === 'dropdown'),
-    iconSize: size === 'small' ? 14 : size === 'large' ? 20 : 16,
+    iconSize,
   };
 }
 

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -338,12 +338,14 @@ export function PlaylistAction({
 
   const label = 'Add to Playlist';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
-  const getIconSize = () => {
-    if (size === 'small') return 14;
-    if (size === 'large') return 20;
-    return 16;
-  };
-  const iconSize = getIconSize();
+  let iconSize: number;
+  if (size === 'small') {
+    iconSize = 14;
+  } else if (size === 'large') {
+    iconSize = 20;
+  } else {
+    iconSize = 16;
+  }
 
   const inPlaylistCount = playlistsContainingClimb.size;
   const renderIcon = () => {

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -338,18 +338,28 @@ export function PlaylistAction({
 
   const label = 'Add to Playlist';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
-  const iconSize = size === 'small' ? 14 : size === 'large' ? 20 : 16;
+  const getIconSize = () => {
+    if (size === 'small') return 14;
+    if (size === 'large') return 20;
+    return 16;
+  };
+  const iconSize = getIconSize();
 
   const inPlaylistCount = playlistsContainingClimb.size;
-  const icon = popoverOpen ? (
-    <CloseOutlined sx={{ fontSize: iconSize }} />
-  ) : inPlaylistCount > 0 ? (
-    <MuiBadge badgeContent={inPlaylistCount} sx={{ '& .MuiBadge-badge': { top: 2, right: -2 } }}>
-      <LocalOfferOutlined sx={{ fontSize: iconSize }} />
-    </MuiBadge>
-  ) : (
-    <LocalOfferOutlined sx={{ fontSize: iconSize }} />
-  );
+  const renderIcon = () => {
+    if (popoverOpen) {
+      return <CloseOutlined sx={{ fontSize: iconSize }} />;
+    }
+    if (inPlaylistCount > 0) {
+      return (
+        <MuiBadge badgeContent={inPlaylistCount} sx={{ '& .MuiBadge-badge': { top: 2, right: -2 } }}>
+          <LocalOfferOutlined sx={{ fontSize: iconSize }} />
+        </MuiBadge>
+      );
+    }
+    return <LocalOfferOutlined sx={{ fontSize: iconSize }} />;
+  };
+  const icon = renderIcon();
 
   // Icon mode - for Card actions (renders inline content below when expanded)
   const iconElement = (

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -179,7 +179,12 @@ export function TickAction({
 
   const label = 'Log ascent';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
-  const iconSize = size === 'small' ? 14 : size === 'large' ? 20 : 16;
+  const getIconSize = () => {
+    if (size === 'small') return 14;
+    if (size === 'large') return 20;
+    return 16;
+  };
+  const iconSize = getIconSize();
 
   const icon = <CheckOutlined sx={{ fontSize: iconSize }} />;
   const badgeColor = hasSuccessfulAscent ? themeTokens.colors.success : themeTokens.colors.error;
@@ -244,11 +249,55 @@ export function TickAction({
     </Stack>
   );
 
-  const drawers = boardProvider ? (
-    // Inside a board route - existing flow unchanged
-    isAuthenticated ? (
-      <LogAscentDrawer open={drawerVisible} onClose={closeDrawer} currentClimb={climb} boardDetails={boardDetails} />
-    ) : (
+  const renderDrawers = () => {
+    if (boardProvider) {
+      // Inside a board route - existing flow unchanged
+      if (isAuthenticated) {
+        return (
+          <LogAscentDrawer
+            open={drawerVisible}
+            onClose={closeDrawer}
+            currentClimb={climb}
+            boardDetails={boardDetails}
+          />
+        );
+      }
+      return (
+        <SwipeableDrawer
+          title="Sign In Required"
+          placement="bottom"
+          onClose={closeDrawer}
+          open={drawerVisible}
+          styles={{ wrapper: { height: '60%' } }}
+        >
+          {renderSignInPrompt()}
+        </SwipeableDrawer>
+      );
+    }
+    if (isAuthenticated) {
+      // Outside board route, authenticated - board selector + log form
+      return (
+        <SwipeableDrawer
+          title={showBoardSelector ? 'Select Board' : 'Log Ascent'}
+          placement="bottom"
+          onClose={closeDrawer}
+          open={drawerVisible}
+          fullHeight={!showBoardSelector}
+          styles={{ wrapper: { height: showBoardSelector ? '60%' : '100%' } }}
+        >
+          {showBoardSelector ? (
+            renderBoardSelector()
+          ) : (
+            <BoardProvider boardName={resolvedBoardName}>
+              {noMatchingBoards && renderNoMatchingBoardsMessage()}
+              {renderLogAscentForm()}
+            </BoardProvider>
+          )}
+        </SwipeableDrawer>
+      );
+    }
+    // Outside board route, not authenticated - sign-in prompt
+    return (
       <SwipeableDrawer
         title="Sign In Required"
         placement="bottom"
@@ -258,38 +307,9 @@ export function TickAction({
       >
         {renderSignInPrompt()}
       </SwipeableDrawer>
-    )
-  ) : isAuthenticated ? (
-    // Outside board route, authenticated - board selector + log form
-    <SwipeableDrawer
-      title={showBoardSelector ? 'Select Board' : 'Log Ascent'}
-      placement="bottom"
-      onClose={closeDrawer}
-      open={drawerVisible}
-      fullHeight={!showBoardSelector}
-      styles={{ wrapper: { height: showBoardSelector ? '60%' : '100%' } }}
-    >
-      {showBoardSelector ? (
-        renderBoardSelector()
-      ) : (
-        <BoardProvider boardName={resolvedBoardName}>
-          {noMatchingBoards && renderNoMatchingBoardsMessage()}
-          {renderLogAscentForm()}
-        </BoardProvider>
-      )}
-    </SwipeableDrawer>
-  ) : (
-    // Outside board route, not authenticated - sign-in prompt
-    <SwipeableDrawer
-      title="Sign In Required"
-      placement="bottom"
-      onClose={closeDrawer}
-      open={drawerVisible}
-      styles={{ wrapper: { height: '60%' } }}
-    >
-      {renderSignInPrompt()}
-    </SwipeableDrawer>
-  );
+    );
+  };
+  const drawers = renderDrawers();
 
   // Icon mode - for Card actions
   const iconElement = (

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -179,12 +179,14 @@ export function TickAction({
 
   const label = 'Log ascent';
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
-  const getIconSize = () => {
-    if (size === 'small') return 14;
-    if (size === 'large') return 20;
-    return 16;
-  };
-  const iconSize = getIconSize();
+  let iconSize: number;
+  if (size === 'small') {
+    iconSize = 14;
+  } else if (size === 'large') {
+    iconSize = 20;
+  } else {
+    iconSize = 16;
+  }
 
   const icon = <CheckOutlined sx={{ fontSize: iconSize }} />;
   const badgeColor = hasSuccessfulAscent ? themeTokens.colors.success : themeTokens.colors.error;

--- a/packages/web/app/components/climb-actions/playlist-selection-content.tsx
+++ b/packages/web/app/components/climb-actions/playlist-selection-content.tsx
@@ -156,7 +156,7 @@ export default function PlaylistSelectionContent({
         </MuiTypography>
       </Box>
 
-      {!isAuthenticated ? (
+      {!isAuthenticated && (
         <Stack spacing={1} sx={{ width: '100%', textAlign: 'center', py: themeTokens.spacing[1] }}>
           <MuiTypography component="span" color="text.secondary" sx={{ fontSize: themeTokens.typography.fontSize.sm }}>
             Sign in to create and manage playlists
@@ -175,7 +175,8 @@ export default function PlaylistSelectionContent({
             Sign In
           </MuiButton>
         </Stack>
-      ) : playlists.length === 0 && !showCreateForm ? (
+      )}
+      {isAuthenticated && playlists.length === 0 && !showCreateForm && (
         <Stack spacing={1} sx={{ width: '100%', textAlign: 'center', py: themeTokens.spacing[1] }}>
           <MuiTypography component="span" color="text.secondary" sx={{ fontSize: themeTokens.typography.fontSize.sm }}>
             No playlists yet
@@ -190,7 +191,8 @@ export default function PlaylistSelectionContent({
             Create Your First Playlist
           </MuiButton>
         </Stack>
-      ) : (
+      )}
+      {isAuthenticated && (playlists.length > 0 || showCreateForm) && (
         <>
           {!showCreateForm && (
             <>

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -269,15 +269,19 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
       </Typography>
     );
 
-    const largeGradeElement =
-      displayDifficulty &&
-      (!gradeFormatLoaded ? (
+    let largeGradeContent: React.ReactNode = null;
+    if (!gradeFormatLoaded) {
+      largeGradeContent = (
         <Skeleton variant="rounded" width={nameFontSize * 2.2} height={nameFontSize} sx={{ flexShrink: 0 }} />
-      ) : formattedGrade ? (
+      );
+    } else if (formattedGrade) {
+      largeGradeContent = (
         <Typography variant="body2" component="span" sx={largeGradeSx}>
           {formattedGrade}
         </Typography>
-      ) : null);
+      );
+    }
+    const largeGradeElement = displayDifficulty && largeGradeContent;
 
     const setterText = climb.is_draft
       ? `Draft by ${climb.setter_username}`

--- a/packages/web/app/components/climb-detail/climb-detail-header.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-header.tsx
@@ -32,6 +32,49 @@ export default function ClimbDetailHeader({ climb, communityGrade }: ClimbDetail
 
   const hasQuality = climb.quality_average && climb.quality_average !== '0';
 
+  const renderGradeContent = () => {
+    if (!gradeFormatLoaded && displayDifficulty) {
+      return <Skeleton variant="rounded" width={48} height={themeTokens.typography.fontSize['2xl']} />;
+    }
+    if (formattedGrade) {
+      return (
+        <Typography
+          variant="h5"
+          component="span"
+          sx={{
+            fontSize: themeTokens.typography.fontSize['2xl'],
+            fontWeight: themeTokens.typography.fontWeight.bold,
+            lineHeight: 1,
+            color: gradeColor ?? 'text.primary',
+          }}
+        >
+          {formattedGrade}
+        </Typography>
+      );
+    }
+    if (displayDifficulty) {
+      return (
+        <Typography
+          variant="h5"
+          component="span"
+          sx={{
+            fontSize: themeTokens.typography.fontSize.xl,
+            fontWeight: themeTokens.typography.fontWeight.semibold,
+            lineHeight: 1,
+            color: 'text.secondary',
+          }}
+        >
+          {displayDifficulty}
+        </Typography>
+      );
+    }
+    return (
+      <Typography variant="body2" component="span" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
+        project
+      </Typography>
+    );
+  };
+
   return (
     <Box
       sx={{
@@ -43,41 +86,7 @@ export default function ClimbDetailHeader({ climb, communityGrade }: ClimbDetail
       }}
     >
       {/* Left: Grade */}
-      <Box sx={{ flexShrink: 0, minWidth: 48 }}>
-        {!gradeFormatLoaded && displayDifficulty ? (
-          <Skeleton variant="rounded" width={48} height={themeTokens.typography.fontSize['2xl']} />
-        ) : formattedGrade ? (
-          <Typography
-            variant="h5"
-            component="span"
-            sx={{
-              fontSize: themeTokens.typography.fontSize['2xl'],
-              fontWeight: themeTokens.typography.fontWeight.bold,
-              lineHeight: 1,
-              color: gradeColor ?? 'text.primary',
-            }}
-          >
-            {formattedGrade}
-          </Typography>
-        ) : displayDifficulty ? (
-          <Typography
-            variant="h5"
-            component="span"
-            sx={{
-              fontSize: themeTokens.typography.fontSize.xl,
-              fontWeight: themeTokens.typography.fontWeight.semibold,
-              lineHeight: 1,
-              color: 'text.secondary',
-            }}
-          >
-            {displayDifficulty}
-          </Typography>
-        ) : (
-          <Typography variant="body2" component="span" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
-            project
-          </Typography>
-        )}
-      </Box>
+      <Box sx={{ flexShrink: 0, minWidth: 48 }}>{renderGradeContent()}</Box>
 
       {/* Center: Name + details */}
       <Box

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -202,6 +202,49 @@ export default function MultiboardClimbList({
     </Box>
   ) : undefined;
 
+  let climbListContent: React.ReactNode;
+  if (isLoading && climbs.length === 0) {
+    climbListContent = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  } else if (climbs.length === 0 && !isLoading) {
+    climbListContent = (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No climbs found
+        </Typography>
+      </Box>
+    );
+  } else if (defaultBoardDetails) {
+    climbListContent = (
+      <FavoritesProvider {...favoritesProviderProps}>
+        <PlaylistsProvider {...playlistsProviderProps}>
+          <ClimbsList
+            boardDetails={defaultBoardDetails}
+            boardDetailsByClimb={boardDetailsByClimb}
+            unsupportedClimbs={unsupportedClimbs}
+            upsizedClimbs={upsizedClimbs}
+            climbs={climbs}
+            selectedClimbUuid={effectiveSelectedUuid}
+            isFetching={isFetching}
+            hasMore={hasMore}
+            onClimbSelect={handleClimbSelect}
+            onLoadMore={onLoadMore}
+            addToQueue={queueActions?.addToQueue}
+            header={header}
+            headerInline={headerInline}
+            hideEndMessage={hideEndMessage}
+            showBottomSpacer={showBottomSpacer}
+          />
+        </PlaylistsProvider>
+      </FavoritesProvider>
+    );
+  } else {
+    climbListContent = null;
+  }
+
   return (
     <Box>
       {/* Board filter - thumbnail scroll cards */}
@@ -216,50 +259,7 @@ export default function MultiboardClimbList({
         />
       )}
 
-      {(() => {
-        if (isLoading && climbs.length === 0) {
-          return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress size={24} />
-            </Box>
-          );
-        }
-        if (climbs.length === 0 && !isLoading) {
-          return (
-            <Box sx={{ py: 4, textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                No climbs found
-              </Typography>
-            </Box>
-          );
-        }
-        if (defaultBoardDetails) {
-          return (
-            <FavoritesProvider {...favoritesProviderProps}>
-              <PlaylistsProvider {...playlistsProviderProps}>
-                <ClimbsList
-                  boardDetails={defaultBoardDetails}
-                  boardDetailsByClimb={boardDetailsByClimb}
-                  unsupportedClimbs={unsupportedClimbs}
-                  upsizedClimbs={upsizedClimbs}
-                  climbs={climbs}
-                  selectedClimbUuid={effectiveSelectedUuid}
-                  isFetching={isFetching}
-                  hasMore={hasMore}
-                  onClimbSelect={handleClimbSelect}
-                  onLoadMore={onLoadMore}
-                  addToQueue={queueActions?.addToQueue}
-                  header={header}
-                  headerInline={headerInline}
-                  hideEndMessage={hideEndMessage}
-                  showBottomSpacer={showBottomSpacer}
-                />
-              </PlaylistsProvider>
-            </FavoritesProvider>
-          );
-        }
-        return null;
-      })()}
+      {climbListContent}
     </Box>
   );
 }

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -216,39 +216,50 @@ export default function MultiboardClimbList({
         />
       )}
 
-      {isLoading && climbs.length === 0 ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <CircularProgress size={24} />
-        </Box>
-      ) : climbs.length === 0 && !isLoading ? (
-        <Box sx={{ py: 4, textAlign: 'center' }}>
-          <Typography variant="body2" color="text.secondary">
-            No climbs found
-          </Typography>
-        </Box>
-      ) : defaultBoardDetails ? (
-        <FavoritesProvider {...favoritesProviderProps}>
-          <PlaylistsProvider {...playlistsProviderProps}>
-            <ClimbsList
-              boardDetails={defaultBoardDetails}
-              boardDetailsByClimb={boardDetailsByClimb}
-              unsupportedClimbs={unsupportedClimbs}
-              upsizedClimbs={upsizedClimbs}
-              climbs={climbs}
-              selectedClimbUuid={effectiveSelectedUuid}
-              isFetching={isFetching}
-              hasMore={hasMore}
-              onClimbSelect={handleClimbSelect}
-              onLoadMore={onLoadMore}
-              addToQueue={queueActions?.addToQueue}
-              header={header}
-              headerInline={headerInline}
-              hideEndMessage={hideEndMessage}
-              showBottomSpacer={showBottomSpacer}
-            />
-          </PlaylistsProvider>
-        </FavoritesProvider>
-      ) : null}
+      {(() => {
+        if (isLoading && climbs.length === 0) {
+          return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          );
+        }
+        if (climbs.length === 0 && !isLoading) {
+          return (
+            <Box sx={{ py: 4, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                No climbs found
+              </Typography>
+            </Box>
+          );
+        }
+        if (defaultBoardDetails) {
+          return (
+            <FavoritesProvider {...favoritesProviderProps}>
+              <PlaylistsProvider {...playlistsProviderProps}>
+                <ClimbsList
+                  boardDetails={defaultBoardDetails}
+                  boardDetailsByClimb={boardDetailsByClimb}
+                  unsupportedClimbs={unsupportedClimbs}
+                  upsizedClimbs={upsizedClimbs}
+                  climbs={climbs}
+                  selectedClimbUuid={effectiveSelectedUuid}
+                  isFetching={isFetching}
+                  hasMore={hasMore}
+                  onClimbSelect={handleClimbSelect}
+                  onLoadMore={onLoadMore}
+                  addToQueue={queueActions?.addToQueue}
+                  header={header}
+                  headerInline={headerInline}
+                  hideEndMessage={hideEndMessage}
+                  showBottomSpacer={showBottomSpacer}
+                />
+              </PlaylistsProvider>
+            </FavoritesProvider>
+          );
+        }
+        return null;
+      })()}
     </Box>
   );
 }

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -310,11 +310,14 @@ export default function CreateClimbForm({
 
   // Common state — in edit mode use the original name, not "{name} fork"
   const isEditMode = !!editClimb;
-  const initialClimbName = (() => {
-    if (isEditMode) return forkName || '';
-    if (forkName) return `${forkName} fork`;
-    return '';
-  })();
+  let initialClimbName: string;
+  if (isEditMode) {
+    initialClimbName = forkName || '';
+  } else if (forkName) {
+    initialClimbName = `${forkName} fork`;
+  } else {
+    initialClimbName = '';
+  }
   const [climbName, setClimbName] = useState(initialClimbName);
   const [description, setDescription] = useState(forkDescription || '');
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
@@ -1352,6 +1355,40 @@ export default function CreateClimbForm({
     [climbName, session?.user?.name],
   );
 
+  let boardRenderer: React.ReactNode = null;
+  if (boardType === 'aurora' && boardDetails) {
+    boardRenderer = (
+      <div className={styles.zoomFill}>
+        <BoardRenderer
+          boardDetails={boardDetails}
+          litUpHoldsMap={litUpHoldsMap}
+          mirrored={false}
+          onHoldClick={picker.handleHoldClick}
+          fillHeight
+        />
+        <CreateClimbHeatmapOverlay
+          boardDetails={boardDetails}
+          angle={angle}
+          litUpHoldsMap={litUpHoldsMap}
+          opacity={heatmapOpacity}
+          enabled={showHeatmap}
+          onLoadingChange={handleHeatmapLoadingChange}
+        />
+      </div>
+    );
+  } else if (boardType === 'moonboard' && layoutFolder && holdSetImages) {
+    boardRenderer = (
+      <div className={styles.moonboardFill}>
+        <MoonBoardRenderer
+          layoutFolder={layoutFolder}
+          holdSetImages={holdSetImages}
+          litUpHoldsMap={litUpHoldsMap}
+          onHoldClick={picker.handleHoldClick}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.pageContainer} data-testid="climb-setter">
       {/* Header section: alerts + control row */}
@@ -1419,44 +1456,7 @@ export default function CreateClimbForm({
 
       {/* Board section: zoomable SVG renderer */}
       <div className={styles.boardSectionWrapper} data-testid="climb-setter-board">
-        <ZoomableBoard resetKey={zoomResetKey}>
-          {(() => {
-            if (boardType === 'aurora' && boardDetails) {
-              return (
-                <div className={styles.zoomFill}>
-                  <BoardRenderer
-                    boardDetails={boardDetails}
-                    litUpHoldsMap={litUpHoldsMap}
-                    mirrored={false}
-                    onHoldClick={picker.handleHoldClick}
-                    fillHeight
-                  />
-                  <CreateClimbHeatmapOverlay
-                    boardDetails={boardDetails}
-                    angle={angle}
-                    litUpHoldsMap={litUpHoldsMap}
-                    opacity={heatmapOpacity}
-                    enabled={showHeatmap}
-                    onLoadingChange={handleHeatmapLoadingChange}
-                  />
-                </div>
-              );
-            }
-            if (boardType === 'moonboard' && layoutFolder && holdSetImages) {
-              return (
-                <div className={styles.moonboardFill}>
-                  <MoonBoardRenderer
-                    layoutFolder={layoutFolder}
-                    holdSetImages={holdSetImages}
-                    litUpHoldsMap={litUpHoldsMap}
-                    onHoldClick={picker.handleHoldClick}
-                  />
-                </div>
-              );
-            }
-            return null;
-          })()}
-        </ZoomableBoard>
+        <ZoomableBoard resetKey={zoomResetKey}>{boardRenderer}</ZoomableBoard>
       </div>
 
       <HoldTypePicker

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -310,7 +310,12 @@ export default function CreateClimbForm({
 
   // Common state — in edit mode use the original name, not "{name} fork"
   const isEditMode = !!editClimb;
-  const [climbName, setClimbName] = useState(isEditMode ? forkName || '' : forkName ? `${forkName} fork` : '');
+  const initialClimbName = (() => {
+    if (isEditMode) return forkName || '';
+    if (forkName) return `${forkName} fork`;
+    return '';
+  })();
+  const [climbName, setClimbName] = useState(initialClimbName);
   const [description, setDescription] = useState(forkDescription || '');
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const [showDraftsDrawer, setShowDraftsDrawer] = useState(false);
@@ -577,33 +582,42 @@ export default function CreateClimbForm({
   // the form doesn't own (difficulty, stars, ascents, etc.) get safe defaults
   // — a brand-new draft has nothing to report for those.
   const buildClimbFromFormState = useCallback(
-    (uuid: string, frames: string): Climb => ({
-      uuid,
-      name: climbName,
-      description,
-      frames,
-      angle: boardType === 'moonboard' ? selectedAngle : angle,
-      setter_username: session?.user?.name || '',
-      // Stable owner identity. The queue list (local + peers) uses this —
-      // not setter_username — to decide whether to show the Edit button,
-      // because usernames can change or be blank but userId is immutable.
-      userId: session?.user?.id ?? null,
-      ascensionist_count: 0,
-      difficulty: '',
-      quality_average: '0',
-      stars: 0,
-      difficulty_error: '0',
-      benchmark_difficulty: null,
-      mirrored: false,
-      is_draft: isDraft,
+    (uuid: string, frames: string): Climb => {
       // Stamp publish time on the first save that flips out of draft. Drafts
       // leave this null; once published it stays stable until the 24h window
       // lapses and the backend refuses further updates.
-      published_at:
-        !isDraft && savedClimb?.publishedAt ? savedClimb.publishedAt : !isDraft ? new Date().toISOString() : null,
-      layoutId: boardType === 'aurora' ? (boardDetails?.layout_id ?? null) : (layoutId ?? null),
-      boardType: boardType === 'aurora' ? boardDetails?.board_name : 'moonboard',
-    }),
+      let publishedAt: string | null;
+      if (isDraft) {
+        publishedAt = null;
+      } else if (savedClimb?.publishedAt) {
+        publishedAt = savedClimb.publishedAt;
+      } else {
+        publishedAt = new Date().toISOString();
+      }
+      return {
+        uuid,
+        name: climbName,
+        description,
+        frames,
+        angle: boardType === 'moonboard' ? selectedAngle : angle,
+        setter_username: session?.user?.name || '',
+        // Stable owner identity. The queue list (local + peers) uses this —
+        // not setter_username — to decide whether to show the Edit button,
+        // because usernames can change or be blank but userId is immutable.
+        userId: session?.user?.id ?? null,
+        ascensionist_count: 0,
+        difficulty: '',
+        quality_average: '0',
+        stars: 0,
+        difficulty_error: '0',
+        benchmark_difficulty: null,
+        mirrored: false,
+        is_draft: isDraft,
+        published_at: publishedAt,
+        layoutId: boardType === 'aurora' ? (boardDetails?.layout_id ?? null) : (layoutId ?? null),
+        boardType: boardType === 'aurora' ? boardDetails?.board_name : 'moonboard',
+      };
+    },
     [
       climbName,
       description,
@@ -1292,8 +1306,17 @@ export default function CreateClimbForm({
       void handlePublish();
     };
 
+    let saveTooltip: string;
+    if (isSaving) {
+      saveTooltip = 'Saving...';
+    } else if (needsTitle) {
+      saveTooltip = 'Name your climb';
+    } else {
+      saveTooltip = 'Save climb';
+    }
+
     return (
-      <MuiTooltip title={isSaving ? 'Saving...' : needsTitle ? 'Name your climb' : 'Save climb'}>
+      <MuiTooltip title={saveTooltip}>
         <span>
           <IconButton
             size="small"
@@ -1397,34 +1420,42 @@ export default function CreateClimbForm({
       {/* Board section: zoomable SVG renderer */}
       <div className={styles.boardSectionWrapper} data-testid="climb-setter-board">
         <ZoomableBoard resetKey={zoomResetKey}>
-          {boardType === 'aurora' && boardDetails ? (
-            <div className={styles.zoomFill}>
-              <BoardRenderer
-                boardDetails={boardDetails}
-                litUpHoldsMap={litUpHoldsMap}
-                mirrored={false}
-                onHoldClick={picker.handleHoldClick}
-                fillHeight
-              />
-              <CreateClimbHeatmapOverlay
-                boardDetails={boardDetails}
-                angle={angle}
-                litUpHoldsMap={litUpHoldsMap}
-                opacity={heatmapOpacity}
-                enabled={showHeatmap}
-                onLoadingChange={handleHeatmapLoadingChange}
-              />
-            </div>
-          ) : boardType === 'moonboard' && layoutFolder && holdSetImages ? (
-            <div className={styles.moonboardFill}>
-              <MoonBoardRenderer
-                layoutFolder={layoutFolder}
-                holdSetImages={holdSetImages}
-                litUpHoldsMap={litUpHoldsMap}
-                onHoldClick={picker.handleHoldClick}
-              />
-            </div>
-          ) : null}
+          {(() => {
+            if (boardType === 'aurora' && boardDetails) {
+              return (
+                <div className={styles.zoomFill}>
+                  <BoardRenderer
+                    boardDetails={boardDetails}
+                    litUpHoldsMap={litUpHoldsMap}
+                    mirrored={false}
+                    onHoldClick={picker.handleHoldClick}
+                    fillHeight
+                  />
+                  <CreateClimbHeatmapOverlay
+                    boardDetails={boardDetails}
+                    angle={angle}
+                    litUpHoldsMap={litUpHoldsMap}
+                    opacity={heatmapOpacity}
+                    enabled={showHeatmap}
+                    onLoadingChange={handleHeatmapLoadingChange}
+                  />
+                </div>
+              );
+            }
+            if (boardType === 'moonboard' && layoutFolder && holdSetImages) {
+              return (
+                <div className={styles.moonboardFill}>
+                  <MoonBoardRenderer
+                    layoutFolder={layoutFolder}
+                    holdSetImages={holdSetImages}
+                    litUpHoldsMap={litUpHoldsMap}
+                    onHoldClick={picker.handleHoldClick}
+                  />
+                </div>
+              );
+            }
+            return null;
+          })()}
         </ZoomableBoard>
       </div>
 

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -174,6 +174,53 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
     [boardDetails, angle],
   );
 
+  let draftsListContent: React.ReactNode;
+  if (isLoading) {
+    draftsListContent = (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: themeTokens.spacing[8],
+        }}
+      >
+        <CircularProgress size={24} />
+      </Box>
+    );
+  } else if (error) {
+    draftsListContent = (
+      <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          Couldn&apos;t load your drafts. Try again.
+        </Typography>
+      </Box>
+    );
+  } else if (drafts.length === 0) {
+    draftsListContent = (
+      <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
+        <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+          No drafts yet
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
+          Save a climb as a draft to pick it up later.
+        </Typography>
+      </Box>
+    );
+  } else {
+    draftsListContent = drafts.map((climb) => (
+      <ClimbListItem
+        key={climb.uuid}
+        climb={climb}
+        boardDetails={boardDetails}
+        pathname={pathname}
+        isDark={isDark}
+        disableSwipe
+        onSelect={() => handleSelectDraft(climb)}
+      />
+    ));
+  }
+
   return (
     <SwipeableDrawer
       placement="bottom"
@@ -225,56 +272,7 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
       </div>
 
       <div className={queueStyles.queueBodyLayout}>
-        <div className={queueStyles.queueScrollContainer}>
-          {(() => {
-            if (isLoading) {
-              return (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    padding: themeTokens.spacing[8],
-                  }}
-                >
-                  <CircularProgress size={24} />
-                </Box>
-              );
-            }
-            if (error) {
-              return (
-                <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
-                  <Typography variant="body2" color="text.secondary">
-                    Couldn&apos;t load your drafts. Try again.
-                  </Typography>
-                </Box>
-              );
-            }
-            if (drafts.length === 0) {
-              return (
-                <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
-                  <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-                    No drafts yet
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
-                    Save a climb as a draft to pick it up later.
-                  </Typography>
-                </Box>
-              );
-            }
-            return drafts.map((climb) => (
-              <ClimbListItem
-                key={climb.uuid}
-                climb={climb}
-                boardDetails={boardDetails}
-                pathname={pathname}
-                isDark={isDark}
-                disableSwipe
-                onSelect={() => handleSelectDraft(climb)}
-              />
-            ));
-          })()}
-        </div>
+        <div className={queueStyles.queueScrollContainer}>{draftsListContent}</div>
       </div>
     </SwipeableDrawer>
   );

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -226,34 +226,43 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
 
       <div className={queueStyles.queueBodyLayout}>
         <div className={queueStyles.queueScrollContainer}>
-          {isLoading ? (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                padding: themeTokens.spacing[8],
-              }}
-            >
-              <CircularProgress size={24} />
-            </Box>
-          ) : error ? (
-            <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                Couldn&apos;t load your drafts. Try again.
-              </Typography>
-            </Box>
-          ) : drafts.length === 0 ? (
-            <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
-              <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-                No drafts yet
-              </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
-                Save a climb as a draft to pick it up later.
-              </Typography>
-            </Box>
-          ) : (
-            drafts.map((climb) => (
+          {(() => {
+            if (isLoading) {
+              return (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: themeTokens.spacing[8],
+                  }}
+                >
+                  <CircularProgress size={24} />
+                </Box>
+              );
+            }
+            if (error) {
+              return (
+                <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    Couldn&apos;t load your drafts. Try again.
+                  </Typography>
+                </Box>
+              );
+            }
+            if (drafts.length === 0) {
+              return (
+                <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
+                  <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                    No drafts yet
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
+                    Save a climb as a draft to pick it up later.
+                  </Typography>
+                </Box>
+              );
+            }
+            return drafts.map((climb) => (
               <ClimbListItem
                 key={climb.uuid}
                 climb={climb}
@@ -263,8 +272,8 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
                 disableSwipe
                 onSelect={() => handleSelectDraft(climb)}
               />
-            ))
-          )}
+            ));
+          })()}
         </div>
       </div>
     </SwipeableDrawer>

--- a/packages/web/app/components/create-climb/hold-indicator.tsx
+++ b/packages/web/app/components/create-climb/hold-indicator.tsx
@@ -19,14 +19,20 @@ export default function HoldIndicator({ count, max, color, label }: HoldIndicato
     <MuiTooltip title={label}>
       <Stack direction="row" alignItems="center" spacing={0.5} aria-label={label} sx={{ cursor: 'default' }}>
         <Box
-          sx={(theme) => ({
-            width: 10,
-            height: 10,
-            borderRadius: '50%',
-            backgroundColor: color,
-            opacity: active ? 1 : theme.palette.mode === 'dark' ? 0.4 : 0.25,
-            flexShrink: 0,
-          })}
+          sx={(theme) => {
+            let opacity = 1;
+            if (!active) {
+              opacity = theme.palette.mode === 'dark' ? 0.4 : 0.25;
+            }
+            return {
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              backgroundColor: color,
+              opacity,
+              flexShrink: 0,
+            };
+          }}
         />
         <Typography
           variant="caption"

--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -167,6 +167,13 @@ type SwatchProps = {
 function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: SwatchProps) {
   const ring = isClear ? themeTokens.neutral[400] : (color ?? themeTokens.neutral[400]);
 
+  let swatchIconColor = 'transparent';
+  if (isClear) {
+    swatchIconColor = ring;
+  } else if (isActive) {
+    swatchIconColor = '#FFFFFF';
+  }
+
   return (
     <ButtonBase
       onClick={onClick}
@@ -195,7 +202,7 @@ function Swatch({ label, color, isActive, isDisabled, isClear, onClick }: Swatch
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          color: isClear ? ring : isActive ? '#FFFFFF' : 'transparent',
+          color: swatchIconColor,
           boxSizing: 'border-box',
         }}
       >

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -54,6 +54,12 @@ const createClimbQueueItem = (
   suggested: !!suggested,
 });
 
+const resolveQueueOperationMode = (isPersistentSessionActive: boolean, isDisconnected: boolean): QueueOperationMode => {
+  if (!isPersistentSessionActive) return 'local';
+  if (isDisconnected) return 'party-offline';
+  return 'party';
+};
+
 // Split contexts: actions (stable) vs data (changes frequently)
 export const QueueActionsContext = createContext<GraphQLQueueActionsType | undefined>(undefined);
 export const QueueDataContext = createContext<GraphQLQueueDataType | undefined>(undefined);
@@ -327,11 +333,7 @@ export const GraphQLQueueProvider = ({
     const r = latestRef.current;
     if (r.guardMutation()) return;
     if (!r.validateQueueAdd(climb)) return;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
     r.dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item: newItem } });
     if (r.isDisconnected && r.isPersistentSessionActive) {
@@ -354,11 +356,7 @@ export const GraphQLQueueProvider = ({
     const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     r.dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: item.uuid } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {
       r.persistentSession
@@ -382,11 +380,7 @@ export const GraphQLQueueProvider = ({
     const r = latestRef.current;
     if (r.guardMutation()) return null;
     if (!r.validateQueueAdd(climb)) return null;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     const newItem = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
     const correlationId = r.clientId ? `${r.clientId}-${++r.correlationCounterRef.current}` : undefined;
     r.dispatch({
@@ -426,11 +420,7 @@ export const GraphQLQueueProvider = ({
     if (r.guardMutation()) return;
     if (!r.validateQueueAdd(climb)) return;
     const existing = r.state.queue.find((qItem) => qItem.uuid === queueItemUuid);
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     const base = createClimbQueueItem(climb, r.clientId, r.currentUserInfo);
     const newItem: ClimbQueueItem = {
       ...base,
@@ -460,11 +450,7 @@ export const GraphQLQueueProvider = ({
     const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     r.dispatch({
       type: 'UPDATE_QUEUE',
       payload: { queue, currentClimbQueueItem: r.state.currentClimbQueueItem },
@@ -486,11 +472,7 @@ export const GraphQLQueueProvider = ({
     const startTime = performance.now();
     const r = latestRef.current;
     if (r.guardMutation()) return;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     const correlationId = r.clientId ? `${r.clientId}-${++r.correlationCounterRef.current}` : undefined;
     r.dispatch({
       type: 'DELTA_UPDATE_CURRENT_CLIMB',
@@ -530,11 +512,7 @@ export const GraphQLQueueProvider = ({
     const r = latestRef.current;
     if (r.guardMutation()) return;
     if (!r.state.currentClimbQueueItem?.climb) return;
-    const mode: QueueOperationMode = !r.isPersistentSessionActive
-      ? 'local'
-      : r.isDisconnected
-        ? 'party-offline'
-        : 'party';
+    const mode: QueueOperationMode = resolveQueueOperationMode(r.isPersistentSessionActive, r.isDisconnected);
     const newMirroredState = !r.state.currentClimbQueueItem.climb?.mirrored;
     r.dispatch({ type: 'DELTA_MIRROR_CURRENT_CLIMB', payload: { mirrored: newMirroredState } });
     if (!r.isDisconnected && r.hasConnected && r.isPersistentSessionActive) {

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -125,132 +125,147 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
         height="90dvh"
         styles={{ body: { padding: 0, overflow: 'hidden' } }}
       >
-        {isLoading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-            <CircularProgress />
-          </Box>
-        ) : !gym ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-            <MuiTypography color="text.secondary">Gym not found</MuiTypography>
-          </Box>
-        ) : isEditing ? (
-          <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
-            <EditGymForm gym={gym} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
-          </Box>
-        ) : (
-          <>
-            {/* Header */}
-            <Box sx={{ px: 2, pb: 2 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'flex-start',
-                  justifyContent: 'space-between',
-                  gap: 1,
-                }}
-              >
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
-                    {gym.name}
+        {(() => {
+          if (isLoading) {
+            return (
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+                <CircularProgress />
+              </Box>
+            );
+          }
+          if (!gym) {
+            return (
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+                <MuiTypography color="text.secondary">Gym not found</MuiTypography>
+              </Box>
+            );
+          }
+          if (isEditing) {
+            return (
+              <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
+                <EditGymForm gym={gym} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
+              </Box>
+            );
+          }
+          return (
+            <>
+              {/* Header */}
+              <Box sx={{ px: 2, pb: 2 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                  }}
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+                      {gym.name}
+                    </MuiTypography>
+                    {gym.address && (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                        <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
+                        <MuiTypography variant="body2" color="text.secondary">
+                          {gym.address}
+                        </MuiTypography>
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
+
+                {/* Owner info */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
+                  <Avatar src={gym.ownerAvatarUrl ?? undefined} sx={{ width: 24, height: 24, fontSize: 11 }}>
+                    {gym.ownerDisplayName?.[0]?.toUpperCase()}
+                  </Avatar>
+                  <MuiTypography variant="body2" color="text.secondary">
+                    {gym.ownerDisplayName}
                   </MuiTypography>
-                  {gym.address && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
-                      <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
-                      <MuiTypography variant="body2" color="text.secondary">
-                        {gym.address}
-                      </MuiTypography>
-                    </Box>
+                </Box>
+
+                {gym.description && (
+                  <MuiTypography variant="body2" sx={{ mt: 1.5, color: 'var(--neutral-600)' }}>
+                    {gym.description}
+                  </MuiTypography>
+                )}
+
+                {/* Stats */}
+                <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
+                  <StatChip
+                    icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />}
+                    value={gym.boardCount}
+                    label="boards"
+                  />
+                  <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={gym.memberCount} label="members" />
+                  <StatChip
+                    icon={<PeopleOutlined sx={{ fontSize: 16 }} />}
+                    value={gym.followerCount}
+                    label="followers"
+                  />
+                  <StatChip
+                    icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
+                    value={gym.commentCount}
+                    label="comments"
+                  />
+                </Box>
+
+                {/* Actions */}
+                <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+                  {!isOwner && (
+                    <FollowButton
+                      entityId={gym.uuid}
+                      initialIsFollowing={gym.isFollowedByMe}
+                      followMutation={FOLLOW_GYM}
+                      unfollowMutation={UNFOLLOW_GYM}
+                      entityLabel="gym"
+                      getFollowVariables={(id) => ({ input: { gymUuid: id } })}
+                      onFollowChange={() => fetchGym()}
+                    />
+                  )}
+                  {isOwner && (
+                    <>
+                      <MuiButton
+                        variant="outlined"
+                        size="small"
+                        startIcon={<EditOutlined />}
+                        onClick={() => setIsEditing(true)}
+                        sx={{ textTransform: 'none' }}
+                      >
+                        Edit
+                      </MuiButton>
+                      <MuiButton
+                        variant="outlined"
+                        size="small"
+                        color="error"
+                        startIcon={<DeleteOutlined />}
+                        onClick={() => setShowDeleteDialog(true)}
+                        disabled={isDeleting}
+                        sx={{ textTransform: 'none' }}
+                      >
+                        {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
+                      </MuiButton>
+                    </>
                   )}
                 </Box>
               </Box>
 
-              {/* Owner info */}
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
-                <Avatar src={gym.ownerAvatarUrl ?? undefined} sx={{ width: 24, height: 24, fontSize: 11 }}>
-                  {gym.ownerDisplayName?.[0]?.toUpperCase()}
-                </Avatar>
-                <MuiTypography variant="body2" color="text.secondary">
-                  {gym.ownerDisplayName}
-                </MuiTypography>
+              <Divider />
+
+              {/* Tabs */}
+              <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
+                <Tab label="Members" sx={{ textTransform: 'none' }} />
+                <Tab label="Comments" sx={{ textTransform: 'none' }} />
+              </Tabs>
+
+              {/* Tab content */}
+              <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
+                {activeTab === 0 && <GymMemberManagement gymUuid={gym.uuid} isOwnerOrAdmin={isOwnerOrAdmin} />}
+                {activeTab === 1 && <CommentSection entityType="gym" entityId={gym.uuid} title="Gym Discussion" />}
               </Box>
-
-              {gym.description && (
-                <MuiTypography variant="body2" sx={{ mt: 1.5, color: 'var(--neutral-600)' }}>
-                  {gym.description}
-                </MuiTypography>
-              )}
-
-              {/* Stats */}
-              <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
-                <StatChip
-                  icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />}
-                  value={gym.boardCount}
-                  label="boards"
-                />
-                <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={gym.memberCount} label="members" />
-                <StatChip icon={<PeopleOutlined sx={{ fontSize: 16 }} />} value={gym.followerCount} label="followers" />
-                <StatChip
-                  icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
-                  value={gym.commentCount}
-                  label="comments"
-                />
-              </Box>
-
-              {/* Actions */}
-              <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
-                {!isOwner && (
-                  <FollowButton
-                    entityId={gym.uuid}
-                    initialIsFollowing={gym.isFollowedByMe}
-                    followMutation={FOLLOW_GYM}
-                    unfollowMutation={UNFOLLOW_GYM}
-                    entityLabel="gym"
-                    getFollowVariables={(id) => ({ input: { gymUuid: id } })}
-                    onFollowChange={() => fetchGym()}
-                  />
-                )}
-                {isOwner && (
-                  <>
-                    <MuiButton
-                      variant="outlined"
-                      size="small"
-                      startIcon={<EditOutlined />}
-                      onClick={() => setIsEditing(true)}
-                      sx={{ textTransform: 'none' }}
-                    >
-                      Edit
-                    </MuiButton>
-                    <MuiButton
-                      variant="outlined"
-                      size="small"
-                      color="error"
-                      startIcon={<DeleteOutlined />}
-                      onClick={() => setShowDeleteDialog(true)}
-                      disabled={isDeleting}
-                      sx={{ textTransform: 'none' }}
-                    >
-                      {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
-                    </MuiButton>
-                  </>
-                )}
-              </Box>
-            </Box>
-
-            <Divider />
-
-            {/* Tabs */}
-            <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
-              <Tab label="Members" sx={{ textTransform: 'none' }} />
-              <Tab label="Comments" sx={{ textTransform: 'none' }} />
-            </Tabs>
-
-            {/* Tab content */}
-            <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
-              {activeTab === 0 && <GymMemberManagement gymUuid={gym.uuid} isOwnerOrAdmin={isOwnerOrAdmin} />}
-              {activeTab === 1 && <CommentSection entityType="gym" entityId={gym.uuid} title="Gym Discussion" />}
-            </Box>
-          </>
-        )}
+            </>
+          );
+        })()}
       </SwipeableDrawer>
 
       {/* Delete confirmation dialog */}

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -116,6 +116,134 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
     setIsEditing(false);
   };
 
+  let drawerContent: React.ReactNode;
+  if (isLoading) {
+    drawerContent = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <CircularProgress />
+      </Box>
+    );
+  } else if (!gym) {
+    drawerContent = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <MuiTypography color="text.secondary">Gym not found</MuiTypography>
+      </Box>
+    );
+  } else if (isEditing) {
+    drawerContent = (
+      <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
+        <EditGymForm gym={gym} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
+      </Box>
+    );
+  } else {
+    drawerContent = (
+      <>
+        {/* Header */}
+        <Box sx={{ px: 2, pb: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              justifyContent: 'space-between',
+              gap: 1,
+            }}
+          >
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+                {gym.name}
+              </MuiTypography>
+              {gym.address && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                  <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
+                  <MuiTypography variant="body2" color="text.secondary">
+                    {gym.address}
+                  </MuiTypography>
+                </Box>
+              )}
+            </Box>
+          </Box>
+
+          {/* Owner info */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
+            <Avatar src={gym.ownerAvatarUrl ?? undefined} sx={{ width: 24, height: 24, fontSize: 11 }}>
+              {gym.ownerDisplayName?.[0]?.toUpperCase()}
+            </Avatar>
+            <MuiTypography variant="body2" color="text.secondary">
+              {gym.ownerDisplayName}
+            </MuiTypography>
+          </Box>
+
+          {gym.description && (
+            <MuiTypography variant="body2" sx={{ mt: 1.5, color: 'var(--neutral-600)' }}>
+              {gym.description}
+            </MuiTypography>
+          )}
+
+          {/* Stats */}
+          <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
+            <StatChip icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />} value={gym.boardCount} label="boards" />
+            <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={gym.memberCount} label="members" />
+            <StatChip icon={<PeopleOutlined sx={{ fontSize: 16 }} />} value={gym.followerCount} label="followers" />
+            <StatChip icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />} value={gym.commentCount} label="comments" />
+          </Box>
+
+          {/* Actions */}
+          <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+            {!isOwner && (
+              <FollowButton
+                entityId={gym.uuid}
+                initialIsFollowing={gym.isFollowedByMe}
+                followMutation={FOLLOW_GYM}
+                unfollowMutation={UNFOLLOW_GYM}
+                entityLabel="gym"
+                getFollowVariables={(id) => ({ input: { gymUuid: id } })}
+                onFollowChange={() => fetchGym()}
+              />
+            )}
+            {isOwner && (
+              <>
+                <MuiButton
+                  variant="outlined"
+                  size="small"
+                  startIcon={<EditOutlined />}
+                  onClick={() => setIsEditing(true)}
+                  sx={{ textTransform: 'none' }}
+                >
+                  Edit
+                </MuiButton>
+                <MuiButton
+                  variant="outlined"
+                  size="small"
+                  color="error"
+                  startIcon={<DeleteOutlined />}
+                  onClick={() => setShowDeleteDialog(true)}
+                  disabled={isDeleting}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
+                </MuiButton>
+              </>
+            )}
+          </Box>
+        </Box>
+
+        <Divider />
+
+        {/* Tabs */}
+        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
+          <Tab label="Members" sx={{ textTransform: 'none' }} />
+          <Tab label="Comments" sx={{ textTransform: 'none' }} />
+        </Tabs>
+
+        {/* Tab content */}
+        <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
+          {activeTab === 0 && <GymMemberManagement gymUuid={gym.uuid} isOwnerOrAdmin={isOwnerOrAdmin} />}
+          {activeTab === 1 && <CommentSection entityType="gym" entityId={gym.uuid} title="Gym Discussion" />}
+        </Box>
+      </>
+    );
+  }
+
   return (
     <>
       <SwipeableDrawer
@@ -125,147 +253,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
         height="90dvh"
         styles={{ body: { padding: 0, overflow: 'hidden' } }}
       >
-        {(() => {
-          if (isLoading) {
-            return (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-                <CircularProgress />
-              </Box>
-            );
-          }
-          if (!gym) {
-            return (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-                <MuiTypography color="text.secondary">Gym not found</MuiTypography>
-              </Box>
-            );
-          }
-          if (isEditing) {
-            return (
-              <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
-                <EditGymForm gym={gym} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
-              </Box>
-            );
-          }
-          return (
-            <>
-              {/* Header */}
-              <Box sx={{ px: 2, pb: 2 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    justifyContent: 'space-between',
-                    gap: 1,
-                  }}
-                >
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
-                      {gym.name}
-                    </MuiTypography>
-                    {gym.address && (
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
-                        <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
-                        <MuiTypography variant="body2" color="text.secondary">
-                          {gym.address}
-                        </MuiTypography>
-                      </Box>
-                    )}
-                  </Box>
-                </Box>
-
-                {/* Owner info */}
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
-                  <Avatar src={gym.ownerAvatarUrl ?? undefined} sx={{ width: 24, height: 24, fontSize: 11 }}>
-                    {gym.ownerDisplayName?.[0]?.toUpperCase()}
-                  </Avatar>
-                  <MuiTypography variant="body2" color="text.secondary">
-                    {gym.ownerDisplayName}
-                  </MuiTypography>
-                </Box>
-
-                {gym.description && (
-                  <MuiTypography variant="body2" sx={{ mt: 1.5, color: 'var(--neutral-600)' }}>
-                    {gym.description}
-                  </MuiTypography>
-                )}
-
-                {/* Stats */}
-                <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
-                  <StatChip
-                    icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />}
-                    value={gym.boardCount}
-                    label="boards"
-                  />
-                  <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={gym.memberCount} label="members" />
-                  <StatChip
-                    icon={<PeopleOutlined sx={{ fontSize: 16 }} />}
-                    value={gym.followerCount}
-                    label="followers"
-                  />
-                  <StatChip
-                    icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
-                    value={gym.commentCount}
-                    label="comments"
-                  />
-                </Box>
-
-                {/* Actions */}
-                <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
-                  {!isOwner && (
-                    <FollowButton
-                      entityId={gym.uuid}
-                      initialIsFollowing={gym.isFollowedByMe}
-                      followMutation={FOLLOW_GYM}
-                      unfollowMutation={UNFOLLOW_GYM}
-                      entityLabel="gym"
-                      getFollowVariables={(id) => ({ input: { gymUuid: id } })}
-                      onFollowChange={() => fetchGym()}
-                    />
-                  )}
-                  {isOwner && (
-                    <>
-                      <MuiButton
-                        variant="outlined"
-                        size="small"
-                        startIcon={<EditOutlined />}
-                        onClick={() => setIsEditing(true)}
-                        sx={{ textTransform: 'none' }}
-                      >
-                        Edit
-                      </MuiButton>
-                      <MuiButton
-                        variant="outlined"
-                        size="small"
-                        color="error"
-                        startIcon={<DeleteOutlined />}
-                        onClick={() => setShowDeleteDialog(true)}
-                        disabled={isDeleting}
-                        sx={{ textTransform: 'none' }}
-                      >
-                        {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
-                      </MuiButton>
-                    </>
-                  )}
-                </Box>
-              </Box>
-
-              <Divider />
-
-              {/* Tabs */}
-              <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
-                <Tab label="Members" sx={{ textTransform: 'none' }} />
-                <Tab label="Comments" sx={{ textTransform: 'none' }} />
-              </Tabs>
-
-              {/* Tab content */}
-              <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
-                {activeTab === 0 && <GymMemberManagement gymUuid={gym.uuid} isOwnerOrAdmin={isOwnerOrAdmin} />}
-                {activeTab === 1 && <CommentSection entityType="gym" entityId={gym.uuid} title="Gym Discussion" />}
-              </Box>
-            </>
-          );
-        })()}
+        {drawerContent}
       </SwipeableDrawer>
 
       {/* Delete confirmation dialog */}

--- a/packages/web/app/components/healthkit/save-to-healthkit-button.tsx
+++ b/packages/web/app/components/healthkit/save-to-healthkit-button.tsx
@@ -27,14 +27,14 @@ export default function SaveToHealthKitButton({
 
   if (!available || !summary) return null;
 
-  const label =
-    state === 'saving'
-      ? 'Saving to Apple Health…'
-      : state === 'saved'
-        ? 'Saved to Apple Health'
-        : state === 'error'
-          ? 'Save to Apple Health (retry)'
-          : 'Save to Apple Health';
+  let label = 'Save to Apple Health';
+  if (state === 'saving') {
+    label = 'Saving to Apple Health…';
+  } else if (state === 'saved') {
+    label = 'Saved to Apple Health';
+  } else if (state === 'error') {
+    label = 'Save to Apple Health (retry)';
+  }
 
   return (
     <Button

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -317,13 +317,17 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     };
   }, [sortState]);
 
-  const activeFilters = useMemo(
-    () => ({
-      statusMode: (filters.includeSends && filters.includeAttempts
-        ? 'both'
-        : filters.includeSends
-          ? 'send'
-          : 'attempt') as StatusMode,
+  const activeFilters = useMemo(() => {
+    let statusMode: StatusMode;
+    if (filters.includeSends && filters.includeAttempts) {
+      statusMode = 'both';
+    } else if (filters.includeSends) {
+      statusMode = 'send';
+    } else {
+      statusMode = 'attempt';
+    }
+    return {
+      statusMode,
       flashOnly: filters.includeSends ? filters.flashOnly : false,
       minDifficulty: filters.minGrade !== '' ? filters.minGrade : undefined,
       maxDifficulty: filters.maxGrade !== '' ? filters.maxGrade : undefined,
@@ -332,9 +336,8 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       minAngle: filters.angleRange[0] !== DEFAULT_ANGLE_RANGE[0] ? filters.angleRange[0] : undefined,
       maxAngle: filters.angleRange[1] !== DEFAULT_ANGLE_RANGE[1] ? filters.angleRange[1] : undefined,
       benchmarkOnly: filters.benchmarkOnly || undefined,
-    }),
-    [filters],
-  );
+    };
+  }, [filters]);
 
   const feedQueryKey = useMemo(
     () => [
@@ -355,12 +358,12 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       const client = createGraphQLHttpClient(token ?? null);
 
       // For single board type, use boardType; for multiple, use boardTypes
-      const boardTypeFilter =
-        selectedBoardTypes?.length === 1
-          ? { boardType: selectedBoardTypes[0] }
-          : selectedBoardTypes && selectedBoardTypes.length > 1
-            ? { boardTypes: selectedBoardTypes }
-            : {};
+      const buildBoardTypeFilter = () => {
+        if (selectedBoardTypes?.length === 1) return { boardType: selectedBoardTypes[0] };
+        if (selectedBoardTypes && selectedBoardTypes.length > 1) return { boardTypes: selectedBoardTypes };
+        return {};
+      };
+      const boardTypeFilter = buildBoardTypeFilter();
 
       const variables: GetUserAscentsFeedQueryVariables = {
         userId: userId!,
@@ -571,6 +574,23 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   }
 
   if (items.length === 0) {
+    const isLogbookUnavailable = !!userId && !authLoading && !token;
+    let emptyTitle: string;
+    if (isLogbookUnavailable) {
+      emptyTitle = 'Logbook unavailable on this device';
+    } else if (hasFilters) {
+      emptyTitle = 'No matching climbs';
+    } else {
+      emptyTitle = 'No logged climbs yet';
+    }
+    let emptyDescription: string;
+    if (isLogbookUnavailable) {
+      emptyDescription = 'Your account is signed in, but the authenticated data connection did not become available.';
+    } else if (hasFilters) {
+      emptyDescription = 'Try adjusting your filters or sort.';
+    } else {
+      emptyDescription = 'Tick your sends and they show up here.';
+    }
     return (
       <>
         {searchForm}
@@ -584,18 +604,10 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
         <div className={styles.emptyContainer}>
           <HistoryOutlined className={styles.emptyIcon} />
           <Typography variant="h6" component="h4" sx={{ mb: 1 }}>
-            {userId && !authLoading && !token
-              ? 'Logbook unavailable on this device'
-              : hasFilters
-                ? 'No matching climbs'
-                : 'No logged climbs yet'}
+            {emptyTitle}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 300 }}>
-            {userId && !authLoading && !token
-              ? 'Your account is signed in, but the authenticated data connection did not become available.'
-              : hasFilters
-                ? 'Try adjusting your filters or sort.'
-                : 'Tick your sends and they show up here.'}
+            {emptyDescription}
           </Typography>
         </div>
       </>

--- a/packages/web/app/components/library/playlist-preview-square.tsx
+++ b/packages/web/app/components/library/playlist-preview-square.tsx
@@ -61,11 +61,14 @@ export default function PlaylistPreviewSquare({
 }: PlaylistPreviewSquareProps) {
   const boardDetails = useMemo(() => getBoardDetailsForPlaylist(boardType, layoutId), [boardType, layoutId]);
 
-  const backgroundColor = isLikedClimbs
-    ? undefined
-    : color && isValidHexColor(color)
-      ? color
-      : PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+  let backgroundColor: string | undefined;
+  if (isLikedClimbs) {
+    backgroundColor = undefined;
+  } else if (color && isValidHexColor(color)) {
+    backgroundColor = color;
+  } else {
+    backgroundColor = PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+  }
 
   const hasBoardPreview = !isLikedClimbs && boardDetails !== null;
 

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -98,6 +98,37 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
 
   if (!item) return null;
 
+  let betaVideosContent: React.ReactNode;
+  if (betaLinksLoading) {
+    betaVideosContent = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  } else if (betaLinksError) {
+    betaVideosContent = (
+      <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1.5 }}>
+        <Typography variant="body2" color="error">
+          Couldn&apos;t load beta videos.
+        </Typography>
+        <Button
+          size="small"
+          onClick={() => {
+            void refetchBetaLinks();
+          }}
+        >
+          Retry
+        </Button>
+      </Box>
+    );
+  } else {
+    betaVideosContent = (
+      <Box sx={{ mt: 1 }}>
+        <BetaVideos betaLinks={betaLinks} />
+      </Box>
+    );
+  }
+
   return (
     <Dialog
       open={open}
@@ -324,29 +355,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
               Existing Beta Videos
             </Typography>
-            {betaLinksLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <CircularProgress size={24} />
-              </Box>
-            ) : betaLinksError ? (
-              <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                <Typography variant="body2" color="error">
-                  Couldn&apos;t load beta videos.
-                </Typography>
-                <Button
-                  size="small"
-                  onClick={() => {
-                    void refetchBetaLinks();
-                  }}
-                >
-                  Retry
-                </Button>
-              </Box>
-            ) : (
-              <Box sx={{ mt: 1 }}>
-                <BetaVideos betaLinks={betaLinks} />
-              </Box>
-            )}
+            {betaVideosContent}
           </Box>
         </Box>
       </Box>

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -111,28 +111,32 @@ export const TickButton: React.FC<TickButtonProps> = ({
         id="button-tick"
         onClick={showDrawer}
         aria-label={tickBarActive ? 'Save tick' : 'Log ascent'}
-        sx={
-          tickBarActive
-            ? {
-                backgroundColor:
-                  ascentType === 'attempt'
-                    ? themeTokens.colors.error
-                    : ascentType === 'flash' || isFlash
-                      ? themeTokens.colors.amber
-                      : themeTokens.colors.success,
-                color: ascentType === 'flash' || isFlash ? themeTokens.neutral[900] : 'common.white',
-                transition: 'background-color 150ms ease, color 150ms ease',
-                '&:hover': {
-                  backgroundColor:
-                    ascentType === 'attempt'
-                      ? themeTokens.colors.error
-                      : ascentType === 'flash' || isFlash
-                        ? themeTokens.colors.amber
-                        : themeTokens.colors.successHover,
-                },
-              }
-            : { opacity: themeTokens.opacity.subtle }
-        }
+        sx={(() => {
+          if (!tickBarActive) {
+            return { opacity: themeTokens.opacity.subtle };
+          }
+          const isFlashVariant = ascentType === 'flash' || isFlash;
+          let backgroundColor: string;
+          let hoverBackgroundColor: string;
+          if (ascentType === 'attempt') {
+            backgroundColor = themeTokens.colors.error;
+            hoverBackgroundColor = themeTokens.colors.error;
+          } else if (isFlashVariant) {
+            backgroundColor = themeTokens.colors.amber;
+            hoverBackgroundColor = themeTokens.colors.amber;
+          } else {
+            backgroundColor = themeTokens.colors.success;
+            hoverBackgroundColor = themeTokens.colors.successHover;
+          }
+          return {
+            backgroundColor,
+            color: isFlashVariant ? themeTokens.neutral[900] : 'common.white',
+            transition: 'background-color 150ms ease, color 150ms ease',
+            '&:hover': {
+              backgroundColor: hoverBackgroundColor,
+            },
+          };
+        })()}
       >
         {tickBarActive && ascentType === 'attempt' ? (
           <PersonFallingIcon />
@@ -143,7 +147,12 @@ export const TickButton: React.FC<TickButtonProps> = ({
     </MuiBadge>
   );
 
-  const tickLabel = ascentType === 'attempt' ? 'attempt' : ascentType === 'flash' || isFlash ? 'flash' : 'tick';
+  const resolveTickLabel = () => {
+    if (ascentType === 'attempt') return 'attempt';
+    if (ascentType === 'flash' || isFlash) return 'flash';
+    return 'tick';
+  };
+  const tickLabel = resolveTickLabel();
 
   return (
     <>

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -147,12 +147,14 @@ export const TickButton: React.FC<TickButtonProps> = ({
     </MuiBadge>
   );
 
-  const resolveTickLabel = () => {
-    if (ascentType === 'attempt') return 'attempt';
-    if (ascentType === 'flash' || isFlash) return 'flash';
-    return 'tick';
-  };
-  const tickLabel = resolveTickLabel();
+  let tickLabel: 'flash' | 'tick' | 'attempt' | 'save';
+  if (ascentType === 'attempt') {
+    tickLabel = 'attempt';
+  } else if (ascentType === 'flash' || isFlash) {
+    tickLabel = 'flash';
+  } else {
+    tickLabel = 'tick';
+  }
 
   return (
     <>

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -7,6 +7,7 @@ import MuiBadge from '@mui/material/Badge';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
+import type { SxProps, Theme } from '@mui/material/styles';
 import Stack from '@mui/material/Stack';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
@@ -96,6 +97,33 @@ export const TickButton: React.FC<TickButtonProps> = ({
   const hasSuccessfulAscent = filteredLogbook.some((asc) => asc.is_ascent);
   const badgeCount = filteredLogbook.length;
 
+  let buttonSx: SxProps<Theme>;
+  if (!tickBarActive) {
+    buttonSx = { opacity: themeTokens.opacity.subtle };
+  } else {
+    const isFlashVariant = ascentType === 'flash' || isFlash;
+    let backgroundColor: string;
+    let hoverBackgroundColor: string;
+    if (ascentType === 'attempt') {
+      backgroundColor = themeTokens.colors.error;
+      hoverBackgroundColor = themeTokens.colors.error;
+    } else if (isFlashVariant) {
+      backgroundColor = themeTokens.colors.amber;
+      hoverBackgroundColor = themeTokens.colors.amber;
+    } else {
+      backgroundColor = themeTokens.colors.success;
+      hoverBackgroundColor = themeTokens.colors.successHover;
+    }
+    buttonSx = {
+      backgroundColor,
+      color: isFlashVariant ? themeTokens.neutral[900] : 'common.white',
+      transition: 'background-color 150ms ease, color 150ms ease',
+      '&:hover': {
+        backgroundColor: hoverBackgroundColor,
+      },
+    };
+  }
+
   const badge = (
     <MuiBadge
       badgeContent={badgeCount > 0 ? badgeCount : 0}
@@ -111,32 +139,7 @@ export const TickButton: React.FC<TickButtonProps> = ({
         id="button-tick"
         onClick={showDrawer}
         aria-label={tickBarActive ? 'Save tick' : 'Log ascent'}
-        sx={(() => {
-          if (!tickBarActive) {
-            return { opacity: themeTokens.opacity.subtle };
-          }
-          const isFlashVariant = ascentType === 'flash' || isFlash;
-          let backgroundColor: string;
-          let hoverBackgroundColor: string;
-          if (ascentType === 'attempt') {
-            backgroundColor = themeTokens.colors.error;
-            hoverBackgroundColor = themeTokens.colors.error;
-          } else if (isFlashVariant) {
-            backgroundColor = themeTokens.colors.amber;
-            hoverBackgroundColor = themeTokens.colors.amber;
-          } else {
-            backgroundColor = themeTokens.colors.success;
-            hoverBackgroundColor = themeTokens.colors.successHover;
-          }
-          return {
-            backgroundColor,
-            color: isFlashVariant ? themeTokens.neutral[900] : 'common.white',
-            transition: 'background-color 150ms ease, color 150ms ease',
-            '&:hover': {
-              backgroundColor: hoverBackgroundColor,
-            },
-          };
-        })()}
+        sx={buttonSx}
       >
         {tickBarActive && ascentType === 'attempt' ? (
           <PersonFallingIcon />
@@ -147,7 +150,7 @@ export const TickButton: React.FC<TickButtonProps> = ({
     </MuiBadge>
   );
 
-  let tickLabel: 'flash' | 'tick' | 'attempt' | 'save';
+  let tickLabel: 'flash' | 'tick' | 'attempt';
   if (ascentType === 'attempt') {
     tickLabel = 'attempt';
   } else if (ascentType === 'flash' || isFlash) {

--- a/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
+++ b/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
@@ -110,6 +110,57 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
       </>
     ) : null;
 
+  const renderListContent = () => {
+    if (error && boards.length === 0) {
+      return (
+        <div className={styles.emptyState} data-testid="my-boards-error">
+          <Alert severity="error" sx={{ width: '100%' }}>
+            {error}
+          </Alert>
+        </div>
+      );
+    }
+    if (isLoading && boards.length === 0) {
+      return (
+        <div className={styles.loadingState} data-testid="my-boards-loading">
+          <CircularProgress size={32} />
+        </div>
+      );
+    }
+    if (boards.length === 0) {
+      return (
+        <div className={styles.emptyState} data-testid="my-boards-empty">
+          <DashboardOutlined sx={{ fontSize: 48, color: 'var(--neutral-300)' }} />
+          <Typography variant="body2" color="text.secondary">
+            No boards yet. Create one from the board selector to get started.
+          </Typography>
+        </div>
+      );
+    }
+    return (
+      <div className={styles.boardList} data-testid="my-boards-list">
+        {boards.map((board) => (
+          <button
+            type="button"
+            key={board.uuid}
+            className={styles.boardItem}
+            onClick={() => handleBoardClick(board)}
+            data-testid={`board-item-${board.uuid}`}
+          >
+            <div className={styles.boardItemIcon}>
+              <DashboardOutlined />
+            </div>
+            <div className={styles.boardItemInfo}>
+              <div className={styles.boardItemName}>{board.name}</div>
+              <div className={styles.boardItemMeta}>{formatBoardMeta(board)}</div>
+            </div>
+            <ChevronRightOutlined className={styles.boardItemAction} />
+          </button>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <SwipeableDrawer
       title={drawerTitle}
@@ -122,46 +173,7 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
       extra={headerExtra}
       styles={{ body: { padding: 0 } }}
     >
-      {view.type === 'list' &&
-        (error && boards.length === 0 ? (
-          <div className={styles.emptyState} data-testid="my-boards-error">
-            <Alert severity="error" sx={{ width: '100%' }}>
-              {error}
-            </Alert>
-          </div>
-        ) : isLoading && boards.length === 0 ? (
-          <div className={styles.loadingState} data-testid="my-boards-loading">
-            <CircularProgress size={32} />
-          </div>
-        ) : boards.length === 0 ? (
-          <div className={styles.emptyState} data-testid="my-boards-empty">
-            <DashboardOutlined sx={{ fontSize: 48, color: 'var(--neutral-300)' }} />
-            <Typography variant="body2" color="text.secondary">
-              No boards yet. Create one from the board selector to get started.
-            </Typography>
-          </div>
-        ) : (
-          <div className={styles.boardList} data-testid="my-boards-list">
-            {boards.map((board) => (
-              <button
-                type="button"
-                key={board.uuid}
-                className={styles.boardItem}
-                onClick={() => handleBoardClick(board)}
-                data-testid={`board-item-${board.uuid}`}
-              >
-                <div className={styles.boardItemIcon}>
-                  <DashboardOutlined />
-                </div>
-                <div className={styles.boardItemInfo}>
-                  <div className={styles.boardItemName}>{board.name}</div>
-                  <div className={styles.boardItemMeta}>{formatBoardMeta(board)}</div>
-                </div>
-                <ChevronRightOutlined className={styles.boardItemAction} />
-              </button>
-            ))}
-          </div>
-        ))}
+      {view.type === 'list' && renderListContent()}
 
       {view.type === 'search' && (
         <>

--- a/packages/web/app/components/new-climb-feed/subscribe-button.tsx
+++ b/packages/web/app/components/new-climb-feed/subscribe-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, type ReactNode } from 'react';
 import ToggleButton from '@mui/material/ToggleButton';
 import NotificationsNoneOutlined from '@mui/icons-material/NotificationsNoneOutlined';
 import NotificationsActiveOutlined from '@mui/icons-material/NotificationsActiveOutlined';
@@ -88,6 +88,15 @@ export default function SubscribeButton({
     }
   };
 
+  let buttonIcon: ReactNode;
+  if (loading) {
+    buttonIcon = <CircularProgress size={16} />;
+  } else if (isSubscribed) {
+    buttonIcon = <NotificationsActiveOutlined fontSize="small" />;
+  } else {
+    buttonIcon = <NotificationsNoneOutlined fontSize="small" />;
+  }
+
   return (
     <ToggleButton
       value="subscribe"
@@ -97,15 +106,7 @@ export default function SubscribeButton({
       disabled={disabled || loading}
       sx={{ gap: 0.5, textTransform: 'none' }}
     >
-      {(() => {
-        if (loading) {
-          return <CircularProgress size={16} />;
-        }
-        if (isSubscribed) {
-          return <NotificationsActiveOutlined fontSize="small" />;
-        }
-        return <NotificationsNoneOutlined fontSize="small" />;
-      })()}
+      {buttonIcon}
       {isSubscribed ? 'Subscribed' : 'Subscribe'}
     </ToggleButton>
   );

--- a/packages/web/app/components/new-climb-feed/subscribe-button.tsx
+++ b/packages/web/app/components/new-climb-feed/subscribe-button.tsx
@@ -97,13 +97,15 @@ export default function SubscribeButton({
       disabled={disabled || loading}
       sx={{ gap: 0.5, textTransform: 'none' }}
     >
-      {loading ? (
-        <CircularProgress size={16} />
-      ) : isSubscribed ? (
-        <NotificationsActiveOutlined fontSize="small" />
-      ) : (
-        <NotificationsNoneOutlined fontSize="small" />
-      )}
+      {(() => {
+        if (loading) {
+          return <CircularProgress size={16} />;
+        }
+        if (isSubscribed) {
+          return <NotificationsActiveOutlined fontSize="small" />;
+        }
+        return <NotificationsNoneOutlined fontSize="small" />;
+      })()}
       {isSubscribed ? 'Subscribed' : 'Subscribe'}
     </ToggleButton>
   );

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -848,6 +848,15 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     );
   }
 
+  let offlineBannerText: string;
+  if (!sessionId) {
+    offlineBannerText = 'Offline';
+  } else if (users && users.length > 1) {
+    offlineBannerText = 'Offline. Queued climbs will still sync.';
+  } else {
+    offlineBannerText = 'Offline. Changes will sync when you reconnect.';
+  }
+
   return (
     <div id="onboarding-queue-bar" className={`queue-bar-shadow ${styles.queueBar}`} data-testid="queue-control-bar">
       {/* Main Control Bar */}
@@ -876,13 +885,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   }}
                 >
                   <CloudOffOutlined sx={{ fontSize: 14, flexShrink: 0 }} />
-                  <span className={styles.offlineBannerText}>
-                    {(() => {
-                      if (!sessionId) return 'Offline';
-                      if (users && users.length > 1) return 'Offline. Queued climbs will still sync.';
-                      return 'Offline. Changes will sync when you reconnect.';
-                    })()}
-                  </span>
+                  <span className={styles.offlineBannerText}>{offlineBannerText}</span>
                   <CloseOutlined sx={{ fontSize: 14, flexShrink: 0, opacity: 0.6 }} />
                 </div>
               )}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -877,11 +877,11 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 >
                   <CloudOffOutlined sx={{ fontSize: 14, flexShrink: 0 }} />
                   <span className={styles.offlineBannerText}>
-                    {sessionId
-                      ? users && users.length > 1
-                        ? 'Offline. Queued climbs will still sync.'
-                        : 'Offline. Changes will sync when you reconnect.'
-                      : 'Offline'}
+                    {(() => {
+                      if (!sessionId) return 'Offline';
+                      if (users && users.length > 1) return 'Offline. Queued climbs will still sync.';
+                      return 'Offline. Changes will sync when you reconnect.';
+                    })()}
                   </span>
                   <CloseOutlined sx={{ fontSize: 14, flexShrink: 0, opacity: 0.6 }} />
                 </div>

--- a/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/recent-searches-storage.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-restricted-globals -- tests cover one-time localStorage migration */
 import 'fake-indexeddb/auto';
 import { openDB } from 'idb';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -52,13 +52,14 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   const isLargestSize = boardDetails.size_name?.toLowerCase().includes('12');
   const showTallClimbsFilter = isKilterHomewall && isLargestSize;
 
-  const statusValue: 'any' | 'drafts' | 'established' | 'projects' = uiSearchParams.onlyDrafts
-    ? 'drafts'
-    : uiSearchParams.projectsOnly
-      ? 'projects'
-      : uiSearchParams.minAscents >= 2
-        ? 'established'
-        : 'any';
+  let statusValue: 'any' | 'drafts' | 'established' | 'projects' = 'any';
+  if (uiSearchParams.onlyDrafts) {
+    statusValue = 'drafts';
+  } else if (uiSearchParams.projectsOnly) {
+    statusValue = 'projects';
+  } else if (uiSearchParams.minAscents >= 2) {
+    statusValue = 'established';
+  }
 
   const handleGradeChange = (type: 'min' | 'max', value: number | undefined) => {
     updateFilters(buildGradeRangeUpdate(type, value, uiSearchParams.minGrade, uiSearchParams.maxGrade));

--- a/packages/web/app/components/search-drawer/recent-searches-storage.ts
+++ b/packages/web/app/components/search-drawer/recent-searches-storage.ts
@@ -87,6 +87,7 @@ export async function getRecentSearches(): Promise<RecentSearch[]> {
     }
 
     // Attempt one-time migration from localStorage
+    // oxlint-disable-next-line no-restricted-globals -- one-time migration from legacy localStorage
     const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
     if (legacy) {
       const parsed = (JSON.parse(legacy) as RecentSearch[]).map((entry) => ({
@@ -94,6 +95,7 @@ export async function getRecentSearches(): Promise<RecentSearch[]> {
         filters: sanitizeFilters(entry.filters).filters,
       }));
       await db.put(STORE_NAME, parsed, STORE_KEY);
+      // oxlint-disable-next-line no-restricted-globals -- one-time migration cleanup
       localStorage.removeItem(LEGACY_STORAGE_KEY);
       return parsed;
     }

--- a/packages/web/app/components/search-drawer/setter-name-select.tsx
+++ b/packages/web/app/components/search-drawer/setter-name-select.tsx
@@ -85,13 +85,11 @@ const SetterNameSelect = () => {
       filterOptions={(x) => x} // Server-side filtering
       loading={isLoading}
       limitTags={2}
-      noOptionsText={
-        isLoading
-          ? 'Loading...'
-          : !isOpen && searchValue.length === 0
-            ? 'Open dropdown to see setters'
-            : 'No setters found'
-      }
+      noOptionsText={(() => {
+        if (isLoading) return 'Loading...';
+        if (!isOpen && searchValue.length === 0) return 'Open dropdown to see setters';
+        return 'No setters found';
+      })()}
       sx={{ width: '100%' }}
       size="small"
       renderInput={(params) => (

--- a/packages/web/app/components/search-drawer/setter-name-select.tsx
+++ b/packages/web/app/components/search-drawer/setter-name-select.tsx
@@ -65,6 +65,15 @@ const SetterNameSelect = () => {
     });
   }, [uiSearchParams.settername, options]);
 
+  let noOptionsText: string;
+  if (isLoading) {
+    noOptionsText = 'Loading...';
+  } else if (!isOpen && searchValue.length === 0) {
+    noOptionsText = 'Open dropdown to see setters';
+  } else {
+    noOptionsText = 'No setters found';
+  }
+
   return (
     <Autocomplete
       multiple
@@ -85,11 +94,7 @@ const SetterNameSelect = () => {
       filterOptions={(x) => x} // Server-side filtering
       loading={isLoading}
       limitTags={2}
-      noOptionsText={(() => {
-        if (isLoading) return 'Loading...';
-        if (!isOpen && searchValue.length === 0) return 'Open dropdown to see setters';
-        return 'No setters found';
-      })()}
+      noOptionsText={noOptionsText}
       sx={{ width: '100%' }}
       size="small"
       renderInput={(params) => (

--- a/packages/web/app/components/search-drawer/unified-search-drawer.tsx
+++ b/packages/web/app/components/search-drawer/unified-search-drawer.tsx
@@ -94,6 +94,13 @@ export default function UnifiedSearchDrawer({
 
   const showCategoryChips = visibleCategories.length > 1;
 
+  const searchPlaceholderByCategory: Record<string, string> = {
+    boards: 'Search boards...',
+    gyms: 'Search gyms...',
+    users: 'Search climbers...',
+  };
+  const searchPlaceholder = searchPlaceholderByCategory[category] ?? 'Search playlists...';
+
   return (
     <SwipeableDrawer
       placement="top"
@@ -142,15 +149,7 @@ export default function UnifiedSearchDrawer({
             <TextField
               fullWidth
               size="small"
-              placeholder={
-                category === 'boards'
-                  ? 'Search boards...'
-                  : category === 'gyms'
-                    ? 'Search gyms...'
-                    : category === 'users'
-                      ? 'Search climbers...'
-                      : 'Search playlists...'
-              }
+              placeholder={searchPlaceholder}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               autoFocus

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -124,7 +124,11 @@ export default function SeshSettingsDrawer({
     onClose();
   }, [onClose]);
 
-  const { session: sessionDetail, isLoading, isError } = useSessionDetail({
+  const {
+    session: sessionDetail,
+    isLoading,
+    isError,
+  } = useSessionDetail({
     sessionId: sessionId ?? undefined,
     enabled: open && !!sessionId && !tourMockSession,
   });
@@ -207,43 +211,50 @@ export default function SeshSettingsDrawer({
     ? displaySession.sessionName || generateSessionName(displaySession.firstTickAt, displaySession.boardTypes)
     : 'Session';
 
-  const inviteContent = tourMockSession ? (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
-          Share this link or QR code with your crew and they&apos;ll show up live.
-        </Typography>
-        <IconButton disabled aria-label="Share session link (preview)">
-          <IosShare />
-        </IconButton>
-        <IconButton disabled aria-label="Show QR code (preview)">
-          <QrCode2Outlined />
-        </IconButton>
-      </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
-        <QRCodeSVG value={TOUR_SHARE_QR_PAYLOAD} size={140} level="M" marginSize={4} aria-hidden />
-      </Box>
-    </Box>
-  ) : !isStopped && shareUrl ? (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
-          Get your crew in by sharing this link or scanning the QR code
-        </Typography>
-        <IconButton onClick={handleShareSession} aria-label="Share session link">
-          <IosShare />
-        </IconButton>
-        <IconButton onClick={() => setShowQr((v) => !v)} aria-label={showQr ? 'Hide QR code' : 'Show QR code'}>
-          <QrCode2Outlined color={showQr ? 'primary' : 'inherit'} />
-        </IconButton>
-      </Box>
-      {showQr && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
-          <QRCodeSVG value={shareUrl} size={180} level="M" marginSize={4} />
+  let inviteContent: React.ReactNode;
+  if (tourMockSession) {
+    inviteContent = (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+            Share this link or QR code with your crew and they&apos;ll show up live.
+          </Typography>
+          <IconButton disabled aria-label="Share session link (preview)">
+            <IosShare />
+          </IconButton>
+          <IconButton disabled aria-label="Show QR code (preview)">
+            <QrCode2Outlined />
+          </IconButton>
         </Box>
-      )}
-    </Box>
-  ) : undefined;
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+          <QRCodeSVG value={TOUR_SHARE_QR_PAYLOAD} size={140} level="M" marginSize={4} aria-hidden />
+        </Box>
+      </Box>
+    );
+  } else if (!isStopped && shareUrl) {
+    inviteContent = (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+            Get your crew in by sharing this link or scanning the QR code
+          </Typography>
+          <IconButton onClick={handleShareSession} aria-label="Share session link">
+            <IosShare />
+          </IconButton>
+          <IconButton onClick={() => setShowQr((v) => !v)} aria-label={showQr ? 'Hide QR code' : 'Show QR code'}>
+            <QrCode2Outlined color={showQr ? 'primary' : 'inherit'} />
+          </IconButton>
+        </Box>
+        {showQr && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+            <QRCodeSVG value={shareUrl} size={180} level="M" marginSize={4} />
+          </Box>
+        )}
+      </Box>
+    );
+  } else {
+    inviteContent = undefined;
+  }
 
   if (!activeSession && !tourMockSession && !isStopped) return null;
 

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -221,11 +221,14 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
       // Local state may be empty when the QueueBridgeInjector is active on a
       // board route — it only syncs to local state on cleanup (navigating away).
       const effectiveBoardDetails = localBoardDetails ?? bridgeBoardDetails;
-      const effectiveBaseBoardPath = localBoardPath
-        ? getBaseBoardPath(localBoardPath)
-        : bridgeBoardDetails && pathname
-          ? getBaseBoardPath(pathname)
-          : null;
+      let effectiveBaseBoardPath: string | null;
+      if (localBoardPath) {
+        effectiveBaseBoardPath = getBaseBoardPath(localBoardPath);
+      } else if (bridgeBoardDetails && pathname) {
+        effectiveBaseBoardPath = getBaseBoardPath(pathname);
+      } else {
+        effectiveBaseBoardPath = null;
+      }
       const effectiveQueue = localQueue.length > 0 ? localQueue : bridgeQueue;
       const effectiveCurrentClimb = localCurrentClimbQueueItem ?? bridgeCurrentClimbQueueItem;
       const boardsMatch = effectiveBaseBoardPath != null && effectiveBaseBoardPath === getBaseBoardPath(boardPath);

--- a/packages/web/app/components/session-summary/session-summary-dialog.tsx
+++ b/packages/web/app/components/session-summary/session-summary-dialog.tsx
@@ -37,14 +37,14 @@ export default function SessionSummaryDialog({
     void save();
   }, [summary, available, autoSyncEnabled, autoSyncLoaded, save]);
 
-  const buttonLabel =
-    state === 'saving'
-      ? 'Saving to Apple Health…'
-      : state === 'saved'
-        ? 'Saved to Apple Health'
-        : state === 'error'
-          ? 'Save to Apple Health (retry)'
-          : 'Save to Apple Health';
+  let buttonLabel = 'Save to Apple Health';
+  if (state === 'saving') {
+    buttonLabel = 'Saving to Apple Health…';
+  } else if (state === 'saved') {
+    buttonLabel = 'Saved to Apple Health';
+  } else if (state === 'error') {
+    buttonLabel = 'Save to Apple Health (retry)';
+  }
 
   return (
     <Dialog open={summary !== null} onClose={onDismiss} maxWidth="sm" fullWidth>

--- a/packages/web/app/components/social/create-proposal-form.tsx
+++ b/packages/web/app/components/social/create-proposal-form.tsx
@@ -97,11 +97,17 @@ export default function CreateProposalForm({
     setLoading(true);
     try {
       const client = createGraphQLHttpClient(token);
+      let proposalAngle: typeof selectedAngle | null;
+      if (type === 'classic' || selectedAngle === 'all') {
+        proposalAngle = null;
+      } else {
+        proposalAngle = selectedAngle;
+      }
       const result = await client.request<{ createProposal: Proposal }>(CREATE_PROPOSAL, {
         input: {
           climbUuid,
           boardType,
-          angle: type === 'classic' ? null : selectedAngle === 'all' ? null : selectedAngle,
+          angle: proposalAngle,
           type,
           proposedValue,
           reason: reason || null,

--- a/packages/web/app/components/social/follower-count.tsx
+++ b/packages/web/app/components/social/follower-count.tsx
@@ -142,58 +142,66 @@ export default function FollowerCount({ userId, followerCount, followingCount }:
           body: { padding: 0 },
         }}
       >
-        {loading && users.length === 0 ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <CircularProgress />
-          </Box>
-        ) : users.length === 0 ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <Typography variant="body2" color="text.secondary">
-              {drawerMode === 'followers' ? 'No followers yet' : 'Not following anyone'}
-            </Typography>
-          </Box>
-        ) : (
-          <>
-            <List>
-              {users.map((user) => (
-                <ListItem
-                  key={user.id}
-                  component={Link}
-                  href={`/profile/${user.id}`}
-                  sx={{
-                    textDecoration: 'none',
-                    color: 'inherit',
-                    '&:hover': { backgroundColor: 'action.hover' },
-                  }}
-                  secondaryAction={
-                    <FollowButton
-                      entityId={user.id}
-                      initialIsFollowing={user.isFollowedByMe}
-                      followMutation={FOLLOW_USER}
-                      unfollowMutation={UNFOLLOW_USER}
-                      entityLabel="user"
-                      getFollowVariables={(id) => ({ input: { userId: id } })}
-                    />
-                  }
-                >
-                  <ListItemAvatar>
-                    <MuiAvatar src={user.avatarUrl ?? undefined} sx={{ width: 40, height: 40 }}>
-                      {!user.avatarUrl && <PersonOutlined />}
-                    </MuiAvatar>
-                  </ListItemAvatar>
-                  <ListItemText primary={user.displayName || 'User'} secondary={`${user.followerCount} followers`} />
-                </ListItem>
-              ))}
-            </List>
-            {hasMore && (
-              <Box sx={{ p: 2 }}>
-                <MuiButton onClick={handleLoadMore} disabled={loading} variant="outlined" fullWidth>
-                  {loading ? 'Loading...' : `Load more (${users.length} of ${totalCount})`}
-                </MuiButton>
+        {(() => {
+          if (loading && users.length === 0) {
+            return (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress />
               </Box>
-            )}
-          </>
-        )}
+            );
+          }
+          if (users.length === 0) {
+            return (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <Typography variant="body2" color="text.secondary">
+                  {drawerMode === 'followers' ? 'No followers yet' : 'Not following anyone'}
+                </Typography>
+              </Box>
+            );
+          }
+          return (
+            <>
+              <List>
+                {users.map((user) => (
+                  <ListItem
+                    key={user.id}
+                    component={Link}
+                    href={`/profile/${user.id}`}
+                    sx={{
+                      textDecoration: 'none',
+                      color: 'inherit',
+                      '&:hover': { backgroundColor: 'action.hover' },
+                    }}
+                    secondaryAction={
+                      <FollowButton
+                        entityId={user.id}
+                        initialIsFollowing={user.isFollowedByMe}
+                        followMutation={FOLLOW_USER}
+                        unfollowMutation={UNFOLLOW_USER}
+                        entityLabel="user"
+                        getFollowVariables={(id) => ({ input: { userId: id } })}
+                      />
+                    }
+                  >
+                    <ListItemAvatar>
+                      <MuiAvatar src={user.avatarUrl ?? undefined} sx={{ width: 40, height: 40 }}>
+                        {!user.avatarUrl && <PersonOutlined />}
+                      </MuiAvatar>
+                    </ListItemAvatar>
+                    <ListItemText primary={user.displayName || 'User'} secondary={`${user.followerCount} followers`} />
+                  </ListItem>
+                ))}
+              </List>
+              {hasMore && (
+                <Box sx={{ p: 2 }}>
+                  <MuiButton onClick={handleLoadMore} disabled={loading} variant="outlined" fullWidth>
+                    {loading ? 'Loading...' : `Load more (${users.length} of ${totalCount})`}
+                  </MuiButton>
+                </Box>
+              )}
+            </>
+          );
+        })()}
       </SwipeableDrawer>
     </>
   );

--- a/packages/web/app/components/social/follower-count.tsx
+++ b/packages/web/app/components/social/follower-count.tsx
@@ -94,6 +94,66 @@ export default function FollowerCount({ userId, followerCount, followingCount }:
     }
   };
 
+  let drawerBody: React.ReactNode;
+  if (loading && users.length === 0) {
+    drawerBody = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  } else if (users.length === 0) {
+    drawerBody = (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <Typography variant="body2" color="text.secondary">
+          {drawerMode === 'followers' ? 'No followers yet' : 'Not following anyone'}
+        </Typography>
+      </Box>
+    );
+  } else {
+    drawerBody = (
+      <>
+        <List>
+          {users.map((user) => (
+            <ListItem
+              key={user.id}
+              component={Link}
+              href={`/profile/${user.id}`}
+              sx={{
+                textDecoration: 'none',
+                color: 'inherit',
+                '&:hover': { backgroundColor: 'action.hover' },
+              }}
+              secondaryAction={
+                <FollowButton
+                  entityId={user.id}
+                  initialIsFollowing={user.isFollowedByMe}
+                  followMutation={FOLLOW_USER}
+                  unfollowMutation={UNFOLLOW_USER}
+                  entityLabel="user"
+                  getFollowVariables={(id) => ({ input: { userId: id } })}
+                />
+              }
+            >
+              <ListItemAvatar>
+                <MuiAvatar src={user.avatarUrl ?? undefined} sx={{ width: 40, height: 40 }}>
+                  {!user.avatarUrl && <PersonOutlined />}
+                </MuiAvatar>
+              </ListItemAvatar>
+              <ListItemText primary={user.displayName || 'User'} secondary={`${user.followerCount} followers`} />
+            </ListItem>
+          ))}
+        </List>
+        {hasMore && (
+          <Box sx={{ p: 2 }}>
+            <MuiButton onClick={handleLoadMore} disabled={loading} variant="outlined" fullWidth>
+              {loading ? 'Loading...' : `Load more (${users.length} of ${totalCount})`}
+            </MuiButton>
+          </Box>
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
@@ -142,66 +202,7 @@ export default function FollowerCount({ userId, followerCount, followingCount }:
           body: { padding: 0 },
         }}
       >
-        {(() => {
-          if (loading && users.length === 0) {
-            return (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <CircularProgress />
-              </Box>
-            );
-          }
-          if (users.length === 0) {
-            return (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <Typography variant="body2" color="text.secondary">
-                  {drawerMode === 'followers' ? 'No followers yet' : 'Not following anyone'}
-                </Typography>
-              </Box>
-            );
-          }
-          return (
-            <>
-              <List>
-                {users.map((user) => (
-                  <ListItem
-                    key={user.id}
-                    component={Link}
-                    href={`/profile/${user.id}`}
-                    sx={{
-                      textDecoration: 'none',
-                      color: 'inherit',
-                      '&:hover': { backgroundColor: 'action.hover' },
-                    }}
-                    secondaryAction={
-                      <FollowButton
-                        entityId={user.id}
-                        initialIsFollowing={user.isFollowedByMe}
-                        followMutation={FOLLOW_USER}
-                        unfollowMutation={UNFOLLOW_USER}
-                        entityLabel="user"
-                        getFollowVariables={(id) => ({ input: { userId: id } })}
-                      />
-                    }
-                  >
-                    <ListItemAvatar>
-                      <MuiAvatar src={user.avatarUrl ?? undefined} sx={{ width: 40, height: 40 }}>
-                        {!user.avatarUrl && <PersonOutlined />}
-                      </MuiAvatar>
-                    </ListItemAvatar>
-                    <ListItemText primary={user.displayName || 'User'} secondary={`${user.followerCount} followers`} />
-                  </ListItem>
-                ))}
-              </List>
-              {hasMore && (
-                <Box sx={{ p: 2 }}>
-                  <MuiButton onClick={handleLoadMore} disabled={loading} variant="outlined" fullWidth>
-                    {loading ? 'Loading...' : `Load more (${users.length} of ${totalCount})`}
-                  </MuiButton>
-                </Box>
-              )}
-            </>
-          );
-        })()}
+        {drawerBody}
       </SwipeableDrawer>
     </>
   );

--- a/packages/web/app/components/social/vote-button.tsx
+++ b/packages/web/app/components/social/vote-button.tsx
@@ -246,12 +246,11 @@ export default function VoteButton({
         sx={{
           minWidth: 20,
           textAlign: 'center',
-          color:
-            userVote === 1
-              ? themeTokens.colors.success
-              : userVote === -1
-                ? themeTokens.colors.error
-                : 'var(--neutral-600)',
+          color: (() => {
+            if (userVote === 1) return themeTokens.colors.success;
+            if (userVote === -1) return themeTokens.colors.error;
+            return 'var(--neutral-600)';
+          })(),
         }}
       >
         {score}

--- a/packages/web/app/components/social/vote-button.tsx
+++ b/packages/web/app/components/social/vote-button.tsx
@@ -219,6 +219,15 @@ export default function VoteButton({
     );
   }
 
+  let scoreColor: string;
+  if (userVote === 1) {
+    scoreColor = themeTokens.colors.success;
+  } else if (userVote === -1) {
+    scoreColor = themeTokens.colors.error;
+  } else {
+    scoreColor = 'var(--neutral-600)';
+  }
+
   return (
     <Box
       sx={{
@@ -246,11 +255,7 @@ export default function VoteButton({
         sx={{
           minWidth: 20,
           textAlign: 'center',
-          color: (() => {
-            if (userVote === 1) return themeTokens.colors.success;
-            if (userVote === -1) return themeTokens.colors.error;
-            return 'var(--neutral-600)';
-          })(),
+          color: scoreColor,
         }}
       >
         {score}

--- a/packages/web/app/components/ui/drawer-header.tsx
+++ b/packages/web/app/components/ui/drawer-header.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { toSxArray } from './sx-utils';
 
 type DrawerHeaderProps = {
   title?: React.ReactNode;
@@ -13,12 +14,6 @@ type DrawerHeaderProps = {
   extra?: React.ReactNode;
   sx?: SxProps<Theme>;
 };
-
-function toSxArray(sx: SxProps<Theme> | undefined) {
-  if (Array.isArray(sx)) return sx;
-  if (sx) return [sx];
-  return [];
-}
 
 export function DrawerHeader({ title, onClose, extra, sx }: DrawerHeaderProps) {
   return (

--- a/packages/web/app/components/ui/drawer-header.tsx
+++ b/packages/web/app/components/ui/drawer-header.tsx
@@ -14,6 +14,12 @@ type DrawerHeaderProps = {
   sx?: SxProps<Theme>;
 };
 
+function toSxArray(sx: SxProps<Theme> | undefined) {
+  if (Array.isArray(sx)) return sx;
+  if (sx) return [sx];
+  return [];
+}
+
 export function DrawerHeader({ title, onClose, extra, sx }: DrawerHeaderProps) {
   return (
     <Box
@@ -26,7 +32,7 @@ export function DrawerHeader({ title, onClose, extra, sx }: DrawerHeaderProps) {
           borderBottom: 1,
           borderColor: 'divider',
         },
-        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ...toSxArray(sx),
       ]}
     >
       {typeof title === 'string' ? <Typography variant="h6">{title}</Typography> : title}

--- a/packages/web/app/components/ui/empty-state.tsx
+++ b/packages/web/app/components/ui/empty-state.tsx
@@ -13,6 +13,12 @@ type EmptyStateProps = {
   sx?: SxProps<Theme>;
 };
 
+function toSxArray(sx: SxProps<Theme> | undefined) {
+  if (Array.isArray(sx)) return sx;
+  if (sx) return [sx];
+  return [];
+}
+
 export function EmptyState({ icon, description = 'No data', children, sx }: EmptyStateProps) {
   return (
     <Box
@@ -25,7 +31,7 @@ export function EmptyState({ icon, description = 'No data', children, sx }: Empt
           padding: 4,
           color: 'text.secondary',
         },
-        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ...toSxArray(sx),
       ]}
     >
       <Box sx={{ fontSize: 48, mb: 1, opacity: 0.4 }}>{icon || <InboxOutlined fontSize="inherit" />}</Box>

--- a/packages/web/app/components/ui/empty-state.tsx
+++ b/packages/web/app/components/ui/empty-state.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import InboxOutlined from '@mui/icons-material/InboxOutlined';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { toSxArray } from './sx-utils';
 
 type EmptyStateProps = {
   icon?: React.ReactNode;
@@ -12,12 +13,6 @@ type EmptyStateProps = {
   children?: React.ReactNode;
   sx?: SxProps<Theme>;
 };
-
-function toSxArray(sx: SxProps<Theme> | undefined) {
-  if (Array.isArray(sx)) return sx;
-  if (sx) return [sx];
-  return [];
-}
 
 export function EmptyState({ icon, description = 'No data', children, sx }: EmptyStateProps) {
   return (

--- a/packages/web/app/components/ui/loading-spinner.tsx
+++ b/packages/web/app/components/ui/loading-spinner.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { toSxArray } from './sx-utils';
 
 type LoadingSpinnerProps = {
   spinning?: boolean;
@@ -12,14 +13,6 @@ type LoadingSpinnerProps = {
   sx?: SxProps<Theme>;
   tip?: React.ReactNode;
 };
-
-type SxArrayItem = Exclude<SxProps<Theme>, readonly unknown[]>;
-
-function toSxArray(sx: SxProps<Theme> | undefined): SxArrayItem[] {
-  if (Array.isArray(sx)) return sx as SxArrayItem[];
-  if (sx) return [sx as SxArrayItem];
-  return [];
-}
 
 export function LoadingSpinner({ spinning = true, size = 40, children, sx, tip }: LoadingSpinnerProps) {
   const sxArray = toSxArray(sx);

--- a/packages/web/app/components/ui/loading-spinner.tsx
+++ b/packages/web/app/components/ui/loading-spinner.tsx
@@ -13,7 +13,16 @@ type LoadingSpinnerProps = {
   tip?: React.ReactNode;
 };
 
+type SxArrayItem = Exclude<SxProps<Theme>, readonly unknown[]>;
+
+function toSxArray(sx: SxProps<Theme> | undefined): SxArrayItem[] {
+  if (Array.isArray(sx)) return sx as SxArrayItem[];
+  if (sx) return [sx as SxArrayItem];
+  return [];
+}
+
 export function LoadingSpinner({ spinning = true, size = 40, children, sx, tip }: LoadingSpinnerProps) {
+  const sxArray = toSxArray(sx);
   if (!children) {
     if (!spinning) return null;
     return (
@@ -26,7 +35,7 @@ export function LoadingSpinner({ spinning = true, size = 40, children, sx, tip }
             justifyContent: 'center',
             padding: 4,
           },
-          ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+          ...sxArray,
         ]}
       >
         <CircularProgress size={size} />
@@ -36,7 +45,7 @@ export function LoadingSpinner({ spinning = true, size = 40, children, sx, tip }
   }
 
   return (
-    <Box sx={[{ position: 'relative' }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}>
+    <Box sx={[{ position: 'relative' }, ...sxArray]}>
       {children}
       {spinning && (
         <Box

--- a/packages/web/app/components/ui/result-page.tsx
+++ b/packages/web/app/components/ui/result-page.tsx
@@ -27,6 +27,12 @@ const statusIcons: Record<ResultStatus, React.ReactNode> = {
   warning: <WarningAmberOutlined sx={{ fontSize: 72, color: 'warning.main' }} />,
 };
 
+function toSxArray(sx: SxProps<Theme> | undefined) {
+  if (Array.isArray(sx)) return sx;
+  if (sx) return [sx];
+  return [];
+}
+
 export function ResultPage({ status, title, subTitle, extra, icon, sx }: ResultPageProps) {
   return (
     <Box
@@ -39,7 +45,7 @@ export function ResultPage({ status, title, subTitle, extra, icon, sx }: ResultP
           padding: 4,
           textAlign: 'center',
         },
-        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ...toSxArray(sx),
       ]}
     >
       <Box sx={{ mb: 3 }}>{icon || statusIcons[status]}</Box>

--- a/packages/web/app/components/ui/result-page.tsx
+++ b/packages/web/app/components/ui/result-page.tsx
@@ -8,6 +8,7 @@ import ErrorOutlined from '@mui/icons-material/ErrorOutlined';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { toSxArray } from './sx-utils';
 
 type ResultStatus = 'success' | 'error' | 'info' | 'warning';
 
@@ -26,12 +27,6 @@ const statusIcons: Record<ResultStatus, React.ReactNode> = {
   info: <InfoOutlined sx={{ fontSize: 72, color: 'info.main' }} />,
   warning: <WarningAmberOutlined sx={{ fontSize: 72, color: 'warning.main' }} />,
 };
-
-function toSxArray(sx: SxProps<Theme> | undefined) {
-  if (Array.isArray(sx)) return sx;
-  if (sx) return [sx];
-  return [];
-}
 
 export function ResultPage({ status, title, subTitle, extra, icon, sx }: ResultPageProps) {
   return (

--- a/packages/web/app/components/ui/sx-utils.ts
+++ b/packages/web/app/components/ui/sx-utils.ts
@@ -1,0 +1,9 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export type SxArrayItem = Exclude<SxProps<Theme>, readonly unknown[]>;
+
+export function toSxArray(sx: SxProps<Theme> | undefined): SxArrayItem[] {
+  if (Array.isArray(sx)) return sx as SxArrayItem[];
+  if (sx) return [sx as SxArrayItem];
+  return [];
+}

--- a/packages/web/app/feed/feed-page-content.tsx
+++ b/packages/web/app/feed/feed-page-content.tsx
@@ -39,8 +39,14 @@ export default function FeedPageContent({
   const searchParams = useSearchParams();
 
   // Trust the SSR hint during the loading phase to prevent flash of unauthenticated content
-  const isAuthenticated =
-    status === 'authenticated' ? true : status === 'loading' ? (isAuthenticatedSSR ?? false) : false;
+  let isAuthenticated: boolean;
+  if (status === 'authenticated') {
+    isAuthenticated = true;
+  } else if (status === 'loading') {
+    isAuthenticated = isAuthenticatedSSR ?? false;
+  } else {
+    isAuthenticated = false;
+  }
   const { boards: myBoards, isLoading: isLoadingBoards } = useMyBoards(isAuthenticated, 50, initialMyBoards);
 
   // Read state from URL params (with fallbacks to server-provided initial values)

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -266,7 +266,11 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
 
     // App-store screenshot tests set this flag so the install CTA matches
     // what users see in the actual iOS build (i.e. nothing).
-    if (typeof window !== 'undefined' && window.sessionStorage.getItem('boardsesh:e2e-suppress-install-card') === '1') {
+    if (
+      typeof window !== 'undefined' &&
+      // oxlint-disable-next-line no-restricted-globals -- e2e flag must be read synchronously during render
+      sessionStorage.getItem('boardsesh:e2e-suppress-install-card') === '1'
+    ) {
       setInstallPlatform('native');
       return;
     }

--- a/packages/web/app/hooks/use-board-details-map.ts
+++ b/packages/web/app/hooks/use-board-details-map.ts
@@ -44,19 +44,22 @@ export function useBoardDetailsMap(
 
     // Use the active session when provided; otherwise synthesize one from the
     // selected board so the playlist board filter still drives the preview.
-    const effectiveSession: SessionBoardConfig | null = sessionBoard
-      ? sessionBoard
-      : selectedBoard
-        ? {
-            boardType: selectedBoard.boardType as BoardName,
-            layoutId: selectedBoard.layoutId,
-            sizeId: selectedBoard.sizeId,
-            setIds: selectedBoard.setIds
-              .split(',')
-              .map(Number)
-              .filter((n) => Number.isFinite(n) && n > 0),
-          }
-        : null;
+    let effectiveSession: SessionBoardConfig | null;
+    if (sessionBoard) {
+      effectiveSession = sessionBoard;
+    } else if (selectedBoard) {
+      effectiveSession = {
+        boardType: selectedBoard.boardType as BoardName,
+        layoutId: selectedBoard.layoutId,
+        sizeId: selectedBoard.sizeId,
+        setIds: selectedBoard.setIds
+          .split(',')
+          .map(Number)
+          .filter((n) => Number.isFinite(n) && n > 0),
+      };
+    } else {
+      effectiveSession = null;
+    }
 
     // Only filter by ownership when the user actually owns at least one board.
     // When myBoards is empty we render every climb normally and let selection

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -124,17 +124,17 @@ export function useTickSave(options: UseTickSaveOptions): {
       // Fire celebration and close the bar -- don't wait for the network.
       // When an explicit ascentType is provided, derive the variant from status
       // (the isAscent boolean is only meaningful for the legacy two-method API).
-      const variant = explicitAscentType
-        ? status === 'attempt'
-          ? 'attempt'
-          : status === 'flash'
-            ? 'flash'
-            : 'ascent'
-        : !isAscent
-          ? 'attempt'
-          : status === 'flash'
-            ? 'flash'
-            : 'ascent';
+      const resolveVariant = () => {
+        if (explicitAscentType) {
+          if (status === 'attempt') return 'attempt';
+          if (status === 'flash') return 'flash';
+          return 'ascent';
+        }
+        if (!isAscent) return 'attempt';
+        if (status === 'flash') return 'flash';
+        return 'ascent';
+      };
+      const variant = resolveVariant();
       fireConfetti(confettiOrigin ?? null, variant);
       // Flash: brief 300ms delay so the button pulse + sparks play before the bar closes.
       if (variant === 'flash') {

--- a/packages/web/app/hooks/use-ws-auth-token.ts
+++ b/packages/web/app/hooks/use-ws-auth-token.ts
@@ -36,10 +36,17 @@ export function useWsAuthToken() {
     enabled: status !== 'loading',
   });
 
+  let errorMessage: string | null;
+  if (error) {
+    errorMessage = error instanceof Error ? error.message : 'Unknown error';
+  } else {
+    errorMessage = data?.error ?? null;
+  }
+
   return {
     token: data?.token ?? null,
     isAuthenticated: data?.authenticated ?? false,
     isLoading: isLoading || status === 'loading',
-    error: error ? (error instanceof Error ? error.message : 'Unknown error') : (data?.error ?? null),
+    error: errorMessage,
   };
 }

--- a/packages/web/app/join/[sessionId]/page.tsx
+++ b/packages/web/app/join/[sessionId]/page.tsx
@@ -49,13 +49,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       : null;
 
     const title = `${joinHeadline} | Boardsesh`;
-    const description = boardInfo
-      ? summary.totalSends > 0
-        ? `${boardInfo}. ${summary.totalSends} send${summary.totalSends !== 1 ? 's' : ''} so far${gradeSummary}. Get on the wall.`
-        : `${boardInfo}. No sends yet. Get on the wall.`
-      : sessionName && sessionName !== 'Climbing Session'
-        ? `${sessionName} is live on Boardsesh. Get on the wall.`
-        : 'Jump into this climbing session on Boardsesh. Get on the wall.';
+    let description: string;
+    if (boardInfo) {
+      if (summary.totalSends > 0) {
+        description = `${boardInfo}. ${summary.totalSends} send${summary.totalSends !== 1 ? 's' : ''} so far${gradeSummary}. Get on the wall.`;
+      } else {
+        description = `${boardInfo}. No sends yet. Get on the wall.`;
+      }
+    } else if (sessionName && sessionName !== 'Climbing Session') {
+      description = `${sessionName} is live on Boardsesh. Get on the wall.`;
+    } else {
+      description = 'Jump into this climbing session on Boardsesh. Get on the wall.';
+    }
 
     const ogImagePath = buildVersionedOgImagePath('/api/og/session', { sessionId, variant: 'join' }, summary.version);
 

--- a/packages/web/app/lib/data/get-logbook.ts
+++ b/packages/web/app/lib/data/get-logbook.ts
@@ -31,23 +31,33 @@ export async function getLogbook(
     .orderBy(desc(boardseshTicks.climbedAt));
 
   // Transform boardsesh_ticks to LogbookEntry format
-  return results.map((tick) => ({
-    uuid: tick.uuid,
-    wall_uuid: null,
-    climb_uuid: tick.climbUuid,
-    angle: tick.angle,
-    is_mirror: tick.isMirror ?? false,
-    user_id: 0, // Placeholder - we use NextAuth userId now, not Aurora user_id
-    attempt_id: tick.status === 'flash' ? 1 : tick.status === 'send' ? 2 : 0,
-    tries: tick.attemptCount,
-    quality: tick.quality ?? 0,
-    difficulty: tick.difficulty ?? 0,
-    is_benchmark: tick.isBenchmark ?? false,
-    is_listed: true,
-    comment: tick.comment ?? '',
-    climbed_at: tick.climbedAt,
-    created_at: tick.createdAt,
-    updated_at: tick.updatedAt,
-    is_ascent: tick.status === 'flash' || tick.status === 'send',
-  }));
+  return results.map((tick) => {
+    let attemptId: number;
+    if (tick.status === 'flash') {
+      attemptId = 1;
+    } else if (tick.status === 'send') {
+      attemptId = 2;
+    } else {
+      attemptId = 0;
+    }
+    return {
+      uuid: tick.uuid,
+      wall_uuid: null,
+      climb_uuid: tick.climbUuid,
+      angle: tick.angle,
+      is_mirror: tick.isMirror ?? false,
+      user_id: 0, // Placeholder - we use NextAuth userId now, not Aurora user_id
+      attempt_id: attemptId,
+      tries: tick.attemptCount,
+      quality: tick.quality ?? 0,
+      difficulty: tick.difficulty ?? 0,
+      is_benchmark: tick.isBenchmark ?? false,
+      is_listed: true,
+      comment: tick.comment ?? '',
+      climbed_at: tick.climbedAt,
+      created_at: tick.createdAt,
+      updated_at: tick.updatedAt,
+      is_ascent: tick.status === 'flash' || tick.status === 'send',
+    };
+  });
 }

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -6,6 +6,7 @@
  */
 import 'server-only';
 import { cache } from 'react';
+// oxlint-disable-next-line no-restricted-imports -- legacy raw Neon sql usage; migrate to drizzle
 import { sql } from '@/app/lib/db/db';
 import { getGradeLabel } from '@boardsesh/db/queries';
 

--- a/packages/web/app/lib/hooks/pull-to-close.ts
+++ b/packages/web/app/lib/hooks/pull-to-close.ts
@@ -133,9 +133,17 @@ export function usePullToClose({
   const onTouchStart = useCallback(
     (clientY: number, scrollContainer: HTMLElement | null) => {
       const atTop = !scrollContainer || scrollContainer.scrollTop <= 0;
+      let pullOriginY: number;
+      if (!trackPullOrigin) {
+        pullOriginY = clientY;
+      } else if (atTop) {
+        pullOriginY = clientY;
+      } else {
+        pullOriginY = 0;
+      }
       stateRef.current = {
         startY: clientY,
-        pullOriginY: trackPullOrigin ? (atTop ? clientY : 0) : clientY,
+        pullOriginY,
         scrollContainer,
         isPulling: false,
         translateY: 0,

--- a/packages/web/app/lib/idb-helper.ts
+++ b/packages/web/app/lib/idb-helper.ts
@@ -52,6 +52,7 @@ export async function migrateFromLocalStorage<T>(
   }
 
   try {
+    // oxlint-disable-next-line no-restricted-globals -- one-time migration from legacy localStorage
     const raw = localStorage.getItem(legacyKey);
     if (raw === null) {
       return false;
@@ -69,6 +70,7 @@ export async function migrateFromLocalStorage<T>(
     }
 
     await idbSetter(parsed);
+    // oxlint-disable-next-line no-restricted-globals -- one-time migration cleanup
     localStorage.removeItem(legacyKey);
     return true;
   } catch (error) {

--- a/packages/web/app/lib/party-profile-db.ts
+++ b/packages/web/app/lib/party-profile-db.ts
@@ -80,7 +80,7 @@ const migrateFromLegacyStorage = async (): Promise<boolean> => {
     });
 
     if (migrated) {
-      // Also clean up legacy username key if present
+      // oxlint-disable-next-line no-restricted-globals -- one-time migration cleanup
       localStorage.removeItem('boardsesh:username');
       console.info('Successfully migrated party profile from localStorage to IndexedDB');
     }

--- a/packages/web/app/lib/seo/dynamic-og-data.ts
+++ b/packages/web/app/lib/seo/dynamic-og-data.ts
@@ -5,6 +5,7 @@ import { sql as drizzleSql } from 'drizzle-orm';
 import { buildBoardRenderUrl } from '@/app/components/board-renderer/util';
 import { boardToRouteParams, resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+// oxlint-disable-next-line no-restricted-imports -- legacy raw Neon sql usage; migrate to drizzle
 import { dbz, sql as rawSql } from '@/app/lib/db/db';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import type { BoardDetails, BoardName, ParsedBoardRouteParameters } from '@/app/lib/types';

--- a/packages/web/app/profile/[user_id]/components/stats-summary.tsx
+++ b/packages/web/app/profile/[user_id]/components/stats-summary.tsx
@@ -212,21 +212,27 @@ export default function StatsSummary({
             Grade Distribution
           </Typography>
 
-          {loadingAggregated ? (
-            <div className={styles.loadingStats}>
-              <CircularProgress size={24} />
-            </div>
-          ) : aggregatedStackedBars?.bars ? (
-            <CssBarChart
-              bars={aggregatedStackedBars.bars}
-              height={160}
-              mobileHeight={120}
-              showLegend={false}
-              ariaLabel="Grade distribution across boards"
-            />
-          ) : (
-            <EmptyState description="No ascent data for this period" />
-          )}
+          {(() => {
+            if (loadingAggregated) {
+              return (
+                <div className={styles.loadingStats}>
+                  <CircularProgress size={24} />
+                </div>
+              );
+            }
+            if (aggregatedStackedBars?.bars) {
+              return (
+                <CssBarChart
+                  bars={aggregatedStackedBars.bars}
+                  height={160}
+                  mobileHeight={120}
+                  showLegend={false}
+                  ariaLabel="Grade distribution across boards"
+                />
+              );
+            }
+            return <EmptyState description="No ascent data for this period" />;
+          })()}
         </div>
 
         {aggregatedFlashRedpointBars && !loadingAggregated && (

--- a/packages/web/app/profile/[user_id]/components/stats-summary.tsx
+++ b/packages/web/app/profile/[user_id]/components/stats-summary.tsx
@@ -103,6 +103,27 @@ export default function StatsSummary({
     </Box>
   );
 
+  let gradeDistributionContent: React.ReactNode;
+  if (loadingAggregated) {
+    gradeDistributionContent = (
+      <div className={styles.loadingStats}>
+        <CircularProgress size={24} />
+      </div>
+    );
+  } else if (aggregatedStackedBars?.bars) {
+    gradeDistributionContent = (
+      <CssBarChart
+        bars={aggregatedStackedBars.bars}
+        height={160}
+        mobileHeight={120}
+        showLegend={false}
+        ariaLabel="Grade distribution across boards"
+      />
+    );
+  } else {
+    gradeDistributionContent = <EmptyState description="No ascent data for this period" />;
+  }
+
   return (
     <MuiCard className={styles.statsCard}>
       <CardContent>
@@ -212,27 +233,7 @@ export default function StatsSummary({
             Grade Distribution
           </Typography>
 
-          {(() => {
-            if (loadingAggregated) {
-              return (
-                <div className={styles.loadingStats}>
-                  <CircularProgress size={24} />
-                </div>
-              );
-            }
-            if (aggregatedStackedBars?.bars) {
-              return (
-                <CssBarChart
-                  bars={aggregatedStackedBars.bars}
-                  height={160}
-                  mobileHeight={120}
-                  showLegend={false}
-                  ariaLabel="Grade distribution across boards"
-                />
-              );
-            }
-            return <EmptyState description="No ascent data for this period" />;
-          })()}
+          {gradeDistributionContent}
         </div>
 
         {aggregatedFlashRedpointBars && !loadingAggregated && (

--- a/packages/web/app/profile/[user_id]/sessions/sessions-content.tsx
+++ b/packages/web/app/profile/[user_id]/sessions/sessions-content.tsx
@@ -12,12 +12,14 @@ type ProfileSessionsContentProps = {
 
 export default function ProfileSessionsContent({ userId, isAuthenticatedSSR }: ProfileSessionsContentProps) {
   const { status } = useSession();
-  const computeIsAuthenticated = () => {
-    if (status === 'authenticated') return true;
-    if (status === 'loading') return isAuthenticatedSSR ?? false;
-    return false;
-  };
-  const isAuthenticated = computeIsAuthenticated();
+  let isAuthenticated: boolean;
+  if (status === 'authenticated') {
+    isAuthenticated = true;
+  } else if (status === 'loading') {
+    isAuthenticated = isAuthenticatedSSR ?? false;
+  } else {
+    isAuthenticated = false;
+  }
 
   return (
     <ProfileSubPageLayout>

--- a/packages/web/app/profile/[user_id]/sessions/sessions-content.tsx
+++ b/packages/web/app/profile/[user_id]/sessions/sessions-content.tsx
@@ -12,8 +12,12 @@ type ProfileSessionsContentProps = {
 
 export default function ProfileSessionsContent({ userId, isAuthenticatedSSR }: ProfileSessionsContentProps) {
   const { status } = useSession();
-  const isAuthenticated =
-    status === 'authenticated' ? true : status === 'loading' ? (isAuthenticatedSSR ?? false) : false;
+  const computeIsAuthenticated = () => {
+    if (status === 'authenticated') return true;
+    if (status === 'loading') return isAuthenticatedSSR ?? false;
+    return false;
+  };
+  const isAuthenticated = computeIsAuthenticated();
 
   return (
     <ProfileSubPageLayout>

--- a/packages/web/app/you/you-tab-bar.tsx
+++ b/packages/web/app/you/you-tab-bar.tsx
@@ -11,8 +11,14 @@ export default function YouTabBar() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const activeTab: YouTab =
-    pathname === '/you/sessions' ? 'sessions' : pathname === '/you/logbook' ? 'logbook' : 'progress';
+  let activeTab: YouTab;
+  if (pathname === '/you/sessions') {
+    activeTab = 'sessions';
+  } else if (pathname === '/you/logbook') {
+    activeTab = 'logbook';
+  } else {
+    activeTab = 'progress';
+  }
 
   const handleTabChange = useCallback(
     (_: React.SyntheticEvent, value: YouTab) => {

--- a/packages/web/e2e/app-store-screenshots.spec.ts
+++ b/packages/web/e2e/app-store-screenshots.spec.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-restricted-globals -- e2e tests run in browser context with full storage access */
 /**
  * App Store Screenshot Generation
  *


### PR DESCRIPTION
## Summary

Several rules in `CLAUDE.md` describe mechanical patterns that oxlint can catch directly. This PR moves enforcement into `.oxlintrc.json` so violations fail `vp check` instead of relying on review or memory, and clears the existing backlog of violations.

### New lint rules

- `no-nested-ternary` — refactored nested `?:` to `if`/`else`, small helpers, or IIFEs in **69 files** (114 violations).
- `no-restricted-globals` — block bare `localStorage` / `sessionStorage`. Legitimate migration code keeps a per-line `// oxlint-disable-next-line no-restricted-globals` with a short reason comment.
- `no-restricted-imports` — block `import { sql } from '@/app/lib/db/db'` (the raw Neon HTTP client). The 4 legacy callers are grandfathered with disable comments until they migrate to drizzle.

`typescript/no-explicit-any` was already enforced; CLAUDE.md was just restating it.

### CLAUDE.md changes

Removed the standalone bullets that restated each rule, and added a single pointer to `.oxlintrc.json` listing the lint-enforced set. The `Database Queries` and `Client-Side Storage` sections now reference the lint rule instead of repeating the prohibition.

## Test plan

- [x] `vp check` — 0 errors (109 pre-existing warnings unchanged)
- [x] `vp run typecheck:web` / `:backend` / `:db` / `:shared` — all pass
- [x] `oxlint` — 0 `no-nested-ternary`, `no-restricted-globals`, or `no-restricted-imports` violations
- [ ] Confirm CI lint + typecheck jobs pass

https://claude.ai/code/session_01AutRXdpyxdrX11w6KotFC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AutRXdpyxdrX11w6KotFC9)_