### PR TITLE
feat(web): hidden light drawer with clear-all and party mode

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-packet.test.ts
@@ -493,6 +493,51 @@ describe('§4 Device Name Format — parseApiLevel', () => {
 });
 
 // =============================================================================
+// §7.5 — Empty-frames "clear all" packet
+// =============================================================================
+
+describe('§7.5 Empty-frames clear packet', () => {
+  it('emits a single-frame ONLY packet with no LED data on v3', () => {
+    const result = getBluetoothPacket('', {}, 'kilter', 3);
+    expect(result.totalPlacements).toBe(0);
+    expect(result.skippedPositionCount).toBe(0);
+    expect(result.skippedRoleCount).toBe(0);
+    expect(result.packet.length).toBeGreaterThan(0);
+
+    const parsed = parseFrames(result.packet);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].commandByte).toBe(84); // T = ONLY
+    expect(parsed[0].payloadLength).toBe(1); // command byte only — no LED entries
+  });
+
+  it('emits a single-frame ONLY packet on v2', () => {
+    const result = getBluetoothPacket('', {}, 'kilter', 2);
+    const parsed = parseFrames(result.packet);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].commandByte).toBe(80); // P = ONLY (v2)
+    expect(parsed[0].payloadLength).toBe(1);
+  });
+
+  it('does not require placement positions to clear', () => {
+    // The clear path must not look up the placement map — passing empty
+    // placements and an unknown layout still produces a valid clear packet.
+    const result = getBluetoothPacket('', {}, 'tension', 3);
+    expect(result.packet.length).toBeGreaterThan(0);
+    const parsed = parseFrames(result.packet);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].commandByte).toBe(84);
+  });
+
+  it('still returns an empty packet when every placement is skipped (not the clear path)', () => {
+    // Non-empty frames with all-unknown placements must NOT take the clear
+    // path — that case represents a render failure, not an intentional clear.
+    const result = getBluetoothPacket('p999r42', {}, 'kilter', 3);
+    expect(result.packet.length).toBe(0);
+    expect(result.skippedPositionCount).toBe(1);
+  });
+});
+
+// =============================================================================
 // §8 — Multi-Part Message Sequencing
 // =============================================================================
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
@@ -188,6 +188,18 @@ export const getAuroraBluetoothPacket = (
   const isV2 = apiLevel < 3;
   const cmds = isV2 ? V2_COMMANDS : V3_COMMANDS;
 
+  // Empty frames is the "clear all LEDs" path — emit a valid ONLY-command
+  // packet with no LED entries so the board overwrites its state to "nothing
+  // lit". A zero-length Uint8Array would never reach the board over BLE.
+  if (frames === '') {
+    return {
+      packet: Uint8Array.from(wrapBytes([cmds.only])),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 0,
+    };
+  }
+
   // Pre-collect LED entries for v2 power scaling
   const ledEntries: Array<{ position: number; color: string }> = [];
   let skippedPositionCount = 0;

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -359,6 +359,7 @@ export function BluetoothProvider({
       clearBoard,
       boardDetails,
       partyActive,
+      setPartyActive,
       isBluetoothSupported,
       isIOS,
     ],

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -37,6 +37,15 @@ type BluetoothContextValue = {
     signal?: AbortSignal,
     climbUuid?: string,
   ) => Promise<boolean | undefined>;
+  /** Send a "clear all LEDs" packet to the connected board. */
+  clearBoard: () => Promise<boolean | undefined>;
+  /** Board configuration for the current route — exposed so light-show
+   * features (party mode) can read holdsData and edge bounds. */
+  boardDetails: BoardDetails;
+  /** True while a non-queue light show (e.g. party mode) is driving the
+   * board. The auto-sender stops emitting queue frames during this. */
+  partyActive: boolean;
+  setPartyActive: (active: boolean) => void;
   isBluetoothSupported: boolean;
   isIOS: boolean;
 };
@@ -130,6 +139,15 @@ export function BluetoothProvider({
   });
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
+
+  const [partyActive, setPartyActive] = useState(false);
+  const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
+
+  // Stop the party loop the moment the board disconnects so a reconnect
+  // doesn't immediately resume an orphaned interval in the drawer.
+  useEffect(() => {
+    if (!isConnected && partyActive) setPartyActive(false);
+  }, [isConnected, partyActive]);
 
   // Both `[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...` and
   // `/b/{slug}/{angle}/...` routes carry `[angle]` as a dynamic segment.
@@ -325,10 +343,25 @@ export function BluetoothProvider({
       connect,
       disconnect,
       sendFramesToBoard,
+      clearBoard,
+      boardDetails,
+      partyActive,
+      setPartyActive,
       isBluetoothSupported,
       isIOS,
     }),
-    [isConnected, loading, connect, disconnect, sendFramesToBoard, isBluetoothSupported, isIOS],
+    [
+      isConnected,
+      loading,
+      connect,
+      disconnect,
+      sendFramesToBoard,
+      clearBoard,
+      boardDetails,
+      partyActive,
+      isBluetoothSupported,
+      isIOS,
+    ],
   );
 
   // Mismatch interception: when the user picks a controller whose resolved
