### PR TITLE
fix(mobile): register com.boardsesh.app scheme on Android for OAuth callback

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -65,6 +65,22 @@
                 <data android:pathPrefix="/you" />
             </intent-filter>
 
+            <!--
+              Custom-scheme intent filter for native OAuth callback. After OAuth
+              completes in a Chrome Custom Tab, /api/auth/native/callback returns
+              an HTML page that redirects to
+              com.boardsesh.app://auth/callback?transferToken=...
+              This filter routes that scheme into MainActivity, where the
+              Capacitor appUrlOpen listener exchanges the transfer token for a
+              NextAuth session. Mirrors CFBundleURLSchemes in iOS Info.plist.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.boardsesh.app" />
+            </intent-filter>
+
         </activity>
 
         <provider


### PR DESCRIPTION
## Summary

Google sign-in on the Android app stranded users on a white screen at `https://www.boardsesh.com/api/auth/native/callback?next=%2F` instead of returning to the app.

The native-OAuth flow ends with `/api/auth/native/callback` returning an HTML page that redirects to the custom scheme `com.boardsesh.app://auth/callback?transferToken=…`. The Capacitor `appUrlOpen` listener in `session-provider.tsx` then exchanges the token for a NextAuth session.

iOS already registers `com.boardsesh.app` via `CFBundleURLSchemes` in `Info.plist`. **Android's manifest never did** — only HTTPS App Links were declared. With no app claiming the custom scheme, Chrome Custom Tabs had nowhere to hand the redirect, so the page just sat there.

This PR adds the missing intent filter:

```xml
<intent-filter>
    <action android:name="android.intent.action.VIEW" />
    <category android:name="android.intent.category.DEFAULT" />
    <category android:name="android.intent.category.BROWSABLE" />
    <data android:scheme="com.boardsesh.app" />
</intent-filter>
```

`MainActivity` already extends `BridgeActivity`, which forwards VIEW intents to Capacitor's `App` plugin and emits `appUrlOpen` — no Java changes needed. `loadDeepLinkIfPresent` short-circuits on non-http(s) schemes, so it correctly leaves custom-scheme intents to the bridge.

The earlier fix in `91152628` (exclude `/api` and `/auth` from App Links) solved a different problem (App Links hijacking the OAuth flow before it reached Google) but didn't add the custom-scheme handler needed for the final hop back into the app.

## Test plan

- [ ] Build the Android app and run `adb shell am start -W -a android.intent.action.VIEW -d "com.boardsesh.app://auth/callback?transferToken=test&next=/"` — app should foreground (without the fix this errors with `Activity not started, unable to resolve Intent`).
- [ ] Fresh install: tap "Continue with Google", complete OAuth in the Custom Tab, confirm the Custom Tab closes, app foregrounds, user is signed in, lands on `/` — no white screen.
- [ ] Regression: `https://www.boardsesh.com/feed` opened from another app still routes into Boardsesh; `https://www.boardsesh.com/api/auth/...` still opens in the browser.
- [ ] iOS Google sign-in still works (manifest-only change but worth a smoke test).

https://claude.ai/code/session_01HeoKa7Vp4YgUe9qSEVcc9W

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeoKa7Vp4YgUe9qSEVcc9W)_