### PR TITLE
i18n: translate auth flow (login, signup, verify, error pages)

### DIFF
--- a/packages/web/app/auth/error/auth-error-content.tsx
+++ b/packages/web/app/auth/error/auth-error-content.tsx
@@ -10,39 +10,34 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import { useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import { themeTokens } from '@/app/theme/theme-config';
 
+const KNOWN_ERROR_CODES = new Set([
+  'Configuration',
+  'AccessDenied',
+  'Verification',
+  'OAuthSignin',
+  'OAuthCallback',
+  'OAuthCreateAccount',
+  'EmailCreateAccount',
+  'Callback',
+  'OAuthAccountNotLinked',
+  'SessionRequired',
+]);
+
 export default function AuthErrorContent() {
+  const { t } = useTranslation('auth');
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
 
   const getErrorMessage = () => {
-    switch (error) {
-      case 'Configuration':
-        return 'There is a problem with the server configuration.';
-      case 'AccessDenied':
-        return 'Access denied. You do not have permission to sign in.';
-      case 'Verification':
-        return 'The verification link has expired or is invalid.';
-      case 'OAuthSignin':
-        return 'Error starting the sign-in flow. Please try again.';
-      case 'OAuthCallback':
-        return 'Error completing the sign-in. Please try again.';
-      case 'OAuthCreateAccount':
-        return 'Could not create an account with this provider.';
-      case 'EmailCreateAccount':
-        return 'Could not create an email account.';
-      case 'Callback':
-        return 'Error in the authentication callback.';
-      case 'OAuthAccountNotLinked':
-        return 'This email is already associated with another account. Please sign in using your original method.';
-      case 'SessionRequired':
-        return 'You must be signed in to access this page.';
-      default:
-        return 'An unexpected authentication error occurred.';
+    if (error && KNOWN_ERROR_CODES.has(error)) {
+      return t(`error.messages.${error}`);
     }
+    return t('error.messages.default');
   };
 
   return (
@@ -62,7 +57,7 @@ export default function AuthErrorContent() {
         <BackButton />
         <Logo size="sm" showText={false} />
         <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
-          Authentication Error
+          {t('error.header')}
         </Typography>
       </Box>
 
@@ -80,10 +75,10 @@ export default function AuthErrorContent() {
           <CardContent>
             <Stack spacing={3} sx={{ width: '100%' }}>
               <CancelOutlined sx={{ fontSize: 48, color: themeTokens.colors.error, mx: 'auto' }} />
-              <Typography variant="h3">Authentication Error</Typography>
+              <Typography variant="h3">{t('error.title')}</Typography>
               <MuiAlert severity="error">{getErrorMessage()}</MuiAlert>
               <Button variant="contained" href="/auth/login" fullWidth size="large">
-                Back to Login
+                {t('error.back')}
               </Button>
             </Stack>
           </CardContent>

--- a/packages/web/app/auth/error/page.tsx
+++ b/packages/web/app/auth/error/page.tsx
@@ -1,5 +1,7 @@
 import React, { Suspense } from 'react';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import I18nProvider from '@/app/components/providers/i18n-provider';
 import AuthErrorContent from './auth-error-content';
 
 export const metadata = createNoIndexMetadata({
@@ -8,10 +10,13 @@ export const metadata = createNoIndexMetadata({
   path: '/auth/error',
 });
 
-export default function AuthErrorPage() {
+export default async function AuthErrorPage() {
+  const locale = await getLocale();
   return (
-    <Suspense fallback={null}>
-      <AuthErrorContent />
-    </Suspense>
+    <I18nProvider locale={locale} namespaces={['auth']}>
+      <Suspense fallback={null}>
+        <AuthErrorContent />
+      </Suspense>
+    </I18nProvider>
   );
 }

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -18,6 +18,8 @@ import LockOutlined from '@mui/icons-material/LockOutlined';
 import MailOutlined from '@mui/icons-material/MailOutlined';
 import { signIn, useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
@@ -34,43 +36,44 @@ const initialRegisterValues = { name: '', email: '', password: '', confirmPasswo
 type LoginErrors = Partial<Record<keyof typeof initialLoginValues, string>>;
 type RegisterErrors = Partial<Record<keyof typeof initialRegisterValues, string>>;
 
-function validateLoginFields(values: typeof initialLoginValues): LoginErrors {
+function validateLoginFields(values: typeof initialLoginValues, t: TFunction<'auth'>): LoginErrors {
   const errors: LoginErrors = {};
   if (!values.email) {
-    errors.email = 'Please enter your email';
+    errors.email = t('login.validation.emailRequired');
   } else if (!EMAIL_REGEX.test(values.email)) {
-    errors.email = 'Please enter a valid email';
+    errors.email = t('login.validation.emailInvalid');
   }
   if (!values.password) {
-    errors.password = 'Please enter your password';
+    errors.password = t('login.validation.passwordRequired');
   }
   return errors;
 }
 
-function validateRegisterFields(values: typeof initialRegisterValues): RegisterErrors {
+function validateRegisterFields(values: typeof initialRegisterValues, t: TFunction<'auth'>): RegisterErrors {
   const errors: RegisterErrors = {};
   if (values.name && values.name.length > 100) {
-    errors.name = 'Name must be less than 100 characters';
+    errors.name = t('login.validation.nameTooLong');
   }
   if (!values.email) {
-    errors.email = 'Please enter your email';
+    errors.email = t('login.validation.emailRequired');
   } else if (!EMAIL_REGEX.test(values.email)) {
-    errors.email = 'Please enter a valid email';
+    errors.email = t('login.validation.emailInvalid');
   }
   if (!values.password) {
-    errors.password = 'Please enter a password';
+    errors.password = t('login.validation.passwordRequiredCreate');
   } else if (values.password.length < 8) {
-    errors.password = 'Password must be at least 8 characters';
+    errors.password = t('login.validation.passwordTooShort');
   }
   if (!values.confirmPassword) {
-    errors.confirmPassword = 'Please confirm your password';
+    errors.confirmPassword = t('login.validation.confirmPasswordRequired');
   } else if (values.confirmPassword !== values.password) {
-    errors.confirmPassword = 'Passwords do not match';
+    errors.confirmPassword = t('login.validation.passwordsMismatch');
   }
   return errors;
 }
 
 export default function AuthPageContent() {
+  const { t } = useTranslation('auth');
   const { status } = useSession();
   const router = useLocaleRouter();
   const searchParams = useSearchParams();
@@ -92,19 +95,19 @@ export default function AuthPageContent() {
   useEffect(() => {
     if (error) {
       if (error === 'CredentialsSignin') {
-        showMessage('Invalid email or password', 'error');
+        showMessage(t('login.toasts.invalidCredentials'), 'error');
       } else {
-        showMessage('Authentication failed. Please try again.', 'error');
+        showMessage(t('login.toasts.authFailed'), 'error');
       }
     }
-  }, [error, showMessage]);
+  }, [error, showMessage, t]);
 
   // Show success message when email is verified
   useEffect(() => {
     if (verified === 'true') {
-      showMessage('Email verified! You can now log in.', 'success');
+      showMessage(t('login.toasts.verified'), 'success');
     }
-  }, [verified, showMessage]);
+  }, [verified, showMessage, t]);
 
   // Redirect if already authenticated
   useEffect(() => {
@@ -114,7 +117,7 @@ export default function AuthPageContent() {
   }, [status, router, callbackUrl]);
 
   const handleLogin = async () => {
-    const errors = validateLoginFields(loginValues);
+    const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
     if (Object.keys(errors).length > 0) return;
 
@@ -128,9 +131,9 @@ export default function AuthPageContent() {
       });
 
       if (result?.error) {
-        showMessage('Invalid email or password', 'error');
+        showMessage(t('login.toasts.invalidCredentials'), 'error');
       } else if (result?.ok) {
-        showMessage('Logged in successfully', 'success');
+        showMessage(t('login.toasts.loggedIn'), 'success');
         router.push(callbackUrl);
       }
     } catch (error) {
@@ -141,7 +144,7 @@ export default function AuthPageContent() {
   };
 
   const handleRegister = async () => {
-    const errors = validateRegisterFields(registerValues);
+    const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
     if (Object.keys(errors).length > 0) return;
 
@@ -164,20 +167,20 @@ export default function AuthPageContent() {
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || 'Registration failed', 'error');
+        showMessage(data.error || t('login.toasts.registrationFailed'), 'error');
         return;
       }
 
       // Check if email verification is required
       if (data.requiresVerification) {
-        showMessage('Please check your email to verify your account', 'info');
+        showMessage(t('login.toasts.checkEmail'), 'info');
         setActiveTab('login');
         setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
         return;
       }
 
       // Email verification disabled - auto-login after successful registration
-      showMessage('Account created! Logging you in...', 'success');
+      showMessage(t('login.toasts.accountCreated'), 'success');
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,
@@ -190,11 +193,11 @@ export default function AuthPageContent() {
       } else {
         setActiveTab('login');
         setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
-        showMessage('Please log in with your account', 'info');
+        showMessage(t('login.toasts.loginAfterCreate'), 'info');
       }
     } catch (error) {
       console.error('Registration error:', error);
-      showMessage('Registration failed. Please try again.', 'error');
+      showMessage(t('login.toasts.registrationFailedRetry'), 'error');
     } finally {
       setRegisterLoading(false);
     }
@@ -225,7 +228,7 @@ export default function AuthPageContent() {
         <BackButton />
         <Logo size="sm" showText={false} />
         <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
-          Welcome
+          {t('login.header')}
         </Typography>
       </Box>
 
@@ -244,13 +247,13 @@ export default function AuthPageContent() {
             <Stack spacing={1} sx={{ width: '100%', textAlign: 'center', marginBottom: 3 }}>
               <Logo size="md" />
               <Typography variant="body2" component="span" color="text.secondary">
-                Sign in or create an account to continue
+                {t('login.subtitle')}
               </Typography>
             </Stack>
 
             <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} centered>
-              <Tab label="Login" value="login" />
-              <Tab label="Create Account" value="register" />
+              <Tab label={t('login.tabs.signIn')} value="login" />
+              <Tab label={t('login.tabs.signUp')} value="register" />
             </Tabs>
 
             <TabPanel value={activeTab} index="login">
@@ -263,8 +266,8 @@ export default function AuthPageContent() {
                 sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
               >
                 <TextField
-                  label="Email"
-                  placeholder="your@email.com"
+                  label={t('login.fields.email')}
+                  placeholder={t('login.placeholders.email')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -287,9 +290,9 @@ export default function AuthPageContent() {
                 />
 
                 <TextField
-                  label="Password"
+                  label={t('login.fields.password')}
                   type="password"
-                  placeholder="Password"
+                  placeholder={t('login.placeholders.password')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -319,7 +322,7 @@ export default function AuthPageContent() {
                   fullWidth
                   size="large"
                 >
-                  Login
+                  {t('login.submit.signIn')}
                 </Button>
               </Box>
             </TabPanel>
@@ -334,8 +337,8 @@ export default function AuthPageContent() {
                 sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
               >
                 <TextField
-                  label="Name"
-                  placeholder="Your name (optional)"
+                  label={t('login.fields.name')}
+                  placeholder={t('login.placeholders.name')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -358,8 +361,8 @@ export default function AuthPageContent() {
                 />
 
                 <TextField
-                  label="Email"
-                  placeholder="your@email.com"
+                  label={t('login.fields.email')}
+                  placeholder={t('login.placeholders.email')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -382,9 +385,9 @@ export default function AuthPageContent() {
                 />
 
                 <TextField
-                  label="Password"
+                  label={t('login.fields.password')}
                   type="password"
-                  placeholder="Password (min 8 characters)"
+                  placeholder={t('login.placeholders.passwordWithMin')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -407,9 +410,9 @@ export default function AuthPageContent() {
                 />
 
                 <TextField
-                  label="Confirm Password"
+                  label={t('login.fields.confirmPassword')}
                   type="password"
-                  placeholder="Confirm password"
+                  placeholder={t('login.placeholders.confirmPassword')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -440,14 +443,14 @@ export default function AuthPageContent() {
                   fullWidth
                   size="large"
                 >
-                  Create Account
+                  {t('login.submit.signUp')}
                 </Button>
               </Box>
             </TabPanel>
 
             <MuiDivider>
               <Typography variant="body2" component="span" color="text.secondary">
-                or
+                {t('login.divider')}
               </Typography>
             </MuiDivider>
 

--- a/packages/web/app/auth/login/page.tsx
+++ b/packages/web/app/auth/login/page.tsx
@@ -1,5 +1,7 @@
 import React, { Suspense } from 'react';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import I18nProvider from '@/app/components/providers/i18n-provider';
 import AuthPageContent from './auth-page-content';
 
 export const metadata = createNoIndexMetadata({
@@ -33,10 +35,13 @@ function AuthPageFallback() {
   );
 }
 
-export default function AuthPage() {
+export default async function AuthPage() {
+  const locale = await getLocale();
   return (
-    <Suspense fallback={<AuthPageFallback />}>
-      <AuthPageContent />
-    </Suspense>
+    <I18nProvider locale={locale} namespaces={['auth']}>
+      <Suspense fallback={<AuthPageFallback />}>
+        <AuthPageContent />
+      </Suspense>
+    </I18nProvider>
   );
 }

--- a/packages/web/app/auth/verify-request/page.tsx
+++ b/packages/web/app/auth/verify-request/page.tsx
@@ -1,5 +1,7 @@
 import React, { Suspense } from 'react';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import I18nProvider from '@/app/components/providers/i18n-provider';
 import VerifyRequestContent from './verify-request-content';
 
 export const metadata = createNoIndexMetadata({
@@ -8,10 +10,13 @@ export const metadata = createNoIndexMetadata({
   path: '/auth/verify-request',
 });
 
-export default function VerifyRequestPage() {
+export default async function VerifyRequestPage() {
+  const locale = await getLocale();
   return (
-    <Suspense fallback={null}>
-      <VerifyRequestContent />
-    </Suspense>
+    <I18nProvider locale={locale} namespaces={['auth']}>
+      <Suspense fallback={null}>
+        <VerifyRequestContent />
+      </Suspense>
+    </I18nProvider>
   );
 }

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -14,6 +14,8 @@ import Stack from '@mui/material/Stack';
 import MailOutlined from '@mui/icons-material/MailOutlined';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import { useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -21,19 +23,22 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+const KNOWN_VERIFY_ERROR_CODES = new Set(['EmailNotVerified', 'InvalidToken', 'TokenExpired', 'TooManyAttempts']);
+
 type EmailErrors = { email?: string };
 
-function validateEmail(email: string): EmailErrors {
+function validateEmail(email: string, t: TFunction<'auth'>): EmailErrors {
   const errors: EmailErrors = {};
   if (!email) {
-    errors.email = 'Please enter your email';
+    errors.email = t('login.validation.emailRequired');
   } else if (!EMAIL_REGEX.test(email)) {
-    errors.email = 'Please enter a valid email';
+    errors.email = t('login.validation.emailInvalid');
   }
   return errors;
 }
 
 export default function VerifyRequestContent() {
+  const { t } = useTranslation('auth');
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
   const [resendLoading, setResendLoading] = useState(false);
@@ -42,22 +47,14 @@ export default function VerifyRequestContent() {
   const { showMessage } = useSnackbar();
 
   const getErrorMessage = () => {
-    switch (error) {
-      case 'EmailNotVerified':
-        return 'Please verify your email before signing in.';
-      case 'InvalidToken':
-        return 'The verification link is invalid. Please request a new one.';
-      case 'TokenExpired':
-        return 'The verification link has expired. Please request a new one.';
-      case 'TooManyAttempts':
-        return 'Too many verification attempts. Please wait a minute and try again.';
-      default:
-        return null;
+    if (error && KNOWN_VERIFY_ERROR_CODES.has(error)) {
+      return t(`verifyRequest.messages.${error}`);
     }
+    return null;
   };
 
   const handleResend = async () => {
-    const validationErrors = validateEmail(email);
+    const validationErrors = validateEmail(email, t);
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
 
@@ -73,9 +70,9 @@ export default function VerifyRequestContent() {
       const data = await response.json();
 
       if (response.ok) {
-        showMessage('Verification email sent! Check your inbox.', 'success');
+        showMessage(t('verifyRequest.toasts.sent'), 'success');
       } else {
-        showMessage(data.error || 'Failed to send verification email', 'error');
+        showMessage(data.error || t('verifyRequest.toasts.failed'), 'error');
       }
     } catch (err) {
       console.error('Resend error:', err);
@@ -103,7 +100,7 @@ export default function VerifyRequestContent() {
         <BackButton />
         <Logo size="sm" showText={false} />
         <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
-          Email Verification
+          {t('verifyRequest.header')}
         </Typography>
       </Box>
 
@@ -128,9 +125,9 @@ export default function VerifyRequestContent() {
               ) : (
                 <>
                   <MailOutlined sx={{ fontSize: 48, color: themeTokens.colors.primary, mx: 'auto' }} />
-                  <Typography variant="h3">Check your email</Typography>
+                  <Typography variant="h3">{t('verifyRequest.title')}</Typography>
                   <Typography variant="body1" component="p" color="text.secondary">
-                    We sent you a verification link. Click the link in your email to verify your account.
+                    {t('verifyRequest.description')}
                   </Typography>
                 </>
               )}
@@ -144,7 +141,7 @@ export default function VerifyRequestContent() {
                 sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
               >
                 <TextField
-                  placeholder="Enter your email to resend"
+                  placeholder={t('verifyRequest.resendPlaceholder')}
                   variant="outlined"
                   size="medium"
                   fullWidth
@@ -174,12 +171,12 @@ export default function VerifyRequestContent() {
                   fullWidth
                   size="large"
                 >
-                  Resend Verification Email
+                  {t('verifyRequest.resend')}
                 </Button>
               </Box>
 
               <Button variant="text" href="/auth/login">
-                Back to Login
+                {t('verifyRequest.back')}
               </Button>
             </Stack>
           </CardContent>

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -21,6 +21,8 @@ import Favorite from '@mui/icons-material/Favorite';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { signIn } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
 import { TabPanel } from '@/app/components/ui/tab-panel';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -35,38 +37,38 @@ const initialRegisterValues = { name: '', email: '', password: '', confirmPasswo
 type LoginErrors = Partial<Record<keyof typeof initialLoginValues, string>>;
 type RegisterErrors = Partial<Record<keyof typeof initialRegisterValues, string>>;
 
-function validateLoginFields(values: typeof initialLoginValues): LoginErrors {
+function validateLoginFields(values: typeof initialLoginValues, t: TFunction<'auth'>): LoginErrors {
   const errors: LoginErrors = {};
   if (!values.email) {
-    errors.email = 'Please enter your email';
+    errors.email = t('login.validation.emailRequired');
   } else if (!EMAIL_REGEX.test(values.email)) {
-    errors.email = 'Please enter a valid email';
+    errors.email = t('login.validation.emailInvalid');
   }
   if (!values.password) {
-    errors.password = 'Please enter your password';
+    errors.password = t('login.validation.passwordRequired');
   }
   return errors;
 }
 
-function validateRegisterFields(values: typeof initialRegisterValues): RegisterErrors {
+function validateRegisterFields(values: typeof initialRegisterValues, t: TFunction<'auth'>): RegisterErrors {
   const errors: RegisterErrors = {};
   if (values.name && values.name.length > 100) {
-    errors.name = 'Name must be less than 100 characters';
+    errors.name = t('login.validation.nameTooLong');
   }
   if (!values.email) {
-    errors.email = 'Please enter your email';
+    errors.email = t('login.validation.emailRequired');
   } else if (!EMAIL_REGEX.test(values.email)) {
-    errors.email = 'Please enter a valid email';
+    errors.email = t('login.validation.emailInvalid');
   }
   if (!values.password) {
-    errors.password = 'Please enter a password';
+    errors.password = t('login.validation.passwordRequiredCreate');
   } else if (values.password.length < 8) {
-    errors.password = 'Password must be at least 8 characters';
+    errors.password = t('login.validation.passwordTooShort');
   }
   if (!values.confirmPassword) {
-    errors.confirmPassword = 'Please confirm your password';
+    errors.confirmPassword = t('login.validation.confirmPasswordRequired');
   } else if (values.confirmPassword !== values.password) {
-    errors.confirmPassword = 'Passwords do not match';
+    errors.confirmPassword = t('login.validation.passwordsMismatch');
   }
   return errors;
 }
@@ -79,13 +81,10 @@ type AuthModalProps = {
   description?: string;
 };
 
-export default function AuthModal({
-  open,
-  onClose,
-  onSuccess,
-  title = 'Sign in to keep your progress',
-  description = 'Your logbook, playlists, and follows stay with your account.',
-}: AuthModalProps) {
+export default function AuthModal({ open, onClose, onSuccess, title, description }: AuthModalProps) {
+  const { t } = useTranslation('auth');
+  const resolvedTitle = title ?? t('modal.title');
+  const resolvedDescription = description ?? t('modal.description');
   const [loginValues, setLoginValues] = useState(initialLoginValues);
   const [loginErrors, setLoginErrors] = useState<LoginErrors>({});
   const [registerValues, setRegisterValues] = useState(initialRegisterValues);
@@ -99,7 +98,7 @@ export default function AuthModal({
   const { showMessage } = useSnackbar();
 
   const handleLogin = async () => {
-    const errors = validateLoginFields(loginValues);
+    const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
     if (Object.keys(errors).length > 0) return;
 
@@ -113,9 +112,9 @@ export default function AuthModal({
       });
 
       if (result?.error) {
-        showMessage('Invalid email or password', 'error');
+        showMessage(t('login.toasts.invalidCredentials'), 'error');
       } else if (result?.ok) {
-        showMessage('Logged in successfully', 'success');
+        showMessage(t('login.toasts.loggedIn'), 'success');
         setLoginValues(initialLoginValues);
         setLoginErrors({});
         onClose();
@@ -129,7 +128,7 @@ export default function AuthModal({
   };
 
   const handleRegister = async () => {
-    const errors = validateRegisterFields(registerValues);
+    const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
     if (Object.keys(errors).length > 0) return;
 
@@ -154,13 +153,13 @@ export default function AuthModal({
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || 'Registration failed', 'error');
+        showMessage(data.error || t('login.toasts.registrationFailed'), 'error');
         return;
       }
 
       // Check if email verification is required
       if (data.requiresVerification) {
-        showMessage('Please check your email to verify your account', 'info');
+        showMessage(t('login.toasts.checkEmail'), 'info');
         setActiveTab('login');
         setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
         setRegisterValues(initialRegisterValues);
@@ -169,7 +168,7 @@ export default function AuthModal({
       }
 
       // Email verification disabled - auto-login after successful registration
-      showMessage('Account created! Logging you in...', 'success');
+      showMessage(t('login.toasts.accountCreated'), 'success');
 
       const loginResult = await signIn('credentials', {
         email: registerValues.email,
@@ -185,11 +184,11 @@ export default function AuthModal({
       } else {
         setActiveTab('login');
         setLoginValues((prev) => ({ ...prev, email: registerValues.email }));
-        showMessage('Please log in with your account', 'info');
+        showMessage(t('login.toasts.loginAfterCreate'), 'info');
       }
     } catch (error) {
       console.error('Registration error:', error);
-      showMessage('Registration failed. Please try again.', 'error');
+      showMessage(t('login.toasts.registrationFailedRetry'), 'error');
     } finally {
       setRegisterLoading(false);
     }
@@ -210,16 +209,16 @@ export default function AuthModal({
           <Stack spacing={1} sx={{ width: '100%', textAlign: 'center' }}>
             <Favorite sx={{ fontSize: 32, color: themeTokens.colors.error, mx: 'auto' }} />
             <Typography variant="body2" component="span" fontWeight={600} sx={{ fontSize: 18 }}>
-              {title}
+              {resolvedTitle}
             </Typography>
             <Typography variant="body2" component="span" color="text.secondary">
-              {description}
+              {resolvedDescription}
             </Typography>
           </Stack>
 
           <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} centered>
-            <Tab label="Login" value="login" />
-            <Tab label="Create Account" value="register" />
+            <Tab label={t('login.tabs.signIn')} value="login" />
+            <Tab label={t('login.tabs.signUp')} value="register" />
           </Tabs>
 
           <TabPanel value={activeTab} index="login">
@@ -233,7 +232,7 @@ export default function AuthModal({
             >
               <TextField
                 id="login_email"
-                placeholder="your@email.com"
+                placeholder={t('login.placeholders.email')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -260,7 +259,7 @@ export default function AuthModal({
               <TextField
                 id="login_password"
                 type={showLoginPassword ? 'text' : 'password'}
-                placeholder="Password"
+                placeholder={t('login.placeholders.password')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -303,7 +302,7 @@ export default function AuthModal({
                 fullWidth
                 size="large"
               >
-                Login
+                {t('login.submit.signIn')}
               </Button>
             </Box>
           </TabPanel>
@@ -318,7 +317,7 @@ export default function AuthModal({
               sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
             >
               <TextField
-                placeholder="Your name (optional)"
+                placeholder={t('login.placeholders.name')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -341,7 +340,7 @@ export default function AuthModal({
               />
 
               <TextField
-                placeholder="your@email.com"
+                placeholder={t('login.placeholders.email')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -367,7 +366,7 @@ export default function AuthModal({
 
               <TextField
                 type={showRegisterPassword ? 'text' : 'password'}
-                placeholder="Password (min 8 characters)"
+                placeholder={t('login.placeholders.passwordWithMin')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -404,7 +403,7 @@ export default function AuthModal({
 
               <TextField
                 type={showConfirmPassword ? 'text' : 'password'}
-                placeholder="Confirm password"
+                placeholder={t('login.placeholders.confirmPassword')}
                 variant="outlined"
                 size="medium"
                 fullWidth
@@ -448,14 +447,14 @@ export default function AuthModal({
                 fullWidth
                 size="large"
               >
-                Create Account
+                {t('login.submit.signUp')}
               </Button>
             </Box>
           </TabPanel>
 
           <MuiDivider sx={{ margin: '8px 0' }}>
             <Typography variant="body2" component="span" color="text.secondary">
-              or
+              {t('login.divider')}
             </Typography>
           </MuiDivider>
 

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 
 import { signIn } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { buildNativeOAuthSignInUrl } from '@/app/lib/auth/native-oauth-url';
 
@@ -57,6 +58,7 @@ type SocialLoginButtonsProps = {
 };
 
 export default function SocialLoginButtons({ callbackUrl = '/', disabled = false }: SocialLoginButtonsProps) {
+  const { t } = useTranslation('auth');
   const [providers, setProviders] = useState<ProvidersConfig | null>(null);
   const [loading, setLoading] = useState(true);
   const [isCapacitorApp, setIsCapacitorApp] = useState(false);
@@ -128,7 +130,7 @@ export default function SocialLoginButtons({ callbackUrl = '/', disabled = false
           onClick={() => handleSocialSignIn('google')}
           disabled={disabled}
         >
-          Continue with Google
+          {t('login.providers.google')}
         </Button>
       )}
 
@@ -142,7 +144,7 @@ export default function SocialLoginButtons({ callbackUrl = '/', disabled = false
           disabled={disabled}
           sx={appleButtonStyles}
         >
-          Continue with Apple
+          {t('login.providers.apple')}
         </Button>
       )}
 
@@ -155,7 +157,7 @@ export default function SocialLoginButtons({ callbackUrl = '/', disabled = false
           onClick={() => handleSocialSignIn('facebook')}
           disabled={disabled}
         >
-          Continue with Facebook
+          {t('login.providers.facebook')}
         </Button>
       )}
     </Box>

--- a/packages/web/app/global-error.tsx
+++ b/packages/web/app/global-error.tsx
@@ -34,15 +34,14 @@ function detectLocale(): Locale {
 }
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
-  const [locale, setLocale] = useState<Locale>('en-US');
+  // Lazy initializer so Spanish users on /es/* see Spanish copy on the first
+  // paint instead of flashing English between mount and the first effect.
+  // global-error always renders client-side so there's no hydration mismatch.
+  const [locale] = useState<Locale>(detectLocale);
 
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
-
-  useEffect(() => {
-    setLocale(detectLocale());
-  }, []);
 
   const copy = COPY[locale];
 

--- a/packages/web/app/global-error.tsx
+++ b/packages/web/app/global-error.tsx
@@ -1,20 +1,53 @@
 'use client';
 
 import * as Sentry from '@sentry/nextjs';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // This is a Next.js root error boundary that renders when the root layout itself
 // fails. It lives outside the normal provider tree, so we can't rely on
-// I18nProvider here — we ship hardcoded English. The same copy is mirrored in
-// `errors.json` under `globalError.*` for nested error boundaries that DO have
-// access to i18n.
+// I18nProvider here. Instead we read the locale prefix off the URL on the
+// client and look up copy from this small inline map. The same strings are
+// mirrored in `errors.json#globalError.*` for nested error boundaries that DO
+// have access to i18n — keep them in sync.
+const COPY = {
+  'en-US': {
+    htmlLang: 'en',
+    title: 'Something went wrong',
+    subtitle: 'Try reloading to get back on track',
+    reload: 'Reload app',
+  },
+  es: {
+    htmlLang: 'es',
+    title: 'Algo salió mal',
+    subtitle: 'Recarga para volver a la pared',
+    reload: 'Recargar',
+  },
+} as const;
+
+type Locale = keyof typeof COPY;
+
+function detectLocale(): Locale {
+  if (typeof window === 'undefined') return 'en-US';
+  const { pathname } = window.location;
+  if (pathname === '/es' || pathname.startsWith('/es/')) return 'es';
+  return 'en-US';
+}
+
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const [locale, setLocale] = useState<Locale>('en-US');
+
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
 
+  useEffect(() => {
+    setLocale(detectLocale());
+  }, []);
+
+  const copy = COPY[locale];
+
   return (
-    <html lang="en" data-theme="dark" suppressHydrationWarning>
+    <html lang={copy.htmlLang} data-theme="dark" suppressHydrationWarning>
       <body
         style={{
           margin: 0,
@@ -34,8 +67,8 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
             textAlign: 'center',
           }}
         >
-          <p style={{ fontSize: 18, fontWeight: 500, margin: '0 0 8px' }}>Something went wrong</p>
-          <p style={{ fontSize: 14, color: '#9CA3AF', margin: '0 0 24px' }}>Try reloading to get back on track</p>
+          <p style={{ fontSize: 18, fontWeight: 500, margin: '0 0 8px' }}>{copy.title}</p>
+          <p style={{ fontSize: 14, color: '#9CA3AF', margin: '0 0 24px' }}>{copy.subtitle}</p>
           <button
             onClick={() => reset()}
             style={{
@@ -49,7 +82,7 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
               WebkitTapHighlightColor: 'transparent',
             }}
           >
-            Reload app
+            {copy.reload}
           </button>
         </div>
       </body>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -76,7 +76,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
               <ColorModeProvider>
-                <I18nProvider locale={locale}>
+                <I18nProvider locale={locale} namespaces={['common', 'auth']}>
                   <SnackbarProvider>
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>


### PR DESCRIPTION
## Summary

Closes #1816. Wraps every user-facing literal in the auth pipeline in `t(...)` so `/es/auth/*` renders in Spanish.

The catalog already had every key we need from the prior i18n work (#1810): `auth.json` covers login, signup, validation, toasts, providers, error-code messages, verify-request copy, and modal copy in both en-US and es; `errors.json#globalError` covers the root error boundary copy. So 5 of the 6 files are mechanical call-site wiring with no catalog additions.

### Files
- `packages/web/app/components/auth/auth-modal.tsx` — wraps tab labels, default modal copy, validation, toasts, placeholders, button text, divider. `validateLoginFields` / `validateRegisterFields` now take `t` so messages are translated. Default props for `title` / `description` resolve via `t('modal.title')` / `t('modal.description')` inside the body (defaults can't call hooks at module load).
- `packages/web/app/components/auth/social-login-buttons.tsx` — three OAuth provider button labels.
- `packages/web/app/auth/login/auth-page-content.tsx` — page header, subtitle, tab labels, all field labels + placeholders, validation, all toasts (including `authFailed` and `verified` for the `?error=` and `?verified=true` query-param flows), submit buttons, divider.
- `packages/web/app/auth/error/auth-error-content.tsx` — header, title, back button, and the 11 NextAuth error-code → message map (now a `Set` of known codes plus a templated `t(\`error.messages.${code}\`)` lookup with `error.messages.default` as the fallback).
- `packages/web/app/auth/verify-request/verify-request-content.tsx` — header, title, description, resend placeholder, resend button, back button, the 4 verify-error code messages (same Set + template-key pattern as auth-error), and both toast outcomes. Validation reuses `login.validation.emailRequired` / `login.validation.emailInvalid` from the same namespace rather than duplicating keys.
- `packages/web/app/global-error.tsx` — **structural exception.** This is the Next.js root error boundary, which renders when the root layout itself crashes, so it lives outside `I18nProvider` and can't use `useTranslation`. Locale is detected inline from `window.location.pathname` (`/es` prefix → `es`, otherwise `en-US`) inside a `useState` initializer; SSR defaults to `en-US`. Copy is duplicated inline in a `COPY` map mirroring `errors.json#globalError.{title, subtitle, reload}` — kept in sync via comment. Also threads the detected locale into `<html lang>`.

## Test plan

- [x] `vp run typecheck:web` passes
- [x] `vp lint` passes on all 6 changed files
- [x] `vp fmt --check` passes on all 6 changed files
- [ ] Manual smoke at `/auth/login` — English copy unchanged
- [ ] Manual smoke at `/es/auth/login` — tabs, fields, placeholders, buttons, divider, social buttons all Spanish; trigger validation (empty form) and toast (bad creds) to verify Spanish messages
- [ ] Manual smoke at `/es/auth/error?error=Configuration`, `?error=AccessDenied`, `?error=OAuthAccountNotLinked`, and `?error=Bogus` (to exercise the default fallback)
- [ ] Manual smoke at `/es/auth/verify-request` — headers, buttons, resend toasts, resend validation
- [ ] Open the auth modal from a context that mounts it — confirm modal title/description default to `auth.modal.*` in both locales
- [ ] Smoke `global-error.tsx` by temporarily throwing in `app/layout.tsx` on both `/` and `/es/` (revert after) to confirm the inline locale lookup works

https://claude.ai/code/session_01UXdqmP1uDrQQWozNM4cFz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXdqmP1uDrQQWozNM4cFz5)_