### PR TITLE
Improve playlist detail SSR loading experience

### DIFF
--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
-import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { serverMyBoards, serverPlaylist, serverPlaylistClimbs } from '@/app/lib/graphql/server-cached-client';
 import { generatePlaylistMetadata } from '@/app/lib/seo/playlist-metadata';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -33,7 +33,20 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+  const [initialMyBoards, initialPlaylist] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    serverPlaylist(authToken, params.playlist_uuid),
+  ]);
+
+  const initialClimbs = initialPlaylist
+    ? await serverPlaylistClimbs(authToken, {
+        playlistId: params.playlist_uuid,
+        boardName: board.boardType,
+        layoutId: board.layoutId,
+        page: 0,
+        pageSize: 20,
+      })
+    : null;
 
   const lcpPreloadUrl = getPlaylistLcpPreloadUrl({
     boardType: board.boardType,
@@ -51,6 +64,8 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
           playlistsBasePath={playlistsBasePath}
           boardSlug={params.board_slug}
           initialMyBoards={initialMyBoards}
+          initialPlaylist={initialPlaylist}
+          initialClimbs={initialClimbs}
         />
       </div>
     </I18nProvider>

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -14,7 +14,13 @@ import type {
 
 // Re-export uncached authenticated server functions so existing imports
 // from this file continue to work without changes.
-export { serverMyBoards, serverUserPlaylists, serverGroupedNotifications } from './server-graphql';
+export {
+  serverMyBoards,
+  serverUserPlaylists,
+  serverGroupedNotifications,
+  serverPlaylist,
+  serverPlaylistClimbs,
+} from './server-graphql';
 
 export const USER_CLIMB_PERCENTILE_CACHE_TAG = 'user-climb-percentile';
 

--- a/packages/web/app/lib/graphql/server-graphql.ts
+++ b/packages/web/app/lib/graphql/server-graphql.ts
@@ -3,7 +3,13 @@ import { type RequestDocument, type Variables, GraphQLClient } from 'graphql-req
 import { getGraphQLHttpUrl } from './client';
 import type { GroupedNotificationConnection, UserBoard } from '@boardsesh/shared-schema';
 import type { GetMyBoardsQueryResponse } from '@/app/lib/graphql/operations/boards';
-import type { Playlist, GetAllUserPlaylistsQueryResponse } from '@/app/lib/graphql/operations/playlists';
+import type {
+  Playlist,
+  GetAllUserPlaylistsQueryResponse,
+  GetPlaylistQueryResponse,
+  GetPlaylistClimbsQueryResponse,
+  GetPlaylistClimbsInput,
+} from '@/app/lib/graphql/operations/playlists';
 
 /**
  * Execute a GraphQL query with an auth token (non-cached, per-user data).
@@ -88,4 +94,43 @@ export async function serverGroupedNotifications(
   const data = await executeAuthenticatedGraphQL<Response>(GET_GROUPED_NOTIFICATIONS, { limit, offset }, authToken);
 
   return data.groupedNotifications;
+}
+
+/**
+ * Server-side fetch of a single playlist.
+ */
+export async function serverPlaylist(authToken: string | undefined, playlistId: string): Promise<Playlist | null> {
+  const { GET_PLAYLIST } = await import('@/app/lib/graphql/operations/playlists');
+
+  try {
+    const response = await executeAuthenticatedGraphQL<GetPlaylistQueryResponse>(
+      GET_PLAYLIST,
+      { playlistId },
+      authToken,
+    );
+    return response.playlist;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Server-side fetch of the first page of playlist climbs.
+ */
+export async function serverPlaylistClimbs(
+  authToken: string | undefined,
+  input: GetPlaylistClimbsInput,
+): Promise<GetPlaylistClimbsQueryResponse['playlistClimbs'] | null> {
+  const { GET_PLAYLIST_CLIMBS } = await import('@/app/lib/graphql/operations/playlists');
+
+  try {
+    const response = await executeAuthenticatedGraphQL<GetPlaylistClimbsQueryResponse>(
+      GET_PLAYLIST_CLIMBS,
+      { input },
+      authToken,
+    );
+    return response.playlistClimbs;
+  } catch {
+    return null;
+  }
 }

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
-import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { serverMyBoards, serverPlaylist, serverPlaylistClimbs } from '@/app/lib/graphql/server-cached-client';
 import { generatePlaylistMetadata } from '@/app/lib/seo/playlist-metadata';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -18,12 +18,27 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+  const [initialMyBoards, initialPlaylist] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    serverPlaylist(authToken, playlist_uuid),
+  ]);
+
+  const initialClimbs = initialPlaylist
+    ? await serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 })
+    : null;
 
   return (
-    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed', 'playlists']}>
+    <I18nProvider
+      locale={locale}
+      namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed', 'playlists']}
+    >
       <div className={styles.pageContainer}>
-        <PlaylistDetailContent playlistUuid={playlist_uuid} initialMyBoards={initialMyBoards} />
+        <PlaylistDetailContent
+          playlistUuid={playlist_uuid}
+          initialMyBoards={initialMyBoards}
+          initialPlaylist={initialPlaylist}
+          initialClimbs={initialClimbs}
+        />
       </div>
     </I18nProvider>
   );

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -49,6 +49,7 @@ import {
   type UnpinPlaylistMutationVariables,
   type GetPlaylistClimbsQueryVariables,
   type GetPlaylistClimbsInput,
+  type PlaylistClimbsResult,
 } from '@/app/lib/graphql/operations/playlists';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { shareWithFallback } from '@/app/lib/share-utils';
@@ -97,6 +98,10 @@ type PlaylistDetailContentProps = {
   boardConfig?: BoardConfig;
   /** SSR-fetched user boards for instant board filter selection (avoids flash). */
   initialMyBoards?: UserBoard[] | null;
+  /** SSR-fetched playlist to avoid first-load spinner. */
+  initialPlaylist?: Playlist | null;
+  /** SSR-fetched first page of climbs to avoid first-load spinner. */
+  initialClimbs?: PlaylistClimbsResult | null;
 };
 
 export default function PlaylistDetailContent({
@@ -105,12 +110,14 @@ export default function PlaylistDetailContent({
   boardSlug,
   boardConfig,
   initialMyBoards,
+  initialPlaylist,
+  initialClimbs,
 }: PlaylistDetailContentProps) {
   const router = useLocaleRouter();
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('playlists');
-  const [playlist, setPlaylist] = useState<Playlist | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [playlist, setPlaylist] = useState<Playlist | null>(initialPlaylist ?? null);
+  const [loading, setLoading] = useState(!initialPlaylist);
   const [error, setError] = useState<string | null>(null);
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [generatorOpen, setGeneratorOpen] = useState(false);
@@ -150,7 +157,7 @@ export default function PlaylistDetailContent({
     if (tokenLoading) return;
 
     try {
-      setLoading(true);
+      if (!playlist) setLoading(true);
       setError(null);
 
       const response = await executeGraphQL<GetPlaylistQueryResponse, GetPlaylistQueryVariables>(
@@ -171,7 +178,7 @@ export default function PlaylistDetailContent({
     } finally {
       setLoading(false);
     }
-  }, [playlistUuid, token, tokenLoading]);
+  }, [playlistUuid, token, tokenLoading, playlist]);
 
   useEffect(() => {
     void fetchPlaylist();
@@ -243,6 +250,12 @@ export default function PlaylistDetailContent({
       return allPages.length;
     },
     staleTime: 5 * 60 * 1000,
+    initialData: initialClimbs
+      ? {
+          pages: [initialClimbs],
+          pageParams: [0],
+        }
+      : undefined,
   });
 
   const allClimbs: Climb[] = useMemo(


### PR DESCRIPTION
### Motivation
- Reduce perceived load time and eliminate first-paint spinners on playlist detail pages by moving playlist and initial climbs fetching to the server. 
- Ensure playlist detail pages have server-rendered content useful for SEO and metadata generation (title/description/OG). 
- Address poor loading UX on both global and board-scoped playlist routes by hydrating the client with SSR data.

### Description
- Add authenticated server GraphQL helpers `serverPlaylist` and `serverPlaylistClimbs` to fetch a single playlist and its first page of climbs server-side in `packages/web/app/lib/graphql/server-graphql.ts`. 
- Re-export the new helpers from `server-cached-client` so existing import patterns continue to work via `packages/web/app/lib/graphql/server-cached-client.ts`. 
- Update both playlist detail routes (`/playlists/[playlist_uuid]` and `/b/[board_slug]/[angle]/playlists/[playlist_uuid]`) to SSR-fetch user boards, playlist details, and the first climbs page and pass them into the client component as initial props. 
- Hydrate `PlaylistDetailContent` with `initialPlaylist` and `initialClimbs`, initialize loading state from SSR data, and provide `initialData` to the `useInfiniteQuery` so the first paint shows real content instead of a spinner.

### Testing
- Ran project typecheck via `cd packages/web && bun run typecheck`, which failed in this environment due to pre-existing/missing project dependencies and type declarations (e.g. unresolved `react`/`next` types) unrelated to the playlist changes. 
- No new unit tests were added for these changes and no other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f491a3273c8326bb48acf2ea2bb63d)