### PR TITLE
i18n: translate board &amp; gym discovery + entity pages

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-view-content.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-view-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
@@ -30,6 +31,7 @@ type LikedClimbsViewContentProps = {
 };
 
 export default function LikedClimbsViewContent({ boardDetails, angle }: LikedClimbsViewContentProps) {
+  const { t } = useTranslation('climbs');
   const { showMessage } = useSnackbar();
   const [isAddingToQueue, setIsAddingToQueue] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
@@ -89,7 +91,7 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
       }
 
       if (allClimbs.length === 0) {
-        showMessage('No climbs to add', 'info');
+        showMessage(t('liked.noClimbsToAdd'), 'info');
         return;
       }
 
@@ -101,16 +103,16 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
         climbCount: allClimbs.length,
       });
 
-      showMessage(`Added ${allClimbs.length} ${allClimbs.length === 1 ? 'climb' : 'climbs'} to queue`, 'success');
+      showMessage(t('liked.addedToQueue', { count: allClimbs.length }), 'success');
     } catch (err) {
       if (abortController.signal.aborted) return;
       console.error('Error adding climbs to queue:', err);
-      showMessage('Failed to add climbs to queue', 'error');
+      showMessage(t('liked.addToQueueFailed'), 'error');
     } finally {
       addingToQueueRef.current = false;
       setIsAddingToQueue(false);
     }
