### PR TITLE
fix(i18n): lazy-load missing namespaces (unbreaks help-screenshots, /you stats)

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -89,7 +89,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['common', 'climbs']}>
+    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session']}>
       <div
         style={{
           minHeight: '100dvh',

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -60,7 +60,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['common', 'climbs']}>
+    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session']}>
       <div
         style={{
           minHeight: '100dvh',

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -44,11 +44,6 @@ function getClientInstance(locale: Locale, resources: Record<string, Record<stri
       supportedLngs: SUPPORTED_LOCALES as unknown as string[],
       defaultNS: DEFAULT_NAMESPACE,
       resources: { [locale]: resources },
-      // Required when init is given pre-bundled `resources`: tells i18next those
-      // bundles aren't the complete set, so the backend is still consulted for
-      // namespaces the page didn't pre-load (e.g. `session` on board pages,
-      // `profile` stats on /you).
-      partialBundledLanguages: true,
       interpolation: { escapeValue: false },
       returnNull: false,
     });

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -44,6 +44,11 @@ function getClientInstance(locale: Locale, resources: Record<string, Record<stri
       supportedLngs: SUPPORTED_LOCALES as unknown as string[],
       defaultNS: DEFAULT_NAMESPACE,
       resources: { [locale]: resources },
+      // Required when init is given pre-bundled `resources`: tells i18next those
+      // bundles aren't the complete set, so the backend is still consulted for
+      // namespaces the page didn't pre-load (e.g. `session` on board pages,
+      // `profile` stats on /you).
+      partialBundledLanguages: true,
       interpolation: { escapeValue: false },
       returnNull: false,
     });

--- a/packages/web/app/you/layout.tsx
+++ b/packages/web/app/you/layout.tsx
@@ -16,7 +16,7 @@ export default async function YouLayout({ children }: { children: React.ReactNod
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['you']}>
+    <I18nProvider locale={locale} namespaces={['you', 'profile']}>
       <Box className={styles.layout}>
         <Box component="main" className={styles.content}>
           <YouTabBar />


### PR DESCRIPTION
## Summary

PR #1810 introduced i18n coverage but two surfaces ended up rendering raw keys instead of translations because their layouts never preloaded the namespace those components needed:

- **Board pages** (`/[board_name]/.../[angle]` and `/b/[board_slug]/[angle]`) preloaded only `common` + `climbs`, but the StartSeshDrawer rendered there reads from `session` — the `Sesh` button rendered as the literal `creation.submitDefault`. This broke `help-screenshots › party mode active session`.
- `/you/layout.tsx` preloaded only `you`, but the shared `StatsSummary` on the progress tab reads from `profile` — labels rendered as `stats.problems`, `stats.send`, etc.

The first attempt was a one-line config flip to `partialBundledLanguages: true` so the existing `resourcesToBackend` would lazy-load missing namespaces. That made `Sesh` resolve correctly, but the resulting re-renders (every `t()` call kicked off a load → re-render) interrupted in-flight NextLink navigation — six shards regressed with click-but-no-URL-change failures. The first commit on this branch makes that change; the second commit reverts it after the bad CI run.

The kept fix preloads the missing namespaces server-side so the client never lazy-loads. JSON payloads are tiny (~4–8 KB each), and there's no re-render-during-click hazard.

## Test plan

- [ ] CI E2E shard 7 (`help-screenshots › party mode active session`) green — confirmed locally before reverting the partial flag.
- [ ] CI E2E shards 1, 2, 5, 6 stay green (the regressions caused by `partialBundledLanguages: true` shouldn't recur with the targeted preload).
- [ ] Open a board page, hit *Start sesh*, and verify the footer button reads **Sesh** (not `creation.submitDefault`).
- [ ] Open `/you` and verify the stat tile labels say **problems / send / flash** (not `stats.*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)