### PR TITLE
i18n: translate social, library, and misc edge cases

### DIFF
--- a/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Skeleton from '@mui/material/Skeleton';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import BoardseshBetaCard from './boardsesh-beta-card';
@@ -12,6 +13,7 @@ type BoardseshBetaListProps = {
 };
 
 const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading }) => {
+  const { t } = useTranslation('common');
   return (
     <div className={styles.section}>
       <div className={styles.scrollContainer}>
@@ -28,7 +30,7 @@ const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading 
             {links.map((link) => (
               <BoardseshBetaCard key={link.link} link={link} />
             ))}
-            {links.length === 0 && <span className={styles.emptyText}>No beta videos yet</span>}
+            {links.length === 0 && <span className={styles.emptyText}>{t('betaVideos.empty')}</span>}
           </>
         )}
       </div>

--- a/packages/web/app/components/board-renderer/__tests__/zoomable-board.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/zoomable-board.test.tsx
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import ZoomableBoard from '../zoomable-board';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock the useZoomPan hook
 const mockResetZoom = vi.fn();

--- a/packages/web/app/components/board-renderer/zoomable-board.tsx
+++ b/packages/web/app/components/board-renderer/zoomable-board.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import CropFreeOutlined from '@mui/icons-material/CropFreeOutlined';
 import { useZoomPan } from '@/app/lib/hooks/use-zoom-pan';
