### PR TITLE
[reverted] fix(mobile): resize Android WebView when soft keyboard opens

### DIFF
--- a/docs/mobile-app-plan.md
+++ b/docs/mobile-app-plan.md
@@ -483,7 +483,13 @@ const config: CapacitorConfig = {
       backgroundColor: '#121212',
     },
     Keyboard: {
-      resize: 'body',
+      // Use 'native' so Android resizes the WebView itself (matching mobile
+      // Chrome's visualViewport behavior). 'body' injects inline styles on
+      // <body>, which fights with @capacitor-community/safe-area's inset
+      // handling. With 'native', existing 100dvh / 100% layouts (e.g. the
+      // climb-name filter drawer with placement="top" fullHeight) shrink to
+      // fit above the keyboard with no web-side changes.
+      resize: 'native',
       resizeOnFullScreen: true,
     },
     SplashScreen: {

--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-geolocation')
+    implementation project(':capacitor-keyboard')
 
 }
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
 
             <intent-filter>

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -22,3 +22,6 @@ project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/
 
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')
+
+include ':capacitor-keyboard'
+project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -15,6 +15,7 @@
         "@capacitor/core": "^8",
         "@capacitor/geolocation": "8.1.0",
         "@capacitor/ios": "^8",
+        "@capacitor/keyboard": "^8",
         "@capacitor/motion": "^8",
       },
       "devDependencies": {
@@ -45,6 +46,8 @@
     "@capacitor/geolocation": ["@capacitor/geolocation@8.1.0", "", { "dependencies": { "@capacitor/synapse": "^1.0.4" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-dHeGuVlT3ELxxn8WaoRsGjfx8tmziaC0ZuaKhUBCoKFjOue4fAnmLczCMQsYW7OykgiyBh0pirNPwWZ0/LXB7Q=="],
 
     "@capacitor/ios": ["@capacitor/ios@8.3.0", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-5Rtwv8SITKlYTt8lAZG+khnVIdzPtqbocH3eP+JkEmX1vpSMwx4TOKtT8OBz8gpQ+pUJDRp7DBYOv3U6l/obCw=="],
+
+    "@capacitor/keyboard": ["@capacitor/keyboard@8.0.3", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ=="],
 
     "@capacitor/motion": ["@capacitor/motion@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-eCTe9+ZSVw2dQLQLvq5vfp2GGnMmsAy5jn4boKB93CHEenD9ZZojXZYJn1u4zUWhfj9cGXSxu+2j7WaQbkMlPg=="],
 

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -23,6 +23,13 @@ const config: CapacitorConfig = {
     SystemBars: {
       insetsHandling: 'disable',
     },
+    // Resize the Android WebView when the soft keyboard opens so 100dvh/100%
+    // layouts (e.g. the climb-name filter drawer) shrink to fit above it,
+    // matching how mobile Chrome behaves natively.
+    Keyboard: {
+      resize: 'native',
+      resizeOnFullScreen: true,
+    },
   },
 };
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
     "@capacitor/core": "^8",
     "@capacitor/geolocation": "8.1.0",
     "@capacitor/ios": "^8",
+    "@capacitor/keyboard": "^8",
     "@capacitor/motion": "^8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Status: reverted — needs deeper investigation

After testing on a real APK build, the symptom persists with my changes (see https://github.com/boardsesh/boardsesh/pull/1796 thread). Reading the `@capacitor-community/safe-area@^8` plugin source revealed that my fix was based on an incorrect mental model:

- The plugin **explicitly logs an error** when `Keyboard.resizeOnFullScreen: true` is set in `capacitor.config.json` ("Other values can lead to unexpected behavior") — exactly what I added.
- For Chromium ≥140 with `viewport-fit=cover` (which we have via `interactiveWidget: 'resizes-visual'` + `viewportFit: 'cover'` in `app/layout.tsx`), the plugin already pads the WebView decorView by `imeInsets.bottom` when the keyboard is visible. Adding `Keyboard.resize: 'native'` is redundant at best and conflicts at worst.
- `safe-area-inset-bottom` reports `systemBarsInsets.bottom` (system bar height, NOT keyboard height) for modern WebViews — so my "double padding via safe-area" theory was also wrong.
- `interactiveWidget: 'resizes-visual'` (added in `40a1966`) signals "keyboard floats over, layout viewport stays full size", which directly conflicts with `Keyboard.resize: 'native'`'s intent.

I reverted both commits (`2bc1a4a`, `9caffe8`). The branch is back to `main`'s state.

## Real cause: still unknown

The screenshot from a fresh APK on this branch shows the bottom tab bar floating roughly mid-screen with a large black band between it and the keyboard. That's not consistent with a simple "WebView didn't resize" or "extra padding from IME inset" — `safe-area-inset-bottom` is only system-bar height (~30–50px), not enough to push the nav up by hundreds of pixels.

Productive next steps (suggesting, not doing yet):

1. **Remote DevTools** the running APK (`chrome://inspect` from desktop Chrome → device's Capacitor WebView) and inspect the actual computed sizes of `body`, the search drawer paper, and the bottom tab bar wrapper when the keyboard is open. That will tell us exactly which container is collapsing.
2. **Check Chromium WebView version** on the test device — the safe-area plugin has version-gated logic (`< 140`, `≥ 140`, `< 144`, `≥ 144`).
3. **Check if `40a1966` itself caused the regression** — if the bug only appeared after `interactiveWidget: 'resizes-visual'` shipped, the fix may belong in that commit's behavior on Capacitor specifically (e.g., conditionally drop it for native).

## Test plan

- [ ] Confirm reverts deploy cleanly (no behavior change vs `main`).
- [ ] Hold this PR until the root cause is actually verified via DevTools inspection on a device.

https://claude.ai/code/session_017fsUwx9ejEFnasADpSdmF1