### PR TITLE
ci: gate merges on GraphQL Documents map tree-shake

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,6 +137,9 @@ jobs:
           DATABASE_URL: postgresql://postgres:password@db.localtest.me:5432/main
           NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
+      - name: Verify GraphQL Documents map is tree-shaken
+        run: vp run boardsesh-monorepo#verify:graphql-treeshake
+
       # Wrap the build outputs in a tarball before handing them to
       # actions/upload-artifact. Two reasons:
       #   1. Next.js (Turbopack) emits chunk filenames with `:` in them


### PR DESCRIPTION
## Summary

- Adds a `Verify GraphQL Documents map is tree-shaken` step to the e2e `build` job in `.github/workflows/e2e-tests.yml`, right after `vp run build`.
- The step runs `vp run boardsesh-monorepo#verify:graphql-treeshake`, which reuses the just-built `.next/` output (the task `dependsOn: ['build:web']` so vp hits cache) and exits non-zero if the SWC plugin transform didn't strip the 167 KB Documents map from live client chunks.
- No new workflow, no path-filter changes, no artifact upload — single file, 3 lines.

## Why

PR #1789 wired in `@swc-contrib/plugin-graphql-codegen-client-preset` and shipped `packages/web/scripts/verify-graphql-treeshake.ts` as a post-build assertion, but nothing runs it. Without a CI gate, any of the following would silently re-ship the 167 KB blob:

- `artifactDirectory` in `next.config.mjs` drifts from `./packages/web/app/lib/graphql/generated`
- The plugin devDep gets removed
- The `swcPlugins` block gets disabled or reordered
- A future Next/SWC ABI bump breaks the plugin without a hard build error

This step turns all of those into red CI instead.

## Test plan

- [ ] Push triggers the e2e workflow (path filter already covers `packages/web/**` and `.github/workflows/e2e-tests.yml`).
- [ ] New step runs after "Build all packages" and prints `verify-graphql-treeshake: OK — N chunk(s) covering …, none leaked.`
- [ ] Negative test (separate throwaway commit, then revert): comment out the `swcPlugins` block in `packages/web/next.config.mjs` and confirm the step fails with `SWC plugin transform did not fire — Documents map leaked into live chunk(s):`.

## Out of scope

- Migrating the remaining 18 op-files from raw `gql` to `graphql()`. With this gate in place, that becomes a one-line-per-file change with a real regression check behind it.

https://claude.ai/code/session_01Gm2FXoXjq1JivNcdxoxnkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm2FXoXjq1JivNcdxoxnkW)_