### PR TITLE
i18n: translate in-session chrome (queue bar, user drawer, tick dialog, create-playlist)

### DIFF
--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -87,10 +87,26 @@ function interpolate(template: string, options?: Record<string, unknown>): strin
  *   is provided
  * - Performs simple `{{var}}` interpolation
  * - Returns the bare key if nothing matches, mirroring i18next's fallback
+ * - Accepts namespace as a string, an array (uses first entry), or undefined
+ * - Honors `options.ns` overrides, mirroring `t(key, { ns: 'common' })`
  */
-export function tFromCatalog(namespace: string | undefined, key: string, options?: Record<string, unknown>): string {
-  // Allow `t('ns:key')` style; otherwise default to common when no namespace
-  let resolvedNs = namespace ?? DEFAULT_NAMESPACE;
+export function tFromCatalog(
+  namespace: string | readonly string[] | undefined,
+  key: string,
+  options?: Record<string, unknown>,
+): string {
+  // Resolve namespace: explicit options.ns wins, then `ns:key` colon syntax,
+  // then the namespace passed to useTranslation (string or first of array),
+  // then the default.
+  const optsNs = typeof options?.ns === 'string' ? (options.ns as string) : undefined;
+  let resolvedNs: string;
+  if (optsNs) {
+    resolvedNs = optsNs;
+  } else if (Array.isArray(namespace)) {
+    resolvedNs = namespace[0] ?? DEFAULT_NAMESPACE;
+  } else {
+    resolvedNs = (namespace as string | undefined) ?? DEFAULT_NAMESPACE;
+  }
   let resolvedKey = key;
   const colon = key.indexOf(':');
   if (colon > 0) {

--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { BoardDetails } from '@/app/lib/types';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import BottomTabBar from '../bottom-tab-bar';
 
 const mockPush = vi.fn();
@@ -34,9 +35,9 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
     i18n: { language: mockLanguage },
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
   }),
 }));
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -101,7 +101,7 @@ const actionSx = {
 };
 
 function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) {
-  const { t } = useTranslation(['playlists', 'climbs', 'common']);
+  const { t } = useTranslation('playlists');
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
   const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
@@ -464,12 +464,12 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const validatePlaylistForm = useCallback((): boolean => {
     const errors: Record<string, string> = {};
     if (!playlistFormValues.name.trim()) {
-      errors.name = t('actions.playlist.validation.nameRequired', { ns: 'climbs' });
+      errors.name = t('climbs:actions.playlist.validation.nameRequired');
     } else if (playlistFormValues.name.length > 100) {
-      errors.name = t('actions.playlist.validation.nameTooLong', { ns: 'climbs' });
+      errors.name = t('climbs:actions.playlist.validation.nameTooLong');
     }
     if (playlistFormValues.description.length > 500) {
-      errors.description = t('actions.playlist.validation.descriptionTooLong', { ns: 'climbs' });
+      errors.description = t('climbs:actions.playlist.validation.descriptionTooLong');
     }
     setPlaylistFormErrors(errors);
     return Object.keys(errors).length === 0;
@@ -662,7 +662,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       {/* Board Selector Drawer */}
       {isBoardSelectorRendered && (
         <SwipeableDrawer
-          title={t('boardSelector.title', { ns: 'common' })}
+          title={t('common:boardSelector.title')}
           placement="bottom"
           open={isBoardSelectorOpen}
           onClose={() => {

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
@@ -100,6 +101,7 @@ const actionSx = {
 };
 
 function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) {
+  const { t } = useTranslation(['playlists', 'climbs', 'common']);
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
   const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
@@ -462,16 +464,16 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const validatePlaylistForm = useCallback((): boolean => {
     const errors: Record<string, string> = {};
     if (!playlistFormValues.name.trim()) {
-      errors.name = 'Please enter a playlist name';
+      errors.name = t('actions.playlist.validation.nameRequired', { ns: 'climbs' });
     } else if (playlistFormValues.name.length > 100) {
-      errors.name = 'Name too long';
+      errors.name = t('actions.playlist.validation.nameTooLong', { ns: 'climbs' });
     }
     if (playlistFormValues.description.length > 500) {
-      errors.description = 'Description too long';
+      errors.description = t('actions.playlist.validation.descriptionTooLong', { ns: 'climbs' });
     }
     setPlaylistFormErrors(errors);
     return Object.keys(errors).length === 0;
-  }, [playlistFormValues]);
+  }, [playlistFormValues, t]);
 
   const handleCreatePlaylist = useCallback(async () => {
     if (!validatePlaylistForm() || !createPlaylist) {
@@ -583,7 +585,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       {/* Create Playlist Drawer */}
       {isCreatePlaylistRendered && (
         <SwipeableDrawer
-          title="Create Playlist"
+          title={t('create.drawerTitle')}
           placement="bottom"
           open={isCreatePlaylistOpen}
           onClose={() => {
@@ -598,17 +600,17 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           }}
           extra={
             <MuiButton variant="contained" onClick={handleCreatePlaylist} disabled={isCreatingPlaylist}>
-              {isCreatingPlaylist ? 'Creating...' : 'Create'}
+              {isCreatingPlaylist ? t('create.submitting') : t('create.submit')}
             </MuiButton>
           }
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <Box>
               <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                Name
+                {t('create.fields.name')}
               </Typography>
               <TextField
-                placeholder="e.g., Hard Crimps"
+                placeholder={t('create.fields.namePlaceholder')}
                 autoFocus
                 fullWidth
                 size="small"
@@ -623,10 +625,10 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             </Box>
             <Box>
               <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                Description (optional)
+                {t('create.fields.description')}
               </Typography>
               <TextField
-                placeholder="Optional description..."
+                placeholder={t('create.fields.descriptionPlaceholder')}
                 multiline
                 rows={2}
                 fullWidth
@@ -643,7 +645,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             </Box>
             <Box>
               <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                Color (optional)
+                {t('create.fields.color')}
               </Typography>
               <TextField
                 type="color"
@@ -660,7 +662,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       {/* Board Selector Drawer */}
       {isBoardSelectorRendered && (
         <SwipeableDrawer
-          title="Pick a board"
+          title={t('boardSelector.title', { ns: 'common' })}
           placement="bottom"
           open={isBoardSelectorOpen}
           onClose={() => {

--- a/packages/web/app/components/logbook/log-ascent-drawer.tsx
+++ b/packages/web/app/components/logbook/log-ascent-drawer.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { LogAscentForm } from './logascent-form';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
@@ -11,9 +14,10 @@ type LogAscentDrawerProps = {
 };
 
 export const LogAscentDrawer: React.FC<LogAscentDrawerProps> = ({ open, onClose, currentClimb, boardDetails }) => {
+  const { t } = useTranslation('climbs');
   return (
     <SwipeableDrawer
-      title="Log Ascent"
+      title={t('actions.tick.drawer.logAscent')}
       placement="bottom"
       onClose={onClose}
       open={open}

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiRating from '@mui/material/Rating';
 import Chip from '@mui/material/Chip';
 import MuiTooltip from '@mui/material/Tooltip';
@@ -56,6 +57,7 @@ type LogAscentFormProps = {
 };
 
 export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boardDetails, onClose }) => {
+  const { t } = useTranslation('climbs');
   const { saveTick, isAuthenticated } = useBoardProvider();
   const grades = TENSION_KILTER_GRADES;
   const angleOptions = ANGLES[boardDetails.board_name];
@@ -205,7 +207,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
                   sx={{ cursor: 'pointer', margin: 0 }}
                   onClick={handleMirrorToggle}
                 />
-                <MuiTooltip title="Click the tag to toggle whether you completed this climb on the mirrored side">
+                <MuiTooltip title={t('actions.tick.drawer.mirroredTooltip')}>
                   <InfoOutlined sx={{ color: 'var(--neutral-400)', cursor: 'pointer' }} />
                 </MuiTooltip>
               </Stack>

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import MuiBadge from '@mui/material/Badge';
@@ -46,6 +47,7 @@ export const TickButton: React.FC<TickButtonProps> = ({
   isFlash,
   ascentType,
 }) => {
+  const { t } = useTranslation('climbs');
   const { logbook, isAuthenticated } = useBoardProvider();
   const [drawerVisible, setDrawerVisible] = useState(false);
   const { openAuthModal } = useAuthModal();
@@ -172,7 +174,7 @@ export const TickButton: React.FC<TickButtonProps> = ({
         />
       ) : (
         <SwipeableDrawer
-          title="Sign In Required"
+          title={t('actions.tick.drawer.signInRequired')}
           placement="bottom"
           onClose={closeDrawer}
           open={drawerVisible}
@@ -180,31 +182,31 @@ export const TickButton: React.FC<TickButtonProps> = ({
         >
           <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
             <Typography variant="body2" component="span" fontWeight={600} sx={{ fontSize: 16 }}>
-              Sign in to record ticks
+              {t('actions.tick.drawer.signInToRecord')}
             </Typography>
             <Typography variant="body1" component="p" color="text.secondary">
-              Create a Boardsesh account to log your climbs and track your progress.
+              {t('actions.tick.drawer.createAccountBlurb')}
             </Typography>
             <Button
               variant="contained"
               startIcon={<LoginOutlined />}
               onClick={() =>
                 openAuthModal({
-                  title: 'Sign in to record ticks',
-                  description: 'Create an account to log your climbs and track your progress.',
+                  title: t('actions.tick.drawer.authModalTitle'),
+                  description: t('actions.tick.drawer.authModalDescription'),
                 })
               }
               fullWidth
             >
-              Sign In
+              {t('actions.tick.drawer.signIn')}
             </Button>
             {openInAppUrl && (
               <>
                 <Typography variant="body1" component="p" color="text.secondary">
-                  Or log your tick in the official app:
+                  {t('actions.tick.drawer.orLogInOfficialApp')}
                 </Typography>
                 <Button variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-                  Open in App
+                  {t('actions.tick.drawer.openInApp')}
                 </Button>
                 <Button
                   variant="text"
@@ -215,7 +217,7 @@ export const TickButton: React.FC<TickButtonProps> = ({
                     handleOpenInApp();
                   }}
                 >
-                  Always open in app
+                  {t('actions.tick.drawer.alwaysOpenInApp')}
                 </Button>
               </>
             )}

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -2,10 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import type { ClimbQueueItem } from '../types';
 import QueueClimbListItem from '../queue-climb-list-item';
 
 // --- Mocks ---
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
 
 let capturedSwipeOptions: Record<string, unknown> | null = null;
 

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import QueueControlBar from '../queue-control-bar';
 
 // -- All mocks before imports --
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
 
 const mockShowMessage = vi.fn();
 vi.mock('@/app/components/providers/snackbar-provider', () => ({

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import QueueControlBar from '../queue-control-bar';
 
 // -- All mocks before imports --
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
 
 const mockShowMessage = vi.fn();
 vi.mock('@/app/components/providers/snackbar-provider', () => ({

--- a/packages/web/app/components/queue-control/__tests__/queue-list-active.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-active.test.tsx
@@ -4,12 +4,20 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import type { ClimbQueueItem } from '../types';
 import QueueList from '../queue-list';
 
 const mockSetCurrentClimb = vi.fn();
 
 // --- Mocks ---
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
 
 const mockSuggestedClimbs: Climb[] = [
   {

--- a/packages/web/app/components/queue-control/__tests__/queue-list-virtualization.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-virtualization.test.tsx
@@ -4,8 +4,16 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import type { ClimbQueueItem } from '../types';
 import QueueList from '../queue-list';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
 
 // --- Mock data ---
 

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useQueueActions, useSessionData } from '../graphql-queue';
 import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
@@ -15,13 +16,15 @@ type NextClimbButtonProps = {
   boardDetails?: BoardDetails;
 };
 
-const NextButton = (props: IconButtonProps) => (
-  <IconButton {...props} aria-label="Next climb">
+const NextButton = ({ ariaLabel, ...props }: IconButtonProps & { ariaLabel: string }) => (
+  <IconButton {...props} aria-label={ariaLabel}>
     <FastForwardOutlined />
   </IconButton>
 );
 
 export default function NextClimbButton({ navigate, boardDetails }: NextClimbButtonProps) {
+  const { t } = useTranslation('climbs');
+  const ariaLabel = t('actions.navigation.nextClimb');
   const { setCurrentClimbQueueItem, getNextClimbQueueItem } = useQueueActions();
   const { viewOnlyMode } = useSessionData();
   const { rawParams, angle, pathname, searchParams, isPlayPage, resolvedDetails } =
@@ -83,15 +86,15 @@ export default function NextClimbButton({ navigate, boardDetails }: NextClimbBut
 
   if (!viewOnlyMode && navigate && nextClimb) {
     if (isPlayPage) {
-      return <NextButton onClick={handleClick} />;
+      return <NextButton ariaLabel={ariaLabel} onClick={handleClick} />;
     }
 
     const climbUrl = buildClimbUrl();
     return (
       <LocaleLink href={climbUrl} prefetch={false} onClick={handleClick}>
-        <NextButton />
+        <NextButton ariaLabel={ariaLabel} />
       </LocaleLink>
     );
   }
-  return <NextButton onClick={handleClick} disabled={!nextClimb || viewOnlyMode} />;
+  return <NextButton ariaLabel={ariaLabel} onClick={handleClick} disabled={!nextClimb || viewOnlyMode} />;
 }

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useQueueActions, useSessionData } from '../graphql-queue';
@@ -16,13 +17,15 @@ type PreviousClimbButtonProps = {
   boardDetails?: BoardDetails;
 };
 
-const PreviousButton = (props: IconButtonProps) => (
-  <IconButton {...props} aria-label="Previous climb">
+const PreviousButton = ({ ariaLabel, ...props }: IconButtonProps & { ariaLabel: string }) => (
+  <IconButton {...props} aria-label={ariaLabel}>
     <FastRewindOutlined />
   </IconButton>
 );
 
 export default function PreviousClimbButton({ navigate, boardDetails }: PreviousClimbButtonProps) {
+  const { t } = useTranslation('climbs');
+  const ariaLabel = t('actions.navigation.previousClimb');
   const { getPreviousClimbQueueItem, setCurrentClimbQueueItem } = useQueueActions();
   const { viewOnlyMode } = useSessionData();
   const { rawParams, angle, pathname, searchParams, isPlayPage, resolvedDetails } =
@@ -84,15 +87,15 @@ export default function PreviousClimbButton({ navigate, boardDetails }: Previous
 
   if (!viewOnlyMode && navigate && previousClimb) {
     if (isPlayPage) {
-      return <PreviousButton onClick={handleClick} />;
+      return <PreviousButton ariaLabel={ariaLabel} onClick={handleClick} />;
     }
 
     const climbUrl = buildClimbUrl();
     return (
       <LocaleLink href={climbUrl} prefetch={false} onClick={handleClick}>
-        <PreviousButton />
+        <PreviousButton ariaLabel={ariaLabel} />
       </LocaleLink>
     );
   }
-  return <PreviousButton onClick={handleClick} disabled={!previousClimb || viewOnlyMode} />;
+  return <PreviousButton ariaLabel={ariaLabel} onClick={handleClick} disabled={!previousClimb || viewOnlyMode} />;
 }

--- a/packages/web/app/components/queue-control/queue-climb-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-climb-list-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiTooltip from '@mui/material/Tooltip';
 import MuiAvatar from '@mui/material/Avatar';
 import MuiCheckbox from '@mui/material/Checkbox';
@@ -65,6 +66,7 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
   onEditClimb,
   isEditable = false,
 }) => {
+  const { t } = useTranslation('session');
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
   const itemRef = useRef<HTMLDivElement>(null);
 
@@ -111,7 +113,7 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
         </MuiAvatar>
       </MuiTooltip>
     ) : (
-      <MuiTooltip title="Added via Bluetooth">
+      <MuiTooltip title={t('queueList.addedViaBluetooth')}>
         <MuiAvatar sx={avatarBluetoothStyle}>
           <BluetoothIcon style={{ color: 'var(--neutral-400)' }} />
         </MuiAvatar>
@@ -124,7 +126,7 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
 
     return (
       <MuiStack direction="row" spacing={0.5} alignItems="center">
-        <MuiTooltip title="Edit this climb">
+        <MuiTooltip title={t('queueList.editClimb')}>
           <MuiIconButton size="small" onClick={handleEditClick} sx={{ width: 24, height: 24 }}>
             <EditOutlined sx={{ fontSize: 16 }} />
           </MuiIconButton>
@@ -132,7 +134,7 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
         {avatar}
       </MuiStack>
     );
-  }, [item.addedByUser, isEditable, onEditClimb, handleEditClick]);
+  }, [item.addedByUser, isEditable, onEditClimb, handleEditClick, t]);
 
   // onSelect handler — double-tap sets current climb
   const handleSelect = useCallback(() => {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -132,7 +132,7 @@ export type QueueControlBarProps = {
 };
 
 const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }) => {
-  const { t } = useTranslation(['session', 'common']);
+  const { t } = useTranslation('session');
   const [activeDrawer, setActiveDrawer] = useState<ActiveDrawer>('none');
   const [startSeshOpen, setStartSeshOpen] = useState(false);
   const pathname = usePathname();
@@ -1330,7 +1330,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               description={t('queueDrawer.clearDescription')}
               onConfirm={handleClearQueue}
               okText={t('queueDrawer.clearConfirm')}
-              cancelText={t('actions.cancel', { ns: 'common' })}
+              cancelText={t('common:actions.cancel')}
             >
               <MuiButton variant="text" startIcon={<DeleteOutlined />} sx={{ color: 'var(--neutral-400)' }}>
                 {t('queueDrawer.clearConfirm')}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -760,7 +760,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   const renderConfirmRow = () => (
     <div className={styles.reconnectRow}>
-      <span className={styles.confirmText}>Cancelling will leave the session. Is that what you want?</span>
+      <span className={styles.confirmText}>{t('queueBar.cancelReconnectConfirm')}</span>
       <IconButton
         aria-label={t('queueBar.ariaLabels.leaveSession')}
         color="error"
@@ -990,7 +990,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       >
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                           <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
-                            Get your crew in by sharing this link or scanning the QR code
+                            {t('settings.share.inviteCopy')}
                           </Typography>
                           <IconButton size="small" onClick={handleInviteShare} aria-label={t('queueBar.ariaLabels.shareSessionLink')}>
                             <IosShare sx={{ fontSize: 18 }} />

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import MuiButton from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -131,6 +132,7 @@ export type QueueControlBarProps = {
 };
 
 const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }) => {
+  const { t } = useTranslation(['session', 'common']);
   const [activeDrawer, setActiveDrawer] = useState<ActiveDrawer>('none');
   const [startSeshOpen, setStartSeshOpen] = useState(false);
   const pathname = usePathname();
@@ -760,7 +762,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     <div className={styles.reconnectRow}>
       <span className={styles.confirmText}>Cancelling will leave the session. Is that what you want?</span>
       <IconButton
-        aria-label="Leave session"
+        aria-label={t('queueBar.ariaLabels.leaveSession')}
         color="error"
         onClick={() => {
           handleLeaveSession();
@@ -769,7 +771,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       >
         <CloseOutlined />
       </IconButton>
-      <IconButton aria-label="Keep reconnecting" onClick={() => setShowCancelConfirm(false)}>
+      <IconButton aria-label={t('queueBar.ariaLabels.keepReconnecting')} onClick={() => setShowCancelConfirm(false)}>
         <CheckOutlined />
       </IconButton>
     </div>
@@ -868,7 +870,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   onClick={() => setDismissedDisconnect(true)}
                   role="button"
                   tabIndex={0}
-                  aria-label="Dismiss offline notice"
+                  aria-label={t('queueBar.ariaLabels.dismissOfflineNotice')}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
@@ -990,7 +992,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                           <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
                             Get your crew in by sharing this link or scanning the QR code
                           </Typography>
-                          <IconButton size="small" onClick={handleInviteShare} aria-label="Share session link">
+                          <IconButton size="small" onClick={handleInviteShare} aria-label={t('queueBar.ariaLabels.shareSessionLink')}>
                             <IosShare sx={{ fontSize: 18 }} />
                           </IconButton>
                         </Box>
@@ -1060,7 +1062,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                     <IconButton
                       onClick={() => setActiveDrawer('none')}
                       size="small"
-                      aria-label="Close tick bar"
+                      aria-label={t('queueBar.ariaLabels.closeTickBar')}
                       sx={{
                         color: 'text.primary',
                         backgroundColor: 'action.selected',
@@ -1264,7 +1266,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                             });
                           }}
                         >
-                          <IconButton aria-label="Enter play mode">
+                          <IconButton aria-label={t('queueBar.ariaLabels.enterPlayMode')}>
                             <OpenInFullOutlined />
                           </IconButton>
                         </LocaleLink>
@@ -1287,7 +1289,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                             color: themeTokens.colors.error,
                             '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
                           }}
-                          aria-label="Log attempt"
+                          aria-label={t('queueBar.ariaLabels.logAttempt')}
                         >
                           <PersonFallingIcon />
                         </IconButton>
@@ -1315,7 +1317,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
       {/* Drawer for showing the queue */}
       <SwipeableDrawer
-        title="Queue"
+        title={t('queueDrawer.title')}
         placement="bottom"
         open={activeDrawer === 'queue'}
         onClose={handleCloseDrawer}
@@ -1324,14 +1326,14 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         extra={
           queue.length > 0 && (
             <ConfirmPopover
-              title="Clear queue"
-              description="Are you sure you want to clear all items from the queue?"
+              title={t('queueDrawer.clearTitle')}
+              description={t('queueDrawer.clearDescription')}
               onConfirm={handleClearQueue}
-              okText="Clear"
-              cancelText="Cancel"
+              okText={t('queueDrawer.clearConfirm')}
+              cancelText={t('actions.cancel', { ns: 'common' })}
             >
               <MuiButton variant="text" startIcon={<DeleteOutlined />} sx={{ color: 'var(--neutral-400)' }}>
-                Clear
+                {t('queueDrawer.clearConfirm')}
               </MuiButton>
             </ConfirmPopover>
           )

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useState, useCallback, useRef, useImperativeHandle, forwardRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
@@ -74,6 +75,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
     },
     ref,
   ) => {
+    const { t } = useTranslation(['climbs', 'session']);
     const currentClimbUuid = useCurrentClimbUuid();
     const { queue, suggestedClimbs } = useQueueList();
     const { hasMoreResults, isFetchingClimbs, isFetchingNextPage } = useSearchData();
@@ -505,7 +507,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
           />
         ) : (
           <SwipeableDrawer
-            title="Sign In Required"
+            title={t('actions.tick.drawer.signInRequired')}
             placement="bottom"
             onClose={closeTickDrawer}
             open={tickDrawerVisible}
@@ -518,23 +520,23 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
                 fontWeight={600}
                 sx={{ fontSize: themeTokens.typography.fontSize.base }}
               >
-                Sign in to record ticks
+                {t('actions.tick.drawer.signInToRecord')}
               </Typography>
               <Typography variant="body1" component="p" color="text.secondary">
-                Create a Boardsesh account to log your climbs and track your progress.
+                {t('actions.tick.drawer.createAccountBlurb')}
               </Typography>
               <Button
                 variant="contained"
                 startIcon={<LoginOutlined />}
                 onClick={() =>
                   openAuthModal({
-                    title: 'Sign in to record ticks',
-                    description: 'Create an account to log your climbs and track your progress.',
+                    title: t('actions.tick.drawer.authModalTitle'),
+                    description: t('actions.tick.drawer.authModalDescription'),
                   })
                 }
                 fullWidth
               >
-                Sign In
+                {t('actions.tick.drawer.signIn')}
               </Button>
             </Stack>
           </SwipeableDrawer>

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -75,7 +75,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
     },
     ref,
   ) => {
-    const { t } = useTranslation(['climbs', 'session']);
+    const { t } = useTranslation('climbs');
     const currentClimbUuid = useCurrentClimbUuid();
     const { queue, suggestedClimbs } = useQueueList();
     const { hasMoreResults, isFetchingClimbs, isFetchingNextPage } = useSearchData();

--- a/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
+++ b/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import UserDrawer from '../user-drawer';
 
 // -------------------------------------------------------------------------
@@ -38,7 +39,10 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ i18n: { language: 'en-US', changeLanguage: vi.fn() }, t: (key: string) => key }),
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US', changeLanguage: vi.fn() },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
 }));
 
 vi.mock('next/link', () => ({

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiAvatar from '@mui/material/Avatar';
 import MuiTypography from '@mui/material/Typography';
 import MuiButton from '@mui/material/Button';
@@ -73,6 +74,7 @@ type UserDrawerProps = {
 };
 
 export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerProps) {
+  const { t } = useTranslation('common');
   const { data: session } = useSession();
   const router = useLocaleRouter();
   const pathname = usePathname();
@@ -212,7 +214,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
           setDrawerRendered(true);
           setIsOpen(true);
         }}
-        aria-label="User menu"
+        aria-label={t('ariaLabels.userMenu')}
         className={styles.avatarButton}
       >
         <MuiAvatar sx={{ width: 28, height: 28 }} src={userAvatar} className={avatarClass}>
@@ -474,7 +476,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 onClick={toggleMode}
                 role="button"
                 tabIndex={0}
-                aria-label="Toggle dark mode"
+                aria-label={t('ariaLabels.toggleDarkMode')}
               >
                 <div className={`${styles.themeToggleThumb} ${mode === 'dark' ? styles.themeToggleThumbDark : ''}`} />
                 <div

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -76,7 +76,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
               <ColorModeProvider>
-                <I18nProvider locale={locale} namespaces={['common', 'auth']}>
+                <I18nProvider locale={locale} namespaces={['common', 'auth', 'playlists']}>
                   <SnackbarProvider>
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -227,8 +227,21 @@
       "drawer": {
         "signInRequired": "Sign In Required",
         "selectBoard": "Select Board",
-        "logAscent": "Log Ascent"
+        "logAscent": "Log Ascent",
+        "signInToRecord": "Sign in to record ticks",
+        "createAccountBlurb": "Create a Boardsesh account to log your climbs and track your progress.",
+        "signIn": "Sign In",
+        "orLogInOfficialApp": "Or log your tick in the official app:",
+        "openInApp": "Open in App",
+        "alwaysOpenInApp": "Always open in app",
+        "authModalTitle": "Sign in to record ticks",
+        "authModalDescription": "Create an account to log your climbs and track your progress.",
+        "mirroredTooltip": "Click the tag to toggle whether you completed this climb on the mirrored side"
       }
+    },
+    "navigation": {
+      "nextClimb": "Next climb",
+      "previousClimb": "Previous climb"
     },
     "mirror": {
       "label": {

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -46,7 +46,12 @@
     "shareProfile": "Share profile",
     "settings": "Settings",
     "notifications": "Notifications",
-    "searchClimbsByName": "Search climbs by name"
+    "searchClimbsByName": "Search climbs by name",
+    "userMenu": "User menu",
+    "toggleDarkMode": "Toggle dark mode"
+  },
+  "boardSelector": {
+    "title": "Pick a board"
   },
   "header": {
     "you": "You",

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -95,6 +95,18 @@
       "updateFailed": "Failed to update playlist"
     }
   },
+  "create": {
+    "drawerTitle": "Create Playlist",
+    "submit": "Create",
+    "submitting": "Creating...",
+    "fields": {
+      "name": "Name",
+      "namePlaceholder": "e.g., Hard Crimps",
+      "description": "Description (optional)",
+      "descriptionPlaceholder": "Optional description...",
+      "color": "Color (optional)"
+    }
+  },
   "generator": {
     "drawerTitle": "Generate Playlist",
     "generatingTitle": "Generating...",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -202,5 +202,26 @@
   },
   "overview": {
     "goal": "Goal: {{goal}}"
+  },
+  "queueBar": {
+    "ariaLabels": {
+      "leaveSession": "Leave session",
+      "keepReconnecting": "Keep reconnecting",
+      "dismissOfflineNotice": "Dismiss offline notice",
+      "shareSessionLink": "Share session link",
+      "closeTickBar": "Close tick bar",
+      "enterPlayMode": "Enter play mode",
+      "logAttempt": "Log attempt"
+    }
+  },
+  "queueDrawer": {
+    "title": "Queue",
+    "clearTitle": "Clear queue",
+    "clearDescription": "Are you sure you want to clear all items from the queue?",
+    "clearConfirm": "Clear"
+  },
+  "queueList": {
+    "editClimb": "Edit this climb",
+    "addedViaBluetooth": "Added via Bluetooth"
   }
 }

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -204,6 +204,7 @@
     "goal": "Goal: {{goal}}"
   },
   "queueBar": {
+    "cancelReconnectConfirm": "Cancelling will leave the session. Is that what you want?",
     "ariaLabels": {
       "leaveSession": "Leave session",
       "keepReconnecting": "Keep reconnecting",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -227,8 +227,21 @@
       "drawer": {
         "signInRequired": "Iniciar sesión requerido",
         "selectBoard": "Selecciona una tabla",
-        "logAscent": "Registrar encadene"
+        "logAscent": "Registrar encadene",
+        "signInToRecord": "Inicia sesión para registrar marcas",
+        "createAccountBlurb": "Crea una cuenta de Boardsesh para registrar tus bloques y seguir tu progreso.",
+        "signIn": "Iniciar sesión",
+        "orLogInOfficialApp": "O registra tu marca en la app oficial:",
+        "openInApp": "Abrir en la app",
+        "alwaysOpenInApp": "Abrir siempre en la app",
+        "authModalTitle": "Inicia sesión para registrar marcas",
+        "authModalDescription": "Crea una cuenta para registrar tus bloques y seguir tu progreso.",
+        "mirroredTooltip": "Pulsa la etiqueta para indicar si completaste este bloque en el lado espejo."
       }
+    },
+    "navigation": {
+      "nextClimb": "Bloque siguiente",
+      "previousClimb": "Bloque anterior"
     },
     "mirror": {
       "label": {

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -38,7 +38,12 @@
     "shareProfile": "Compartir perfil",
     "settings": "Ajustes",
     "notifications": "Notificaciones",
-    "searchClimbsByName": "Buscar bloques por nombre"
+    "searchClimbsByName": "Buscar bloques por nombre",
+    "userMenu": "Menú de usuario",
+    "toggleDarkMode": "Cambiar modo oscuro"
+  },
+  "boardSelector": {
+    "title": "Elige un panel"
   },
   "header": {
     "you": "Tú",

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -95,6 +95,18 @@
       "updateFailed": "No se pudo actualizar la lista"
     }
   },
+  "create": {
+    "drawerTitle": "Crear playlist",
+    "submit": "Crear",
+    "submitting": "Creando...",
+    "fields": {
+      "name": "Nombre",
+      "namePlaceholder": "p. ej., Regletas duras",
+      "description": "Descripción (opcional)",
+      "descriptionPlaceholder": "Descripción opcional...",
+      "color": "Color (opcional)"
+    }
+  },
   "generator": {
     "drawerTitle": "Generar playlist",
     "generatingTitle": "Generando...",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -204,6 +204,7 @@
     "goal": "Objetivo: {{goal}}"
   },
   "queueBar": {
+    "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
     "ariaLabels": {
       "leaveSession": "Salir de la sesión",
       "keepReconnecting": "Seguir reconectando",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -202,5 +202,26 @@
   },
   "overview": {
     "goal": "Objetivo: {{goal}}"
+  },
+  "queueBar": {
+    "ariaLabels": {
+      "leaveSession": "Salir de la sesión",
+      "keepReconnecting": "Seguir reconectando",
+      "dismissOfflineNotice": "Descartar aviso sin conexión",
+      "shareSessionLink": "Compartir enlace de sesión",
+      "closeTickBar": "Cerrar barra de marca",
+      "enterPlayMode": "Entrar en modo juego",
+      "logAttempt": "Registrar intento"
+    }
+  },
+  "queueDrawer": {
+    "title": "Cola",
+    "clearTitle": "Vaciar cola",
+    "clearDescription": "¿Seguro que quieres vaciar la cola?",
+    "clearConfirm": "Vaciar"
+  },
+  "queueList": {
+    "editClimb": "Editar este bloque",
+    "addedViaBluetooth": "Añadido por Bluetooth"
   }
 }


### PR DESCRIPTION
Closes #1817.

## Summary

Wraps the user-rendered strings called out in #1817 with `t(...)` so the queue control bar, queue list items, tick sign-in dialog, log-ascent drawer, user drawer, navigation buttons, and bottom-tab create-playlist drawer render in Spanish under `/es/*`.

## Files touched

- `queue-control-bar.tsx` — aria-labels (Leave session, Keep reconnecting, Dismiss offline notice, Share session link, Close tick bar, Enter play mode, Log attempt) + Queue / Clear queue drawer titles + Clear-confirm popover.
- `next-climb-button.tsx`, `previous-climb-button.tsx` — Next climb / Previous climb aria-labels.
- `queue-climb-list-item.tsx` — Edit this climb / Added via Bluetooth tooltips.
- `queue-list.tsx` — Sign-in-required auth-gate dialog.
- `user-drawer.tsx` — User menu + Toggle dark mode aria-labels.
- `tick-button.tsx` — Full sign-in dialog (Sign In Required, body copy, Sign In, Or log your tick in the official app, Open in App, Always open in app).
- `log-ascent-drawer.tsx` — Log Ascent drawer title (added `'use client'`).
- `logascent-form.tsx` — Mirrored-ascent tooltip.
- `bottom-tab-bar.tsx` — Create Playlist drawer (title, Name/Description/Color labels + placeholders, validation, Create/Creating button), Pick a board board-selector title.

## Translation keys

Reuses existing keys where they fit (`climbs:actions.tick.drawer.signInRequired/selectBoard/logAscent`, `climbs:actions.playlist.validation.*`, `common:actions.cancel`).

New keys added to:
- `common`: `ariaLabels.userMenu`, `ariaLabels.toggleDarkMode`, `boardSelector.title`
- `session`: `queueBar.ariaLabels.*`, `queueDrawer.*`, `queueList.*`
- `climbs`: `actions.tick.drawer.{signInToRecord, createAccountBlurb, signIn, orLogInOfficialApp, openInApp, alwaysOpenInApp, authModalTitle, authModalDescription, mirroredTooltip}`, `actions.navigation.{nextClimb, previousClimb}`
- `playlists`: `create.{drawerTitle, submit, submitting, fields.*}`

Spanish translations added in lockstep.

## Test plan

- [ ] `vp run typecheck:web` passes
- [ ] `vp check` passes
- [ ] Open `/es/<board>/.../view/<uuid>` and confirm queue control bar aria-labels and Queue drawer / Clear-queue confirm copy render in Spanish.
- [ ] Tap the tick button while signed out under `/es/...` → drawer title and body copy in Spanish, including "Abrir en la app" / "Abrir siempre en la app".
- [ ] Open the user drawer under `/es/...` → user-menu aria-label and dark-mode toggle aria-label in Spanish.
- [ ] Open the bottom-tab create-playlist drawer under `/es/...` → "Crear playlist" title, all field labels and placeholders, validation messages in Spanish.
- [ ] Trigger a session reconnect (DevTools network throttle) → "Salir de la sesión" / "Seguir reconectando" aria-labels.
- [ ] Spot-check English (no `/es/` prefix) for regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMMtyV3SiCaBHegk6sLZfJ)_