### PR TITLE
fix(i18n): consistent ns usage, cancel labels, e2e bell selector

### DIFF
--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -127,6 +127,7 @@ const TickItemRow: React.FC<{
         description="Are you sure? This cannot be undone."
         onConfirm={() => onDelete(item.uuid)}
         okText={t('actions.delete')}
+        cancelText={t('actions.cancel')}
         okButtonProps={{ color: 'error' }}
       >
         <IconButton size="small" disabled={isDeleting} sx={{ color: 'text.secondary' }}>

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -17,6 +17,7 @@ import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { formatTickRelativeTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
@@ -60,20 +61,20 @@ const getLayoutDisplayName = (boardType: string, layoutId: number | null): strin
   return layoutNames[key] || `${boardType.charAt(0).toUpperCase() + boardType.slice(1)}`;
 };
 
-// Generate status summary for grouped attempts
 const getGroupStatusSummary = (
   group: GroupedAscentFeedItem,
+  t: TFunction,
 ): { text: string; icon: React.ReactNode; color: string } => {
   const parts: string[] = [];
 
   if (group.flashCount > 0) {
-    parts.push(group.flashCount === 1 ? 'Flashed' : `${group.flashCount} flashes`);
+    parts.push(t('ascents.flashed', { count: group.flashCount }));
   }
   if (group.sendCount > 0) {
-    parts.push(group.sendCount === 1 ? 'Sent' : `${group.sendCount} sends`);
+    parts.push(t('ascents.sent', { count: group.sendCount }));
   }
   if (group.attemptCount > 0) {
-    parts.push(group.attemptCount === 1 ? '1 attempt' : `${group.attemptCount} attempts`);
+    parts.push(t('ascents.attempts', { count: group.attemptCount }));
   }
 
   let icon: React.ReactNode;
@@ -98,6 +99,13 @@ const getItemStatusColor = (status: string): 'success' | 'primary' | 'default' =
   return 'default';
 };
 
+const getItemStatusLabel = (status: string, t: TFunction): string => {
+  if (status === 'flash') return t('ascents.statusFlash');
+  if (status === 'send') return t('ascents.statusSend');
+  if (status === 'attempt') return t('ascents.statusAttempt');
+  return status;
+};
+
 const TickItemRow: React.FC<{
   item: AscentFeedItem;
   onDelete: (uuid: string) => void;
@@ -108,7 +116,7 @@ const TickItemRow: React.FC<{
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
       <Chip
-        label={item.status}
+        label={getItemStatusLabel(item.status, t)}
         size="small"
         color={getItemStatusColor(item.status)}
         variant={item.status === 'attempt' ? 'outlined' : 'filled'}
@@ -118,7 +126,7 @@ const TickItemRow: React.FC<{
         }}
       />
       <MuiTypography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
-        {item.attemptCount > 1 ? `${item.attemptCount} attempts` : null} {timeAgo}
+        {item.attemptCount > 1 ? t('ascents.attempts', { count: item.attemptCount }) : null} {timeAgo}
       </MuiTypography>
       <ConfirmPopover
         title={t('ascents.deleteTitle')}
@@ -142,12 +150,13 @@ const GroupedFeedItem: React.FC<{
   onDeleteTick?: (uuid: string) => void;
   isDeleting?: boolean;
 }> = ({ group, isOwnProfile = false, onDeleteTick, isDeleting = false }) => {
+  const { t } = useTranslation('common');
   const latestItem = group.items.reduce((latest, item) =>
     tickTimeMs(item.climbedAt) > tickTimeMs(latest.climbedAt) ? item : latest,
   );
   const timeAgo = formatTickRelativeTime(latestItem.climbedAt);
   const boardDisplay = getLayoutDisplayName(group.boardType, group.layoutId);
-  const statusSummary = getGroupStatusSummary(group);
+  const statusSummary = getGroupStatusSummary(group, t);
   const hasSuccess = group.flashCount > 0 || group.sendCount > 0;
 
   return (

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -121,10 +121,8 @@ const TickItemRow: React.FC<{
         {item.attemptCount > 1 ? `${item.attemptCount} attempts` : null} {timeAgo}
       </MuiTypography>
       <ConfirmPopover
-        // i18n-ignore-next-line
-        title="Delete ascent"
-        // i18n-ignore-next-line
-        description="Are you sure? This cannot be undone."
+        title={t('ascents.deleteTitle')}
+        description={t('ascents.deleteDescription')}
         onConfirm={() => onDelete(item.uuid)}
         okText={t('actions.delete')}
         cancelText={t('actions.cancel')}

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1536,19 +1536,15 @@ export default function CreateClimbForm({
           </MuiTooltip>
         )}
         <ConfirmPopover
-          // i18n-ignore-next-line
-          title="Clear climb"
-          // i18n-ignore-next-line
-          description="This will clear all holds and reset the form. Are you sure?"
+          title={t('create.clear.title')}
+          description={t('create.clear.description')}
           onConfirm={resetHolds}
           okText={tCommon('actions.clear')}
           cancelText={tCommon('actions.cancel')}
         >
-          {/* i18n-ignore-next-line */}
-          <MuiTooltip title="Clear all holds">
+          <MuiTooltip title={t('create.clear.tooltip')}>
             <span>
-              {/* i18n-ignore-next-line */}
-              <IconButton size="small" disabled={totalHolds === 0} aria-label="Clear all holds">
+              <IconButton size="small" disabled={totalHolds === 0} aria-label={t('create.clear.tooltip')}>
                 <DeleteOutlined fontSize="small" />
               </IconButton>
             </span>

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -135,6 +135,7 @@ export default function CreateClimbForm({
   holdSetImages,
 }: CreateClimbFormProps) {
   const { t } = useTranslation('climbs');
+  const { t: tCommon } = useTranslation('common');
   const pathname = usePathname();
   const { data: session } = useSession();
   const { mode } = useColorMode();
@@ -1540,8 +1541,8 @@ export default function CreateClimbForm({
           // i18n-ignore-next-line
           description="This will clear all holds and reset the form. Are you sure?"
           onConfirm={resetHolds}
-          okText={t('common:actions.clear')}
-          cancelText={t('common:actions.cancel')}
+          okText={tCommon('actions.clear')}
+          cancelText={tCommon('actions.cancel')}
         >
           {/* i18n-ignore-next-line */}
           <MuiTooltip title="Clear all holds">

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -98,11 +98,10 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     // The bell is rendered as `<IconButton component={LocaleLink} href="/notifications" />`.
     // MUI 7 emits role="button" on the polymorphic anchor, so target by href to stay
     // resilient regardless of whether the implicit role lands as "link" or "button".
-    // No `.first()` — strict mode catches it if the header ever renders two bells
-    // (e.g. desktop + mobile slot) so we don't silently click whichever happens
-    // to be first. Also waits for the anchor to ensure the global-header has
-    // hydrated before we click.
-    const bell = page.locator('header a[href="/notifications"]');
+    // `.first()` because Next.js prefetch may emit a duplicate anchor in the same
+    // header during hydration; we only need to click the bell, not enforce uniqueness.
+    // The earlier visibility check ensures the global header has hydrated before we click.
+    const bell = page.locator('header a[href="/notifications"]').first();
     await expect(bell).toBeVisible({ timeout: 15000 });
     await bell.click();
     await expect(page).toHaveURL(/\/notifications/, { timeout: 15000 });

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -95,7 +95,14 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     await loginAs(page, '/you');
     await waitForPageReady(page);
 
-    await page.getByRole('link', { name: 'Notifications' }).click();
+    // The bell is rendered as `<IconButton component={LocaleLink} href="/notifications" />`.
+    // MUI 7 emits role="button" on the polymorphic anchor, so target by href to stay
+    // resilient regardless of whether the implicit role lands as "link" or "button".
+    // Also wait for the anchor (not just the bottom tab bar) to ensure the
+    // global-header has hydrated before we click.
+    const bell = page.locator('header a[href="/notifications"]').first();
+    await expect(bell).toBeVisible({ timeout: 15000 });
+    await bell.click();
     await expect(page).toHaveURL(/\/notifications/, { timeout: 15000 });
     await expect(page.locator(bottomTabBar)).toBeVisible();
   });

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -94,17 +94,21 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     // there). `/you` renders the full header with the bell unconditionally.
     await loginAs(page, '/you');
     await waitForPageReady(page);
+    // Wait for hydration so the NextLink click handler is wired up before we click.
+    // /you has no long-poll endpoints, so networkidle settles within ~2s.
+    await page.waitForLoadState('networkidle').catch(() => {});
 
     // The bell is rendered as `<IconButton component={LocaleLink} href="/notifications" />`.
-    // MUI 7 emits role="button" on the polymorphic anchor, so target by href to stay
-    // resilient regardless of whether the implicit role lands as "link" or "button".
-    // `.first()` because Next.js prefetch may emit a duplicate anchor in the same
-    // header during hydration; we only need to click the bell, not enforce uniqueness.
-    // The earlier visibility check ensures the global header has hydrated before we click.
+    // Target by href so we don't depend on whether MUI 7's polymorphic anchor surfaces
+    // as role="link" or role="button". `.first()` because Next.js prefetch may emit a
+    // duplicate anchor in the same header during hydration.
     const bell = page.locator('header a[href="/notifications"]').first();
     await expect(bell).toBeVisible({ timeout: 15000 });
-    await bell.click();
-    await expect(page).toHaveURL(/\/notifications/, { timeout: 15000 });
+
+    // NextLink does client-side routing, so we wait for the URL change atomically
+    // with the click rather than asserting after — the assertion timing window
+    // races with NextLink's own pushState in practice.
+    await Promise.all([page.waitForURL(/\/notifications/, { timeout: 15000 }), bell.click()]);
     await expect(page.locator(bottomTabBar)).toBeVisible();
   });
 

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -98,9 +98,11 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     // The bell is rendered as `<IconButton component={LocaleLink} href="/notifications" />`.
     // MUI 7 emits role="button" on the polymorphic anchor, so target by href to stay
     // resilient regardless of whether the implicit role lands as "link" or "button".
-    // Also wait for the anchor (not just the bottom tab bar) to ensure the
-    // global-header has hydrated before we click.
-    const bell = page.locator('header a[href="/notifications"]').first();
+    // No `.first()` — strict mode catches it if the header ever renders two bells
+    // (e.g. desktop + mobile slot) so we don't silently click whichever happens
+    // to be first. Also waits for the anchor to ensure the global-header has
+    // hydrated before we click.
+    const bell = page.locator('header a[href="/notifications"]');
     await expect(bell).toBeVisible({ timeout: 15000 });
     await bell.click();
     await expect(page).toHaveURL(/\/notifications/, { timeout: 15000 });

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -100,9 +100,10 @@ test.describe('Bottom Tab Bar - Navigation', () => {
 
     // The bell is rendered as `<IconButton component={LocaleLink} href="/notifications" />`.
     // Target by href so we don't depend on whether MUI 7's polymorphic anchor surfaces
-    // as role="link" or role="button". `.first()` because Next.js prefetch may emit a
-    // duplicate anchor in the same header during hydration.
-    const bell = page.locator('header a[href="/notifications"]').first();
+    // as role="link" or role="button", and combine with the bell's aria-label so the
+    // selector lands on exactly the visible header bell rather than any stray anchor a
+    // portaled MUI Drawer/Modal may inject during hydration.
+    const bell = page.locator('header a[href="/notifications"][aria-label="Notifications"]');
     await expect(bell).toBeVisible({ timeout: 15000 });
 
     // NextLink does client-side routing, so we wait for the URL change atomically

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -205,6 +205,11 @@
       "editLockedAria": "Edit window closed",
       "savedTitle": "Saved",
       "savedAria": "Saved"
+    },
+    "clear": {
+      "title": "Clear climb",
+      "description": "This will clear all holds and reset the form. Are you sure?",
+      "tooltip": "Clear all holds"
     }
   },
   "actions": {

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -199,6 +199,10 @@
   "moonboardImport": {
     "removeConfirmTitle": "Remove this climb?"
   },
+  "ascents": {
+    "deleteTitle": "Delete ascent",
+    "deleteDescription": "Are you sure? This cannot be undone."
+  },
   "board": {
     "resetZoom": "Reset zoom"
   }

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -201,7 +201,16 @@
   },
   "ascents": {
     "deleteTitle": "Delete ascent",
-    "deleteDescription": "Are you sure? This cannot be undone."
+    "deleteDescription": "Are you sure? This cannot be undone.",
+    "statusFlash": "flash",
+    "statusSend": "send",
+    "statusAttempt": "attempt",
+    "flashed_one": "Flashed",
+    "flashed_other": "{{count}} flashes",
+    "sent_one": "Sent",
+    "sent_other": "{{count}} sends",
+    "attempts_one": "1 attempt",
+    "attempts_other": "{{count}} attempts"
   },
   "board": {
     "resetZoom": "Reset zoom"

--- a/packages/web/scripts/check-untranslated-strings.test.ts
+++ b/packages/web/scripts/check-untranslated-strings.test.ts
@@ -1,8 +1,14 @@
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { applyFixes, checkFile, formatReport, looksTranslatable } from './check-untranslated-strings';
+
+// Match the script's own `repoRoot` so the relative paths in formatReport
+// output land where the test expects, rather than spanning back to `/`.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const fixtureFile = (name: string) => join(repoRoot, 'packages', 'web', 'app', name);
 
 const fakePath = '/tmp/fake-component.tsx';
 
@@ -402,13 +408,13 @@ describe('formatReport — exit code', () => {
       totalFiles: 3,
       filesWithViolations: 0,
       totalViolations: 0,
-      staleMarkers: [{ file: '/repo/packages/web/app/foo.tsx', line: 42 }],
+      staleMarkers: [{ file: fixtureFile('foo.tsx'), line: 42 }],
       violations: [],
     });
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toEqual([]);
     const stderr = result.stderr.join('\n');
-    expect(stderr).toMatch(/foo\.tsx:42\s+stale i18n-ignore-next-line marker/);
+    expect(stderr).toMatch(/^packages\/web\/app\/foo\.tsx:42\s+stale i18n-ignore-next-line marker/m);
     expect(stderr).toMatch(/Found 1 stale i18n-ignore-next-line marker/);
   });
 
@@ -420,7 +426,7 @@ describe('formatReport — exit code', () => {
       staleMarkers: [],
       violations: [
         {
-          file: '/repo/packages/web/app/bar.tsx',
+          file: fixtureFile('bar.tsx'),
           line: 10,
           column: 5,
           kind: 'jsx-text',
@@ -438,10 +444,10 @@ describe('formatReport — exit code', () => {
       totalFiles: 3,
       filesWithViolations: 1,
       totalViolations: 1,
-      staleMarkers: [{ file: '/repo/packages/web/app/foo.tsx', line: 7 }],
+      staleMarkers: [{ file: fixtureFile('foo.tsx'), line: 7 }],
       violations: [
         {
-          file: '/repo/packages/web/app/bar.tsx',
+          file: fixtureFile('bar.tsx'),
           line: 10,
           column: 5,
           kind: 'jsx-text',

--- a/packages/web/scripts/check-untranslated-strings.test.ts
+++ b/packages/web/scripts/check-untranslated-strings.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { applyFixes, checkFile, looksTranslatable } from './check-untranslated-strings';
+import { applyFixes, checkFile, formatReport, looksTranslatable } from './check-untranslated-strings';
 
 const fakePath = '/tmp/fake-component.tsx';
 
@@ -378,5 +378,80 @@ export default function Foo() {
       const { violations: violationsAfter } = checkFile(path);
       expect(violationsAfter).toHaveLength(0);
     });
+  });
+});
+
+describe('formatReport — exit code', () => {
+  it('exits 0 with stdout only when there are neither violations nor stale markers', () => {
+    const result = formatReport({
+      totalFiles: 5,
+      filesWithViolations: 0,
+      totalViolations: 0,
+      staleMarkers: [],
+      violations: [],
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toEqual([]);
+    expect(result.stdout.join('\n')).toMatch(/scanned 5/);
+  });
+
+  it('exits 1 when only stale markers exist (no violations)', () => {
+    // Combined-exit guarantee: stale markers alone must fail the check so
+    // the next contributor can't ignore the warning into oblivion.
+    const result = formatReport({
+      totalFiles: 3,
+      filesWithViolations: 0,
+      totalViolations: 0,
+      staleMarkers: [{ file: '/repo/packages/web/app/foo.tsx', line: 42 }],
+      violations: [],
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toEqual([]);
+    const stderr = result.stderr.join('\n');
+    expect(stderr).toMatch(/foo\.tsx:42\s+stale i18n-ignore-next-line marker/);
+    expect(stderr).toMatch(/Found 1 stale i18n-ignore-next-line marker/);
+  });
+
+  it('exits 1 when only violations exist (no stale markers)', () => {
+    const result = formatReport({
+      totalFiles: 3,
+      filesWithViolations: 1,
+      totalViolations: 1,
+      staleMarkers: [],
+      violations: [
+        {
+          file: '/repo/packages/web/app/bar.tsx',
+          line: 10,
+          column: 5,
+          kind: 'jsx-text',
+          text: 'Hello world',
+        },
+      ],
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toEqual([]);
+    expect(result.stderr.join('\n')).toMatch(/Found 1 hardcoded user-facing string/);
+  });
+
+  it('exits 1 and reports both classes when violations and stale markers coexist', () => {
+    const result = formatReport({
+      totalFiles: 3,
+      filesWithViolations: 1,
+      totalViolations: 1,
+      staleMarkers: [{ file: '/repo/packages/web/app/foo.tsx', line: 7 }],
+      violations: [
+        {
+          file: '/repo/packages/web/app/bar.tsx',
+          line: 10,
+          column: 5,
+          kind: 'jsx-text',
+          text: 'Hello world',
+        },
+      ],
+    });
+    expect(result.exitCode).toBe(1);
+    const stderr = result.stderr.join('\n');
+    expect(stderr).toMatch(/Found 1 hardcoded user-facing string/);
+    expect(stderr).toMatch(/Found 1 stale i18n-ignore-next-line marker/);
   });
 });

--- a/packages/web/scripts/check-untranslated-strings.ts
+++ b/packages/web/scripts/check-untranslated-strings.ts
@@ -469,6 +469,47 @@ function describe(violation: Violation): string {
   return `${head}  hardcoded ${violation.caller}({ ${violation.attribute} }): ${JSON.stringify(violation.text)}`;
 }
 
+function formatReport(report: Report): { exitCode: 0 | 1; stderr: string[]; stdout: string[] } {
+  const hasViolations = report.violations.length > 0;
+  const hasStaleMarkers = report.staleMarkers.length > 0;
+  const stderr: string[] = [];
+  const stdout: string[] = [];
+
+  if (hasViolations) {
+    for (const violation of report.violations) {
+      stderr.push(describe(violation));
+    }
+    stderr.push('');
+    stderr.push(
+      `Found ${report.totalViolations} hardcoded user-facing string(s) in ${report.filesWithViolations} file(s).`,
+    );
+    stderr.push(
+      "Wrap each in t('namespace:key') (see CLAUDE.md i18n section) or add " +
+        '`// i18n-ignore-next-line` on the line above to mark it as deliberately untranslated. ' +
+        'Run `bun packages/web/scripts/check-untranslated-strings.ts --fix` to bulk-add markers above existing violations.',
+    );
+  }
+
+  if (hasStaleMarkers) {
+    if (hasViolations) stderr.push('');
+    for (const stale of report.staleMarkers) {
+      const rel = relative(repoRoot, stale.file);
+      stderr.push(`${rel}:${stale.line}  stale i18n-ignore-next-line marker (no violation on the next line)`);
+    }
+    stderr.push('');
+    stderr.push(`Found ${report.staleMarkers.length} stale i18n-ignore-next-line marker(s); remove them.`);
+  }
+
+  if (hasViolations || hasStaleMarkers) {
+    return { exitCode: 1, stderr, stdout };
+  }
+
+  stdout.push(
+    `check-untranslated-strings: OK — scanned ${report.totalFiles} .tsx file(s), no hardcoded user-facing strings.`,
+  );
+  return { exitCode: 0, stderr, stdout };
+}
+
 function main(): never {
   const fixMode = process.argv.includes('--fix');
 
@@ -494,45 +535,15 @@ function main(): never {
   }
 
   const report = run();
-  const hasViolations = report.violations.length > 0;
-  const hasStaleMarkers = report.staleMarkers.length > 0;
-
-  if (hasViolations) {
-    for (const violation of report.violations) {
-      console.error(describe(violation));
-    }
-    console.error('');
-    console.error(
-      `Found ${report.totalViolations} hardcoded user-facing string(s) in ${report.filesWithViolations} file(s).`,
-    );
-    console.error(
-      "Wrap each in t('namespace:key') (see CLAUDE.md i18n section) or add " +
-        '`// i18n-ignore-next-line` on the line above to mark it as deliberately untranslated. ' +
-        'Run `bun packages/web/scripts/check-untranslated-strings.ts --fix` to bulk-add markers above existing violations.',
-    );
-  }
-
-  if (hasStaleMarkers) {
-    if (hasViolations) console.error('');
-    for (const stale of report.staleMarkers) {
-      const rel = relative(repoRoot, stale.file);
-      console.error(`${rel}:${stale.line}  stale i18n-ignore-next-line marker (no violation on the next line)`);
-    }
-    console.error('');
-    console.error(`Found ${report.staleMarkers.length} stale i18n-ignore-next-line marker(s); remove them.`);
-  }
-
-  if (hasViolations || hasStaleMarkers) process.exit(1);
-
-  console.info(
-    `check-untranslated-strings: OK — scanned ${report.totalFiles} .tsx file(s), no hardcoded user-facing strings.`,
-  );
-  process.exit(0);
+  const formatted = formatReport(report);
+  for (const line of formatted.stderr) console.error(line);
+  for (const line of formatted.stdout) console.info(line);
+  process.exit(formatted.exitCode);
 }
 
 if (import.meta.main) {
   main();
 }
 
-export { applyFixes, checkFile, looksTranslatable, run };
-export type { Violation };
+export { applyFixes, checkFile, formatReport, looksTranslatable, run };
+export type { Report, Violation };


### PR DESCRIPTION
## Summary

Three review nits from the recent i18n sweep + a fix for the failing `bottom-tab-bar.spec.ts` e2e test (shard 3/8).

### 1. `create-climb-form.tsx` — consistent namespace usage
Was using `useTranslation('climbs')` but reaching into `common` via the colon-prefix syntax (`t('common:actions.clear')`). Every other file in the recent i18n sweep uses a second `useTranslation('common')` call. Switched to that pattern with `tCommon('actions.clear' | 'actions.cancel')`.

### 2. `ascents-feed.tsx` — translated cancelText
`ConfirmPopover` was passing `okText={t('actions.delete')}` but no `cancelText`, leaving the implicit default visible alongside a translated okText. Added `cancelText={t('actions.cancel')}` to match every other confirm popover.

### 3. `check-untranslated-strings` — main()-level test for stale-markers-only branch
The combined-exit refactor was correct by inspection but untested. Extracted `formatReport()` from `main()` so the exit-decision branch is unit-testable, then added coverage for:
- clean run (no violations, no stale markers) → exit 0
- stale-markers-only → exit 1
- violations-only → exit 1
- both classes coexisting → exit 1, both reported

### 4. e2e: notifications bell selector
The `bottom-tab-bar.spec.ts:92` test was failing in CI because `getByRole('link', { name: 'Notifications' })` doesn't reliably find the MUI 7 `IconButton component={LocaleLink}` — the implicit role is ambiguous between "link" and "button" depending on how MUI handles the polymorphic component. Switched to `header a[href="/notifications"]` which is unambiguous, and explicitly wait for the anchor (not just the bottom tab bar) so the global header has hydrated before we click.

## Test plan

- [x] `vp test run --project web` (291 files / 3998 tests passing)
- [x] `vp run typecheck:web` clean
- [x] `vp lint` (0 errors, only pre-existing warnings)
- [x] `vp run check:i18n` clean
- [ ] e2e `bottom-tab-bar.spec.ts` shard 3/8 in CI

https://claude.ai/code/session_01QFT8oAaS4rS4U2Eqdb4cJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFT8oAaS4rS4U2Eqdb4cJr)_