### PR TITLE
fix(beta-videos): use embed page for IG verification, drop climb-name check

### DIFF
--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -1,305 +1,89 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  fetchInstagramPageMetadata,
-  InstagramBetaValidationError,
-  instagramBetaValidationInternals,
-  instagramValidationCircuitForTesting,
-  validateInstagramBetaLink,
-} from '../utils/instagram-beta-validation';
-import { getInstagramMediaId } from '../lib/instagram-meta';
 
-const fetchMock = vi.fn();
+vi.mock('../lib/instagram-meta', async () => {
+  const actual = await vi.importActual<typeof import('../lib/instagram-meta')>('../lib/instagram-meta');
+  return {
+    ...actual,
+    fetchInstagramMeta: vi.fn(),
+  };
+});
 
-describe('instagram-beta-validation', () => {
+import { fetchInstagramMeta } from '../lib/instagram-meta';
+import { InstagramBetaValidationError, validateInstagramBetaLink } from '../utils/instagram-beta-validation';
+
+const fetchInstagramMetaMock = vi.mocked(fetchInstagramMeta);
+
+describe('validateInstagramBetaLink', () => {
   beforeEach(() => {
-    fetchMock.mockReset();
-    vi.stubGlobal('fetch', fetchMock);
-    instagramValidationCircuitForTesting.reset();
+    fetchInstagramMetaMock.mockReset();
   });
 
-  it('extracts public metadata from instagram html', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta name="description" content="13 likes - climber on Instagram: &quot;Fell From Heaven&quot; @ 35° on the Kilter Board Homewall." />
-          <meta property="og:title" content="climber on Instagram: &quot;Fell From Heaven&quot; @ 35° on the Kilter Board Homewall." />
-          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
+  it('returns metadata for a public post', async () => {
+    fetchInstagramMetaMock.mockResolvedValue({
+      status: 'ok',
+      thumbnail: 'https://cdn.example.com/photo.jpg',
+      username: 'camgibbs',
     });
 
-    await expect(fetchInstagramPageMetadata('https://www.instagram.com/reel/DLM2nf9S1h6/')).resolves.toMatchObject({
-      description: expect.stringContaining('Fell From Heaven'),
-      imageUrl: 'https://cdn.example.com/image.jpg',
-      mediaId: '123456789',
-      ogTitle: expect.stringContaining('Fell From Heaven'),
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toEqual({
+      imageUrl: 'https://cdn.example.com/photo.jpg',
+      mediaId: 'CU-NOpdL8Kf',
+      username: 'camgibbs',
     });
   });
 
-  it('accepts captions that mention the climb name with forgiving normalization', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta name="description" content="Had a great day. Vid #3: Cut to the Chase V10 @ 35°." />
-          <meta property="og:title" content="camgibbs on Instagram: Vid #3: Cut to the Chase V10 @ 35°" />
-          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
+  it('returns metadata even when the caption does not mention the climb', async () => {
+    // Regression: write-time validation no longer requires the caption to
+    // mention the climb name. A reel with a caption like
+    // `"Giraff" v6 @ 35° on the Kilter Board` should attach successfully
+    // regardless of whether the resolver knows the climb's name.
+    fetchInstagramMetaMock.mockResolvedValue({
+      status: 'ok',
+      thumbnail: 'https://cdn.example.com/photo.jpg',
+      username: 'someone',
     });
 
-    await expect(
-      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
-    ).resolves.toBeTruthy();
+    await expect(validateInstagramBetaLink('https://www.instagram.com/reel/DLM2nf9S1h6/')).resolves.toMatchObject({
+      mediaId: 'DLM2nf9S1h6',
+    });
   });
 
-  it('rejects posts that do not mention the climb name', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta name="description" content="Random climbing day montage." />
-          <meta property="og:title" content="climber on Instagram: random climbing day montage" />
-          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
-    });
+  it('rejects a deleted/private post with the post-unavailable message', async () => {
+    fetchInstagramMetaMock.mockResolvedValue({ status: 'gone' });
 
-    await expect(
-      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
-    ).rejects.toThrow(
-      `We couldn't confirm this video is for "Cut to the Chase". Please use a public Instagram post or reel whose caption or title mentions the climb name.`,
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).rejects.toThrowError(
+      "This Instagram post isn't available",
     );
   });
 
-  it('rejects pages that are not previewable instagram media', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => '<html><head><title>Instagram</title></head></html>',
-    });
+  it('surfaces transient Instagram failures with a retry-friendly message', async () => {
+    fetchInstagramMetaMock.mockResolvedValue({ status: 'transient_error' });
 
-    await expect(
-      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
-    ).rejects.toBeInstanceOf(InstagramBetaValidationError);
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).rejects.toThrowError(
+      'Instagram is temporarily blocking us',
+    );
   });
 
-  it('normalizes punctuation and entity differences when matching climb names', () => {
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on instagram: &quot;There, There&quot; @ 40° on the Kilter Board',
-        'There, There',
-      ),
-    ).toBe(true);
-  });
-
-  it('extracts the same media id from equivalent instagram url variants', () => {
-    expect(getInstagramMediaId('https://www.instagram.com/reel/ABC123xyz/')).toBe('ABC123xyz');
-    expect(getInstagramMediaId('https://www.instagram.com/p/ABC123xyz/?img_index=1')).toBe('ABC123xyz');
-  });
-
-  it('wraps fetch failures in InstagramBetaValidationError', async () => {
-    fetchMock.mockRejectedValue(new Error('TimeoutError: signal timed out'));
-
-    await expect(
-      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
-    ).rejects.toBeInstanceOf(InstagramBetaValidationError);
-  });
-
-  it('matches climb names in non-Latin scripts after Unicode-aware normalization', () => {
-    // Cyrillic — would have been wiped to empty by [^a-z0-9].
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: Покатушки @ 40° on the Kilter Board',
-        'Покатушки',
-      ),
-    ).toBe(true);
-    // CJK — shouldn't survive lowercase but should survive the filter.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: 攀岩 @ 40° on the Kilter Board',
-        '攀岩',
-      ),
-    ).toBe(true);
-  });
-
-  it('rejects single-word climb names that only appear inside other words', () => {
-    // "Gravity" climb shouldn't validate against a post that just mentions
-    // "antigravity" — that's the false-positive the ordered-token fallback
-    // used to allow.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: antigravity training session',
-        'Gravity',
-      ),
-    ).toBe(false);
-    // But the same short name still matches when it appears as a whole word.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: sent Gravity today!',
-        'Gravity',
-      ),
-    ).toBe(true);
-  });
-
-  it('parses og:image even when og:title comes first with a long caption', async () => {
-    // Regression guard: parseMetaContent's attrRegex used to be a /g regex
-    // shared across iterations. After the long og:title tag exhausted the
-    // regex's lastIndex, the shorter og:image tag could be silently skipped.
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta property="og:title" content="${'a'.repeat(500)} on Instagram: Cut to the Chase V10 ${'b'.repeat(500)}" />
-          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
-          <meta name="description" content="Cut to the Chase V10" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
-    });
-
-    await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toMatchObject({
-      imageUrl: 'https://cdn.example.com/image.jpg',
-      mediaId: '123456789',
-    });
-  });
-
-  it('skips the ordered-token fallback when any token is too short to be distinguishing', () => {
-    // "The Project" — "the" is 3 chars. The full phrase doesn't appear as a
-    // whole-word substring in this caption, but the tokens "the" and
-    // "project" do appear separately in order. Without the min-length guard
-    // the fallback would false-positive on any English text.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: the climb after our project debrief was tough',
-        'The Project',
-      ),
-    ).toBe(false);
-    // "Power Up" — "up" is 2 chars. Same risk.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: power moves and warming up first',
-        'Power Up',
-      ),
-    ).toBe(false);
-    // But the word-bounded substring path still matches when the full phrase
-    // appears — we don't gate that path on token length.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: sent The Project today',
-        'The Project',
-      ),
-    ).toBe(true);
-  });
-
-  it('still matches multi-word names when every token is long enough', () => {
-    // "Fell From Heaven" — all tokens >= 4 chars, fallback kicks in for
-    // captions that interleave noise between the climb-name tokens.
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'climber on Instagram: fell down from the great heaven yesterday',
-        'Fell From Heaven',
-      ),
-    ).toBe(true);
-  });
-
-  it('does not match fallback tokens that appear inside larger words', () => {
-    // "Fell From Heaven" — "fell" should not match inside "befell".
-    expect(
-      instagramBetaValidationInternals.containsNormalizedClimbName(
-        'the storm that befell us from on high seemed heaven sent',
-        'Fell From Heaven',
-      ),
-    ).toBe(false);
-  });
-
-  it('indexOfWord requires whole-word matches', () => {
-    expect(instagramBetaValidationInternals.indexOfWord('the storm befell us', 'fell', 0)).toBe(-1);
-    expect(instagramBetaValidationInternals.indexOfWord('we fell hard today', 'fell', 0)).toBe(3);
-    expect(instagramBetaValidationInternals.indexOfWord('fell at the start', 'fell', 0)).toBe(0);
-    expect(instagramBetaValidationInternals.indexOfWord('one then fell', 'fell', 0)).toBe(9);
-  });
-
-  it('opens the circuit after enough fetch failures and stops calling out', async () => {
-    fetchMock.mockRejectedValue(new Error('TimeoutError'));
-
-    // Trip the circuit. The threshold is 10; drive it past that.
-    for (let i = 0; i < 10; i++) {
-      await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/CU-NOpdL8Kf/')).rejects.toBeInstanceOf(
-        InstagramBetaValidationError,
-      );
-    }
-    expect(instagramValidationCircuitForTesting.isOpen()).toBe(true);
-    fetchMock.mockClear();
-
-    // Once open, further calls short-circuit without hitting fetch.
-    await expect(fetchInstagramPageMetadata('https://www.instagram.com/p/AnyOther/')).rejects.toBeInstanceOf(
+  it('rejects URLs with no parseable media id without hitting the network', async () => {
+    await expect(validateInstagramBetaLink('https://www.instagram.com/explore/')).rejects.toBeInstanceOf(
       InstagramBetaValidationError,
     );
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
   });
 
-  it('matches climb names with word boundaries via containsAsWord', () => {
-    expect(instagramBetaValidationInternals.containsAsWord('sent gravity today', 'gravity')).toBe(true);
-    expect(instagramBetaValidationInternals.containsAsWord('gravity is the project', 'gravity')).toBe(true);
-    expect(instagramBetaValidationInternals.containsAsWord('the project is gravity', 'gravity')).toBe(true);
-    expect(instagramBetaValidationInternals.containsAsWord('gravity', 'gravity')).toBe(true);
-    expect(instagramBetaValidationInternals.containsAsWord('antigravity training', 'gravity')).toBe(false);
-    expect(instagramBetaValidationInternals.containsAsWord('gravityfall demo', 'gravity')).toBe(false);
-  });
-
-  it('parses username from Instagram og:title patterns', () => {
-    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('camgibbs on Instagram: "Cut to the Chase"')).toBe(
-      'camgibbs',
-    );
-    expect(
-      instagramBetaValidationInternals.parseUsernameFromOgTitle('@cam.gibbs on Instagram in Boulder, CO: ...'),
-    ).toBe('cam.gibbs');
-    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle(null)).toBeNull();
-    expect(instagramBetaValidationInternals.parseUsernameFromOgTitle('Random title without pattern')).toBeNull();
-  });
-
-  it('accepts a public post that mentions the climb name even when og:image is missing', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta name="description" content="Cut to the Chase V10 from yesterday's session." />
-          <meta property="og:title" content="camgibbs on Instagram: Cut to the Chase V10" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
+  it('passes through a null thumbnail when Instagram omits it', async () => {
+    fetchInstagramMetaMock.mockResolvedValue({
+      status: 'ok',
+      // fetchInstagramMeta normally rejects status:'ok' without a thumbnail,
+      // but the validator shouldn't care — `enrichInstagramBetaInsert` is
+      // resilient to a null thumbnail (it skips the S3 cache step).
+      thumbnail: '',
+      username: null,
     });
 
-    await expect(
-      validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase'),
-    ).resolves.toMatchObject({ imageUrl: null, mediaId: '123456789' });
-  });
-
-  it('returns the parsed username on the metadata', async () => {
-    fetchMock.mockResolvedValue({
-      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
-      ok: true,
-      text: async () => `
-        <html><head>
-          <meta property="og:title" content="camgibbs on Instagram: Cut to the Chase V10" />
-          <meta name="description" content="Cut to the Chase V10" />
-          <meta property="og:image" content="https://cdn.example.com/image.jpg" />
-          <meta property="al:ios:url" content="instagram://media?id=123456789" />
-        </head></html>
-      `,
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toMatchObject({
+      mediaId: 'CU-NOpdL8Kf',
+      username: null,
     });
-
-    const metadata = await validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/', 'Cut to the Chase');
-    expect(metadata.username).toBe('camgibbs');
   });
 });

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -71,19 +71,33 @@ describe('validateInstagramBetaLink', () => {
     expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
   });
 
-  it('passes through a null thumbnail when Instagram omits it', async () => {
+  it('normalizes an empty-string thumbnail to null', async () => {
+    // fetchInstagramMeta in practice returns 'gone' when no thumbnail is
+    // found, so a status:'ok' with thumbnail:'' is a defensive contract test
+    // — the validator shouldn't propagate '' as a fake imageUrl since
+    // downstream consumers may null-check rather than truthy-check.
     fetchInstagramMetaMock.mockResolvedValue({
       status: 'ok',
-      // fetchInstagramMeta normally rejects status:'ok' without a thumbnail,
-      // but the validator shouldn't care — `enrichInstagramBetaInsert` is
-      // resilient to a null thumbnail (it skips the S3 cache step).
       thumbnail: '',
       username: null,
     });
 
-    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toMatchObject({
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toEqual({
+      imageUrl: null,
       mediaId: 'CU-NOpdL8Kf',
       username: null,
     });
+  });
+
+  it('wraps unexpected fetchInstagramMeta errors as a transient validation error', async () => {
+    // fetchInstagramMeta is designed to return status enums, never throw —
+    // but if it ever does (regex blowup, dependency regression), the user
+    // should see our specific transient-error message, not Yoga's generic
+    // "Unexpected error." toast from masked errors in production.
+    fetchInstagramMetaMock.mockRejectedValue(new Error('boom'));
+
+    await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).rejects.toThrowError(
+      'Instagram is temporarily blocking us',
+    );
   });
 });

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -21,20 +21,6 @@ import {
 } from '../../../utils/instagram-beta-validation';
 import { cacheInstagramThumbnail, isS3Configured } from '../../../lib/beta-link-thumbnails';
 
-async function getClimbNameForBetaValidation(boardType: string, climbUuid: string): Promise<string> {
-  const [climb] = await db
-    .select({ name: dbSchema.boardClimbs.name })
-    .from(dbSchema.boardClimbs)
-    .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, climbUuid)))
-    .limit(1);
-
-  const climbName = climb?.name?.trim();
-  if (!climbName) {
-    throw new InstagramBetaValidationError("We couldn't verify this Instagram link for the selected climb.");
-  }
-  return climbName;
-}
-
 // Beta links are only attached on successful ascents (flash / send), never on
 // `attempt`. Returns the URL to attach, or null if the tick shouldn't carry
 // one. Exported so the rule can be unit-tested without integration setup.
