### PR TITLE
i18n: load boards namespace on home page

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
   ]);
 
   return (
-    <I18nProvider locale={locale} namespaces={['marketing']}>
+    <I18nProvider locale={locale} namespaces={['marketing', 'boards']}>
       <HomePageContent boardConfigs={boardConfigs} initialPopularConfigs={popularConfigs} />
     </I18nProvider>
   );


### PR DESCRIPTION
## Summary

The home page's discovery scroll renders raw key strings instead of translations for `discovery.section.nearby`, `discovery.findNearby.idle`, `discovery.custom.label`, `discovery.search.label`, and `discovery.bluetooth.idle`.

Root cause: `packages/web/app/page.tsx` wraps the page in `<I18nProvider namespaces={['marketing']}>`, but every card under `packages/web/app/components/board-scroll/*.tsx` calls `useTranslation('boards')`. The `boards` namespace is never loaded on this route, so i18next falls back to returning the literal keys.

The keys are already defined in `packages/web/i18n/locales/en-US/boards.json` and `packages/web/i18n/locales/es/boards.json`, and `'boards'` is already in `SEED_NAMESPACES` (`packages/web/app/lib/i18n/config.ts`). The fix is to add `'boards'` to the per-page namespace list passed to `I18nProvider` so the catalog is preloaded for SSR + hydration.

- Adds `'boards'` to the `I18nProvider` namespaces array in `packages/web/app/page.tsx` (1 line).

## Test plan

- [ ] `vp run dev`, open `/` and confirm the discovery section reads "Boards near you" / "Find nearby" / "Search" / "Custom board" / "Quick start" instead of raw keys.
- [ ] Open `/es/` and confirm Spanish copy renders.
- [ ] View page source on `/` to confirm the strings are server-rendered (no client-only flash of raw keys).
- [ ] `vp check` and `vp run typecheck:web` pass.

https://claude.ai/code/session_011pv9EnQH8U7AQzhtbciwyX

---
_Generated by [Claude Code](https://claude.ai/code/session_011pv9EnQH8U7AQzhtbciwyX)_