### PR TITLE
i18n: flag okText/cancelText props and combine stale-marker reporting

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -8,6 +8,7 @@ import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { DeleteOutlined } from '@mui/icons-material';
 import { track } from '@vercel/analytics';
+import { useTranslation } from 'react-i18next';
 import type { BoardDetails } from '@/app/lib/types';
 import dynamic from 'next/dynamic';
 
@@ -53,6 +54,7 @@ const QueueTabLabel: React.FC = () => {
 
 // Isolated component for the queue tab content - subscribes to context independently
 const QueueTabContent: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }) => {
+  const { t } = useTranslation('common');
   const { queue } = useQueueList();
   const { setQueue } = useQueueActions();
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
@@ -75,8 +77,8 @@ const QueueTabContent: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetail
             // i18n-ignore-next-line
             description="Are you sure you want to clear all items from the queue?"
             onConfirm={handleClearQueue}
-            okText="Clear"
-            cancelText="Cancel"
+            okText={t('actions.clear')}
+            cancelText={t('actions.cancel')}
           >
             <MuiButton variant="text" startIcon={<DeleteOutlined />} size="small" sx={{ color: 'var(--neutral-400)' }}>
               {/* i18n-ignore-next-line */}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
@@ -6,6 +6,7 @@ import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { DeleteOutlined } from '@mui/icons-material';
 import { track } from '@vercel/analytics';
+import { useTranslation } from 'react-i18next';
 import type { BoardDetails } from '@/app/lib/types';
 
 import QueueList from '@/app/components/queue-control/queue-list';
@@ -18,6 +19,7 @@ type PlayLayoutClientProps = {
 };
 
 const QueueSidebar: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }) => {
+  const { t } = useTranslation('common');
   const { queue } = useQueueList();
   const { setQueue } = useQueueActions();
 
@@ -51,8 +53,8 @@ const QueueSidebar: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }
             // i18n-ignore-next-line
             description="Are you sure you want to clear all items from the queue?"
             onConfirm={handleClearQueue}
