### PR TITLE
feat(i18n): language switcher in user drawer with sticky locale

### DIFF
--- a/packages/web/app/components/i18n/language-switcher.tsx
+++ b/packages/web/app/components/i18n/language-switcher.tsx
@@ -10,6 +10,8 @@ import {
   LOCALE_LABELS,
   SUPPORTED_LOCALES,
   DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  LOCALE_COOKIE_MAX_AGE,
   type Locale,
   isSupportedLocale,
 } from '@/app/lib/i18n/config';
@@ -29,6 +31,9 @@ function LanguageSwitcherInner() {
     if (!isSupportedLocale(next) || next === currentLocale) {
       return;
     }
+    // Persist the choice so subsequent navigation to plain (un-prefixed) paths
+    // gets redirected to the matching localised URL by middleware.
+    document.cookie = `${LOCALE_COOKIE}=${next}; path=/; max-age=${LOCALE_COOKIE_MAX_AGE}; samesite=lax`;
     const basePath = stripLocalePrefix(pathname, currentLocale);
     const target = localeHref(basePath, next);
     const query = searchParams?.toString();

--- a/packages/web/app/components/user-drawer/user-drawer.module.css
+++ b/packages/web/app/components/user-drawer/user-drawer.module.css
@@ -162,6 +162,12 @@
   padding: 16px 0 8px;
 }
 
+.languageSwitcherContainer {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+}
+
 .themeToggle {
   position: relative;
   display: flex;

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -47,6 +47,7 @@ import { StoreReviewPromptDialog } from '../feedback/store-review-prompt-dialog'
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
+import LanguageSwitcher from '../i18n/language-switcher';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
@@ -464,6 +465,10 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
 
             {/* Spacer to push toggle to bottom */}
             <div className={styles.bottomSpacer} />
+
+            <div className={styles.languageSwitcherContainer}>
+              <LanguageSwitcher />
+            </div>
 
             {/* Sun/Moon toggle */}
             <div className={styles.themeToggleContainer}>

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -24,6 +24,10 @@ export const SEED_NAMESPACES = ['common', 'marketing'] as const;
 export type SeedNamespace = (typeof SEED_NAMESPACES)[number];
 
 export const LOCALE_HEADER = 'x-boardsesh-locale';
+export const LOCALE_COOKIE = 'boardsesh-locale';
+// 1 year — long enough to survive between sessions, short enough that abandoned
+// devices don't carry the preference forever.
+export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
 export function isSupportedLocale(value: string | undefined | null): value is Locale {
   return value != null && (SUPPORTED_LOCALES as readonly string[]).includes(value);

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getListPageCacheTTL } from './app/lib/list-page-cache';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
-import { DEFAULT_LOCALE, LOCALE_HEADER } from './app/lib/i18n/config';
+import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALE_HEADER, isSupportedLocale } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
@@ -62,6 +62,19 @@ export function middleware(request: NextRequest) {
   const { locale, strippedPath, needsRewrite } = isApi
     ? { locale: DEFAULT_LOCALE, strippedPath: pathname, needsRewrite: false }
     : detectLocale(pathname);
+
+  // If the URL has no locale prefix but the user previously chose a non-default
+  // locale (cookie set by the language switcher), redirect to the prefixed URL.
+  // This makes locale stick across plain `<Link href="/foo">` / `router.push`
+  // calls throughout the app without retrofitting every call site.
+  if (!isApi && !needsRewrite) {
+    const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value;
+    if (isSupportedLocale(cookieLocale) && cookieLocale !== DEFAULT_LOCALE) {
+      const redirectUrl = request.nextUrl.clone();
+      redirectUrl.pathname = pathname === '/' ? `/${cookieLocale}` : `/${cookieLocale}${pathname}`;
+      return NextResponse.redirect(redirectUrl, 307);
+    }
+  }
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set(LOCALE_HEADER, locale);


### PR DESCRIPTION
## Summary

- Mount the existing `LanguageSwitcher` component in the left user drawer (between the menu and the theme toggle), so users can actually pick a language.
- Persist the chosen locale in a `boardsesh-locale` cookie (1 year, `samesite=lax`) when the switcher fires.
- Update middleware: when a request has no `/es` prefix but the cookie is set to a non-default locale, redirect to the prefixed URL. API routes are excluded.

## Why

Two issues reported:

1. Locale didn't stick during navigation. `<Link href="/playlists">` and `router.push("/playlists")` calls across the app don't carry the locale prefix, so going from `/es` to a plain link dropped the user back to English. Retrofitting every `Link`/`router.push` would be invasive — middleware-level cookie-based redirect is one surgical change that fixes navigation app-wide.
2. There was no UI to switch language. The `LanguageSwitcher` component existed at `packages/web/app/components/i18n/language-switcher.tsx` but was never mounted.

Note: `/es/playlists` *did* route correctly already (middleware rewrites it internally) — but `LibraryPageContent` is mostly hardcoded English and not yet wired up to `useTranslation`, so visually it looked unchanged. That's a content-translation gap, not a routing bug.

## Test plan

- [ ] On `/`, open the user drawer, switch to Español. Page navigates to `/es` and renders Spanish copy.
- [ ] From `/es`, click around the drawer (Settings, My Playlists, Help, About). URL stays under `/es/...`.
- [ ] Reload to `/playlists` directly. Browser is redirected to `/es/playlists` because the cookie is set.
- [ ] Switch back to English. URL drops the `/es` prefix and subsequent navigation stays un-prefixed.
- [ ] Confirm `/api/...` requests are not redirected (cookie path covers them but middleware skips API routes explicitly).
- [ ] Confirm `vp run typecheck` and `vp check` pass in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_015HD4aVy5nrCCiEy6tdWoJ8)_