### PR TITLE
fix(web): catch BLE errors in light drawer + cover long-press and party loop

### DIFF
--- a/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
@@ -225,6 +225,23 @@ describe('LightControlDrawer', () => {
       expect(showMessageMock).toHaveBeenCalledWith('lightControl.clearFailed', 'error');
     });
 
+    it('shows the failure snackbar when clearBoard returns undefined (early-bail)', async () => {
+      // sendFramesToBoard returns `undefined` (not `false`) when the BLE
+      // adapter or boardDetails is missing — handleClearAll must treat that
+      // as a failure too, otherwise the user gets no feedback.
+      mockPartyActive = false;
+      clearBoardMock.mockResolvedValueOnce(undefined);
+
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+        await Promise.resolve();
+      });
+
+      expect(showMessageMock).toHaveBeenCalledWith('lightControl.clearFailed', 'error');
+    });
+
     it('catches thrown BLE errors and shows the failure snackbar', async () => {
       mockPartyActive = false;
       clearBoardMock.mockRejectedValueOnce(new Error('GATT disconnect'));

--- a/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails } from '@/app/lib/types';
+
+// Mocks must be hoisted; declare the function refs first so mock factories can capture them.
+const sendFramesToBoardMock = vi.fn(async () => true as boolean | undefined);
+const clearBoardMock = vi.fn(async () => true as boolean | undefined);
+const setPartyActiveMock = vi.fn();
+const showMessageMock = vi.fn();
+
+let mockIsConnected = true;
+let mockPartyActive = false;
+let mockBoardName: BoardDetails['board_name'] = 'kilter';
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: mockBoardName,
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1],
+    image_filename: 'kilter.png',
+    layout_name: 'Kilter Original',
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 144,
+    edge_bottom: 0,
+    edge_top: 156,
+    boardWidth: 144,
+    boardHeight: 156,
+    supportsMirroring: false,
+  } as unknown as BoardDetails;
+}
+
+vi.mock('@/app/components/board-bluetooth-control/bluetooth-context', () => ({
+  useBluetoothContext: () => ({
+    isConnected: mockIsConnected,
+    sendFramesToBoard: sendFramesToBoardMock,
+    clearBoard: clearBoardMock,
+    boardDetails: makeBoardDetails(),
+    partyActive: mockPartyActive,
+    setPartyActive: setPartyActiveMock,
+  }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: showMessageMock }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children, title }: { open: boolean; children: React.ReactNode; title: React.ReactNode }) =>
+    open ? (
+      <div data-testid="drawer">
+        <div data-testid="drawer-title">{title}</div>
+        {children}
+      </div>
+    ) : null,
+}));
+
+import { LightControlDrawer } from '../light-control-drawer';
+
+describe('LightControlDrawer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendFramesToBoardMock.mockClear();
+    sendFramesToBoardMock.mockResolvedValue(true);
+    clearBoardMock.mockClear();
+    clearBoardMock.mockResolvedValue(true);
+    setPartyActiveMock.mockClear();
+    showMessageMock.mockClear();
+    mockIsConnected = true;
+    mockPartyActive = false;
+    mockBoardName = 'kilter';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('party loop lifecycle', () => {
+    it('sends a frame immediately when party becomes active and ticks on the interval', () => {
+      mockPartyActive = false;
+      const { rerender } = render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      expect(sendFramesToBoardMock).not.toHaveBeenCalled();
+
+      // Flip partyActive on
+      mockPartyActive = true;
+      act(() => {
+        rerender(<LightControlDrawer open={true} onClose={vi.fn()} />);
+      });
+
+      // First letter sent immediately
+      expect(sendFramesToBoardMock).toHaveBeenCalledTimes(1);
+
+      // Each subsequent tick (600ms) sends the next letter
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(sendFramesToBoardMock).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(sendFramesToBoardMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not start the interval when the board is disconnected', () => {
+      mockIsConnected = false;
+      mockPartyActive = true;
+
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(sendFramesToBoardMock).not.toHaveBeenCalled();
+    });
+
+    it('does not start the interval on moonboard', () => {
+      mockBoardName = 'moonboard';
+      mockPartyActive = true;
+
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(sendFramesToBoardMock).not.toHaveBeenCalled();
+    });
+
+    it('clears the board exactly once when partyActive flips from true to false', async () => {
+      mockPartyActive = true;
+      const { rerender } = render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      // Drain the immediate send so we're past startup.
+      expect(sendFramesToBoardMock).toHaveBeenCalledTimes(1);
+
+      // Flip party off
+      mockPartyActive = false;
+      act(() => {
+        rerender(<LightControlDrawer open={true} onClose={vi.fn()} />);
+      });
+
+      // Allow the microtask from `void clearBoard()` to settle.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(clearBoardMock).toHaveBeenCalledTimes(1);
+
+      // No interval ticks after the stop.
+      sendFramesToBoardMock.mockClear();
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(sendFramesToBoardMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call clearBoard on the very first render when partyActive starts false', () => {
+      mockPartyActive = false;
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+      expect(clearBoardMock).not.toHaveBeenCalled();
+    });
+
+    it('stops the interval on unmount', () => {
+      mockPartyActive = true;
+      const { unmount } = render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+      expect(sendFramesToBoardMock).toHaveBeenCalledTimes(1);
+
+      unmount();
+      sendFramesToBoardMock.mockClear();
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(sendFramesToBoardMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleClearAll', () => {
+    it('flips partyActive off without calling clearBoard directly when party is running', () => {
+      mockPartyActive = true;
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      // Drain the immediate party send
+      sendFramesToBoardMock.mockClear();
+      clearBoardMock.mockClear();
+
+      fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+
+      expect(setPartyActiveMock).toHaveBeenCalledWith(false);
+      expect(clearBoardMock).not.toHaveBeenCalled();
+    });
+
+    it('calls clearBoard and shows no message on success', async () => {
+      mockPartyActive = false;
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+        await Promise.resolve();
+      });
+
+      expect(clearBoardMock).toHaveBeenCalledTimes(1);
+      expect(showMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('shows the failure snackbar when clearBoard returns false', async () => {
+      mockPartyActive = false;
+      clearBoardMock.mockResolvedValueOnce(false);
+
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+        await Promise.resolve();
+      });
+
+      expect(showMessageMock).toHaveBeenCalledWith('lightControl.clearFailed', 'error');
+    });
+
+    it('catches thrown BLE errors and shows the failure snackbar', async () => {
+      mockPartyActive = false;
+      clearBoardMock.mockRejectedValueOnce(new Error('GATT disconnect'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+        await Promise.resolve();
+      });
+
+      expect(showMessageMock).toHaveBeenCalledWith('lightControl.clearFailed', 'error');
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handlePartyToggle', () => {
+    it('toggles partyActive on a supported board', () => {
+      mockPartyActive = false;
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      fireEvent.click(screen.getByText('lightControl.partyMode'));
+
+      expect(setPartyActiveMock).toHaveBeenCalledWith(true);
+    });
+
+    it('shows the unsupported hint and does not toggle on moonboard', () => {
+      mockBoardName = 'moonboard';
+      mockPartyActive = false;
+      render(<LightControlDrawer open={true} onClose={vi.fn()} />);
+
+      // The party row is rendered but disabled on moonboard. The drawer
+      // surfaces the unsupported state via secondary text.
+      const button = screen.getByText('lightControl.partyMode').closest('[role="button"]');
+      expect(button?.getAttribute('aria-disabled')).toBe('true');
+      expect(screen.getByText('lightControl.partyUnsupported')).toBeTruthy();
+      expect(setPartyActiveMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -190,8 +190,15 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
       setPartyMode('off');
       return;
     }
-    const result = await clearBoard();
-    if (result === false) {
+    try {
+      const success = await clearBoard();
+      if (!success) {
+        showMessage(t('lightControl.clearFailed'), 'error');
+      }
+    } catch (error) {
+      // sendFramesToBoard normally catches BLE errors and returns false,
+      // but a disconnect mid-write can still surface a rejected promise.
+      console.error('Failed to clear board lights:', error);
       showMessage(t('lightControl.clearFailed'), 'error');
     }
   };

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -196,8 +196,9 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
         showMessage(t('lightControl.clearFailed'), 'error');
       }
     } catch (error) {
-      // sendFramesToBoard normally catches BLE errors and returns false,
-      // but a disconnect mid-write can still surface a rejected promise.
+      // clearBoard's underlying BLE write usually has its own try/catch and
+      // returns false on failure, but a disconnect mid-write can still
+      // surface here as a rejected promise.
       console.error('Failed to clear board lights:', error);
       showMessage(t('lightControl.clearFailed'), 'error');
     }

--- a/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
+++ b/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
@@ -117,7 +117,7 @@ describe('useLongPress', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('cancels when the pointer drags past the movement threshold', () => {
+  it('does not cancel when movement is exactly at the threshold (boundary)', () => {
     const callback = vi.fn();
     const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
 
@@ -130,14 +130,15 @@ describe('useLongPress', () => {
       element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100, clientY: 100 }));
     });
     act(() => {
-      // hypot(8, 6) === 10 — at the threshold but not past it
+      // hypot(8, 6) === 10 — the hook uses strict `>`, so exactly at the
+      // threshold should NOT cancel.
       element.dispatchEvent(createPointerEvent('pointermove', { clientX: 108, clientY: 106 }));
       vi.advanceTimersByTime(500);
     });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it('cancels when the pointer drags past the movement threshold (jitter past 10px)', () => {
+  it('cancels when the pointer drags past the movement threshold', () => {
     const callback = vi.fn();
     const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
 

--- a/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
+++ b/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPress } from '../use-long-press';
+
+/**
+ * jsdom doesn't implement the PointerEvent constructor, so synthesize a
+ * plain Event and tack on the pointer-specific properties the hook reads.
+ */
+function createPointerEvent(
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel' | 'pointerleave',
+  { clientX = 0, clientY = 0, button = 0 }: { clientX?: number; clientY?: number; button?: number } = {},
+): Event {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, 'clientX', { value: clientX });
+  Object.defineProperty(event, 'clientY', { value: clientY });
+  Object.defineProperty(event, 'button', { value: button });
+  return event;
+}
+
+describe('useLongPress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires the callback after the press threshold elapses', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the timer when the pointer is released before the threshold', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+      element.dispatchEvent(createPointerEvent('pointerup'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointercancel', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointercancel'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointerleave', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerleave'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancels when the pointer drags past the movement threshold', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      // hypot(8, 6) === 10 — at the threshold but not past it
+      element.dispatchEvent(createPointerEvent('pointermove', { clientX: 108, clientY: 106 }));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels when the pointer drags past the movement threshold (jitter past 10px)', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointermove', { clientX: 120, clientY: 100 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-primary mouse buttons', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { button: 2 }));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('consumeLongPress returns true exactly once after a long-press fires', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.consumeLongPress()).toBe(true);
+    expect(result.current.consumeLongPress()).toBe(false);
+  });
+
+  it('consumeLongPress returns false when no long-press has fired', () => {
+    const { result } = renderHook(() => useLongPress(vi.fn(), { thresholdMs: 500 }));
+
+    expect(result.current.consumeLongPress()).toBe(false);
+  });
+
+  it('preventDefault is called on contextmenu to suppress the iOS callout', () => {
+    const { result } = renderHook(() => useLongPress(vi.fn(), { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    const contextMenuEvent = new Event('contextmenu', { bubbles: true, cancelable: true });
+    element.dispatchEvent(contextMenuEvent);
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+  });
+
+  it('detaches listeners from the previous element when the ref node changes', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+
+    act(() => {
+      result.current.ref(first);
+    });
+    act(() => {
+      result.current.ref(second);
+    });
+
+    // The old element no longer fires the callback.
+    act(() => {
+      first.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    // The new element does.
+    act(() => {
+      second.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears any pending timer when the hook unmounts mid-press', () => {
+    const callback = vi.fn();
+    const { result, unmount } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('handles undefined callback without throwing when the timer fires', () => {
+    const { result } = renderHook(() => useLongPress(undefined, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    expect(() => {
+      act(() => {
+        element.dispatchEvent(createPointerEvent('pointerdown'));
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to #1814 addressing two review notes that landed after merge.

## Summary

- **`handleClearAll` now catches BLE errors.** A mid-write GATT disconnect can surface as a rejected promise from `clearBoard()` rather than the `false` return that `sendFramesToBoard`'s outer catch produces. Wrapping the call in try/catch keeps the failure snackbar reliable instead of silently swallowing the error. Also treats `null`/`undefined` returns as failure (only `true` counts as success).
- **`useLongPress` is now under test.** Covers timer firing at the threshold, early-release cancellation, drag past the movement threshold, non-primary mouse buttons, contextmenu suppression, ref re-attachment, unmount cleanup, and `consumeLongPress` semantics.
- **`LightControlDrawer` party-loop lifecycle is now under test.** Covers immediate send on activation, interval ticks, the disconnect and moonboard guards, the `wasPartyActiveRef` one-shot clear when stopping, unmount cleanup. Also covers `handleClearAll`'s three branches (party-running, success, failure return, thrown error) and the moonboard unsupported path.

25 new tests; all green locally.

## Test plan

- [x] `vp test run` for the two new files passes (25/25)
- [x] `vp run typecheck:web` passes
- [ ] CI green

https://claude.ai/code/session_019g5D8ASHwYrtefaD79wf8h

---
_Generated by [Claude Code](https://claude.ai/code/session_019g5D8ASHwYrtefaD79wf8h)_