-            okText="Clear"
-            cancelText="Cancel"
+            okText={t('actions.clear')}
+            cancelText={t('actions.cancel')}
           >
             <MuiButton variant="text" startIcon={<DeleteOutlined />} size="small" sx={{ color: 'var(--neutral-400)' }}>
               {/* i18n-ignore-next-line */}

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -16,6 +16,7 @@ import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { formatTickRelativeTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
@@ -102,6 +103,7 @@ const TickItemRow: React.FC<{
   onDelete: (uuid: string) => void;
   isDeleting: boolean;
 }> = ({ item, onDelete, isDeleting }) => {
+  const { t } = useTranslation('common');
   const timeAgo = formatTickRelativeTime(item.climbedAt);
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
@@ -124,7 +126,7 @@ const TickItemRow: React.FC<{
         // i18n-ignore-next-line
         description="Are you sure? This cannot be undone."
         onConfirm={() => onDelete(item.uuid)}
-        okText="Delete"
+        okText={t('actions.delete')}
         okButtonProps={{ color: 'error' }}
       >
         <IconButton size="small" disabled={isDeleting} sx={{ color: 'text.secondary' }}>

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1540,8 +1540,8 @@ export default function CreateClimbForm({
           // i18n-ignore-next-line
           description="This will clear all holds and reset the form. Are you sure?"
           onConfirm={resetHolds}
-          okText="Clear"
-          cancelText="Cancel"
+          okText={t('common:actions.clear')}
+          cancelText={t('common:actions.cancel')}
         >
           {/* i18n-ignore-next-line */}
           <MuiTooltip title="Clear all holds">

--- a/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
@@ -101,8 +101,8 @@ export default function MoonBoardImportCard({
           // i18n-ignore-next-line
           description="This climb will not be imported."
           onConfirm={onRemove}
-          okText="Remove"
-          cancelText="Cancel"
+          okText={t('actions.remove')}
+          cancelText={t('actions.cancel')}
         >
           <MuiButton variant="text" color="error" startIcon={<DeleteOutlined />}>
             {/* i18n-ignore-next-line */}

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -33,7 +33,9 @@
     "loading": "Loading...",
     "share": "Share",
     "copy": "Copy",
-    "submit": "Submit"
+    "submit": "Submit",
+    "clear": "Clear",
+    "remove": "Remove"
   },
   "ariaLabels": {
     "close": "Close",

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -25,7 +25,9 @@
     "loading": "Cargando...",
     "share": "Compartir",
     "copy": "Copiar",
-    "submit": "Enviar"
+    "submit": "Enviar",
+    "clear": "Limpiar",
+    "remove": "Quitar"
   },
   "ariaLabels": {
     "close": "Cerrar",

--- a/packages/web/scripts/check-untranslated-strings.test.ts
+++ b/packages/web/scripts/check-untranslated-strings.test.ts
@@ -140,6 +140,39 @@ export default function Foo() {
 `);
     expect(violations).toHaveLength(0);
   });
+
+  it('flags hardcoded okText / cancelText on confirm-style components', () => {
+    const { violations } = scan(`
+export default function Foo() {
+  return (
+    <ConfirmPopover okText="Delete" cancelText="Cancel" onConfirm={() => {}}>
+      <button />
+    </ConfirmPopover>
+  );
+}
+`);
+    const flagged = violations
+      .filter((violation) => violation.kind === 'jsx-attribute')
+      .map((violation) => ({ attribute: violation.attribute, text: violation.text }))
+      .sort((a, b) => (a.attribute ?? '').localeCompare(b.attribute ?? ''));
+    expect(flagged).toEqual([
+      { attribute: 'cancelText', text: 'Cancel' },
+      { attribute: 'okText', text: 'Delete' },
+    ]);
+  });
+
+  it('passes when okText / cancelText use t()', () => {
+    const { violations } = scan(`
+export default function Foo({ t }: { t: (key: string) => string }) {
+  return (
+    <ConfirmPopover okText={t('actions.delete')} cancelText={t('actions.cancel')} onConfirm={() => {}}>
+      <button />
+    </ConfirmPopover>
+  );
+}
+`);
+    expect(violations).toHaveLength(0);
+  });
 });
 
 describe('checkFile — imperative call sites', () => {
@@ -238,6 +271,24 @@ export default function Foo() {
 }
 `);
     expect(violations.some((violation) => violation.text.includes('i18n-ignore-next-line'))).toBe(true);
+  });
+
+  it('returns fresh violations and stale markers from the same file in a single pass', () => {
+    // Combined-reporting guarantee: the data layer must surface both classes
+    // so main() can print them together without short-circuiting.
+    const { violations, staleMarkers } = scan(`
+export default function Foo({ t }: { t: (key: string) => string }) {
+  return (
+    <>
+      <button aria-label="Submit form" />
+      {/* i18n-ignore-next-line */}
+      <span>{t('translated.string')}</span>
+    </>
+  );
+}
+`);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(staleMarkers.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/web/scripts/check-untranslated-strings.ts
+++ b/packages/web/scripts/check-untranslated-strings.ts
@@ -8,7 +8,8 @@
  *   1. JSX text nodes      e.g. <Button>Save</Button>
  *   2. Specific JSX string-literal attributes (aria-label, placeholder,
  *      title, alt, helperText, label, description, tooltip, primary,
- *      secondary, aria-description, aria-placeholder, aria-roledescription)
+ *      secondary, aria-description, aria-placeholder, aria-roledescription,
+ *      okText, cancelText)
  *   3. Imperative call sites: enqueueSnackbar / showMessage / openAuthModal
  *      with a literal message arg or a literal title/description/body/message
  *      object property
@@ -49,6 +50,8 @@ const FLAGGED_ATTRIBUTES = new Set([
   'tooltip',
   'primary',
   'secondary',
+  'okText',
+  'cancelText',
 ]);
 
 // Map of call name → which positional arguments to scan. For toast-style
@@ -491,8 +494,10 @@ function main(): never {
   }
 
   const report = run();
+  const hasViolations = report.violations.length > 0;
+  const hasStaleMarkers = report.staleMarkers.length > 0;
 
-  if (report.violations.length > 0) {
+  if (hasViolations) {
     for (const violation of report.violations) {
       console.error(describe(violation));
     }
@@ -505,18 +510,19 @@ function main(): never {
         '`// i18n-ignore-next-line` on the line above to mark it as deliberately untranslated. ' +
         'Run `bun packages/web/scripts/check-untranslated-strings.ts --fix` to bulk-add markers above existing violations.',
     );
-    process.exit(1);
   }
 
-  if (report.staleMarkers.length > 0) {
+  if (hasStaleMarkers) {
+    if (hasViolations) console.error('');
     for (const stale of report.staleMarkers) {
       const rel = relative(repoRoot, stale.file);
       console.error(`${rel}:${stale.line}  stale i18n-ignore-next-line marker (no violation on the next line)`);
     }
     console.error('');
     console.error(`Found ${report.staleMarkers.length} stale i18n-ignore-next-line marker(s); remove them.`);
-    process.exit(1);
   }
+
+  if (hasViolations || hasStaleMarkers) process.exit(1);
 
   console.info(
     `check-untranslated-strings: OK — scanned ${report.totalFiles} .tsx file(s), no hardcoded user-facing strings.`,


### PR DESCRIPTION
## Summary

Two follow-ups to the i18n scanner (`packages/web/scripts/check-untranslated-strings.ts`):

- **`okText` / `cancelText` props are now flagged.** Added both names to `FLAGGED_ATTRIBUTES`, then translated the 9 hardcoded call sites the new rule surfaced across `ConfirmPopover` users (5 files: `list/layout-client.tsx`, `play/layout-client.tsx`, `create-climb-form.tsx`, `ascents-feed.tsx`, `moonboard-import-card.tsx`). Reused `actions.cancel` / `actions.delete`; added new `actions.clear` and `actions.remove` keys to the `en-US` and `es` `common` catalogs.
- **Stale ignore markers no longer hide behind violations.** `main()` previously short-circuited after printing violations, so a contributor who introduced both a new violation and a now-stale `// i18n-ignore-next-line` only saw one error per CI run. Both classes now print together before the single non-zero exit.

Two new unit tests cover the new attribute coverage and the combined data-layer guarantee.

## Test plan

- [x] `vp run check:i18n` — green (391 `.tsx` files scanned, no violations)
- [x] `vp test run --reporter=agent --project web` — 3994/3994 pass
- [x] `vp lint` on changed files — 0 errors (2 pre-existing warnings unrelated)
- [x] `vp fmt --check` on changed files — all formatted
- [x] `vp run typecheck:web` — exits 0
- [x] Manual combined-output check: temp file with one fresh violation + one stale marker prints both before exit 1
- [ ] Locale rendering smoke test in `vp run dev` (skipped — no browser in this environment; reviewer to verify "Clear" / "Cancel" buttons render in `/` and `/es/` ConfirmPopover triggers)

https://claude.ai/code/session_01RHZpWpaStsDo2fuQiv6ji9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHZpWpaStsDo2fuQiv6ji9)_