### PR TITLE
fix(boards): honest delete copy + MUI dialog for board delete

### DIFF
--- a/packages/web/app/components/board-entity/board-detail.tsx
+++ b/packages/web/app/components/board-entity/board-detail.tsx
@@ -10,6 +10,11 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Divider from '@mui/material/Divider';
 import MuiButton from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
 import CircularProgress from '@mui/material/CircularProgress';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
@@ -78,6 +83,7 @@ export function BoardDetailContent({
   const [activeTab, setActiveTab] = useState(0);
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showGymDetail, setShowGymDetail] = useState(false);
   const [showGymSelector, setShowGymSelector] = useState(false);
   const { token } = useWsAuthToken();
@@ -113,10 +119,10 @@ export function BoardDetailContent({
 
   const isOwner = !!currentUserId && board?.ownerId === currentUserId;
 
-  const handleDelete = async () => {
+  const handleDeleteConfirm = async () => {
     if (!token || !board) return;
-    if (!window.confirm(t('boardEntity.delete.confirm', { name: board.name }))) return;
 
+    setShowDeleteDialog(false);
     setIsDeleting(true);
     try {
       const client = createGraphQLHttpClient(token);
@@ -340,7 +346,7 @@ export function BoardDetailContent({
                 size="small"
                 color="error"
                 startIcon={<DeleteOutlined />}
-                onClick={handleDelete}
+                onClick={() => setShowDeleteDialog(true)}
                 disabled={isDeleting}
                 sx={{ textTransform: 'none' }}
               >
@@ -371,6 +377,20 @@ export function BoardDetailContent({
       {board.gymUuid && (
         <GymDetail gymUuid={board.gymUuid} open={showGymDetail} onClose={() => setShowGymDetail(false)} anchor="top" />
       )}
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
+        <DialogTitle>{t('boardEntity.delete.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('boardEntity.delete.confirm', { name: board.name })}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <MuiButton onClick={() => setShowDeleteDialog(false)}>{t('boardEntity.delete.cancel')}</MuiButton>
+          <MuiButton onClick={handleDeleteConfirm} color="error" autoFocus>
+            {t('boardEntity.delete.delete')}
+          </MuiButton>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/packages/web/i18n/locales/en-US/boards.json
+++ b/packages/web/i18n/locales/en-US/boards.json
@@ -51,7 +51,10 @@
       "comments": "comments"
     },
     "delete": {
-      "confirm": "Delete \"{{name}}\"? This action can be undone later."
+      "title": "Delete Board",
+      "confirm": "Delete \"{{name}}\"? This can't be undone.",
+      "cancel": "Cancel",
+      "delete": "Delete"
     },
     "snackbar": {
       "deleted": "Board deleted",
@@ -107,7 +110,7 @@
     },
     "delete": {
       "title": "Delete Gym",
-      "confirm": "Delete \"{{name}}\"? This action can be undone later.",
+      "confirm": "Delete \"{{name}}\"? This can't be undone.",
       "cancel": "Cancel",
       "delete": "Delete"
     },

--- a/packages/web/i18n/locales/es/boards.json
+++ b/packages/web/i18n/locales/es/boards.json
@@ -51,7 +51,10 @@
       "comments": "comentarios"
     },
     "delete": {
-      "confirm": "¿Eliminar \"{{name}}\"? Esta acción se puede deshacer más tarde."
+      "title": "Eliminar tablero",
+      "confirm": "¿Eliminar \"{{name}}\"? No se puede deshacer.",
+      "cancel": "Cancelar",
+      "delete": "Eliminar"
     },
     "snackbar": {
       "deleted": "Tablero eliminado",
@@ -107,7 +110,7 @@
     },
     "delete": {
       "title": "Eliminar gimnasio",
-      "confirm": "¿Eliminar \"{{name}}\"? Esta acción se puede deshacer más tarde.",
+      "confirm": "¿Eliminar \"{{name}}\"? No se puede deshacer.",
       "cancel": "Cancelar",
       "delete": "Eliminar"
     },


### PR DESCRIPTION
## Summary

- Reword `boardEntity.delete.confirm` and `gymEntity.delete.confirm` from "This action can be undone later." to "This can't be undone." in both en-US and es. The backend soft-deletes (sets `deletedAt`), but no `restoreBoard`/`restoreGym` mutation exists in the GraphQL schema and there's no trash/restore UI — from the user's perspective the action is permanent, so the old copy was misleading.
- Migrate `board-detail.tsx` from `window.confirm` to an MUI `Dialog`, mirroring `gym-detail.tsx:280-291` (same `showDeleteDialog` state pattern, same Dialog/DialogTitle/DialogContent/DialogContentText/DialogActions structure, autofocused red Delete button).
- Add the matching `boardEntity.delete.{title,cancel,delete}` keys to both catalogs, parallel to the existing `gymEntity.delete` keys.

## Test plan

- [ ] `vp run typecheck:web` passes (verified locally — exit 0).
- [ ] `vp lint packages/web/app/components/board-entity/board-detail.tsx` clean (verified locally — 0 warnings, 0 errors).
- [ ] Manual: open a board you own → click red Delete → MUI dialog appears (not native `window.confirm`) with title "Delete Board" and body "Delete \"{name}\"? This can't be undone." → Cancel keeps the board, red Delete shows the existing "Board deleted" snackbar and closes the drawer.
- [ ] Repeat under `/es/...` and confirm "¿Eliminar … ? No se puede deshacer." renders.
- [ ] Smoke test gym delete flow under both locales to confirm the reworded `gymEntity.delete.confirm` shows correctly with no other regression.

https://claude.ai/code/session_01Me1U6PRJM9eJeHtpXxG6Dm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Me1U6PRJM9eJeHtpXxG6Dm)_