### PR TITLE
i18n: load session namespace in root layout

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -76,7 +76,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
               <ColorModeProvider>
-                <I18nProvider locale={locale} namespaces={['common', 'playlists']}>
+                <I18nProvider locale={locale} namespaces={['common', 'playlists', 'session']}>
                   <SnackbarProvider>
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>


### PR DESCRIPTION
## Summary

The session drawer was rendering raw i18n keys (e.g. `settings.stopSession`, `settings.share.inviteCopy`) instead of the translated strings on most pages.

## Root cause

`SeshSettingsDrawer` is mounted at the root via `RootSeshSettingsDrawer` inside `PersistentSessionWrapper`, so it can be opened from any page (home, profile, settings, etc.). It calls `useTranslation('session')`, but the root layout's `I18nProvider` only preloaded `['common', 'playlists']`. The `session` namespace was only added by board-route layouts (`/b/[board_slug]/...`, `/[board_name]/...`) and the `/session/*` and `/join/*` routes.

When the drawer opened on a page that didn't preload `session` (e.g. `/`, which loads `['marketing', 'boards']`), i18next had no bundle for that namespace and react-i18next rendered the bare keys.

The same applied to `OnboardingDummySeshMount` (also mounted at the root) and to `StartSeshDrawer` rendered from the home page.

## Fix

Add `'session'` to the root layout's `I18nProvider` namespace list. Resources merge into the singleton client instance, so the per-route layouts that already include `session` continue to work and pages without it now also get it.

## Test plan

- [ ] Open the session settings drawer on `/` (no active board) and confirm header / share copy / stop button labels render in English instead of as `settings.*` keys
- [ ] Same check on `/es` to confirm Spanish strings load
- [ ] Open the start-sesh drawer from the home page and verify creation copy renders
- [ ] Board-route pages (`/b/...`, `/[board_name]/...`) still translate everything
- [ ] `vp run typecheck:web` passes (already verified locally)
- [ ] `vp run check:i18n` passes (already verified locally)

https://claude.ai/code/session_0122JfNjH8hezdop23f2bXJi

---
_Generated by [Claude Code](https://claude.ai/code/session_0122JfNjH8hezdop23f2bXJi)_