### PR TITLE
fix(web): keep climb list visible on Android when search is focused

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -50,6 +50,10 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   viewportFit: 'cover',
+  // Match Mobile Safari behavior on Android: keyboard overlays the page
+  // without resizing the layout viewport, so 100dvh and position:fixed
+  // bottom bars stay anchored when an input is focused.
+  interactiveWidget: 'resizes-visual',
   themeColor: '#101012',
 };
 


### PR DESCRIPTION
## Summary

- On Android, focusing the climb name search in the global header on a climb list page caused the climb list to collapse and the persistent queue control bar to fly to the top of the screen.
- iOS was unaffected because Mobile Safari's default `interactive-widget` value is `resizes-visual` — the keyboard overlays the page without resizing the layout viewport. Android Chrome's default is `resizes-content`, which shrinks both the layout viewport and `100dvh`, so `position: fixed; bottom: 0` re-anchors and `100dvh`-sized flex containers crush their children.
- This change sets `interactiveWidget: 'resizes-visual'` on the root `Viewport` export in `packages/web/app/layout.tsx`, making Android match iOS so `100dvh` and bottom-anchored fixed bars stay stable across the app while typing.

## Why this fix

The codebase has many `100dvh` + `flex: 1` + `position: fixed; bottom: 0` layouts (board pages under `[board_name]/.../layout.tsx` and `b/[board_slug]/...`, the queue/tab bar in `bottom-bar-wrapper.module.css`, drawers, feed, playlists, notifications). Reworking each to be Android-keyboard-resize-safe would be a sweeping change. Setting `interactiveWidget` at the document root is a one-line fix that aligns Android with the existing iOS behavior the layouts already assume. `resizes-visual` is supported in Chrome on Android since 108 (Nov 2022); older clients fall back to today's behavior, so this change can't regress any client.

## Test plan

- [ ] On a real Android device or Chrome DevTools Android emulation, navigate to a board climb list (e.g. `/kilter/<layout>/<size>/<sets>/<angle>/list`), focus the climb name search, and confirm the climb list stays visible and the persistent queue control bar stays anchored to the bottom of the viewport while the keyboard is open.
- [ ] On iOS Safari and the iOS native (Capacitor) build, confirm the same flow is unchanged.
- [ ] `vp check` passes.
- [ ] `vp run typecheck:web` passes.
- [ ] `vp run test:e2e` passes (no regression in screenshot or search specs — desktop Chromium has no software keyboard, so behavior is unaffected).

https://claude.ai/code/session_01Sey7WiM9CvrrjGXGx8yzrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sey7WiM9CvrrjGXGx8yzrB)_