-  }, [token, boardDetails, angle, addToQueue, showMessage]);
+  }, [token, boardDetails, angle, addToQueue, showMessage, t]);
 
   if (tokenLoading) {
     return (
@@ -124,8 +126,8 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
     return (
       <div className={styles.errorContainer}>
         <SentimentDissatisfiedOutlined className={styles.errorIcon} />
-        <div className={styles.errorTitle}>Sign In Required</div>
-        <div className={styles.errorMessage}>Please sign in to view your liked climbs.</div>
+        <div className={styles.errorTitle}>{t('liked.signInRequired')}</div>
+        <div className={styles.errorMessage}>{t('liked.signInBody')}</div>
       </div>
     );
   }
@@ -150,10 +152,10 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
             </div>
             <div className={styles.heroInfo}>
               <Typography variant="h5" component="h2" className={styles.heroName}>
-                Liked Climbs
+                {t('liked.heroTitle')}
               </Typography>
               <div className={styles.heroMeta}>
-                <span className={styles.heroMetaItem}>Your favorite climbs</span>
+                <span className={styles.heroMetaItem}>{t('liked.heroSubtitle')}</span>
               </div>
             </div>
           </div>
@@ -162,7 +164,7 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
           <IconButton
             className={styles.heroMenuButton}
             onClick={(e) => setMenuAnchor(e.currentTarget)}
-            aria-label="Actions"
+            aria-label={t('liked.actionsAriaLabel')}
           >
             <MoreVertOutlined />
           </IconButton>
@@ -172,7 +174,7 @@ export default function LikedClimbsViewContent({ boardDetails, angle }: LikedCli
               <ListItemIcon>
                 <AddOutlined />
               </ListItemIcon>
-              <ListItemText>{isAddingToQueue ? 'Adding...' : 'Queue All'}</ListItemText>
+              <ListItemText>{isAddingToQueue ? t('liked.adding') : t('liked.queueAll')}</ListItemText>
             </MenuItem>
           </Menu>
         </div>

--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -26,6 +26,7 @@
 import enAdmin from '@/i18n/locales/en-US/admin.json';
 import enAurora from '@/i18n/locales/en-US/aurora.json';
 import enAuth from '@/i18n/locales/en-US/auth.json';
+import enBoards from '@/i18n/locales/en-US/boards.json';
 import enClimbs from '@/i18n/locales/en-US/climbs.json';
 import enCommon from '@/i18n/locales/en-US/common.json';
 import enErrors from '@/i18n/locales/en-US/errors.json';
@@ -42,6 +43,7 @@ const CATALOGS: Record<string, unknown> = {
   admin: enAdmin,
   aurora: enAurora,
   auth: enAuth,
+  boards: enBoards,
   climbs: enClimbs,
   common: enCommon,
   errors: enErrors,

--- a/packages/web/app/components/board-entity/board-detail.tsx
+++ b/packages/web/app/components/board-entity/board-detail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import MuiTypography from '@mui/material/Typography';
@@ -71,6 +72,7 @@ export function BoardDetailContent({
   onDeleted,
   onFollowChange,
 }: BoardDetailContentProps) {
+  const { t } = useTranslation('boards');
   const [board, setBoard] = useState<UserBoard | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
@@ -113,7 +115,7 @@ export function BoardDetailContent({
 
   const handleDelete = async () => {
     if (!token || !board) return;
-    if (!window.confirm(`Delete "${board.name}"? This action can be undone later.`)) return;
+    if (!window.confirm(t('boardEntity.delete.confirm', { name: board.name }))) return;
 
     setIsDeleting(true);
     try {
@@ -121,11 +123,11 @@ export function BoardDetailContent({
       await client.request<DeleteBoardMutationResponse, DeleteBoardMutationVariables>(DELETE_BOARD, {
         boardUuid: board.uuid,
       });
-      showMessage('Board deleted', 'success');
+      showMessage(t('boardEntity.snackbar.deleted'), 'success');
       onDeleted?.();
     } catch (error) {
       console.error('Failed to delete board:', error);
-      showMessage('Failed to delete board', 'error');
+      showMessage(t('boardEntity.snackbar.deleteFailed'), 'error');
     } finally {
       setIsDeleting(false);
     }
@@ -143,12 +145,15 @@ export function BoardDetailContent({
       await client.request<LinkBoardToGymMutationResponse, LinkBoardToGymMutationVariables>(LINK_BOARD_TO_GYM, {
         input: { boardUuid: board.uuid, gymUuid },
       });
-      showMessage(gymUuid ? 'Board linked to gym' : 'Board unlinked from gym', 'success');
+      showMessage(
+        gymUuid ? t('boardEntity.snackbar.linkedToGym') : t('boardEntity.snackbar.unlinkedFromGym'),
+        'success',
+      );
       setShowGymSelector(false);
       void fetchBoard();
     } catch (error) {
       console.error('Failed to link board to gym:', error);
-      showMessage('Failed to link board to gym', 'error');
+      showMessage(t('boardEntity.snackbar.linkFailed'), 'error');
     }
   };
 
@@ -173,7 +178,7 @@ export function BoardDetailContent({
   if (!board) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-        <MuiTypography color="text.secondary">Board not found</MuiTypography>
+        <MuiTypography color="text.secondary">{t('boardEntity.notFound')}</MuiTypography>
       </Box>
     );
   }
@@ -237,8 +242,12 @@ export function BoardDetailContent({
 
         {isOwner && (board.isUnlisted || board.hideLocation) && (
           <Box sx={{ display: 'flex', gap: 1, mt: 1.5, flexWrap: 'wrap' }}>
-            {board.isUnlisted && <Chip label="Unlisted" size="small" variant="outlined" color="warning" />}
-            {board.hideLocation && <Chip label="Location hidden" size="small" variant="outlined" color="warning" />}
+            {board.isUnlisted && (
+              <Chip label={t('boardEntity.chips.unlisted')} size="small" variant="outlined" color="warning" />
+            )}
+            {board.hideLocation && (
+              <Chip label={t('boardEntity.chips.locationHidden')} size="small" variant="outlined" color="warning" />
+            )}
           </Box>
         )}
 
@@ -269,7 +278,7 @@ export function BoardDetailContent({
             onClick={() => setShowGymSelector(true)}
             sx={{ textTransform: 'none', mt: 1, alignSelf: 'flex-start' }}
           >
-            Add to Gym
+            {t('boardEntity.actions.addToGym')}
           </MuiButton>
         )}
         {showGymSelector && isOwner && (
@@ -280,10 +289,26 @@ export function BoardDetailContent({
 
         {/* Stats */}
         <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
-          <StatChip icon={<TrendingUpOutlined sx={{ fontSize: 16 }} />} value={board.totalAscents} label="ascents" />
-          <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={board.uniqueClimbers} label="climbers" />
-          <StatChip icon={<PeopleOutlined sx={{ fontSize: 16 }} />} value={board.followerCount} label="followers" />
-          <StatChip icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />} value={board.commentCount} label="comments" />
+          <StatChip
+            icon={<TrendingUpOutlined sx={{ fontSize: 16 }} />}
+            value={board.totalAscents}
+            label={t('boardEntity.stats.ascents')}
+          />
+          <StatChip
+            icon={<PersonOutlined sx={{ fontSize: 16 }} />}
+            value={board.uniqueClimbers}
+            label={t('boardEntity.stats.climbers')}
+          />
+          <StatChip
+            icon={<PeopleOutlined sx={{ fontSize: 16 }} />}
+            value={board.followerCount}
+            label={t('boardEntity.stats.followers')}
+          />
+          <StatChip
+            icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
+            value={board.commentCount}
+            label={t('boardEntity.stats.comments')}
+          />
         </Box>
 
         {/* Actions */}
@@ -294,7 +319,7 @@ export function BoardDetailContent({
               initialIsFollowing={board.isFollowedByMe}
               followMutation={FOLLOW_BOARD}
               unfollowMutation={UNFOLLOW_BOARD}
-              entityLabel="board"
+              entityLabel={t('boardEntity.follow.entityLabel')}
               getFollowVariables={(id) => ({ input: { boardUuid: id } })}
               onFollowChange={handleFollowChange}
             />
@@ -308,7 +333,7 @@ export function BoardDetailContent({
                 onClick={() => setIsEditing(true)}
                 sx={{ textTransform: 'none' }}
               >
-                Edit
+                {t('boardEntity.actions.edit')}
               </MuiButton>
               <MuiButton
                 variant="outlined"
@@ -319,7 +344,7 @@ export function BoardDetailContent({
                 disabled={isDeleting}
                 sx={{ textTransform: 'none' }}
               >
-                {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
+                {isDeleting ? <CircularProgress size={16} /> : t('boardEntity.actions.delete')}
               </MuiButton>
             </>
           )}
@@ -330,14 +355,16 @@ export function BoardDetailContent({
 
       {/* Tabs */}
       <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
-        <Tab label="Leaderboard" sx={{ textTransform: 'none' }} />
-        <Tab label="Comments" sx={{ textTransform: 'none' }} />
+        <Tab label={t('boardEntity.tabs.leaderboard')} sx={{ textTransform: 'none' }} />
+        <Tab label={t('boardEntity.tabs.comments')} sx={{ textTransform: 'none' }} />
       </Tabs>
 
       {/* Tab content */}
       <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
         {activeTab === 0 && <BoardLeaderboard boardUuid={board.uuid} />}
-        {activeTab === 1 && <CommentSection entityType="board" entityId={board.uuid} title="Board Discussion" />}
+        {activeTab === 1 && (
+          <CommentSection entityType="board" entityId={board.uuid} title={t('boardEntity.comments.title')} />
+        )}
       </Box>
 
       {/* Gym detail drawer */}

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
@@ -34,14 +35,15 @@ export default function CreateBoardForm({
   onSuccess,
   onCancel,
 }: CreateBoardFormProps) {
+  const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
   const router = useLocaleRouter();
 
   const availableAngles = ANGLES[boardType as BoardName] ?? [];
 
   const { execute } = useEntityMutation<CreateBoardMutationResponse, CreateBoardMutationVariables>(CREATE_BOARD, {
-    errorMessage: 'Failed to create board. It may already exist for this configuration.',
-    authRequiredMessage: 'You must be signed in to create a board',
+    errorMessage: t('boardForm.create.errorMessage'),
+    authRequiredMessage: t('boardForm.create.authRequired'),
   });
 
   const handleSubmit = useCallback(
@@ -59,7 +61,7 @@ export default function CreateBoardForm({
       isAngleAdjustable?: boolean;
     }) => {
       if (!values.name) {
-        showMessage('Board name is required', 'error');
+        showMessage(t('boardForm.create.nameRequired'), 'error');
         return;
       }
 
@@ -85,7 +87,7 @@ export default function CreateBoardForm({
 
       if (data) {
         const board = data.createBoard;
-        showMessage(`Board "${board.name}" created!`, 'success');
+        showMessage(t('boardForm.create.createdNamed', { name: board.name }), 'success');
 
         if (onSuccess) {
           onSuccess(board);
@@ -94,13 +96,13 @@ export default function CreateBoardForm({
         }
       }
     },
-    [execute, boardType, layoutId, sizeId, setIds, defaultAngle, showMessage, router, onSuccess],
+    [execute, boardType, layoutId, sizeId, setIds, defaultAngle, showMessage, router, onSuccess, t],
   );
 
   return (
     <BoardForm
       title=""
-      submitLabel="Create Board"
+      submitLabel={t('boardForm.create.submit')}
       initialValues={{
         name: '',
         description: '',
@@ -110,8 +112,8 @@ export default function CreateBoardForm({
         hideLocation: false,
         isOwned: true,
       }}
-      namePlaceholder="e.g., Home Board, Gym Name"
-      locationPlaceholder="e.g., City, Gym Name"
+      namePlaceholder={t('boardForm.create.namePlaceholder')}
+      locationPlaceholder={t('boardForm.create.locationPlaceholder')}
       availableAngles={availableAngles}
       onSubmit={handleSubmit}
       onCancel={onCancel}

--- a/packages/web/app/components/board-scroll/__tests__/find-nearby-card.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/find-nearby-card.test.tsx
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi } from 'vite-plus/test';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import FindNearbyCard from '../find-nearby-card';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock BoardRenderer
 vi.mock('../../board-renderer/board-renderer', () => ({

--- a/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
+++ b/packages/web/app/components/board-scroll/bluetooth-quick-start-card.tsx
@@ -6,6 +6,7 @@ import BluetoothSearching from '@mui/icons-material/BluetoothSearching';
 import BluetoothDisabled from '@mui/icons-material/BluetoothDisabled';
 import SearchOffOutlined from '@mui/icons-material/SearchOffOutlined';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useTranslation } from 'react-i18next';
 import { getBoardDetails, FALLBACK_BOARD_PREVIEW_CONFIGS } from '@/app/lib/board-constants';
 import BoardRenderer from '../board-renderer/board-renderer';
 import styles from './board-scroll.module.css';
@@ -25,6 +26,7 @@ export default function BluetoothQuickStartCard({
   hasResults = false,
   size = 'default',
 }: BluetoothQuickStartCardProps) {
+  const { t } = useTranslation('boards');
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
@@ -45,24 +47,24 @@ export default function BluetoothQuickStartCard({
   switch (status) {
     case 'scanning':
       icon = <CircularProgress size={iconSize} className={styles.findNearbyIconPrimary} />;
-      label = 'Scanning…';
+      label = t('discovery.bluetooth.scanning');
       break;
     case 'done':
       if (hasResults) {
         icon = <BluetoothSearching className={styles.findNearbyIconPrimary} />;
-        label = 'Boards found';
+        label = t('discovery.bluetooth.boardsFound');
       } else {
         icon = <SearchOffOutlined className={styles.findNearbyIconMuted} />;
-        label = 'No boards found';
+        label = t('discovery.bluetooth.noBoardsFound');
       }
       break;
     case 'unavailable':
       icon = <BluetoothDisabled sx={{ fontSize: iconSize, color: 'var(--neutral-500)' }} />;
-      label = 'Bluetooth unavailable';
+      label = t('discovery.bluetooth.unavailable');
       break;
     default:
       icon = <BluetoothOutlined className={styles.findNearbyIconPrimary} />;
-      label = 'Quick start';
+      label = t('discovery.bluetooth.idle');
       break;
   }
 

--- a/packages/web/app/components/board-scroll/board-discovery-scroll.tsx
+++ b/packages/web/app/components/board-scroll/board-discovery-scroll.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import BoardScrollSection from './board-scroll-section';
 import BoardScrollCard from './board-scroll-card';
@@ -55,6 +56,7 @@ export default function BoardDiscoveryScroll({
   initialPopularConfigs,
   myBoards: externalMyBoards,
 }: BoardDiscoveryScrollProps) {
+  const { t } = useTranslation('boards');
   const { status } = useSession();
   const isAuthenticated = status === 'authenticated';
   const router = useLocaleRouter();
@@ -175,7 +177,7 @@ export default function BoardDiscoveryScroll({
   return (
     <>
       <BoardScrollSection
-        title="Boards near you"
+        title={t('discovery.section.nearby')}
         loading={isBoardsLoading && popularConfigs.length === 0 && myBoards.length === 0}
         onLoadMore={loadMore}
         hasMore={hasMore}

--- a/packages/web/app/components/board-scroll/create-board-card.tsx
+++ b/packages/web/app/components/board-scroll/create-board-card.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import AddOutlined from '@mui/icons-material/AddOutlined';
+import { useTranslation } from 'react-i18next';
 import styles from './board-scroll.module.css';
 
 type CreateBoardCardProps = {
@@ -10,15 +11,17 @@ type CreateBoardCardProps = {
   size?: 'default' | 'small';
 };
 
-export default function CreateBoardCard({ onClick, label = 'New Board', size = 'default' }: CreateBoardCardProps) {
+export default function CreateBoardCard({ onClick, label, size = 'default' }: CreateBoardCardProps) {
+  const { t } = useTranslation('boards');
   const isSmall = size === 'small';
   const iconSize = isSmall ? 24 : 32;
+  const resolvedLabel = label ?? t('discovery.create.defaultLabel');
 
   return (
     <div className={`${styles.cardScroll} ${isSmall ? styles.cardScrollSmall : ''}`} onClick={onClick}>
       <div className={`${styles.cardSquare} ${styles.createSquare}`}>
         <AddOutlined sx={{ fontSize: iconSize }} />
-        <span className={styles.createLabel}>{label}</span>
+        <span className={styles.createLabel}>{resolvedLabel}</span>
       </div>
     </div>
   );

--- a/packages/web/app/components/board-scroll/custom-board-card.tsx
+++ b/packages/web/app/components/board-scroll/custom-board-card.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import AddOutlined from '@mui/icons-material/AddOutlined';
+import { useTranslation } from 'react-i18next';
 import BoardThumbnailGrid from './board-thumbnail-grid';
 import styles from './board-scroll.module.css';
 
@@ -11,6 +12,7 @@ type CustomBoardCardProps = {
 };
 
 export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoardCardProps) {
+  const { t } = useTranslation('boards');
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
@@ -28,7 +30,7 @@ export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoa
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label="Build a custom board"
+      aria-label={t('discovery.custom.ariaLabel')}
     >
       <div className={styles.cardSquare}>
         <BoardThumbnailGrid />
@@ -36,7 +38,7 @@ export default function CustomBoardCard({ onClick, size = 'default' }: CustomBoa
           <AddOutlined sx={{ fontSize: iconSize, color: 'var(--color-primary)' }} />
         </div>
       </div>
-      <div className={styles.cardName}>Custom board</div>
+      <div className={styles.cardName}>{t('discovery.custom.label')}</div>
     </div>
   );
 }

--- a/packages/web/app/components/board-scroll/find-nearby-card.tsx
+++ b/packages/web/app/components/board-scroll/find-nearby-card.tsx
@@ -6,6 +6,7 @@ import LocationOffOutlined from '@mui/icons-material/LocationOffOutlined';
 import SearchOffOutlined from '@mui/icons-material/SearchOffOutlined';
 import ErrorOutlineOutlined from '@mui/icons-material/ErrorOutlineOutlined';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useTranslation } from 'react-i18next';
 import { getBoardDetails } from '@/app/lib/board-constants';
 import BoardRenderer from '../board-renderer/board-renderer';
 import styles from './board-scroll.module.css';
@@ -19,6 +20,7 @@ type FindNearbyCardProps = {
 };
 
 export default function FindNearbyCard({ onClick, status = 'idle', size = 'default' }: FindNearbyCardProps) {
+  const { t } = useTranslation('boards');
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
@@ -40,23 +42,23 @@ export default function FindNearbyCard({ onClick, status = 'idle', size = 'defau
   switch (status) {
     case 'loading':
       icon = <CircularProgress size={iconSize} className={styles.findNearbyIconPrimary} />;
-      label = 'Finding boards…';
+      label = t('discovery.findNearby.loading');
       break;
     case 'geo-denied':
       icon = <LocationOffOutlined className={styles.findNearbyIconError} />;
-      label = 'Location unavailable';
+      label = t('discovery.findNearby.geoDenied');
       break;
     case 'error':
       icon = <ErrorOutlineOutlined className={styles.findNearbyIconError} />;
-      label = 'Failed to load nearby boards';
+      label = t('discovery.findNearby.error');
       break;
     case 'no-results':
       icon = <SearchOffOutlined className={styles.findNearbyIconMuted} />;
-      label = 'No nearby boards found';
+      label = t('discovery.findNearby.noResults');
       break;
     default:
       icon = <LocationOnOutlined className={styles.findNearbyIconPrimary} />;
-      label = 'Find nearby';
+      label = t('discovery.findNearby.idle');
       break;
   }
 

--- a/packages/web/app/components/board-scroll/search-boards-card.tsx
+++ b/packages/web/app/components/board-scroll/search-boards-card.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import { useTranslation } from 'react-i18next';
 import BoardThumbnailGrid from './board-thumbnail-grid';
 import styles from './board-scroll.module.css';
 
@@ -11,6 +12,7 @@ type SearchBoardsCardProps = {
 };
 
 export default function SearchBoardsCard({ onClick, size = 'default' }: SearchBoardsCardProps) {
+  const { t } = useTranslation('boards');
   const isSmall = size === 'small';
   const iconSize = isSmall ? 28 : 36;
 
@@ -28,7 +30,7 @@ export default function SearchBoardsCard({ onClick, size = 'default' }: SearchBo
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label="Search for a board"
+      aria-label={t('discovery.search.ariaLabel')}
     >
       <div className={styles.cardSquare}>
         <BoardThumbnailGrid />
@@ -36,7 +38,7 @@ export default function SearchBoardsCard({ onClick, size = 'default' }: SearchBo
           <SearchOutlined sx={{ fontSize: iconSize, color: 'var(--color-primary)' }} />
         </div>
       </div>
-      <div className={styles.cardName}>Search</div>
+      <div className={styles.cardName}>{t('discovery.search.label')}</div>
     </div>
   );
 }

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -39,6 +40,7 @@ export default function BoardSelectorDrawer({
   placement = 'bottom',
   onBoardSelected,
 }: BoardSelectorDrawerProps) {
+  const { t } = useTranslation('boards');
   const router = useLocaleRouter();
   const guardBoardSwitch = useBoardSwitchGuard();
   const [showCreateBoardForm, setShowCreateBoardForm] = useState(false);
@@ -210,7 +212,7 @@ export default function BoardSelectorDrawer({
   return (
     <>
       <SwipeableDrawer
-        title="Custom Board"
+        title={t('selectorDrawer.customTitle')}
         placement={placement}
         {...topDrawerDismissProps}
         open={open}
@@ -243,10 +245,10 @@ export default function BoardSelectorDrawer({
               onClick={() => setShowCreateBoardForm(true)}
               disabled={!isFormComplete}
             >
-              Create board
+              {t('selectorDrawer.createButton')}
             </Button>
             <Button variant="contained" size="large" fullWidth onClick={handleStartClimbing} disabled={!isFormComplete}>
-              Quick session
+              {t('selectorDrawer.quickSession')}
             </Button>
           </Box>
         </Box>
@@ -255,7 +257,7 @@ export default function BoardSelectorDrawer({
       {/* Create Board form drawer */}
       {selectedBoard && selectedLayout && selectedSize && (
         <SwipeableDrawer
-          title="Create Board"
+          title={t('selectorDrawer.createTitle')}
           placement={placement}
           {...topDrawerDismissProps}
           open={showCreateBoardForm}
@@ -267,9 +269,9 @@ export default function BoardSelectorDrawer({
               sections={[
                 {
                   key: 'config',
-                  label: 'Board config',
-                  title: 'Board config',
-                  defaultSummary: 'Select a board',
+                  label: t('selectorDrawer.configSection.label'),
+                  title: t('selectorDrawer.configSection.title'),
+                  defaultSummary: t('selectorDrawer.configSection.defaultSummary'),
                   getSummary: () => {
                     const parts: string[] = [];
                     if (selectedBoard) parts.push(selectedBoard.charAt(0).toUpperCase() + selectedBoard.slice(1));

--- a/packages/web/app/components/gym-entity/create-gym-form.tsx
+++ b/packages/web/app/components/gym-entity/create-gym-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
@@ -18,17 +19,18 @@ type CreateGymFormProps = {
 };
 
 export default function CreateGymForm({ boardUuid, onSuccess, onCancel }: CreateGymFormProps) {
+  const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
   const { execute } = useEntityMutation<CreateGymMutationResponse, CreateGymMutationVariables>(CREATE_GYM, {
-    errorMessage: 'Failed to create gym',
-    authRequiredMessage: 'You must be signed in to create a gym',
+    errorMessage: t('gymForm.create.errorMessage'),
+    authRequiredMessage: t('gymForm.create.authRequired'),
   });
 
   const handleSubmit = useCallback(
     async (values: GymFormFieldValues) => {
       if (!values.name) {
-        showMessage('Gym name is required', 'error');
+        showMessage(t('gymForm.create.nameRequired'), 'error');
         return;
       }
 
@@ -45,17 +47,17 @@ export default function CreateGymForm({ boardUuid, onSuccess, onCancel }: Create
       });
 
       if (data) {
-        showMessage(`Gym "${data.createGym.name}" created!`, 'success');
+        showMessage(t('gymForm.create.createdNamed', { name: data.createGym.name }), 'success');
         onSuccess?.(data.createGym);
       }
     },
-    [execute, boardUuid, showMessage, onSuccess],
+    [execute, boardUuid, showMessage, onSuccess, t],
   );
 
   return (
     <GymForm
-      title="Create Gym"
-      submitLabel="Create Gym"
+      title={t('gymForm.create.title')}
+      submitLabel={t('gymForm.create.submit')}
       initialValues={{
         name: '',
         description: '',

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import MuiTypography from '@mui/material/Typography';
@@ -52,6 +53,7 @@ type GymDetailProps = {
 };
 
 export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 'bottom' }: GymDetailProps) {
+  const { t } = useTranslation('boards');
   const [gym, setGym] = useState<Gym | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
@@ -100,12 +102,12 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
       await client.request<DeleteGymMutationResponse, DeleteGymMutationVariables>(DELETE_GYM, {
         gymUuid: gym.uuid,
       });
-      showMessage('Gym deleted', 'success');
+      showMessage(t('gymEntity.snackbar.deleted'), 'success');
       onDeleted?.();
       onClose();
     } catch (error) {
       console.error('Failed to delete gym:', error);
-      showMessage('Failed to delete gym', 'error');
+      showMessage(t('gymEntity.snackbar.deleteFailed'), 'error');
     } finally {
       setIsDeleting(false);
     }
@@ -126,7 +128,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
   } else if (!gym) {
     drawerContent = (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-        <MuiTypography color="text.secondary">Gym not found</MuiTypography>
+        <MuiTypography color="text.secondary">{t('gymEntity.notFound')}</MuiTypography>
       </Box>
     );
   } else if (isEditing) {
@@ -181,10 +183,26 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
 
           {/* Stats */}
           <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
-            <StatChip icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />} value={gym.boardCount} label="boards" />
-            <StatChip icon={<PersonOutlined sx={{ fontSize: 16 }} />} value={gym.memberCount} label="members" />
-            <StatChip icon={<PeopleOutlined sx={{ fontSize: 16 }} />} value={gym.followerCount} label="followers" />
-            <StatChip icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />} value={gym.commentCount} label="comments" />
+            <StatChip
+              icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />}
+              value={gym.boardCount}
+              label={t('gymEntity.stats.boards')}
+            />
+            <StatChip
+              icon={<PersonOutlined sx={{ fontSize: 16 }} />}
+              value={gym.memberCount}
+              label={t('gymEntity.stats.members')}
+            />
+            <StatChip
+              icon={<PeopleOutlined sx={{ fontSize: 16 }} />}
+              value={gym.followerCount}
+              label={t('gymEntity.stats.followers')}
+            />
+            <StatChip
+              icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
+              value={gym.commentCount}
+              label={t('gymEntity.stats.comments')}
+            />
           </Box>
 
           {/* Actions */}
@@ -195,7 +213,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                 initialIsFollowing={gym.isFollowedByMe}
                 followMutation={FOLLOW_GYM}
                 unfollowMutation={UNFOLLOW_GYM}
-                entityLabel="gym"
+                entityLabel={t('gymEntity.follow.entityLabel')}
                 getFollowVariables={(id) => ({ input: { gymUuid: id } })}
                 onFollowChange={() => fetchGym()}
               />
@@ -209,7 +227,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                   onClick={() => setIsEditing(true)}
                   sx={{ textTransform: 'none' }}
                 >
-                  Edit
+                  {t('gymEntity.actions.edit')}
                 </MuiButton>
                 <MuiButton
                   variant="outlined"
@@ -220,7 +238,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                   disabled={isDeleting}
                   sx={{ textTransform: 'none' }}
                 >
-                  {isDeleting ? <CircularProgress size={16} /> : 'Delete'}
+                  {isDeleting ? <CircularProgress size={16} /> : t('gymEntity.actions.delete')}
                 </MuiButton>
               </>
             )}
@@ -231,14 +249,16 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
 
         {/* Tabs */}
         <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ px: 2 }}>
-          <Tab label="Members" sx={{ textTransform: 'none' }} />
-          <Tab label="Comments" sx={{ textTransform: 'none' }} />
+          <Tab label={t('gymEntity.tabs.members')} sx={{ textTransform: 'none' }} />
+          <Tab label={t('gymEntity.tabs.comments')} sx={{ textTransform: 'none' }} />
         </Tabs>
 
         {/* Tab content */}
         <Box sx={{ flex: 1, overflow: 'auto', px: 2, py: 2 }}>
           {activeTab === 0 && <GymMemberManagement gymUuid={gym.uuid} isOwnerOrAdmin={isOwnerOrAdmin} />}
-          {activeTab === 1 && <CommentSection entityType="gym" entityId={gym.uuid} title="Gym Discussion" />}
+          {activeTab === 1 && (
+            <CommentSection entityType="gym" entityId={gym.uuid} title={t('gymEntity.comments.title')} />
+          )}
         </Box>
       </>
     );
@@ -258,14 +278,14 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
 
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
-        <DialogTitle>Delete Gym</DialogTitle>
+        <DialogTitle>{t('gymEntity.delete.title')}</DialogTitle>
         <DialogContent>
-          <DialogContentText>Delete &quot;{gym?.name}&quot;? This action can be undone later.</DialogContentText>
+          <DialogContentText>{t('gymEntity.delete.confirm', { name: gym?.name ?? '' })}</DialogContentText>
         </DialogContent>
         <DialogActions>
-          <MuiButton onClick={() => setShowDeleteDialog(false)}>Cancel</MuiButton>
+          <MuiButton onClick={() => setShowDeleteDialog(false)}>{t('gymEntity.delete.cancel')}</MuiButton>
           <MuiButton onClick={handleDeleteConfirm} color="error" autoFocus>
-            Delete
+            {t('gymEntity.delete.delete')}
           </MuiButton>
         </DialogActions>
       </Dialog>

--- a/packages/web/app/components/gym-entity/gym-form.tsx
+++ b/packages/web/app/components/gym-entity/gym-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Switch from '@mui/material/Switch';
@@ -36,6 +37,7 @@ export default function GymForm({
   onSubmit,
   onCancel,
 }: GymFormProps) {
+  const { t } = useTranslation('boards');
   const [name, setName] = useState(initialValues.name);
   const [slug, setSlug] = useState(initialValues.slug ?? '');
   const [description, setDescription] = useState(initialValues.description);
@@ -69,19 +71,19 @@ export default function GymForm({
       <MuiTypography variant="h6">{title}</MuiTypography>
 
       <TextField
-        label="Gym Name"
+        label={t('gymForm.fields.name')}
         value={name}
         onChange={(e) => setName(e.target.value)}
         required
         fullWidth
         size="small"
-        placeholder="e.g., Boulder World, The Climbing Factory"
+        placeholder={t('gymForm.placeholders.name')}
         inputProps={{ maxLength: 100 }}
       />
 
       {showSlugField && (
         <TextField
-          label="URL Slug"
+          label={t('gymForm.fields.slug')}
           value={slug}
           onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
           fullWidth
@@ -91,7 +93,7 @@ export default function GymForm({
       )}
 
       <TextField
-        label="Description"
+        label={t('gymForm.fields.description')}
         value={description}
         onChange={(e) => setDescription(e.target.value)}
         fullWidth
@@ -99,46 +101,46 @@ export default function GymForm({
         multiline
         minRows={2}
         maxRows={4}
-        placeholder="Optional description"
+        placeholder={t('gymForm.placeholders.description')}
       />
 
       <TextField
-        label="Address"
+        label={t('gymForm.fields.address')}
         value={address}
         onChange={(e) => setAddress(e.target.value)}
         fullWidth
         size="small"
-        placeholder="e.g., 123 Main St, City"
+        placeholder={t('gymForm.placeholders.address')}
       />
 
       <TextField
-        label="Contact Email"
+        label={t('gymForm.fields.contactEmail')}
         value={contactEmail}
         onChange={(e) => setContactEmail(e.target.value)}
         fullWidth
         size="small"
         type="email"
-        placeholder="Optional contact email"
+        placeholder={t('gymForm.placeholders.contactEmail')}
       />
 
       <TextField
-        label="Contact Phone"
+        label={t('gymForm.fields.contactPhone')}
         value={contactPhone}
         onChange={(e) => setContactPhone(e.target.value)}
         fullWidth
         size="small"
-        placeholder="Optional contact phone"
+        placeholder={t('gymForm.placeholders.contactPhone')}
       />
 
       <FormControlLabel
         control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />}
-        label="Public gym"
+        label={t('gymForm.fields.isPublic')}
       />
 
       <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end', mt: 1 }}>
         {onCancel && (
           <MuiButton variant="text" onClick={onCancel} disabled={isSubmitting}>
-            Cancel
+            {t('gymForm.actions.cancel')}
           </MuiButton>
         )}
         <MuiButton type="submit" variant="contained" disabled={isSubmitting || !name.trim()}>

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -35,6 +35,7 @@ export const SEED_NAMESPACES = [
   'admin',
   'aurora',
   'errors',
+  'boards',
 ] as const;
 export type SeedNamespace = (typeof SEED_NAMESPACES)[number];
 

--- a/packages/web/i18n/locales/en-US/boards.json
+++ b/packages/web/i18n/locales/en-US/boards.json
@@ -1,0 +1,154 @@
+{
+  "discovery": {
+    "section": {
+      "nearby": "Boards near you"
+    },
+    "findNearby": {
+      "loading": "Finding boards…",
+      "geoDenied": "Location unavailable",
+      "error": "Failed to load nearby boards",
+      "noResults": "No nearby boards found",
+      "idle": "Find nearby"
+    },
+    "search": {
+      "ariaLabel": "Search for a board",
+      "label": "Search"
+    },
+    "custom": {
+      "ariaLabel": "Build a custom board",
+      "label": "Custom board"
+    },
+    "create": {
+      "defaultLabel": "New Board"
+    },
+    "bluetooth": {
+      "scanning": "Scanning…",
+      "boardsFound": "Boards found",
+      "noBoardsFound": "No boards found",
+      "unavailable": "Bluetooth unavailable",
+      "idle": "Quick start"
+    }
+  },
+  "boardEntity": {
+    "notFound": "Board not found",
+    "chips": {
+      "unlisted": "Unlisted",
+      "locationHidden": "Location hidden"
+    },
+    "tabs": {
+      "leaderboard": "Leaderboard",
+      "comments": "Comments"
+    },
+    "actions": {
+      "addToGym": "Add to Gym",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "stats": {
+      "ascents": "ascents",
+      "climbers": "climbers",
+      "followers": "followers",
+      "comments": "comments"
+    },
+    "delete": {
+      "confirm": "Delete \"{{name}}\"? This action can be undone later."
+    },
+    "snackbar": {
+      "deleted": "Board deleted",
+      "deleteFailed": "Failed to delete board",
+      "linkedToGym": "Board linked to gym",
+      "unlinkedFromGym": "Board unlinked from gym",
+      "linkFailed": "Failed to link board to gym"
+    },
+    "comments": {
+      "title": "Board Discussion"
+    },
+    "follow": {
+      "entityLabel": "board"
+    }
+  },
+  "boardForm": {
+    "create": {
+      "submit": "Create Board",
+      "authRequired": "You must be signed in to create a board",
+      "errorMessage": "Failed to create board. It may already exist for this configuration.",
+      "nameRequired": "Board name is required",
+      "createdNamed": "Board \"{{name}}\" created!",
+      "namePlaceholder": "e.g., Home Board, Gym Name",
+      "locationPlaceholder": "e.g., City, Gym Name"
+    }
+  },
+  "selectorDrawer": {
+    "customTitle": "Custom Board",
+    "createTitle": "Create Board",
+    "createButton": "Create board",
+    "quickSession": "Quick session",
+    "configSection": {
+      "label": "Board config",
+      "title": "Board config",
+      "defaultSummary": "Select a board"
+    }
+  },
+  "gymEntity": {
+    "notFound": "Gym not found",
+    "tabs": {
+      "members": "Members",
+      "comments": "Comments"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "stats": {
+      "boards": "boards",
+      "members": "members",
+      "followers": "followers",
+      "comments": "comments"
+    },
+    "delete": {
+      "title": "Delete Gym",
+      "confirm": "Delete \"{{name}}\"? This action can be undone later.",
+      "cancel": "Cancel",
+      "delete": "Delete"
+    },
+    "snackbar": {
+      "deleted": "Gym deleted",
+      "deleteFailed": "Failed to delete gym"
+    },
+    "comments": {
+      "title": "Gym Discussion"
+    },
+    "follow": {
+      "entityLabel": "gym"
+    }
+  },
+  "gymForm": {
+    "fields": {
+      "name": "Gym Name",
+      "slug": "URL Slug",
+      "description": "Description",
+      "address": "Address",
+      "contactEmail": "Contact Email",
+      "contactPhone": "Contact Phone",
+      "isPublic": "Public gym"
+    },
+    "placeholders": {
+      "name": "e.g., Boulder World, The Climbing Factory",
+      "description": "Optional description",
+      "address": "e.g., 123 Main St, City",
+      "contactEmail": "Optional contact email",
+      "contactPhone": "Optional contact phone"
+    },
+    "actions": {
+      "cancel": "Cancel"
+    },
+    "create": {
+      "title": "Create Gym",
+      "submit": "Create Gym",
+      "authRequired": "You must be signed in to create a gym",
+      "errorMessage": "Failed to create gym",
+      "nameRequired": "Gym name is required",
+      "createdNamed": "Gym \"{{name}}\" created!"
+    }
+  }
+}

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -246,5 +246,18 @@
         "saveFailed": "Failed to save favorite. Please try again."
       }
     }
+  },
+  "liked": {
+    "heroTitle": "Liked Climbs",
+    "heroSubtitle": "Your favorite climbs",
+    "signInRequired": "Sign In Required",
+    "signInBody": "Please sign in to view your liked climbs.",
+    "actionsAriaLabel": "Actions",
+    "queueAll": "Queue All",
+    "adding": "Adding...",
+    "noClimbsToAdd": "No climbs to add",
+    "addedToQueue_one": "Added {{count}} climb to queue",
+    "addedToQueue_other": "Added {{count}} climbs to queue",
+    "addToQueueFailed": "Failed to add climbs to queue"
   }
 }

--- a/packages/web/i18n/locales/es/boards.json
+++ b/packages/web/i18n/locales/es/boards.json
@@ -1,0 +1,154 @@
+{
+  "discovery": {
+    "section": {
+      "nearby": "Tableros cerca de ti"
+    },
+    "findNearby": {
+      "loading": "Buscando tableros…",
+      "geoDenied": "Ubicación no disponible",
+      "error": "Error al cargar tableros cercanos",
+      "noResults": "No se encontraron tableros cercanos",
+      "idle": "Buscar cerca"
+    },
+    "search": {
+      "ariaLabel": "Buscar un tablero",
+      "label": "Buscar"
+    },
+    "custom": {
+      "ariaLabel": "Crear un tablero personalizado",
+      "label": "Tablero personalizado"
+    },
+    "create": {
+      "defaultLabel": "Nuevo tablero"
+    },
+    "bluetooth": {
+      "scanning": "Escaneando…",
+      "boardsFound": "Tableros encontrados",
+      "noBoardsFound": "No se encontraron tableros",
+      "unavailable": "Bluetooth no disponible",
+      "idle": "Inicio rápido"
+    }
+  },
+  "boardEntity": {
+    "notFound": "Tablero no encontrado",
+    "chips": {
+      "unlisted": "No listado",
+      "locationHidden": "Ubicación oculta"
+    },
+    "tabs": {
+      "leaderboard": "Clasificación",
+      "comments": "Comentarios"
+    },
+    "actions": {
+      "addToGym": "Añadir al gimnasio",
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "stats": {
+      "ascents": "ascensiones",
+      "climbers": "escaladores",
+      "followers": "seguidores",
+      "comments": "comentarios"
+    },
+    "delete": {
+      "confirm": "¿Eliminar \"{{name}}\"? Esta acción se puede deshacer más tarde."
+    },
+    "snackbar": {
+      "deleted": "Tablero eliminado",
+      "deleteFailed": "Error al eliminar el tablero",
+      "linkedToGym": "Tablero vinculado al gimnasio",
+      "unlinkedFromGym": "Tablero desvinculado del gimnasio",
+      "linkFailed": "Error al vincular el tablero al gimnasio"
+    },
+    "comments": {
+      "title": "Discusión del tablero"
+    },
+    "follow": {
+      "entityLabel": "tablero"
+    }
+  },
+  "boardForm": {
+    "create": {
+      "submit": "Crear tablero",
+      "authRequired": "Debes iniciar sesión para crear un tablero",
+      "errorMessage": "Error al crear el tablero. Puede que ya exista para esta configuración.",
+      "nameRequired": "Se requiere el nombre del tablero",
+      "createdNamed": "¡Tablero \"{{name}}\" creado!",
+      "namePlaceholder": "p. ej., Tablero de casa, Nombre del gimnasio",
+      "locationPlaceholder": "p. ej., Ciudad, Nombre del gimnasio"
+    }
+  },
+  "selectorDrawer": {
+    "customTitle": "Tablero personalizado",
+    "createTitle": "Crear tablero",
+    "createButton": "Crear tablero",
+    "quickSession": "Sesión rápida",
+    "configSection": {
+      "label": "Configuración del tablero",
+      "title": "Configuración del tablero",
+      "defaultSummary": "Selecciona un tablero"
+    }
+  },
+  "gymEntity": {
+    "notFound": "Gimnasio no encontrado",
+    "tabs": {
+      "members": "Miembros",
+      "comments": "Comentarios"
+    },
+    "actions": {
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "stats": {
+      "boards": "tableros",
+      "members": "miembros",
+      "followers": "seguidores",
+      "comments": "comentarios"
+    },
+    "delete": {
+      "title": "Eliminar gimnasio",
+      "confirm": "¿Eliminar \"{{name}}\"? Esta acción se puede deshacer más tarde.",
+      "cancel": "Cancelar",
+      "delete": "Eliminar"
+    },
+    "snackbar": {
+      "deleted": "Gimnasio eliminado",
+      "deleteFailed": "Error al eliminar el gimnasio"
+    },
+    "comments": {
+      "title": "Discusión del gimnasio"
+    },
+    "follow": {
+      "entityLabel": "gimnasio"
+    }
+  },
+  "gymForm": {
+    "fields": {
+      "name": "Nombre del gimnasio",
+      "slug": "URL personalizada",
+      "description": "Descripción",
+      "address": "Dirección",
+      "contactEmail": "Correo de contacto",
+      "contactPhone": "Teléfono de contacto",
+      "isPublic": "Gimnasio público"
+    },
+    "placeholders": {
+      "name": "p. ej., Boulder World, The Climbing Factory",
+      "description": "Descripción opcional",
+      "address": "p. ej., Calle Mayor 123, Ciudad",
+      "contactEmail": "Correo de contacto opcional",
+      "contactPhone": "Teléfono de contacto opcional"
+    },
+    "actions": {
+      "cancel": "Cancelar"
+    },
+    "create": {
+      "title": "Crear gimnasio",
+      "submit": "Crear gimnasio",
+      "authRequired": "Debes iniciar sesión para crear un gimnasio",
+      "errorMessage": "Error al crear el gimnasio",
+      "nameRequired": "Se requiere el nombre del gimnasio",
+      "createdNamed": "¡Gimnasio \"{{name}}\" creado!"
+    }
+  }
+}

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -246,5 +246,18 @@
         "saveFailed": "No se pudo guardar el favorito. Inténtalo de nuevo."
       }
     }
+  },
+  "liked": {
+    "heroTitle": "Bloques favoritos",
+    "heroSubtitle": "Tus bloques favoritos",
+    "signInRequired": "Inicio de sesión requerido",
+    "signInBody": "Inicia sesión para ver tus bloques favoritos.",
+    "actionsAriaLabel": "Acciones",
+    "queueAll": "Añadir todos a la cola",
+    "adding": "Añadiendo...",
+    "noClimbsToAdd": "No hay bloques que añadir",
+    "addedToQueue_one": "Se añadió {{count}} bloque a la cola",
+    "addedToQueue_other": "Se añadieron {{count}} bloques a la cola",
+    "addToQueueFailed": "Error al añadir los bloques a la cola"
   }
 }


### PR DESCRIPTION
## Summary

Closes #1818. Adds Spanish coverage for board/gym discovery and entity surfaces — what was previously hardcoded English literals on `/es/*`.

- New `boards` namespace (`packages/web/i18n/locales/{en-US,es}/boards.json`) registered in `SEED_NAMESPACES`. Covers discovery cards (find-nearby, search, custom, create, bluetooth, "Boards near you"), the board entity drawer (chips, tabs, stats, snackbars, delete confirm, "Add to Gym"), the create-board form, the gym entity drawer (tabs, stats, delete dialog, snackbars), the gym form (labels + placeholders), the create-gym form, and the board selector drawer (drawer titles, buttons, config section labels).
- New `climbs.liked.*` keys for `liked-climbs-view-content.tsx`, including ICU plural for "Added {{count}} climb(s) to queue".
- 13 component files wrapped: every user-facing string the issue listed now flows through `t(...)`. Spanish catalog ships full translations rather than relying on the English fallback.

## Test plan

- [ ] `vp run typecheck:web` (passes)
- [ ] `vp lint` on changed files — 0 errors (only the pre-existing `no-floating-promises` warning on `startScan()`)
- [ ] `vp fmt --check` on changed files — clean
- [ ] Manual smoke on `/es/*`: board discovery scroll, create board, edit/delete board, gym detail drawer, liked climbs view

https://claude.ai/code/session_01M4b5JqYtKagDDxQyjs6a89

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4b5JqYtKagDDxQyjs6a89)_