@@ -154,9 +140,8 @@ export async function validateAndEnrichBetaLinkInsert(
   // loop from getting our IP rate-limited or blocked by Instagram.
   await applyRateLimit(ctx, 30, 'instagram-beta-validation');
 
-  const climbName = await getClimbNameForBetaValidation(boardType, climbUuid);
   await ensureInstagramShortcodeIsNotAlreadyLinked(boardType, climbUuid, url);
-  const metadata = await validateInstagramBetaLink(url, climbName);
+  const metadata = await validateInstagramBetaLink(url);
   return enrichInstagramBetaInsert(metadata);
 }
 

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -34,7 +34,17 @@ export async function validateInstagramBetaLink(url: string): Promise<InstagramP
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
-  const result = await fetchInstagramMeta(url);
+  // fetchInstagramMeta is designed to return a status enum rather than throw,
+  // but a try/catch keeps any unexpected runtime error (regex/JSON edge case,
+  // dependency change) inside the InstagramBetaValidationError envelope so
+  // Yoga's maskedErrors: true doesn't surface a generic "Unexpected error."
+  // toast to the user.
+  let result;
+  try {
+    result = await fetchInstagramMeta(url);
+  } catch {
+    throw new InstagramBetaValidationError(TRANSIENT_ERROR);
+  }
 
   if (result.status === 'gone') {
     throw new InstagramBetaValidationError(POST_UNAVAILABLE_ERROR);
@@ -45,7 +55,10 @@ export async function validateInstagramBetaLink(url: string): Promise<InstagramP
   }
 
   return {
-    imageUrl: result.thumbnail,
+    // Normalize empty-string thumbnail to null so downstream consumers that
+    // null-check (rather than truthy-check) imageUrl behave consistently with
+    // the previous validator's contract.
+    imageUrl: result.thumbnail || null,
     mediaId,
     username: result.username,
   };