@@ -392,7 +425,7 @@ export function BluetoothProvider({
 
   return (
     <BluetoothContext.Provider value={value}>
-      {isConnected && (
+      {isConnected && !partyActive && (
         <BluetoothAutoSender sendFramesToBoard={sendFramesToBoard} layoutName={boardDetails.layout_name ?? ''} />
       )}
       {activePickerState && (

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -138,16 +138,32 @@ export function useBoardBluetooth({ boardDetails, boardUuid, onConnectionChange 
     onConnectionChange?.(false);
   }, [onConnectionChange]);
 
-  // Function to send frames string to the board
+  // Function to send frames string to the board.
+  // An empty `frames` string is the "clear all LEDs" path: Aurora's packet
+  // builder already returns a zero-length placement set, which the board
+  // interprets as "no LEDs lit", overwriting whatever was on the wall.
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, climbUuid?: string) => {
-      if (!adapterRef.current || !frames || !boardDetails) return;
+      if (!adapterRef.current || !boardDetails) return;
 
       try {
         if (boardDetails.board_name === 'moonboard') {
+          // MoonBoard's packet format isn't designed to encode "clear" via an
+          // empty frame string — skip the write rather than send a malformed
+          // packet to the board.
+          if (!frames) return;
           const bluetoothPacket = getMoonboardBluetoothPacket(frames);
           await adapterRef.current.write(bluetoothPacket, signal);
           void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
+          return true;
+        }
+
+        // Empty frames is the "clear all LEDs" path. Skip mirroring and the
+        // LED-placement load entirely — the Aurora packet builder produces a
+        // standalone clear packet that doesn't depend on placement data.
+        if (frames === '') {
+          const clearResult = getAuroraBluetoothPacket('', {}, boardDetails.board_name, apiLevelRef.current);
+          await adapterRef.current.write(clearResult.packet, signal);
           return true;
         }
 

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -164,6 +164,7 @@ export function useBoardBluetooth({ boardDetails, boardUuid, onConnectionChange 
         if (frames === '') {
           const clearResult = getAuroraBluetoothPacket('', {}, boardDetails.board_name, apiLevelRef.current);
           await adapterRef.current.write(clearResult.packet, signal);
+          void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           return true;
         }
 

--- a/packages/web/app/components/board-page/__tests__/party-glyphs.test.ts
+++ b/packages/web/app/components/board-page/__tests__/party-glyphs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { GLYPHS, PARTY_LETTERS, buildPartyFrames, mapGlyphToHolds } from '../party-glyphs';
+import type { BoardDetails } from '@/app/lib/types';
+import type { HoldRenderData } from '../../board-renderer/types';
+
+function makeBoardDetails(overrides: Partial<BoardDetails> & { holdsData: HoldRenderData[] }): BoardDetails {
+  return {
+    images_to_holds: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_top: 100,
+    edge_bottom: 0,
+    boardHeight: 100,
+    boardWidth: 100,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1,2',
+    ...overrides,
+  } as BoardDetails;
+}
+
+function gridHolds(cols: number, rows: number, width = 100, height = 100): HoldRenderData[] {
+  const holds: HoldRenderData[] = [];
+  let id = 1;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      holds.push({
+        id: id++,
+        mirroredHoldId: null,
+        cx: ((col + 0.5) * width) / cols,
+        cy: ((row + 0.5) * height) / rows,
+        r: 1,
+      });
+    }
+  }
+  return holds;
+}
+
+describe('PARTY_LETTERS / GLYPHS', () => {
+  it('spells BOARDSESH in order', () => {
+    expect(PARTY_LETTERS.join('')).toBe('BOARDSESH');
+  });
+
+  it('every letter has a 7-row, 5-col bitmap', () => {
+    for (const letter of new Set(PARTY_LETTERS)) {
+      const glyph = GLYPHS[letter];
+      expect(glyph, `glyph for ${letter}`).toBeDefined();
+      expect(glyph).toHaveLength(7);
+      for (const row of glyph) {
+        expect(row).toHaveLength(5);
+      }
+    }
+  });
+});
+
+describe('buildPartyFrames', () => {
+  it('formats hold IDs with the role code in the canonical p{id}r{code} format', () => {
+    expect(buildPartyFrames([1, 2, 3], 42)).toBe('p1r42p2r42p3r42');
+  });
+
+  it('returns an empty string for an empty hold list', () => {
+    expect(buildPartyFrames([], 42)).toBe('');
+  });
+});
+
+describe('mapGlyphToHolds', () => {
+  it('returns an empty array when holdsData is empty', () => {
+    const board = makeBoardDetails({ holdsData: [] });
+    expect(mapGlyphToHolds(GLYPHS.B, board)).toEqual([]);
+  });
+
+  it('returns an empty array when board dimensions collapse to zero', () => {
+    const board = makeBoardDetails({
+      holdsData: gridHolds(5, 7),
+      edge_left: 50,
+      edge_right: 50,
+      edge_top: 50,
+      edge_bottom: 50,
+    });
+    expect(mapGlyphToHolds(GLYPHS.B, board)).toEqual([]);
+  });
+
+  it('returns deduped hold IDs when the bitmap snaps multiple cells onto the same hold', () => {
+    // Single hold in the centre — every "#" cell collapses onto it.
+    const board = makeBoardDetails({
+      holdsData: [{ id: 99, mirroredHoldId: null, cx: 50, cy: 50, r: 1 }],
+    });
+    const lit = mapGlyphToHolds(GLYPHS.O, board);
+    expect(lit).toEqual([99]);
+  });
+
+  it('lights distinct holds for each "#" cell on a fine grid', () => {
+    const board = makeBoardDetails({ holdsData: gridHolds(20, 20) });
+    const lit = mapGlyphToHolds(GLYPHS.B, board);
+    // The "B" glyph has 20 "#" cells; on a fine grid each should snap to a
+    // unique hold.
+    const onCells = GLYPHS.B.reduce((sum, row) => sum + (row.match(/#/g)?.length ?? 0), 0);
+    expect(lit.length).toBe(onCells);
+    expect(new Set(lit).size).toBe(lit.length);
+  });
+
+  it('snaps glyphs upright when edge_top > edge_bottom (math-style Y axis)', () => {
+    // Use the "E" glyph: top row is "#####", bottom row is "#####", so we can
+    // verify orientation by checking that the topmost lit row holds (smallest
+    // row index, i.e. furthest from edge_bottom) come from the glyph's top row.
+    const board = makeBoardDetails({
+      holdsData: gridHolds(20, 20),
+      edge_left: 0,
+      edge_right: 100,
+      edge_top: 100,
+      edge_bottom: 0,
+    });
+    const lit = new Set(mapGlyphToHolds(GLYPHS.E, board));
+    expect(lit.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
+import Celebration from '@mui/icons-material/Celebration';
+import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
+import { STATE_TO_PRIMARY_CODE } from '../board-renderer/types';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { GLYPHS, PARTY_LETTERS, buildPartyFrames, mapGlyphToHolds } from './party-glyphs';
+
+const PARTY_TICK_MS = 600;
+
+type LightControlDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, onClose }) => {
+  const { t } = useTranslation('common');
+  const { showMessage } = useSnackbar();
+  const { isConnected, sendFramesToBoard, clearBoard, boardDetails, partyActive, setPartyActive } =
+    useBluetoothContext();
+
+  const isMoonboard = boardDetails.board_name === 'moonboard';
+
+  // Pre-snap each unique letter's bitmap to hold IDs once per board config —
+  // the snap is deterministic so we don't need to re-run it every tick.
+  const lettersToHoldIds = useMemo(() => {
+    if (isMoonboard) return new Map<string, number[]>();
+    const map = new Map<string, number[]>();
+    for (const letter of new Set(PARTY_LETTERS)) {
+      const glyph = GLYPHS[letter];
+      if (!glyph) continue;
+      map.set(letter, mapGlyphToHolds(glyph, boardDetails));
+    }
+    return map;
+  }, [boardDetails, isMoonboard]);
+
+  // Cycle through the letters of "BOARDSESH", rotating through the board's
+  // available role colours so each letter is visually distinct.
+  useEffect(() => {
+    if (!partyActive || !isConnected || isMoonboard) return;
+
+    const stateCodes = Object.values(STATE_TO_PRIMARY_CODE[boardDetails.board_name] ?? {}).filter(
+      (code): code is number => typeof code === 'number',
+    );
+    if (stateCodes.length === 0) return;
+
+    let letterIndex = 0;
+    const sendCurrentLetter = () => {
+      const letter = PARTY_LETTERS[letterIndex % PARTY_LETTERS.length];
+      const holdIds = lettersToHoldIds.get(letter) ?? [];
+      const stateCode = stateCodes[letterIndex % stateCodes.length];
+      void sendFramesToBoard(buildPartyFrames(holdIds, stateCode));
+      letterIndex++;
+    };
+    sendCurrentLetter();
+    const intervalId = window.setInterval(sendCurrentLetter, PARTY_TICK_MS);
+    return () => window.clearInterval(intervalId);
+  }, [partyActive, isConnected, isMoonboard, boardDetails.board_name, lettersToHoldIds, sendFramesToBoard]);
+
+  // When the user stops party mode, the wall would otherwise stay frozen on
+  // the last letter — clear it once so the board returns to a blank state.
+  const wasPartyActiveRef = useRef(partyActive);
+  useEffect(() => {
+    if (wasPartyActiveRef.current && !partyActive && isConnected) {
+      void clearBoard();
+    }
+    wasPartyActiveRef.current = partyActive;
+  }, [partyActive, isConnected, clearBoard]);
+
+  const handleClearAll = async () => {
+    if (partyActive) setPartyActive(false);
+    const result = await clearBoard();
+    if (result === false) {
+      showMessage(t('lightControl.clearFailed'), 'error');
+    }
+  };
+
+  const handlePartyToggle = () => {
+    if (isMoonboard) {
+      showMessage(t('lightControl.partyUnsupported'), 'info');
+      return;
+    }
+    setPartyActive(!partyActive);
+  };
+
+  return (
+    <SwipeableDrawer placement="bottom" open={open} onClose={onClose} title={t('lightControl.title')} height="auto">
+      <List disablePadding>
+        <ListItemButton onClick={handleClearAll} disabled={!isConnected}>
+          <ListItemIcon>
+            <LightbulbOutlined />
+          </ListItemIcon>
+          <ListItemText primary={t('lightControl.turnOffAll')} />
+        </ListItemButton>
+        <ListItemButton onClick={handlePartyToggle} disabled={!isConnected || isMoonboard}>
+          <ListItemIcon>{partyActive ? <StopCircleOutlined /> : <Celebration />}</ListItemIcon>
+          <ListItemText
+            primary={partyActive ? t('lightControl.stopParty') : t('lightControl.partyMode')}
+            secondary={isMoonboard ? t('lightControl.partyUnsupported') : undefined}
+          />
+        </ListItemButton>
+      </List>
+    </SwipeableDrawer>
+  );
+};

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -77,7 +77,13 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
   }, [partyActive, isConnected, clearBoard]);
 
   const handleClearAll = async () => {
-    if (partyActive) setPartyActive(false);
+    // When party is active, the stop-party effect already issues a
+    // clearBoard() once partyActive flips false — calling clearBoard()
+    // here too would double up the BLE write for one tap.
+    if (partyActive) {
+      setPartyActive(false);
+      return;
+    }
     const result = await clearBoard();
     if (result === false) {
       showMessage(t('lightControl.clearFailed'), 'error');

--- a/packages/web/app/components/board-page/party-glyphs.ts
+++ b/packages/web/app/components/board-page/party-glyphs.ts
@@ -1,0 +1,97 @@
+import type { BoardDetails } from '@/app/lib/types';
+
+/**
+ * 5×7 bitmap glyphs for the letters in "BOARDSESH". `#` = on, anything else = off.
+ * Rows are top → bottom from the climber's reading orientation. Each row is
+ * exactly 5 chars; trailing dots keep the columns aligned.
+ */
+export const PARTY_LETTERS = ['B', 'O', 'A', 'R', 'D', 'S', 'E', 'S', 'H'] as const;
+
+export const GLYPH_COLS = 5;
+export const GLYPH_ROWS = 7;
+
+export const GLYPHS: Record<string, string[]> = {
+  B: ['####.', '#...#', '#...#', '####.', '#...#', '#...#', '####.'],
+  O: ['.###.', '#...#', '#...#', '#...#', '#...#', '#...#', '.###.'],
+  A: ['..#..', '.#.#.', '#...#', '#...#', '#####', '#...#', '#...#'],
+  R: ['####.', '#...#', '#...#', '####.', '#.#..', '#..#.', '#...#'],
+  D: ['####.', '#...#', '#...#', '#...#', '#...#', '#...#', '####.'],
+  S: ['.####', '#....', '#....', '.###.', '....#', '....#', '####.'],
+  E: ['#####', '#....', '#....', '###..', '#....', '#....', '#####'],
+  H: ['#...#', '#...#', '#...#', '#####', '#...#', '#...#', '#...#'],
+};
+
+const LETTER_WIDTH_FRACTION = 0.6;
+const LETTER_HEIGHT_FRACTION = 0.7;
+
+/**
+ * Snap a glyph onto the nearest holds on the board. Returns the deduped list
+ * of hold IDs that should be lit to render the letter.
+ *
+ * The glyph bitmap is centred in the playable area, occupying ~60% of the
+ * board's width and ~70% of its height. Each `#` cell is mapped to its
+ * target (x, y) in board coordinates and we pick the closest hold by
+ * Euclidean distance — multiple cells may collapse to the same hold on
+ * small boards, which is fine (we dedupe via a `Set`).
+ */
+export function mapGlyphToHolds(glyph: string[], boardDetails: BoardDetails): number[] {
+  const { holdsData, edge_left, edge_right, edge_top, edge_bottom } = boardDetails;
+  if (!holdsData?.length) return [];
+
+  // Edge values aren't guaranteed to be ordered (top vs bottom depends on the
+  // board's coordinate convention), so derive the bounds with min/max.
+  const boardMinX = Math.min(edge_left, edge_right);
+  const boardMaxX = Math.max(edge_left, edge_right);
+  const boardMinY = Math.min(edge_top, edge_bottom);
+  const boardMaxY = Math.max(edge_top, edge_bottom);
+  const boardWidth = boardMaxX - boardMinX;
+  const boardHeight = boardMaxY - boardMinY;
+  if (boardWidth <= 0 || boardHeight <= 0) return [];
+
+  const letterWidth = boardWidth * LETTER_WIDTH_FRACTION;
+  const letterHeight = boardHeight * LETTER_HEIGHT_FRACTION;
+  const letterMinX = boardMinX + (boardWidth - letterWidth) / 2;
+  const letterMinY = boardMinY + (boardHeight - letterHeight) / 2;
+  const cellWidth = letterWidth / GLYPH_COLS;
+  const cellHeight = letterHeight / GLYPH_ROWS;
+
+  // edge_top in this codebase is numerically greater than edge_bottom (Y
+  // increases upward, math-style) — verify when QAing on a real board. If
+  // letters render upside-down, swap row → (rows - 1 - row) below.
+  const yIncreasesUpward = edge_top > edge_bottom;
+
+  const litHoldIds = new Set<number>();
+  for (let row = 0; row < GLYPH_ROWS; row++) {
+    const rowString = glyph[row] ?? '';
+    for (let col = 0; col < GLYPH_COLS; col++) {
+      if (rowString[col] !== '#') continue;
+      const targetX = letterMinX + (col + 0.5) * cellWidth;
+      const flippedRow = yIncreasesUpward ? GLYPH_ROWS - 1 - row : row;
+      const targetY = letterMinY + (flippedRow + 0.5) * cellHeight;
+
+      let nearestId: number | null = null;
+      let nearestDistSq = Infinity;
+      for (const hold of holdsData) {
+        const dx = hold.cx - targetX;
+        const dy = hold.cy - targetY;
+        const distSq = dx * dx + dy * dy;
+        if (distSq < nearestDistSq) {
+          nearestDistSq = distSq;
+          nearestId = hold.id;
+        }
+      }
+      if (nearestId !== null) litHoldIds.add(nearestId);
+    }
+  }
+
+  return Array.from(litHoldIds);
+}
+
+/**
+ * Build the BLE frame string for a set of hold IDs lit with a single role
+ * code. Format matches the rest of the codebase: `p{holdId}r{stateCode}`
+ * concatenated with no separator.
+ */
+export function buildPartyFrames(holdIds: number[], stateCode: number): string {
+  return holdIds.map((id) => `p${id}r${stateCode}`).join('');
+}

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -34,6 +34,10 @@ export const ShareBoardButton = () => {
   const { currentClimbQueueItem } = useCurrentClimb();
   const [unsupportedOpen, setUnsupportedOpen] = useState(false);
   const [lightDrawerOpen, setLightDrawerOpen] = useState(false);
+  // Defer mounting the drawer until the user actually long-presses. Keeps it
+  // out of the initial board-page render path (the glyph-snap useMemo and
+  // related effects only run for users who opt into the feature).
+  const [hasOpenedDrawer, setHasOpenedDrawer] = useState(false);
 
   const isConnecting = !!(sessionId && !hasConnected);
 
@@ -41,6 +45,7 @@ export const ShareBoardButton = () => {
   // when there's no board to control would dead-end the user.
   const handleLongPress = useCallback(() => {
     if (!isBoardConnected) return;
+    setHasOpenedDrawer(true);
     setLightDrawerOpen(true);
   }, [isBoardConnected]);
 
@@ -102,7 +107,7 @@ export const ShareBoardButton = () => {
         {lightbulbIcon}
       </IconButton>
 
-      <LightControlDrawer open={lightDrawerOpen} onClose={() => setLightDrawerOpen(false)} />
+      {hasOpenedDrawer && <LightControlDrawer open={lightDrawerOpen} onClose={() => setLightDrawerOpen(false)} />}
 
       <Dialog open={unsupportedOpen} onClose={() => setUnsupportedOpen(false)}>
         <DialogTitle>Board lighting unavailable</DialogTitle>

--- a/packages/web/app/components/board-page/share-button.tsx
+++ b/packages/web/app/components/board-page/share-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import Lightbulb from '@mui/icons-material/Lightbulb';
@@ -17,6 +17,8 @@ import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-contex
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { isCapacitor } from '@/app/lib/ble/capacitor-utils';
+import { useLongPress } from '@/app/lib/hooks/use-long-press';
+import { LightControlDrawer } from './light-control-drawer';
 
 export const ShareBoardButton = () => {
   const { showMessage } = useSnackbar();
@@ -31,10 +33,23 @@ export const ShareBoardButton = () => {
   } = useBluetoothContext();
   const { currentClimbQueueItem } = useCurrentClimb();
   const [unsupportedOpen, setUnsupportedOpen] = useState(false);
+  const [lightDrawerOpen, setLightDrawerOpen] = useState(false);
 
   const isConnecting = !!(sessionId && !hasConnected);
 
+  // Long-press is only meaningful while connected — opening the light drawer
+  // when there's no board to control would dead-end the user.
+  const handleLongPress = useCallback(() => {
+    if (!isBoardConnected) return;
+    setLightDrawerOpen(true);
+  }, [isBoardConnected]);
+
+  const { ref: longPressRef, consumeLongPress } = useLongPress<HTMLButtonElement>(handleLongPress);
+
   const handleLightbulbClick = async () => {
+    // Suppress the click that follows a long-press so opening the drawer
+    // doesn't also disconnect the board.
+    if (consumeLongPress()) return;
     // Allow connection in Capacitor apps even if the async isBluetoothSupported
     // state hasn't resolved yet — the native bridge is available by click time.
     if (!isBluetoothSupported && !isCapacitor()) {
@@ -79,12 +94,15 @@ export const ShareBoardButton = () => {
   return (
     <>
       <IconButton
+        ref={longPressRef}
         aria-label={isBoardConnected ? 'Disconnect from board' : 'Connect to board'}
         onClick={handleLightbulbClick}
         color={isSessionActive ? 'primary' : 'default'}
       >
         {lightbulbIcon}
       </IconButton>
+
+      <LightControlDrawer open={lightDrawerOpen} onClose={() => setLightDrawerOpen(false)} />
 
       <Dialog open={unsupportedOpen} onClose={() => setUnsupportedOpen(false)}>
         <DialogTitle>Board lighting unavailable</DialogTitle>

--- a/packages/web/app/lib/hooks/use-long-press.ts
+++ b/packages/web/app/lib/hooks/use-long-press.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, type RefCallback } from 'react';
+
+const DEFAULT_THRESHOLD_MS = 500;
+const DEFAULT_MOVE_THRESHOLD_PX = 10;
+
+type UseLongPressOptions = {
+  thresholdMs?: number;
+  moveThresholdPx?: number;
+};
+
+type UseLongPressResult<E extends HTMLElement> = {
+  ref: RefCallback<E>;
+  /**
+   * Call from the element's click handler before doing anything else.
+   * Returns `true` (and clears the flag) when a long-press just fired —
+   * the caller should bail so the long-press doesn't double up with a tap.
+   */
+  consumeLongPress: () => boolean;
+};
+
+/**
+ * Pointer-event-based long-press detector. Attach `ref` to any element to
+ * detect a held press of `thresholdMs`. A drag past `moveThresholdPx` cancels
+ * the press. The synthesized click that follows a long-press is suppressed
+ * by checking `consumeLongPress()` from inside the element's click handler.
+ */
+export function useLongPress<E extends HTMLElement = HTMLElement>(
+  callback: (() => void) | undefined,
+  { thresholdMs = DEFAULT_THRESHOLD_MS, moveThresholdPx = DEFAULT_MOVE_THRESHOLD_PX }: UseLongPressOptions = {},
+): UseLongPressResult<E> {
+  const timerRef = useRef<number | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+  const longPressFiredRef = useRef(false);
+  const elementRef = useRef<E | null>(null);
+
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent) => {
+      if (event.button !== undefined && event.button !== 0) return;
+      longPressFiredRef.current = false;
+      startPosRef.current = { x: event.clientX, y: event.clientY };
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
+        longPressFiredRef.current = true;
+        callbackRef.current?.();
+      }, thresholdMs);
+    },
+    [thresholdMs],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!startPosRef.current) return;
+      const dx = event.clientX - startPosRef.current.x;
+      const dy = event.clientY - startPosRef.current.y;
+      if (Math.hypot(dx, dy) > moveThresholdPx) {
+        clearTimer();
+      }
+    },
+    [clearTimer, moveThresholdPx],
+  );
+
+  const handlePointerUp = useCallback(() => clearTimer(), [clearTimer]);
+  const handlePointerCancel = useCallback(() => clearTimer(), [clearTimer]);
+
+  const handleContextMenu = useCallback((event: Event) => {
+    // Suppress the right-click / iOS callout menu so a long-press doesn't
+    // surface the system context menu on top of the drawer we're opening.
+    event.preventDefault();
+  }, []);
+
+  const ref: RefCallback<E> = useCallback(
+    (node) => {
+      if (elementRef.current) {
+        elementRef.current.removeEventListener('pointerdown', handlePointerDown);
+        elementRef.current.removeEventListener('pointermove', handlePointerMove);
+        elementRef.current.removeEventListener('pointerup', handlePointerUp);
+        elementRef.current.removeEventListener('pointercancel', handlePointerCancel);
+        elementRef.current.removeEventListener('pointerleave', handlePointerCancel);
+        elementRef.current.removeEventListener('contextmenu', handleContextMenu);
+      }
+      elementRef.current = node;
+      if (node) {
+        node.addEventListener('pointerdown', handlePointerDown);
+        node.addEventListener('pointermove', handlePointerMove);
+        node.addEventListener('pointerup', handlePointerUp);
+        node.addEventListener('pointercancel', handlePointerCancel);
+        node.addEventListener('pointerleave', handlePointerCancel);
+        node.addEventListener('contextmenu', handleContextMenu);
+      }
+    },
+    [handlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, handleContextMenu],
+  );
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const consumeLongPress = useCallback(() => {
+    if (longPressFiredRef.current) {
+      longPressFiredRef.current = false;
+      return true;
+    }
+    return false;
+  }, []);
+
+  return { ref, consumeLongPress };
+}

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -7,5 +7,13 @@
   "languages": {
     "en-US": "English",
     "es": "Español"
+  },
+  "lightControl": {
+    "title": "Lights",
+    "turnOffAll": "Turn off all lights",
+    "partyMode": "Party mode",
+    "stopParty": "Stop party",
+    "partyUnsupported": "Party mode isn't available on this board",
+    "clearFailed": "Couldn't clear the board"
   }
 }


### PR DESCRIPTION
## Summary

Long-press the lightbulb in the action bar (while connected) to open a hidden bottom drawer with two actions:

- **Turn off all lights** — sends an Aurora `ONLY`-command packet with no LED entries so the board overwrites its state to blank. Fixes a pre-existing no-op where `sendFramesToBoard('')` was short-circuited by the `!frames` guard and never reached the BLE write path. The same call site in `create-climb-form.tsx:458` (clear holds) now actually clears.
- **Party mode** — cycles through the letters of "BOARDSESH" by snapping a 5×7 bitmap glyph onto the nearest holds (using each hold's `cx`/`cy`) and rotating the role colours per letter. The auto-sender pauses while party is active so queue changes don't fight the loop, and the wall is cleared on stop.

Single-tap connect/disconnect on the lightbulb is unchanged. Long-press is a no-op when not connected. MoonBoard hides the party row (the empty-frames clear path is also gated since MoonBoard's packet format can't encode a clear).

## Files

- `packages/web/app/lib/hooks/use-long-press.ts` — pointer-event-based long-press hook with click suppression
- `packages/web/app/components/board-page/party-glyphs.ts` — 5×7 bitmaps for `B O A R D S E H` + `mapGlyphToHolds` snap
- `packages/web/app/components/board-page/light-control-drawer.tsx` — drawer UI + party loop
- `packages/web/app/components/board-page/share-button.tsx` — wires long-press + drawer
- `packages/web/app/components/board-bluetooth-control/{bluetooth-aurora,use-board-bluetooth,bluetooth-context}.ts(x)` — clear-packet path, `clearBoard()`, `partyActive` gating of `BluetoothAutoSender`
- `packages/web/i18n/locales/en-US/common.json` — `lightControl.*` strings

## Test plan

- [ ] `vp check` clean ✅
- [ ] `vp run typecheck:web` clean ✅
- [ ] `vp test --project web` — 3918 passed ✅
- [ ] Single-tap lightbulb still connects / disconnects (regression)
- [ ] Long-press (~500 ms) on lightbulb opens the bottom drawer
- [ ] "Turn off all lights" blanks every LED on a real Kilter / Tension board
- [ ] "Party mode" spells out BOARDSESH letter-by-letter (~600 ms tick) — verify glyphs are right-side-up; if not, flip the row index in `mapGlyphToHolds`
- [ ] Swiping the queue while party is active doesn't overwrite party frames
- [ ] Stop party clears the wall instead of leaving the last letter lit
- [ ] Long-press is a no-op when not connected
- [ ] iOS Safari: long-press doesn't surface the system callout menu

https://claude.ai/code/session_019g5D8ASHwYrtefaD79wf8h

---
_Generated by [Claude Code](https://claude.ai/code/session_019g5D8ASHwYrtefaD79wf8h)_