### PR TITLE
fix(mobile): exclude /api and /auth from Android App Links

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -28,13 +28,41 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!--
+              Android App Links must NOT intercept /api/* or /auth/* paths.
+              OAuth providers (Google, Apple, Facebook) redirect the user to
+              /api/auth/callback/<provider> via a Chrome Custom Tab; the
+              state cookie that NextAuth sets lives in Chrome's cookie jar,
+              not the app's WebView. If the OS routes the callback URL into
+              the app, NextAuth throws "State cookie was missing." Enumerate
+              the deep-linkable top-level paths instead of using a catch-all.
+            -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="https" android:host="www.boardsesh.com" android:pathPrefix="/" />
+                <data android:scheme="https" android:host="www.boardsesh.com" />
+
+                <data android:pathPrefix="/about" />
+                <data android:pathPrefix="/aurora-migration" />
+                <data android:pathPrefix="/b/" />
+                <data android:pathPrefix="/docs" />
+                <data android:pathPrefix="/feed" />
+                <data android:pathPrefix="/help" />
+                <data android:pathPrefix="/join" />
+                <data android:pathPrefix="/kilter" />
+                <data android:pathPrefix="/legal" />
+                <data android:pathPrefix="/notifications" />
+                <data android:pathPrefix="/playlists" />
+                <data android:pathPrefix="/privacy" />
+                <data android:pathPrefix="/profile" />
+                <data android:pathPrefix="/session" />
+                <data android:pathPrefix="/setter" />
+                <data android:pathPrefix="/settings" />
+                <data android:pathPrefix="/tension" />
+                <data android:pathPrefix="/you" />
             </intent-filter>
 
         </activity>


### PR DESCRIPTION
## Summary

Fixes the `[next-auth][error][OAUTH_CALLBACK_ERROR] State cookie was missing.` error users see when signing in with Google on Android.

### Root cause

`mobile/android/app/src/main/AndroidManifest.xml` declared a catch-all App Link filter:

```xml
<data android:scheme="https" android:host="www.boardsesh.com" android:pathPrefix="/" />
```

combined with `delegate_permission/common.handle_all_urls` in `/.well-known/assetlinks.json`. With `autoVerify="true"`, Android routes **every** `https://www.boardsesh.com/*` URL into the app — including `/api/auth/callback/google`.

The OAuth flow on Android:

1. Capacitor Browser plugin opens Chrome Custom Tabs at `/auth/native-start`.
2. Form auto-POSTs to `/api/auth/signin/google`. NextAuth sets `__Secure-next-auth.state` in **Chrome's** cookie jar and redirects to Google.
3. User authenticates with Google.
4. Google redirects to `https://www.boardsesh.com/api/auth/callback/google?state=…&code=…`.
5. **Android's App Link verification hijacks the URL into the app's main WebView** (`MainActivity.loadDeepLinkIfPresent` does `webView.loadUrl(...)`).
6. The WebView has a different cookie jar than Chrome Custom Tabs → state cookie missing → NextAuth throws.

iOS works because `SFSafariViewController` (used by Capacitor's Browser plugin) explicitly does NOT trigger Universal Links, so the OAuth callback stays in the browser tab where the cookie lives.

### Fix

Replace the catch-all `pathPrefix="/"` with an explicit list of top-level routes the app should deep-link. `/api/*` and `/auth/*` are deliberately excluded so OAuth callbacks stay in Chrome Custom Tabs and the state cookie survives the round trip.

The trade-off: new top-level public routes will need to be added to the manifest to be deep-linkable. This is the standard pattern recommended by Google/Auth0 for OAuth + App Links coexistence.

## Test plan

- [ ] Build a release Android APK, install on a device where the App Link is auto-verified
- [ ] Tap "Continue with Google" from the login screen — verify Custom Tab opens, Google sign-in completes, and the app receives the `com.boardsesh.app://auth/callback?transferToken=…` deep link
- [ ] Tap "Continue with Apple" — verify the same flow works (Apple uses `response_mode=form_post`, which is why the state cookies are `SameSite=None`)
- [ ] Tap a `https://www.boardsesh.com/profile/...` shared link from another app — verify it still opens in Boardsesh (App Link still works for content paths)
- [ ] Tap a `https://www.boardsesh.com/api/...` link — verify it opens in the browser (expected new behavior)

https://claude.ai/code/session_014AAZ2f7b96cSRp1rrU4A1S

---
_Generated by [Claude Code](https://claude.ai/code/session_014AAZ2f7b96cSRp1rrU4A1S)_