--- a/packages/backend/src/utils/instagram-beta-validation.ts
+++ b/packages/backend/src/utils/instagram-beta-validation.ts
@@ -1,65 +1,13 @@
 import { GraphQLError } from 'graphql';
-import { getInstagramMediaId } from '../lib/instagram-meta';
-import { createCircuitBreaker } from '../lib/circuit-breaker';
-
-const HTML_ENTITY_MAP: Record<string, string> = {
-  amp: '&',
-  apos: "'",
-  gt: '>',
-  lt: '<',
-  nbsp: ' ',
-  quot: '"',
-};
-
-// Hardcoding a desktop User-Agent to scrape Instagram's og:* tags is fragile
-// and at the edge of Meta's ToS — IG has historically responded with a
-// login-wall HTML to unrecognized clients, in which case the validator
-// rejects with the generic error. The circuit breaker below limits the
-// blast radius if/when that starts happening at scale; the rate limiter at
-// the resolver layer caps per-user abuse. If validation acceptance rates
-// drop, revisit by switching to oEmbed + Graph API or removing this
-// write-time check entirely (1736's read-time live check still filters
-// `gone` posts).
-const INSTAGRAM_FETCH_HEADERS = {
-  'accept-language': 'en-US,en;q=0.9',
-  'user-agent':
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-};
-
-// Per-process circuit breaker for the canonical-post fetch. If we observe a
-// burst of failures (timeouts, non-200, non-HTML, login-wall), stop calling
-// out for `cooldownMs` so we don't keep poking IG while it's actively
-// rejecting us. While the breaker is open the validator throws the generic
-// error immediately — users see "we couldn't verify this Instagram link"
-// instead of waiting for a guaranteed-failing fetch.
-//
-// Known limitation: state is per-process. In a multi-pod deploy each
-// instance tracks its own failures, so one pod tripping the breaker
-// doesn't stop another from continuing to hit Instagram. The per-user
-// rate limit at the resolver layer is the cluster-wide protection;
-// this breaker is best-effort per-instance back-off. If this becomes
-// a problem (e.g. fleet-wide IP block from IG) the failure window
-// could move to Redis using the same key pattern as redis-rate-limiter.
-const validationCircuit = createCircuitBreaker({
-  windowMs: 60 * 1000,
-  threshold: 10,
-  cooldownMs: 5 * 60 * 1000,
-  onOpen: (failures, cooldownMs) => {
-    console.warn(`[InstagramBetaValidation] circuit OPEN: ${failures} failures in window, cooldown ${cooldownMs}ms`);
-  },
-});
-
-export const instagramValidationCircuitForTesting = validationCircuit;
-
-const GENERIC_VALIDATION_ERROR =
-  "We couldn't verify this Instagram link. Make sure it's a public post or reel that Boardsesh can preview, and that the caption or title mentions the climb name.";
+import { fetchInstagramMeta, getInstagramMediaId } from '../lib/instagram-meta';
 
 // Extends GraphQLError so the user-facing message survives Yoga's
 // `maskedErrors: true` in production. Plain Error subclasses are replaced
 // with the generic "Unexpected error." string before reaching the client,
 // which would surface as the fallback "Couldn't add video. Try again."