@@ -13,6 +14,7 @@ type ZoomableBoardProps = {
 };
 
 const ZoomableBoard = memo(function ZoomableBoard({ children, onZoomChange, resetKey }: ZoomableBoardProps) {
+  const { t } = useTranslation('common');
   const { containerRef, contentRef, isZoomed, resetZoom, gestureHandlers } = useZoomPan();
   const prevResetKeyRef = useRef(resetKey);
 
@@ -43,7 +45,7 @@ const ZoomableBoard = memo(function ZoomableBoard({ children, onZoomChange, rese
       <Button
         className={`${styles.zoomResetButton} ${isZoomed ? styles.zoomResetButtonVisible : ''}`}
         onClick={resetZoom}
-        aria-label="Reset zoom"
+        aria-label={t('board.resetZoom')}
         size="small"
         startIcon={<CropFreeOutlined sx={{ fontSize: '18px !important' }} />}
         tabIndex={isZoomed ? 0 : -1}

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import MuiAlert from '@mui/material/Alert';
 import MuiTooltip from '@mui/material/Tooltip';
@@ -133,6 +134,7 @@ export default function CreateClimbForm({
   layoutId,
   holdSetImages,
 }: CreateClimbFormProps) {
+  const { t } = useTranslation('climbs');
   const pathname = usePathname();
   const { data: session } = useSession();
   const { mode } = useColorMode();
@@ -1086,8 +1088,8 @@ export default function CreateClimbForm({
       if (boardType === 'aurora') {
         setPendingFormValues({ name: climbName, description, isDraft });
         openAuthModal({
-          title: 'Sign in to save your climb',
-          description: 'Create an account or sign in to save your climb to the board.',
+          title: t('create.auth.signInTitle'),
+          description: t('create.auth.signInDescription'),
           onSuccess: handleAuthSuccess,
         });
       }
@@ -1113,6 +1115,7 @@ export default function CreateClimbForm({
     openAuthModal,
     handleAuthSuccess,
     showMessage,
+    t,
   ]);
 
   const canSave =
@@ -1259,18 +1262,18 @@ export default function CreateClimbForm({
   const saveIconButton = useMemo(() => {
     if (boardType === 'aurora' && !isAuthenticated) {
       return (
-        <MuiTooltip title="Sign in to save your climb">
+        <MuiTooltip title={t('create.auth.signInTitle')}>
           <IconButton
             size="small"
             color="primary"
             onClick={() =>
               openAuthModal({
-                title: 'Sign in to save your climb',
-                description: 'Create an account or sign in to save your climb to the board.',
+                title: t('create.auth.signInTitle'),
+                description: t('create.auth.signInDescription'),
                 onSuccess: handleAuthSuccess,
               })
             }
-            aria-label="Sign in to save"
+            aria-label={t('create.auth.signInAria')}
           >
             <LoginOutlined fontSize="small" />
           </IconButton>
@@ -1280,8 +1283,14 @@ export default function CreateClimbForm({
 
     if (boardType === 'moonboard' && !hasMoonBoardSessionUser) {
       return (
-        <MuiTooltip title="Log in to save your climb">
-          <IconButton size="small" color="primary" component={LocaleLink} href="/api/auth/signin" aria-label="Log in to save">
+        <MuiTooltip title={t('create.auth.logInTitle')}>
+          <IconButton
+            size="small"
+            color="primary"
+            component={LocaleLink}
+            href="/api/auth/signin"
+            aria-label={t('create.auth.logInAria')}
+          >
             <LoginOutlined fontSize="small" />
           </IconButton>
         </MuiTooltip>
@@ -1290,9 +1299,9 @@ export default function CreateClimbForm({
 
     if (editLocked) {
       return (
-        <MuiTooltip title="Published climbs can only be edited for 24 hours after first publish.">
+        <MuiTooltip title={t('create.auth.editLockedTitle')}>
           <span>
-            <IconButton size="small" disabled aria-label="Edit window closed">
+            <IconButton size="small" disabled aria-label={t('create.auth.editLockedAria')}>
               <LockOutlined fontSize="small" />
             </IconButton>
           </span>
@@ -1305,8 +1314,8 @@ export default function CreateClimbForm({
       // another save. Flips back automatically on the next edit or after
       // the 3s timeout.
       return (
-        <MuiTooltip title="Saved">
-          <IconButton size="small" color="success" disableRipple aria-label="Saved">
+        <MuiTooltip title={t('create.auth.savedTitle')}>
+          <IconButton size="small" color="success" disableRipple aria-label={t('create.auth.savedAria')}>
             <CheckCircleOutlined fontSize="small" />
           </IconButton>
         </MuiTooltip>
@@ -1359,6 +1368,7 @@ export default function CreateClimbForm({
     handlePublish,
     openAuthModal,
     handleAuthSuccess,
+    t,
   ]);
 
   const titleClimb: ClimbTitleData = useMemo(

--- a/packages/web/app/components/feedback/feedback-prompt-banner.tsx
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Paper from '@mui/material/Paper';
 import Fade from '@mui/material/Fade';
 import IconButton from '@mui/material/IconButton';
@@ -20,6 +21,7 @@ type BannerBodyProps = {
 };
 
 const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubmitted, titleId }) => {
+  const { t } = useTranslation('common');
   const { mutate } = useSubmitAppFeedback();
   const { showMessage } = useSnackbar();
 
@@ -49,7 +51,7 @@ const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubm
       </IconButton>
       <FeedbackForm
         mode="prompt"
-        title="Enjoying Boardsesh?"
+        title={t('feedback.title')}
         submitLabel="Save"
         onSubmit={handleSubmit}
         titleId={titleId}

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -306,6 +307,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     allowInstagramLinking,
     isSwipeHintTarget,
   }) => {
+    const { t } = useTranslation('common');
     const [isActionsOpen, setIsActionsOpen] = useState(false);
     const [instagramDialogOpen, setInstagramDialogOpen] = useState(false);
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
@@ -771,7 +773,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                     fullWidth
                     size="small"
                     variant="outlined"
-                    placeholder="Comment..."
+                    placeholder={t('comment.shortPlaceholder')}
                     multiline
                     minRows={1}
                     maxRows={commentFocused ? 4 : 1}

--- a/packages/web/app/components/library/playlist-edit-drawer.tsx
+++ b/packages/web/app/components/library/playlist-edit-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import dynamic from 'next/dynamic';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import MuiButton from '@mui/material/Button';
@@ -62,6 +63,7 @@ type PlaylistEditDrawerProps = {
 const INITIAL_FORM_VALUES = { name: '', description: '', color: '', icon: '', isPublic: false };
 
 export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess }: PlaylistEditDrawerProps) {
+  const { t } = useTranslation('playlists');
   const [formValues, setFormValues] = useState(INITIAL_FORM_VALUES);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
@@ -88,12 +90,12 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
   const validateForm = (): boolean => {
     const errors: Record<string, string> = {};
     if (!formValues.name.trim()) {
-      errors.name = 'Please enter a playlist name';
+      errors.name = t('edit.validation.nameRequired');
     } else if (formValues.name.length > 100) {
-      errors.name = 'Name must be 100 characters or less';
+      errors.name = t('edit.validation.nameTooLong');
     }
     if (formValues.description.length > 500) {
-      errors.description = 'Description must be 500 characters or less';
+      errors.description = t('edit.validation.descriptionTooLong');
     }
     setFormErrors(errors);
     return Object.keys(errors).length === 0;
@@ -128,12 +130,12 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
         token,
       );
 
-      showMessage('Playlist updated successfully', 'success');
+      showMessage(t('edit.messages.updated'), 'success');
       onSuccess(response.updatePlaylist);
       onClose();
     } catch (error) {
       console.error('Error updating playlist:', error);
-      showMessage('Failed to update playlist', 'error');
+      showMessage(t('edit.messages.updateFailed'), 'error');
     } finally {
       setLoading(false);
     }
@@ -153,7 +155,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
   return (
     <SwipeableDrawer
-      title="Edit Playlist"
+      title={t('edit.title')}
       open={open}
       onClose={handleCancel}
       placement="bottom"
@@ -166,10 +168,10 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
       extra={
         <Stack direction="row" spacing={1}>
           <MuiButton variant="outlined" onClick={handleCancel}>
-            Cancel
+            {t('edit.actions.cancel')}
           </MuiButton>
           <MuiButton variant="contained" onClick={handleSubmit} disabled={loading}>
-            {loading ? 'Saving...' : 'Save'}
+            {loading ? t('edit.actions.saving') : t('edit.actions.save')}
           </MuiButton>
         </Stack>
       }
@@ -177,10 +179,10 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
       <Box sx={{ maxWidth: 600, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            Playlist Name
+            {t('edit.fields.name')}
           </Typography>
           <TextField
-            placeholder="e.g., Hard Crimps"
+            placeholder={t('edit.fields.namePlaceholder')}
             slotProps={{ htmlInput: { maxLength: 100 } }}
             fullWidth
             size="small"
@@ -196,10 +198,10 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            Description
+            {t('edit.fields.description')}
           </Typography>
           <TextField
-            placeholder="Optional description for your playlist..."
+            placeholder={t('edit.fields.descriptionPlaceholder')}
             multiline
             rows={3}
             slotProps={{ htmlInput: { maxLength: 500 } }}
@@ -217,7 +219,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            Color
+            {t('edit.fields.color')}
           </Typography>
           <TextField
             type="color"
@@ -230,7 +232,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            Icon
+            {t('edit.fields.icon')}
           </Typography>
           <Stack direction="row" spacing={1} alignItems="center">
             <MuiButton
@@ -247,7 +249,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
                 startIcon={<CloseOutlined />}
                 onClick={() => setFormValues((prev) => ({ ...prev, icon: '' }))}
               >
-                Remove
+                {t('edit.fields.removeIcon')}
               </MuiButton>
             )}
           </Stack>
@@ -270,7 +272,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            Visibility
+            {t('edit.fields.visibility')}
           </Typography>
           <Stack spacing={0.5}>
             <Stack direction="row" spacing={1} alignItems="center">
@@ -279,9 +281,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
               <PublicOutlined sx={{ fontSize: 18, color: isPublic ? 'text.secondary' : 'text.disabled' }} />
             </Stack>
             <Typography variant="body2" component="span" color="text.secondary" sx={{ fontSize: 12 }}>
-              {isPublic
-                ? 'Public playlists can be viewed by anyone with the link'
-                : 'Private playlists are only visible to you'}
+              {isPublic ? t('edit.fields.publicHint') : t('edit.fields.privateHint')}
             </Typography>
           </Stack>
         </Box>

--- a/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Stack from '@mui/material/Stack';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -36,6 +37,7 @@ export default function MoonBoardImportCard({
   onEdit,
   onRemove,
 }: MoonBoardImportCardProps) {
+  const { t } = useTranslation('common');
   const totalHolds = climb.holds.start.length + climb.holds.hand.length + climb.holds.finish.length;
   const duplicateMessage = duplicateMatch?.existingClimbName
     ? `Skipping: Already Exists as "${duplicateMatch.existingClimbName}"`
@@ -93,7 +95,7 @@ export default function MoonBoardImportCard({
           Edit
         </MuiButton>
         <ConfirmPopover
-          title="Remove this climb?"
+          title={t('moonboardImport.removeConfirmTitle')}
           description="This climb will not be imported."
           onConfirm={onRemove}
           okText="Remove"

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, useDeferredValue } from 'react';
+import { useTranslation } from 'react-i18next';
 import { track } from '@vercel/analytics';
 import MuiBadge from '@mui/material/Badge';
 import IconButton from '@mui/material/IconButton';
@@ -194,6 +195,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
   onClose,
   onError,
 }) {
+  const { t } = useTranslation('common');
   const { logbook } = useBoardProvider();
   const [tickComment, setTickComment] = useState('');
   const [commentFocused, setCommentFocused] = useState(false);
@@ -309,7 +311,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                     fullWidth
                     size="small"
                     variant="outlined"
-                    placeholder="Comment..."
+                    placeholder={t('comment.shortPlaceholder')}
                     multiline
                     minRows={1}
                     maxRows={commentFocused ? 4 : 1}

--- a/packages/web/app/components/social/__tests__/vote-button.test.tsx
+++ b/packages/web/app/components/social/__tests__/vote-button.test.tsx
@@ -1,9 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import VoteButton from '../vote-button';
 
 // --- Mocks ---
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockRequest = vi.fn();
 vi.mock('@/app/lib/graphql/client', () => ({

--- a/packages/web/app/components/social/comment-item.tsx
+++ b/packages/web/app/components/social/comment-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import MuiAvatar from '@mui/material/Avatar';
@@ -57,6 +58,7 @@ export default function CommentItem({
   depth = 0,
   currentUserId,
 }: CommentItemProps) {
+  const { t } = useTranslation('common');
   const [isEditing, setIsEditing] = useState(false);
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [replies, setReplies] = useState<CommentType[]>([]);
@@ -81,10 +83,10 @@ export default function CommentItem({
         onCommentUpdated(response.updateComment);
         setIsEditing(false);
       } catch {
-        showMessage('Failed to update comment', 'error');
+        showMessage(t('comment.errors.update'), 'error');
       }
     },
-    [token, comment.uuid, onCommentUpdated, showMessage],
+    [token, comment.uuid, onCommentUpdated, showMessage, t],
   );
 
   const handleDelete = useCallback(async () => {
@@ -96,9 +98,9 @@ export default function CommentItem({
       });
       onCommentDeleted(comment.uuid);
     } catch {
-      showMessage('Failed to delete comment', 'error');
+      showMessage(t('comment.errors.delete'), 'error');
     }
-  }, [token, comment.uuid, onCommentDeleted, showMessage]);
+  }, [token, comment.uuid, onCommentDeleted, showMessage, t]);
 
   const handleReply = useCallback(
     async (body: string) => {
@@ -117,10 +119,10 @@ export default function CommentItem({
         setShowReplyForm(false);
         setRepliesLoaded(true);
       } catch {
-        showMessage('Failed to post reply', 'error');
+        showMessage(t('comment.errors.reply'), 'error');
       }
     },
-    [token, entityType, entityId, comment.uuid, showMessage],
+    [token, entityType, entityId, comment.uuid, showMessage, t],
   );
 
   const loadReplies = useCallback(async () => {
@@ -141,11 +143,11 @@ export default function CommentItem({
       setReplies(response.comments.comments);
       setRepliesLoaded(true);
     } catch {
-      showMessage('Failed to load replies', 'error');
+      showMessage(t('comment.errors.loadReplies'), 'error');
     } finally {
       setRepliesLoading(false);
     }
-  }, [token, entityType, entityId, comment.uuid, repliesLoaded, repliesLoading, showMessage]);
+  }, [token, entityType, entityId, comment.uuid, repliesLoaded, repliesLoading, showMessage, t]);
 
   const handleReplyUpdated = useCallback((updated: CommentType) => {
     setReplies((prev) => prev.map((r) => (r.uuid === updated.uuid ? updated : r)));
@@ -163,7 +165,7 @@ export default function CommentItem({
     return (
       <Box sx={{ pl: depth > 0 ? 6 : 0, py: 0.5 }}>
         <MuiTypography variant="body2" color="text.disabled" sx={{ fontStyle: 'italic' }}>
-          [deleted]
+          {t('comment.deleted')}
         </MuiTypography>
         {/* Still show replies if they exist */}
         {comment.replyCount > 0 && !repliesLoaded && depth === 0 && (
@@ -173,7 +175,9 @@ export default function CommentItem({
             disabled={repliesLoading}
             sx={{ textTransform: 'none', ml: -0.5 }}
           >
-            Show {comment.replyCount} {comment.replyCount === 1 ? 'reply' : 'replies'}
+            {comment.replyCount === 1
+              ? t('comment.showRepliesOne')
+              : t('comment.showRepliesMany', { count: comment.replyCount })}
           </MuiButton>
         )}
         {replies.map((reply) => (
@@ -215,14 +219,14 @@ export default function CommentItem({
               href={`/profile/${comment.userId}`}
               sx={{ textDecoration: 'none', color: 'text.primary' }}
             >
-              {comment.userDisplayName || 'User'}
+              {comment.userDisplayName || t('comment.userFallback')}
             </MuiTypography>
             <MuiTypography variant="caption" color="text.secondary">
               {timeAgo}
             </MuiTypography>
             {wasEdited && (
               <MuiTypography variant="caption" color="text.secondary">
-                (edited)
+                {t('comment.edited')}
               </MuiTypography>
             )}
           </Box>
@@ -233,7 +237,7 @@ export default function CommentItem({
               initialBody={comment.body || ''}
               onSubmit={handleEdit}
               onCancel={() => setIsEditing(false)}
-              submitLabel="Save"
+              submitLabel={t('comment.save')}
               autoFocus
             />
           ) : (
@@ -263,7 +267,7 @@ export default function CommentItem({
                     fontSize: themeTokens.typography.fontSize.xs,
                   }}
                 >
-                  Reply
+                  {t('comment.reply')}
                 </MuiButton>
               )}
               {isAuthor && (
@@ -272,19 +276,23 @@ export default function CommentItem({
                     size="small"
                     onClick={() => setIsEditing(true)}
                     sx={{ color: 'var(--neutral-400)' }}
-                    aria-label="Edit comment"
+                    aria-label={t('comment.delete.editAria')}
                   >
                     <EditOutlined sx={{ fontSize: 16 }} />
                   </IconButton>
                   {/* TODO: Consider lifting ConfirmPopover to parent to avoid per-comment instances */}
                   <ConfirmPopover
-                    title="Delete comment"
-                    description="Are you sure you want to delete this comment? This cannot be undone."
+                    title={t('comment.delete.title')}
+                    description={t('comment.delete.description')}
                     onConfirm={handleDelete}
-                    okText="Delete"
+                    okText={t('comment.delete.confirm')}
                     okButtonProps={{ color: 'error' }}
                   >
-                    <IconButton size="small" sx={{ color: 'var(--neutral-400)' }} aria-label="Delete comment">
+                    <IconButton
+                      size="small"
+                      sx={{ color: 'var(--neutral-400)' }}
+                      aria-label={t('comment.delete.deleteAria')}
+                    >
                       <DeleteOutlined sx={{ fontSize: 16 }} />
                     </IconButton>
                   </ConfirmPopover>
@@ -299,7 +307,7 @@ export default function CommentItem({
               <CommentForm
                 onSubmit={handleReply}
                 onCancel={() => setShowReplyForm(false)}
-                placeholder="Write a reply..."
+                placeholder={t('comment.replyPlaceholder')}
                 autoFocus
               />
             </Box>
@@ -313,7 +321,9 @@ export default function CommentItem({
               disabled={repliesLoading}
               sx={{ textTransform: 'none', mt: 0.5, ml: -0.5 }}
             >
-              Show {comment.replyCount} {comment.replyCount === 1 ? 'reply' : 'replies'}
+              {comment.replyCount === 1
+                ? t('comment.showRepliesOne')
+                : t('comment.showRepliesMany', { count: comment.replyCount })}
             </MuiButton>
           )}
           {replies.map((reply) => (

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -60,6 +61,7 @@ type ProposalCardProps = {
 };
 
 export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDelete, highlight }: ProposalCardProps) {
+  const { t } = useTranslation('common');
   const pathname = usePathname();
   const isDark = useIsDarkMode();
   const { token } = useWsAuthToken();
@@ -78,7 +80,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
   const handleVote = useCallback(
     async (value: number) => {
       if (!token) {
-        setSnackbar('Sign in to vote on proposals');
+        setSnackbar(t('proposal.validation.signInToVote'));
         return;
       }
       setLoading(true);
@@ -90,12 +92,12 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
         setLocalProposal(result.voteOnProposal);
         onUpdate?.(result.voteOnProposal);
       } catch {
-        setSnackbar('Failed to vote');
+        setSnackbar(t('proposal.validation.failedToVote'));
       } finally {
         setLoading(false);
       }
     },
-    [token, localProposal.uuid, onUpdate],
+    [token, localProposal.uuid, onUpdate, t],
   );
 
   const handleResolve = useCallback(
@@ -110,12 +112,12 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
         setLocalProposal(result.resolveProposal);
         onUpdate?.(result.resolveProposal);
       } catch {
-        setSnackbar('Failed to resolve proposal');
+        setSnackbar(t('proposal.validation.failedToResolve'));
       } finally {
         setLoading(false);
       }
     },
-    [token, localProposal.uuid, onUpdate],
+    [token, localProposal.uuid, onUpdate, t],
   );
 
   const handleDelete = useCallback(async () => {
@@ -129,11 +131,11 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
       setShowDeleteDialog(false);
       onDelete?.(localProposal.uuid);
     } catch {
-      setSnackbar('Failed to delete proposal');
+      setSnackbar(t('proposal.validation.failedToDelete'));
     } finally {
       setLoading(false);
     }
-  }, [token, localProposal.uuid, onDelete]);
+  }, [token, localProposal.uuid, onDelete, t]);
 
   const climbAndBoardDetails = useMemo(() => {
     const { climbUuid, climbName, frames, layoutId, boardType, angle } = localProposal;

--- a/packages/web/app/components/social/vote-button.tsx
+++ b/packages/web/app/components/social/vote-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import MuiTypography from '@mui/material/Typography';
@@ -48,6 +49,7 @@ export default function VoteButton({
   const voteSummaryCtx = useVoteSummaryContext();
   const batchSummary = voteSummaryCtx?.getVoteSummary(entityId);
 
+  const { t } = useTranslation('common');
   const [upvotes, setUpvotes] = useState(initialUpvotes);
   const [downvotes, setDownvotes] = useState(initialDownvotes);
   const [userVote, setUserVote] = useState(initialUserVote ?? 0);
@@ -114,7 +116,7 @@ export default function VoteButton({
   const handleVote = useCallback(
     async (value: 1 | -1) => {
       if (!isAuthenticated || !token) {
-        showMessage('Sign in to vote', 'info');
+        showMessage(t('vote.signInPrompt'), 'info');
         return;
       }
 
@@ -177,12 +179,12 @@ export default function VoteButton({
           voteScore: prevUpvotes - prevDownvotes,
           userVote: prevUserVote,
         });
-        showMessage('Failed to vote', 'error');
+        showMessage(t('vote.failed'), 'error');
       } finally {
         setIsLoading(false);
       }
     },
-    [upvotes, downvotes, userVote, isAuthenticated, token, entityType, entityId, onVoteChange, showMessage],
+    [upvotes, downvotes, userVote, isAuthenticated, token, entityType, entityId, onVoteChange, showMessage, t],
   );
 
   const score = upvotes - downvotes;
@@ -196,7 +198,7 @@ export default function VoteButton({
           size="small"
           onClick={() => handleVote(1)}
           disabled={isLoading}
-          aria-label={isLiked ? 'Unlike' : 'Like'}
+          aria-label={isLiked ? t('vote.unlike') : t('vote.like')}
           sx={{
             color: isLiked ? themeTokens.colors.error : 'var(--neutral-400)',
             p: 0.5,
@@ -241,7 +243,7 @@ export default function VoteButton({
         size="small"
         onClick={() => handleVote(1)}
         disabled={isLoading}
-        aria-label="Upvote"
+        aria-label={t('vote.upvote')}
         sx={{
           color: userVote === 1 ? themeTokens.colors.success : 'var(--neutral-400)',
           p: 0.5,
@@ -264,7 +266,7 @@ export default function VoteButton({
         size="small"
         onClick={() => handleVote(-1)}
         disabled={isLoading}
-        aria-label="Downvote"
+        aria-label={t('vote.downvote')}
         sx={{
           color: userVote === -1 ? themeTokens.colors.error : 'var(--neutral-400)',
           p: 0.5,

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -194,6 +194,19 @@
       "to": "To"
     }
   },
+  "create": {
+    "auth": {
+      "signInTitle": "Sign in to save your climb",
+      "signInDescription": "Create an account or sign in to save your climb to the board.",
+      "signInAria": "Sign in to save",
+      "logInTitle": "Log in to save your climb",
+      "logInAria": "Log in to save",
+      "editLockedTitle": "Published climbs can only be edited for 24 hours after first publish.",
+      "editLockedAria": "Edit window closed",
+      "savedTitle": "Saved",
+      "savedAria": "Saved"
+    }
+  },
   "actions": {
     "playlist": {
       "toast": {

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -96,6 +96,7 @@
     "placeholder": "Add a comment...",
     "replyPlaceholder": "Write a reply...",
     "thoughtsPlaceholder": "Share your thoughts...",
+    "shortPlaceholder": "Comment...",
     "submit": "Post",
     "save": "Save",
     "cancel": "Cancel",
@@ -131,6 +132,14 @@
       "loadReplies": "Failed to load replies"
     }
   },
+  "vote": {
+    "upvote": "Upvote",
+    "downvote": "Downvote",
+    "like": "Like",
+    "unlike": "Unlike",
+    "signInPrompt": "Sign in to vote",
+    "failed": "Failed to vote"
+  },
   "proposal": {
     "trigger": "Propose Change",
     "drawerTitle": "Create Proposal",
@@ -158,10 +167,14 @@
     "outlierWarning": "The grade at this angle appears to be an outlier compared to adjacent angles. This proposal may be auto-approved if it aligns with neighboring data.",
     "validation": {
       "signIn": "Sign in to create proposals",
+      "signInToVote": "Sign in to vote on proposals",
       "missingValue": "Please enter a proposed value",
       "sameGrade": "Proposed grade is the same as the current grade",
       "noData": "Failed to create proposal: no data returned",
-      "failed": "Failed to create proposal"
+      "failed": "Failed to create proposal",
+      "failedToVote": "Failed to vote",
+      "failedToResolve": "Failed to resolve proposal",
+      "failedToDelete": "Failed to delete proposal"
     },
     "created": "Proposal created"
   },
@@ -169,5 +182,17 @@
     "follow": "Follow",
     "following": "Following",
     "unfollow": "Unfollow"
+  },
+  "feedback": {
+    "title": "Enjoying Boardsesh?"
+  },
+  "betaVideos": {
+    "empty": "No beta videos yet"
+  },
+  "moonboardImport": {
+    "removeConfirmTitle": "Remove this climb?"
+  },
+  "board": {
+    "resetZoom": "Reset zoom"
   }
 }

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -66,6 +66,35 @@
       "tryAgain": "Try Again"
     }
   },
+  "edit": {
+    "title": "Edit Playlist",
+    "fields": {
+      "name": "Playlist Name",
+      "namePlaceholder": "e.g., Hard Crimps",
+      "description": "Description",
+      "descriptionPlaceholder": "Optional description for your playlist...",
+      "color": "Color",
+      "icon": "Icon",
+      "removeIcon": "Remove",
+      "visibility": "Visibility",
+      "publicHint": "Public playlists can be viewed by anyone with the link",
+      "privateHint": "Private playlists are only visible to you"
+    },
+    "actions": {
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving..."
+    },
+    "validation": {
+      "nameRequired": "Please enter a playlist name",
+      "nameTooLong": "Name must be 100 characters or less",
+      "descriptionTooLong": "Description must be 500 characters or less"
+    },
+    "messages": {
+      "updated": "Playlist updated successfully",
+      "updateFailed": "Failed to update playlist"
+    }
+  },
   "generator": {
     "drawerTitle": "Generate Playlist",
     "generatingTitle": "Generating...",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -194,6 +194,19 @@
       "to": "Hasta"
     }
   },
+  "create": {
+    "auth": {
+      "signInTitle": "Inicia sesión para guardar tu bloque",
+      "signInDescription": "Crea una cuenta o inicia sesión para guardar tu bloque en la tabla.",
+      "signInAria": "Inicia sesión para guardar",
+      "logInTitle": "Inicia sesión para guardar tu bloque",
+      "logInAria": "Inicia sesión para guardar",
+      "editLockedTitle": "Los bloques publicados solo se pueden editar durante 24 horas tras la primera publicación.",
+      "editLockedAria": "Periodo de edición cerrado",
+      "savedTitle": "Guardado",
+      "savedAria": "Guardado"
+    }
+  },
   "actions": {
     "playlist": {
       "toast": {

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -88,6 +88,7 @@
     "placeholder": "Escribe un comentario...",
     "replyPlaceholder": "Escribe una respuesta...",
     "thoughtsPlaceholder": "Comparte tus pensamientos...",
+    "shortPlaceholder": "Comentar...",
     "submit": "Publicar",
     "save": "Guardar",
     "cancel": "Cancelar",
@@ -123,6 +124,14 @@
       "loadReplies": "No se pudieron cargar las respuestas"
     }
   },
+  "vote": {
+    "upvote": "Voto positivo",
+    "downvote": "Voto negativo",
+    "like": "Me gusta",
+    "unlike": "Quitar me gusta",
+    "signInPrompt": "Inicia sesión para votar",
+    "failed": "No se pudo votar"
+  },
   "proposal": {
     "trigger": "Proponer cambio",
     "drawerTitle": "Crear propuesta",
@@ -150,10 +159,14 @@
     "outlierWarning": "El grado en este ángulo parece atípico comparado con los ángulos adyacentes. Esta propuesta puede aprobarse automáticamente si concuerda con los datos vecinos.",
     "validation": {
       "signIn": "Inicia sesión para proponer cambios",
+      "signInToVote": "Inicia sesión para votar propuestas",
       "missingValue": "Introduce un valor propuesto",
       "sameGrade": "El grado propuesto es el mismo que el actual",
       "noData": "No se pudo crear la propuesta: sin datos",
-      "failed": "No se pudo crear la propuesta"
+      "failed": "No se pudo crear la propuesta",
+      "failedToVote": "No se pudo votar",
+      "failedToResolve": "No se pudo resolver la propuesta",
+      "failedToDelete": "No se pudo eliminar la propuesta"
     },
     "created": "Propuesta creada"
   },
@@ -161,5 +174,17 @@
     "follow": "Seguir",
     "following": "Siguiendo",
     "unfollow": "Dejar de seguir"
+  },
+  "feedback": {
+    "title": "¿Te gusta Boardsesh?"
+  },
+  "betaVideos": {
+    "empty": "Sin vídeos de beta todavía"
+  },
+  "moonboardImport": {
+    "removeConfirmTitle": "¿Quitar este bloque?"
+  },
+  "board": {
+    "resetZoom": "Restablecer zoom"
   }
 }

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -66,6 +66,35 @@
       "tryAgain": "Reintentar"
     }
   },
+  "edit": {
+    "title": "Editar lista",
+    "fields": {
+      "name": "Nombre de la lista",
+      "namePlaceholder": "ej., Crimps duros",
+      "description": "Descripción",
+      "descriptionPlaceholder": "Descripción opcional para tu lista...",
+      "color": "Color",
+      "icon": "Icono",
+      "removeIcon": "Quitar",
+      "visibility": "Visibilidad",
+      "publicHint": "Las listas públicas pueden ser vistas por cualquiera con el enlace",
+      "privateHint": "Las listas privadas solo son visibles para ti"
+    },
+    "actions": {
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "saving": "Guardando..."
+    },
+    "validation": {
+      "nameRequired": "Introduce un nombre de lista",
+      "nameTooLong": "El nombre debe tener 100 caracteres o menos",
+      "descriptionTooLong": "La descripción debe tener 500 caracteres o menos"
+    },
+    "messages": {
+      "updated": "Lista actualizada correctamente",
+      "updateFailed": "No se pudo actualizar la lista"
+    }
+  },
   "generator": {
     "drawerTitle": "Generar playlist",
     "generatingTitle": "Generando...",


### PR DESCRIPTION
## Summary

Follow-up to #1810. Wraps the long-tail English literals from issue #1819 in `t(...)` calls.

- **Social** (`proposal-card`, `comment-item`, `vote-button`): vote/resolve/delete error toasts, edit/delete aria-labels, upvote/downvote labels, deleted/edited markers, reply prompts.
- **Library** (`playlist-edit-drawer`, `logbook-feed-item`): full edit drawer (title, fields, validation, snackbars) plus the inline `Comment...` placeholder.
- **Create-climb** (`create-climb-form`): all auth gate tooltips/aria-labels (sign in, log in, edit window closed, saved indicator) including the modal description.
- **Misc**: `play-view-drawer` comment placeholders, `feedback-prompt-banner` title, `boardsesh-beta-list` empty state, `moonboard-import-card` confirm title, `zoomable-board` reset zoom aria-label.

Extends en-US/es catalogs in `common`, `playlists`, and `climbs` namespaces with the new keys (Spanish copy filled in directly per the existing pattern).

Closes #1819

## Test plan

- [x] `vp run typecheck:web` passes
- [x] `vp check` passes for all touched files (pre-existing formatting issues in unrelated files remain)
- [ ] Manual smoke (vote on a proposal, comment on a climb, edit a playlist, hit create-climb auth gate, view beta-videos empty state) in `/es/*`


---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZoGrMkpjhHaiJAr3LfjR)_