### PR TITLE
fix(web): keep playlist share + kebab buttons anchored to hero card

### DIFF
--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -77,7 +77,7 @@
   margin: 0 0 4px 0 !important;
   font-weight: 600 !important;
   word-break: break-word;
-  padding-right: 32px;
+  padding-right: 88px;
 }
 
 .heroMeta {
@@ -177,27 +177,6 @@
 .errorMessage {
   color: var(--neutral-500);
   margin-bottom: 20px;
-}
-
-/* Visibility badge */
-.visibilityBadge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.publicBadge {
-  background-color: var(--neutral-100);
-  color: var(--color-success);
-}
-
-.privateBadge {
-  background-color: var(--neutral-100);
-  color: var(--neutral-500);
 }
 
 /* Mobile adjustments */

--- a/packages/web/app/components/library/playlist-view.module.css
+++ b/packages/web/app/components/library/playlist-view.module.css
@@ -77,6 +77,10 @@
   margin: 0 0 4px 0 !important;
   font-weight: 600 !important;
   word-break: break-word;
+  padding-right: 32px;
+}
+
+.heroNameWithShare {
   padding-right: 88px;
 }
 

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -410,14 +410,22 @@ export default function PlaylistDetailContent({
           </div>
 
           {/* Share + Ellipsis Menu */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              display: 'flex',
+              flexDirection: 'row',
+              gap: 0.5,
+            }}
+          >
             {playlist.isPublic && (
               <IconButton onClick={handleShare} aria-label="Share playlist">
                 <IosShare />
               </IconButton>
             )}
             <IconButton
-              className={styles.heroMenuButton}
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => setMenuAnchor(e.currentTarget)}
               aria-label="Playlist actions"
             >

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -354,7 +354,11 @@ export default function PlaylistDetailContent({
               />
             </div>
             <div className={styles.heroInfo}>
-              <Typography variant="h5" component="h2" className={styles.heroName}>
+              <Typography
+                variant="h5"
+                component="h2"
+                className={`${styles.heroName} ${playlist.isPublic ? styles.heroNameWithShare : ''}`}
+              >
                 {playlist.name}
               </Typography>
               <div className={styles.heroMeta}>
@@ -413,8 +417,8 @@ export default function PlaylistDetailContent({
           <Box
             sx={{
               position: 'absolute',
-              top: 8,
-              right: 8,
+              top: 1.5,
+              right: 1.5,
               display: 'flex',
               flexDirection: 'row',
               gap: 0.5,


### PR DESCRIPTION
## Summary

Fixes #1759.

On public playlists the Share button rendered as a stray button below the hero content, and the kebab menu sat in an awkward spot. Root cause: only the kebab `IconButton` had absolute positioning (`.heroMenuButton`); the Share button (rendered as its sibling inside a flex `Box`) stayed in normal flow with nothing to anchor it.

- Move both buttons into a single absolutely-positioned `Box` at top-right of the hero card so they sit together whether the playlist is public or private.
- Drop the now-redundant `.heroMenuButton` className from the kebab on this surface (the class itself stays — `liked-climbs-view-content.tsx` still uses it).
- Bump `.heroName` `padding-right` from 32px to 88px so the title doesn't run under both buttons.
- Remove a duplicated `.visibilityBadge` / `.publicBadge` / `.privateBadge` rule block that had been pasted twice.

## Test plan

- [ ] Visit a private playlist (test user owns it) — kebab appears at top-right, opens the Edit/Delete/Generate menu, no Share button shown.
- [ ] Visit a public playlist — Share + kebab appear side-by-side at top-right; Share no longer appears below the hero; kebab menu opens correctly anchored.
- [ ] Resize to mobile width (≤767px) — both buttons fit in the corner; title wraps without colliding.
- [ ] `vp check` and `vp run typecheck:web` pass (couldn't run locally — `vp` not available in this env).

https://claude.ai/code/session_01UKCGMmdm2GWFy8BAzPLqA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKCGMmdm2GWFy8BAzPLqA5)_