-// toast instead of our specific guidance ("post must mention the climb",
-// "already linked to <other climb>", etc.).
+// toast instead of our specific guidance ("post is private/deleted",
+// "already linked to <other climb>", "Instagram is temporarily blocking
+// us", etc.).
 export class InstagramBetaValidationError extends GraphQLError {
   constructor(message: string) {
     super(message, { extensions: { code: 'INSTAGRAM_BETA_VALIDATION' } });
@@ -67,226 +15,38 @@ export class InstagramBetaValidationError extends GraphQLError {
   }
 }
 
+const GENERIC_VALIDATION_ERROR = "We couldn't read this Instagram link. Double-check the URL and try again.";
+const POST_UNAVAILABLE_ERROR = "This Instagram post isn't available — it may be private, deleted, or region-locked.";
+const TRANSIENT_ERROR = 'Instagram is temporarily blocking us from previewing this link. Try again in a minute.';
+
 export interface InstagramPageMetadata {
-  description: string | null;
   imageUrl: string | null;
-  mediaId: string | null;
-  ogTitle: string | null;
+  mediaId: string;
   username: string | null;
 }
 
-function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replace(/&([a-z]+);/gi, (_, entity) => HTML_ENTITY_MAP[entity.toLowerCase()] ?? `&${entity};`);
-}
-
-function normalizeText(value: string): string {
-  // Strip combining marks (NFKD splits accented chars into base + mark, then
-  // we drop the marks). Replace anything that isn't a Unicode letter or
-  // number with a single space so non-Latin climb names (Cyrillic, CJK, etc.)
-  // survive normalization. Lowercase last because some scripts have
-  // case-folding rules but most don't — applying to the whole string is fine.
-  return decodeHtmlEntities(value)
-    .normalize('NFKD')
-    .replace(/\p{M}+/gu, '')
-    .replace(/[^\p{L}\p{N}]+/gu, ' ')
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, ' ');
-}
-
-// Word-bounded substring: `needle` must appear with whitespace or string
-// edges on both sides in the (already-normalized) haystack. This prevents a
-// climb name like "Gravity" from matching unrelated text that happens to
-// contain the substring (e.g. "antigravity").
-function containsAsWord(haystack: string, needle: string): boolean {
-  if (!haystack || !needle) return false;
-  if (haystack === needle) return true;
-  if (haystack.startsWith(`${needle} `)) return true;
-  if (haystack.endsWith(` ${needle}`)) return true;
-  return haystack.includes(` ${needle} `);
-}
-
-// Word-bounded indexOf for the ordered-token fallback. Returns the start
-// index of `needle` if it appears as a whole word at or after `fromIndex`,
-// otherwise -1. Necessary because plain indexOf would match "fell" inside
-// "befell".
-function indexOfWord(haystack: string, needle: string, fromIndex: number): number {
-  let cursor = fromIndex;
-  while (cursor <= haystack.length) {
-    const idx = haystack.indexOf(needle, cursor);
-    if (idx === -1) return -1;
-    const before = idx === 0 ? ' ' : haystack[idx - 1];
-    const afterIdx = idx + needle.length;
-    const after = afterIdx >= haystack.length ? ' ' : haystack[afterIdx];
-    if (before === ' ' && after === ' ') return idx;
-    cursor = idx + 1;
-  }
-  return -1;
-}
-
-// Minimum length per token before we'll allow the ordered-token fallback to
-// fire. Short tokens like "the", "to", "for", "up" appear in nearly every
-// English Instagram caption, so a climb name like "The Project" or "Power
-// Up" would otherwise produce false positives on unrelated posts. Four
-// characters keeps "fell", "from", "cut", etc. out of the fallback while
-// still allowing genuinely distinguishing words.
-const MIN_TOKEN_LENGTH_FOR_FALLBACK = 4;
-
-function containsNormalizedClimbName(haystack: string, climbName: string): boolean {
-  const normalizedHaystack = normalizeText(haystack);
-  const normalizedClimbName = normalizeText(climbName);
-
-  if (!normalizedHaystack || !normalizedClimbName) return false;
-  if (containsAsWord(normalizedHaystack, normalizedClimbName)) return true;
-
-  // Ordered-token fallback handles multi-word names with intervening noise
-  // (e.g. "Fell From Heaven" matching "fell down from the heaven"). Only
-  // fire it when every token is long enough to be meaningfully
-  // distinguishing — otherwise common-word climb names would match almost
-  // any English caption.
-  const tokens = normalizedClimbName.split(' ').filter(Boolean);
-  if (tokens.length < 2) return false;
-  if (tokens.some((t) => t.length < MIN_TOKEN_LENGTH_FOR_FALLBACK)) return false;
-
-  let cursor = 0;
-  for (const token of tokens) {
-    const nextIndex = indexOfWord(normalizedHaystack, token, cursor);
-    if (nextIndex === -1) return false;
-    cursor = nextIndex + token.length;
-  }
-  return true;
-}
-
-function parseMetaContent(html: string, target: string): string | null {
-  const metaTagRegex = /<meta\b[^>]*>/gi;
-  const normalizedTarget = target.toLowerCase();
-
-  for (const metaTag of html.match(metaTagRegex) ?? []) {
-    // Construct attrRegex inside the loop so its `/g` `lastIndex` state
-    // can't carry over between iterations and silently skip a shorter
-    // tag's attributes after a longer one.
-    const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
-    const attrs: Record<string, string> = {};
-    let match: RegExpExecArray | null;
-    while ((match = attrRegex.exec(metaTag)) !== null) {
-      attrs[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? '';
-    }
-
-    if (attrs.property?.toLowerCase() === normalizedTarget || attrs.name?.toLowerCase() === normalizedTarget) {
-      return attrs.content ? decodeHtmlEntities(attrs.content) : null;
-    }
-  }
-
-  return null;
-}
-
-// Instagram's og:title is consistently "<username> on Instagram: <caption…>"
-// (with an optional leading "@"). Pull the username out so the caller can
-// persist it eagerly when the row is inserted.
-function parseUsernameFromOgTitle(ogTitle: string | null): string | null {
-  if (!ogTitle) return null;
-  const match = ogTitle.match(/^@?([\w.]+)\s+on\s+Instagram\b/i);
-  return match?.[1] ?? null;
-}
-
-export async function fetchInstagramPageMetadata(url: string): Promise<InstagramPageMetadata> {
-  // Short-circuit when the breaker is open — IG is failing us in bulk, so
-  // there's no point spending the client's request budget on a likely-doomed
-  // fetch. Don't record this as a circuit failure (it isn't a fresh signal).
-  if (validationCircuit.isOpen()) {
+export async function validateInstagramBetaLink(url: string): Promise<InstagramPageMetadata> {
+  const mediaId = getInstagramMediaId(url);
+  // mediaId is the canonical identity for the post (used for dedup + S3 cache
+  // key). Without it we can't safely persist regardless of what Instagram
+  // returns.
+  if (!mediaId) {
     throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
   }
 
-  // Wrap the network leg in a try/catch so timeouts (AbortSignal.timeout),
-  // DNS failures, and connection resets surface as InstagramBetaValidationError
-  // instead of leaking raw runtime errors to the resolver.
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      headers: INSTAGRAM_FETCH_HEADERS,
-      redirect: 'follow',
-      // Keep the timeout tight so the GraphQL mutation doesn't hang the
-      // client when Instagram is slow or rate-limited. A healthy fetch
-      // returns in well under a second; the user can retry on transient
-      // failures.
-      signal: AbortSignal.timeout(4000),
-    });
-  } catch {
-    validationCircuit.recordFailure();
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  const result = await fetchInstagramMeta(url);
+
+  if (result.status === 'gone') {
+    throw new InstagramBetaValidationError(POST_UNAVAILABLE_ERROR);
   }
 
-  if (!response.ok) {
-    validationCircuit.recordFailure();
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
-  }
-
-  const contentType = response.headers.get('content-type') ?? '';
-  if (!contentType.includes('text/html')) {
-    validationCircuit.recordFailure();
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
-  }
-
-  let html: string;
-  try {
-    html = await response.text();
-  } catch {
-    validationCircuit.recordFailure();
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
-  }
-
-  const description = parseMetaContent(html, 'description') ?? parseMetaContent(html, 'og:description');
-  const ogTitle = parseMetaContent(html, 'og:title') ?? parseMetaContent(html, 'twitter:title');
-  const imageUrl = parseMetaContent(html, 'og:image') ?? parseMetaContent(html, 'twitter:image');
-  const mediaIdFromAppUrl = parseMetaContent(html, 'al:ios:url')?.match(/instagram:\/\/media\?id=(\d+)/)?.[1] ?? null;
-
-  if (!description && !ogTitle) {
-    // 200 OK with no og data usually means IG served a login-wall page.
-    // Treat it as a transient failure for breaker purposes so a sustained
-    // wall response trips the cooldown.
-    validationCircuit.recordFailure();
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
+  if (result.status === 'transient_error') {
+    throw new InstagramBetaValidationError(TRANSIENT_ERROR);
   }
 
   return {
-    description,
-    imageUrl,
-    mediaId: mediaIdFromAppUrl ?? getInstagramMediaId(url),
-    ogTitle,
-    username: parseUsernameFromOgTitle(ogTitle),
+    imageUrl: result.thumbnail,
+    mediaId,
+    username: result.username,
   };
 }
-
-export async function validateInstagramBetaLink(url: string, climbName: string): Promise<InstagramPageMetadata> {
-  const metadata = await fetchInstagramPageMetadata(url);
-
-  // mediaId is the canonical identity for the post (used for dedup + S3 cache
-  // key), so without it we can't safely persist. imageUrl is just enrichment —
-  // a public post with a caption mentioning the climb name should pass even
-  // if og:image happens to be missing.
-  if (!metadata.mediaId) {
-    throw new InstagramBetaValidationError(GENERIC_VALIDATION_ERROR);
-  }
-
-  const searchableText = [metadata.ogTitle, metadata.description].filter(Boolean).join(' ');
-  if (!containsNormalizedClimbName(searchableText, climbName)) {
-    throw new InstagramBetaValidationError(
-      `We couldn't confirm this video is for "${climbName}". Please use a public Instagram post or reel whose caption or title mentions the climb name.`,
-    );
-  }
-
-  return metadata;
-}
-
-export const instagramBetaValidationInternals = {
-  containsAsWord,
-  containsNormalizedClimbName,
-  decodeHtmlEntities,
-  indexOfWord,
-  normalizeText,
-  parseMetaContent,
-  parseUsernameFromOgTitle,
-};

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -134,9 +134,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
         helperText={
           validationError ??
           helperText ??
-          (climbName
-            ? `Paste a public Instagram reel or post that mentions ${climbName}, or a TikTok URL.`
-            : 'Paste a public Instagram reel/post or TikTok URL so others can see your beta.')
+          'Paste a public Instagram reel/post or TikTok URL so others can see your beta.'
         }
         onKeyDown={(e) => {
           if (e.key === 'Enter' && canSubmit) {


### PR DESCRIPTION
## Summary

Users attaching Instagram reels/posts to a climb were hitting:

> "We couldn't verify this Instagram link. Make sure it's a public post or reel that Boardsesh can preview, and that the caption or title mentions the climb name."

…even on normal public reels whose captions clearly named the climb (e.g. `"Giraff" v6 @ 35° on the Kilter Board`). Two compounding problems:

1. **Wrong endpoint, login walls.** The write-time validator (`packages/backend/src/utils/instagram-beta-validation.ts`) scraped `https://www.instagram.com/p/<shortcode>/` with a desktop User-Agent and parsed `og:*` meta tags. Instagram increasingly returns a 200 OK login wall to unrecognized clients with no `og:title`/`og:description`, which the validator mapped to the generic error. Meanwhile the **read-time** path (`packages/backend/src/lib/instagram-meta.ts`) already side-stepped this by hitting the public `/embed/captioned/` endpoint and explicitly detecting login walls via `looksLikeLoginWall`.
2. **Strict caption-must-mention-climb-name rule.** The word-bounded matcher correctly handled the `"Giraff"` case in isolation, but because the fetch was failing first, users still saw "make sure the caption mentions the climb name" and were rewriting captions that already worked.

## What changed

- `instagram-beta-validation.ts` is rewritten as a thin wrapper around `fetchInstagramMeta`. `validateInstagramBetaLink(url)` (no more `climbName` arg) returns `{ mediaId, imageUrl, username }` for `status: 'ok'`, and throws specific messages for `'gone'` (private/deleted) vs. `'transient_error'` (Instagram throttling us). The duplicate per-process circuit breaker is gone — `fetchInstagramMeta`'s breaker covers both read and write paths.
- `validateAndEnrichBetaLinkInsert` no longer looks up the climb name; the helper that did is deleted. Rate limit (30/min/user), dedup (`ensureInstagramShortcodeIsNotAlreadyLinked`), and S3 thumbnail caching are unchanged.
- Form helper text drops the `that mentions ${climbName}` clause.
- Tests rewritten to mock `fetchInstagramMeta` and cover the new shape (ok / gone / transient_error / missing mediaId).

Net diff: **+82 / -555 lines.**

## Test plan

- [x] `vp run typecheck:backend` — passes
- [x] `vp run typecheck:web` — passes
- [x] `vp test run` for `instagram-beta-validation`, `beta-link-write-gate`, `instagram-meta` — 31 / 31 pass
- [x] `vp check` — no new lint/format issues on changed files
- [ ] Manual end-to-end via `vp run dev`:
  - [ ] Paste a public IG reel URL whose caption does **not** mention the climb name → attaches successfully
  - [ ] Paste a deleted/private post URL → "This Instagram post isn't available — it may be private, deleted, or region-locked."
  - [ ] Paste a TikTok URL → still bypasses validator (existing `isInstagramUrl` short-circuit)
  - [ ] Re-attach the same shortcode → existing dedup error still fires

https://claude.ai/code/session_0123BRwuR6E36pBSdQkZMhMN

---
_Generated by [Claude Code](https://claude.ai/code/session_0123BRwuR6E36pBSdQkZMhMN)_