### PR TITLE
i18n: translate ~580 hardcoded strings flagged by check:i18n

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/create/page.tsx
@@ -53,10 +53,8 @@ export default async function CreateClimbPage(props: CreateClimbPageProps) {
   if (parsedParams.board_name === 'moonboard') {
     const layoutInfo = getMoonBoardLayoutInfo(parsedParams.layout_id);
     if (!layoutInfo) {
-      {
-        /* i18n-ignore-next-line */
-      }
-      return <div>Invalid MoonBoard layout</div>;
+      const { t } = await getServerTranslation('climbs');
+      return <div>{t('moonboard.invalidLayout')}</div>;
     }
 
     const holdSetImages = getMoonBoardHoldSetImages(layoutInfo.layoutKey, parsedParams.set_ids);

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/import/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/import/page.tsx
@@ -48,10 +48,8 @@ export default async function ImportPage(props: ImportPageProps) {
 
   const layoutInfo = getMoonBoardLayoutInfo(parsedParams.layout_id);
   if (!layoutInfo) {
-    {
-      /* i18n-ignore-next-line */
-    }
-    return <div>Invalid MoonBoard layout</div>;
+    const { t } = await getServerTranslation('climbs');
+    return <div>{t('moonboard.invalidLayout')}</div>;
   }
 
   const holdSetImages = getMoonBoardHoldSetImages(layoutInfo.layoutKey, parsedParams.set_ids);

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton';
 import { FormatListBulletedOutlined, AppsOutlined } from '@mui/icons-material';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { track } from '@vercel/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
@@ -167,6 +168,7 @@ const ClimbsListSkeleton = ({ aspectRatio }: { aspectRatio: number }) => {
 };
 
 export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsListProps) {
+  const { t } = useTranslation('climbs');
   const pathname = usePathname();
   const isDark = useIsDarkMode();
   const { token, isLoading: tokenLoading } = useWsAuthToken();
@@ -223,8 +225,7 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
   useEffect(() => {
     if (error) {
       console.error('Error loading liked climbs:', error);
-      // i18n-ignore-next-line
-      showMessage('Failed to load liked climbs', 'error');
+      showMessage(t('liked.loadFailed'), 'error');
     }
   }, [error, showMessage]);
 
@@ -338,8 +339,7 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
   if (error && allClimbs.length === 0) {
     return (
       <div className={styles.climbsSection}>
-        {/* i18n-ignore-next-line */}
-        <EmptyState description="Failed to load liked climbs" />
+        <EmptyState description={t('liked.loadFailed')} />
       </div>
     );
   }
@@ -347,8 +347,7 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
   if (visibleClimbs.length === 0 && !isFetching) {
     return (
       <div className={styles.climbsSection}>
-        {/* i18n-ignore-next-line */}
-        <EmptyState description="No liked climbs yet. Heart some climbs to see them here!" />
+        <EmptyState description={t('liked.emptyState')} />
       </div>
     );
   }
@@ -362,8 +361,7 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
             size="small"
             color={viewMode === 'list' ? 'primary' : 'default'}
             onClick={() => handleViewModeChange('list')}
-            // i18n-ignore-next-line
-            aria-label="List view"
+            aria-label={t('list.viewMode.list')}
           >
             <FormatListBulletedOutlined />
           </IconButton>
@@ -371,8 +369,7 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
             size="small"
             color={viewMode === 'grid' ? 'primary' : 'default'}
             onClick={() => handleViewModeChange('grid')}
-            // i18n-ignore-next-line
-            aria-label="Grid view"
+            aria-label={t('list.viewMode.grid')}
           >
             <AppsOutlined />
           </IconButton>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -37,6 +37,7 @@ type ListLayoutClientProps = {
 
 // Isolated component for the queue tab label - subscribes to context independently
 const QueueTabLabel: React.FC = () => {
+  const { t } = useTranslation('session');
   const { queue } = useQueueList();
   return (
     <Badge
@@ -46,15 +47,14 @@ const QueueTabLabel: React.FC = () => {
       color="primary"
       sx={{ '& .MuiBadge-badge': { right: -8, top: -2 } }}
     >
-      {/* i18n-ignore-next-line */}
-      Queue
+      {t('queueDrawer.title')}
     </Badge>
   );
 };
 
 // Isolated component for the queue tab content - subscribes to context independently
 const QueueTabContent: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }) => {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation('session');
   const { queue } = useQueueList();
   const { setQueue } = useQueueActions();
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
@@ -72,17 +72,14 @@ const QueueTabContent: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetail
       {queue.length > 0 && (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 8px 0 8px' }}>
           <ConfirmPopover
-            // i18n-ignore-next-line
-            title="Clear queue"
-            // i18n-ignore-next-line
-            description="Are you sure you want to clear all items from the queue?"
+            title={t('queueDrawer.clearTitle')}
+            description={t('queueDrawer.clearDescription')}
             onConfirm={handleClearQueue}
-            okText={t('actions.clear')}
-            cancelText={t('actions.cancel')}
+            okText={t('queueDrawer.clearConfirm')}
+            cancelText={t('common:actions.cancel')}
           >
             <MuiButton variant="text" startIcon={<DeleteOutlined />} size="small" sx={{ color: 'var(--neutral-400)' }}>
-              {/* i18n-ignore-next-line */}
-              Clear
+              {t('queueDrawer.clear')}
             </MuiButton>
           </ConfirmPopover>
         </Box>
@@ -95,14 +92,14 @@ const QueueTabContent: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetail
 };
 
 const TabsWrapper: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }) => {
+  const { t } = useTranslation('climbs');
   const [activeTab, setActiveTab] = useState('queue');
 
   return (
     <>
       <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} className={styles.siderTabs}>
         <Tab label={<QueueTabLabel />} value="queue" />
-        {/* i18n-ignore-next-line */}
-        <Tab label="Search" value="search" />
+        <Tab label={t('search.actions.search')} value="search" />
       </Tabs>
       <TabPanel value={activeTab} index="queue">
         <QueueTabContent boardDetails={boardDetails} />

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import MuiButton from '@mui/material/Button';
 import { useSearchParams } from 'next/navigation';
 import { track } from '@vercel/analytics';
+import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import type { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useQueueActions, useCurrentClimb, useQueueList } from '@/app/components/graphql-queue';
@@ -23,6 +24,7 @@ type PlayViewClientProps = {
 };
 
 const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialClimb, angle }) => {
+  const { t } = useTranslation('session');
   const router = useLocaleRouter();
   const searchParams = useSearchParams();
   const { currentClimb } = useCurrentClimb();
@@ -135,11 +137,9 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
     return (
       <div className={styles.pageContainer} style={{ backgroundColor: 'var(--semantic-background)' }}>
         <div className={styles.emptyState} style={{ color: 'var(--neutral-400)' }}>
-          {/* i18n-ignore-next-line */}
-          <EmptyState description="No climb selected" />
+          <EmptyState description={t('playView.noClimbSelected')} />
           <MuiButton variant="contained" onClick={() => router.push(getBackToListUrl())}>
-            {/* i18n-ignore-next-line */}
-            Browse Climbs
+            {t('playView.browseClimbs')}
           </MuiButton>
         </div>
       </div>

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
@@ -19,7 +19,7 @@ type PlayLayoutClientProps = {
 };
 
 const QueueSidebar: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }) => {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation('session');
   const { queue } = useQueueList();
   const { setQueue } = useQueueActions();
 
@@ -42,23 +42,19 @@ const QueueSidebar: React.FC<{ boardDetails: BoardDetails }> = ({ boardDetails }
             color="primary"
             sx={{ '& .MuiBadge-badge': { right: -8, top: 0 } }}
           >
-            {/* i18n-ignore-next-line */}
-            Queue
+            {t('queueDrawer.title')}
           </Badge>
         </h3>
         {queue.length > 0 && (
           <ConfirmPopover
-            // i18n-ignore-next-line
-            title="Clear queue"
-            // i18n-ignore-next-line
-            description="Are you sure you want to clear all items from the queue?"
+            title={t('queueDrawer.clearTitle')}
+            description={t('queueDrawer.clearDescription')}
             onConfirm={handleClearQueue}
-            okText={t('actions.clear')}
-            cancelText={t('actions.cancel')}
+            okText={t('queueDrawer.clearConfirm')}
+            cancelText={t('common:actions.cancel')}
           >
             <MuiButton variant="text" startIcon={<DeleteOutlined />} size="small" sx={{ color: 'var(--neutral-400)' }}>
-              {/* i18n-ignore-next-line */}
-              Clear
+              {t('queueDrawer.clear')}
             </MuiButton>
           </ConfirmPopover>
         )}

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -173,7 +173,7 @@ export async function GET(request: NextRequest) {
             fontWeight: 600,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- OG image, brand-only text */}
           boardsesh.com
         </div>
       </div>,

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -224,7 +224,7 @@ export async function GET(request: NextRequest) {
             fontWeight: 600,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- OG image, brand-only text */}
           boardsesh.com
         </div>
       </div>,

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -261,7 +261,7 @@ export async function GET(request: NextRequest) {
                 color: darkTokens.neutral[900],
               }}
             >
-              {/* i18n-ignore-next-line */}
+              {/* i18n-ignore-next-line -- OG image, English-only */}
               Grades climbed so far
             </div>
 
@@ -330,7 +330,7 @@ export async function GET(request: NextRequest) {
                   color: darkTokens.neutral[600],
                 }}
               >
-                {/* i18n-ignore-next-line */}
+                {/* i18n-ignore-next-line -- OG image, English-only */}
                 No sends yet.
               </div>
             )}
@@ -348,7 +348,7 @@ export async function GET(request: NextRequest) {
             letterSpacing: '0.04em',
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- OG image, brand-only text */}
           boardsesh.com
         </div>
       </div>
@@ -470,7 +470,7 @@ export async function GET(request: NextRequest) {
             fontWeight: 600,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- OG image, brand-only text */}
           boardsesh.com
         </div>
       </div>

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -229,7 +229,7 @@ export async function GET(request: NextRequest) {
             fontWeight: 600,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- OG image, brand-only text */}
           boardsesh.com
         </div>
       </div>,

--- a/packages/web/app/auth/native-start/native-start-client.tsx
+++ b/packages/web/app/auth/native-start/native-start-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { getCsrfToken } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
@@ -10,6 +11,7 @@ import Typography from '@mui/material/Typography';
 const ALLOWED_PROVIDERS = new Set(['google', 'apple', 'facebook']);
 
 function NativeStartInner() {
+  const { t } = useTranslation('auth');
   const params = useSearchParams();
   const formRef = useRef<HTMLFormElement>(null);
   const submitted = useRef(false);
@@ -40,8 +42,7 @@ function NativeStartInner() {
           minHeight: '100vh',
         }}
       >
-        {/* i18n-ignore-next-line */}
-        <Typography>Invalid sign-in provider</Typography>
+        <Typography>{t('nativeStart.invalidProvider')}</Typography>
       </Box>
     );
   }
@@ -58,8 +59,7 @@ function NativeStartInner() {
       }}
     >
       <CircularProgress />
-      {/* i18n-ignore-next-line */}
-      <Typography>Signing in...</Typography>
+      <Typography>{t('nativeStart.signingIn')}</Typography>
       <form
         ref={formRef}
         method="POST"

--- a/packages/web/app/b/[board_slug]/[angle]/create/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/create/page.tsx
@@ -56,10 +56,8 @@ export default async function BoardSlugCreatePage(props: CreatePageProps) {
   if (parsedParams.board_name === 'moonboard') {
     const layoutInfo = getMoonBoardLayoutInfo(parsedParams.layout_id);
     if (!layoutInfo) {
-      {
-        /* i18n-ignore-next-line */
-      }
-      return <div>Invalid MoonBoard layout</div>;
+      const { t } = await getServerTranslation('climbs');
+      return <div>{t('moonboard.invalidLayout')}</div>;
     }
 
     const holdSetImages = getMoonBoardHoldSetImages(layoutInfo.layoutKey, parsedParams.set_ids);

--- a/packages/web/app/b/[board_slug]/[angle]/import/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/import/page.tsx
@@ -50,10 +50,8 @@ export default async function BoardSlugImportPage(props: ImportPageProps) {
 
   const layoutInfo = getMoonBoardLayoutInfo(parsedParams.layout_id);
   if (!layoutInfo) {
-    {
-      /* i18n-ignore-next-line */
-    }
-    return <div>Invalid MoonBoard layout</div>;
+    const { t } = await getServerTranslation('climbs');
+    return <div>{t('moonboard.invalidLayout')}</div>;
   }
 
   const holdSetImages = getMoonBoardHoldSetImages(layoutInfo.layoutKey, parsedParams.set_ids);

--- a/packages/web/app/components/activity-feed/__tests__/activity-feed.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/activity-feed.test.tsx
@@ -6,6 +6,15 @@ import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import type { SessionFeedItem } from '@boardsesh/shared-schema';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import ActivityFeed from '../activity-feed';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 

--- a/packages/web/app/components/activity-feed/__tests__/comment-feed.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/comment-feed.test.tsx
@@ -6,6 +6,15 @@ import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import type { Comment as CommentType } from '@boardsesh/shared-schema';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import CommentFeed from '../comment-feed';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 
@@ -257,7 +266,7 @@ describe('CommentFeed', () => {
         expect(screen.getByText(/Failed to load comments/)).toBeTruthy();
       });
 
-      expect(screen.getByText('Retry')).toBeTruthy();
+      expect(screen.getByText('Try again')).toBeTruthy();
     });
 
     it('calls refetch when retry button is clicked', async () => {
@@ -274,7 +283,7 @@ describe('CommentFeed', () => {
       render(<CommentFeed isAuthenticated={false} />, { wrapper: createWrapper() });
 
       await waitFor(() => {
-        expect(screen.getByText('Retry')).toBeTruthy();
+        expect(screen.getByText('Try again')).toBeTruthy();
       });
 
       // Set up success response for retry
@@ -287,7 +296,7 @@ describe('CommentFeed', () => {
         },
       });
 
-      fireEvent.click(screen.getByText('Retry'));
+      fireEvent.click(screen.getByText('Try again'));
 
       await waitFor(() => {
         expect(mockRequest).toHaveBeenCalledTimes(2);

--- a/packages/web/app/components/activity-feed/__tests__/proposal-feed.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/proposal-feed.test.tsx
@@ -6,6 +6,15 @@ import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import type { Proposal } from '@boardsesh/shared-schema';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import ProposalFeed from '../proposal-feed';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 
@@ -228,7 +237,7 @@ describe('ProposalFeed', () => {
         expect(screen.getByText(/Failed to load proposals/)).toBeTruthy();
       });
 
-      expect(screen.getByText('Retry')).toBeTruthy();
+      expect(screen.getByText('Try again')).toBeTruthy();
     });
 
     it('calls refetch when retry button is clicked', async () => {
@@ -245,7 +254,7 @@ describe('ProposalFeed', () => {
       render(<ProposalFeed isAuthenticated={false} />, { wrapper: createWrapper() });
 
       await waitFor(() => {
-        expect(screen.getByText('Retry')).toBeTruthy();
+        expect(screen.getByText('Try again')).toBeTruthy();
       });
 
       // Set up success response for retry
@@ -253,7 +262,7 @@ describe('ProposalFeed', () => {
         browseProposals: { proposals: [makeProposal('p1')], totalCount: 1, hasMore: false },
       });
 
-      fireEvent.click(screen.getByText('Retry'));
+      fireEvent.click(screen.getByText('Try again'));
 
       await waitFor(() => {
         expect(mockRequest).toHaveBeenCalledTimes(2);

--- a/packages/web/app/components/activity-feed/activity-feed.tsx
+++ b/packages/web/app/components/activity-feed/activity-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
 import MuiAlert from '@mui/material/Alert';
@@ -38,6 +39,7 @@ export default function ActivityFeed({
   onFindClimbers,
   initialFeedResult,
 }: ActivityFeedProps) {
+  const { t } = useTranslation('feed');
   const { token, isLoading: authLoading, error: authError } = useWsAuthToken();
 
   const hasInitialData = !!initialFeedResult && initialFeedResult.sessions.length > 0;
@@ -102,20 +104,17 @@ export default function ActivityFeed({
   let emptyStateContent: React.ReactNode = null;
   if (isAuthenticated) {
     emptyStateContent = (
-      // i18n-ignore-next-line
-      <EmptyState icon={<PersonSearchOutlined fontSize="inherit" />} description="Follow some climbers to fill this up">
+      <EmptyState icon={<PersonSearchOutlined fontSize="inherit" />} description={t('emptyStates.followClimbers')}>
         {onFindClimbers && (
           <MuiButton variant="contained" onClick={onFindClimbers}>
-            {/* i18n-ignore-next-line */}
-            Find Climbers
+            {t('emptyStates.findClimbers')}
           </MuiButton>
         )}
       </EmptyState>
     );
   } else {
     emptyStateContent = (
-      // i18n-ignore-next-line
-      <EmptyState icon={<PublicOutlined fontSize="inherit" />} description="No recent activity yet" />
+      <EmptyState icon={<PublicOutlined fontSize="inherit" />} description={t('emptyStates.noRecentActivity')} />
     );
   }
 
@@ -123,8 +122,7 @@ export default function ActivityFeed({
     <Box data-testid="activity-feed" sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       {!isAuthenticated && (
         <MuiAlert severity="info" sx={{ mb: 1 }}>
-          {/* i18n-ignore-next-line */}
-          Sign in to see a personalized feed from climbers you follow.
+          {t('activityFeed.signInPrompt')}
         </MuiAlert>
       )}
 
@@ -137,14 +135,9 @@ export default function ActivityFeed({
       )}
 
       {error && (
-        <EmptyState
-          icon={<ErrorOutline fontSize="inherit" />}
-          // i18n-ignore-next-line
-          description="Failed to load activity feed. Please try again."
-        >
+        <EmptyState icon={<ErrorOutline fontSize="inherit" />} description={t('errors.loadFeed')}>
           <MuiButton variant="contained" onClick={() => refetch()}>
-            {/* i18n-ignore-next-line */}
-            Retry
+            {t('common:actions.retry')}
           </MuiButton>
         </EmptyState>
       )}

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import MuiTypography from '@mui/material/Typography';
@@ -16,7 +17,6 @@ import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { formatTickRelativeTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -214,10 +214,8 @@ const GroupedFeedItem: React.FC<{
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.boardType}>
                 {boardDisplay}
               </MuiTypography>
-              {/* i18n-ignore-next-line */}
-              {group.isMirror && <Chip label="Mirrored" size="small" color="secondary" />}
-              {/* i18n-ignore-next-line */}
-              {group.isBenchmark && <Chip label="Benchmark" size="small" />}
+              {group.isMirror && <Chip label={t('ascentsFeed.mirrored')} size="small" color="secondary" />}
+              {group.isBenchmark && <Chip label={t('ascentsFeed.benchmark')} size="small" />}
             </Box>
 
             {hasSuccess && group.bestQuality && (
@@ -226,8 +224,7 @@ const GroupedFeedItem: React.FC<{
 
             {group.setterUsername && (
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.setter}>
-                {/* i18n-ignore-next-line */}
-                Set by {group.setterUsername}
+                {t('ascentsFeed.setBy', { name: group.setterUsername })}
               </MuiTypography>
             )}
 
@@ -260,6 +257,7 @@ const GroupedFeedItem: React.FC<{
 };
 
 export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10, isOwnProfile = false }) => {
+  const { t } = useTranslation('feed');
   const deleteTick = useDeleteTick();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useInfiniteQuery({
     queryKey: ['ascentsFeed', userId, pageSize],
@@ -300,13 +298,11 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10,
   }
 
   if (error) {
-    // i18n-ignore-next-line
-    return <EmptyState description="Failed to load activity feed" />;
+    return <EmptyState description={t('errors.loadActivity')} />;
   }
 
   if (groups.length === 0) {
-    // i18n-ignore-next-line
-    return <EmptyState description="No ascents logged yet" />;
+    return <EmptyState description={t('ascentsFeed.empty')} />;
   }
 
   return (

--- a/packages/web/app/components/activity-feed/comment-feed.tsx
+++ b/packages/web/app/components/activity-feed/comment-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -46,6 +47,7 @@ type CommentFeedProps = {
 };
 
 export default function CommentFeed({ isAuthenticated, boardUuid }: CommentFeedProps) {
+  const { t } = useTranslation('feed');
   const { token, isLoading: authLoading } = useWsAuthToken();
 
   const queryKey = ['globalCommentFeed', boardUuid] as const;
@@ -96,18 +98,15 @@ export default function CommentFeed({ isAuthenticated, boardUuid }: CommentFeedP
   return (
     <Box data-testid="comment-feed" sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       {error && (
-        // i18n-ignore-next-line
-        <EmptyState icon={<ErrorOutline fontSize="inherit" />} description="Failed to load comments. Please try again.">
+        <EmptyState icon={<ErrorOutline fontSize="inherit" />} description={t('errors.loadComments')}>
           <MuiButton variant="contained" onClick={() => refetch()}>
-            {/* i18n-ignore-next-line */}
-            Retry
+            {t('common:actions.retry')}
           </MuiButton>
         </EmptyState>
       )}
 
       {!error && comments.length === 0 ? (
-        // i18n-ignore-next-line
-        <EmptyState icon={<ChatBubbleOutlineOutlined fontSize="inherit" />} description="No comments yet" />
+        <EmptyState icon={<ChatBubbleOutlineOutlined fontSize="inherit" />} description={t('commentFeed.empty')} />
       ) : (
         <>
           {comments.map((comment) => (
@@ -132,6 +131,7 @@ export default function CommentFeed({ isAuthenticated, boardUuid }: CommentFeedP
 }
 
 function CommentFeedCard({ comment }: { comment: CommentType }) {
+  const { t } = useTranslation('feed');
   const timeAgo = dayjs(comment.createdAt).fromNow();
   const entityLabel = ENTITY_TYPE_LABELS[comment.entityType] || comment.entityType;
 
@@ -160,8 +160,7 @@ function CommentFeedCard({ comment }: { comment: CommentType }) {
             </Typography>
             <Typography variant="body2" component="span" color="text.secondary">
               {' '}
-              {/* i18n-ignore-next-line */}
-              commented on {entityLabel}
+              {t('commentFeed.commentedOn', { entity: entityLabel })}
             </Typography>
           </Box>
           <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>

--- a/packages/web/app/components/activity-feed/feed-item-comment.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-comment.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -22,6 +23,7 @@ type FeedItemCommentProps = {
 };
 
 export default function FeedItemComment({ item }: FeedItemCommentProps) {
+  const { t } = useTranslation('feed');
   const timeAgo = dayjs(item.createdAt).fromNow();
   const actorProfileHref = item.actorId ? `/profile/${item.actorId}` : null;
 
@@ -48,8 +50,7 @@ export default function FeedItemComment({ item }: FeedItemCommentProps) {
             </MuiTypography>
             <MuiTypography variant="body2" component="span" color="text.secondary">
               {' '}
-              {/* i18n-ignore-next-line */}
-              commented
+              {t('feedItemComment.commented')}
             </MuiTypography>
             {item.climbName && (
               <>

--- a/packages/web/app/components/activity-feed/feed-item-new-climb.tsx
+++ b/packages/web/app/components/activity-feed/feed-item-new-climb.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -30,6 +31,7 @@ type FeedItemNewClimbProps = {
 };
 
 export default function FeedItemNewClimb({ item }: FeedItemNewClimbProps) {
+  const { t } = useTranslation('feed');
   const [commentsOpen, setCommentsOpen] = useState(false);
   const timeAgo = dayjs(item.createdAt).fromNow();
   const actorProfileHref = item.actorId ? `/profile/${item.actorId}` : null;
@@ -57,8 +59,7 @@ export default function FeedItemNewClimb({ item }: FeedItemNewClimbProps) {
             </MuiTypography>
             <MuiTypography variant="body2" component="span" color="text.secondary">
               {' '}
-              {/* i18n-ignore-next-line */}
-              created a new climb{' '}
+              {t('feedItemNewClimb.createdClimb')}{' '}
             </MuiTypography>
             <MuiTypography variant="body2" component="span" fontWeight={600}>
               {item.climbName}
@@ -111,8 +112,11 @@ export default function FeedItemNewClimb({ item }: FeedItemNewClimbProps) {
         {/* Comments */}
         <Collapse in={commentsOpen} unmountOnExit>
           <Box sx={{ mt: 1 }}>
-            {/* i18n-ignore-next-line */}
-            <CommentSection entityType="climb" entityId={item.climbUuid || item.entityId} title="Comments" />
+            <CommentSection
+              entityType="climb"
+              entityId={item.climbUuid || item.entityId}
+              title={t('feedCommentButton.commentsTitle')}
+            />
           </Box>
         </Collapse>
       </CardContent>

--- a/packages/web/app/components/activity-feed/proposal-feed.tsx
+++ b/packages/web/app/components/activity-feed/proposal-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
@@ -25,6 +26,7 @@ type ProposalFeedProps = {
 };
 
 export default function ProposalFeed({ isAuthenticated, boardUuid }: ProposalFeedProps) {
+  const { t } = useTranslation('feed');
   const { token, isLoading: authLoading } = useWsAuthToken();
   const PAGE_SIZE = 20;
 
@@ -78,21 +80,15 @@ export default function ProposalFeed({ isAuthenticated, boardUuid }: ProposalFee
   return (
     <Box data-testid="proposal-feed" sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       {error && (
-        <EmptyState
-          icon={<ErrorOutline fontSize="inherit" />}
-          // i18n-ignore-next-line
-          description="Failed to load proposals. Please try again."
-        >
+        <EmptyState icon={<ErrorOutline fontSize="inherit" />} description={t('errors.loadProposals')}>
           <MuiButton variant="contained" onClick={() => refetch()}>
-            {/* i18n-ignore-next-line */}
-            Retry
+            {t('common:actions.retry')}
           </MuiButton>
         </EmptyState>
       )}
 
       {!error && proposals.length === 0 ? (
-        // i18n-ignore-next-line
-        <EmptyState icon={<GavelOutlined fontSize="inherit" />} description="No proposals yet" />
+        <EmptyState icon={<GavelOutlined fontSize="inherit" />} description={t('proposalFeed.empty')} />
       ) : (
         <>
           {proposals.map((proposal) => (

--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -57,6 +58,7 @@ function formatRelativeTime(isoString: string): string {
 }
 
 export default function SessionFeedCard({ session }: SessionFeedCardProps) {
+  const { t } = useTranslation('feed');
   const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
 
   const {
@@ -303,8 +305,9 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
                 {boardTypes.map((bt) => bt.charAt(0).toUpperCase() + bt.slice(1)).join(', ')}
               </Typography>
               <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                {/* i18n-ignore-next-line */}
-                {tickCount} climb{tickCount !== 1 ? 's' : ''}
+                {tickCount === 1
+                  ? t('sessionFeedCard.climbCountOne', { count: tickCount })
+                  : t('sessionFeedCard.climbCountMany', { count: tickCount })}
               </Typography>
             </Box>
           )}

--- a/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/session-summary-feed-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -32,6 +33,7 @@ type SessionSummaryFeedItemProps = {
 };
 
 export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemProps) {
+  const { t } = useTranslation('feed');
   const { formatGrade, loaded: gradeFormatLoaded } = useGradeFormat();
 
   let metadata: SessionSummaryMetadata = {};
@@ -69,8 +71,7 @@ export default function SessionSummaryFeedItem({ item }: SessionSummaryFeedItemP
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
           <GroupsOutlined fontSize="small" color="primary" />
           <Typography variant="body2" fontWeight={600}>
-            {/* i18n-ignore-next-line */}
-            Session completed
+            {t('sessionSummary.completed')}
           </Typography>
           {item.actorDisplayName && (
             <Typography variant="body2" color="text.secondary">

--- a/packages/web/app/components/activity-feed/social-feed-item.tsx
+++ b/packages/web/app/components/activity-feed/social-feed-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -64,6 +65,7 @@ type SocialFeedItemProps = {
 };
 
 const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = false }) => {
+  const { t } = useTranslation('feed');
   const [commentsOpen, setCommentsOpen] = useState(false);
   const timeAgo = formatTickRelativeTime(item.climbedAt);
   const statusDisplay = getStatusDisplay(item.status);
@@ -95,8 +97,7 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
               </MuiTypography>
               <MuiTypography variant="body2" component="span" color="text.secondary">
                 {' '}
-                {/* i18n-ignore-next-line */}
-                climbed{' '}
+                {t('socialFeedItem.climbed')}{' '}
               </MuiTypography>
               <MuiTypography variant="body2" component="span" fontWeight={600}>
                 {item.climbName}
@@ -166,10 +167,8 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.boardType}>
                 {boardDisplay}
               </MuiTypography>
-              {/* i18n-ignore-next-line */}
-              {item.isMirror && <Chip label="Mirrored" size="small" color="secondary" />}
-              {/* i18n-ignore-next-line */}
-              {item.isBenchmark && <Chip label="Benchmark" size="small" />}
+              {item.isMirror && <Chip label={t('ascentsFeed.mirrored')} size="small" color="secondary" />}
+              {item.isBenchmark && <Chip label={t('ascentsFeed.benchmark')} size="small" />}
             </Box>
 
             {/* Comment */}
@@ -196,8 +195,7 @@ const SocialFeedItem: React.FC<SocialFeedItemProps> = ({ item, showUserHeader = 
         {/* Comments */}
         <Collapse in={commentsOpen} unmountOnExit>
           <Box sx={{ mt: 1 }}>
-            {/* i18n-ignore-next-line */}
-            <CommentSection entityType="tick" entityId={item.uuid} title="Comments" />
+            <CommentSection entityType="tick" entityId={item.uuid} title={t('feedCommentButton.commentsTitle')} />
           </Box>
         </Collapse>
       </CardContent>

--- a/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -23,9 +24,12 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
   climbName,
   angle,
 }) => {
+  const { t } = useTranslation('feed');
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>{climbName ? `Share beta for ${climbName}` : 'Share beta video'}</DialogTitle>
+      <DialogTitle>
+        {climbName ? t('betaVideos.shareBetaFor', { name: climbName }) : t('betaVideos.shareBetaVideo')}
+      </DialogTitle>
       <DialogContent>
         <AttachBetaLinkForm
           boardType={boardType}
@@ -33,9 +37,8 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
           climbName={climbName}
           angle={angle}
           resetTrigger={open}
-          submitLabel="Share beta"
-          // i18n-ignore-next-line
-          helperText="Paste a reel or post link so others can see your beta."
+          submitLabel={t('betaVideos.shareBeta')}
+          helperText={t('betaVideos.dialogHelper')}
           onSuccess={onClose}
           onCancel={onClose}
           showCancel

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -61,7 +62,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   climbName,
   angle,
   resetTrigger,
-  submitLabel = 'Share beta',
+  submitLabel,
   helperText,
   onSuccess,
   onCancel,
@@ -69,6 +70,8 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   autoFocus = false,
   compact = false,
 }) => {
+  const { t } = useTranslation('feed');
+  const resolvedSubmitLabel = submitLabel ?? t('betaVideos.shareBeta');
   const [url, setUrl] = useState('');
   const { token } = useWsAuthToken();
   const queryClient = useQueryClient();
@@ -104,8 +107,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
         platform = 'Instagram';
       }
       track('Beta Video Added', { boardType, climbUuid, platform });
-      // i18n-ignore-next-line
-      showMessage('Video added to beta', 'success');
+      showMessage(t('betaVideos.addedToast'), 'success');
       setUrl('');
       onSuccess?.();
     },
@@ -116,7 +118,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       // (network, library internals, type assertions) that field can carry
       // raw stack traces or implementation strings that shouldn't be shown.
       const serverMessage = extractGraphQLErrorMessage(error);
-      showMessage(serverMessage ?? 'Couldn’t add video. Try again.', 'error');
+      showMessage(serverMessage ?? t('betaVideos.addError'), 'error');
     },
   });
 
@@ -127,17 +129,12 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       <TextField
         autoFocus={autoFocus}
         fullWidth
-        // i18n-ignore-next-line
-        placeholder="Instagram or TikTok URL"
-        label={climbName ? `Beta video URL for ${climbName}` : 'Beta video URL'}
+        placeholder={t('betaVideos.urlPlaceholder')}
+        label={climbName ? t('betaVideos.urlLabelForClimb', { name: climbName }) : t('betaVideos.urlLabel')}
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         error={!!validationError}
-        helperText={
-          validationError ??
-          helperText ??
-          'Paste a public Instagram reel/post or TikTok URL so others can see your beta.'
-        }
+        helperText={validationError ?? helperText ?? t('betaVideos.defaultHelper')}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && canSubmit) {
             e.preventDefault();
@@ -149,8 +146,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
         {showCancel && onCancel && (
           <Button onClick={onCancel} disabled={mutation.isPending}>
-            {/* i18n-ignore-next-line */}
-            Cancel
+            {t('betaVideos.cancel')}
           </Button>
         )}
         <Button
@@ -159,7 +155,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
           disabled={!canSubmit}
           startIcon={mutation.isPending ? <CircularProgress size={16} /> : undefined}
         >
-          {submitLabel}
+          {resolvedSubmitLabel}
         </Button>
       </Box>
     </Box>

--- a/packages/web/app/components/beta-videos/beta-videos.tsx
+++ b/packages/web/app/components/beta-videos/beta-videos.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -23,6 +24,7 @@ type BetaVideosProps = {
 };
 
 const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
+  const { t } = useTranslation('feed');
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedVideo, setSelectedVideo] = useState<BetaLink | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
@@ -68,7 +70,9 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                     pointerEvents: 'none',
                   }}
                   scrolling="no"
-                  title={`Beta video by ${betaLink.foreign_username || 'unknown'}`}
+                  title={t('betaVideos.videoTitleByUser', {
+                    name: betaLink.foreign_username || t('betaVideos.unknownUser'),
+                  })}
                 />
               </Box>
             ) : (
@@ -81,8 +85,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
               >
                 <Instagram sx={{ fontSize: 32, color: 'var(--neutral-400)' }} />
                 <Box component="p" sx={{ margin: `${themeTokens.spacing[2]}px 0 0`, color: 'var(--neutral-500)' }}>
-                  {/* i18n-ignore-next-line */}
-                  Unable to load video
+                  {t('betaVideos.unableToLoad')}
                 </Box>
               </Box>
             )}
@@ -106,8 +109,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                   {betaLink.foreign_username}
                   {betaLink.angle && (
                     <Box component="span" sx={{ marginLeft: 8 }}>
-                      {/* i18n-ignore-next-line */}
-                      {betaLink.angle}&deg;
+                      {t('betaVideos.angleSuffix', { angle: betaLink.angle })}
                     </Box>
                   )}
                 </Typography>
@@ -126,8 +128,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                   gap: 4,
                 }}
               >
-                {/* i18n-ignore-next-line */}
-                <Instagram sx={{ fontSize: 'inherit' }} /> View
+                <Instagram sx={{ fontSize: 'inherit' }} /> {t('betaVideos.viewLink')}
               </Box>
             </Box>
           </CardContent>
@@ -137,8 +138,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
   };
 
   if (uniqueBetaLinks.length === 0) {
-    // i18n-ignore-next-line
-    return <EmptyState description="No beta videos available" />;
+    return <EmptyState description={t('betaVideos.noVideosAvailable')} />;
   }
 
   const visibleVideos = showAllVideos ? uniqueBetaLinks : uniqueBetaLinks.slice(0, 1);
@@ -160,9 +160,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
           }}
           startIcon={showAllVideos ? <ExpandLessOutlined /> : <ExpandMoreOutlined />}
         >
-          {showAllVideos
-            ? 'Show less'
-            : `Show ${uniqueBetaLinks.length - 1} more video${uniqueBetaLinks.length - 1 !== 1 ? 's' : ''}`}
+          {showAllVideos ? t('betaVideos.showLess') : t('betaVideos.showMore', { count: uniqueBetaLinks.length - 1 })}
         </Button>
       )}
 
@@ -175,7 +173,9 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
           sx={{ '& .MuiDialog-paper': { maxWidth: '500px', width: '90%' } }}
         >
           <DialogTitle>
-            {selectedVideo?.foreign_username ? `Beta by @${selectedVideo.foreign_username}` : 'Beta Video'}
+            {selectedVideo?.foreign_username
+              ? t('betaVideos.modalTitleByUser', { name: selectedVideo.foreign_username })
+              : t('betaVideos.modalTitle')}
           </DialogTitle>
           <DialogContent>
             {selectedVideo && (
@@ -199,8 +199,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                     border: 'none',
                   }}
                   scrolling="no"
-                  // i18n-ignore-next-line
-                  title="Beta video"
+                  title={t('betaVideos.videoTitle')}
                 />
               </Box>
             )}
@@ -218,8 +217,7 @@ const BetaVideos: React.FC<BetaVideosProps> = ({ betaLinks }) => {
                 gap: 6,
               }}
             >
-              {/* i18n-ignore-next-line */}
-              <Instagram sx={{ fontSize: 'inherit' }} /> View on Instagram
+              <Instagram sx={{ fontSize: 'inherit' }} /> {t('betaVideos.viewOnInstagram')}
             </Box>
           </DialogActions>
         </Dialog>

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -3,6 +3,15 @@ import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { BluetoothProvider, useBluetoothContext } from '../bluetooth-context';
 import type { BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock dependencies before importing the module
 const mockTrack = vi.fn();

--- a/packages/web/app/components/board-bluetooth-control/__tests__/board-config-mismatch-dialog.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/board-config-mismatch-dialog.test.tsx
@@ -4,6 +4,23 @@ import React from 'react';
 import { BoardConfigMismatchDialog } from '../board-config-mismatch-dialog';
 import type { BoardDetails } from '@/app/lib/types';
 import type { ResolvedBoardConfig } from '@/app/lib/ble/board-config-match';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  // Render the resolved translation for Trans with `i18nKey`. Strip `<strong>` etc.
+  // tags so plain-text matchers in tests still find the copy.
+  Trans: ({ i18nKey, children }: { i18nKey?: string; children?: React.ReactNode }) => {
+    if (i18nKey) {
+      const value = tFromCatalog('settings', i18nKey);
+      return value.replace(/<\/?[a-zA-Z][^>]*>/g, '');
+    }
+    return children ?? null;
+  },
+}));
 
 function makeBoardDetails(overrides: Partial<BoardDetails> = {}): BoardDetails {
   return {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/device-picker-dialog.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/device-picker-dialog.test.tsx
@@ -2,6 +2,16 @@ import { describe, it, expect, vi } from 'vite-plus/test';
 import { render, screen, within, fireEvent } from '@testing-library/react';
 import { DevicePickerDialog } from '../device-picker-dialog';
 import type { DiscoveredDevice } from '@/app/lib/ble/types';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'next/navigation';
 import { track } from '@vercel/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
@@ -139,6 +140,7 @@ export function BluetoothProvider({
   });
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
+  const { t } = useTranslation('settings');
 
   const [partyActive, setPartyActive] = useState(false);
   const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
@@ -406,8 +408,7 @@ export function BluetoothProvider({
       // Provider mounted on a route that doesn't carry an [angle] segment.
       // Silently building a URL at angle 0 would yank the user to a fake
       // angle they never picked — surface the issue and let them choose.
-      // i18n-ignore-next-line
-      showMessage("Couldn't switch — open a climb at a specific angle first.", 'warning');
+      showMessage(t('bluetoothMismatch.switchNoAngleToast'), 'warning');
       return;
     }
     const target = buildSwitchUrl(mismatch.config, routeAngle);
@@ -415,8 +416,7 @@ export function BluetoothProvider({
       // Couldn't resolve a switch URL (unknown layout/size, missing slug data).
       // Don't silently close both dialogs and strand the user — surface the
       // failure so they can pick "Connect anyway" or cancel deliberately.
-      // i18n-ignore-next-line
-      showMessage("Couldn't switch to that board's config. Try Connect anyway.", 'warning');
+      showMessage(t('bluetoothMismatch.switchUrlFailedToast'), 'warning');
       return;
     }
     setMismatch(null);
@@ -424,7 +424,7 @@ export function BluetoothProvider({
     // BluetoothProvider that auto-connects via the ?autoConnect serial param.
     activePickerState?.handleCancel();
     router.push(`${target}?autoConnect=${encodeURIComponent(mismatch.serial)}`);
-  }, [mismatch, routeAngle, activePickerState, router, showMessage]);
+  }, [mismatch, routeAngle, activePickerState, router, showMessage, t]);
 
   return (
     <BluetoothContext.Provider value={value}>

--- a/packages/web/app/components/board-bluetooth-control/board-config-mismatch-dialog.tsx
+++ b/packages/web/app/components/board-bluetooth-control/board-config-mismatch-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Trans, useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -45,6 +46,7 @@ export function BoardConfigMismatchDialog({
   onConnectAnyway,
   onCancel,
 }: BoardConfigMismatchDialogProps) {
+  const { t } = useTranslation('settings');
   const currentLabel = describeBoardConfig(
     currentBoardDetails.board_name,
     currentBoardDetails.layout_id,
@@ -60,21 +62,17 @@ export function BoardConfigMismatchDialog({
 
   return (
     <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
-      {/* i18n-ignore-next-line */}
-      <DialogTitle>Board configuration doesn&apos;t match</DialogTitle>
+      <DialogTitle>{t('boardConfigMismatch.title')}</DialogTitle>
       <DialogContent>
-        <DialogContentText component="div">
-          {/* i18n-ignore-next-line */}
-          Our records show this board has a different config than you have configured.
-        </DialogContentText>
+        <DialogContentText component="div">{t('boardConfigMismatch.intro')}</DialogContentText>
         <Stack spacing={`${themeTokens.spacing[1]}px`} sx={{ mt: `${themeTokens.spacing[2]}px` }}>
           <Typography variant="body2">
-            {/* i18n-ignore-next-line */}
-            <strong>You&apos;re configured for:</strong> {currentLabel}
+            <Trans i18nKey="boardConfigMismatch.currentLabel" t={t} components={{ strong: <strong /> }} />{' '}
+            {currentLabel}
           </Typography>
           <Typography variant="body2">
-            {/* i18n-ignore-next-line */}
-            <strong>Recorded for this controller:</strong> {recordedLabel}
+            <Trans i18nKey="boardConfigMismatch.recordedLabel" t={t} components={{ strong: <strong /> }} />{' '}
+            {recordedLabel}
           </Typography>
         </Stack>
       </DialogContent>
@@ -86,15 +84,12 @@ export function BoardConfigMismatchDialog({
           pb: `${themeTokens.spacing[2]}px`,
         }}
       >
-        {/* i18n-ignore-next-line */}
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onCancel}>{t('boardConfigMismatch.cancel')}</Button>
         <Button onClick={onConnectAnyway} color="warning">
-          {/* i18n-ignore-next-line */}
-          Connect anyway
+          {t('boardConfigMismatch.connectAnyway')}
         </Button>
         <Button onClick={onSwitch} variant="contained" autoFocus>
-          {/* i18n-ignore-next-line */}
-          Switch to correct config
+          {t('boardConfigMismatch.switchToCorrect')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/web/app/components/board-bluetooth-control/device-picker-dialog.tsx
+++ b/packages/web/app/components/board-bluetooth-control/device-picker-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import BluetoothSearching from '@mui/icons-material/BluetoothSearching';
 import HelpOutline from '@mui/icons-material/HelpOutline';
 import SignalCellularAlt from '@mui/icons-material/SignalCellularAlt';
@@ -105,6 +106,7 @@ function SignalBadge({ rssi }: { rssi: number }) {
 }
 
 export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards }: DevicePickerDialogProps) {
+  const { t } = useTranslation('settings');
   const sorted = [...devices].sort((a, b) => b.rssi - a.rssi);
 
   return (
@@ -112,8 +114,7 @@ export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards
       <DialogTitle>
         <Stack direction="row" alignItems="center" spacing={1}>
           <BluetoothSearching />
-          {/* i18n-ignore-next-line */}
-          <span>Select your board</span>
+          <span>{t('devicePicker.title')}</span>
         </Stack>
       </DialogTitle>
       <DialogContent sx={{ minHeight: 160, px: 1 }}>
@@ -121,8 +122,7 @@ export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards
           <Stack direction="row" alignItems="center" spacing={2} sx={{ py: 4, justifyContent: 'center' }}>
             <CircularProgress size={20} />
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Scanning for boards nearby&hellip;
+              {t('devicePicker.scanning')}
             </Typography>
           </Stack>
         ) : (
@@ -139,10 +139,10 @@ export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards
                 label = entry.board.name;
               } else if (entry?.kind === 'recorded') {
                 preview = <RecordedBoardPreview config={configFromResolvedEntry(entry)} />;
-                label = device.name || 'Last connected board';
+                label = device.name || t('devicePicker.lastConnected');
               } else {
                 preview = <UnknownBoardPreview boardType={inferredType} />;
-                label = device.name || 'Unknown device';
+                label = device.name || t('devicePicker.unknownDevice');
               }
 
               return (
@@ -169,8 +169,7 @@ export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards
                   )}
                   {entry?.kind === 'recorded' && (
                     <div className={styles.deviceCardMeta}>
-                      {/* i18n-ignore-next-line */}
-                      Last connected {formatRelativeTime(entry.config.updatedAt)}
+                      {t('devicePicker.lastConnectedAt', { time: formatRelativeTime(entry.config.updatedAt) })}
                     </div>
                   )}
                 </div>
@@ -180,8 +179,7 @@ export function DevicePickerDialog({ devices, onSelect, onCancel, resolvedBoards
         )}
       </DialogContent>
       <DialogActions>
-        {/* i18n-ignore-next-line */}
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onCancel}>{t('devicePicker.cancel')}</Button>
       </DialogActions>
     </Dialog>
   );

--- a/packages/web/app/components/board-entity/__tests__/board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/board-form.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import BoardForm from '../board-form';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 vi.mock('../map-location-picker', () => ({
   default: ({

--- a/packages/web/app/components/board-entity/board-card.tsx
+++ b/packages/web/app/components/board-entity/board-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
@@ -33,6 +34,7 @@ const BOARD_TYPE_LABELS: Record<string, string> = {
 };
 
 export default function BoardCard({ board, onClick, trailingAction }: BoardCardProps) {
+  const { t } = useTranslation('boards');
   return (
     <Card
       variant="outlined"
@@ -92,12 +94,21 @@ export default function BoardCard({ board, onClick, trailingAction }: BoardCardP
           </Box>
 
           <Box sx={{ display: 'flex', gap: 2, mt: 1.5, flexWrap: 'wrap' }}>
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<TrendingUpOutlined sx={{ fontSize: 14 }} />} value={board.totalAscents} label="ascents" />
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<PersonOutlined sx={{ fontSize: 14 }} />} value={board.uniqueClimbers} label="climbers" />
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<PeopleOutlined sx={{ fontSize: 14 }} />} value={board.followerCount} label="followers" />
+            <StatItem
+              icon={<TrendingUpOutlined sx={{ fontSize: 14 }} />}
+              value={board.totalAscents}
+              label={t('boardEntity.stats.ascents')}
+            />
+            <StatItem
+              icon={<PersonOutlined sx={{ fontSize: 14 }} />}
+              value={board.uniqueClimbers}
+              label={t('boardEntity.stats.climbers')}
+            />
+            <StatItem
+              icon={<PeopleOutlined sx={{ fontSize: 14 }} />}
+              value={board.followerCount}
+              label={t('boardEntity.stats.followers')}
+            />
           </Box>
         </CardContent>
       </CardActionArea>

--- a/packages/web/app/components/board-entity/board-form.tsx
+++ b/packages/web/app/components/board-entity/board-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Switch from '@mui/material/Switch';
@@ -80,13 +81,15 @@ export default function BoardForm({
   showSlugField = false,
   slugHelperPrefix = 'boardsesh.com/b/',
   namePlaceholder,
-  descriptionPlaceholder = 'Optional description',
+  descriptionPlaceholder,
   locationPlaceholder,
   availableAngles,
   configEditable,
   onSubmit,
   onCancel,
 }: BoardFormProps) {
+  const { t } = useTranslation('boards');
+  const resolvedDescriptionPlaceholder = descriptionPlaceholder ?? t('boardForm.placeholders.description');
   const [name, setName] = useState(initialValues.name);
   const [slug, setSlug] = useState(initialValues.slug ?? '');
   const [description, setDescription] = useState(initialValues.description);
@@ -155,17 +158,14 @@ export default function BoardForm({
       {configEditable && (
         <>
           <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
-            {/* i18n-ignore-next-line */}
-            You can change the board layout because no climbs have been logged yet.
+            {t('boardForm.alerts.configEditable')}
           </Alert>
 
           <FormControl size="small" fullWidth>
-            {/* i18n-ignore-next-line */}
-            <InputLabel>Layout</InputLabel>
+            <InputLabel>{t('boardForm.fields.layout')}</InputLabel>
             <MuiSelect
               value={layoutId ?? ''}
-              // i18n-ignore-next-line
-              label="Layout"
+              label={t('boardForm.fields.layout')}
               onChange={(e: SelectChangeEvent<number | string>) => {
                 const newLayout = e.target.value as number;
                 setLayoutId(newLayout);
@@ -185,12 +185,10 @@ export default function BoardForm({
 
           {availableSizes.length > 0 && (
             <FormControl size="small" fullWidth>
-              {/* i18n-ignore-next-line */}
-              <InputLabel>Size</InputLabel>
+              <InputLabel>{t('boardForm.fields.size')}</InputLabel>
               <MuiSelect
                 value={sizeId ?? ''}
-                // i18n-ignore-next-line
-                label="Size"
+                label={t('boardForm.fields.size')}
                 onChange={(e: SelectChangeEvent<number | string>) => {
                   setSizeId(e.target.value as number);
                   setSelectedSets([]);
@@ -205,13 +203,11 @@ export default function BoardForm({
 
           {availableSets.length > 0 && (
             <FormControl size="small" fullWidth>
-              {/* i18n-ignore-next-line */}
-              <InputLabel>Hold Sets</InputLabel>
+              <InputLabel>{t('boardForm.fields.holdSets')}</InputLabel>
               <MuiSelect
                 multiple
                 value={selectedSets}
-                // i18n-ignore-next-line
-                label="Hold Sets"
+                label={t('boardForm.fields.holdSets')}
                 onChange={(e) => {
                   const val = e.target.value as unknown as number[];
                   setSelectedSets(val);
@@ -243,8 +239,7 @@ export default function BoardForm({
       )}
 
       <TextField
-        // i18n-ignore-next-line
-        label="Board Name"
+        label={t('boardForm.fields.name')}
         value={name}
         onChange={(e) => setName(e.target.value)}
         required
@@ -256,8 +251,7 @@ export default function BoardForm({
 
       {showSlugField && (
         <TextField
-          // i18n-ignore-next-line
-          label="URL Slug"
+          label={t('boardForm.fields.slug')}
           value={slug}
           onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
           fullWidth
@@ -267,8 +261,7 @@ export default function BoardForm({
       )}
 
       <TextField
-        // i18n-ignore-next-line
-        label="Description"
+        label={t('boardForm.fields.description')}
         value={description}
         onChange={(e) => setDescription(e.target.value)}
         fullWidth
@@ -276,12 +269,11 @@ export default function BoardForm({
         multiline
         minRows={2}
         maxRows={4}
-        placeholder={descriptionPlaceholder}
+        placeholder={resolvedDescriptionPlaceholder}
       />
 
       <TextField
-        // i18n-ignore-next-line
-        label="Location"
+        label={t('boardForm.fields.location')}
         value={locationName}
         onChange={(e) => setLocationName(e.target.value)}
         fullWidth
@@ -299,21 +291,18 @@ export default function BoardForm({
       />
 
       <TextField
-        // i18n-ignore-next-line
-        label="Controller Serial Number"
+        label={t('boardForm.fields.serialNumber')}
         value={serialNumber}
         onChange={(e) => setSerialNumber(e.target.value)}
         fullWidth
         size="small"
-        // i18n-ignore-next-line
-        placeholder="e.g. ABC-12345"
+        placeholder={t('boardForm.placeholders.serialNumber')}
         inputProps={{ maxLength: 100 }}
       />
 
       {availableAngles && availableAngles.length > 0 && (
         <TextField
-          // i18n-ignore-next-line
-          label="Default Angle"
+          label={t('boardForm.fields.defaultAngle')}
           value={angle}
           onChange={(e) => setAngle(Number(e.target.value))}
           select
@@ -330,51 +319,39 @@ export default function BoardForm({
 
       <FormControlLabel
         control={<Switch checked={isAngleAdjustable} onChange={(e) => setIsAngleAdjustable(e.target.checked)} />}
-        // i18n-ignore-next-line
-        label="Angle is adjustable"
+        label={t('boardForm.fields.angleAdjustable')}
       />
 
       <FormControlLabel
         control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />}
-        // i18n-ignore-next-line
-        label="Public board"
+        label={t('boardForm.fields.isPublic')}
       />
 
       <Box>
         <FormControlLabel
           control={<Switch checked={isUnlisted} onChange={(e) => setIsUnlisted(e.target.checked)} />}
-          // i18n-ignore-next-line
-          label="Unlisted"
+          label={t('boardForm.fields.unlisted')}
         />
-        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>
-          {/* i18n-ignore-next-line */}
-          Hidden from search results but accessible via direct link
-        </FormHelperText>
+        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{t('boardForm.helperText.unlisted')}</FormHelperText>
       </Box>
 
       <Box>
         <FormControlLabel
           control={<Switch checked={hideLocation} onChange={(e) => setHideLocation(e.target.checked)} />}
-          // i18n-ignore-next-line
-          label="Hide from nearby boards"
+          label={t('boardForm.fields.hideLocation')}
         />
-        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>
-          {/* i18n-ignore-next-line */}
-          Hidden from nearby board searches unless you follow the searcher
-        </FormHelperText>
+        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{t('boardForm.helperText.hideLocation')}</FormHelperText>
       </Box>
 
       <FormControlLabel
         control={<Switch checked={isOwned} onChange={(e) => setIsOwned(e.target.checked)} />}
-        // i18n-ignore-next-line
-        label="I own this board"
+        label={t('boardForm.fields.isOwned')}
       />
 
       <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end', mt: 1 }}>
         {onCancel && (
           <MuiButton variant="text" onClick={onCancel} disabled={isSubmitting}>
-            {/* i18n-ignore-next-line */}
-            Cancel
+            {t('common:actions.cancel')}
           </MuiButton>
         )}
         <MuiButton type="submit" variant="contained" disabled={isSubmitting || !name.trim()}>

--- a/packages/web/app/components/board-entity/board-leaderboard.tsx
+++ b/packages/web/app/components/board-entity/board-leaderboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -25,18 +26,21 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 type Period = 'week' | 'month' | 'year' | 'all';
 
-const PERIOD_OPTIONS: { value: Period; label: string }[] = [
-  { value: 'week', label: 'Week' },
-  { value: 'month', label: 'Month' },
-  { value: 'year', label: 'Year' },
-  { value: 'all', label: 'All Time' },
-];
-
 type BoardLeaderboardProps = {
   boardUuid: string;
 };
 
 export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
+  const { t } = useTranslation('boards');
+  const periodOptions = useMemo<{ value: Period; label: string }[]>(
+    () => [
+      { value: 'week', label: t('boardLeaderboard.period.week') },
+      { value: 'month', label: t('boardLeaderboard.period.month') },
+      { value: 'year', label: t('boardLeaderboard.period.year') },
+      { value: 'all', label: t('boardLeaderboard.period.all') },
+    ],
+    [t],
+  );
   const [period, setPeriod] = useState<Period>('all');
   const [leaderboard, setLeaderboard] = useState<BoardLeaderboardType | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -97,7 +101,7 @@ export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
   return (
     <Box>
       <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
-        {PERIOD_OPTIONS.map((opt) => (
+        {periodOptions.map((opt) => (
           <Chip
             key={opt.value}
             label={opt.label}
@@ -116,8 +120,7 @@ export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
       )}
       {!isLoading && (!leaderboard || leaderboard.entries.length === 0) && (
         <MuiTypography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-          {/* i18n-ignore-next-line */}
-          No activity yet for this period.
+          {t('boardLeaderboard.empty')}
         </MuiTypography>
       )}
       {!isLoading && leaderboard && leaderboard.entries.length > 0 && (
@@ -127,11 +130,11 @@ export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, width: 40 }}>#</TableCell>
-                  {/* i18n-ignore-next-line */}
-                  <TableCell sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>Climber</TableCell>
+                  <TableCell sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                    {t('boardLeaderboard.columns.climber')}
+                  </TableCell>
                   <TableCell align="right" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-                    {/* i18n-ignore-next-line */}
-                    Sends
+                    {t('boardLeaderboard.columns.sends')}
                   </TableCell>
                   <TableCell
                     align="right"
@@ -140,12 +143,10 @@ export default function BoardLeaderboard({ boardUuid }: BoardLeaderboardProps) {
                       display: { xs: 'none', sm: 'table-cell' },
                     }}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Flashes
+                    {t('boardLeaderboard.columns.flashes')}
                   </TableCell>
                   <TableCell align="right" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-                    {/* i18n-ignore-next-line */}
-                    Hardest
+                    {t('boardLeaderboard.columns.hardest')}
                   </TableCell>
                 </TableRow>
               </TableHead>

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
@@ -22,13 +23,14 @@ type EditBoardFormProps = {
 };
 
 export default function EditBoardForm({ board, totalAscents, onSuccess, onCancel }: EditBoardFormProps) {
+  const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
   const availableAngles = ANGLES[board.boardType as BoardName] ?? [];
 
   const { execute } = useEntityMutation<UpdateBoardMutationResponse, UpdateBoardMutationVariables>(UPDATE_BOARD, {
-    successMessage: 'Board updated!',
-    errorMessage: 'Failed to update board',
+    successMessage: t('editBoard.snackbar.updated'),
+    errorMessage: t('editBoard.snackbar.updateFailed'),
   });
 
   const configEditable = useMemo(() => {
@@ -60,8 +62,7 @@ export default function EditBoardForm({ board, totalAscents, onSuccess, onCancel
       serialNumber?: string;
     }) => {
       if (!values.name) {
-        // i18n-ignore-next-line
-        showMessage('Board name is required', 'error');
+        showMessage(t('boardForm.create.nameRequired'), 'error');
         return;
       }
 
@@ -95,14 +96,13 @@ export default function EditBoardForm({ board, totalAscents, onSuccess, onCancel
         onSuccess?.(data.updateBoard);
       }
     },
-    [execute, board.uuid, showMessage, onSuccess, configEditable],
+    [execute, board.uuid, showMessage, onSuccess, configEditable, t],
   );
 
   return (
     <BoardForm
-      // i18n-ignore-next-line
-      title="Edit Board"
-      submitLabel="Save Changes"
+      title={t('editBoard.title')}
+      submitLabel={t('editBoard.submitLabel')}
       initialValues={{
         name: board.name,
         slug: board.slug,

--- a/packages/web/app/components/board-entity/map-location-picker.tsx
+++ b/packages/web/app/components/board-entity/map-location-picker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
@@ -31,6 +32,7 @@ type MapLocationPickerProps = {
 };
 
 export default function MapLocationPicker({ latitude, longitude, onChange }: MapLocationPickerProps) {
+  const { t } = useTranslation('boards');
   const mapRef = useRef<LeafletMap | null>(null);
   const markerRef = useRef<LeafletMarker | null>(null);
   const leafletRef = useRef<typeof LeafletNamespace | null>(null);
@@ -209,7 +211,12 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <MapOutlined fontSize="small" color="action" />
           <MuiTypography variant="body2">
-            {hasLocation ? `Location: ${latitude.toFixed(4)}, ${longitude.toFixed(4)}` : 'Set location on map'}
+            {hasLocation
+              ? t('mapLocationPicker.locationDisplay', {
+                  lat: latitude.toFixed(4),
+                  lng: longitude.toFixed(4),
+                })
+              : t('mapLocationPicker.setOnMap')}
           </MuiTypography>
         </Box>
       </AccordionSummary>
@@ -218,8 +225,7 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
           <TextField
             size="small"
             fullWidth
-            // i18n-ignore-next-line
-            placeholder="Search address or city..."
+            placeholder={t('mapLocationPicker.searchPlaceholder')}
             value={searchQuery}
             onChange={(e) => handleAddressSearch(e.target.value)}
             onKeyDown={(e) => {
@@ -258,14 +264,12 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
                 textTransform: 'none',
               }}
             >
-              {/* i18n-ignore-next-line */}
-              My location
+              {t('mapLocationPicker.myLocation')}
             </MuiButton>
           )}
         </Box>
         <MuiTypography variant="caption" color="text.secondary" sx={{ px: 2, py: 1, display: 'block' }}>
-          {/* i18n-ignore-next-line */}
-          Click the map to set your board&apos;s location, or drag the marker to adjust
+          {t('mapLocationPicker.helpText')}
         </MuiTypography>
       </AccordionDetails>
     </Accordion>

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -50,6 +51,7 @@ type DialogState = {
 };
 
 export function BoardSwitchConfirmProvider({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation('boards');
   const [state, setState] = useState<DialogState | null>(null);
   // Hold onConfirmed in a ref so handlers never read a stale closure and
   // the render doesn't need to re-run when the callback changes.
@@ -83,11 +85,12 @@ export function BoardSwitchConfirmProvider({ children }: { children: React.React
 
   const value = useMemo<BoardSwitchConfirmContextValue>(() => ({ confirmBoardSwitch }), [confirmBoardSwitch]);
 
-  const title = state?.reason === 'session' ? 'Leave your session?' : 'Disconnect your board?';
+  const title =
+    state?.reason === 'session' ? t('boardSwitchConfirm.session.title') : t('boardSwitchConfirm.connection.title');
   const body =
     state?.reason === 'session'
-      ? `You're in a session on ${state?.lockedLabel}. Switching to ${state?.targetLabel} disconnects your board but keeps the session running.`
-      : `Your ${state?.lockedLabel} is still connected. Switching to ${state?.targetLabel} disconnects it.`;
+      ? t('boardSwitchConfirm.session.body', { lockedLabel: state?.lockedLabel, targetLabel: state?.targetLabel })
+      : t('boardSwitchConfirm.connection.body', { lockedLabel: state?.lockedLabel, targetLabel: state?.targetLabel });
 
   return (
     <BoardSwitchConfirmContext.Provider value={value}>
@@ -105,11 +108,9 @@ export function BoardSwitchConfirmProvider({ children }: { children: React.React
           <DialogContentText>{body}</DialogContentText>
         </DialogContent>
         <DialogActions>
-          {/* i18n-ignore-next-line */}
-          <Button onClick={handleCancel}>Stay</Button>
+          <Button onClick={handleCancel}>{t('boardSwitchConfirm.stay')}</Button>
           <Button variant="contained" onClick={handleConfirm} autoFocus>
-            {/* i18n-ignore-next-line */}
-            Switch boards
+            {t('boardSwitchConfirm.switch')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/packages/web/app/components/board-renderer/__tests__/zoom-hint.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/zoom-hint.test.tsx
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import ZoomHint from '../zoom-hint';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock IndexedDB preferences
 const mockGetPreference = vi.fn();

--- a/packages/web/app/components/board-renderer/board-heatmap.tsx
+++ b/packages/web/app/components/board-renderer/board-heatmap.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getImageUrl } from './util';
 import type { BoardDetails } from '@/app/lib/types';
 import type { HeatmapData, LitUpHoldsMap } from './types';
@@ -59,6 +60,7 @@ type ColorMode =
   | 'userAttempts';
 
 const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap, onHoldClick }) => {
+  const { t } = useTranslation('boards');
   const pathname = usePathname();
   const { uiSearchParams } = useUISearchParams();
 
@@ -259,16 +261,13 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
         </defs>
         <rect width={legendWidth} height={legendHeight} fill={`url(#${gradientId})`} rx={8} />
         <text x="0" y="-10" fontSize="28" textAnchor="start" fontWeight="500">
-          {/* i18n-ignore-next-line */}
-          Low ({minValue})
+          {t('boardHeatmap.legend.low', { value: minValue })}
         </text>
         <text x={legendWidth / 2} y="-10" fontSize="28" textAnchor="middle" fontWeight="500">
-          {/* i18n-ignore-next-line */}
-          Mid ({midValue})
+          {t('boardHeatmap.legend.mid', { value: midValue })}
         </text>
         <text x={legendWidth} y="-10" fontSize="28" textAnchor="end" fontWeight="500">
-          {/* i18n-ignore-next-line */}
-          High ({maxValue})
+          {t('boardHeatmap.legend.high', { value: maxValue })}
         </text>
       </g>
     );
@@ -320,8 +319,7 @@ const BoardHeatmap: React.FC<BoardHeatmapProps> = ({ boardDetails, litUpHoldsMap
               <BoardRenderer litUpHoldsMap={animatedHoldsMap} mirrored={false} boardDetails={boardDetails} thumbnail />
             </div>
             <span style={{ fontSize: '14px', color: 'var(--semantic-surface)', fontWeight: 500 }}>
-              {/* i18n-ignore-next-line */}
-              Loading heatmap...
+              {t('boardHeatmap.loading')}
             </span>
           </div>
         )}

--- a/packages/web/app/components/board-renderer/zoom-hint.tsx
+++ b/packages/web/app/components/board-renderer/zoom-hint.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import ZoomInOutlined from '@mui/icons-material/ZoomInOutlined';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import styles from './swipe-board-carousel.module.css';
@@ -13,6 +14,7 @@ type ZoomHintProps = {
 };
 
 export default function ZoomHint({ visible }: ZoomHintProps) {
+  const { t } = useTranslation('boards');
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -48,8 +50,7 @@ export default function ZoomHint({ visible }: ZoomHintProps) {
     <div className={styles.zoomHintOverlay} onClick={dismiss}>
       <div className={styles.zoomHintPill}>
         <ZoomInOutlined sx={{ fontSize: 20 }} />
-        {/* i18n-ignore-next-line */}
-        <span>Pinch to zoom</span>
+        <span>{t('zoomHint.pinchToZoom')}</span>
       </div>
     </div>
   );

--- a/packages/web/app/components/board-renderer/zoomable-board.tsx
+++ b/packages/web/app/components/board-renderer/zoomable-board.tsx
@@ -50,8 +50,7 @@ const ZoomableBoard = memo(function ZoomableBoard({ children, onZoomChange, rese
         startIcon={<CropFreeOutlined sx={{ fontSize: '18px !important' }} />}
         tabIndex={isZoomed ? 0 : -1}
       >
-        {/* i18n-ignore-next-line */}
-        Reset
+        {t('boards:zoomableBoard.reset')}
       </Button>
     </div>
   );

--- a/packages/web/app/components/board-scroll/__tests__/board-filter-strip.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/board-filter-strip.test.tsx
@@ -3,6 +3,15 @@ import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import BoardFilterStrip from '../board-filter-strip';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock BoardRenderer (transitive dep via BoardScrollCard)
 vi.mock('../../board-renderer/board-renderer', () => ({

--- a/packages/web/app/components/board-scroll/board-filter-strip.tsx
+++ b/packages/web/app/components/board-scroll/board-filter-strip.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import BoardScrollSection from './board-scroll-section';
 import BoardScrollCard from './board-scroll-card';
@@ -33,6 +34,7 @@ type BoardFilterStripMultiProps = {
 type BoardFilterStripProps = BoardFilterStripSingleProps | BoardFilterStripMultiProps;
 
 export default function BoardFilterStrip(props: BoardFilterStripProps) {
+  const { t } = useTranslation('boards');
   const { boards, loading, boardTypes, disabledText } = props;
 
   // Extract the appropriate handler based on mode to avoid depending on the whole props object
@@ -82,10 +84,11 @@ export default function BoardFilterStrip(props: BoardFilterStripProps) {
         <div
           className={`${styles.cardSquare} ${styles.filterSquare} ${isAllSelected ? styles.cardSquareSelected : ''}`}
         >
-          <span className={styles.filterLabel}>All</span>
+          <span className={styles.filterLabel}>{t('boardFilterStrip.all')}</span>
         </div>
-        {/* i18n-ignore-next-line */}
-        <div className={`${styles.cardName} ${isAllSelected ? styles.cardNameSelected : ''}`}>All Boards</div>
+        <div className={`${styles.cardName} ${isAllSelected ? styles.cardNameSelected : ''}`}>
+          {t('boardFilterStrip.allBoards')}
+        </div>
       </div>
       {boards.map((board) => (
         <BoardScrollCard

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-map.test.tsx
@@ -3,6 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { render, act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import BoardSearchMap from '../board-search-map';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Shared mock state. `vi.hoisted` runs before the `vi.mock` factory below
 // (which is itself hoisted above imports), so the factory can reference it.

--- a/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -36,6 +37,7 @@ type BoardSearchDrawerProps = {
 };
 
 export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardSearchDrawerProps) {
+  const { t } = useTranslation('boards');
   const { coordinates: userCoords, requestPermission } = useGeolocation();
 
   const [query, setQuery] = useState('');
@@ -165,8 +167,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
       placement="bottom"
       open={open}
       onClose={onClose}
-      // i18n-ignore-next-line
-      title="Find a board"
+      title={t('boardSearchDrawer.title')}
       fullHeight
       height="100dvh"
       showCloseButton
@@ -179,8 +180,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
           <TextField
             fullWidth
             size="small"
-            // i18n-ignore-next-line
-            placeholder="Search boards by name or location"
+            placeholder={t('boardSearchDrawer.searchPlaceholder')}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             slotProps={{
@@ -192,8 +192,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                 ),
                 endAdornment: query ? (
                   <InputAdornment position="end">
-                    {/* i18n-ignore-next-line */}
-                    <IconButton size="small" onClick={() => setQuery('')} aria-label="Clear">
+                    <IconButton size="small" onClick={() => setQuery('')} aria-label={t('boardSearchDrawer.clear')}>
                       <CloseOutlined fontSize="small" />
                     </IconButton>
                   </InputAdornment>
@@ -210,8 +209,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
             }}
           >
             <Typography variant="caption" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Showing boards within {radiusKm} km of map center
+              {t('boardSearchDrawer.radiusInfo', { radiusKm })}
             </Typography>
             {isFetching && boards.length > 0 && <CircularProgress size={14} />}
           </Box>
@@ -248,8 +246,8 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
             <Box sx={{ py: 3, textAlign: 'center', px: 2 }}>
               <Typography variant="body2" color="text.secondary">
                 {query.trim().length >= 2
-                  ? `No boards match "${query.trim()}" here. Try zooming out or searching elsewhere.`
-                  : 'No boards in this area. Pan or zoom out to find more.'}
+                  ? t('boardSearchDrawer.emptyWithQuery', { query: query.trim() })
+                  : t('boardSearchDrawer.empty')}
               </Typography>
             </Box>
           )}
@@ -307,8 +305,7 @@ export default function BoardSearchDrawer({ open, onClose, onBoardOpen }: BoardS
                               }}
                               sx={{ textTransform: 'none' }}
                             >
-                              {/* i18n-ignore-next-line */}
-                              Open
+                              {t('boardSearchDrawer.open')}
                             </Button>
                           </Stack>
                         ) : undefined

--- a/packages/web/app/components/board-search-drawer/board-search-map.tsx
+++ b/packages/web/app/components/board-search-drawer/board-search-map.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
 import MyLocationOutlined from '@mui/icons-material/MyLocationOutlined';
@@ -46,6 +47,7 @@ export default function BoardSearchMap({
   onBoardClick,
   onViewportChange,
 }: BoardSearchMapProps) {
+  const { t } = useTranslation('boards');
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<LeafletMap | null>(null);
   const leafletRef = useRef<typeof LeafletNamespace | null>(null);
@@ -351,8 +353,7 @@ export default function BoardSearchMap({
             textTransform: 'none',
           }}
         >
-          {/* i18n-ignore-next-line */}
-          My location
+          {t('boardSearchMap.myLocation')}
         </MuiButton>
       )}
     </Box>

--- a/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
@@ -41,15 +42,14 @@ export default function BoardConfigSelects({
   onSetsChange,
   onAngleChange,
 }: BoardConfigSelectsProps) {
+  const { t } = useTranslation('boards');
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
       <FormControl fullWidth size="small">
-        {/* i18n-ignore-next-line */}
-        <InputLabel>Board</InputLabel>
+        <InputLabel>{t('boardConfigSelects.board')}</InputLabel>
         <MuiSelect
           value={selectedBoard || ''}
-          // i18n-ignore-next-line
-          label="Board"
+          label={t('boardConfigSelects.board')}
           onChange={(e: SelectChangeEvent) => onBoardChange(e.target.value as BoardName)}
         >
           {SUPPORTED_BOARDS.map((board) => (
@@ -61,12 +61,10 @@ export default function BoardConfigSelects({
       </FormControl>
 
       <FormControl fullWidth size="small">
-        {/* i18n-ignore-next-line */}
-        <InputLabel>Layout</InputLabel>
+        <InputLabel>{t('boardConfigSelects.layout')}</InputLabel>
         <MuiSelect
           value={selectedLayout ?? ''}
-          // i18n-ignore-next-line
-          label="Layout"
+          label={t('boardConfigSelects.layout')}
           onChange={(e: SelectChangeEvent<number | string>) => onLayoutChange(e.target.value as number)}
           disabled={!selectedBoard}
         >
@@ -80,12 +78,10 @@ export default function BoardConfigSelects({
 
       {selectedBoard !== 'moonboard' && (
         <FormControl fullWidth size="small">
-          {/* i18n-ignore-next-line */}
-          <InputLabel>Size</InputLabel>
+          <InputLabel>{t('boardConfigSelects.size')}</InputLabel>
           <MuiSelect
             value={selectedSize ?? ''}
-            // i18n-ignore-next-line
-            label="Size"
+            label={t('boardConfigSelects.size')}
             onChange={(e: SelectChangeEvent<number | string>) => onSizeChange(e.target.value as number)}
             disabled={!selectedLayout}
           >
@@ -97,13 +93,11 @@ export default function BoardConfigSelects({
       )}
 
       <FormControl fullWidth size="small">
-        {/* i18n-ignore-next-line */}
-        <InputLabel>Hold Sets</InputLabel>
+        <InputLabel>{t('boardConfigSelects.holdSets')}</InputLabel>
         <MuiSelect<number[]>
           multiple
           value={selectedSets}
-          // i18n-ignore-next-line
-          label="Hold Sets"
+          label={t('boardConfigSelects.holdSets')}
           onChange={(e) => onSetsChange(e.target.value as number[])}
           disabled={!selectedSize}
         >
@@ -116,12 +110,10 @@ export default function BoardConfigSelects({
       </FormControl>
 
       <FormControl fullWidth size="small">
-        {/* i18n-ignore-next-line */}
-        <InputLabel>Angle</InputLabel>
+        <InputLabel>{t('boardConfigSelects.angle')}</InputLabel>
         <MuiSelect
           value={selectedAngle}
-          // i18n-ignore-next-line
-          label="Angle"
+          label={t('boardConfigSelects.angle')}
           onChange={(e: SelectChangeEvent<number>) => onAngleChange(e.target.value)}
           disabled={!selectedBoard}
         >

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -317,10 +317,8 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     setIsCreatePlaylistOpen(false);
     if (!isAuthenticated || !session?.user?.id) {
       openAuthModal({
-        // i18n-ignore-next-line
-        title: 'Sign in to see your progress',
-        // i18n-ignore-next-line
-        description: 'Sign in to track your climbing stats, sessions, and logbook.',
+        title: t('bottomTabBar.youSignInTitle'),
+        description: t('bottomTabBar.youSignInDescription'),
         onSuccess: () => {
           router.push('/you');
         },
@@ -384,8 +382,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
 
       if (pendingCreateAction === 'playlist') {
         if (!selectedContext) {
-          // i18n-ignore-next-line
-          showMessage('Unable to determine board details for playlist creation', 'error');
+          showMessage(t('bottomTabBar.boardDetailsMissing'), 'error');
           setPendingCreateAction(null);
           return;
         }
@@ -407,7 +404,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         router.push(url);
       }
     },
-    [pendingCreateAction, router, showMessage, guardBoardSwitch],
+    [pendingCreateAction, router, showMessage, guardBoardSwitch, t],
   );
 
   const handleDiscoveryBoardClick = useCallback(
@@ -484,8 +481,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     }
 
     if (!canCreatePlaylistHere) {
-      // i18n-ignore-next-line
-      showMessage('Select a board before creating a playlist', 'error');
+      showMessage(t('bottomTabBar.selectBoardForPlaylist'), 'error');
       return;
     }
 
@@ -505,7 +501,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         undefined,
       );
 
-      showMessage(`Created playlist "${playlistFormValues.name}"`, 'success');
+      showMessage(t('bottomTabBar.createdPlaylistToast', { name: playlistFormValues.name }), 'success');
       track('Create Playlist', {
         boardName: playlistBoardName || 'unknown',
         playlistName: playlistFormValues.name,
@@ -519,8 +515,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       // Navigate to the new playlist
       router.push(getPlaylistUrl(newPlaylist.uuid));
     } catch {
-      // i18n-ignore-next-line
-      showMessage('Failed to create playlist', 'error');
+      showMessage(t('bottomTabBar.createPlaylistFailed'), 'error');
     } finally {
       setIsCreatingPlaylist(false);
     }
@@ -559,37 +554,42 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           },
         }}
       >
-        {/* i18n-ignore-next-line */}
-        <BottomNavigationAction label="Home" icon={<HomeOutlined sx={{ fontSize: 20 }} />} value="home" sx={actionSx} />
         <BottomNavigationAction
-          // i18n-ignore-next-line
-          label="Climb"
+          label={t('bottomTabBar.home')}
+          icon={<HomeOutlined sx={{ fontSize: 20 }} />}
+          value="home"
+          sx={actionSx}
+        />
+        <BottomNavigationAction
+          label={t('bottomTabBar.climb')}
           icon={<FormatListBulletedOutlined sx={{ fontSize: 20 }} />}
           value="climbs"
           sx={actionSx}
         />
         <BottomNavigationAction
-          // i18n-ignore-next-line
-          label="Discover"
+          label={t('bottomTabBar.discover')}
           icon={<LocalOfferOutlined sx={{ fontSize: 20 }} />}
           value="library"
           sx={actionSx}
         />
         <BottomNavigationAction
-          // i18n-ignore-next-line
-          label="Feed"
+          label={t('bottomTabBar.feed')}
           icon={<DynamicFeedOutlined sx={{ fontSize: 20 }} />}
           value="feed"
           sx={actionSx}
         />
         <BottomNavigationAction
-          // i18n-ignore-next-line
-          label="Create"
+          label={t('bottomTabBar.create')}
           icon={<AddOutlined sx={{ fontSize: 20 }} />}
           value="create"
           sx={actionSx}
         />
-        <BottomNavigationAction label="You" icon={<PersonOutlined sx={{ fontSize: 20 }} />} value="you" sx={actionSx} />
+        <BottomNavigationAction
+          label={t('bottomTabBar.you')}
+          icon={<PersonOutlined sx={{ fontSize: 20 }} />}
+          value="you"
+          sx={actionSx}
+        />
       </BottomNavigation>
 
       {/* Create Playlist Drawer */}

--- a/packages/web/app/components/brand/logo.tsx
+++ b/packages/web/app/components/brand/logo.tsx
@@ -30,7 +30,7 @@ const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) =>
         color: 'inherit',
       }}
     >
-      {/* i18n-ignore-next-line */}
+      {/* i18n-ignore-next-line -- brand name, not translated */}
       <Image src="/icon.svg" width={icon} height={icon} alt="Boardsesh logo" priority />
       {showText && (
         <span
@@ -42,7 +42,7 @@ const Logo = ({ size = 'md', showText = true, linkToHome = true }: LogoProps) =>
             lineHeight: 1,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- brand name, not translated */}
           boardsesh
         </span>
       )}

--- a/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
+++ b/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
@@ -4,6 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import ClimbAnalytics from '../climb-analytics';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockRequest = vi.fn();
 const mockLineChart = vi.fn();

--- a/packages/web/app/components/charts/climb-analytics.tsx
+++ b/packages/web/app/components/charts/climb-analytics.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { LineChart } from '@mui/x-charts/LineChart';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -137,6 +138,7 @@ type ClimbAnalyticsProps = {
 };
 
 export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsProps) {
+  const { t } = useTranslation('profile');
   const [rows, setRows] = useState<ClimbStatsHistoryEntry[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -214,8 +216,7 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
   if (error || !rows || rows.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
-        {/* i18n-ignore-next-line */}
-        No analytics data available yet. Data is collected during sync.
+        {t('analytics.noData')}
       </Typography>
     );
   }
@@ -250,8 +251,7 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
       {ascentsData && ascentsData.labels.length > 0 && (
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {/* i18n-ignore-next-line */}
-            Ascents Over Time
+            {t('analytics.ascentsOverTime')}
           </Typography>
           <LineChart
             series={buildLineSeries(ascentsData, {
@@ -288,8 +288,7 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
       {qualityData && qualityData.labels.length > 0 && (
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {/* i18n-ignore-next-line */}
-            Quality Over Time
+            {t('analytics.qualityOverTime')}
           </Typography>
           <LineChart
             series={buildLineSeries(qualityData)}

--- a/packages/web/app/components/climb-actions/__tests__/action-labels-and-colors.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/action-labels-and-colors.test.tsx
@@ -8,6 +8,15 @@ import { TickAction } from '../actions/tick-action';
 import { FavoriteAction } from '../actions/favorite-action';
 import { QueueAction } from '../actions/queue-action';
 import { MirrorAction } from '../actions/mirror-action';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mock factories ---
 
@@ -433,7 +442,7 @@ describe('List mode uses neutral colors (no per-action colored icons)', () => {
       });
 
       const button = screen.getByRole('button');
-      expect(screen.getByText('actions.mirror.label.mirrored')).toBeTruthy();
+      expect(screen.getByText('Mirrored')).toBeTruthy();
 
       // The list icon is created as:
       //   const listIcon = <SwapHorizOutlined sx={{ fontSize: iconSize }} />;
@@ -457,7 +466,7 @@ describe('List mode uses neutral colors (no per-action colored icons)', () => {
       });
 
       const button = screen.getByRole('button');
-      expect(screen.getByText('actions.mirror.label.mirror')).toBeTruthy();
+      expect(screen.getByText('Mirror')).toBeTruthy();
 
       const svg = button.querySelector('svg');
       expect(svg).toBeTruthy();

--- a/packages/web/app/components/climb-actions/__tests__/playlist-selection-content.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/playlist-selection-content.test.tsx
@@ -2,6 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { BoardDetails } from '@/app/lib/types';
 import PlaylistSelectionContent from '../playlist-selection-content';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockUsePlaylists = vi.fn();
 const mockShowMessage = vi.fn();
@@ -63,7 +73,7 @@ describe('PlaylistSelectionContent failures', () => {
     fireEvent.click(screen.getByText('Test Playlist'));
 
     await waitFor(() => {
-      expect(mockShowMessage).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
+      expect(mockShowMessage).toHaveBeenCalledWith('Failed to add to playlist', 'error');
     });
   });
 
@@ -83,7 +93,7 @@ describe('PlaylistSelectionContent failures', () => {
     fireEvent.click(screen.getByText('Test Playlist'));
 
     await waitFor(() => {
-      expect(mockShowMessage).toHaveBeenCalledWith('actions.playlist.toast.removeFailed', 'error');
+      expect(mockShowMessage).toHaveBeenCalledWith('Failed to remove from playlist', 'error');
     });
   });
 
@@ -110,7 +120,7 @@ describe('PlaylistSelectionContent failures', () => {
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
     await waitFor(() => {
-      expect(mockShowMessage).toHaveBeenCalledWith('actions.playlist.toast.createFailed', 'error');
+      expect(mockShowMessage).toHaveBeenCalledWith('Failed to create playlist', 'error');
     });
     expect(onDone).not.toHaveBeenCalled();
   });

--- a/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
@@ -5,6 +5,15 @@ import type { Climb, BoardDetails, BoardName } from '@/app/lib/types';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { TickAction } from '../actions/tick-action';
 import type { ClimbActionProps } from '../types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mock factories ---
 
@@ -368,7 +377,7 @@ describe('TickAction', () => {
       });
 
       const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('actions.tick.drawer.signInRequired');
+      expect(drawer.getAttribute('data-title')).toBe('Sign in required');
       expect(screen.getByText('Sign in to record ticks')).toBeTruthy();
     });
 
@@ -401,7 +410,7 @@ describe('TickAction', () => {
       });
 
       const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('actions.tick.drawer.selectBoard');
+      expect(drawer.getAttribute('data-title')).toBe('Select board');
       expect(screen.getByText('Which board did you climb on?')).toBeTruthy();
       expect(screen.getByTestId('board-card-board-1')).toBeTruthy();
       expect(screen.getByTestId('board-card-board-2')).toBeTruthy();
@@ -439,7 +448,7 @@ describe('TickAction', () => {
 
       // Drawer title should change to "Log Ascent"
       const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('actions.tick.drawer.logAscent');
+      expect(drawer.getAttribute('data-title')).toBe('Log ascent');
     });
 
     it('passes selected board type to BoardProvider', async () => {
@@ -522,7 +531,7 @@ describe('TickAction', () => {
 
       // Should show the board selector (in loading state), NOT skip to form
       const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('actions.tick.drawer.selectBoard');
+      expect(drawer.getAttribute('data-title')).toBe('Select board');
       expect(screen.getByTestId('board-scroll-loading')).toBeTruthy();
     });
 
@@ -636,7 +645,7 @@ describe('TickAction', () => {
       });
 
       const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('actions.tick.drawer.signInRequired');
+      expect(drawer.getAttribute('data-title')).toBe('Sign in required');
       expect(screen.getByText('Sign in to record ticks')).toBeTruthy();
     });
 

--- a/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
@@ -3,6 +3,16 @@ import { renderHook, render, fireEvent, screen } from '@testing-library/react';
 import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import { PlaylistAction } from '../playlist-action';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockUsePlaylists = vi.fn();
 const mockShowMessage = vi.fn();

--- a/packages/web/app/components/climb-actions/actions/favorite-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/favorite-action.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
 import Favorite from '@mui/icons-material/Favorite';
 import { track } from '@vercel/analytics';
+import { useTranslation } from 'react-i18next';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useFavorite } from '../use-favorite';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
@@ -21,6 +22,7 @@ export function FavoriteAction({
   className,
   onComplete,
 }: ClimbActionProps): ClimbActionResult {
+  const { t } = useTranslation('climbs');
   const { openAuthModal } = useAuthModal();
   const { iconSize } = computeActionDisplay(viewMode, size, showLabel);
 
@@ -58,9 +60,8 @@ export function FavoriteAction({
 
       if (!isAuthenticated) {
         openAuthModal({
-          // i18n-ignore-next-line
-          title: 'Sign in to save favorites',
-          description: `Sign in to save "${climb.name}" to your favorites.`,
+          title: t('actions.favorite.auth.title'),
+          description: t('actions.favorite.auth.descriptionWithName', { climbName: climb.name }),
           onSuccess: handleAuthSuccess,
         });
         return;
@@ -87,10 +88,11 @@ export function FavoriteAction({
       onComplete,
       openAuthModal,
       handleAuthSuccess,
+      t,
     ],
   );
 
-  const label = isFavorited ? 'Favorited' : 'Favorite';
+  const label = isFavorited ? t('actions.favorite.label.favorited') : t('actions.favorite.label.favorite');
   const HeartIcon = isFavorited ? Favorite : FavoriteBorderOutlined;
   const iconStyle = isFavorited ? { color: themeTokens.colors.error, fontSize: iconSize } : { fontSize: iconSize };
   const listIcon = <HeartIcon sx={{ fontSize: iconSize }} />;

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -75,10 +75,8 @@ export function PlaylistAction({
 
       if (!isAuthenticated) {
         openAuthModal({
-          // i18n-ignore-next-line
-          title: 'Sign in to create playlists',
-          // i18n-ignore-next-line
-          description: 'Sign in to organize your climbs into custom playlists.',
+          title: t('actions.playlist.auth.title'),
+          description: t('actions.playlist.auth.description'),
         });
         return;
       }
@@ -91,7 +89,7 @@ export function PlaylistAction({
 
       setPopoverOpen((prev) => !prev);
     },
-    [isAuthenticated, onComplete, onOpenPlaylistSelector, viewMode, openAuthModal],
+    [isAuthenticated, onComplete, onOpenPlaylistSelector, viewMode, openAuthModal, t],
   );
 
   const { showMessage } = useSnackbar();
@@ -194,15 +192,13 @@ export function PlaylistAction({
     >
       <div style={{ marginBottom: themeTokens.spacing[2] }}>
         <MuiTypography variant="body2" component="span" fontWeight={600}>
-          {/* i18n-ignore-next-line */}
-          Add to Playlist
+          {t('actions.playlist.popover.title')}
         </MuiTypography>
       </div>
       {playlists.length === 0 && !showCreateForm ? (
         <Stack spacing={1} style={{ width: '100%', textAlign: 'center', padding: themeTokens.spacing[2] }}>
           <MuiTypography variant="body2" component="span" color="text.secondary">
-            {/* i18n-ignore-next-line */}
-            No playlists yet
+            {t('actions.playlist.popover.empty')}
           </MuiTypography>
           <MuiButton
             variant="contained"
@@ -211,8 +207,7 @@ export function PlaylistAction({
             fullWidth
             size="small"
           >
-            {/* i18n-ignore-next-line */}
-            Create Your First Playlist
+            {t('actions.playlist.popover.createFirst')}
           </MuiButton>
         </Stack>
       ) : (
@@ -268,8 +263,7 @@ export function PlaylistAction({
                 size="small"
                 sx={{ marginTop: `${themeTokens.spacing[2]}px` }}
               >
-                {/* i18n-ignore-next-line */}
-                Create New Playlist
+                {t('actions.playlist.popover.createNew')}
               </MuiButton>
             </>
           )}
@@ -279,12 +273,10 @@ export function PlaylistAction({
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Playlist Name
+                    {t('actions.playlist.create.nameLabel')}
                   </MuiTypography>
                   <TextField
-                    // i18n-ignore-next-line
-                    placeholder="e.g., Hard Crimps"
+                    placeholder={t('actions.playlist.create.namePlaceholder')}
                     autoFocus
                     fullWidth
                     size="small"
@@ -295,12 +287,10 @@ export function PlaylistAction({
                 </Box>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Description (optional)
+                    {t('actions.playlist.create.descriptionLabel')}
                   </MuiTypography>
                   <TextField
-                    // i18n-ignore-next-line
-                    placeholder="Optional description..."
+                    placeholder={t('actions.playlist.create.descriptionPlaceholder')}
                     multiline
                     rows={2}
                     fullWidth
@@ -312,8 +302,7 @@ export function PlaylistAction({
                 </Box>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Color (optional)
+                    {t('actions.playlist.create.colorLabel')}
                   </MuiTypography>
                   <TextField
                     type="color"
@@ -333,8 +322,7 @@ export function PlaylistAction({
                     setCreateFormValues({ name: '', description: '', color: '' });
                   }}
                 >
-                  {/* i18n-ignore-next-line */}
-                  Cancel
+                  {t('common:actions.cancel')}
                 </MuiButton>
                 <MuiButton
                   variant="contained"
@@ -343,8 +331,7 @@ export function PlaylistAction({
                   disabled={creatingPlaylist}
                   startIcon={creatingPlaylist ? <CircularProgress size={16} /> : undefined}
                 >
-                  {/* i18n-ignore-next-line */}
-                  Create
+                  {t('actions.playlist.create.submit')}
                 </MuiButton>
               </Stack>
             </div>
@@ -354,7 +341,7 @@ export function PlaylistAction({
     </div>
   );
 
-  const label = 'Add to Playlist';
+  const label = t('actions.playlist.popover.title');
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
   let iconSize: number;
   if (size === 'small') {

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -137,38 +137,31 @@ export function TickAction({
   const renderSignInPrompt = () => (
     <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
       <Typography variant="body2" component="span" fontWeight={600} sx={{ fontSize: 16 }}>
-        {/* i18n-ignore-next-line */}
-        Sign in to record ticks
+        {t('actions.tick.drawer.signInToRecord')}
       </Typography>
       <Typography variant="body1" component="p" color="text.secondary">
-        {/* i18n-ignore-next-line */}
-        Create a Boardsesh account to log your climbs and track your progress.
+        {t('actions.tick.drawer.createAccountBlurb')}
       </Typography>
       <MuiButton
         variant="contained"
         startIcon={<LoginOutlined />}
         onClick={() =>
           openAuthModal({
-            // i18n-ignore-next-line
-            title: 'Sign in to record ticks',
-            // i18n-ignore-next-line
-            description: 'Create an account to log your climbs and track your progress.',
+            title: t('actions.tick.drawer.authModalTitle'),
+            description: t('actions.tick.drawer.authModalDescription'),
           })
         }
         fullWidth
       >
-        {/* i18n-ignore-next-line */}
-        Sign In
+        {t('actions.tick.drawer.signIn')}
       </MuiButton>
       {openInAppUrl && (
         <>
           <Typography variant="body1" component="p" color="text.secondary">
-            {/* i18n-ignore-next-line */}
-            Or log your tick in the official app:
+            {t('actions.tick.drawer.orLogInOfficialApp')}
           </Typography>
           <MuiButton variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-            {/* i18n-ignore-next-line */}
-            Open in App
+            {t('actions.tick.drawer.openInApp')}
           </MuiButton>
           <MuiButton
             variant="text"
@@ -179,15 +172,14 @@ export function TickAction({
               handleOpenInApp();
             }}
           >
-            {/* i18n-ignore-next-line */}
-            Always open in app
+            {t('actions.tick.drawer.alwaysOpenInApp')}
           </MuiButton>
         </>
       )}
     </Stack>
   );
 
-  const label = 'Log ascent';
+  const label = t('actions.tick.drawer.logAscent');
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
   let iconSize: number;
   if (size === 'small') {
@@ -233,8 +225,7 @@ export function TickAction({
   const renderBoardSelector = () => (
     <Stack spacing={2} sx={{ py: 2 }}>
       <Typography variant="body2" fontWeight={600} sx={{ fontSize: 16, textAlign: 'center' }}>
-        {/* i18n-ignore-next-line */}
-        Which board did you climb on?
+        {t('actions.tick.drawer.whichBoard')}
       </Typography>
       <BoardScrollSection loading={!boardsReady} size="small">
         {matchingBoards.map((board) => (

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -91,8 +91,7 @@ export default function FavoriteButton({
       }
     } catch (error) {
       console.error(`[FavoriteButton] Error after auth for ${climbUuid}:`, error);
-      // i18n-ignore-next-line
-      showMessage('Failed to save favorite. Please try again.', 'error');
+      showMessage(t('actions.favorite.toast.saveFailed'), 'error');
     }
   };
 

--- a/packages/web/app/components/climb-actions/playlist-selection-content.tsx
+++ b/packages/web/app/components/climb-actions/playlist-selection-content.tsx
@@ -157,40 +157,34 @@ export default function PlaylistSelectionContent({
             fontSize: themeTokens.typography.fontSize.base,
           }}
         >
-          {/* i18n-ignore-next-line */}
-          Add to Playlist
+          {t('actions.playlist.popover.title')}
         </MuiTypography>
       </Box>
 
       {!isAuthenticated && (
         <Stack spacing={1} sx={{ width: '100%', textAlign: 'center', py: themeTokens.spacing[1] }}>
           <MuiTypography component="span" color="text.secondary" sx={{ fontSize: themeTokens.typography.fontSize.sm }}>
-            {/* i18n-ignore-next-line */}
-            Sign in to create and manage playlists
+            {t('actions.playlist.popover.signInBlurb')}
           </MuiTypography>
           <MuiButton
             variant="contained"
             onClick={() =>
               openAuthModal({
-                // i18n-ignore-next-line
-                title: 'Sign in to create playlists',
-                // i18n-ignore-next-line
-                description: 'Sign in to organize your climbs into custom playlists.',
+                title: t('actions.playlist.auth.title'),
+                description: t('actions.playlist.auth.description'),
               })
             }
             fullWidth
             size="small"
           >
-            {/* i18n-ignore-next-line */}
-            Sign In
+            {t('actions.tick.drawer.signIn')}
           </MuiButton>
         </Stack>
       )}
       {isAuthenticated && playlists.length === 0 && !showCreateForm && (
         <Stack spacing={1} sx={{ width: '100%', textAlign: 'center', py: themeTokens.spacing[1] }}>
           <MuiTypography component="span" color="text.secondary" sx={{ fontSize: themeTokens.typography.fontSize.sm }}>
-            {/* i18n-ignore-next-line */}
-            No playlists yet
+            {t('actions.playlist.popover.empty')}
           </MuiTypography>
           <MuiButton
             variant="contained"
@@ -199,8 +193,7 @@ export default function PlaylistSelectionContent({
             fullWidth
             size="small"
           >
-            {/* i18n-ignore-next-line */}
-            Create Your First Playlist
+            {t('actions.playlist.popover.createFirst')}
           </MuiButton>
         </Stack>
       )}
@@ -265,8 +258,7 @@ export default function PlaylistSelectionContent({
                 size="medium"
                 sx={{ marginTop: `${themeTokens.spacing[2]}px` }}
               >
-                {/* i18n-ignore-next-line */}
-                Create New Playlist
+                {t('actions.playlist.popover.createNew')}
               </MuiButton>
             </>
           )}
@@ -276,12 +268,10 @@ export default function PlaylistSelectionContent({
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Playlist Name
+                    {t('actions.playlist.create.nameLabel')}
                   </MuiTypography>
                   <TextField
-                    // i18n-ignore-next-line
-                    placeholder="e.g., Hard Crimps"
+                    placeholder={t('actions.playlist.create.namePlaceholder')}
                     autoFocus
                     fullWidth
                     size="small"
@@ -292,12 +282,10 @@ export default function PlaylistSelectionContent({
                 </Box>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Description (optional)
+                    {t('actions.playlist.create.descriptionLabel')}
                   </MuiTypography>
                   <TextField
-                    // i18n-ignore-next-line
-                    placeholder="Optional description..."
+                    placeholder={t('actions.playlist.create.descriptionPlaceholder')}
                     multiline
                     rows={2}
                     fullWidth
@@ -309,8 +297,7 @@ export default function PlaylistSelectionContent({
                 </Box>
                 <Box>
                   <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {/* i18n-ignore-next-line */}
-                    Color (optional)
+                    {t('actions.playlist.create.colorLabel')}
                   </MuiTypography>
                   <TextField
                     type="color"
@@ -334,8 +321,7 @@ export default function PlaylistSelectionContent({
                     setCreateFormValues({ name: '', description: '', color: '' });
                   }}
                 >
-                  {/* i18n-ignore-next-line */}
-                  Cancel
+                  {t('common:actions.cancel')}
                 </MuiButton>
                 <MuiButton
                   variant="contained"
@@ -344,8 +330,7 @@ export default function PlaylistSelectionContent({
                   disabled={creatingPlaylist}
                   startIcon={creatingPlaylist ? <CircularProgress size={16} /> : undefined}
                 >
-                  {/* i18n-ignore-next-line */}
-                  Create
+                  {t('actions.playlist.create.submit')}
                 </MuiButton>
               </Stack>
             </div>

--- a/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-list-item.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbListItem from '../climb-list-item';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 

--- a/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/climb-title.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import ClimbTitle, { type ClimbTitleData } from '../climb-title';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useRef, useState, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import IconButton from '@mui/material/IconButton';
 import dynamic from 'next/dynamic';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
@@ -253,6 +254,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     centerBottomSlot,
     contentPadding,
   }) => {
+    const { t } = useTranslation('climbs');
     // Subscribe to selection store — only re-renders when THIS item's selected state changes.
     // When `selectedOverride` or `disableSelection` is provided, ignore the store value.
     const storeSelected = useIsClimbSelected(climb.uuid);
@@ -432,9 +434,8 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
     }, []);
 
     const handleTickError = useCallback(() => {
-      // i18n-ignore-next-line
-      showMessage("Couldn't save your tick — it's saved as a draft", 'error');
-    }, [showMessage]);
+      showMessage(t('card.list.tickError'), 'error');
+    }, [showMessage, t]);
 
     // --- Actions drawer drag-to-resize (Spotify-style) ---
     const { paperRef: actionsPaperRef, dragHandlers: actionsDragHandlers } = useDrawerDragResize({
@@ -635,8 +636,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
             {menuSlot ?? (
               <IconButton
                 size="small"
-                // i18n-ignore-next-line
-                aria-label="More actions"
+                aria-label={t('card.list.moreActions')}
                 onClick={handleMenuClick}
                 style={iconButtonStyle}
                 disableRipple

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
@@ -184,6 +185,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     isNoMatch = false,
     subtitleOverride,
   }) => {
+    const { t } = useTranslation('climbs');
     const isDark = useIsDarkMode();
     const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
@@ -235,8 +237,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     if (!climb) {
       return (
         <Typography variant="body2" component="span" sx={noClimbSx}>
-          {/* i18n-ignore-next-line */}
-          No climb selected
+          {t('card.title.noClimbSelected')}
         </Typography>
       );
     }
@@ -249,7 +250,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
         const baseText = `${displayDifficulty} ${formatQuality(climb.quality_average!)}★`;
         return showAngle ? `${baseText} @ ${climb.angle}°` : baseText;
       }
-      const projectText = showAngle ? `project @ ${climb.angle}°` : 'project';
+      const projectText = showAngle ? t('card.title.projectAtAngle', { angle: climb.angle }) : t('card.title.project');
       return (
         <Box component="span" sx={italicSx}>
           {projectText}
@@ -319,8 +320,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
           subtitleParts.join(' \u00b7 ')
         ) : (
           <Box component="span" sx={italicSx}>
-            {/* i18n-ignore-next-line */}
-            project
+            {t('card.title.project')}
           </Box>
         ));
 
@@ -384,8 +384,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
                 secondLineContent.join(' · ')
               ) : (
                 <Box component="span" sx={italicSx}>
-                  {/* i18n-ignore-next-line */}
-                  project
+                  {t('card.title.project')}
                 </Box>
               )}
             </Typography>

--- a/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/climb-detail-header-grade-format.test.tsx
@@ -4,6 +4,15 @@ import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import ClimbDetailHeader from '../climb-detail-header';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import VideocamOutlined from '@mui/icons-material/VideocamOutlined';
@@ -18,22 +19,6 @@ import { GET_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
 import { dedupeBetaLinks, mapBetaLinksResponse } from '@/app/lib/beta-video-url';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import type { Climb } from '@/app/lib/types';
-
-const betaLabel = (
-  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
-    <VideocamOutlined sx={{ fontSize: 16 }} />
-    {/* i18n-ignore-next-line */}
-    Beta
-  </Box>
-);
-
-const betaTitle = (
-  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
-    <VideocamOutlined sx={{ fontSize: 22 }} />
-    {/* i18n-ignore-next-line */}
-    Beta
-  </Box>
-);
 
 type BuildClimbDetailSectionsProps = {
   climb: Climb;
@@ -56,6 +41,19 @@ export function useBuildClimbDetailSections({
   boardName,
   enabled: enabledProp = true,
 }: BuildClimbDetailSectionsProps): CollapsibleSectionConfig[] {
+  const { t } = useTranslation('climbs');
+  const betaLabel = (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+      <VideocamOutlined sx={{ fontSize: 16 }} />
+      {t('detail.sections.beta')}
+    </Box>
+  );
+  const betaTitle = (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+      <VideocamOutlined sx={{ fontSize: 22 }} />
+      {t('detail.sections.beta')}
+    </Box>
+  );
   const searchParams = useSearchParams();
   const highlightProposalUuid = searchParams.get('proposalUuid') ?? undefined;
   const logbookSummary = useLogbookSummary(climb.uuid);

--- a/packages/web/app/components/climb-detail/climb-detail-header.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
@@ -22,6 +23,7 @@ type ClimbDetailHeaderProps = {
  * Layout: Grade (left) | Name + details (center) | Spacer (right, balances grade)
  */
 export default function ClimbDetailHeader({ climb, communityGrade }: ClimbDetailHeaderProps) {
+  const { t } = useTranslation('climbs');
   const isDark = useIsDarkMode();
   const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
@@ -70,8 +72,7 @@ export default function ClimbDetailHeader({ climb, communityGrade }: ClimbDetail
     }
     return (
       <Typography variant="body2" component="span" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
-        {/* i18n-ignore-next-line */}
-        project
+        {t('card.detailHeader.project')}
       </Typography>
     );
   };

--- a/packages/web/app/components/climb-list/multiboard-climb-list.tsx
+++ b/packages/web/app/components/climb-list/multiboard-climb-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -83,6 +84,7 @@ export default function MultiboardClimbList({
   boards: externalBoards,
   boardsLoading: externalBoardsLoading,
 }: MultiboardClimbListProps) {
+  const { t } = useTranslation('climbs');
   // Only fetch boards internally when the caller hasn't supplied them.
   // Passing `enabled={false}` short-circuits useMyBoards so we don't fire a
   // duplicate GraphQL request against the same endpoint.
@@ -191,14 +193,12 @@ export default function MultiboardClimbList({
       }}
     >
       <ToggleButtonGroup exclusive size="small" value={sortBy} onChange={handleSortChange}>
-        {/* i18n-ignore-next-line */}
-        <ToggleButton value="popular">Popular</ToggleButton>
-        <ToggleButton value="new">New</ToggleButton>
+        <ToggleButton value="popular">{t('multiboardList.popular')}</ToggleButton>
+        <ToggleButton value="new">{t('multiboardList.new')}</ToggleButton>
       </ToggleButtonGroup>
       {totalCount != null && totalCount > 0 && (
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          {totalCount} climb{totalCount !== 1 ? 's' : ''}
+          {t('multiboardList.count', { count: totalCount })}
         </Typography>
       )}
     </Box>
@@ -215,8 +215,7 @@ export default function MultiboardClimbList({
     climbListContent = (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No climbs found
+          {t('multiboardList.noClimbsFound')}
         </Typography>
       </Box>
     );

--- a/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/drafts-drawer.test.tsx
@@ -4,6 +4,15 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DraftsDrawer from '../drafts-drawer';
 import type { BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockPush = vi.fn();
 const mockRequest = vi.fn();

--- a/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/hold-type-picker.test.tsx
@@ -2,6 +2,15 @@ import { afterEach, describe, it, expect, vi } from 'vite-plus/test';
 import React, { useRef, useEffect } from 'react';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import HoldTypePicker, { buildOptions } from '../hold-type-picker';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // Mock HOLD_STATE_MAP so picker color assertions don't depend on the real LED
 // colors — if production LED hex values change, these tests should keep passing

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1070,8 +1070,7 @@ export default function CreateClimbForm({
       // MoonBoard: drafts are allowed to be incomplete; only block publish.
       if (boardType === 'moonboard') {
         if (!isDraft) {
-          // i18n-ignore-next-line
-          showMessage('A valid climb needs at least 1 start hold and 1 finish hold', 'warning');
+          showMessage(t('createClimbForm.validation.needsStartFinish'), 'warning');
           return;
         }
       } else {
@@ -1423,15 +1422,13 @@ export default function CreateClimbForm({
         {/* MoonBoard OCR errors */}
         {boardType === 'moonboard' && ocrError && (
           <MuiAlert severity="error" onClose={() => setOcrError(null)} className={styles.alertBanner}>
-            {/* i18n-ignore-next-line */}
-            Import Failed: {ocrError}
+            {t('createClimbForm.alerts.importFailed', { error: ocrError })}
           </MuiAlert>
         )}
 
         {boardType === 'moonboard' && ocrWarnings.length > 0 && (
           <MuiAlert severity="warning" onClose={() => setOcrWarnings([])} className={styles.alertBanner}>
-            {/* i18n-ignore-next-line */}
-            Import Warnings:{' '}
+            {t('createClimbForm.alerts.importWarnings')}{' '}
             {ocrWarnings.map((w, i) => (
               <div key={i}>{w}</div>
             ))}
@@ -1446,8 +1443,7 @@ export default function CreateClimbForm({
 
         {boardType === 'moonboard' && !moonBoardDuplicateError && isCheckingMoonBoardDuplicate && isValid && (
           <MuiAlert severity="info" className={styles.alertBanner}>
-            {/* i18n-ignore-next-line */}
-            Checking whether this MoonBoard climb already exists...
+            {t('createClimbForm.alerts.checkingMoonBoardDuplicate')}
           </MuiAlert>
         )}
 
@@ -1477,8 +1473,7 @@ export default function CreateClimbForm({
                 color="text.secondary"
                 className={styles.climbTitleDraftBadge}
               >
-                {/* i18n-ignore-next-line */}
-                Draft
+                {t('createClimbForm.draftBadge')}
               </Typography>
             </div>
           )}
@@ -1551,8 +1546,7 @@ export default function CreateClimbForm({
           </MuiTooltip>
         </ConfirmPopover>
         {canShowDrafts && (
-          // i18n-ignore-next-line
-          <MuiTooltip title="Drafts">
+          <MuiTooltip title={t('draftsDrawer.title')}>
             <Badge
               color="primary"
               badgeContent={draftsCount ?? 0}
@@ -1560,8 +1554,7 @@ export default function CreateClimbForm({
               invisible={!draftsCount}
               overlap="rectangular"
             >
-              {/* i18n-ignore-next-line */}
-              <IconButton size="small" onClick={handleOpenDrafts} aria-label="Open drafts">
+              <IconButton size="small" onClick={handleOpenDrafts} aria-label={t('createClimbForm.openDrafts')}>
                 <DraftsOutlined fontSize="small" />
               </IconButton>
             </Badge>
@@ -1569,23 +1562,27 @@ export default function CreateClimbForm({
         )}
         {boardType === 'moonboard' && (
           <>
-            <MuiTooltip title={isOcrProcessing ? 'Processing...' : 'Import from screenshot'}>
+            <MuiTooltip
+              title={isOcrProcessing ? t('createClimbForm.processing') : t('createClimbForm.importFromScreenshot')}
+            >
               <span>
                 <IconButton
                   size="small"
                   disabled={isOcrProcessing}
                   onClick={() => fileInputRef.current?.click()}
-                  // i18n-ignore-next-line
-                  aria-label="Import from screenshot"
+                  aria-label={t('createClimbForm.importFromScreenshot')}
                 >
                   {isOcrProcessing ? <CircularProgress size={16} /> : <CloudUploadOutlined fontSize="small" />}
                 </IconButton>
               </span>
             </MuiTooltip>
-            {/* i18n-ignore-next-line */}
-            <MuiTooltip title="Bulk import">
-              {/* i18n-ignore-next-line */}
-              <IconButton size="small" component={LocaleLink} href={bulkImportUrl} aria-label="Bulk import">
+            <MuiTooltip title={t('createClimbForm.bulkImport')}>
+              <IconButton
+                size="small"
+                component={LocaleLink}
+                href={bulkImportUrl}
+                aria-label={t('createClimbForm.bulkImport')}
+              >
                 <GetAppOutlined fontSize="small" />
               </IconButton>
             </MuiTooltip>
@@ -1619,10 +1616,8 @@ export default function CreateClimbForm({
               </span>
             </MuiTooltip>
           )}
-          {/* i18n-ignore-next-line */}
-          <MuiTooltip title="Climb settings">
-            {/* i18n-ignore-next-line */}
-            <IconButton size="small" onClick={handleToggleSettings} aria-label="Climb settings">
+          <MuiTooltip title={t('createClimbForm.settings.tooltip')}>
+            <IconButton size="small" onClick={handleToggleSettings} aria-label={t('createClimbForm.settings.tooltip')}>
               <SettingsOutlined fontSize="small" />
             </IconButton>
           </MuiTooltip>
@@ -1643,8 +1638,7 @@ export default function CreateClimbForm({
 
       {/* Settings nested drawer */}
       <SwipeableDrawer
-        // i18n-ignore-next-line
-        title="Climb Settings"
+        title={t('createClimbForm.settings.title')}
         placement="bottom"
         open={showSettingsPanel}
         onClose={() => setShowSettingsPanel(false)}
@@ -1655,14 +1649,12 @@ export default function CreateClimbForm({
           {/* Name */}
           <div className={styles.settingsField}>
             <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-              {/* i18n-ignore-next-line */}
-              Name
+              {t('createClimbForm.fields.name')}
             </Typography>
             <TextField
               value={climbName}
               onChange={(e) => setClimbName(e.target.value)}
-              // i18n-ignore-next-line
-              placeholder="Climb name"
+              placeholder={t('createClimbForm.namePlaceholder')}
               inputProps={{ maxLength: 100 }}
               variant="outlined"
               size="small"
@@ -1675,8 +1667,7 @@ export default function CreateClimbForm({
             <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
               <MuiSwitch size="small" checked={isDraft} onChange={(_, checked) => setIsDraft(checked)} />
               <Typography variant="body2" component="span">
-                {/* i18n-ignore-next-line */}
-                Draft
+                {t('createClimbForm.draftBadge')}
               </Typography>
             </Box>
           </div>
@@ -1684,29 +1675,53 @@ export default function CreateClimbForm({
           {/* Hold count indicators */}
           <div className={styles.settingsField}>
             <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-              {/* i18n-ignore-next-line */}
-              Holds
+              {t('createClimbForm.fields.holds')}
             </Typography>
             <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap">
               {boardType === 'aurora' ? (
                 <>
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={startingCount} max={2} color={themeTokens.colors.success} label="Starting" />
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={finishCount} max={2} color={themeTokens.colors.pink} label="Finish" />
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={totalHolds} color={themeTokens.colors.primary} label="Total" />
+                  <HoldIndicator
+                    count={startingCount}
+                    max={2}
+                    color={themeTokens.colors.success}
+                    label={t('createClimbForm.holds.starting')}
+                  />
+                  <HoldIndicator
+                    count={finishCount}
+                    max={2}
+                    color={themeTokens.colors.pink}
+                    label={t('createClimbForm.holds.finish')}
+                  />
+                  <HoldIndicator
+                    count={totalHolds}
+                    color={themeTokens.colors.primary}
+                    label={t('createClimbForm.holds.total')}
+                  />
                 </>
               ) : (
                 <>
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={startingCount} max={2} color={themeTokens.colors.error} label="Start" />
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={handCount} color={themeTokens.colors.primary} label="Hand" />
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={finishCount} max={2} color={themeTokens.colors.success} label="Finish" />
-                  {/* i18n-ignore-next-line */}
-                  <HoldIndicator count={totalHolds} color={themeTokens.colors.secondary} label="Total" />
+                  <HoldIndicator
+                    count={startingCount}
+                    max={2}
+                    color={themeTokens.colors.error}
+                    label={t('createClimbForm.holds.start')}
+                  />
+                  <HoldIndicator
+                    count={handCount}
+                    color={themeTokens.colors.primary}
+                    label={t('createClimbForm.holds.hand')}
+                  />
+                  <HoldIndicator
+                    count={finishCount}
+                    max={2}
+                    color={themeTokens.colors.success}
+                    label={t('createClimbForm.holds.finish')}
+                  />
+                  <HoldIndicator
+                    count={totalHolds}
+                    color={themeTokens.colors.secondary}
+                    label={t('createClimbForm.holds.total')}
+                  />
                 </>
               )}
             </Stack>
@@ -1717,8 +1732,7 @@ export default function CreateClimbForm({
             <>
               <div className={styles.settingsField}>
                 <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-                  {/* i18n-ignore-next-line */}
-                  Angle
+                  {t('createClimbForm.fields.angle')}
                 </Typography>
                 <MuiSelect
                   value={selectedAngle}
@@ -1728,16 +1742,14 @@ export default function CreateClimbForm({
                 >
                   {MOONBOARD_ANGLES.map((a) => (
                     <MenuItem key={a} value={a}>
-                      {/* i18n-ignore-next-line */}
-                      {a}&deg;
+                      {`${a}°`}
                     </MenuItem>
                   ))}
                 </MuiSelect>
               </div>
               <div className={styles.settingsField}>
                 <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-                  {/* i18n-ignore-next-line */}
-                  Grade
+                  {t('createClimbForm.fields.grade')}
                 </Typography>
                 <MuiSelect
                   displayEmpty
@@ -1747,8 +1759,7 @@ export default function CreateClimbForm({
                   size="small"
                 >
                   <MenuItem value="">
-                    {/* i18n-ignore-next-line */}
-                    <em>None</em>
+                    <em>{t('createClimbForm.fields.gradeNone')}</em>
                   </MenuItem>
                   {MOONBOARD_GRADES.map((g) => (
                     <MenuItem key={g.value} value={g.value}>
@@ -1761,8 +1772,7 @@ export default function CreateClimbForm({
                 <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
                   <MuiSwitch size="small" checked={isBenchmark} onChange={(_, checked) => setIsBenchmark(checked)} />
                   <Typography variant="body2" component="span">
-                    {/* i18n-ignore-next-line */}
-                    Benchmark
+                    {t('createClimbForm.fields.benchmark')}
                   </Typography>
                 </Box>
               </div>
@@ -1771,14 +1781,12 @@ export default function CreateClimbForm({
           {/* Common: Description */}
           <div className={styles.settingsField}>
             <Typography variant="body2" component="span" color="text.secondary" className={styles.settingsLabel}>
-              {/* i18n-ignore-next-line */}
-              Description (optional)
+              {t('createClimbForm.fields.description')}
             </Typography>
             <TextField
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              // i18n-ignore-next-line
-              placeholder="Add beta or notes about your climb..."
+              placeholder={t('createClimbForm.descriptionPlaceholder')}
               multiline
               rows={3}
               inputProps={{ maxLength: 500 }}
@@ -1800,8 +1808,7 @@ export default function CreateClimbForm({
               fontWeight: 600,
             }}
           >
-            {/* i18n-ignore-next-line */}
-            Dismiss
+            {t('createClimbForm.dismiss')}
           </MuiButton>
           <MuiButton
             variant="contained"

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -45,6 +46,7 @@ export type DraftsDrawerProps = {
 };
 
 const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails, angle, onLoadDraft }) => {
+  const { t } = useTranslation('climbs');
   const router = useLocaleRouter();
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
@@ -192,8 +194,7 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
     draftsListContent = (
       <Box sx={{ padding: themeTokens.spacing[6], textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Couldn&apos;t load your drafts. Try again.
+          {t('draftsDrawer.loadError')}
         </Typography>
       </Box>
     );
@@ -201,12 +202,10 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
     draftsListContent = (
       <Box sx={{ padding: themeTokens.spacing[8], textAlign: 'center' }}>
         <Typography variant="body1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-          {/* i18n-ignore-next-line */}
-          No drafts yet
+          {t('draftsDrawer.empty.title')}
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ marginTop: 1 }}>
-          {/* i18n-ignore-next-line */}
-          Save a climb as a draft to pick it up later.
+          {t('draftsDrawer.empty.subtitle')}
         </Typography>
       </Box>
     );
@@ -264,13 +263,11 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({ open, onClose, boardDetails
               fontSize: themeTokens.typography.fontSize.base,
             }}
           >
-            {/* i18n-ignore-next-line */}
-            Drafts
+            {t('draftsDrawer.title')}
           </Typography>
           {drafts.length > 0 && (
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              {drafts.length} draft{drafts.length === 1 ? '' : 's'}
+              {t('draftsDrawer.count', { count: drafts.length })}
             </Typography>
           )}
         </Box>

--- a/packages/web/app/components/create-climb/hold-type-picker.tsx
+++ b/packages/web/app/components/create-climb/hold-type-picker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Popover from '@mui/material/Popover';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -91,7 +92,10 @@ export default function HoldTypePicker({
   onSelect,
   onClose,
 }: HoldTypePickerProps) {
+  const { t } = useTranslation('climbs');
   const options = useMemo(() => buildOptions(boardName), [boardName]);
+  const localizedLabel = (state: PickerHoldState) =>
+    t(`holdTypePicker.states.${state.toLowerCase() as Lowercase<PickerHoldState>}`);
 
   const handleSelect = (state: SelectableState, disabled: boolean) => {
     if (disabled) return;
@@ -117,8 +121,7 @@ export default function HoldTypePicker({
     >
       <Box
         role="toolbar"
-        // i18n-ignore-next-line
-        aria-label="Hold type"
+        aria-label={t('holdTypePicker.toolbarAriaLabel')}
         sx={{
           display: 'flex',
           alignItems: 'flex-start',
@@ -135,7 +138,7 @@ export default function HoldTypePicker({
           return (
             <Swatch
               key={option.state}
-              label={option.label}
+              label={localizedLabel(option.state)}
               color={option.color}
               isActive={isActive}
               isDisabled={isDisabled}
@@ -145,8 +148,7 @@ export default function HoldTypePicker({
         })}
         <Swatch
           key="clear"
-          // i18n-ignore-next-line
-          label="Clear"
+          label={t('holdTypePicker.clear')}
           isClear
           isActive={currentState === 'OFF'}
           isDisabled={currentState === 'OFF'}

--- a/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
+++ b/packages/web/app/components/dev-url-dialog/dev-url-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -23,21 +24,22 @@ type DevUrlDialogProps = {
 // the plugin call silently no-ops in a release build).
 const RESTART_TIMEOUT_MS = 1500;
 
-function validateUrl(input: string): string | null {
+function validateUrl(input: string, t: (key: string) => string): string | null {
   const trimmed = input.trim();
-  if (!trimmed) return 'Enter a URL';
+  if (!trimmed) return t('devUrlDialog.validation.enterUrl');
   try {
     const parsed = new URL(trimmed);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return 'URL must start with http:// or https://';
+      return t('devUrlDialog.validation.mustBeHttp');
     }
     return null;
   } catch {
-    return 'Not a valid URL';
+    return t('devUrlDialog.validation.invalid');
   }
 }
 
 export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
+  const { t } = useTranslation('settings');
   const [state, setState] = useState<DevUrlState | null>(null);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
@@ -77,7 +79,7 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
       await action();
       succeeded = true;
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong');
+      setError(e instanceof Error ? e.message : t('devUrlDialog.validation.generic'));
     } finally {
       if (succeeded) {
         // Plugin resolved — native side should now kill the process. If it
@@ -91,7 +93,7 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
   };
 
   const save = () => {
-    const validationError = validateUrl(input);
+    const validationError = validateUrl(input, t);
     if (validationError) {
       setError(validationError);
       return;
@@ -110,17 +112,14 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
 
   return (
     <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="xs">
-      {/* i18n-ignore-next-line */}
-      <DialogTitle>Dev URL</DialogTitle>
+      <DialogTitle>{t('devUrlDialog.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <Typography variant="body2" color="text.secondary">
-            {/* i18n-ignore-next-line */}
-            Point the WebView at a different origin. The app will restart after saving.
+            {t('devUrlDialog.intro')}
           </Typography>
           <TextField
-            // i18n-ignore-next-line
-            label="Server URL"
+            label={t('devUrlDialog.urlLabel')}
             placeholder={state?.defaultUrl ?? 'https://www.boardsesh.com'}
             value={input}
             onChange={(e) => {
@@ -136,25 +135,21 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
             spellCheck={false}
           />
           <Button size="small" variant="outlined" onClick={useDefault} disabled={busy}>
-            {/* i18n-ignore-next-line */}
-            Use production
+            {t('devUrlDialog.useProduction')}
           </Button>
           {state?.currentUrl && (
             <Typography variant="caption" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Currently overriding to: {state.currentUrl}
+              {t('devUrlDialog.currentlyOverriding', { url: state.currentUrl })}
             </Typography>
           )}
         </Stack>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={busy}>
-          {/* i18n-ignore-next-line */}
-          Cancel
+          {t('devUrlDialog.cancel')}
         </Button>
         <Button onClick={clear} disabled={busy || !state?.currentUrl} color="warning">
-          {/* i18n-ignore-next-line */}
-          Clear override
+          {t('devUrlDialog.clearOverride')}
         </Button>
         <Button
           onClick={save}
@@ -162,7 +157,7 @@ export default function DevUrlDialog({ open, onClose }: DevUrlDialogProps) {
           variant="contained"
           startIcon={busy ? <CircularProgress size={14} color="inherit" /> : undefined}
         >
-          {busy ? 'Restarting…' : 'Save & restart'}
+          {busy ? t('devUrlDialog.restarting') : t('devUrlDialog.save')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/feedback-dialog.test.tsx
@@ -4,6 +4,15 @@ import React from 'react';
 import { FeedbackDialog } from '../feedback-dialog';
 import { useSubmitAppFeedback } from '@/app/hooks/use-submit-app-feedback';
 import { setFeedbackStatus } from '@/app/lib/feedback-prompt-db';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // The dialog pulls in a React Query hook, a snackbar provider, and an
 // IndexedDB-backed db module. Stub them out so these tests focus on the

--- a/packages/web/app/components/feedback/__tests__/feedback-form.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/feedback-form.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi } from 'vite-plus/test';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { FeedbackForm } from '../feedback-form';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 function pickStars(n: number) {
   fireEvent.click(screen.getByRole('option', { name: `${n} star${n > 1 ? 's' : ''}` }));

--- a/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/shake-to-report-provider.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { render, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { ShakeToReportProvider } from '../shake-to-report-provider';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 type DismissedResolver = {
   resolve: (value: boolean) => void;

--- a/packages/web/app/components/feedback/__tests__/store-review-prompt-dialog.test.tsx
+++ b/packages/web/app/components/feedback/__tests__/store-review-prompt-dialog.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { StoreReviewPromptDialog } from '../store-review-prompt-dialog';
 import { requestInAppReview } from '@/app/lib/in-app-review';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 vi.mock('@/app/lib/in-app-review', () => ({
   requestInAppReview: vi.fn().mockResolvedValue(undefined),

--- a/packages/web/app/components/feedback/feedback-dialog.tsx
+++ b/packages/web/app/components/feedback/feedback-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -54,10 +55,11 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
   onSubmitted,
   secondaryAction,
 }) => {
+  const { t } = useTranslation('settings');
   const { mutate } = useSubmitAppFeedback();
   const { showMessage } = useSnackbar();
   const isBug = mode === 'bug';
-  const resolvedTitle = title ?? (isBug ? 'Report a bug' : 'Rate Boardsesh');
+  const resolvedTitle = title ?? (isBug ? t('feedbackDialog.titleBug') : t('feedbackDialog.titleRating'));
 
   const handleSubmit = (values: FeedbackSubmission) => {
     if (isBug) {
@@ -84,15 +86,14 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
       },
       {
         onSuccess: () => {
-          showMessage(isBug ? 'Bug logged — thanks.' : 'Thanks — logged.', 'success');
+          showMessage(isBug ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
           // Fire chained follow-ups (e.g. "also leave a store review?") only
           // on successful submission. Otherwise we'd be prompting the user to
           // publicly review the app right after telling them their feedback
           // didn't save.
           onSubmitted?.(values);
         },
-        // i18n-ignore-next-line
-        onError: () => showMessage("Couldn't send — we'll keep your feedback.", 'warning'),
+        onError: () => showMessage(t('feedbackDialog.errorRating'), 'warning'),
       },
     );
     onClose();
@@ -100,15 +101,19 @@ const FeedbackDialogBody: React.FC<Omit<FeedbackDialogProps, 'open'>> = ({
 
   return (
     <div className={styles.dialogBody}>
-      {/* i18n-ignore-next-line */}
-      <IconButton aria-label="Close" onClick={onClose} className={styles.closeButton} size="small">
+      <IconButton
+        aria-label={t('feedbackDialog.closeAria')}
+        onClick={onClose}
+        className={styles.closeButton}
+        size="small"
+      >
         <CloseOutlined fontSize="small" />
       </IconButton>
       <DialogContent>
         <FeedbackForm
           mode={isBug ? 'bug' : 'drawer-feedback'}
           title={resolvedTitle}
-          submitLabel={isBug ? 'Send bug report' : 'Send'}
+          submitLabel={isBug ? t('feedbackDialog.submitBug') : t('feedbackDialog.submitRating')}
           onSubmit={handleSubmit}
           onCancel={onClose}
         />

--- a/packages/web/app/components/feedback/feedback-form.tsx
+++ b/packages/web/app/components/feedback/feedback-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
@@ -33,9 +34,11 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
   onSubmit,
   onCancel,
   title,
-  submitLabel = 'Save',
+  submitLabel,
   titleId,
 }) => {
+  const { t } = useTranslation('settings');
+  const resolvedSubmitLabel = submitLabel ?? t('feedbackForm.saveDefault');
   const generatedId = useId();
   const resolvedTitleId = titleId ?? generatedId;
   const [rating, setRating] = useState<number | null>(null);
@@ -92,7 +95,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
     return true;
   })();
 
-  const heading = isPromptComment ? "What's missing?" : title;
+  const heading = isPromptComment ? t('feedbackForm.missingHeading') : title;
 
   if (mode === 'prompt') {
     return (
@@ -105,7 +108,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
           <div className={styles.compactRow}>
             <InlineStarPicker quality={rating} onSelect={setRating} />
             <IconButton
-              aria-label={rating !== null && rating < 3 ? 'Next' : submitLabel}
+              aria-label={rating !== null && rating < 3 ? t('feedbackForm.nextAria') : resolvedSubmitLabel}
               onClick={handlePrimary}
               disabled={!canSubmit}
               size="small"
@@ -125,8 +128,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
             <TextField
               value={comment}
               onChange={(event) => setComment(event.target.value)}
-              // i18n-ignore-next-line
-              placeholder="Tell us what would help"
+              placeholder={t('feedbackForm.compactPlaceholder')}
               multiline
               minRows={2}
               maxRows={4}
@@ -137,12 +139,10 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
             />
             <div className={styles.compactActions}>
               <MuiButton onClick={handleSecondary} disabled={submitting} size="small">
-                {/* i18n-ignore-next-line */}
-                Skip
+                {t('feedbackForm.skip')}
               </MuiButton>
               <IconButton
-                // i18n-ignore-next-line
-                aria-label="Send"
+                aria-label={t('feedbackForm.sendAria')}
                 onClick={handlePrimary}
                 disabled={!canSubmit}
                 size="small"
@@ -172,7 +172,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
       <TextField
         value={comment}
         onChange={(event) => setComment(event.target.value)}
-        placeholder={isBug ? 'What were you doing? What did you expect vs see?' : "What's on your mind?"}
+        placeholder={isBug ? t('feedbackForm.bugPlaceholder') : t('feedbackForm.ratingPlaceholder')}
         multiline
         minRows={isBug ? 4 : 3}
         maxRows={isBug ? 8 : 6}
@@ -182,7 +182,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
         helperText={(() => {
           if (!isBug) return undefined;
           const remaining = BUG_COMMENT_MIN - comment.trim().length;
-          return remaining > 0 ? `${remaining} more characters to go` : ' ';
+          return remaining > 0 ? t('feedbackForm.remainingChars', { count: remaining }) : ' ';
         })()}
         slotProps={{ htmlInput: { maxLength: 2000 } }}
         className={styles.comment}
@@ -191,12 +191,11 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
       <div className={styles.actions}>
         {onCancel && (
           <MuiButton onClick={handleSecondary} disabled={submitting} size="small">
-            {/* i18n-ignore-next-line */}
-            Cancel
+            {t('feedbackForm.cancel')}
           </MuiButton>
         )}
         <MuiButton variant="contained" onClick={handlePrimary} disabled={!canSubmit} size="small">
-          {submitLabel}
+          {resolvedSubmitLabel}
         </MuiButton>
       </div>
     </div>

--- a/packages/web/app/components/feedback/feedback-prompt-banner.tsx
+++ b/packages/web/app/components/feedback/feedback-prompt-banner.tsx
@@ -22,6 +22,7 @@ type BannerBodyProps = {
 
 const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubmitted, titleId }) => {
   const { t } = useTranslation('common');
+  const { t: tSettings } = useTranslation('settings');
   const { mutate } = useSubmitAppFeedback();
   const { showMessage } = useSnackbar();
 
@@ -38,24 +39,26 @@ const FeedbackPromptBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onSubm
         source: 'prompt',
       },
       {
-        // i18n-ignore-next-line
-        onSuccess: () => showMessage('Thanks — logged.', 'success'),
-        // i18n-ignore-next-line
-        onError: () => showMessage("Couldn't send — we'll keep your rating.", 'warning'),
+        onSuccess: () => showMessage(tSettings('feedbackBanner.successToast'), 'success'),
+        onError: () => showMessage(tSettings('feedbackBanner.errorToast'), 'warning'),
       },
     );
   };
 
   return (
     <Paper elevation={1} className={styles.banner} role="region" aria-labelledby={titleId}>
-      {/* i18n-ignore-next-line */}
-      <IconButton aria-label="Dismiss" onClick={onDismiss} className={styles.closeButton} size="small">
+      <IconButton
+        aria-label={tSettings('feedbackBanner.dismissAria')}
+        onClick={onDismiss}
+        className={styles.closeButton}
+        size="small"
+      >
         <CloseOutlined fontSize="small" />
       </IconButton>
       <FeedbackForm
         mode="prompt"
         title={t('feedback.title')}
-        submitLabel="Save"
+        submitLabel={tSettings('feedbackForm.saveDefault')}
         onSubmit={handleSubmit}
         titleId={titleId}
       />

--- a/packages/web/app/components/feedback/shake-to-report-provider.tsx
+++ b/packages/web/app/components/feedback/shake-to-report-provider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useShakeDetector } from '@/app/hooks/use-shake-detector';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { getShakeToReportDismissed, setShakeToReportDismissed } from '@/app/lib/user-preferences-db';
@@ -16,6 +17,7 @@ import { BugReportDialog } from './bug-report-dialog';
  * good. The manual drawer entry is unaffected.
  */
 export const ShakeToReportProvider: React.FC = () => {
+  const { t } = useTranslation('settings');
   const [open, setOpen] = useState(false);
   // null = hydration pending. We keep the detector detached until IndexedDB
   // resolves: defaulting to "not dismissed" would let a previously opted-out
@@ -51,9 +53,8 @@ export const ShakeToReportProvider: React.FC = () => {
     setDismissed(true);
     setOpen(false);
     void setShakeToReportDismissed(true);
-    // i18n-ignore-next-line
-    showMessage('Shake to report off. Tap your avatar up top to send feedback.', 'info', undefined, 6000);
-  }, [showMessage]);
+    showMessage(t('shakeToReport.disabledToast'), 'info', undefined, 6000);
+  }, [showMessage, t]);
 
   useShakeDetector(handleShake, { enabled: !open && dismissed === false });
 
@@ -62,7 +63,7 @@ export const ShakeToReportProvider: React.FC = () => {
       open={open}
       onClose={handleClose}
       source="shake-bug"
-      secondaryAction={{ label: "Don't show this again", onClick: handleDontShowAgain }}
+      secondaryAction={{ label: t('shakeToReport.dontShowAgain'), onClick: handleDontShowAgain }}
     />
   );
 };

--- a/packages/web/app/components/feedback/store-review-prompt-dialog.tsx
+++ b/packages/web/app/components/feedback/store-review-prompt-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -21,6 +22,7 @@ type StoreReviewPromptDialogProps = {
  * to publicly 1-star the app — gating lives in the caller.
  */
 export const StoreReviewPromptDialog: React.FC<StoreReviewPromptDialogProps> = ({ open, onClose }) => {
+  const { t } = useTranslation('settings');
   const handleReview = () => {
     void requestInAppReview();
     onClose();
@@ -28,21 +30,14 @@ export const StoreReviewPromptDialog: React.FC<StoreReviewPromptDialogProps> = (
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      {/* i18n-ignore-next-line */}
-      <DialogTitle>Help others find Boardsesh</DialogTitle>
+      <DialogTitle>{t('storeReview.title')}</DialogTitle>
       <DialogContent>
-        <DialogContentText>
-          {/* i18n-ignore-next-line */}
-          Thanks for the rating. Would you also leave a quick review on your app store? It&apos;s the single best thing
-          you can do to help other climbers find us.
-        </DialogContentText>
+        <DialogContentText>{t('storeReview.body')}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        {/* i18n-ignore-next-line */}
-        <Button onClick={onClose}>Not now</Button>
+        <Button onClick={onClose}>{t('storeReview.notNow')}</Button>
         <Button variant="contained" onClick={handleReview}>
-          {/* i18n-ignore-next-line */}
-          Leave a review
+          {t('storeReview.leaveReview')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useContext, createContext, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
 import { useQueueReducer } from '../queue-control/reducer';
@@ -90,6 +91,7 @@ export const GraphQLQueueProvider = ({
   const isOffBoardMode = propsBaseBoardPath !== undefined;
   const correlationCounterRef = useRef(0);
   const { showMessage } = useSnackbar();
+  const { t } = useTranslation('session');
 
   const { profile, username, avatarUrl } = usePartyProfile();
   const { state: connectionState } = useWebSocketConnection();
@@ -172,10 +174,9 @@ export const GraphQLQueueProvider = ({
   // Warn user when offline buffer is full
   useEffect(() => {
     if (rawOfflineBuffer.isBufferFull) {
-      // i18n-ignore-next-line
-      showMessage("You've hit the offline queue limit. Reconnect to sync your climbs.", 'warning');
+      showMessage(t('queueProvider.offlineLimitReached'), 'warning');
     }
-  }, [rawOfflineBuffer.isBufferFull, showMessage]);
+  }, [rawOfflineBuffer.isBufferFull, showMessage, t]);
 
   // --- Offline reconciliation (push buffered additions on reconnect) ---
   useOfflineReconciliation({

--- a/packages/web/app/components/gym-entity/edit-gym-form.tsx
+++ b/packages/web/app/components/gym-entity/edit-gym-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
@@ -18,18 +19,18 @@ type EditGymFormProps = {
 };
 
 export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormProps) {
+  const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
   const { execute } = useEntityMutation<UpdateGymMutationResponse, UpdateGymMutationVariables>(UPDATE_GYM, {
-    successMessage: 'Gym updated!',
-    errorMessage: 'Failed to update gym',
+    successMessage: t('editGym.snackbar.updated'),
+    errorMessage: t('editGym.snackbar.updateFailed'),
   });
 
   const handleSubmit = useCallback(
     async (values: GymFormFieldValues) => {
       if (!values.name) {
-        // i18n-ignore-next-line
-        showMessage('Gym name is required', 'error');
+        showMessage(t('gymForm.create.nameRequired'), 'error');
         return;
       }
 
@@ -50,14 +51,13 @@ export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormPro
         onSuccess?.(data.updateGym);
       }
     },
-    [execute, gym.uuid, showMessage, onSuccess],
+    [execute, gym.uuid, showMessage, onSuccess, t],
   );
 
   return (
     <GymForm
-      // i18n-ignore-next-line
-      title="Edit Gym"
-      submitLabel="Save Changes"
+      title={t('editGym.title')}
+      submitLabel={t('editGym.submitLabel')}
       initialValues={{
         name: gym.name,
         slug: gym.slug ?? '',

--- a/packages/web/app/components/gym-entity/gym-card.tsx
+++ b/packages/web/app/components/gym-entity/gym-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
@@ -20,6 +21,7 @@ type GymCardProps = {
 };
 
 export default function GymCard({ gym, onClick }: GymCardProps) {
+  const { t } = useTranslation('boards');
   return (
     <Card
       variant="outlined"
@@ -69,12 +71,21 @@ export default function GymCard({ gym, onClick }: GymCardProps) {
           </Box>
 
           <Box sx={{ display: 'flex', gap: 2, mt: 1.5, flexWrap: 'wrap' }}>
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<FitnessCenterOutlined sx={{ fontSize: 14 }} />} value={gym.boardCount} label="boards" />
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<PersonOutlined sx={{ fontSize: 14 }} />} value={gym.memberCount} label="members" />
-            {/* i18n-ignore-next-line */}
-            <StatItem icon={<PeopleOutlined sx={{ fontSize: 14 }} />} value={gym.followerCount} label="followers" />
+            <StatItem
+              icon={<FitnessCenterOutlined sx={{ fontSize: 14 }} />}
+              value={gym.boardCount}
+              label={t('gymEntity.stats.boards')}
+            />
+            <StatItem
+              icon={<PersonOutlined sx={{ fontSize: 14 }} />}
+              value={gym.memberCount}
+              label={t('gymEntity.stats.members')}
+            />
+            <StatItem
+              icon={<PeopleOutlined sx={{ fontSize: 14 }} />}
+              value={gym.followerCount}
+              label={t('gymEntity.stats.followers')}
+            />
           </Box>
         </CardContent>
       </CardActionArea>

--- a/packages/web/app/components/gym-entity/gym-member-management.tsx
+++ b/packages/web/app/components/gym-entity/gym-member-management.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -32,6 +33,7 @@ type GymMemberManagementProps = {
 };
 
 export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemberManagementProps) {
+  const { t } = useTranslation('boards');
   const [members, setMembers] = useState<GymMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(false);
@@ -71,7 +73,7 @@ export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemb
 
   const handleRemove = async (userId: string) => {
     if (!token) return;
-    if (!window.confirm('Remove this member from the gym?')) return;
+    if (!window.confirm(t('gymMemberManagement.removeConfirm'))) return;
 
     try {
       const client = createGraphQLHttpClient(token);
@@ -80,12 +82,10 @@ export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemb
       });
       setMembers((prev) => prev.filter((m) => m.userId !== userId));
       setTotalCount((prev) => prev - 1);
-      // i18n-ignore-next-line
-      showMessage('Member removed', 'success');
+      showMessage(t('gymMemberManagement.snackbar.removed'), 'success');
     } catch (error) {
       console.error('Failed to remove member:', error);
-      // i18n-ignore-next-line
-      showMessage('Failed to remove member', 'error');
+      showMessage(t('gymMemberManagement.snackbar.removeFailed'), 'error');
     }
   };
 
@@ -101,8 +101,7 @@ export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemb
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <MuiTypography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No members yet
+          {t('gymMemberManagement.empty')}
         </MuiTypography>
       </Box>
     );
@@ -128,7 +127,7 @@ export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemb
               </Avatar>
             </ListItemAvatar>
             <ListItemText
-              primary={member.displayName ?? 'Unknown User'}
+              primary={member.displayName ?? t('gymMemberManagement.unknownUser')}
               secondary={
                 <Chip label={member.role} size="small" variant="outlined" sx={{ fontSize: 11, height: 20, mt: 0.5 }} />
               }
@@ -145,7 +144,9 @@ export default function GymMemberManagement({ gymUuid, isOwnerOrAdmin }: GymMemb
             fullWidth
             size="small"
           >
-            {loading ? 'Loading...' : `Load more (${members.length} of ${totalCount})`}
+            {loading
+              ? t('common:actions.loading')
+              : t('gymMemberManagement.loadMore', { count: members.length, total: totalCount })}
           </MuiButton>
         </Box>
       )}

--- a/packages/web/app/components/gym-entity/gym-selector.tsx
+++ b/packages/web/app/components/gym-entity/gym-selector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import MuiTypography from '@mui/material/Typography';
@@ -19,6 +20,7 @@ type GymSelectorProps = {
 };
 
 export default function GymSelector({ selectedGymUuid, onSelect }: GymSelectorProps) {
+  const { t } = useTranslation('boards');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const { token } = useWsAuthToken();
   const queryClient = useQueryClient();
@@ -49,8 +51,7 @@ export default function GymSelector({ selectedGymUuid, onSelect }: GymSelectorPr
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
         <CircularProgress size={16} />
         <MuiTypography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Loading gyms...
+          {t('gymSelector.loading')}
         </MuiTypography>
       </Box>
     );
@@ -63,13 +64,11 @@ export default function GymSelector({ selectedGymUuid, onSelect }: GymSelectorPr
   return (
     <Box>
       <MuiTypography variant="body2" sx={{ mb: 1 }}>
-        {/* i18n-ignore-next-line */}
-        Link to a gym
+        {t('gymSelector.linkToGym')}
       </MuiTypography>
       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
         <Chip
-          // i18n-ignore-next-line
-          label="No gym"
+          label={t('gymSelector.noGym')}
           variant={selectedGymUuid === null ? 'filled' : 'outlined'}
           color={selectedGymUuid === null ? 'primary' : 'default'}
           onClick={() => onSelect(null)}
@@ -87,8 +86,7 @@ export default function GymSelector({ selectedGymUuid, onSelect }: GymSelectorPr
         ))}
         <Chip
           icon={<AddOutlined />}
-          // i18n-ignore-next-line
-          label="Create new"
+          label={t('gymSelector.createNew')}
           variant="outlined"
           onClick={() => setShowCreateForm(true)}
           size="small"

--- a/packages/web/app/components/hold-classification/direction-picker.tsx
+++ b/packages/web/app/components/hold-classification/direction-picker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './direction-picker.module.css';
 
@@ -17,6 +18,7 @@ type DirectionPickerProps = {
  * 0 = up, 90 = right, 180 = down, 270 = left
  */
 const DirectionPicker: React.FC<DirectionPickerProps> = ({ value, onChange, disabled = false, size = 120 }) => {
+  const { t } = useTranslation('climbs');
   const circleRef = useRef<SVGSVGElement>(null);
 
   const calculateAngleFromEvent = useCallback((clientX: number, clientY: number) => {
@@ -121,8 +123,7 @@ const DirectionPicker: React.FC<DirectionPickerProps> = ({ value, onChange, disa
           R
         </text>
         <text x={center} y={size - 4} textAnchor="middle" className={styles.label}>
-          {/* i18n-ignore-next-line */}
-          Down
+          {t('directionPicker.down')}
         </text>
         <text x={8} y={center + 4} textAnchor="start" className={styles.label}>
           L

--- a/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
+++ b/packages/web/app/components/hold-classification/hold-classification-wizard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiButton from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Rating from '@mui/material/Rating';
@@ -112,6 +113,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
   boardDetails,
   onComplete,
 }) => {
+  const { t } = useTranslation('climbs');
   const { status: sessionStatus } = useSession();
   const { showMessage } = useSnackbar();
   const [loading, setLoading] = useState(true);
@@ -209,13 +211,12 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         }
       } catch (error) {
         console.error('Failed to save classification:', error);
-        // i18n-ignore-next-line
-        showMessage('Failed to save classification', 'error');
+        showMessage(t('holdClassification.toast.saveFailed'), 'error');
       } finally {
         setSaving(false);
       }
     },
-    [boardDetails, showMessage],
+    [boardDetails, showMessage, t],
   );
 
   // Debounced save - waits 500ms after last change before saving
@@ -370,8 +371,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
   if (loading) {
     return (
       <SwipeableDrawer
-        // i18n-ignore-next-line
-        title="Hold Classification"
+        title={t('holdClassification.drawerTitle')}
         open={open}
         onClose={onClose}
         placement="bottom"
@@ -384,8 +384,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         <div className={styles.loadingContainer}>
           <CircularProgress size={48} />
           <Typography variant="body2" component="span" className={styles.loadingText}>
-            {/* i18n-ignore-next-line */}
-            Loading holds...
+            {t('holdClassification.loadingHolds')}
           </Typography>
         </div>
       </SwipeableDrawer>
@@ -396,8 +395,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
   if (holds.length === 0) {
     return (
       <SwipeableDrawer
-        // i18n-ignore-next-line
-        title="Hold Classification"
+        title={t('holdClassification.drawerTitle')}
         open={open}
         onClose={onClose}
         placement="bottom"
@@ -409,12 +407,10 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
       >
         <div className={styles.emptyState}>
           <Typography variant="body2" component="span">
-            {/* i18n-ignore-next-line */}
-            No holds found for this board configuration.
+            {t('holdClassification.emptyState')}
           </Typography>
           <MuiButton variant="outlined" onClick={onClose}>
-            {/* i18n-ignore-next-line */}
-            Close
+            {t('common:actions.close')}
           </MuiButton>
         </div>
       </SwipeableDrawer>
@@ -425,8 +421,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
   if (isComplete) {
     return (
       <SwipeableDrawer
-        // i18n-ignore-next-line
-        title="Hold Classification"
+        title={t('holdClassification.drawerTitle')}
         open={open}
         onClose={onClose}
         placement="bottom"
@@ -439,17 +434,13 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         <div className={styles.completeContainer}>
           <CheckCircle className={styles.completeIcon} />
           <Typography variant="h5" component="h3" className={styles.completeTitle}>
-            {/* i18n-ignore-next-line */}
-            Classification Complete!
+            {t('holdClassification.complete.title')}
           </Typography>
           <Typography variant="body2" component="span" className={styles.completeSubtitle}>
-            {/* i18n-ignore-next-line */}
-            You&apos;ve classified {classifiedCount} of {holds.length} holds. You can run through this wizard again
-            anytime to update your ratings.
+            {t('holdClassification.complete.subtitle', { classified: classifiedCount, total: holds.length })}
           </Typography>
           <MuiButton variant="contained" size="large" onClick={onClose}>
-            {/* i18n-ignore-next-line */}
-            Done
+            {t('common:actions.done')}
           </MuiButton>
         </div>
       </SwipeableDrawer>
@@ -460,8 +451,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
 
   return (
     <SwipeableDrawer
-      // i18n-ignore-next-line
-      title="Classify Hold"
+      title={t('holdClassification.classifyHoldTitle')}
       open={open}
       onClose={onClose}
       placement="bottom"
@@ -482,8 +472,11 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
         {/* Progress indicator */}
         <div className={styles.progressSection}>
           <Typography variant="body2" component="span" className={styles.progressText}>
-            {/* i18n-ignore-next-line */}
-            Hold {currentIndex + 1} of {holds.length} ({classifiedCount} classified)
+            {t('holdClassification.progress', {
+              current: currentIndex + 1,
+              total: holds.length,
+              classified: classifiedCount,
+            })}
           </Typography>
           <LinearProgress
             variant="determinate"
@@ -513,8 +506,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           {/* Hold type selection */}
           <div>
             <Typography variant="body2" component="span" className={styles.sectionTitle}>
-              {/* i18n-ignore-next-line */}
-              Hold Type
+              {t('holdClassification.fields.holdType')}
             </Typography>
             <div className={styles.holdTypeList}>
               {filteredHoldTypeOptions.map((option) => (
@@ -537,11 +529,9 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           {/* Hand rating */}
           <div className={styles.ratingSection}>
             <Typography variant="body2" component="span" className={styles.sectionTitle}>
-              {/* i18n-ignore-next-line */}
-              Hand Rating (1-5)
+              {t('holdClassification.fields.handRating')}
             </Typography>
-            {/* i18n-ignore-next-line */}
-            <div className={styles.ratingLabel}>5 = Easy to grip, 1 = Very difficult</div>
+            <div className={styles.ratingLabel}>{t('holdClassification.hints.handRating')}</div>
             <Rating
               value={currentClassification.handRating || 0}
               onChange={(_, val) => val !== null && handleHandRatingChange(val)}
@@ -552,11 +542,9 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           {/* Foot rating */}
           <div className={styles.ratingSection}>
             <Typography variant="body2" component="span" className={styles.sectionTitle}>
-              {/* i18n-ignore-next-line */}
-              Foot Rating (1-5)
+              {t('holdClassification.fields.footRating')}
             </Typography>
-            {/* i18n-ignore-next-line */}
-            <div className={styles.ratingLabel}>5 = Easy to stand on, 1 = Very difficult</div>
+            <div className={styles.ratingLabel}>{t('holdClassification.hints.footRating')}</div>
             <Rating
               value={currentClassification.footRating || 0}
               onChange={(_, val) => val !== null && handleFootRatingChange(val)}
@@ -567,11 +555,9 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
           {/* Direction of pull */}
           <div className={styles.directionSection}>
             <Typography variant="body2" component="span" className={styles.sectionTitle}>
-              {/* i18n-ignore-next-line */}
-              Direction of Pull
+              {t('holdClassification.fields.pullDirection')}
             </Typography>
-            {/* i18n-ignore-next-line */}
-            <div className={styles.ratingLabel}>Click or drag to set the best pulling direction</div>
+            <div className={styles.ratingLabel}>{t('holdClassification.hints.pullDirection')}</div>
             <DirectionPicker
               value={currentClassification.pullDirection}
               onChange={handlePullDirectionChange}
@@ -589,12 +575,10 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
             onClick={handlePrevious}
             disabled={currentIndex === 0 || saving}
           >
-            {/* i18n-ignore-next-line */}
-            Previous
+            {t('holdClassification.actions.previous')}
           </MuiButton>
           <MuiButton className={styles.skipButton} variant="outlined" onClick={handleNext} disabled={saving}>
-            {/* i18n-ignore-next-line */}
-            Skip
+            {t('holdClassification.actions.skip')}
           </MuiButton>
           <MuiButton
             className={styles.navButton}
@@ -603,7 +587,7 @@ const HoldClassificationWizard: React.FC<HoldClassificationWizardProps> = ({
             onClick={handleNext}
             disabled={saving}
           >
-            {currentIndex === holds.length - 1 ? 'Finish' : 'Next'}
+            {currentIndex === holds.length - 1 ? t('holdClassification.actions.finish') : t('common:actions.next')}
           </MuiButton>
         </div>
       </div>

--- a/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
@@ -5,6 +5,15 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import type { LayoutStats } from '@/app/lib/graphql/operations/ticks';
 import LogbookFeed from '../logbook-feed';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Capture hook arguments ---
 // vi.fn() holds its own call history and is reset in beforeEach, so tests stay

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import LogbookFeedItem from '../logbook-feed-item';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Capture hooks ---
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -162,6 +162,7 @@ function LogbookGradeRow({
   gradeButtonRef?: React.RefObject<HTMLButtonElement | null>;
   triesButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }) {
+  const { t } = useTranslation('profile');
   const isDark = useIsDarkMode();
   const { formatGrade, getGradeColor } = useGradeFormat();
 
@@ -202,8 +203,7 @@ function LogbookGradeRow({
           className={styles.statValue}
           style={{ color: themeTokens.colors.amber }}
         >{`\u2605${consensusStarsLabel}`}</span>
-        {/* i18n-ignore-next-line */}
-        <span className={styles.statLabel}>stars</span>
+        <span className={styles.statLabel}>{t('logbook.feed.stars')}</span>
       </div>
       {/* User stars */}
       {isEditing ? (
@@ -217,8 +217,7 @@ function LogbookGradeRow({
             className={styles.statValue}
             style={{ color: themeTokens.colors.amber }}
           >{`\u2605${editQuality ?? '\u2014'}`}</span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>user</span>
+          <span className={styles.statLabel}>{t('logbook.feed.user')}</span>
         </ButtonBase>
       ) : (
         <div className={styles.statCell}>
@@ -226,8 +225,7 @@ function LogbookGradeRow({
             className={styles.statValue}
             style={{ color: themeTokens.colors.amber }}
           >{`\u2605${quality ?? '\u2014'}`}</span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>user</span>
+          <span className={styles.statLabel}>{t('logbook.feed.user')}</span>
         </div>
       )}
       {/* Consensus grade */}
@@ -235,32 +233,28 @@ function LogbookGradeRow({
         <span className={styles.statValue} style={{ color: consensusColor }}>
           {consensusLabel}
         </span>
-        {/* i18n-ignore-next-line */}
-        <span className={styles.statLabel}>grade</span>
+        <span className={styles.statLabel}>{t('logbook.feed.grade')}</span>
       </div>
       {/* User grade */}
       {isEditing ? (
         <ButtonBase
           ref={gradeButtonRef}
           onClick={() => handleToggle('grade')}
-          // i18n-ignore-next-line
-          aria-label="Select logged grade"
+          aria-label={t('logbook.feed.selectGrade')}
           className={styles.gradeCell}
           disableRipple={false}
         >
           <span className={styles.statValue} style={{ color: editGradeColor }}>
             {editGradeLabel}
           </span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>user</span>
+          <span className={styles.statLabel}>{t('logbook.feed.user')}</span>
         </ButtonBase>
       ) : (
         <div className={styles.gradeCell}>
           <span className={styles.statValue} style={{ color: userColor }}>
             {userLabel}
           </span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>user</span>
+          <span className={styles.statLabel}>{t('logbook.feed.user')}</span>
         </div>
       )}
       {/* Tries */}
@@ -273,14 +267,12 @@ function LogbookGradeRow({
           disableRipple={false}
         >
           <span className={styles.statValue}>{editAttemptCount}</span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>tries</span>
+          <span className={styles.statLabel}>{t('logbook.feed.tries')}</span>
         </ButtonBase>
       ) : (
         <div className={styles.statCell}>
           <span className={styles.statValue}>{attemptCount}</span>
-          {/* i18n-ignore-next-line */}
-          <span className={styles.statLabel}>tries</span>
+          <span className={styles.statLabel}>{t('logbook.feed.tries')}</span>
         </div>
       )}
     </div>
@@ -317,6 +309,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
     isSwipeHintTarget,
   }) => {
     const { t } = useTranslation('common');
+    const { t: tProfile } = useTranslation('profile');
     const [isActionsOpen, setIsActionsOpen] = useState(false);
     const [instagramDialogOpen, setInstagramDialogOpen] = useState(false);
     const [betaLinkDialogOpen, setBetaLinkDialogOpen] = useState(false);
@@ -620,8 +613,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
           {/* aria-hidden: the 3-dot menu exposes Delete to assistive tech. */}
           <div ref={leftActionCombinedRef} className={styles.leftActionLayer} aria-hidden="true">
             <DeleteOutlined className={styles.swipeIcon} />
-            {/* i18n-ignore-next-line */}
-            <span className={styles.deleteLabel}>Delete</span>
+            <span className={styles.deleteLabel}>{tProfile('logbook.feed.deleteSwipeLabel')}</span>
           </div>
 
           {/* aria-hidden: the 3-dot menu exposes Edit to assistive tech. */}
@@ -732,8 +724,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                   <IconButton
                     size="small"
                     onClick={onCancelEdit}
-                    // i18n-ignore-next-line
-                    aria-label="Cancel editing"
+                    aria-label={tProfile('logbook.feed.cancelEditing')}
                     sx={{
                       width: 44,
                       height: 44,
@@ -746,8 +737,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                     size="small"
                     onClick={handleSave}
                     disabled={isSaving}
-                    // i18n-ignore-next-line
-                    aria-label="Save"
+                    aria-label={tProfile('logbook.feed.saveEdit')}
                     sx={{
                       width: 44,
                       height: 44,
@@ -762,8 +752,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
               ) : (
                 <IconButton
                   size="small"
-                  // i18n-ignore-next-line
-                  aria-label="More actions"
+                  aria-label={tProfile('logbook.feed.moreActions')}
                   onClick={handleOpenActions}
                   className={styles.menuButton}
                   disableRipple
@@ -834,22 +823,19 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
             <ListItemIcon>
               <ElectricBoltOutlined sx={{ color: themeTokens.colors.amber }} />
             </ListItemIcon>
-            {/* i18n-ignore-next-line */}
-            <ListItemText>Flash</ListItemText>
+            <ListItemText>{tProfile('logbook.feed.status.flash')}</ListItemText>
           </MenuItem>
           <MenuItem onClick={() => handleStatusSelect('send')}>
             <ListItemIcon>
               <CheckOutlined sx={{ color: themeTokens.colors.success }} />
             </ListItemIcon>
-            {/* i18n-ignore-next-line */}
-            <ListItemText>Send</ListItemText>
+            <ListItemText>{tProfile('logbook.feed.status.send')}</ListItemText>
           </MenuItem>
           <MenuItem onClick={() => handleStatusSelect('attempt')}>
             <ListItemIcon>
               <PersonFallingIcon sx={{ color: themeTokens.colors.error }} />
             </ListItemIcon>
-            {/* i18n-ignore-next-line */}
-            <ListItemText>Attempt</ListItemText>
+            <ListItemText>{tProfile('logbook.feed.status.attempt')}</ListItemText>
           </MenuItem>
         </Popover>
 
@@ -875,8 +861,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                 <ListItemIcon>
                   <EditOutlined fontSize="small" />
                 </ListItemIcon>
-                {/* i18n-ignore-next-line */}
-                <ListItemText>Edit log</ListItemText>
+                <ListItemText>{tProfile('logbook.feed.editLog')}</ListItemText>
               </MenuItem>
             )}
             {onDelete && (
@@ -884,8 +869,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                 <ListItemIcon>
                   <DeleteOutlined sx={{ color: 'error.main' }} fontSize="small" />
                 </ListItemIcon>
-                {/* i18n-ignore-next-line */}
-                <ListItemText>Delete log</ListItemText>
+                <ListItemText>{tProfile('logbook.feed.deleteLog')}</ListItemText>
               </MenuItem>
             )}
             {allowInstagramPosting && (
@@ -893,8 +877,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                 <ListItemIcon>
                   <InstagramIcon fontSize="small" />
                 </ListItemIcon>
-                {/* i18n-ignore-next-line */}
-                <ListItemText>Post to Instagram</ListItemText>
+                <ListItemText>{tProfile('logbook.feed.postToInstagram')}</ListItemText>
               </MenuItem>
             )}
             {allowInstagramLinking && (
@@ -902,8 +885,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                 <ListItemIcon>
                   <LinkOutlined fontSize="small" />
                 </ListItemIcon>
-                {/* i18n-ignore-next-line */}
-                <ListItemText>Link Instagram post</ListItemText>
+                <ListItemText>{tProfile('logbook.feed.linkInstagramPost')}</ListItemText>
               </MenuItem>
             )}
             {(onEdit || onDelete || allowInstagramPosting || allowInstagramLinking) && <Divider />}

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
@@ -62,6 +63,7 @@ type LogbookFeedProps = {
 };
 
 export default function LogbookFeed({ layoutStats, loadingLayoutStats }: LogbookFeedProps) {
+  const { t } = useTranslation('profile');
   const { data: session } = useSession();
   const pathname = usePathnameWithoutLocale();
   const searchParams = useSearchParams();
@@ -210,8 +212,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       if (matched.length > 0) {
         setSelectedBoards(matched);
       } else {
-        // i18n-ignore-next-line
-        showMessage("Couldn't find the linked board — showing all your entries.", 'warning');
+        showMessage(t('logbook.feed.snackbar.boardsLinkMissing'), 'warning');
       }
     }
     setBoardsInitialized(true);
@@ -441,8 +442,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
             uuid: prevUuid,
           })
           .catch(() => {
-            // i18n-ignore-next-line
-            showMessage('Failed to delete tick', 'error');
+            showMessage(t('logbook.feed.snackbar.deleteFailed'), 'error');
           });
       }
 
@@ -477,8 +477,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
           })
           .catch(() => {
             void queryClient.invalidateQueries({ queryKey: ['logbookFeed'] });
-            // i18n-ignore-next-line
-            showMessage('Failed to delete tick', 'error');
+            showMessage(t('logbook.feed.snackbar.deleteFailed'), 'error');
           });
       }, 5000);
 
@@ -489,11 +488,10 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       };
 
       showMessage(
-        // i18n-ignore-next-line
-        'Tick deleted',
+        t('logbook.feed.snackbar.tickDeleted'),
         'success',
         {
-          label: 'Undo',
+          label: t('logbook.feed.snackbar.undo'),
           onClick: () => {
             if (pendingDeleteRef.current?.uuid === uuid) {
               clearTimeout(pendingDeleteRef.current.timerId);
@@ -505,7 +503,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
         5000,
       );
     },
-    [queryClient, showMessage, feedQueryKey],
+    [queryClient, showMessage, feedQueryKey, t],
   );
 
   const handleEdit = useCallback((item: AscentFeedItem) => {

--- a/packages/web/app/components/library/logbook-search-form.tsx
+++ b/packages/web/app/components/library/logbook-search-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
@@ -124,6 +125,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
   filters,
   onFiltersChange,
 }) => {
+  const { t } = useTranslation('profile');
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [showSort, setShowSort] = useState(false);
 
@@ -197,8 +199,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
         <div className={styles.switchGroup}>
           <div className={styles.switchRow}>
             <MuiTypography variant="body2" component="span">
-              {/* i18n-ignore-next-line */}
-              Include Sends
+              {t('logbook.search.resultType.includeSends')}
             </MuiTypography>
             <MuiSwitch
               size="small"
@@ -210,8 +211,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           </div>
           <div className={styles.switchRow}>
             <MuiTypography variant="body2" component="span">
-              {/* i18n-ignore-next-line */}
-              Include Attempts
+              {t('logbook.search.resultType.includeAttempts')}
             </MuiTypography>
             <MuiSwitch
               size="small"
@@ -223,8 +223,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           </div>
           <div className={styles.switchRow}>
             <MuiTypography variant="body2" component="span">
-              {/* i18n-ignore-next-line */}
-              Flash Only
+              {t('logbook.search.resultType.flashOnly')}
             </MuiTypography>
             <MuiSwitch
               size="small"
@@ -236,8 +235,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           </div>
           <div className={styles.switchRow}>
             <MuiTypography variant="body2" component="span">
-              {/* i18n-ignore-next-line */}
-              Benchmark Only
+              {t('logbook.search.resultType.benchmarkOnly')}
             </MuiTypography>
             <MuiSwitch
               size="small"
@@ -258,13 +256,11 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
       content: (
         <div className={styles.panelContent}>
           <div className={styles.inputGroup}>
-            {/* i18n-ignore-next-line */}
-            <span className={styles.fieldLabel}>Date Range</span>
+            <span className={styles.fieldLabel}>{t('logbook.search.dateAngle.dateRange')}</span>
             <div className={styles.gradeRow}>
               <TextField
                 type="date"
-                // i18n-ignore-next-line
-                label="Start date"
+                label={t('logbook.search.dateAngle.startDate')}
                 value={filters.fromDate}
                 onChange={(e) => onFiltersChange((prev) => ({ ...prev, fromDate: e.target.value }))}
                 size="small"
@@ -273,8 +269,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
               />
               <TextField
                 type="date"
-                // i18n-ignore-next-line
-                label="End date"
+                label={t('logbook.search.dateAngle.endDate')}
                 value={filters.toDate}
                 onChange={(e) => onFiltersChange((prev) => ({ ...prev, toDate: e.target.value }))}
                 size="small"
@@ -286,8 +281,10 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
 
           <div className={styles.inputGroup}>
             <span className={styles.fieldLabel}>
-              {/* i18n-ignore-next-line */}
-              Wall angle range ({filters.angleRange[0]}&deg;&ndash;{filters.angleRange[1]}&deg;)
+              {t('logbook.search.dateAngle.wallAngleRange', {
+                min: filters.angleRange[0],
+                max: filters.angleRange[1],
+              })}
             </span>
             <Slider
               value={filters.angleRange}
@@ -319,9 +316,8 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           <Stack direction="row" spacing={1}>
             <FilterListOutlined sx={{ color: themeTokens.colors.primary }} />
             <MuiTypography variant="body2" component="span" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              <span className={footerStyles.resultBadge}>{activeFilterCount}</span> active{' '}
-              {activeFilterCount === 1 ? 'filter' : 'filters'}
+              <span className={footerStyles.resultBadge}>{activeFilterCount}</span>{' '}
+              {t('logbook.search.filterCount', { count: activeFilterCount })}
             </MuiTypography>
           </Stack>
         </div>
@@ -332,8 +328,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           onClick={handleClearAll}
           sx={{ textTransform: 'none' }}
         >
-          {/* i18n-ignore-next-line */}
-          Clear All
+          {t('logbook.search.clearAll')}
         </MuiButton>
       </div>
     ) : undefined;
@@ -348,8 +343,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
               <TextField
                 value={searchText}
                 onChange={onSearchChange}
-                // i18n-ignore-next-line
-                placeholder="Search climbs or notes"
+                placeholder={t('logbook.search.placeholder')}
                 fullWidth
                 size="small"
                 slotProps={{
@@ -363,8 +357,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                 }}
               />
               <div className={headerStyles.filterButton}>
-                {/* i18n-ignore-next-line */}
-                <IconButton onClick={openDrawer} aria-label="Open filters" size="small">
+                <IconButton onClick={openDrawer} aria-label={t('logbook.search.openFilters')} size="small">
                   <FilterListOutlined />
                 </IconButton>
                 {activeFilterCount > 0 && <span className={headerStyles.filterActiveIndicator} />}
@@ -399,13 +392,11 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
           <div className={styles.primaryContent}>
             <div className={styles.panelContent}>
               <div className={styles.inputGroup}>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.fieldLabel}>Search</span>
+                <span className={styles.fieldLabel}>{t('logbook.search.search')}</span>
                 <TextField
                   value={searchText}
                   onChange={onSearchChange}
-                  // i18n-ignore-next-line
-                  placeholder="Search climbs or notes"
+                  placeholder={t('logbook.search.placeholder')}
                   variant="outlined"
                   fullWidth
                   size="small"
@@ -422,8 +413,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
               </div>
 
               <div className={styles.inputGroup}>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.fieldLabel}>Grade Range</span>
+                <span className={styles.fieldLabel}>{t('logbook.search.gradeRange')}</span>
                 <div className={styles.gradeRow}>
                   <MuiSelect
                     value={minGrade === '' ? '' : minGrade}
@@ -471,8 +461,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                 className={styles.sortToggle}
                 onClick={() => setShowSort(!showSort)}
               >
-                {/* i18n-ignore-next-line */}
-                Sort
+                {t('logbook.search.sort')}
               </MuiButton>
 
               {showSort && (
@@ -485,16 +474,11 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                       size="small"
                       MenuProps={{ disableScrollLock: true }}
                     >
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="date">Date</MenuItem>
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="climbName">Climb name</MenuItem>
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="loggedGrade">Logged Grade</MenuItem>
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="consensusGrade">Consensus Grade</MenuItem>
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="attemptCount">Attempts</MenuItem>
+                      <MenuItem value="date">{t('logbook.search.sortFields.date')}</MenuItem>
+                      <MenuItem value="climbName">{t('logbook.search.sortFields.climbName')}</MenuItem>
+                      <MenuItem value="loggedGrade">{t('logbook.search.sortFields.loggedGrade')}</MenuItem>
+                      <MenuItem value="consensusGrade">{t('logbook.search.sortFields.consensusGrade')}</MenuItem>
+                      <MenuItem value="attemptCount">{t('logbook.search.sortFields.attemptCount')}</MenuItem>
                     </MuiSelect>
                     <MuiSelect
                       value={sortState.primaryDirection}
@@ -503,8 +487,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                       size="small"
                       MenuProps={{ disableScrollLock: true }}
                     >
-                      {/* i18n-ignore-next-line */}
-                      <MenuItem value="desc">Desc</MenuItem>
+                      <MenuItem value="desc">{t('logbook.search.sortDirection.desc')}</MenuItem>
                       <MenuItem value="asc">Asc</MenuItem>
                     </MuiSelect>
                   </div>

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -37,15 +38,18 @@ type PostToInstagramDialogProps = {
   item: InstagramPostingTarget | null;
 };
 
-const instructions = [
-  'Copy the caption and open Instagram.',
-  'Paste the caption when creating your post.',
-  'Once your post is live, come back here.',
-  'Paste the Instagram link so we can display your ascent video here.',
-];
-
 export default function PostToInstagramDialog({ open, onClose, item }: PostToInstagramDialogProps) {
+  const { t } = useTranslation('profile');
   const { showMessage } = useSnackbar();
+  const instructions = useMemo(
+    () => [
+      t('logbook.instagram.steps.copy'),
+      t('logbook.instagram.steps.paste'),
+      t('logbook.instagram.steps.comeBack'),
+      t('logbook.instagram.steps.pasteLink'),
+    ],
+    [t],
+  );
   const [isLaunching, setIsLaunching] = useState(false);
   const {
     data: betaLinks = [],
@@ -84,20 +88,17 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
     setIsLaunching(false);
 
     if (!result.copied) {
-      // i18n-ignore-next-line
-      showMessage('Couldn’t copy caption. Try again.', 'error');
+      showMessage(t('logbook.instagram.snackbar.copyFailed'), 'error');
       return;
     }
 
     if (!result.opened) {
-      // i18n-ignore-next-line
-      showMessage('Couldn’t open Instagram. Open it manually and paste the copied caption.', 'error');
+      showMessage(t('logbook.instagram.snackbar.openFailed'), 'error');
       return;
     }
 
-    // i18n-ignore-next-line
-    showMessage('Caption copied. Instagram should open next.', 'success');
-  }, [caption, showMessage]);
+    showMessage(t('logbook.instagram.snackbar.copied'), 'success');
+  }, [caption, showMessage, t]);
 
   if (!item) return null;
 
@@ -112,8 +113,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
     betaVideosContent = (
       <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1.5 }}>
         <Typography variant="body2" color="error">
-          {/* i18n-ignore-next-line */}
-          Couldn&apos;t load beta videos.
+          {t('logbook.instagram.betaLoadFailed')}
         </Typography>
         <Button
           size="small"
@@ -121,8 +121,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             void refetchBetaLinks();
           }}
         >
-          {/* i18n-ignore-next-line */}
-          Retry
+          {t('logbook.instagram.retry')}
         </Button>
       </Box>
     );
@@ -162,18 +161,15 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             zIndex: 1,
           }}
         >
-          {/* i18n-ignore-next-line */}
-          <IconButton onClick={onClose} sx={{ color: 'text.primary' }} aria-label="Back">
+          <IconButton onClick={onClose} sx={{ color: 'text.primary' }} aria-label={t('logbook.instagram.back')}>
             <ArrowBackIosNewOutlined />
           </IconButton>
           <Box sx={{ minWidth: 0 }}>
             <Typography variant="h6" component="h1" fontWeight={700}>
-              {/* i18n-ignore-next-line */}
-              Post to Instagram
+              {t('logbook.instagram.title')}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Share your ascent and link it back here.
+              {t('logbook.instagram.subtitle')}
             </Typography>
           </Box>
         </Box>
@@ -213,12 +209,10 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             >
               <Box sx={{ minWidth: 0 }}>
                 <Typography variant="h5" component="h2" fontWeight={700} sx={{ mb: 0.5 }}>
-                  {/* i18n-ignore-next-line */}
-                  Share your beta video
+                  {t('logbook.instagram.shareYourBeta')}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {/* i18n-ignore-next-line */}
-                  We’ll copy the caption, open Instagram, and let you paste the final link back into Boardsesh.
+                  {t('logbook.instagram.shareYourBetaBody')}
                 </Typography>
               </Box>
               <InstagramIcon sx={{ color: 'primary.main', fontSize: 28, flexShrink: 0 }} />
@@ -247,8 +241,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             }}
           >
             <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
-              {/* i18n-ignore-next-line */}
-              How It Works
+              {t('logbook.instagram.howItWorks')}
             </Typography>
             <Box
               sx={{
@@ -281,8 +274,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             }}
           >
             <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
-              {/* i18n-ignore-next-line */}
-              Caption
+              {t('logbook.instagram.caption')}
             </Typography>
             <Typography
               variant="h5"
@@ -316,8 +308,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
               fontSize: themeTokens.typography.fontSize.lg,
             }}
           >
-            {/* i18n-ignore-next-line */}
-            Copy & Open Instagram
+            {t('logbook.instagram.copyAndOpen')}
           </Button>
 
           <Box
@@ -336,13 +327,11 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <InstagramIcon sx={{ color: 'text.secondary' }} />
               <Typography variant="h6" component="h3" fontWeight={700}>
-                {/* i18n-ignore-next-line */}
-                Paste your Instagram link
+                {t('logbook.instagram.pasteLinkTitle')}
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              When your post is live, paste the reel or post link here so Boardsesh can show your ascent video.
+              {t('logbook.instagram.pasteLinkBody')}
             </Typography>
             <AttachBetaLinkForm
               boardType={item.boardType}
@@ -350,9 +339,8 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
               climbName={item.climbName}
               angle={item.angle}
               resetTrigger={open}
-              submitLabel="Add Instagram link"
-              // i18n-ignore-next-line
-              helperText="Paste the live Instagram reel or post URL."
+              submitLabel={t('logbook.instagram.addLinkSubmit')}
+              helperText={t('logbook.instagram.pasteLinkHelper')}
             />
           </Box>
 
@@ -369,8 +357,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
             }}
           >
             <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.06em' }}>
-              {/* i18n-ignore-next-line */}
-              Existing Beta Videos
+              {t('logbook.instagram.existingBetaVideos')}
             </Typography>
             {betaVideosContent}
           </Box>

--- a/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/crew-logbook-view.test.tsx
@@ -6,6 +6,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Climb } from '@/app/lib/types';
 import { CrewLogbookView } from '../crew-logbook-view';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockRequest = vi.fn();
 const mockUseWsAuthToken = vi.fn();

--- a/packages/web/app/components/logbook/__tests__/inline-list-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/inline-list-tick-bar.test.tsx
@@ -4,6 +4,15 @@ import { render, screen, act } from '@testing-library/react';
 import type { Angle, BoardDetails, BoardName, Climb } from '@/app/lib/types';
 import type { LogbookEntry } from '@/app/hooks/use-logbook';
 import { InlineListTickBar } from '../inline-list-tick-bar';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks (must be hoisted before imports of the component under test) ---
 

--- a/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-entry-card.test.tsx
@@ -3,6 +3,15 @@ import { describe, expect, it, vi } from 'vite-plus/test';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { LogbookEntryCard } from '../logbook-entry-card';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 vi.mock('@/app/components/ascent-status/ascent-status-icon', () => ({
   AscentStatusIcon: ({ status }: { status: string }) => <div data-testid="ascent-status-icon" data-status={status} />,

--- a/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logbook-view.test.tsx
@@ -5,6 +5,15 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import type { Climb } from '@/app/lib/types';
 import { LogbookView } from '../logbook-view';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockUseBoardProvider = vi.fn();
 

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -5,6 +5,15 @@ import type { Angle, BoardDetails, BoardName, Climb } from '@/app/lib/types';
 import type { LogbookEntry } from '@/app/hooks/use-logbook';
 import { type QuickTickBarHandle, QuickTickBar } from '../quick-tick-bar';
 import { hasPriorHistoryForClimb } from '@/app/hooks/use-tick-save';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks (must be hoisted before imports of the component under test) ---
 

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useQuery } from '@tanstack/react-query';
@@ -23,6 +24,7 @@ type CrewLogbookViewProps = {
 };
 
 export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, boardType }) => {
+  const { t } = useTranslation('profile');
   const { token, isAuthenticated, isLoading: authLoading } = useWsAuthToken();
   const { data: session } = useSession();
   const userId = session?.user?.id ?? null;
@@ -59,18 +61,15 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
   }
 
   if (!isAuthenticated) {
-    // i18n-ignore-next-line
-    return <EmptyState description="Sign in to see your crew's logbook for this climb" />;
+    return <EmptyState description={t('logbook.crew.signInPrompt')} />;
   }
 
   if (isError) {
-    // i18n-ignore-next-line
-    return <EmptyState description="Couldn't load your crew's logbook. Try again in a bit." />;
+    return <EmptyState description={t('logbook.crew.loadError')} />;
   }
 
   if (items.length === 0) {
-    // i18n-ignore-next-line
-    return <EmptyState description="None of your crew have logged this climb yet" />;
+    return <EmptyState description={t('logbook.crew.noneYet')} />;
   }
 
   const showMirrorTag = boardType === 'tension';

--- a/packages/web/app/components/logbook/inline-list-tick-bar.tsx
+++ b/packages/web/app/components/logbook/inline-list-tick-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
@@ -38,6 +39,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
   onClose,
   onError,
 }) => {
+  const { t } = useTranslation('climbs');
   const { logbook } = useBoardProvider();
 
   // Snapshot the tick target once on mount. climb is a required prop so the
@@ -183,8 +185,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
               ref={saveButtonRef}
               size="small"
               onClick={handleSaveClick}
-              // i18n-ignore-next-line
-              aria-label="Log ascent"
+              aria-label={t('tick.bar.logAscent')}
               sx={{
                 width: 36,
                 height: 36,
@@ -199,8 +200,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
               ref={attemptButtonRef}
               size="small"
               onClick={handleAttemptClick}
-              // i18n-ignore-next-line
-              aria-label="Log attempt"
+              aria-label={t('tick.bar.logAttempt')}
               sx={{
                 width: 36,
                 height: 36,
@@ -214,8 +214,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
             <IconButton
               size="small"
               onClick={onClose}
-              // i18n-ignore-next-line
-              aria-label="Cancel"
+              aria-label={t('tick.bar.cancel')}
               sx={{
                 width: 28,
                 height: 28,

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -58,6 +58,7 @@ type LogAscentFormProps = {
 
 export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boardDetails, onClose }) => {
   const { t } = useTranslation('climbs');
+  const { t: tProfile } = useTranslation('profile');
   const { saveTick, isAuthenticated } = useBoardProvider();
   const grades = TENSION_KILTER_GRADES;
   const angleOptions = ANGLES[boardDetails.board_name];
@@ -188,24 +189,20 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     >
       <Box sx={{ mb: 2 }}>
         <ToggleButtonGroup exclusive fullWidth value={logType} onChange={(_, val) => val && setLogType(val as LogType)}>
-          {/* i18n-ignore-next-line */}
-          <ToggleButton value="ascent">Ascent</ToggleButton>
-          {/* i18n-ignore-next-line */}
-          <ToggleButton value="attempt">Attempt</ToggleButton>
+          <ToggleButton value="ascent">{tProfile('logbook.form.ascent')}</ToggleButton>
+          <ToggleButton value="attempt">{tProfile('logbook.form.attempt')}</ToggleButton>
         </ToggleButtonGroup>
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        <Typography sx={{ width: 120, flexShrink: 0 }}>Boulder</Typography>
+        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.boulder')}</Typography>
         <Box sx={{ flex: 1 }}>
           <Stack direction="row" spacing={1}>
             <strong>{currentClimb?.name || 'N/A'}</strong>
             {showMirrorTag && (
               <Stack direction="row" spacing={0.5}>
                 <Chip
-                  // i18n-ignore-next-line
-                  label="Mirrored"
+                  label={tProfile('logbook.form.mirrored')}
                   size="small"
                   color={isMirrored ? 'secondary' : undefined}
                   sx={{ cursor: 'pointer', margin: 0 }}
@@ -221,8 +218,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        <Typography sx={{ width: 120, flexShrink: 0 }}>Date and Time</Typography>
+        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.dateAndTime')}</Typography>
         <Box sx={{ flex: 1 }}>
           <DateTimePicker
             value={formValues.date}
@@ -234,8 +230,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        <Typography sx={{ width: 120, flexShrink: 0 }}>Angle</Typography>
+        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.angle')}</Typography>
         <Box sx={{ flex: 1 }}>
           <MuiSelect
             value={formValues.angle}
@@ -253,8 +248,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        <Typography sx={{ width: 120, flexShrink: 0 }}>Attempts</Typography>
+        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.attempts')}</Typography>
         <Box sx={{ flex: 1 }}>
           <TextField
             type="number"
@@ -269,8 +263,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
 
       {logType === 'ascent' && (
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-          {/* i18n-ignore-next-line */}
-          <Typography sx={{ width: 120, flexShrink: 0 }}>Quality</Typography>
+          <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.quality')}</Typography>
           <Box sx={{ flex: 1 }}>
             <MuiRating
               value={formValues.quality}
@@ -283,8 +276,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
 
       {logType === 'ascent' && (
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-          {/* i18n-ignore-next-line */}
-          <Typography sx={{ width: 120, flexShrink: 0 }}>Difficulty</Typography>
+          <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.difficulty')}</Typography>
           <Box sx={{ flex: 1 }}>
             <MuiSelect
               value={formValues.difficulty}
@@ -303,8 +295,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       )}
 
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        <Typography sx={{ width: 120, flexShrink: 0 }}>Notes</Typography>
+        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.notes')}</Typography>
         <Box sx={{ flex: 1 }}>
           <TextField
             multiline
@@ -320,19 +311,17 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
 
       {logType === 'ascent' && (
         <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
-          {/* i18n-ignore-next-line */}
-          <Typography sx={{ width: 120, flexShrink: 0, pt: 1 }}>Video</Typography>
+          <Typography sx={{ width: 120, flexShrink: 0, pt: 1 }}>{tProfile('logbook.form.video')}</Typography>
           <Box sx={{ flex: 1 }}>
             <TextField
-              // i18n-ignore-next-line
-              placeholder="Instagram or TikTok URL"
+              placeholder={tProfile('logbook.form.videoPlaceholder')}
               variant="outlined"
               size="small"
               fullWidth
               value={formValues.videoUrl || ''}
               onChange={(e) => setFormValues((prev) => ({ ...prev, videoUrl: e.target.value }))}
               error={!!videoUrlError}
-              helperText={videoUrlError ?? 'Paste an Instagram or TikTok link so others can see your beta. (Optional)'}
+              helperText={videoUrlError ?? tProfile('logbook.form.videoHelper')}
             />
           </Box>
         </Box>
@@ -347,15 +336,13 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
           fullWidth
           size="large"
         >
-          {/* i18n-ignore-next-line */}
-          Submit
+          {tProfile('logbook.form.submit')}
         </Button>
       </Box>
 
       <Box>
         <Button variant="outlined" fullWidth size="large" onClick={onClose} disabled={isSaving}>
-          {/* i18n-ignore-next-line */}
-          Cancel
+          {tProfile('logbook.form.cancel')}
         </Button>
       </Box>
     </Box>

--- a/packages/web/app/components/logbook/logbook-entry-card.tsx
+++ b/packages/web/app/components/logbook/logbook-entry-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
@@ -61,6 +62,7 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
   showMirrorTag,
   user,
 }) => {
+  const { t } = useTranslation('profile');
   const ascentStatus = normalizeAscentStatus({
     // normalizeAscentStatus does a runtime check for the three known values
     // and falls back to 'attempt' for anything else — safe for raw strings.
@@ -103,8 +105,9 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
                 <AscentStatusIcon status={ascentStatus} variant="icon" />
               </>
             )}
-            {/* i18n-ignore-next-line */}
-            {showMirrorTag && entry.isMirror && <Chip label="Mirrored" size="small" color="secondary" />}
+            {showMirrorTag && entry.isMirror && (
+              <Chip label={t('logbook.entry.mirroredTag')} size="small" color="secondary" />
+            )}
           </Stack>
           {hasSuccess && entry.quality != null && entry.quality > 0 && (
             <Stack direction="row" spacing={1}>
@@ -113,8 +116,7 @@ export const LogbookEntryCard: React.FC<LogbookEntryCardProps> = ({
           )}
           <Stack direction="row" spacing={1}>
             <Typography variant="body2" component="span">
-              {/* i18n-ignore-next-line */}
-              Attempts: {entry.attemptCount}
+              {t('logbook.entry.attemptsLabel', { count: entry.attemptCount })}
             </Typography>
           </Stack>
           {entry.comment && (

--- a/packages/web/app/components/logbook/logbook-section.tsx
+++ b/packages/web/app/components/logbook/logbook-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import BookOutlined from '@mui/icons-material/BookOutlined';
 import { LogbookView } from './logbook-view';
@@ -48,6 +49,7 @@ export function useLogbookSummary(climbUuid: string): LogbookSummary | null {
 }
 
 export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
+  const { t } = useTranslation('profile');
   const summary = useLogbookSummary(climb.uuid);
 
   if (!summary) {
@@ -59,8 +61,7 @@ export const LogbookSection: React.FC<LogbookSectionProps> = ({ climb }) => {
         sx={{ display: 'block', textAlign: 'center', py: 2 }}
       >
         <BookOutlined sx={{ mr: 1, verticalAlign: 'middle' }} />
-        {/* i18n-ignore-next-line */}
-        No ascents logged for this climb
+        {t('logbook.section.noAscentsLogged')}
       </Typography>
     );
   }

--- a/packages/web/app/components/logbook/logbook-view.tsx
+++ b/packages/web/app/components/logbook/logbook-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import { tickTimeMs } from '@/app/lib/format-tick-time';
 import { EmptyState } from '@/app/components/ui/empty-state';
@@ -27,6 +28,7 @@ const isPersistedUuid = (uuid: string | undefined): uuid is string => !!uuid && 
 const VOTE_SUMMARY_BATCH_LIMIT = 100;
 
 export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
+  const { t } = useTranslation('profile');
   const { logbook, boardName } = useBoardProvider();
 
   const climbAscents = useMemo(
@@ -52,8 +54,7 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ currentClimb }) => {
   const showMirrorTag = boardName === 'tension';
 
   if (climbAscents.length === 0) {
-    // i18n-ignore-next-line
-    return <EmptyState description="No ascents logged for this climb" />;
+    return <EmptyState description={t('logbook.section.noAscentsLogged')} />;
   }
 
   return (

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useMemo, useImperativeHandle, useRef, forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Stack from '@mui/material/Stack';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
@@ -82,6 +83,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
     },
     ref,
   ) => {
+    const { t } = useTranslation('profile');
     const { logbook } = useBoardProvider();
 
     // Snapshot the target climb the first time we get a non-null climb.
@@ -251,8 +253,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
             <div className={styles.expandedPanelContent}>
               {/* Grade row */}
               <div className={styles.labeledRow}>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.labeledRowLabel}>grade</span>
+                <span className={styles.labeledRowLabel}>{t('logbook.feed.grade')}</span>
                 <div className={styles.labeledRowPicker}>
                   <InlineGradePicker
                     grades={grades}
@@ -266,8 +267,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
 
               {/* Tries row */}
               <div className={styles.labeledRow}>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.labeledRowLabel}>tries</span>
+                <span className={styles.labeledRowLabel}>{t('logbook.feed.tries')}</span>
                 <div className={styles.labeledRowPicker}>
                   <InlineTriesPicker
                     attemptCount={attemptCount}
@@ -279,8 +279,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
 
               {/* Stars row — left-aligned since picker is shorter */}
               <div className={styles.labeledRow}>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.labeledRowLabel}>stars</span>
+                <span className={styles.labeledRowLabel}>{t('logbook.feed.stars')}</span>
                 <div className={styles.labeledRowPickerStart}>
                   <InlineStarPicker quality={quality} onSelect={handleStarSelect} />
                 </div>

--- a/packages/web/app/components/logbook/tick-controls.tsx
+++ b/packages/web/app/components/logbook/tick-controls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useRef, useState, useLayoutEffect, useEffect, useCallback, forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import ButtonBase from '@mui/material/ButtonBase';
 import Skeleton from '@mui/material/Skeleton';
 import StarIcon from '@mui/icons-material/Star';
@@ -148,6 +149,7 @@ export type TickGradeButtonProps = {
  */
 export const TickGradeButton = forwardRef<HTMLButtonElement, TickGradeButtonProps>(
   ({ difficulty, displayedGrades, expandedControl, onExpandedControlChange }, ref) => {
+    const { t } = useTranslation('climbs');
     const isDark = useIsDarkMode();
     const { formatGrade, getGradeColor, loaded: gradeFormatLoaded } = useGradeFormat();
 
@@ -162,8 +164,7 @@ export const TickGradeButton = forwardRef<HTMLButtonElement, TickGradeButtonProp
       <ButtonBase
         ref={ref}
         onClick={() => onExpandedControlChange(expandedControl === 'grade' ? null : 'grade')}
-        // i18n-ignore-next-line
-        aria-label="Select logged grade"
+        aria-label={t('tick.controls.selectGrade')}
         aria-haspopup="listbox"
         aria-expanded={expandedControl === 'grade'}
         data-testid="quick-tick-grade"
@@ -180,8 +181,7 @@ export const TickGradeButton = forwardRef<HTMLButtonElement, TickGradeButtonProp
             {gradeLabel}
           </span>
         )}
-        {/* i18n-ignore-next-line */}
-        <span className={styles.gradeByline}>user</span>
+        <span className={styles.gradeByline}>{t('tick.controls.userByline')}</span>
       </ButtonBase>
     );
   },
@@ -217,6 +217,7 @@ export const TickControls: React.FC<TickControlsProps> = ({
   onExpandedControlChange,
   triesButtonRef,
 }) => {
+  const { t } = useTranslation('climbs');
   const attemptDisplay = String(attemptCount);
 
   const toggle = (control: 'stars' | 'tries') => {
@@ -237,8 +238,7 @@ export const TickControls: React.FC<TickControlsProps> = ({
       >
         <StarIcon sx={{ fontSize: 14, color: quality ? themeTokens.colors.amber : 'inherit' }} />
         <span className={styles.starNumber}>{quality ?? '—'}</span>
-        {/* i18n-ignore-next-line */}
-        <span className={styles.starLabel}>stars</span>
+        <span className={styles.starLabel}>{t('tick.controls.starsLabel')}</span>
       </ButtonBase>
 
       {/* Tries counter */}
@@ -253,8 +253,7 @@ export const TickControls: React.FC<TickControlsProps> = ({
         disableRipple={false}
       >
         <span className={styles.attemptNumber}>{attemptDisplay}</span>
-        {/* i18n-ignore-next-line */}
-        <span className={styles.attemptLabel}>tries</span>
+        <span className={styles.attemptLabel}>{t('tick.controls.triesLabel')}</span>
       </ButtonBase>
     </>
   );
@@ -268,39 +267,44 @@ export const TickControls: React.FC<TickControlsProps> = ({
 export const InlineStarPicker: React.FC<{
   quality: number | null;
   onSelect: (value: number | null) => void;
-}> = ({ quality, onSelect }) => (
-  // i18n-ignore-next-line
-  <div className={`${styles.pickerRow} ${styles.pickerRowEnd}`} role="listbox" aria-label="Star rating">
-    <ButtonBase
-      onClick={() => onSelect(null)}
-      className={`${styles.pickerItem} ${quality === null ? styles.pickerItemSelected : ''}`}
-      // i18n-ignore-next-line
-      aria-label="No rating"
-      aria-selected={quality === null}
-      role="option"
+}> = ({ quality, onSelect }) => {
+  const { t } = useTranslation('climbs');
+  return (
+    <div
+      className={`${styles.pickerRow} ${styles.pickerRowEnd}`}
+      role="listbox"
+      aria-label={t('tick.controls.starRating')}
     >
-      <span className={styles.pickerClear}>—</span>
-    </ButtonBase>
-    {[1, 2, 3, 4, 5].map((n) => (
       <ButtonBase
-        key={n}
-        onClick={() => onSelect(n)}
-        className={`${styles.pickerItem} ${n === quality ? styles.pickerItemSelected : ''}`}
-        aria-label={`${n} star${n > 1 ? 's' : ''}`}
-        aria-selected={n === quality}
+        onClick={() => onSelect(null)}
+        className={`${styles.pickerItem} ${quality === null ? styles.pickerItemSelected : ''}`}
+        aria-label={t('tick.controls.noRating')}
+        aria-selected={quality === null}
         role="option"
       >
-        <StarIcon
-          sx={{
-            fontSize: 22,
-            color: n <= (quality ?? 0) ? themeTokens.colors.amber : 'inherit',
-            opacity: n <= (quality ?? 0) ? 1 : 0.3,
-          }}
-        />
+        <span className={styles.pickerClear}>—</span>
       </ButtonBase>
-    ))}
-  </div>
-);
+      {[1, 2, 3, 4, 5].map((n) => (
+        <ButtonBase
+          key={n}
+          onClick={() => onSelect(n)}
+          className={`${styles.pickerItem} ${n === quality ? styles.pickerItemSelected : ''}`}
+          aria-label={`${n} star${n > 1 ? 's' : ''}`}
+          aria-selected={n === quality}
+          role="option"
+        >
+          <StarIcon
+            sx={{
+              fontSize: 22,
+              color: n <= (quality ?? 0) ? themeTokens.colors.amber : 'inherit',
+              opacity: n <= (quality ?? 0) ? 1 : 0.3,
+            }}
+          />
+        </ButtonBase>
+      ))}
+    </div>
+  );
+};
 
 export const InlineGradePicker: React.FC<{
   grades: readonly { difficulty_id: number; difficulty_name: string; v_grade: string }[];
@@ -311,6 +315,7 @@ export const InlineGradePicker: React.FC<{
   /** Ref to the grade button for scroll alignment positioning. */
   gradeButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }> = ({ grades, currentGradeId, focusGradeId, onSelect, gradeButtonRef }) => {
+  const { t } = useTranslation('climbs');
   const { formatGrade, getGradeColor } = useGradeFormat();
   const isDark = useIsDarkMode();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -348,15 +353,13 @@ export const InlineGradePicker: React.FC<{
         ref={containerRef}
         className={styles.pickerRowScrollable}
         role="listbox"
-        // i18n-ignore-next-line
-        aria-label="Grade override"
+        aria-label={t('tick.controls.gradeOverride')}
         data-scrollable-picker
       >
         <ButtonBase
           onClick={() => onSelect(undefined)}
           className={`${styles.pickerItem} ${currentGradeId === undefined ? styles.pickerItemSelected : ''}`}
-          // i18n-ignore-next-line
-          aria-label="Clear grade override"
+          aria-label={t('tick.controls.clearGradeOverride')}
           aria-selected={currentGradeId === undefined}
           role="option"
         >
@@ -400,6 +403,7 @@ export const InlineTriesPicker: React.FC<{
   /** Ref to the tries button for scroll alignment when attemptCount > 10. */
   triesButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }> = ({ attemptCount, onSelect, triesButtonRef }) => {
+  const { t } = useTranslation('climbs');
   const containerRef = useRef<HTMLDivElement>(null);
 
   useStopHorizontalTouchPropagation(containerRef);
@@ -431,8 +435,7 @@ export const InlineTriesPicker: React.FC<{
         ref={containerRef}
         className={styles.pickerRowScrollable}
         role="listbox"
-        // i18n-ignore-next-line
-        aria-label="Attempt count"
+        aria-label={t('tick.controls.attemptCount')}
         data-scrollable-picker
       >
         {ATTEMPT_OPTIONS.map((n) => (

--- a/packages/web/app/components/logbook/tick-icon.tsx
+++ b/packages/web/app/components/logbook/tick-icon.tsx
@@ -14,7 +14,7 @@ export const TickIcon: React.FC<TickIconProps> = ({ isFlash }) => {
 };
 
 type TickButtonWithLabelProps = {
-  label: 'flash' | 'tick' | 'attempt' | 'save';
+  label: string;
   children: React.ReactNode;
 };
 

--- a/packages/web/app/components/moonboard-import/__tests__/moonboard-bulk-import.test.tsx
+++ b/packages/web/app/components/moonboard-import/__tests__/moonboard-bulk-import.test.tsx
@@ -3,6 +3,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MoonBoardBulkImport from '../moonboard-bulk-import';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockShowMessage = vi.fn();
 const mockRequest = vi.fn();

--- a/packages/web/app/components/moonboard-import/moonboard-bulk-import.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-bulk-import.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useReducer, useCallback, useEffect, useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import MuiAlert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
@@ -154,6 +155,7 @@ export default function MoonBoardBulkImport({
   holdSetImages,
   angle,
 }: MoonBoardBulkImportProps) {
+  const { t } = useTranslation('climbs');
   const router = useLocaleRouter();
   const pathname = usePathname();
   const { data: session } = useSession();
@@ -290,8 +292,7 @@ export default function MoonBoardBulkImport({
 
     const userId = session?.user?.id;
     if (!userId || !authToken) {
-      // i18n-ignore-next-line
-      showMessage('Please log in to save climbs', 'error');
+      showMessage(t('moonboardImport.bulk.loginRequired'), 'error');
       return;
     }
 
@@ -368,8 +369,7 @@ export default function MoonBoardBulkImport({
       }
     } catch (error) {
       console.error('Failed to save climbs:', error);
-      // i18n-ignore-next-line
-      showMessage('Failed to save climbs. Please try again.', 'error');
+      showMessage(t('moonboardImport.bulk.saveFailed'), 'error');
     } finally {
       setIsSaving(false);
     }
@@ -386,6 +386,7 @@ export default function MoonBoardBulkImport({
     showMessage,
     angle,
     runDuplicateCheck,
+    t,
   ]);
 
   const handleRemoveClimb = useCallback((sourceFile: string) => {
@@ -420,25 +421,20 @@ export default function MoonBoardBulkImport({
     <div className={styles.container}>
       <div className={styles.header}>
         <MuiButton variant="outlined" startIcon={<ArrowBackOutlined />} onClick={handleBack}>
-          {/* i18n-ignore-next-line */}
-          Back
+          {t('common:actions.back')}
         </MuiButton>
         <Typography variant="h3" className={styles.title}>
-          {/* i18n-ignore-next-line */}
-          Import MoonBoard Climbs - {layoutName} @ {angle}°
+          {t('moonboardImport.bulk.title', { layoutName, angle })}
         </Typography>
       </div>
 
       {!session?.user && (
         <MuiAlert severity="warning" variant="filled" sx={warningAlertSx} className={styles.warningAlert}>
-          {/* i18n-ignore-next-line */}
-          <AlertTitle>Login Required</AlertTitle>
-          {/* i18n-ignore-next-line */}
-          Please log in to save climbs to the database.{' '}
+          <AlertTitle>{t('moonboardImport.bulk.loginRequiredTitle')}</AlertTitle>
+          {t('moonboardImport.bulk.loginRequiredBody')}{' '}
           <LocaleLink href="/api/auth/signin">
             <MuiButton variant="text" startIcon={<LoginOutlined />} sx={{ padding: 0, color: 'inherit' }}>
-              {/* i18n-ignore-next-line */}
-              Log in
+              {t('moonboardImport.bulk.logIn')}
             </MuiButton>
           </LocaleLink>
         </MuiAlert>
@@ -482,11 +478,9 @@ export default function MoonBoardBulkImport({
               }}
             />
             <InboxOutlined sx={{ fontSize: 48, color: 'text.secondary', mb: 1 }} />
-            {/* i18n-ignore-next-line */}
-            <Typography variant="body1">Click or drag screenshot files to this area</Typography>
+            <Typography variant="body1">{t('moonboardImport.bulk.uploadPrompt')}</Typography>
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Support for MoonBoard app screenshots. Drop multiple files to bulk import.
+              {t('moonboardImport.bulk.uploadHelp')}
             </Typography>
           </Box>
         </div>
@@ -495,8 +489,7 @@ export default function MoonBoardBulkImport({
       {/* Processing Section */}
       {state.status === 'processing' && (
         <div className={styles.processingSection}>
-          {/* i18n-ignore-next-line */}
-          <Typography variant="h4">Processing Screenshots...</Typography>
+          <Typography variant="h4">{t('moonboardImport.bulk.processing')}</Typography>
           <LinearProgress
             variant="determinate"
             value={Math.round((state.progress.current / state.progress.total) * 100)}
@@ -526,8 +519,7 @@ export default function MoonBoardBulkImport({
 
           {isCheckingDuplicates && state.climbs.length > 0 && (
             <MuiAlert severity="info" className={styles.successAlert}>
-              {/* i18n-ignore-next-line */}
-              Checking imported climbs against existing MoonBoard problems...
+              {t('moonboardImport.bulk.checkingDuplicates')}
             </MuiAlert>
           )}
 
@@ -535,8 +527,7 @@ export default function MoonBoardBulkImport({
           {readyToImportClimbs.length > 0 && (
             <MuiAlert severity="success" className={styles.successAlert}>
               <AlertTitle>{`${readyToImportClimbs.length} climb(s) ready to import`}</AlertTitle>
-              {/* i18n-ignore-next-line */}
-              Review the climbs below. You can edit or remove any before saving.
+              {t('moonboardImport.bulk.reviewBeforeSaving')}
             </MuiAlert>
           )}
 
@@ -552,12 +543,10 @@ export default function MoonBoardBulkImport({
                     size="large"
                     disabled={isSaving || isCheckingDuplicates || !session?.user || readyToImportClimbs.length === 0}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Save All ({readyToImportClimbs.length})
+                    {t('moonboardImport.bulk.saveAll', { count: readyToImportClimbs.length })}
                   </MuiButton>
                   <MuiButton variant="outlined" startIcon={<ClearOutlined />} onClick={handleReset}>
-                    {/* i18n-ignore-next-line */}
-                    Clear & Start Over
+                    {t('moonboardImport.bulk.clearAndRestart')}
                   </MuiButton>
                 </Stack>
                 {backendUrl && (
@@ -565,8 +554,7 @@ export default function MoonBoardBulkImport({
                     control={
                       <MuiCheckbox checked={contributeImages} onChange={(e) => setContributeImages(e.target.checked)} />
                     }
-                    // i18n-ignore-next-line
-                    label="Contribute images to improve OCR accuracy"
+                    label={t('moonboardImport.bulk.contributeImages')}
                   />
                 )}
               </Stack>
@@ -607,8 +595,7 @@ export default function MoonBoardBulkImport({
               }
               extra={
                 <MuiButton onClick={handleReset} variant="contained">
-                  {/* i18n-ignore-next-line */}
-                  Try Again
+                  {t('moonboardImport.bulk.tryAgain')}
                 </MuiButton>
               }
             />

--- a/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-edit-modal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
@@ -86,6 +87,7 @@ export default function MoonBoardEditModal({
   onSave,
   onCancel,
 }: MoonBoardEditModalProps) {
+  const { t } = useTranslation('climbs');
   const [climbName, setClimbName] = useState(climb.name);
 
   const initialHoldsMap = convertClimbToHoldsMap(climb);
@@ -116,8 +118,7 @@ export default function MoonBoardEditModal({
 
   return (
     <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth className={styles.modal}>
-      {/* i18n-ignore-next-line */}
-      <DialogTitle>Edit Climb</DialogTitle>
+      <DialogTitle>{t('moonboardEditModal.title')}</DialogTitle>
       <DialogContent>
         <div className={styles.content}>
           <div className={styles.boardSection}>
@@ -139,63 +140,69 @@ export default function MoonBoardEditModal({
             />
 
             <Stack direction="row" spacing={1.5} flexWrap="wrap" justifyContent="center" className={styles.holdCounts}>
-              {/* i18n-ignore-next-line */}
-              <HoldIndicator count={startingCount} max={2} color={themeTokens.colors.error} label="Start" />
-              {/* i18n-ignore-next-line */}
-              <HoldIndicator count={handCount} color={themeTokens.colors.primary} label="Hand" />
-              {/* i18n-ignore-next-line */}
-              <HoldIndicator count={finishCount} max={2} color={themeTokens.colors.success} label="Finish" />
-              {/* i18n-ignore-next-line */}
-              <HoldIndicator count={totalHolds} color={themeTokens.colors.secondary} label="Total" />
+              <HoldIndicator
+                count={startingCount}
+                max={2}
+                color={themeTokens.colors.error}
+                label={t('createClimbForm.holds.start')}
+              />
+              <HoldIndicator
+                count={handCount}
+                color={themeTokens.colors.primary}
+                label={t('createClimbForm.holds.hand')}
+              />
+              <HoldIndicator
+                count={finishCount}
+                max={2}
+                color={themeTokens.colors.success}
+                label={t('createClimbForm.holds.finish')}
+              />
+              <HoldIndicator
+                count={totalHolds}
+                color={themeTokens.colors.secondary}
+                label={t('createClimbForm.holds.total')}
+              />
             </Stack>
 
             {!isValid && totalHolds > 0 && (
               <Typography variant="body2" component="span" color="text.secondary" className={styles.validationHint}>
-                {/* i18n-ignore-next-line */}
-                A valid climb needs at least 1 start hold and 1 finish hold
+                {t('createClimbForm.validation.needsStartFinish')}
               </Typography>
             )}
           </div>
 
           <div className={styles.formSection}>
             <TextField
-              // i18n-ignore-next-line
-              label="Climb Name"
+              label={t('moonboardEditModal.nameLabel')}
               value={climbName}
               onChange={(e) => setClimbName(e.target.value)}
               required
               fullWidth
               size="small"
-              // i18n-ignore-next-line
-              placeholder="Climb name"
+              placeholder={t('createClimbForm.namePlaceholder')}
               slotProps={{ htmlInput: { maxLength: 100 } }}
               error={!climbName.trim()}
-              helperText={!climbName.trim() ? 'Please enter a name' : undefined}
+              helperText={!climbName.trim() ? t('moonboardEditModal.nameRequired') : undefined}
             />
 
             <div className={styles.climbInfo}>
               <Typography variant="body2" component="span" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Setter: {climb.setter || 'Unknown'}
+                {t('moonboardEditModal.setter', { setter: climb.setter || t('moonboardEditModal.unknown') })}
               </Typography>
               <Typography variant="body2" component="span" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Grade: {climb.userGrade || 'Unknown'}
+                {t('moonboardEditModal.grade', { grade: climb.userGrade || t('moonboardEditModal.unknown') })}
               </Typography>
               <Typography variant="body2" component="span" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Angle: {climb.angle}°
+                {t('moonboardEditModal.angle', { angle: climb.angle })}
               </Typography>
             </div>
           </div>
         </div>
       </DialogContent>
       <DialogActions>
-        {/* i18n-ignore-next-line */}
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onCancel}>{t('common:actions.cancel')}</Button>
         <Button variant="contained" onClick={handleOk} disabled={!isValid}>
-          {/* i18n-ignore-next-line */}
-          Save Changes
+          {t('moonboardEditModal.save')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
+++ b/packages/web/app/components/moonboard-import/moonboard-import-card.tsx
@@ -37,11 +37,11 @@ export default function MoonBoardImportCard({
   onEdit,
   onRemove,
 }: MoonBoardImportCardProps) {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation('climbs');
   const totalHolds = climb.holds.start.length + climb.holds.hand.length + climb.holds.finish.length;
   const duplicateMessage = duplicateMatch?.existingClimbName
-    ? `Skipping: Already Exists as "${duplicateMatch.existingClimbName}"`
-    : 'Skipping: Already Exists';
+    ? t('moonboardImport.card.duplicateNamed', { name: duplicateMatch.existingClimbName })
+    : t('moonboardImport.card.duplicate');
 
   return (
     <MuiCard className={styles.card}>
@@ -55,8 +55,7 @@ export default function MoonBoardImportCard({
           </Typography>
           {duplicateMatch?.exists && (
             <Chip
-              // i18n-ignore-next-line
-              label="Skipping"
+              label={t('moonboardImport.card.skipping')}
               size="small"
               className={styles.duplicateTag}
               sx={{
@@ -93,20 +92,17 @@ export default function MoonBoardImportCard({
       </CardContent>
       <CardActions>
         <MuiButton key="edit" variant="text" startIcon={<EditOutlined />} onClick={onEdit}>
-          {/* i18n-ignore-next-line */}
-          Edit
+          {t('common:actions.edit')}
         </MuiButton>
         <ConfirmPopover
-          title={t('moonboardImport.removeConfirmTitle')}
-          // i18n-ignore-next-line
-          description="This climb will not be imported."
+          title={t('common:moonboardImport.removeConfirmTitle')}
+          description={t('moonboardImport.card.removeDescription')}
           onConfirm={onRemove}
-          okText={t('actions.remove')}
-          cancelText={t('actions.cancel')}
+          okText={t('moonboardImport.card.removeAction')}
+          cancelText={t('common:actions.cancel')}
         >
           <MuiButton variant="text" color="error" startIcon={<DeleteOutlined />}>
-            {/* i18n-ignore-next-line */}
-            Remove
+            {t('moonboardImport.card.removeAction')}
           </MuiButton>
         </ConfirmPopover>
       </CardActions>

--- a/packages/web/app/components/new-climb-feed/new-climb-feed.tsx
+++ b/packages/web/app/components/new-climb-feed/new-climb-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
@@ -37,6 +38,7 @@ export default function NewClimbFeed({
   isAuthenticated,
   isSubscribed = false,
 }: NewClimbFeedProps) {
+  const { t } = useTranslation('feed');
   const { token: wsAuthToken } = useWsAuthToken();
   const clientRef = useRef<Client | null>(null);
   const subscriptionRef = useRef<(() => void) | undefined>(undefined);
@@ -128,8 +130,7 @@ export default function NewClimbFeed({
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
         <Typography variant="h6" fontWeight={700}>
-          {/* i18n-ignore-next-line */}
-          New Climbs
+          {t('newClimbFeed.title')}
         </Typography>
         <SubscribeButton
           boardType={boardType}
@@ -142,8 +143,7 @@ export default function NewClimbFeed({
 
       {error && (
         <Alert severity="error" sx={{ mb: 1 }}>
-          {/* i18n-ignore-next-line */}
-          Failed to load climbs. Please try again.
+          {t('newClimbFeed.errorLoad')}
         </Alert>
       )}
 
@@ -165,8 +165,7 @@ export default function NewClimbFeed({
 
       {!isLoading && items.length === 0 && !error && (
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No climbs yet for this layout. Be the first to set one!
+          {t('newClimbFeed.empty')}
         </Typography>
       )}
     </Box>

--- a/packages/web/app/components/new-climb-feed/subscribe-button.tsx
+++ b/packages/web/app/components/new-climb-feed/subscribe-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useCallback, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import ToggleButton from '@mui/material/ToggleButton';
 import NotificationsNoneOutlined from '@mui/icons-material/NotificationsNoneOutlined';
 import NotificationsActiveOutlined from '@mui/icons-material/NotificationsActiveOutlined';
@@ -33,6 +34,7 @@ export default function SubscribeButton({
   onSubscriptionChange,
   disabled,
 }: SubscribeButtonProps) {
+  const { t } = useTranslation('feed');
   const { token: wsAuthToken } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const clientRef = useRef<Client | null>(null);
@@ -51,8 +53,7 @@ export default function SubscribeButton({
   const handleToggle = async () => {
     if (loading || disabled) return;
     if (!wsAuthToken) {
-      // i18n-ignore-next-line
-      showMessage('Please sign in to manage subscriptions', 'warning');
+      showMessage(t('subscribeButton.signInPrompt'), 'warning');
       return;
     }
 
@@ -69,8 +70,7 @@ export default function SubscribeButton({
           variables,
         });
         onSubscriptionChange?.(false);
-        // i18n-ignore-next-line
-        showMessage('Unsubscribed from new climbs', 'success');
+        showMessage(t('subscribeButton.unsubscribed'), 'success');
       } else {
         const variables: SubscribeNewClimbsVariables = {
           input: { boardType, layoutId },
@@ -80,13 +80,11 @@ export default function SubscribeButton({
           variables,
         });
         onSubscriptionChange?.(true);
-        // i18n-ignore-next-line
-        showMessage('Subscribed to new climbs', 'success');
+        showMessage(t('subscribeButton.subscribed'), 'success');
       }
     } catch (err) {
       console.error('Subscription toggle failed', err);
-      // i18n-ignore-next-line
-      showMessage('Could not update subscription', 'error');
+      showMessage(t('subscribeButton.updateFailed'), 'error');
     } finally {
       setLoading(false);
     }

--- a/packages/web/app/components/onboarding/__tests__/onboarding-tour-overlay.test.tsx
+++ b/packages/web/app/components/onboarding/__tests__/onboarding-tour-overlay.test.tsx
@@ -47,6 +47,15 @@ vi.mock('@mui/material/Popper', () => ({
 }));
 
 import OnboardingTourOverlay from '../onboarding-tour-overlay';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 /* eslint-enable import/first */
 
 // --- Helpers ---------------------------------------------------------------

--- a/packages/web/app/components/onboarding/onboarding-tour-overlay.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour-overlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { usePathname } from 'next/navigation';
 import Popper from '@mui/material/Popper';
 import Paper from '@mui/material/Paper';
@@ -159,8 +160,9 @@ function OverlayContent({
   onNext,
   onSkip,
 }: OverlayContentProps) {
+  const { t } = useTranslation('settings');
   const isLast = stepIndex === totalSteps - 1;
-  const buttonLabel = step.primaryLabel ?? (isLast ? 'Finish' : 'Next');
+  const buttonLabel = step.primaryLabel ?? (isLast ? t('onboarding.finish') : t('onboarding.next'));
   const showPrimary = step.primaryLabel !== null;
 
   return (
@@ -177,8 +179,7 @@ function OverlayContent({
         </span>
         <div className={styles.buttonRow}>
           <button type="button" className={styles.skipLink} onClick={onSkip}>
-            {/* i18n-ignore-next-line */}
-            Skip tour
+            {t('onboarding.skipTour')}
           </button>
           {showPrimary && (
             <Button ref={primaryButtonRef} variant="contained" size="small" onClick={onNext}>

--- a/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
@@ -4,6 +4,15 @@ import { describe, it, expect, vi } from 'vite-plus/test';
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PlayViewActionBar } from '../play-view-drawer';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // ---------------------------------------------------------------------------
 // Mock heavy deps that PlayViewActionBar imports transitively.

--- a/packages/web/app/components/play-view/__tests__/play-view-comments.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-comments.test.tsx
@@ -4,6 +4,15 @@ import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import PlayViewComments from '../play-view-comments';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockUseBoardProvider = vi.fn();
 

--- a/packages/web/app/components/play-view/__tests__/play-view-tick-bar-overlay.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-tick-bar-overlay.test.tsx
@@ -4,6 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { PlayViewTickBar } from '../play-view-drawer';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks — must come before imports

--- a/packages/web/app/components/play-view/play-view-comments.tsx
+++ b/packages/web/app/components/play-view/play-view-comments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
@@ -12,10 +13,13 @@ import { formatTickAbsoluteTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '@/app/components/ascent-status/ascent-status-utils';
 
-function getAscentChipLabel(status: AscentStatusValue): string {
-  if (status === 'flash') return 'Flash';
-  if (status === 'send') return 'Send';
-  return 'Attempt';
+function useAscentChipLabel() {
+  const { t } = useTranslation('profile');
+  return (status: AscentStatusValue): string => {
+    if (status === 'flash') return t('logbook.feed.status.flash');
+    if (status === 'send') return t('logbook.feed.status.send');
+    return t('logbook.feed.status.attempt');
+  };
 }
 
 type PlayViewCommentsProps = {
@@ -23,6 +27,8 @@ type PlayViewCommentsProps = {
 };
 
 const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
+  const { t } = useTranslation('session');
+  const getAscentChipLabel = useAscentChipLabel();
   const { logbook } = useBoardProvider();
 
   const ascents = useMemo(
@@ -52,8 +58,7 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
         }}
       >
         <ChatBubbleOutlineOutlined sx={{ fontSize: themeTokens.typography.fontSize.sm }} />
-        {/* i18n-ignore-next-line */}
-        Your Ascents ({ascents.length})
+        {t('playView.yourAscents', { count: ascents.length })}
       </Typography>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: `${themeTokens.spacing[1]}px` }}>
@@ -110,8 +115,7 @@ const PlayViewComments: React.FC<PlayViewCommentsProps> = ({ climbUuid }) => {
                       color="text.secondary"
                       sx={{ fontSize: themeTokens.typography.fontSize.xs }}
                     >
-                      {/* i18n-ignore-next-line */}
-                      {ascent.tries} tries
+                      {t('playView.triesCount', { count: ascent.tries })}
                     </Typography>
                   )}
                 </Box>

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -120,6 +120,7 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   onOpenQueue,
   angleSelector,
 }: PlayViewActionBarProps) {
+  const { t } = useTranslation('session');
   return (
     <div className={styles.actionBar}>
       <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
@@ -148,8 +149,7 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
       </IconButton>
       <ShareBoardButton />
       {angleSelector}
-      {/* i18n-ignore-next-line */}
-      <IconButton onClick={onOpenActions} aria-label="Climb actions">
+      <IconButton onClick={onOpenActions} aria-label={t('playView.actionBar.climbActionsAria')}>
         <MoreHorizOutlined />
       </IconButton>
       <MuiBadge
@@ -162,8 +162,7 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
           },
         }}
       >
-        {/* i18n-ignore-next-line */}
-        <IconButton onClick={onOpenQueue} aria-label="Open queue">
+        <IconButton onClick={onOpenQueue} aria-label={t('playView.actionBar.openQueueAria')}>
           <FormatListBulletedOutlined />
         </IconButton>
       </MuiBadge>
@@ -197,7 +196,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
   onClose,
   onError,
 }) {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation('session');
   const { logbook } = useBoardProvider();
   const [tickComment, setTickComment] = useState('');
   const [commentFocused, setCommentFocused] = useState(false);
@@ -271,21 +270,22 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') handleTickBarExpandedChange(!tickBarExpanded);
                 }}
-                aria-label={tickBarExpanded ? 'Collapse tick bar' : 'Expand tick bar'}
+                aria-label={tickBarExpanded ? t('playView.tickBar.collapseAria') : t('playView.tickBar.expandAria')}
               >
                 {tickBarExpanded ? (
                   <KeyboardArrowDownOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
                 ) : (
                   <KeyboardArrowUpOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
                 )}
-                <span className={styles.tickBarExpandLabel}>{tickBarExpanded ? 'Collapse' : 'Expand'}</span>
+                <span className={styles.tickBarExpandLabel}>
+                  {tickBarExpanded ? t('queueBar.tickBar.collapse') : t('queueBar.tickBar.expand')}
+                </span>
               </div>
               <div className={styles.tickBarCloseButton}>
                 <IconButton
                   size="small"
                   onClick={handleClose}
-                  // i18n-ignore-next-line
-                  aria-label="Close tick bar"
+                  aria-label={t('playView.tickBar.closeAria')}
                   sx={{
                     color: 'text.primary',
                     backgroundColor: 'action.selected',
@@ -314,7 +314,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                     fullWidth
                     size="small"
                     variant="outlined"
-                    placeholder={t('comment.shortPlaceholder')}
+                    placeholder={t('common:comment.shortPlaceholder')}
                     multiline
                     minRows={1}
                     maxRows={commentFocused ? 4 : 1}
@@ -349,8 +349,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                   fullWidth
                   size="small"
                   variant="outlined"
-                  // i18n-ignore-next-line
-                  placeholder="Comment..."
+                  placeholder={t('playView.tickBar.commentPlaceholder')}
                   multiline
                   minRows={2}
                   maxRows={4}
@@ -376,8 +375,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
             {/* Action buttons — attempt + tick (order matches queue control bar) */}
 
             <div className={styles.tickBarButtons}>
-              {/* i18n-ignore-next-line */}
-              <TickButtonWithLabel label="attempt">
+              <TickButtonWithLabel label={t('playView.tickBar.attemptLabel')}>
                 <IconButton
                   onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
                   sx={{
@@ -385,8 +383,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                     color: themeTokens.colors.error,
                     '&:hover': { backgroundColor: themeTokens.colors.errorMutedHover },
                   }}
-                  // i18n-ignore-next-line
-                  aria-label="Log attempt"
+                  aria-label={t('playView.tickBar.logAttemptAria')}
                 >
                   <PersonFallingIcon />
                 </IconButton>
@@ -403,8 +400,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                       backgroundColor: isFlash ? themeTokens.colors.amber : themeTokens.colors.successHover,
                     },
                   }}
-                  // i18n-ignore-next-line
-                  aria-label="Save tick"
+                  aria-label={t('playView.tickBar.saveTickAria')}
                 >
                   <TickIcon isFlash={!!isFlash} />
                 </IconButton>
@@ -426,6 +422,7 @@ type PlayViewDrawerProps = {
 };
 
 const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActiveDrawer, boardDetails, angle }) => {
+  const { t } = useTranslation('session');
   const isOpen = activeDrawer === 'play';
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [isQueueOpen, setIsQueueOpen] = useState(false);
@@ -562,9 +559,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
   }, [currentClimb?.uuid]);
 
   const handleTickBarError = useCallback(() => {
-    // i18n-ignore-next-line
-    showMessage("Couldn't save your tick — it's saved as a draft", 'error');
-  }, [showMessage]);
+    showMessage(t('playView.tickError'), 'error');
+  }, [showMessage, t]);
 
   const handlePrevNavClick = useCallback(() => {
     const prev = getPreviousClimbQueueItem();
@@ -792,8 +788,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
               <button
                 className={`${styles.tickFab} ${hasSuccessfulAscent ? styles.tickFabSuccess : ''} ${isTickBarActive ? styles.tickFabHiding : ''}`}
                 onClick={handleTickFabClick}
-                // i18n-ignore-next-line
-                aria-label="Log ascent"
+                aria-label={t('playView.tickFab.logAscentAria')}
                 disabled={isTickBarActive}
               >
                 <CheckOutlined className={styles.tickFabIcon} />
@@ -906,8 +901,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({ activeDrawer, setActive
           <IconButton
             size="small"
             onClick={handleClose}
-            // i18n-ignore-next-line
-            aria-label="Close"
+            aria-label={t('playView.closeAria')}
             sx={{
               position: 'absolute',
               top: 8,

--- a/packages/web/app/components/play-view/queue-drawer.tsx
+++ b/packages/web/app/components/play-view/queue-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiButton from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
@@ -48,6 +49,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
   boardDetails,
   initialShowHistory = false,
 }) => {
+  const { t } = useTranslation('session');
   // Internal state
   const [isEditMode, setIsEditMode] = useState(false);
   const [showHistory, setShowHistory] = useState(initialShowHistory);
@@ -185,8 +187,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
               fontSize: themeTokens.typography.fontSize.base,
             }}
           >
-            {/* i18n-ignore-next-line */}
-            Queue
+            {t('queueDrawer.title')}
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             {queue.length > 0 &&
@@ -202,8 +203,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
                       handleExitEditMode();
                     }}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Clear
+                    {t('queueDrawer.clear')}
                   </MuiButton>
                   <IconButton onClick={handleExitEditMode}>
                     <CloseOutlined />
@@ -248,8 +248,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
         {isEditMode && selectedItems.size > 0 && (
           <div className={styles.bulkRemoveBar}>
             <MuiButton variant="contained" color="error" fullWidth onClick={handleBulkRemove}>
-              {/* i18n-ignore-next-line */}
-              Remove {selectedItems.size} {selectedItems.size === 1 ? 'item' : 'items'}
+              {t('queueDrawer.removeItems', { count: selectedItems.size })}
             </MuiButton>
           </div>
         )}

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -375,8 +375,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
             onClick={handleGenerate}
             disabled={plannedSlots.length === 0}
           >
-            {/* i18n-ignore-next-line */}
-            Generate
+            {t('generator.generate')}
           </MuiButton>
         ) : null
       }

--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { RootBottomBar } from '../persistent-session-wrapper';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 let mockPathname = '/';
 let mockQueueBridgeBoardInfo = {

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SessionProvider, signIn } from 'next-auth/react';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
@@ -12,6 +13,7 @@ type SessionProviderWrapperProps = {
 };
 
 export default function SessionProviderWrapper({ children }: SessionProviderWrapperProps) {
+  const { t } = useTranslation('settings');
   const [deepLinkError, setDeepLinkError] = useState(false);
 
   useEffect(() => {
@@ -98,8 +100,7 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
       {children}
       <Snackbar open={deepLinkError} autoHideDuration={8000} onClose={() => setDeepLinkError(false)}>
         <Alert severity="warning" onClose={() => setDeepLinkError(false)}>
-          {/* i18n-ignore-next-line */}
-          Sign-in with Google, Apple, or Facebook may not work. Try restarting the app.
+          {t('sessionProvider.deepLinkError')}
         </Alert>
       </Snackbar>
     </SessionProvider>

--- a/packages/web/app/components/queue-control/queue-control-bar-shell.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar-shell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
@@ -13,7 +14,9 @@ type QueueControlBarShellProps = {
   message?: string;
 };
 
-export default function QueueControlBarShell({ message = 'No climb selected' }: QueueControlBarShellProps) {
+export default function QueueControlBarShell({ message }: QueueControlBarShellProps) {
+  const { t } = useTranslation('session');
+  const displayMessage = message ?? t('queueBar.shellMessage');
   return (
     <div
       id="onboarding-queue-bar"
@@ -32,8 +35,7 @@ export default function QueueControlBarShell({ message = 'No climb selected' }: 
                 style={{ backgroundColor: 'var(--semantic-surface)', justifyContent: 'flex-end' }}
               >
                 <PlayCircleOutlineOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
-                {/* i18n-ignore-next-line */}
-                <span className={styles.sessionName}>Start sesh</span>
+                <span className={styles.sessionName}>{t('queueBar.startSesh')}</span>
               </div>
             </div>
           </div>
@@ -57,7 +59,7 @@ export default function QueueControlBarShell({ message = 'No climb selected' }: 
                 <Box sx={{ flex: 1 }} className={styles.climbInfoCol}>
                   <div className={styles.climbInfoInner} style={{ gap: themeTokens.spacing[2] }}>
                     <div aria-hidden="true" className={`${styles.boardPreviewContainer} ${styles.shellThumbnail}`} />
-                    <span className={styles.shellTitle}>{message}</span>
+                    <span className={styles.shellTitle}>{displayMessage}</span>
                   </div>
                 </Box>
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -252,12 +252,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       text: 'Jump in and climb with me on Boardsesh',
       trackingEvent: 'Session Shared',
       trackingProps: { sessionId: activeSession?.sessionId ?? '' },
-      // i18n-ignore-next-line
-      onClipboardSuccess: () => showMessage('Link copied!', 'success'),
-      // i18n-ignore-next-line
-      onError: () => showMessage('Failed to share', 'error'),
+      onClipboardSuccess: () => showMessage(t('queueBar.linkCopied'), 'success'),
+      onError: () => showMessage(t('queueBar.shareFailed'), 'error'),
     });
-  }, [sessionShareUrl, activeSession?.sessionId, showMessage]);
+  }, [sessionShareUrl, activeSession?.sessionId, showMessage, t]);
 
   // Local tracking of which climbs the current user ticked this session,
   // since the backend doesn't populate tickedBy on queue items.
@@ -735,7 +733,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       : `translateX(min(0px, calc(-100% + ${swipeOffset}px)))`;
   };
 
-  const reconnectMessage = connectionState === 'error' ? 'Connection error – retrying…' : 'Reconnecting…';
+  const reconnectMessage =
+    connectionState === 'error' ? t('queueBar.reconnect.connectionError') : t('queueBar.reconnect.reconnecting');
 
   const handleLeaveSession = useCallback(() => {
     if (endSession) {
@@ -745,10 +744,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     if (disconnect) {
       disconnect();
     } else {
-      // i18n-ignore-next-line
-      showMessage('Unable to leave session. Please try again.', 'warning');
+      showMessage(t('queueBar.leaveFailed'), 'warning');
     }
-  }, [endSession, disconnect, showMessage]);
+  }, [endSession, disconnect, showMessage, t]);
 
   // Reconnect-only view helpers
   const renderReconnectingRow = () => (
@@ -756,8 +754,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       <CircularProgress size={16} thickness={5} />
       <span>{reconnectMessage}</span>
       <MuiButton variant="text" size="small" onClick={() => setShowCancelConfirm(true)}>
-        {/* i18n-ignore-next-line */}
-        Cancel
+        {t('queueBar.cancelReconnect')}
       </MuiButton>
     </div>
   );
@@ -969,8 +966,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                   }}
                 >
                   <PlayCircleOutlineOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.sessionName}>Start sesh</span>
+                  <span className={styles.sessionName}>{t('queueBar.startSesh')}</span>
                 </div>
               )}
               {/* Expandable participant bar — only for active sessions with participants */}
@@ -1096,8 +1092,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       }
                       setActiveDrawer('none');
                     }}
-                    // i18n-ignore-next-line
-                    onError={() => showMessage('Couldn\u2019t save your tick. Give it another go.', 'error')}
+                    onError={() => showMessage(t('queueBar.tickError'), 'error')}
                     onDraftRestored={(draftComment) => setTickComment(draftComment)}
                     onIsFlashChange={setIsFlash}
                     onAscentTypeChange={setAscentType}
@@ -1108,8 +1103,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                           fullWidth
                           size="small"
                           variant="outlined"
-                          // i18n-ignore-next-line
-                          placeholder="Comment..."
+                          placeholder={t('queueBar.tickCommentPlaceholder')}
                           multiline
                           minRows={1}
                           maxRows={tickCommentFocused ? 4 : 1}
@@ -1144,8 +1138,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         fullWidth
                         size="small"
                         variant="outlined"
-                        // i18n-ignore-next-line
-                        placeholder="Comment..."
+                        placeholder={t('queueBar.tickCommentPlaceholder')}
                         multiline
                         minRows={2}
                         maxRows={4}
@@ -1293,8 +1286,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                     </span>
                     {/* Attempt button — visible whenever tick mode is active */}
                     {tickBarActive && (
-                      // i18n-ignore-next-line
-                      <TickButtonWithLabel label="attempt">
+                      <TickButtonWithLabel label={t('queueBar.tickAttemptLabel')}>
                         <IconButton
                           onClick={(e) => quickTickBarRef.current?.saveAttempt(e.currentTarget)}
                           sx={{

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -445,8 +445,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
                 {row.type === 'suggestion-header' && (
                   <div className={styles.suggestedSectionHeader}>
                     <Typography variant="overline" color="text.secondary">
-                      {/* i18n-ignore-next-line */}
-                      Suggestions
+                      {t('session:queueList.suggestionsHeader')}
                     </Typography>
                   </div>
                 )}
@@ -489,8 +488,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
                 {row.type === 'end-message' && (
                   <div className={styles.noMoreSuggestions}>
                     <Typography variant="body2" color="text.disabled">
-                      {/* i18n-ignore-next-line */}
-                      That&apos;s all for now
+                      {t('session:queueList.endMessage')}
                     </Typography>
                   </div>
                 )}

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -393,23 +393,18 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
                   startIcon={<LoginOutlined />}
                   onClick={() =>
                     openAuthModal({
-                      // i18n-ignore-next-line
-                      title: 'Sign in to Boardsesh',
-                      // i18n-ignore-next-line
-                      description: 'Create an account to filter by your climbing progress and save favorites.',
+                      title: t('search.progress.signInModalTitle'),
+                      description: t('search.progress.signInModalDescription'),
                     })
                   }
                 >
-                  {/* i18n-ignore-next-line */}
-                  Sign In
+                  {t('search.actions.signIn')}
                 </MuiButton>
               }
             >
-              {/* i18n-ignore-next-line */}
-              <strong>Sign in to filter by your data</strong>
+              <strong>{t('search.progress.signInTitle')}</strong>
               <br />
-              {/* i18n-ignore-next-line */}
-              Login to filter climbs based on your attempt and completion history.
+              {t('search.progress.signInBody')}
             </MuiAlert>
           ) : (
             <div className={styles.switchGroup}>
@@ -426,8 +421,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
                 }
                 label={
                   <MuiTypography variant="body2" component="span">
-                    {/* i18n-ignore-next-line */}
-                    Hide Attempted
+                    {t('search.progress.hideAttempted')}
                   </MuiTypography>
                 }
               />
@@ -444,8 +438,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
                 }
                 label={
                   <MuiTypography variant="body2" component="span">
-                    {/* i18n-ignore-next-line */}
-                    Hide Completed
+                    {t('search.progress.hideCompleted')}
                   </MuiTypography>
                 }
               />
@@ -462,8 +455,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
                 }
                 label={
                   <MuiTypography variant="body2" component="span">
-                    {/* i18n-ignore-next-line */}
-                    Only Attempted
+                    {t('search.progress.onlyAttempted')}
                   </MuiTypography>
                 }
               />
@@ -480,8 +472,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
                 }
                 label={
                   <MuiTypography variant="body2" component="span">
-                    {/* i18n-ignore-next-line */}
-                    Only Completed
+                    {t('search.progress.onlyCompleted')}
                   </MuiTypography>
                 }
               />

--- a/packages/web/app/components/search-drawer/clear-button.tsx
+++ b/packages/web/app/components/search-drawer/clear-button.tsx
@@ -3,15 +3,16 @@
 import React from 'react';
 import Button from '@mui/material/Button';
 import ClearOutlined from '@mui/icons-material/ClearOutlined';
+import { useTranslation } from 'react-i18next';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 
 const ClearButton = () => {
+  const { t } = useTranslation('climbs');
   const { clearClimbSearchParams } = useUISearchParams();
 
   return (
     <Button variant="text" startIcon={<ClearOutlined />} onClick={clearClimbSearchParams}>
-      {/* i18n-ignore-next-line */}
-      Clear All
+      {t('search.actions.clearAll')}
     </Button>
   );
 };

--- a/packages/web/app/components/search-drawer/climb-hold-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-hold-search-form.tsx
@@ -12,6 +12,7 @@ import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import BoardHeatmap from '../board-renderer/board-heatmap';
 import { track } from '@vercel/analytics';
+import { useTranslation } from 'react-i18next';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './search-form.module.css';
 
@@ -20,6 +21,7 @@ type ClimbHoldSearchFormProps = {
 };
 
 const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails }) => {
+  const { t } = useTranslation('climbs');
   const { uiSearchParams, updateFilters } = useUISearchParams();
   const [selectedState, setSelectedState] = React.useState<HoldState>('ANY');
 
@@ -47,12 +49,12 @@ const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails 
   const stateItems = [
     {
       value: 'ANY',
-      label: 'Include',
+      label: t('search.holds.include'),
       icon: <CheckCircleOutlined style={{ color: themeTokens.colors.primary }} />,
     },
     {
       value: 'NOT',
-      label: 'Exclude',
+      label: t('search.holds.exclude'),
       icon: <CancelOutlined style={{ color: themeTokens.colors.error }} />,
     },
   ];
@@ -65,8 +67,7 @@ const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails 
       <div className={styles.holdSearchHeaderCompact}>
         <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
           <MuiTypography variant="body2" component="span" color="text.secondary">
-            {/* i18n-ignore-next-line */}
-            Tap to:
+            {t('search.holds.tapTo')}
           </MuiTypography>
           <MuiSelect
             value={selectedState}
@@ -93,14 +94,14 @@ const ClimbHoldSearchForm: React.FC<ClimbHoldSearchFormProps> = ({ boardDetails 
           </MuiSelect>
           {anyHoldsCount > 0 && (
             <Chip
-              label={`${anyHoldsCount} included`}
+              label={t('search.holds.included', { count: anyHoldsCount })}
               size="small"
               sx={{ bgcolor: themeTokens.colors.primary, color: 'common.white' }}
             />
           )}
           {notHoldsCount > 0 && (
             <Chip
-              label={`${notHoldsCount} excluded`}
+              label={t('search.holds.excluded', { count: notHoldsCount })}
               size="small"
               sx={{ bgcolor: themeTokens.colors.error, color: 'common.white' }}
             />

--- a/packages/web/app/components/search-drawer/search-climb-name-input.tsx
+++ b/packages/web/app/components/search-drawer/search-climb-name-input.tsx
@@ -4,15 +4,16 @@ import React from 'react';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import { useTranslation } from 'react-i18next';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
 
 const SearchClimbNameInput = () => {
+  const { t } = useTranslation('climbs');
   const { uiSearchParams, updateFilters } = useUISearchParams();
 
   return (
     <TextField
-      // i18n-ignore-next-line
-      placeholder="Search climbs..."
+      placeholder={t('search.placeholders.climbs')}
       variant="outlined"
       size="small"
       fullWidth

--- a/packages/web/app/components/search-drawer/search-results-footer.tsx
+++ b/packages/web/app/components/search-drawer/search-results-footer.tsx
@@ -5,6 +5,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import MuiTypography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
+import { useTranslation } from 'react-i18next';
 import { useSearchData } from '@/app/components/graphql-queue';
 import ClearButton from './clear-button';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
@@ -13,6 +14,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import styles from './search-form.module.css';
 
 const SearchResultsFooter = () => {
+  const { t } = useTranslation('climbs');
   const { totalSearchResultCount, isFetchingClimbs } = useSearchData();
   const { uiSearchParams } = useUISearchParams();
 
@@ -39,8 +41,8 @@ const SearchResultsFooter = () => {
           <Stack direction="row" spacing={1}>
             <FilterListOutlined style={{ color: themeTokens.colors.primary }} />
             <MuiTypography variant="body2" component="span" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              <span className={styles.resultBadge}>{(totalSearchResultCount ?? 0).toLocaleString()}</span> results
+              <span className={styles.resultBadge}>{(totalSearchResultCount ?? 0).toLocaleString()}</span>{' '}
+              {t('search.results.count')}
             </MuiTypography>
           </Stack>
         )}

--- a/packages/web/app/components/session-summary/session-summary-view.tsx
+++ b/packages/web/app/components/session-summary/session-summary-view.tsx
@@ -50,8 +50,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
               {summary.totalSends}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Sends
+              {t('summary.sends')}
             </Typography>
           </CardContent>
         </Card>
@@ -61,8 +60,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
               {summary.totalAttempts}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {/* i18n-ignore-next-line */}
-              Attempts
+              {t('summary.attempts')}
             </Typography>
           </CardContent>
         </Card>
@@ -76,8 +74,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
                 </Typography>
               </Box>
               <Typography variant="body2" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Duration
+                {t('summary.duration')}
               </Typography>
             </CardContent>
           </Card>
@@ -91,8 +88,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <FlagOutlined fontSize="small" color="action" />
               <Typography variant="body2" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Goal:
+                {t('summary.goal')}
               </Typography>
               <Typography variant="body2" fontWeight={500}>
                 {summary.goal}
@@ -109,8 +105,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <EmojiEventsOutlined fontSize="small" sx={{ color: 'warning.main' }} />
               <Typography variant="body2" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Hardest send:
+                {t('summary.hardestSend')}
               </Typography>
               <Typography variant="body2" fontWeight={600}>
                 {summary.hardestClimb.climbName}
@@ -138,8 +133,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
         <Card>
           <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" gutterBottom>
-              {/* i18n-ignore-next-line */}
-              Grade Distribution
+              {t('summary.gradeDistribution')}
             </Typography>
             <Stack spacing={0.75}>
               {summary.gradeDistribution.map((g) => (
@@ -180,8 +174,7 @@ export default function SessionSummaryView({ summary }: SessionSummaryViewProps)
         <Card>
           <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" gutterBottom>
-              {/* i18n-ignore-next-line */}
-              Participants
+              {t('summary.participants')}
             </Typography>
             <List disablePadding dense>
               {summary.participants.map((p) => (

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -39,6 +40,7 @@ type BoardImportPromptProps = {
 };
 
 export default function BoardImportPrompt({ boardType, onImportComplete }: BoardImportPromptProps) {
+  const { t } = useTranslation('settings');
   const { showMessage } = useSnackbar();
   const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
 
@@ -110,12 +112,12 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         throw new Error(error.error || 'Failed to save credentials');
       }
 
-      showMessage(`${boardName} account linked. Your data will show up within 12 hours.`, 'success');
+      showMessage(t('aurora.linkDialog.linkSuccess', { boardName }), 'success');
       setIsModalOpen(false);
       setFormValues({ username: '', password: '' });
       await fetchCredential();
     } catch (error) {
-      showMessage(error instanceof Error ? error.message : 'Failed to link account', 'error');
+      showMessage(error instanceof Error ? error.message : t('aurora.linkDialog.linkError'), 'error');
     } finally {
       setIsSaving(false);
     }
@@ -135,11 +137,10 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         throw new Error(error.error || 'Failed to remove credentials');
       }
 
-      // i18n-ignore-next-line
-      showMessage('Account unlinked successfully', 'success');
+      showMessage(t('auroraImport.unlinkSuccessToast'), 'success');
       await fetchCredential();
     } catch (error) {
-      showMessage(error instanceof Error ? error.message : 'Failed to unlink account', 'error');
+      showMessage(error instanceof Error ? error.message : t('aurora.unlinkError'), 'error');
     } finally {
       setIsRemoving(false);
     }
@@ -166,8 +167,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
 
     const maxSizeBytes = 200 * 1024 * 1024;
     if (file.size > maxSizeBytes) {
-      // i18n-ignore-next-line
-      showMessage('File is too large (max 200MB). Please check you selected the correct file.', 'error');
+      showMessage(t('aurora.import.tooLarge'), 'error');
       event.target.value = '';
       return;
     }
@@ -186,15 +186,11 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         setImportPreview(parsed.preview);
         setImportPhase('preview');
       } catch (err) {
-        showMessage(
-          err instanceof Error ? err.message : 'Failed to parse JSON file. Please check the file format.',
-          'error',
-        );
+        showMessage(err instanceof Error ? err.message : t('aurora.import.parseError'), 'error');
       }
     };
     reader.onerror = () => {
-      // i18n-ignore-next-line
-      showMessage('Failed to read file. Please try again.', 'error');
+      showMessage(t('aurora.import.readError'), 'error');
     };
     reader.readAsText(file);
     event.target.value = '';
@@ -230,7 +226,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                 event.results.ascents.imported +
                 event.results.attempts.imported +
                 event.results.circuits.imported;
-              showMessage(`Successfully imported ${totalImported} items`, 'success');
+              showMessage(t('aurora.import.successCount', { count: totalImported }), 'success');
             }
             break;
           case 'error':
@@ -243,15 +239,12 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
       });
 
       if (!receivedCompleteRef.current) {
-        setImportError(
-          'Import was interrupted. The server may have timed out. Your data may have been partially imported.',
-        );
+        setImportError(t('aurora.import.interrupted'));
         setImportPhase('error');
-        // i18n-ignore-next-line
-        showMessage('Import was interrupted', 'error');
+        showMessage(t('aurora.import.interruptedShort'), 'error');
       }
     } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Import failed';
+      const msg = error instanceof Error ? error.message : t('aurora.import.failed');
       setImportError(msg);
       setImportPhase('error');
       showMessage(msg, 'error');
@@ -272,13 +265,13 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
   const getImportDialogTitle = () => {
     switch (importPhase) {
       case 'preview':
-        return 'Import Aurora Data';
+        return t('aurora.import.dialog.previewTitle');
       case 'importing':
-        return 'Importing Aurora Data...';
+        return t('aurora.import.dialog.importingTitle');
       case 'complete':
-        return 'Import Complete';
+        return t('aurora.import.dialog.completeTitle');
       case 'error':
-        return 'Import Failed';
+        return t('aurora.import.dialog.errorTitle');
       default:
         return '';
     }
@@ -305,19 +298,16 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
         type="file"
         accept=".json"
         onChange={handleFileSelected}
-        // i18n-ignore-next-line
-        aria-label="Upload Aurora JSON export file"
+        aria-label={t('auroraImport.uploadAriaLabel')}
         hidden
       />
 
       {/* Link Account Dialog */}
       <Dialog open={isModalOpen} onClose={handleModalCancel} maxWidth="sm" fullWidth>
-        <DialogTitle>{`Link ${boardName} Account`}</DialogTitle>
+        <DialogTitle>{t('aurora.linkDialog.title', { boardName })}</DialogTitle>
         <DialogContent>
           <Typography variant="body2" component="span" color="text.secondary" className={styles.modalDescription}>
-            {/* i18n-ignore-next-line */}
-            Enter your {boardName} Board username and password to import your Aurora data. Your credentials are
-            encrypted and securely stored. Data syncs every 12 hours.
+            {t('aurora.linkDialog.description', { boardName })}
           </Typography>
           <Box
             component="form"
@@ -329,10 +319,8 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
             sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}
           >
             <TextField
-              // i18n-ignore-next-line
-              label="Username"
-              // i18n-ignore-next-line
-              placeholder="Enter your username"
+              label={t('aurora.linkDialog.usernameLabel')}
+              placeholder={t('aurora.linkDialog.usernamePlaceholder')}
               variant="outlined"
               size="small"
               fullWidth
@@ -341,11 +329,9 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
               onChange={(e) => setFormValues((prev) => ({ ...prev, username: e.target.value }))}
             />
             <TextField
-              // i18n-ignore-next-line
-              label="Password"
+              label={t('aurora.linkDialog.passwordLabel')}
               type="password"
-              // i18n-ignore-next-line
-              placeholder="Enter your password"
+              placeholder={t('aurora.linkDialog.passwordPlaceholder')}
               variant="outlined"
               size="small"
               fullWidth
@@ -360,7 +346,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
               startIcon={isSaving ? <CircularProgress size={16} /> : undefined}
               fullWidth
             >
-              {isSaving ? 'Linking...' : 'Link Account'}
+              {isSaving ? t('aurora.linkDialog.submitting') : t('aurora.linkDialog.submit')}
             </Button>
           </Box>
         </DialogContent>
@@ -379,29 +365,31 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
           {importPhase === 'preview' && importPreview && (
             <>
               <Typography variant="body2" color="text.secondary" className={styles.modalDescription}>
-                {/* i18n-ignore-next-line */}
-                Import data from <strong>{importPreview.username}</strong> to <strong>{boardName}</strong>:
+                <Trans
+                  i18nKey="aurora.import.dialog.previewIntro"
+                  t={t}
+                  values={{ username: importPreview.username, boardName }}
+                  components={{ strong: <strong /> }}
+                />
               </Typography>
               <List dense>
                 {importPreview.climbs > 0 && (
                   <ListItem>
-                    <ListItemText primary={`${importPreview.climbs} draft climbs`} />
+                    <ListItemText primary={t('aurora.import.dialog.draftClimbs', { count: importPreview.climbs })} />
                   </ListItem>
                 )}
                 <ListItem>
-                  <ListItemText primary={`${importPreview.ascents} ascents`} />
+                  <ListItemText primary={t('aurora.import.dialog.ascents', { count: importPreview.ascents })} />
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary={`${importPreview.attempts} attempts`} />
+                  <ListItemText primary={t('aurora.import.dialog.attempts', { count: importPreview.attempts })} />
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary={`${importPreview.circuits} circuits`} />
+                  <ListItemText primary={t('aurora.import.dialog.circuits', { count: importPreview.circuits })} />
                 </ListItem>
               </List>
               <Typography variant="body2" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                Climbs will be matched by name. Any that can&apos;t be matched will be reported after import.
-                Re-importing the same file will not create duplicates.
+                {t('aurora.import.dialog.previewNote')}
               </Typography>
             </>
           )}
@@ -414,41 +402,50 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                 {(importResult.climbs.imported > 0 || importResult.climbs.failed > 0) && (
                   <ListItem>
                     <ListItemText
-                      // i18n-ignore-next-line
-                      primary="Draft Climbs"
-                      secondary={`${importResult.climbs.imported} imported, ${importResult.climbs.skipped} skipped, ${importResult.climbs.failed} failed`}
+                      primary={t('aurora.import.results.draftClimbs')}
+                      secondary={t('aurora.import.results.draftClimbsSummary', {
+                        imported: importResult.climbs.imported,
+                        skipped: importResult.climbs.skipped,
+                        failed: importResult.climbs.failed,
+                      })}
                     />
                   </ListItem>
                 )}
                 <ListItem>
                   <ListItemText
-                    // i18n-ignore-next-line
-                    primary="Ascents"
-                    secondary={`${importResult.ascents.imported} imported, ${importResult.ascents.skipped} skipped (already exist), ${importResult.ascents.failed} unmatched`}
+                    primary={t('aurora.import.results.ascents')}
+                    secondary={t('aurora.import.results.ascentsSummary', {
+                      imported: importResult.ascents.imported,
+                      skipped: importResult.ascents.skipped,
+                      failed: importResult.ascents.failed,
+                    })}
                   />
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    // i18n-ignore-next-line
-                    primary="Attempts"
-                    secondary={`${importResult.attempts.imported} imported, ${importResult.attempts.skipped} skipped (already exist), ${importResult.attempts.failed} unmatched`}
+                    primary={t('aurora.import.results.attempts')}
+                    secondary={t('aurora.import.results.attemptsSummary', {
+                      imported: importResult.attempts.imported,
+                      skipped: importResult.attempts.skipped,
+                      failed: importResult.attempts.failed,
+                    })}
                   />
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    // i18n-ignore-next-line
-                    primary="Circuits"
-                    secondary={`${importResult.circuits.imported} imported, ${importResult.circuits.skipped} skipped, ${importResult.circuits.failed} failed`}
+                    primary={t('aurora.import.results.circuits')}
+                    secondary={t('aurora.import.results.circuitsSummary', {
+                      imported: importResult.circuits.imported,
+                      skipped: importResult.circuits.skipped,
+                      failed: importResult.circuits.failed,
+                    })}
                   />
                 </ListItem>
               </List>
               {importResult.unresolvedClimbs.length > 0 && (
                 <MuiAlert severity="warning" className={styles.unsyncedAlert}>
                   <AlertTitle>
-                    {/* i18n-ignore-next-line */}
-                    {importResult.unresolvedClimbs.length} climb
-                    {/* i18n-ignore-next-line */}
-                    {importResult.unresolvedClimbs.length > 1 ? 's' : ''} could not be matched
+                    {t('aurora.import.results.unresolvedTitle', { count: importResult.unresolvedClimbs.length })}
                   </AlertTitle>
                   <div className={styles.unresolvedList}>
                     {importResult.unresolvedClimbs.slice(0, 20).map((name) => (
@@ -458,8 +455,9 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                     ))}
                     {importResult.unresolvedClimbs.length > 20 && (
                       <Typography variant="body2" color="text.secondary">
-                        {/* i18n-ignore-next-line */}
-                        ...and {importResult.unresolvedClimbs.length - 20} more
+                        {t('aurora.import.results.unresolvedMore', {
+                          count: importResult.unresolvedClimbs.length - 20,
+                        })}
                       </Typography>
                     )}
                   </div>
@@ -470,8 +468,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
 
           {importPhase === 'error' && importError && (
             <MuiAlert severity="error">
-              {/* i18n-ignore-next-line */}
-              <AlertTitle>Import failed</AlertTitle>
+              <AlertTitle>{t('aurora.import.dialog.errorTitleShort')}</AlertTitle>
               {importError}
             </MuiAlert>
           )}
@@ -479,19 +476,16 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
 
         {importPhase === 'preview' && (
           <DialogActions>
-            {/* i18n-ignore-next-line */}
-            <Button onClick={handleImportDialogClose}>Cancel</Button>
+            <Button onClick={handleImportDialogClose}>{t('aurora.import.dialog.cancel')}</Button>
             <Button variant="contained" onClick={handleImportConfirm}>
-              {/* i18n-ignore-next-line */}
-              Import
+              {t('aurora.import.dialog.confirm')}
             </Button>
           </DialogActions>
         )}
         {(importPhase === 'complete' || importPhase === 'error') && (
           <DialogActions>
             <Button variant="contained" onClick={handleImportDialogClose}>
-              {/* i18n-ignore-next-line */}
-              Close
+              {t('aurora.import.dialog.close')}
             </Button>
           </DialogActions>
         )}

--- a/packages/web/app/components/settings/controllers-section.tsx
+++ b/packages/web/app/components/settings/controllers-section.tsx
@@ -460,9 +460,9 @@ export default function ControllersSection() {
                 label={t('controllers.register.boardLabel')}
                 onChange={(e) => handleBoardChange(e.target.value)}
               >
-                {/* i18n-ignore-next-line */}
+                {/* i18n-ignore-next-line -- brand name, not translated */}
                 <MenuItem value="kilter">Kilter</MenuItem>
-                {/* i18n-ignore-next-line */}
+                {/* i18n-ignore-next-line -- brand name, not translated */}
                 <MenuItem value="tension">Tension</MenuItem>
               </MuiSelect>
             </FormControl>

--- a/packages/web/app/components/social/__tests__/feed-comment-button.test.tsx
+++ b/packages/web/app/components/social/__tests__/feed-comment-button.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import FeedCommentButton from '../feed-comment-button';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 

--- a/packages/web/app/components/social/__tests__/proposal-card.test.tsx
+++ b/packages/web/app/components/social/__tests__/proposal-card.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { Proposal } from '@boardsesh/shared-schema';
 import ProposalCard from '../proposal-card';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 // --- Mocks ---
 

--- a/packages/web/app/components/social/board-search-results.tsx
+++ b/packages/web/app/components/social/board-search-results.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -36,6 +37,7 @@ export default function BoardSearchResults({
   showFollowButton,
   onBoardSelect,
 }: BoardSearchResultsProps) {
+  const { t } = useTranslation('feed');
   const [selectedBoardUuid, setSelectedBoardUuid] = useState<string | null>(null);
   const debouncedQuery = useDebouncedValue(query, 300);
   const queryClient = useQueryClient();
@@ -111,8 +113,7 @@ export default function BoardSearchResults({
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Type at least 2 characters to search
+          {t('search.minCharsHint')}
         </Typography>
       </Box>
     );
@@ -130,8 +131,7 @@ export default function BoardSearchResults({
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No boards found for &quot;{debouncedQuery}&quot;
+          {t('search.noBoards', { query: debouncedQuery })}
         </Typography>
       </Box>
     );

--- a/packages/web/app/components/social/climb-social-section.tsx
+++ b/packages/web/app/components/social/climb-social-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import VoteButton from './vote-button';
 import CommentSection from './comment-section';
@@ -23,6 +24,7 @@ export default function ClimbSocialSection({
   boardName,
   highlightProposalUuid,
 }: ClimbSocialSectionProps) {
+  const { t } = useTranslation('common');
   return (
     <Box>
       {boardType && angle != null && (
@@ -38,8 +40,7 @@ export default function ClimbSocialSection({
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
         <VoteButton entityType="climb" entityId={climbUuid} />
       </Box>
-      {/* i18n-ignore-next-line */}
-      <CommentSection entityType="climb" entityId={climbUuid} title="Discussion" />
+      <CommentSection entityType="climb" entityId={climbUuid} title={t('comment.discussionTitle')} />
     </Box>
   );
 }

--- a/packages/web/app/components/social/comment-list.tsx
+++ b/packages/web/app/components/social/comment-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -27,6 +28,7 @@ type CommentListProps = {
 const PAGE_SIZE = 20;
 
 export default function CommentList({ entityType, entityId, refreshKey = 0, currentUserId }: CommentListProps) {
+  const { t } = useTranslation('common');
   const [comments, setComments] = useState<CommentType[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -137,21 +139,22 @@ export default function CommentList({ entityType, entityId, refreshKey = 0, curr
       {totalCount > 0 && (
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
           <MuiTypography variant="caption" color="text.secondary">
-            {totalCount} {totalCount === 1 ? 'comment' : 'comments'}
+            {totalCount === 1
+              ? t('comment.countOne', { count: totalCount })
+              : t('comment.countMany', { count: totalCount })}
           </MuiTypography>
           <ToggleButtonGroup value={sortBy} exclusive onChange={handleSortChange} size="small">
             <ToggleButton value="new" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
-              New
+              {t('comment.sort.new')}
             </ToggleButton>
             <ToggleButton value="top" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
-              Top
+              {t('comment.sort.top')}
             </ToggleButton>
             <ToggleButton value="controversial" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
-              {/* i18n-ignore-next-line */}
-              Controversial
+              {t('comment.sort.controversial')}
             </ToggleButton>
             <ToggleButton value="hot" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>
-              Hot
+              {t('comment.sort.hot')}
             </ToggleButton>
           </ToggleButtonGroup>
         </Box>
@@ -162,8 +165,7 @@ export default function CommentList({ entityType, entityId, refreshKey = 0, curr
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 4, gap: 1 }}>
           <ChatBubbleOutlineOutlined sx={{ fontSize: 32, color: 'var(--neutral-300)' }} />
           <MuiTypography variant="body2" color="text.secondary">
-            {/* i18n-ignore-next-line */}
-            No comments yet. Say something.
+            {t('comment.empty')}
           </MuiTypography>
         </Box>
       ) : (

--- a/packages/web/app/components/social/comment-section.tsx
+++ b/packages/web/app/components/social/comment-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import type { SocialEntityType } from '@boardsesh/shared-schema';
@@ -27,13 +28,15 @@ type CommentSectionProps = {
   title?: string;
 };
 
-export default function CommentSection({ entityType, entityId, title = 'Discussion' }: CommentSectionProps) {
+export default function CommentSection({ entityType, entityId, title }: CommentSectionProps) {
+  const { t } = useTranslation('common');
   const [refreshKey, setRefreshKey] = useState(0);
   const { data: session } = useSession();
   const { token, isAuthenticated } = useWsAuthToken();
   const currentUserId = session?.user?.id ?? null;
   const { showMessage } = useSnackbar();
   const wsClientRef = useRef<ReturnType<typeof createGraphQLClient> | null>(null);
+  const resolvedTitle = title ?? t('comment.discussionTitle');
 
   // Set up live comment updates subscription
   useEffect(() => {
@@ -82,29 +85,26 @@ export default function CommentSection({ entityType, entityId, title = 'Discussi
         });
         setRefreshKey((prev) => prev + 1);
       } catch {
-        // i18n-ignore-next-line
-        showMessage('Failed to post comment', 'error');
+        showMessage(t('comment.errors.post'), 'error');
         throw new Error('Failed to post comment');
       }
     },
-    [token, entityType, entityId, showMessage],
+    [token, entityType, entityId, showMessage, t],
   );
 
   return (
     <Box>
       <MuiTypography variant="h6" sx={{ mb: 2 }}>
-        {title}
+        {resolvedTitle}
       </MuiTypography>
 
       {isAuthenticated ? (
         <Box sx={{ mb: 2 }}>
-          {/* i18n-ignore-next-line */}
-          <CommentForm onSubmit={handleAddComment} placeholder="Share your thoughts..." />
+          <CommentForm onSubmit={handleAddComment} placeholder={t('comment.thoughtsPlaceholder')} />
         </Box>
       ) : (
         <MuiTypography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {/* i18n-ignore-next-line */}
-          Sign in to leave a comment.
+          {t('comment.signInPrompt')}
         </MuiTypography>
       )}
 

--- a/packages/web/app/components/social/feed-comment-button.tsx
+++ b/packages/web/app/components/social/feed-comment-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
@@ -22,6 +23,7 @@ export default function FeedCommentButton({
   commentCount = 0,
   defaultExpanded = false,
 }: FeedCommentButtonProps) {
+  const { t } = useTranslation('feed');
   const [open, setOpen] = useState(defaultExpanded);
 
   const handleToggle = useCallback((e: React.MouseEvent) => {
@@ -52,8 +54,7 @@ export default function FeedCommentButton({
 
       <Collapse in={open} unmountOnExit>
         <Box sx={{ mt: 1 }}>
-          {/* i18n-ignore-next-line */}
-          <CommentSection entityType={entityType} entityId={entityId} title="Comments" />
+          <CommentSection entityType={entityType} entityId={entityId} title={t('feedCommentButton.commentsTitle')} />
         </Box>
       </Collapse>
     </Box>

--- a/packages/web/app/components/social/follower-count.tsx
+++ b/packages/web/app/components/social/follower-count.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import MuiButton from '@mui/material/Button';
@@ -37,6 +38,7 @@ type FollowerCountProps = {
 type DrawerMode = 'followers' | 'following' | null;
 
 export default function FollowerCount({ userId, followerCount, followingCount }: FollowerCountProps) {
+  const { t } = useTranslation('feed');
   const [drawerMode, setDrawerMode] = useState<DrawerMode>(null);
   const [users, setUsers] = useState<PublicUserProfile[]>([]);
   const [loading, setLoading] = useState(false);
@@ -188,8 +190,7 @@ export default function FollowerCount({ userId, followerCount, followingCount }:
             '&:hover': { textDecoration: 'underline' },
           }}
         >
-          {/* i18n-ignore-next-line */}
-          <strong>{followingCount}</strong> following
+          <strong>{followingCount}</strong> {t('followerCount.followingLabel')}
         </Typography>
       </Box>
 

--- a/packages/web/app/components/social/following-ascents-feed.tsx
+++ b/packages/web/app/components/social/following-ascents-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -24,6 +25,7 @@ type FollowingAscentsFeedProps = {
 };
 
 export default function FollowingAscentsFeed({ onFindClimbers }: FollowingAscentsFeedProps) {
+  const { t } = useTranslation('feed');
   const { token, isAuthenticated, isLoading: authLoading } = useWsAuthToken();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
@@ -65,12 +67,10 @@ export default function FollowingAscentsFeed({ onFindClimbers }: FollowingAscent
 
   if (items.length === 0) {
     return (
-      // i18n-ignore-next-line
-      <EmptyState icon={<PersonSearchOutlined fontSize="inherit" />} description="Follow some climbers to fill this up">
+      <EmptyState icon={<PersonSearchOutlined fontSize="inherit" />} description={t('emptyStates.followClimbers')}>
         {onFindClimbers && (
           <MuiButton variant="contained" onClick={onFindClimbers}>
-            {/* i18n-ignore-next-line */}
-            Find Climbers
+            {t('emptyStates.findClimbers')}
           </MuiButton>
         )}
       </EmptyState>

--- a/packages/web/app/components/social/freeze-climb-dialog.tsx
+++ b/packages/web/app/components/social/freeze-climb-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -32,6 +33,7 @@ export default function FreezeClimbDialog({
   currentlyFrozen,
   onFreezeChanged,
 }: FreezeClimbDialogProps) {
+  const { t } = useTranslation('feed');
   const { token } = useWsAuthToken();
   const [frozen, setFrozen] = useState(currentlyFrozen);
   const [reason, setReason] = useState('');
@@ -71,22 +73,19 @@ export default function FreezeClimbDialog({
             sx={{ mb: 2, mt: 1 }}
           />
           <TextField
-            // i18n-ignore-next-line
-            label="Reason (optional)"
+            label={t('freezeDialog.reasonLabel')}
             value={reason}
             onChange={(e) => setReason(e.target.value)}
             multiline
             rows={2}
             size="small"
             fullWidth
-            // i18n-ignore-next-line
-            placeholder="Why freeze/unfreeze this climb?"
+            placeholder={t('freezeDialog.reasonPlaceholder')}
           />
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose} sx={{ textTransform: 'none' }}>
-            {/* i18n-ignore-next-line */}
-            Cancel
+            {t('common:actions.cancel')}
           </Button>
           <Button
             onClick={handleSubmit}

--- a/packages/web/app/components/social/freeze-indicator.tsx
+++ b/packages/web/app/components/social/freeze-indicator.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Alert from '@mui/material/Alert';
 import LockIcon from '@mui/icons-material/Lock';
 
@@ -9,11 +10,11 @@ type FreezeIndicatorProps = {
 };
 
 export default function FreezeIndicator({ reason }: FreezeIndicatorProps) {
+  const { t } = useTranslation('feed');
   return (
     <Alert severity="warning" icon={<LockIcon fontSize="small" />} sx={{ mb: 2, fontSize: 13 }}>
-      {/* i18n-ignore-next-line */}
-      This climb is frozen from receiving new proposals.
-      {reason && ` Reason: ${reason}`}
+      {t('freezeIndicator.frozen')}
+      {reason && ` ${t('freezeIndicator.reasonPrefix', { reason })}`}
     </Alert>
   );
 }

--- a/packages/web/app/components/social/global-ascents-feed.tsx
+++ b/packages/web/app/components/social/global-ascents-feed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import PublicOutlined from '@mui/icons-material/PublicOutlined';
@@ -18,6 +19,7 @@ import SocialFeedItem from '@/app/components/activity-feed/social-feed-item';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 
 export default function GlobalAscentsFeed() {
+  const { t } = useTranslation('feed');
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
     queryKey: ['globalAscentsFeed'],
     queryFn: async ({ pageParam }) => {
@@ -55,8 +57,7 @@ export default function GlobalAscentsFeed() {
   }
 
   if (items.length === 0) {
-    // i18n-ignore-next-line
-    return <EmptyState icon={<PublicOutlined fontSize="inherit" />} description="No recent activity yet" />;
+    return <EmptyState icon={<PublicOutlined fontSize="inherit" />} description={t('emptyStates.noRecentActivity')} />;
   }
 
   return (

--- a/packages/web/app/components/social/gym-search-results.tsx
+++ b/packages/web/app/components/social/gym-search-results.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -20,6 +21,7 @@ type GymSearchResultsProps = {
 };
 
 export default function GymSearchResults({ query, authToken }: GymSearchResultsProps) {
+  const { t } = useTranslation('feed');
   const [selectedGymUuid, setSelectedGymUuid] = useState<string | null>(null);
   const debouncedQuery = useDebouncedValue(query, 300);
 
@@ -53,8 +55,7 @@ export default function GymSearchResults({ query, authToken }: GymSearchResultsP
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Type at least 2 characters to search
+          {t('search.minCharsHint')}
         </Typography>
       </Box>
     );
@@ -72,8 +73,7 @@ export default function GymSearchResults({ query, authToken }: GymSearchResultsP
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No gyms found for &quot;{debouncedQuery}&quot;
+          {t('search.noGyms', { query: debouncedQuery })}
         </Typography>
       </Box>
     );

--- a/packages/web/app/components/social/playlist-search-results.tsx
+++ b/packages/web/app/components/social/playlist-search-results.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -33,6 +34,7 @@ type PlaylistPage = {
 };
 
 export default function PlaylistSearchResults({ query, authToken }: PlaylistSearchResultsProps) {
+  const { t } = useTranslation('feed');
   const router = useLocaleRouter();
   const pathname = usePathname();
   const debouncedQuery = useDebouncedValue(query, 300);
@@ -70,8 +72,7 @@ export default function PlaylistSearchResults({ query, authToken }: PlaylistSear
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Type at least 2 characters to search
+          {t('search.minCharsHint')}
         </Typography>
       </Box>
     );
@@ -89,8 +90,7 @@ export default function PlaylistSearchResults({ query, authToken }: PlaylistSear
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No playlists found for &quot;{debouncedQuery}&quot;
+          {t('search.noPlaylists', { query: debouncedQuery })}
         </Typography>
       </Box>
     );
@@ -133,9 +133,10 @@ export default function PlaylistSearchResults({ query, authToken }: PlaylistSear
                 {playlist.name}
               </Typography>
               <Typography variant="body2" color="text.secondary" noWrap>
-                {/* i18n-ignore-next-line */}
-                {playlist.creatorName} · {playlist.climbCount} climb
-                {playlist.climbCount !== 1 ? 's' : ''}
+                {playlist.creatorName} ·{' '}
+                {playlist.climbCount === 1
+                  ? t('search.climbCountOne', { count: playlist.climbCount })
+                  : t('search.climbCountMany', { count: playlist.climbCount })}
               </Typography>
             </Box>
             <Chip label={playlist.boardType} size="small" variant="outlined" sx={{ flexShrink: 0 }} />

--- a/packages/web/app/components/social/proposal-card.tsx
+++ b/packages/web/app/components/social/proposal-card.tsx
@@ -245,8 +245,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
           {/* Reason */}
           {localProposal.reason && (
             <Typography variant="body2" sx={{ color: themeTokens.neutral[600], mb: 1.5, fontStyle: 'italic' }}>
-              {/* i18n-ignore-next-line */}
-              &ldquo;{localProposal.reason}&rdquo;
+              {t('feed:proposalCard.quotedReason', { reason: localProposal.reason })}
             </Typography>
           )}
 
@@ -261,8 +260,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
           {/* Vote buttons + admin actions */}
           {localProposal.status === 'open' && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
-              {/* i18n-ignore-next-line */}
-              <Tooltip title="Support">
+              <Tooltip title={t('feed:proposalCard.support')}>
                 <IconButton
                   size="small"
                   disabled={loading}
@@ -278,8 +276,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
                   )}
                 </IconButton>
               </Tooltip>
-              {/* i18n-ignore-next-line */}
-              <Tooltip title="Oppose">
+              <Tooltip title={t('feed:proposalCard.oppose')}>
                 <IconButton
                   size="small"
                   disabled={loading}
@@ -311,8 +308,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
                       textTransform: 'none',
                     }}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Approve
+                    {t('feed:proposalCard.approve')}
                   </Button>
                   <Button
                     size="small"
@@ -327,8 +323,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
                       textTransform: 'none',
                     }}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Reject
+                    {t('feed:proposalCard.reject')}
                   </Button>
                 </Box>
               )}
@@ -351,8 +346,7 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
                   textTransform: 'none',
                 }}
               >
-                {/* i18n-ignore-next-line */}
-                Delete Proposal
+                {t('feed:proposalCard.deleteProposal')}
               </Button>
             </Box>
           )}
@@ -371,23 +365,16 @@ export default function ProposalCard({ proposal, isAdminOrLeader, onUpdate, onDe
 
       {/* TODO: Lift delete Dialog to parent (proposal-section/proposal-feed) to avoid N Dialog instances in lists */}
       <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
-        {/* i18n-ignore-next-line */}
-        <DialogTitle>Delete Accepted Proposal</DialogTitle>
+        <DialogTitle>{t('feed:proposalCard.deleteDialog.title')}</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            {/* i18n-ignore-next-line */}
-            This will revert the effects of this proposal (e.g., grade change, benchmark/classic status) and permanently
-            delete it. This action cannot be undone.
-          </DialogContentText>
+          <DialogContentText>{t('feed:proposalCard.deleteDialog.description')}</DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setShowDeleteDialog(false)} disabled={loading}>
-            {/* i18n-ignore-next-line */}
-            Cancel
+            {t('actions.cancel')}
           </Button>
           <Button onClick={handleDelete} color="error" disabled={loading}>
-            {/* i18n-ignore-next-line */}
-            Delete
+            {t('actions.delete')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/packages/web/app/components/social/proposal-section.tsx
+++ b/packages/web/app/components/social/proposal-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
@@ -42,6 +43,7 @@ export default function ProposalSection({
   boardName,
   highlightProposalUuid,
 }: ProposalSectionProps) {
+  const { t } = useTranslation('feed');
   const { token } = useWsAuthToken();
   const [communityStatus, setCommunityStatus] = useState<ClimbCommunityStatusType | null>(null);
   const [proposals, setProposals] = useState<Proposal[]>([]);
@@ -187,8 +189,7 @@ export default function ProposalSection({
             ))
           ) : (
             <Typography variant="body2" sx={{ color: themeTokens.neutral[400], textAlign: 'center', py: 2 }}>
-              {/* i18n-ignore-next-line */}
-              No open proposals
+              {t('proposalSection.noOpen')}
             </Typography>
           )}
         </Box>
@@ -237,8 +238,7 @@ export default function ProposalSection({
 
       {/* Section header */}
       <Typography variant="subtitle2" sx={{ fontWeight: 600, color: themeTokens.neutral[700], mb: 1.5 }}>
-        {/* i18n-ignore-next-line */}
-        Community Proposals
+        {t('proposalSection.title')}
         {proposals.length > 0 && (
           <Typography component="span" variant="caption" sx={{ ml: 0.5, color: themeTokens.neutral[400] }}>
             ({proposals.length})

--- a/packages/web/app/components/social/proposal-vote-bar.tsx
+++ b/packages/web/app/components/social/proposal-vote-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
@@ -21,6 +22,7 @@ export default function ProposalVoteBar({
   requiredUpvotes,
   status,
 }: ProposalVoteBarProps) {
+  const { t } = useTranslation('feed');
   const progress = requiredUpvotes > 0 ? Math.min((weightedUpvotes / requiredUpvotes) * 100, 100) : 0;
   const isApproved = status === 'approved';
   const isRejected = status === 'rejected';
@@ -30,8 +32,7 @@ export default function ProposalVoteBar({
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Chip
           icon={<CheckCircleIcon />}
-          // i18n-ignore-next-line
-          label="Approved"
+          label={t('proposalVoteBar.approved')}
           size="small"
           sx={{
             bgcolor: themeTokens.colors.successBg,
@@ -48,8 +49,7 @@ export default function ProposalVoteBar({
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Chip
-          // i18n-ignore-next-line
-          label="Rejected"
+          label={t('proposalVoteBar.rejected')}
           size="small"
           sx={{
             bgcolor: themeTokens.colors.errorBg,
@@ -65,13 +65,11 @@ export default function ProposalVoteBar({
     <Box sx={{ width: '100%' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
         <Typography variant="caption" sx={{ color: themeTokens.neutral[500] }}>
-          {/* i18n-ignore-next-line */}
-          {weightedUpvotes} / {requiredUpvotes} votes needed
+          {t('proposalVoteBar.votesNeeded', { current: weightedUpvotes, required: requiredUpvotes })}
         </Typography>
         {weightedDownvotes > 0 && (
           <Typography variant="caption" sx={{ color: themeTokens.colors.error }}>
-            {/* i18n-ignore-next-line */}
-            {weightedDownvotes} opposed
+            {t('proposalVoteBar.opposed', { count: weightedDownvotes })}
           </Typography>
         )}
       </Box>

--- a/packages/web/app/components/social/user-search-results.tsx
+++ b/packages/web/app/components/social/user-search-results.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -34,6 +35,7 @@ type UserSearchResultsProps = {
 };
 
 export default function UserSearchResults({ query, authToken }: UserSearchResultsProps) {
+  const { t } = useTranslation('feed');
   const debouncedQuery = useDebouncedValue(query, 300);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery<
@@ -72,8 +74,7 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          Type at least 2 characters to search
+          {t('search.minCharsHint')}
         </Typography>
       </Box>
     );
@@ -91,8 +92,7 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
-          No users or setters found for &quot;{debouncedQuery}&quot;
+          {t('search.noUsers', { query: debouncedQuery })}
         </Typography>
       </Box>
     );
@@ -135,15 +135,14 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
                     <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
                       {result.recentAscentCount > 0 && (
                         <Typography variant="caption" component="span" color="text.secondary">
-                          {/* i18n-ignore-next-line */}
-                          {result.recentAscentCount} ascents this month
+                          {t('userSearch.ascentsThisMonth', { count: result.recentAscentCount })}
                         </Typography>
                       )}
                       {result.setter && (
                         <Typography variant="caption" component="span" color="text.secondary">
-                          {/* i18n-ignore-next-line */}
-                          {result.setter.climbCount} climb
-                          {result.setter.climbCount !== 1 ? 's' : ''} set
+                          {result.setter.climbCount === 1
+                            ? t('userSearch.climbsSetOne', { count: result.setter.climbCount })
+                            : t('userSearch.climbsSetMany', { count: result.setter.climbCount })}
                         </Typography>
                       )}
                     </Box>
@@ -185,8 +184,9 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
                   secondary={
                     <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
                       <Typography variant="caption" component="span" color="text.secondary">
-                        {/* i18n-ignore-next-line */}
-                        {result.setter.climbCount} climb{result.setter.climbCount !== 1 ? 's' : ''}
+                        {result.setter.climbCount === 1
+                          ? t('userSearch.climbCountOne', { count: result.setter.climbCount })
+                          : t('userSearch.climbCountMany', { count: result.setter.climbCount })}
                       </Typography>
                       {result.setter.boardTypes.map((bt) => (
                         <Chip

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import MuiCard from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
@@ -52,6 +53,7 @@ type GradeBar = {
 const CHIP_SX = { height: 20, fontSize: '0.7rem' } as const;
 
 export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardProps) {
+  const { t } = useTranslation('feed');
   const router = useLocaleRouter();
   const { gradeFormat, loaded: gradeFormatLoaded } = useGradeFormat();
   const [profile, setProfile] = useState<ProfileData | null>(null);
@@ -160,11 +162,11 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
               </div>
 
               <Typography variant="caption" component="span" color="text.secondary">
-                {/* i18n-ignore-next-line */}
-                {profile.followerCount} follower{profile.followerCount !== 1 ? 's' : ''}
+                {profile.followerCount === 1
+                  ? t('userSmartCard.followerOne', { count: profile.followerCount })
+                  : t('userSmartCard.followerMany', { count: profile.followerCount })}
                 {' · '}
-                {/* i18n-ignore-next-line */}
-                {profile.followingCount} following
+                {t('userSmartCard.following', { count: profile.followingCount })}
               </Typography>
 
               {profile.credentials && profile.credentials.length > 0 && (
@@ -188,8 +190,9 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
           {gradeBars.length > 0 && (
             <div className={styles.chartSection}>
               <Typography variant="caption" component="span" color="text.secondary" className={styles.chartLabel}>
-                {/* i18n-ignore-next-line */}
-                {totalClimbs} distinct climb{totalClimbs !== 1 ? 's' : ''}
+                {totalClimbs === 1
+                  ? t('userSmartCard.distinctClimbOne', { count: totalClimbs })
+                  : t('userSmartCard.distinctClimbMany', { count: totalClimbs })}
               </Typography>
 
               <div className={styles.gradeBarContainer}>

--- a/packages/web/app/components/stats-filter-drawer/stats-filter-drawer.tsx
+++ b/packages/web/app/components/stats-filter-drawer/stats-filter-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -42,14 +43,19 @@ export default function StatsFilterDrawer({
   onToDateChange,
   onTransitionEnd,
 }: StatsFilterDrawerProps) {
+  const { t } = useTranslation('profile');
   return (
-    // i18n-ignore-next-line
-    <SwipeableDrawer open={open} onClose={onClose} placement="top" title="Filters" onTransitionEnd={onTransitionEnd}>
+    <SwipeableDrawer
+      open={open}
+      onClose={onClose}
+      placement="top"
+      title={t('filter.drawer.title')}
+      onTransitionEnd={onTransitionEnd}
+    >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pb: 2 }}>
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
-            {/* i18n-ignore-next-line */}
-            Board
+            {t('filter.drawer.board')}
           </Typography>
           <ToggleButtonGroup
             exclusive
@@ -70,8 +76,7 @@ export default function StatsFilterDrawer({
 
         <Box>
           <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
-            {/* i18n-ignore-next-line */}
-            Time Range
+            {t('filter.drawer.timeRange')}
           </Typography>
           <ToggleButtonGroup
             exclusive
@@ -97,14 +102,13 @@ export default function StatsFilterDrawer({
               value={fromDate ? dayjs(fromDate) : null}
               onChange={(val) => onFromDateChange(val ? val.format('YYYY-MM-DD') : '')}
               slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              // i18n-ignore-next-line
-              label="From"
+              label={t('filter.drawer.from')}
             />
             <MuiDatePicker
               value={toDate ? dayjs(toDate) : null}
               onChange={(val) => onToDateChange(val ? val.format('YYYY-MM-DD') : '')}
               slotProps={{ textField: { size: 'small', fullWidth: true } }}
-              label="To"
+              label={t('filter.drawer.to')}
             />
           </Stack>
         )}

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import MuiSwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -69,6 +70,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   open,
   children,
 }) => {
+  const { t } = useTranslation('common');
   // If swipeEnabled is explicitly passed, use it directly.
   // Otherwise, disable swipe when showCloseButton is explicitly false.
   const effectiveSwipeEnabled = swipeEnabled ?? showCloseButton !== false;
@@ -175,8 +177,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
         className="drawer-close-btn"
         size="small"
         onClick={(e) => onClose?.(e)}
-        // i18n-ignore-next-line
-        aria-label="Close"
+        aria-label={t('ariaLabels.close')}
         sx={{
           position: 'absolute',
           zIndex: 2,
@@ -189,7 +190,7 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
         <CloseOutlined />
       </IconButton>
     );
-  }, [showCloseButton, placement, onClose]);
+  }, [showCloseButton, placement, onClose, t]);
 
   // Drag handles for top/bottom placements are rendered OUTSIDE the scrollable
   // body Box so MUI's getDomTreeShapes doesn't find a scroll container between

--- a/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
+++ b/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
@@ -139,7 +139,7 @@ async function openBoardSelector() {
   await act(async () => {
     fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
   });
-  fireEvent.click(screen.getByText('Change Board'));
+  fireEvent.click(screen.getByText('Change board'));
   expect(screen.getByTestId('board-discovery-scroll')).toBeTruthy();
   // Verify the mock captured the callbacks — a null here would otherwise surface
   // as a confusing "TypeError: null is not a function" inside individual tests.

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -268,16 +268,12 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                     onClick={() => {
                       handleClose();
                       openAuthModal({
-                        // i18n-ignore-next-line
-                        title: 'Sign in to Boardsesh',
-                        description:
-                          // i18n-ignore-next-line
-                          'Sign in to access all features including saving favorites, tracking ascents, and more.',
+                        title: t('feed:userDrawer.signInModalTitle'),
+                        description: t('feed:userDrawer.signInModalDescription'),
                       });
                     }}
                   >
-                    {/* i18n-ignore-next-line */}
-                    Sign in
+                    {t('feed:userDrawer.signIn')}
                   </MuiButton>
                 </>
               )}
@@ -299,8 +295,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemIcon}>
                   <SwapHorizOutlined />
                 </span>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.menuItemLabel}>Change Board</span>
+                <span className={styles.menuItemLabel}>{t('feed:userDrawer.changeBoard')}</span>
               </button>
 
               {session?.user && (
@@ -316,8 +311,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <DashboardOutlined />
                   </span>
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.menuItemLabel}>My Boards</span>
+                  <span className={styles.menuItemLabel}>{t('myBoards.title')}</span>
                 </button>
               )}
 
@@ -325,8 +319,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemIcon}>
                   <SettingsOutlined />
                 </span>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.menuItemLabel}>Settings</span>
+                <span className={styles.menuItemLabel}>{t('ariaLabels.settings')}</span>
               </LocaleLink>
 
               {devUrlAvailable && (
@@ -341,8 +334,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <BuildOutlined />
                   </span>
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.menuItemLabel}>Dev URL</span>
+                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.devUrl')}</span>
                 </button>
               )}
 
@@ -351,8 +343,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <DeveloperBoardOutlined />
                   </span>
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.menuItemLabel}>Development</span>
+                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.development')}</span>
                 </LocaleLink>
               )}
 
@@ -368,8 +359,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <GpsFixedOutlined />
                   </span>
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.menuItemLabel}>Classify Holds</span>
+                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.classifyHolds')}</span>
                 </button>
               )}
 
@@ -377,8 +367,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemIcon}>
                   <LocalOfferOutlined />
                 </span>
-                {/* i18n-ignore-next-line */}
-                <span className={styles.menuItemLabel}>My Playlists</span>
+                <span className={styles.menuItemLabel}>{t('feed:userDrawer.myPlaylists')}</span>
               </LocaleLink>
             </nav>
 
@@ -387,8 +376,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <>
                 <div className={styles.divider} />
                 <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.sectionLabel}>
-                  {/* i18n-ignore-next-line */}
-                  Recent Sessions
+                  {t('feed:userDrawer.recentSessions')}
                 </MuiTypography>
                 {recentSessions.slice(0, 5).map((storedSession) => (
                   <button
@@ -426,16 +414,14 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <HelpOutlineOutlined />
               </span>
-              {/* i18n-ignore-next-line */}
-              <span className={styles.menuItemLabel}>Help</span>
+              <span className={styles.menuItemLabel}>{t('feed:userDrawer.help')}</span>
             </LocaleLink>
 
             <LocaleLink href="/about" className={styles.menuItem} onClick={handleClose}>
               <span className={styles.menuItemIcon}>
                 <InfoOutlined />
               </span>
-              {/* i18n-ignore-next-line */}
-              <span className={styles.menuItemLabel}>About</span>
+              <span className={styles.menuItemLabel}>{t('feed:userDrawer.about')}</span>
             </LocaleLink>
 
             <button
@@ -449,8 +435,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <StarBorderOutlined />
               </span>
-              {/* i18n-ignore-next-line */}
-              <span className={styles.menuItemLabel}>Rate Boardsesh</span>
+              <span className={styles.menuItemLabel}>{t('feed:userDrawer.rateBoardsesh')}</span>
             </button>
 
             <button
@@ -464,8 +449,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <BugReportOutlined />
               </span>
-              {/* i18n-ignore-next-line */}
-              <span className={styles.menuItemLabel}>Report a bug</span>
+              <span className={styles.menuItemLabel}>{t('feed:userDrawer.reportBug')}</span>
             </button>
 
             {/* Logout */}
@@ -476,8 +460,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <LogoutOutlined />
                   </span>
-                  {/* i18n-ignore-next-line */}
-                  <span className={styles.menuItemLabel}>Logout</span>
+                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.logout')}</span>
                 </button>
               </>
             )}
@@ -520,8 +503,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
 
       {boardSelectorRendered && (
         <SwipeableDrawer
-          // i18n-ignore-next-line
-          title="Pick a board"
+          title={t('boardSelector.title')}
           placement="bottom"
           open={showBoardSelector}
           onClose={() => setShowBoardSelector(false)}

--- a/packages/web/app/development/components/add-esp32-dialog.tsx
+++ b/packages/web/app/development/components/add-esp32-dialog.tsx
@@ -113,7 +113,7 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField
-            // i18n-ignore-next-line
+            // i18n-ignore-next-line -- internal dev tool, English only
             label="Label"
             value={form.label}
             onChange={(e) => setForm({ ...form, label: e.target.value })}
@@ -121,7 +121,7 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
             size="small"
           />
           <TextField
-            // i18n-ignore-next-line
+            // i18n-ignore-next-line -- internal dev tool, English only
             label="IP address"
             value={form.ip}
             onChange={(e) => setForm({ ...form, ip: e.target.value })}
@@ -130,17 +130,17 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
             size="small"
           />
           <TextField
-            // i18n-ignore-next-line
+            // i18n-ignore-next-line -- internal dev tool, English only
             label="Serial"
             value={form.serial}
             onChange={(e) => setForm({ ...form, serial: e.target.value })}
-            // i18n-ignore-next-line
+            // i18n-ignore-next-line -- internal dev tool, English only
             helperText="Used in the BLE advertised name (e.g. Kilter Board#751737@3)"
             fullWidth
             size="small"
           />
           <TextField
-            // i18n-ignore-next-line
+            // i18n-ignore-next-line -- internal dev tool, English only
             label="API level"
             value={form.apiLevel}
             onChange={(e) => setForm({ ...form, apiLevel: e.target.value === '2' ? 2 : 3 })}
@@ -172,7 +172,7 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
         </Stack>
       </DialogContent>
       <DialogActions>
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- internal dev tool, English only */}
         <Button onClick={onClose}>Cancel</Button>
         <Button onClick={handleSubmit} variant="contained" disabled={!isComplete}>
           {isEdit ? 'Save' : 'Add'}

--- a/packages/web/app/development/components/esp32-tab.tsx
+++ b/packages/web/app/development/components/esp32-tab.tsx
@@ -138,19 +138,19 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
           />
         )}
         <Box flexGrow={1} />
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- internal dev tool, English only */}
         <Tooltip title="Reconnect">
           <IconButton size="small" onClick={socket.reconnect}>
             <RefreshOutlined fontSize="small" />
           </IconButton>
         </Tooltip>
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- internal dev tool, English only */}
         <Tooltip title="Edit">
           <IconButton size="small" onClick={onEdit}>
             <EditOutlined fontSize="small" />
           </IconButton>
         </Tooltip>
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- internal dev tool, English only */}
         <Tooltip title="Remove">
           <IconButton size="small" onClick={onRemove}>
             <DeleteOutline fontSize="small" />
@@ -166,12 +166,12 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
 
       <Stack direction="row" spacing={2} alignItems="baseline" flexWrap="wrap">
         <Typography variant="body2" color="text.secondary">
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- internal dev tool, English only */}
           ws://{connection.ip}:81/
         </Typography>
         {latestAt && (
           <Typography variant="caption" color="text.secondary">
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- internal dev tool, English only */}
             last frame: {new Date(latestAt).toLocaleTimeString()}
           </Typography>
         )}
@@ -181,7 +181,7 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
         {boardDetails ? (
           <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={false} fillHeight />
         ) : (
-          // i18n-ignore-next-line
+          // i18n-ignore-next-line -- internal dev tool, English only
           <Typography color="error">Could not load board details for this configuration.</Typography>
         )}
       </Box>
@@ -193,7 +193,7 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
           color="text.secondary"
           sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- internal dev tool, English only */}
           frames: {latest.framesString || '(empty)'}
         </Typography>
       )}

--- a/packages/web/app/development/development-content.tsx
+++ b/packages/web/app/development/development-content.tsx
@@ -119,7 +119,7 @@ export default function DevelopmentContent({ boardConfigs }: DevelopmentContentP
           {connections.map((conn) => (
             <Tab key={conn.id} value={conn.id} label={conn.label || conn.ip} sx={{ textTransform: 'none' }} />
           ))}
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- internal dev tool, English only */}
           <Tab value={ADD_TAB} icon={<AddOutlined />} aria-label="Add ESP32" onClick={openAddDialog} />
         </Tabs>
       </Box>
@@ -128,13 +128,13 @@ export default function DevelopmentContent({ boardConfigs }: DevelopmentContentP
         {connections.length === 0 ? (
           <Box sx={{ p: 4 }}>
             <Typography variant="h6" gutterBottom>
-              {/* i18n-ignore-next-line */}
+              {/* i18n-ignore-next-line -- internal dev tool, English only */}
               No ESP32 emulators yet
             </Typography>
             <Typography color="text.secondary">
-              {/* i18n-ignore-next-line */}
+              {/* i18n-ignore-next-line -- internal dev tool, English only */}
               Click the <strong>+</strong> tab to add one. Flash the firmware from
-              {/* i18n-ignore-next-line */}
+              {/* i18n-ignore-next-line -- internal dev tool, English only */}
               <code> packages/board-controller/esp32/ </code> with <code>pio run -e esp32-emulator -t upload</code> and
               enter the IP it logs at boot.
             </Typography>

--- a/packages/web/app/docs/docs-client.tsx
+++ b/packages/web/app/docs/docs-client.tsx
@@ -144,7 +144,7 @@ function WebSocketGuideTab() {
       <Typography variant="body1" component="p" sx={{ mb: 2 }}>
         {t('docs.ws.introStart')}{' '}
         <MuiLink href="https://github.com/enisdenjo/graphql-ws" target="_blank">
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- technical reference, English only */}
           graphql-ws
         </MuiLink>{' '}
         {t('docs.ws.introEnd')}

--- a/packages/web/app/docs/graphql-schema.tsx
+++ b/packages/web/app/docs/graphql-schema.tsx
@@ -188,7 +188,7 @@ export default function GraphQLSchemaViewer() {
     <div>
       <div className={styles.searchContainer}>
         <TextField
-          // i18n-ignore-next-line
+          // i18n-ignore-next-line -- technical reference, English only
           placeholder="Search types, fields, descriptions..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
@@ -215,14 +215,14 @@ export default function GraphQLSchemaViewer() {
         <Tab label={`Inputs (${groupedSections.inputs.length})`} value="inputs" />
         <Tab label={`Enums (${groupedSections.enums.length})`} value="enums" />
         <Tab label={`Others (${groupedSections.others.length})`} value="others" />
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- technical reference, English only */}
         <Tab label="Full Schema" value="full" />
       </Tabs>
 
       <TabPanel value={activeTab} index="operations">
         <div>
           <Typography variant="body1" component="p" color="text.secondary" className={styles.operationsDescription}>
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- technical reference, English only */}
             Queries, Mutations, and Subscriptions available via the WebSocket GraphQL API.
           </Typography>
           {renderSectionList(groupedSections.operations)}

--- a/packages/web/app/docs/swagger-ui.tsx
+++ b/packages/web/app/docs/swagger-ui.tsx
@@ -55,7 +55,7 @@ export default function SwaggerUIComponent() {
         <CircularProgress size={48} />
         <div className={styles.swaggerLoadingText}>
           <Typography variant="body2" component="span" color="text.secondary">
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- technical reference, English only */}
             Loading API documentation...
           </Typography>
         </div>
@@ -66,20 +66,20 @@ export default function SwaggerUIComponent() {
   if (loadState === 'not-found') {
     return (
       <MuiAlert severity="warning" className={styles.swaggerAlert}>
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- technical reference, English only */}
         <AlertTitle>OpenAPI Specification Not Generated</AlertTitle>
         <div>
           <Typography variant="body1" component="p" className={styles.swaggerInstructions}>
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- technical reference, English only */}
             The OpenAPI specification file has not been generated yet. This is expected during local development.
           </Typography>
           <Typography variant="body1" component="p" className={styles.swaggerInstructionsFinal}>
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- technical reference, English only */}
             Run the following command to generate it:
           </Typography>
           <pre className={styles.swaggerCommandBlock}>bun run generate:openapi</pre>
           <Typography variant="body1" component="p" color="text.secondary" className={styles.swaggerNote}>
-            {/* i18n-ignore-next-line */}
+            {/* i18n-ignore-next-line -- technical reference, English only */}
             In production, this runs automatically during the build process.
           </Typography>
         </div>
@@ -90,7 +90,7 @@ export default function SwaggerUIComponent() {
   if (loadState === 'error') {
     return (
       <MuiAlert severity="error" className={styles.swaggerAlert}>
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- technical reference, English only */}
         <AlertTitle>Failed to Load API Documentation</AlertTitle>
         {`Error: ${errorMessage}`}
       </MuiAlert>

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -405,7 +405,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
             py: 1,
           }}
         >
-          {/* i18n-ignore-next-line */}
+          {/* i18n-ignore-next-line -- brand name, not translated */}
           <Image src="/brand/icon-transparent.svg" width={130} height={130} alt="Boardsesh" priority />
           <Typography
             variant="h5"

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -5,6 +5,16 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useClimbActionsData } from '../use-climb-actions-data';
 import { createQueryWrapper } from '@/app/test-utils/test-providers';
 import type { Playlist } from '@/app/lib/graphql/operations/playlists';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: vi.fn(),

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -53,6 +54,7 @@ const EMPTY_SET = new Set<string>();
 const EMPTY_MAP = new Map<string, Set<string>>();
 
 export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: UseClimbActionsDataOptions) {
+  const { t } = useTranslation('climbs');
   const { token, isAuthenticated, isLoading: isAuthLoading } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
@@ -125,8 +127,7 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
       if (context?.previousFavorites) {
         queryClient.setQueryData(favAccKey, context.previousFavorites);
       }
-      // i18n-ignore-next-line
-      showMessage('Failed to update favorite. Please try again.', 'error');
+      showMessage(t('actions.favorite.toast.updateFailed'), 'error');
     },
   });
 

--- a/packages/web/app/legal/legal-content.tsx
+++ b/packages/web/app/legal/legal-content.tsx
@@ -182,7 +182,8 @@ export default function LegalContent() {
                   {t('legal.dmca.review1')}
                 </Typography>
                 <Typography variant="body1" component="p">
-                  <strong>{t('legal.dmca.contactLabel')}</strong> {/* i18n-ignore-next-line */}
+                  <strong>{t('legal.dmca.contactLabel')}</strong>{' '}
+                  {/* i18n-ignore-next-line -- contact email, not translated */}
                   <MuiLink href="mailto:legal@mdj.ac">legal@mdj.ac</MuiLink>
                 </Typography>
               </section>

--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -45,7 +45,7 @@ export default function Image() {
           marginTop: 24,
         }}
       >
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- OG image, brand-only text */}
         boardsesh
       </div>
 
@@ -58,7 +58,7 @@ export default function Image() {
           letterSpacing: '6px',
         }}
       >
-        {/* i18n-ignore-next-line */}
+        {/* i18n-ignore-next-line -- OG image, English-only */}
         ONE APP FOR YOUR BOARDS
       </div>
     </div>,

--- a/packages/web/i18n/locales/en-US/auth.json
+++ b/packages/web/i18n/locales/en-US/auth.json
@@ -104,5 +104,9 @@
   "modal": {
     "title": "Sign in to keep your progress",
     "description": "Your logbook, playlists, and follows stay with your account."
+  },
+  "nativeStart": {
+    "invalidProvider": "Invalid sign-in provider",
+    "signingIn": "Signing in..."
   }
 }

--- a/packages/web/i18n/locales/en-US/boards.json
+++ b/packages/web/i18n/locales/en-US/boards.json
@@ -79,7 +79,137 @@
       "createdNamed": "Board \"{{name}}\" created!",
       "namePlaceholder": "e.g., Home Board, Gym Name",
       "locationPlaceholder": "e.g., City, Gym Name"
+    },
+    "fields": {
+      "name": "Board Name",
+      "slug": "URL Slug",
+      "description": "Description",
+      "location": "Location",
+      "serialNumber": "Controller Serial Number",
+      "defaultAngle": "Default Angle",
+      "angleAdjustable": "Angle is adjustable",
+      "isPublic": "Public board",
+      "unlisted": "Unlisted",
+      "hideLocation": "Hide from nearby boards",
+      "isOwned": "I own this board",
+      "layout": "Layout",
+      "size": "Size",
+      "holdSets": "Hold Sets"
+    },
+    "placeholders": {
+      "description": "Optional description",
+      "serialNumber": "e.g. ABC-12345"
+    },
+    "helperText": {
+      "unlisted": "Hidden from search results but accessible via direct link",
+      "hideLocation": "Hidden from nearby board searches unless you follow the searcher"
+    },
+    "alerts": {
+      "configEditable": "You can change the board layout because no climbs have been logged yet."
     }
+  },
+  "editBoard": {
+    "title": "Edit Board",
+    "submitLabel": "Save Changes",
+    "snackbar": {
+      "updated": "Board updated!",
+      "updateFailed": "Failed to update board"
+    }
+  },
+  "editGym": {
+    "title": "Edit Gym",
+    "submitLabel": "Save Changes",
+    "snackbar": {
+      "updated": "Gym updated!",
+      "updateFailed": "Failed to update gym"
+    }
+  },
+  "mapLocationPicker": {
+    "locationDisplay": "Location: {{lat}}, {{lng}}",
+    "setOnMap": "Set location on map",
+    "searchPlaceholder": "Search address or city...",
+    "myLocation": "My location",
+    "helpText": "Click the map to set your board's location, or drag the marker to adjust"
+  },
+  "boardLeaderboard": {
+    "empty": "No activity yet for this period.",
+    "period": {
+      "week": "Week",
+      "month": "Month",
+      "year": "Year",
+      "all": "All Time"
+    },
+    "columns": {
+      "climber": "Climber",
+      "sends": "Sends",
+      "flashes": "Flashes",
+      "hardest": "Hardest"
+    }
+  },
+  "boardHeatmap": {
+    "loading": "Loading heatmap...",
+    "legend": {
+      "low": "Low ({{value}})",
+      "mid": "Mid ({{value}})",
+      "high": "High ({{value}})"
+    }
+  },
+  "boardConfigSelects": {
+    "board": "Board",
+    "layout": "Layout",
+    "size": "Size",
+    "holdSets": "Hold Sets",
+    "angle": "Angle"
+  },
+  "boardFilterStrip": {
+    "all": "All",
+    "allBoards": "All Boards"
+  },
+  "boardSwitchConfirm": {
+    "session": {
+      "title": "Leave your session?",
+      "body": "You're in a session on {{lockedLabel}}. Switching to {{targetLabel}} disconnects your board but keeps the session running."
+    },
+    "connection": {
+      "title": "Disconnect your board?",
+      "body": "Your {{lockedLabel}} is still connected. Switching to {{targetLabel}} disconnects it."
+    },
+    "stay": "Stay",
+    "switch": "Switch boards"
+  },
+  "boardSearchDrawer": {
+    "title": "Find a board",
+    "searchPlaceholder": "Search boards by name or location",
+    "clear": "Clear",
+    "radiusInfo": "Showing boards within {{radiusKm}} km of map center",
+    "empty": "No boards in this area. Pan or zoom out to find more.",
+    "emptyWithQuery": "No boards match \"{{query}}\" here. Try zooming out or searching elsewhere.",
+    "open": "Open"
+  },
+  "boardSearchMap": {
+    "myLocation": "My location"
+  },
+  "zoomableBoard": {
+    "reset": "Reset"
+  },
+  "zoomHint": {
+    "pinchToZoom": "Pinch to zoom"
+  },
+  "gymMemberManagement": {
+    "removeConfirm": "Remove this member from the gym?",
+    "empty": "No members yet",
+    "unknownUser": "Unknown User",
+    "loadMore": "Load more ({{count}} of {{total}})",
+    "snackbar": {
+      "removed": "Member removed",
+      "removeFailed": "Failed to remove member"
+    }
+  },
+  "gymSelector": {
+    "loading": "Loading gyms...",
+    "linkToGym": "Link to a gym",
+    "noGym": "No gym",
+    "createNew": "Create new"
   },
   "selectorDrawer": {
     "customTitle": "Custom Board",

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -226,13 +226,32 @@
         "nameRequired": "Please enter a playlist name",
         "nameTooLong": "Name too long",
         "descriptionTooLong": "Description too long"
+      },
+      "auth": {
+        "title": "Sign in to create playlists",
+        "description": "Sign in to organize your climbs into custom playlists."
+      },
+      "popover": {
+        "title": "Add to Playlist",
+        "empty": "No playlists yet",
+        "createFirst": "Create Your First Playlist",
+        "createNew": "Create New Playlist",
+        "signInBlurb": "Sign in to create and manage playlists"
+      },
+      "create": {
+        "nameLabel": "Playlist Name",
+        "namePlaceholder": "e.g., Hard Crimps",
+        "descriptionLabel": "Description (optional)",
+        "descriptionPlaceholder": "Optional description...",
+        "colorLabel": "Color (optional)",
+        "submit": "Create"
       }
     },
     "tick": {
       "drawer": {
-        "signInRequired": "Sign In Required",
-        "selectBoard": "Select Board",
-        "logAscent": "Log Ascent",
+        "signInRequired": "Sign in required",
+        "selectBoard": "Select board",
+        "logAscent": "Log ascent",
         "signInToRecord": "Sign in to record ticks",
         "createAccountBlurb": "Create a Boardsesh account to log your climbs and track your progress.",
         "signIn": "Sign In",
@@ -241,7 +260,8 @@
         "alwaysOpenInApp": "Always open in app",
         "authModalTitle": "Sign in to record ticks",
         "authModalDescription": "Create an account to log your climbs and track your progress.",
-        "mirroredTooltip": "Click the tag to toggle whether you completed this climb on the mirrored side"
+        "mirroredTooltip": "Click the tag to toggle whether you completed this climb on the mirrored side",
+        "whichBoard": "Which board did you climb on?"
       }
     },
     "navigation": {
@@ -278,6 +298,62 @@
       }
     }
   },
+  "card": {
+    "title": {
+      "noClimbSelected": "No climb selected",
+      "project": "project",
+      "projectAtAngle": "project @ {{angle}}°",
+      "draftBy": "Draft by {{name}}",
+      "by": "By {{name}}",
+      "byWithSends": "By {{name}} - {{sends}}"
+    },
+    "list": {
+      "moreActions": "More actions",
+      "tickError": "Couldn't save your tick — it's saved as a draft"
+    },
+    "detailHeader": {
+      "project": "project",
+      "unknownSetter": "Unknown setter"
+    }
+  },
+  "detail": {
+    "sections": {
+      "beta": "Beta",
+      "logbook": "Your Logbook",
+      "logbookEmpty": "No ascents",
+      "crewLogbook": "Crew Logbook",
+      "crewLogbookSummary": "See your crew's sends",
+      "community": "Community",
+      "communitySummary": "Votes, comments, proposals",
+      "analytics": "Analytics",
+      "analyticsSummary": "Ascents, quality trends"
+    }
+  },
+  "multiboardList": {
+    "noClimbsFound": "No climbs found",
+    "popular": "Popular",
+    "new": "New",
+    "count_one": "{{count}} climb",
+    "count_other": "{{count}} climbs"
+  },
+  "tick": {
+    "controls": {
+      "selectGrade": "Select logged grade",
+      "userByline": "user",
+      "starsLabel": "stars",
+      "triesLabel": "tries",
+      "starRating": "Star rating",
+      "noRating": "No rating",
+      "gradeOverride": "Grade override",
+      "clearGradeOverride": "Clear grade override",
+      "attemptCount": "Attempt count"
+    },
+    "bar": {
+      "logAscent": "Log ascent",
+      "logAttempt": "Log attempt",
+      "cancel": "Cancel"
+    }
+  },
   "liked": {
     "heroTitle": "Liked Climbs",
     "heroSubtitle": "Your favorite climbs",
@@ -289,6 +365,144 @@
     "noClimbsToAdd": "No climbs to add",
     "addedToQueue_one": "Added {{count}} climb to queue",
     "addedToQueue_other": "Added {{count}} climbs to queue",
-    "addToQueueFailed": "Failed to add climbs to queue"
+    "addToQueueFailed": "Failed to add climbs to queue",
+    "loadFailed": "Failed to load liked climbs",
+    "emptyState": "No liked climbs yet. Heart some climbs to see them here!"
+  },
+  "moonboard": {
+    "invalidLayout": "Invalid MoonBoard layout"
+  },
+  "createClimbForm": {
+    "draftBadge": "Draft",
+    "namePlaceholder": "Climb name",
+    "descriptionPlaceholder": "Add beta or notes about your climb...",
+    "openDrafts": "Open drafts",
+    "processing": "Processing...",
+    "importFromScreenshot": "Import from screenshot",
+    "bulkImport": "Bulk import",
+    "dismiss": "Dismiss",
+    "alerts": {
+      "importFailed": "Import Failed: {{error}}",
+      "importWarnings": "Import Warnings:",
+      "checkingMoonBoardDuplicate": "Checking whether this MoonBoard climb already exists..."
+    },
+    "clear": {
+      "title": "Clear climb",
+      "description": "This will clear all holds and reset the form. Are you sure?",
+      "confirm": "Clear",
+      "tooltip": "Clear all holds"
+    },
+    "settings": {
+      "tooltip": "Climb settings",
+      "title": "Climb Settings"
+    },
+    "fields": {
+      "name": "Name",
+      "holds": "Holds",
+      "angle": "Angle",
+      "grade": "Grade",
+      "gradeNone": "None",
+      "benchmark": "Benchmark",
+      "description": "Description (optional)"
+    },
+    "holds": {
+      "starting": "Starting",
+      "start": "Start",
+      "hand": "Hand",
+      "finish": "Finish",
+      "total": "Total"
+    },
+    "validation": {
+      "needsStartFinish": "A valid climb needs at least 1 start hold and 1 finish hold"
+    }
+  },
+  "draftsDrawer": {
+    "title": "Drafts",
+    "count_one": "{{count}} draft",
+    "count_other": "{{count}} drafts",
+    "loadError": "Couldn't load your drafts. Try again.",
+    "empty": {
+      "title": "No drafts yet",
+      "subtitle": "Save a climb as a draft to pick it up later."
+    }
+  },
+  "holdTypePicker": {
+    "toolbarAriaLabel": "Hold type",
+    "clear": "Clear",
+    "states": {
+      "starting": "Start",
+      "hand": "Mid",
+      "finish": "Finish",
+      "foot": "Foot"
+    }
+  },
+  "directionPicker": {
+    "down": "Down"
+  },
+  "holdClassification": {
+    "drawerTitle": "Hold Classification",
+    "classifyHoldTitle": "Classify Hold",
+    "loadingHolds": "Loading holds...",
+    "emptyState": "No holds found for this board configuration.",
+    "progress": "Hold {{current}} of {{total}} ({{classified}} classified)",
+    "complete": {
+      "title": "Classification Complete!",
+      "subtitle": "You've classified {{classified}} of {{total}} holds. You can run through this wizard again anytime to update your ratings."
+    },
+    "fields": {
+      "holdType": "Hold Type",
+      "handRating": "Hand Rating (1-5)",
+      "footRating": "Foot Rating (1-5)",
+      "pullDirection": "Direction of Pull"
+    },
+    "hints": {
+      "handRating": "5 = Easy to grip, 1 = Very difficult",
+      "footRating": "5 = Easy to stand on, 1 = Very difficult",
+      "pullDirection": "Click or drag to set the best pulling direction"
+    },
+    "actions": {
+      "previous": "Previous",
+      "skip": "Skip",
+      "finish": "Finish"
+    },
+    "toast": {
+      "saveFailed": "Failed to save classification"
+    }
+  },
+  "moonboardImport": {
+    "card": {
+      "skipping": "Skipping",
+      "duplicate": "Skipping: Already Exists",
+      "duplicateNamed": "Skipping: Already Exists as \"{{name}}\"",
+      "removeAction": "Remove",
+      "removeDescription": "This climb will not be imported."
+    },
+    "bulk": {
+      "title": "Import MoonBoard Climbs - {{layoutName}} @ {{angle}}°",
+      "loginRequired": "Please log in to save climbs",
+      "loginRequiredTitle": "Login Required",
+      "loginRequiredBody": "Please log in to save climbs to the database.",
+      "logIn": "Log in",
+      "uploadPrompt": "Click or drag screenshot files to this area",
+      "uploadHelp": "Support for MoonBoard app screenshots. Drop multiple files to bulk import.",
+      "processing": "Processing Screenshots...",
+      "checkingDuplicates": "Checking imported climbs against existing MoonBoard problems...",
+      "reviewBeforeSaving": "Review the climbs below. You can edit or remove any before saving.",
+      "saveAll": "Save All ({{count}})",
+      "clearAndRestart": "Clear & Start Over",
+      "contributeImages": "Contribute images to improve OCR accuracy",
+      "tryAgain": "Try Again",
+      "saveFailed": "Failed to save climbs. Please try again."
+    }
+  },
+  "moonboardEditModal": {
+    "title": "Edit Climb",
+    "nameLabel": "Climb Name",
+    "nameRequired": "Please enter a name",
+    "save": "Save Changes",
+    "setter": "Setter: {{setter}}",
+    "grade": "Grade: {{grade}}",
+    "angle": "Angle: {{angle}}°",
+    "unknown": "Unknown"
   }
 }

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -11,5 +11,165 @@
     "sessions": "Sessions",
     "proposals": "Proposals",
     "comments": "Comments"
+  },
+  "activityFeed": {
+    "signInPrompt": "Sign in to see a personalized feed from climbers you follow."
+  },
+  "ascentsFeed": {
+    "attempts": "{{count}} attempts",
+    "deleteAscent": {
+      "title": "Delete ascent",
+      "description": "Are you sure? This cannot be undone."
+    },
+    "mirrored": "Mirrored",
+    "benchmark": "Benchmark",
+    "setBy": "Set by {{name}}",
+    "empty": "No ascents logged yet"
+  },
+  "betaVideos": {
+    "shareBetaFor": "Share beta for {{name}}",
+    "shareBetaVideo": "Share beta video",
+    "shareBeta": "Share beta",
+    "dialogHelper": "Paste a reel or post link so others can see your beta.",
+    "addedToast": "Video added to beta",
+    "addError": "Couldn't add video. Try again.",
+    "urlPlaceholder": "Instagram or TikTok URL",
+    "urlLabel": "Beta video URL",
+    "urlLabelForClimb": "Beta video URL for {{name}}",
+    "defaultHelper": "Paste a public Instagram reel/post or TikTok URL so others can see your beta.",
+    "cancel": "Cancel",
+    "unableToLoad": "Unable to load video",
+    "viewLink": "View",
+    "videoTitle": "Beta video",
+    "videoTitleByUser": "Beta video by {{name}}",
+    "modalTitle": "Beta Video",
+    "modalTitleByUser": "Beta by @{{name}}",
+    "viewOnInstagram": "View on Instagram",
+    "showLess": "Show less",
+    "showMore_one": "Show 1 more video",
+    "showMore_other": "Show {{count}} more videos",
+    "noVideosAvailable": "No beta videos available",
+    "angleSuffix": "{{angle}}°",
+    "unknownUser": "unknown"
+  },
+  "commentFeed": {
+    "empty": "No comments yet",
+    "commentedOn": "commented on {{entity}}"
+  },
+  "emptyStates": {
+    "followClimbers": "Follow some climbers to fill this up",
+    "findClimbers": "Find Climbers",
+    "noRecentActivity": "No recent activity yet"
+  },
+  "errors": {
+    "loadFeed": "Failed to load activity feed. Please try again.",
+    "loadActivity": "Failed to load activity feed",
+    "loadComments": "Failed to load comments. Please try again.",
+    "loadProposals": "Failed to load proposals. Please try again."
+  },
+  "feedCommentButton": {
+    "commentsTitle": "Comments"
+  },
+  "feedItemComment": {
+    "commented": "commented"
+  },
+  "feedItemNewClimb": {
+    "createdClimb": "created a new climb"
+  },
+  "followerCount": {
+    "followingLabel": "following"
+  },
+  "freezeDialog": {
+    "reasonLabel": "Reason (optional)",
+    "reasonPlaceholder": "Why freeze/unfreeze this climb?"
+  },
+  "freezeIndicator": {
+    "frozen": "This climb is frozen from receiving new proposals.",
+    "reasonPrefix": "Reason: {{reason}}"
+  },
+  "newClimbFeed": {
+    "title": "New Climbs",
+    "errorLoad": "Failed to load climbs. Please try again.",
+    "empty": "No climbs yet for this layout. Be the first to set one!"
+  },
+  "proposalCard": {
+    "quotedReason": "“{{reason}}”",
+    "support": "Support",
+    "oppose": "Oppose",
+    "approve": "Approve",
+    "reject": "Reject",
+    "deleteProposal": "Delete Proposal",
+    "deleteDialog": {
+      "title": "Delete Accepted Proposal",
+      "description": "This will revert the effects of this proposal (e.g., grade change, benchmark/classic status) and permanently delete it. This action cannot be undone."
+    }
+  },
+  "proposalFeed": {
+    "empty": "No proposals yet"
+  },
+  "proposalSection": {
+    "title": "Community Proposals",
+    "noOpen": "No open proposals"
+  },
+  "proposalVoteBar": {
+    "approved": "Approved",
+    "rejected": "Rejected",
+    "votesNeeded": "{{current}} / {{required}} votes needed",
+    "opposed": "{{count}} opposed"
+  },
+  "search": {
+    "minCharsHint": "Type at least 2 characters to search",
+    "noBoards": "No boards found for \"{{query}}\"",
+    "noGyms": "No gyms found for \"{{query}}\"",
+    "noPlaylists": "No playlists found for \"{{query}}\"",
+    "noUsers": "No users or setters found for \"{{query}}\"",
+    "climbCountOne": "{{count}} climb",
+    "climbCountMany": "{{count}} climbs"
+  },
+  "sessionFeedCard": {
+    "climbCountOne": "{{count}} climb",
+    "climbCountMany": "{{count}} climbs"
+  },
+  "sessionSummary": {
+    "completed": "Session completed"
+  },
+  "socialFeedItem": {
+    "climbed": "climbed"
+  },
+  "subscribeButton": {
+    "signInPrompt": "Please sign in to manage subscriptions",
+    "subscribed": "Subscribed to new climbs",
+    "unsubscribed": "Unsubscribed from new climbs",
+    "updateFailed": "Couldn't update subscription"
+  },
+  "userDrawer": {
+    "signIn": "Sign in",
+    "signInModalTitle": "Sign in to Boardsesh",
+    "signInModalDescription": "Sign in to save favorites, log ascents, and more.",
+    "changeBoard": "Change board",
+    "devUrl": "Dev URL",
+    "development": "Development",
+    "classifyHolds": "Classify holds",
+    "myPlaylists": "My playlists",
+    "recentSessions": "Recent sessions",
+    "help": "Help",
+    "about": "About",
+    "rateBoardsesh": "Rate Boardsesh",
+    "reportBug": "Report a bug",
+    "logout": "Log out"
+  },
+  "userSearch": {
+    "ascentsThisMonth": "{{count}} ascents this month",
+    "climbsSetOne": "{{count}} climb set",
+    "climbsSetMany": "{{count}} climbs set",
+    "climbCountOne": "{{count}} climb",
+    "climbCountMany": "{{count}} climbs"
+  },
+  "userSmartCard": {
+    "followerOne": "{{count}} follower",
+    "followerMany": "{{count}} followers",
+    "following": "{{count}} following",
+    "distinctClimbOne": "{{count}} distinct climb",
+    "distinctClimbMany": "{{count}} distinct climbs"
   }
 }

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -186,5 +186,19 @@
       "addedPartial": "Added {{added}} climbs. {{failed}} slots couldn't be filled.",
       "failed": "Failed to generate playlist. No suitable climbs found."
     }
+  },
+  "bottomTabBar": {
+    "home": "Home",
+    "climb": "Climb",
+    "discover": "Discover",
+    "feed": "Feed",
+    "create": "Create",
+    "you": "You",
+    "youSignInTitle": "Sign in to see your progress",
+    "youSignInDescription": "Sign in to track your climbing stats, sessions, and logbook.",
+    "selectBoardForPlaylist": "Select a board before creating a playlist",
+    "boardDetailsMissing": "Unable to determine board details for playlist creation",
+    "createdPlaylistToast": "Created playlist \"{{name}}\"",
+    "createPlaylistFailed": "Failed to create playlist"
   }
 }

--- a/packages/web/i18n/locales/en-US/profile.json
+++ b/packages/web/i18n/locales/en-US/profile.json
@@ -70,7 +70,136 @@
     "noClimbingData": "No climbing data for this period"
   },
   "filter": {
-    "pageTitle": "Statistics"
+    "pageTitle": "Statistics",
+    "drawer": {
+      "title": "Filters",
+      "board": "Board",
+      "timeRange": "Time Range",
+      "from": "From",
+      "to": "To"
+    }
+  },
+  "analytics": {
+    "noData": "No analytics data available yet. Data is collected during sync.",
+    "ascentsOverTime": "Ascents Over Time",
+    "qualityOverTime": "Quality Over Time"
+  },
+  "logbook": {
+    "section": {
+      "noAscentsLogged": "No ascents logged for this climb"
+    },
+    "crew": {
+      "signInPrompt": "Sign in to see your crew's logbook for this climb",
+      "loadError": "Couldn't load your crew's logbook. Try again in a bit.",
+      "noneYet": "None of your crew have logged this climb yet"
+    },
+    "entry": {
+      "mirroredTag": "Mirrored",
+      "attemptsLabel": "Attempts: {{count}}"
+    },
+    "form": {
+      "ascent": "Ascent",
+      "attempt": "Attempt",
+      "boulder": "Boulder",
+      "dateAndTime": "Date and Time",
+      "angle": "Angle",
+      "attempts": "Attempts",
+      "quality": "Quality",
+      "difficulty": "Difficulty",
+      "notes": "Notes",
+      "video": "Video",
+      "videoPlaceholder": "Instagram or TikTok URL",
+      "videoHelper": "Paste an Instagram or TikTok link so others can see your beta. (Optional)",
+      "mirrored": "Mirrored",
+      "submit": "Submit",
+      "cancel": "Cancel"
+    },
+    "feed": {
+      "deleteSwipeLabel": "Delete",
+      "cancelEditing": "Cancel editing",
+      "saveEdit": "Save",
+      "moreActions": "More actions",
+      "editLog": "Edit log",
+      "deleteLog": "Delete log",
+      "postToInstagram": "Post to Instagram",
+      "linkInstagramPost": "Link Instagram post",
+      "stars": "stars",
+      "user": "user",
+      "grade": "grade",
+      "tries": "tries",
+      "selectGrade": "Select logged grade",
+      "status": {
+        "flash": "Flash",
+        "send": "Send",
+        "attempt": "Attempt"
+      },
+      "snackbar": {
+        "boardsLinkMissing": "Couldn't find the linked board — showing all your entries.",
+        "deleteFailed": "Failed to delete tick",
+        "tickDeleted": "Tick deleted",
+        "undo": "Undo"
+      }
+    },
+    "search": {
+      "placeholder": "Search climbs or notes",
+      "openFilters": "Open filters",
+      "search": "Search",
+      "gradeRange": "Grade Range",
+      "sort": "Sort",
+      "clearAll": "Clear All",
+      "filterCount_one": "active filter",
+      "filterCount_other": "active filters",
+      "resultType": {
+        "includeSends": "Include Sends",
+        "includeAttempts": "Include Attempts",
+        "flashOnly": "Flash Only",
+        "benchmarkOnly": "Benchmark Only"
+      },
+      "dateAngle": {
+        "dateRange": "Date Range",
+        "startDate": "Start date",
+        "endDate": "End date",
+        "wallAngleRange": "Wall angle range ({{min}}°–{{max}}°)"
+      },
+      "sortFields": {
+        "date": "Date",
+        "climbName": "Climb name",
+        "loggedGrade": "Logged Grade",
+        "consensusGrade": "Consensus Grade",
+        "attemptCount": "Attempts"
+      },
+      "sortDirection": {
+        "desc": "Desc"
+      }
+    },
+    "instagram": {
+      "back": "Back",
+      "title": "Post to Instagram",
+      "subtitle": "Share your ascent and link it back here.",
+      "betaLoadFailed": "Couldn't load beta videos.",
+      "retry": "Retry",
+      "steps": {
+        "copy": "Copy the caption and open Instagram.",
+        "paste": "Paste the caption when creating your post.",
+        "comeBack": "Once your post is live, come back here.",
+        "pasteLink": "Paste the Instagram link so we can display your ascent video here."
+      },
+      "addLinkSubmit": "Add Instagram link",
+      "shareYourBeta": "Share your beta video",
+      "shareYourBetaBody": "We'll copy the caption, open Instagram, and let you paste the final link back into Boardsesh.",
+      "howItWorks": "How It Works",
+      "caption": "Caption",
+      "copyAndOpen": "Copy & Open Instagram",
+      "pasteLinkTitle": "Paste your Instagram link",
+      "pasteLinkBody": "When your post is live, paste the reel or post link here so Boardsesh can show your ascent video.",
+      "pasteLinkHelper": "Paste the live Instagram reel or post URL.",
+      "existingBetaVideos": "Existing Beta Videos",
+      "snackbar": {
+        "copyFailed": "Couldn't copy caption. Try again.",
+        "openFailed": "Couldn't open Instagram. Open it manually and paste the copied caption.",
+        "copied": "Caption copied. Instagram should open next."
+      }
+    }
   },
   "setter": {
     "notFoundTitle": "Setter Not Found",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -205,6 +205,26 @@
   },
   "queueBar": {
     "cancelReconnectConfirm": "Cancelling will leave the session. Is that what you want?",
+    "shellMessage": "No climb selected",
+    "startSesh": "Start sesh",
+    "linkCopied": "Link copied!",
+    "shareFailed": "Failed to share",
+    "leaveFailed": "Unable to leave session. Please try again.",
+    "cancelReconnect": "Cancel",
+    "tickError": "Couldn't save your tick. Give it another go.",
+    "tickCommentPlaceholder": "Comment...",
+    "tickCommentAria": "Tick comment",
+    "tickAttemptLabel": "attempt",
+    "reconnect": {
+      "connectionError": "Connection error – retrying…",
+      "reconnecting": "Reconnecting…"
+    },
+    "tickBar": {
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "collapseAria": "Collapse tick bar",
+      "expandAria": "Expand tick bar"
+    },
     "ariaLabels": {
       "leaveSession": "Leave session",
       "keepReconnecting": "Keep reconnecting",
@@ -219,10 +239,45 @@
     "title": "Queue",
     "clearTitle": "Clear queue",
     "clearDescription": "Are you sure you want to clear all items from the queue?",
-    "clearConfirm": "Clear"
+    "clearConfirm": "Clear",
+    "clear": "Clear",
+    "removeItems_one": "Remove {{count}} item",
+    "removeItems_other": "Remove {{count}} items"
   },
   "queueList": {
     "editClimb": "Edit this climb",
-    "addedViaBluetooth": "Added via Bluetooth"
+    "addedViaBluetooth": "Added via Bluetooth",
+    "suggestionsHeader": "Suggestions",
+    "endMessage": "That's all for now"
+  },
+  "queueProvider": {
+    "offlineLimitReached": "You've hit the offline queue limit. Reconnect to sync your climbs."
+  },
+  "playView": {
+    "yourAscents_one": "Your Ascent ({{count}})",
+    "yourAscents_other": "Your Ascents ({{count}})",
+    "triesCount_one": "{{count}} try",
+    "triesCount_other": "{{count}} tries",
+    "tickError": "Couldn't save your tick — it's saved as a draft",
+    "closeAria": "Close",
+    "noClimbSelected": "No climb selected",
+    "browseClimbs": "Browse Climbs",
+    "actionBar": {
+      "climbActionsAria": "Climb actions",
+      "openQueueAria": "Open queue"
+    },
+    "tickFab": {
+      "logAscentAria": "Log ascent"
+    },
+    "tickBar": {
+      "commentPlaceholder": "Comment...",
+      "commentAria": "Tick comment",
+      "closeAria": "Close tick bar",
+      "collapseAria": "Collapse tick bar",
+      "expandAria": "Expand tick bar",
+      "attemptLabel": "attempt",
+      "logAttemptAria": "Log attempt",
+      "saveTickAria": "Save tick"
+    }
   }
 }

--- a/packages/web/i18n/locales/en-US/settings.json
+++ b/packages/web/i18n/locales/en-US/settings.json
@@ -267,5 +267,93 @@
     "saving": "Saving to Apple Health…",
     "saved": "Saved to Apple Health",
     "retry": "Save to Apple Health (retry)"
+  },
+  "feedbackDialog": {
+    "titleRating": "Rate Boardsesh",
+    "titleBug": "Report a bug",
+    "submitRating": "Send",
+    "submitBug": "Send bug report",
+    "successRating": "Thanks — logged.",
+    "successBug": "Bug logged — thanks.",
+    "errorRating": "Couldn't send — we'll keep your feedback.",
+    "closeAria": "Close"
+  },
+  "feedbackForm": {
+    "missingHeading": "What's missing?",
+    "compactPlaceholder": "Tell us what would help",
+    "skip": "Skip",
+    "sendAria": "Send",
+    "cancel": "Cancel",
+    "saveDefault": "Save",
+    "bugPlaceholder": "What were you doing? What did you expect vs see?",
+    "ratingPlaceholder": "What's on your mind?",
+    "remainingChars": "{{count}} more characters to go",
+    "nextAria": "Next"
+  },
+  "feedbackBanner": {
+    "successToast": "Thanks — logged.",
+    "errorToast": "Couldn't send — we'll keep your rating.",
+    "dismissAria": "Dismiss"
+  },
+  "shakeToReport": {
+    "disabledToast": "Shake to report off. Tap your avatar up top to send feedback.",
+    "dontShowAgain": "Don't show this again"
+  },
+  "storeReview": {
+    "title": "Help others find Boardsesh",
+    "body": "Thanks for the rating. Would you also leave a quick review on your app store? It's the single best thing you can do to help other climbers find us.",
+    "notNow": "Not now",
+    "leaveReview": "Leave a review"
+  },
+  "sessionProvider": {
+    "deepLinkError": "Sign-in with Google, Apple, or Facebook may not work. Try restarting the app."
+  },
+  "onboarding": {
+    "skipTour": "Skip tour",
+    "finish": "Finish",
+    "next": "Next",
+    "stepProgress": "{{current}} of {{total}}"
+  },
+  "devUrlDialog": {
+    "title": "Dev URL",
+    "intro": "Point the WebView at a different origin. The app will restart after saving.",
+    "urlLabel": "Server URL",
+    "useProduction": "Use production",
+    "currentlyOverriding": "Currently overriding to: {{url}}",
+    "cancel": "Cancel",
+    "clearOverride": "Clear override",
+    "save": "Save & restart",
+    "restarting": "Restarting…",
+    "validation": {
+      "enterUrl": "Enter a URL",
+      "mustBeHttp": "URL must start with http:// or https://",
+      "invalid": "Not a valid URL",
+      "generic": "Something went wrong"
+    }
+  },
+  "boardConfigMismatch": {
+    "title": "Board configuration doesn't match",
+    "intro": "Our records show this board has a different config than you have configured.",
+    "currentLabel": "<strong>You're configured for:</strong>",
+    "recordedLabel": "<strong>Recorded for this controller:</strong>",
+    "cancel": "Cancel",
+    "connectAnyway": "Connect anyway",
+    "switchToCorrect": "Switch to correct config"
+  },
+  "devicePicker": {
+    "title": "Select your board",
+    "scanning": "Scanning for boards nearby…",
+    "lastConnected": "Last connected board",
+    "unknownDevice": "Unknown device",
+    "lastConnectedAt": "Last connected {{time}}",
+    "cancel": "Cancel"
+  },
+  "bluetoothMismatch": {
+    "switchNoAngleToast": "Couldn't switch — open a climb at a specific angle first.",
+    "switchUrlFailedToast": "Couldn't switch to that board's config. Try Connect anyway."
+  },
+  "auroraImport": {
+    "unlinkSuccessToast": "Account unlinked successfully",
+    "uploadAriaLabel": "Upload Aurora JSON export file"
   }
 }

--- a/packages/web/i18n/locales/es/auth.json
+++ b/packages/web/i18n/locales/es/auth.json
@@ -104,5 +104,9 @@
   "modal": {
     "title": "Inicia sesión para guardar tu progreso",
     "description": "Tu bitácora, playlists y seguidos se quedan con tu cuenta."
+  },
+  "nativeStart": {
+    "invalidProvider": "Proveedor de inicio de sesión no válido",
+    "signingIn": "Iniciando sesión..."
   }
 }

--- a/packages/web/i18n/locales/es/boards.json
+++ b/packages/web/i18n/locales/es/boards.json
@@ -79,7 +79,137 @@
       "createdNamed": "¡Tablero \"{{name}}\" creado!",
       "namePlaceholder": "p. ej., Tablero de casa, Nombre del gimnasio",
       "locationPlaceholder": "p. ej., Ciudad, Nombre del gimnasio"
+    },
+    "fields": {
+      "name": "Nombre del tablero",
+      "slug": "URL personalizada",
+      "description": "Descripción",
+      "location": "Ubicación",
+      "serialNumber": "Número de serie del controlador",
+      "defaultAngle": "Ángulo por defecto",
+      "angleAdjustable": "Ángulo ajustable",
+      "isPublic": "Tablero público",
+      "unlisted": "No listado",
+      "hideLocation": "Ocultar de tableros cercanos",
+      "isOwned": "Soy dueño de este tablero",
+      "layout": "Disposición",
+      "size": "Tamaño",
+      "holdSets": "Conjuntos de presas"
+    },
+    "placeholders": {
+      "description": "Descripción opcional",
+      "serialNumber": "p. ej. ABC-12345"
+    },
+    "helperText": {
+      "unlisted": "Oculto de los resultados de búsqueda pero accesible por enlace directo",
+      "hideLocation": "Oculto de las búsquedas de tableros cercanos a menos que sigas al buscador"
+    },
+    "alerts": {
+      "configEditable": "Puedes cambiar la disposición del tablero porque aún no se han registrado bloques."
     }
+  },
+  "editBoard": {
+    "title": "Editar tablero",
+    "submitLabel": "Guardar cambios",
+    "snackbar": {
+      "updated": "¡Tablero actualizado!",
+      "updateFailed": "Error al actualizar el tablero"
+    }
+  },
+  "editGym": {
+    "title": "Editar gimnasio",
+    "submitLabel": "Guardar cambios",
+    "snackbar": {
+      "updated": "¡Gimnasio actualizado!",
+      "updateFailed": "Error al actualizar el gimnasio"
+    }
+  },
+  "mapLocationPicker": {
+    "locationDisplay": "Ubicación: {{lat}}, {{lng}}",
+    "setOnMap": "Marca la ubicación en el mapa",
+    "searchPlaceholder": "Busca una dirección o ciudad...",
+    "myLocation": "Mi ubicación",
+    "helpText": "Haz clic en el mapa para fijar la ubicación del tablero, o arrastra el marcador para ajustar"
+  },
+  "boardLeaderboard": {
+    "empty": "Aún no hay actividad en este periodo.",
+    "period": {
+      "week": "Semana",
+      "month": "Mes",
+      "year": "Año",
+      "all": "Todo el tiempo"
+    },
+    "columns": {
+      "climber": "Escalador",
+      "sends": "Encadenes",
+      "flashes": "Flashes",
+      "hardest": "Más difícil"
+    }
+  },
+  "boardHeatmap": {
+    "loading": "Cargando mapa de calor...",
+    "legend": {
+      "low": "Bajo ({{value}})",
+      "mid": "Medio ({{value}})",
+      "high": "Alto ({{value}})"
+    }
+  },
+  "boardConfigSelects": {
+    "board": "Tablero",
+    "layout": "Disposición",
+    "size": "Tamaño",
+    "holdSets": "Conjuntos de presas",
+    "angle": "Ángulo"
+  },
+  "boardFilterStrip": {
+    "all": "Todos",
+    "allBoards": "Todos los tableros"
+  },
+  "boardSwitchConfirm": {
+    "session": {
+      "title": "¿Salir de tu sesión?",
+      "body": "Estás en una sesión en {{lockedLabel}}. Cambiar a {{targetLabel}} desconecta tu tablero pero mantiene la sesión activa."
+    },
+    "connection": {
+      "title": "¿Desconectar tu tablero?",
+      "body": "Tu {{lockedLabel}} sigue conectado. Cambiar a {{targetLabel}} lo desconecta."
+    },
+    "stay": "Quedarse",
+    "switch": "Cambiar de tablero"
+  },
+  "boardSearchDrawer": {
+    "title": "Buscar un tablero",
+    "searchPlaceholder": "Busca tableros por nombre o ubicación",
+    "clear": "Limpiar",
+    "radiusInfo": "Mostrando tableros en un radio de {{radiusKm}} km del centro del mapa",
+    "empty": "No hay tableros en esta zona. Mueve el mapa o aleja el zoom para encontrar más.",
+    "emptyWithQuery": "No hay tableros que coincidan con \"{{query}}\" aquí. Aleja el zoom o busca en otra zona.",
+    "open": "Abrir"
+  },
+  "boardSearchMap": {
+    "myLocation": "Mi ubicación"
+  },
+  "zoomableBoard": {
+    "reset": "Restablecer"
+  },
+  "zoomHint": {
+    "pinchToZoom": "Pellizca para hacer zoom"
+  },
+  "gymMemberManagement": {
+    "removeConfirm": "¿Quitar a este miembro del gimnasio?",
+    "empty": "Aún no hay miembros",
+    "unknownUser": "Usuario desconocido",
+    "loadMore": "Ver más ({{count}} de {{total}})",
+    "snackbar": {
+      "removed": "Miembro eliminado",
+      "removeFailed": "Error al eliminar miembro"
+    }
+  },
+  "gymSelector": {
+    "loading": "Cargando gimnasios...",
+    "linkToGym": "Vincular a un gimnasio",
+    "noGym": "Sin gimnasio",
+    "createNew": "Crear nuevo"
   },
   "selectorDrawer": {
     "customTitle": "Tablero personalizado",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -221,11 +221,30 @@
         "nameRequired": "Introduce un nombre para la playlist",
         "nameTooLong": "Nombre demasiado largo",
         "descriptionTooLong": "Descripción demasiado larga"
+      },
+      "auth": {
+        "title": "Inicia sesión para crear playlists",
+        "description": "Inicia sesión para organizar tus bloques en playlists personalizadas."
+      },
+      "popover": {
+        "title": "Añadir a la playlist",
+        "empty": "Aún no hay playlists",
+        "createFirst": "Crea tu primera playlist",
+        "createNew": "Crear nueva playlist",
+        "signInBlurb": "Inicia sesión para crear y gestionar playlists"
+      },
+      "create": {
+        "nameLabel": "Nombre de la playlist",
+        "namePlaceholder": "p. ej., Regletas duras",
+        "descriptionLabel": "Descripción (opcional)",
+        "descriptionPlaceholder": "Descripción opcional...",
+        "colorLabel": "Color (opcional)",
+        "submit": "Crear"
       }
     },
     "tick": {
       "drawer": {
-        "signInRequired": "Iniciar sesión requerido",
+        "signInRequired": "Inicia sesión",
         "selectBoard": "Selecciona una tabla",
         "logAscent": "Registrar encadene",
         "signInToRecord": "Inicia sesión para registrar marcas",
@@ -236,7 +255,8 @@
         "alwaysOpenInApp": "Abrir siempre en la app",
         "authModalTitle": "Inicia sesión para registrar marcas",
         "authModalDescription": "Crea una cuenta para registrar tus bloques y seguir tu progreso.",
-        "mirroredTooltip": "Pulsa la etiqueta para indicar si completaste este bloque en el lado espejo."
+        "mirroredTooltip": "Pulsa la etiqueta para indicar si completaste este bloque en el lado espejo.",
+        "whichBoard": "¿En qué tabla escalaste?"
       }
     },
     "navigation": {
@@ -273,6 +293,62 @@
       }
     }
   },
+  "card": {
+    "title": {
+      "noClimbSelected": "Ningún bloque seleccionado",
+      "project": "proyecto",
+      "projectAtAngle": "proyecto @ {{angle}}°",
+      "draftBy": "Borrador de {{name}}",
+      "by": "Por {{name}}",
+      "byWithSends": "Por {{name}} - {{sends}}"
+    },
+    "list": {
+      "moreActions": "Más acciones",
+      "tickError": "No se pudo guardar tu marca — se guardó como borrador"
+    },
+    "detailHeader": {
+      "project": "proyecto",
+      "unknownSetter": "Aperturista desconocido"
+    }
+  },
+  "detail": {
+    "sections": {
+      "beta": "Beta",
+      "logbook": "Tu bitácora",
+      "logbookEmpty": "Sin encadenes",
+      "crewLogbook": "Bitácora del crew",
+      "crewLogbookSummary": "Mira los encadenes de tu crew",
+      "community": "Comunidad",
+      "communitySummary": "Votos, comentarios, propuestas",
+      "analytics": "Analíticas",
+      "analyticsSummary": "Encadenes, tendencias de calidad"
+    }
+  },
+  "multiboardList": {
+    "noClimbsFound": "No se encontraron bloques",
+    "popular": "Popular",
+    "new": "Nuevos",
+    "count_one": "{{count}} bloque",
+    "count_other": "{{count}} bloques"
+  },
+  "tick": {
+    "controls": {
+      "selectGrade": "Selecciona el grado registrado",
+      "userByline": "usuario",
+      "starsLabel": "estrellas",
+      "triesLabel": "intentos",
+      "starRating": "Valoración con estrellas",
+      "noRating": "Sin valoración",
+      "gradeOverride": "Grado personalizado",
+      "clearGradeOverride": "Borrar grado personalizado",
+      "attemptCount": "Número de intentos"
+    },
+    "bar": {
+      "logAscent": "Registrar encadene",
+      "logAttempt": "Registrar intento",
+      "cancel": "Cancelar"
+    }
+  },
   "liked": {
     "heroTitle": "Bloques favoritos",
     "heroSubtitle": "Tus bloques favoritos",
@@ -284,6 +360,144 @@
     "noClimbsToAdd": "No hay bloques que añadir",
     "addedToQueue_one": "Se añadió {{count}} bloque a la cola",
     "addedToQueue_other": "Se añadieron {{count}} bloques a la cola",
-    "addToQueueFailed": "Error al añadir los bloques a la cola"
+    "addToQueueFailed": "Error al añadir los bloques a la cola",
+    "loadFailed": "Error al cargar los bloques favoritos",
+    "emptyState": "Aún no tienes bloques favoritos. Marca algunos con el corazón para verlos aquí."
+  },
+  "moonboard": {
+    "invalidLayout": "Layout de MoonBoard no válido"
+  },
+  "createClimbForm": {
+    "draftBadge": "Borrador",
+    "namePlaceholder": "Nombre del bloque",
+    "descriptionPlaceholder": "Añade beta o notas sobre tu bloque...",
+    "openDrafts": "Abrir borradores",
+    "processing": "Procesando...",
+    "importFromScreenshot": "Importar desde captura",
+    "bulkImport": "Importación masiva",
+    "dismiss": "Descartar",
+    "alerts": {
+      "importFailed": "Importación fallida: {{error}}",
+      "importWarnings": "Avisos de importación:",
+      "checkingMoonBoardDuplicate": "Comprobando si este bloque de MoonBoard ya existe..."
+    },
+    "clear": {
+      "title": "Limpiar bloque",
+      "description": "Esto borrará todas las presas y reiniciará el formulario. ¿Seguro?",
+      "confirm": "Limpiar",
+      "tooltip": "Limpiar todas las presas"
+    },
+    "settings": {
+      "tooltip": "Ajustes del bloque",
+      "title": "Ajustes del bloque"
+    },
+    "fields": {
+      "name": "Nombre",
+      "holds": "Presas",
+      "angle": "Ángulo",
+      "grade": "Grado",
+      "gradeNone": "Ninguno",
+      "benchmark": "Benchmark",
+      "description": "Descripción (opcional)"
+    },
+    "holds": {
+      "starting": "Salida",
+      "start": "Salida",
+      "hand": "Mano",
+      "finish": "Final",
+      "total": "Total"
+    },
+    "validation": {
+      "needsStartFinish": "Un bloque válido necesita al menos 1 presa de salida y 1 de final"
+    }
+  },
+  "draftsDrawer": {
+    "title": "Borradores",
+    "count_one": "{{count}} borrador",
+    "count_other": "{{count}} borradores",
+    "loadError": "No se pudieron cargar tus borradores. Inténtalo de nuevo.",
+    "empty": {
+      "title": "Aún no hay borradores",
+      "subtitle": "Guarda un bloque como borrador para retomarlo más tarde."
+    }
+  },
+  "holdTypePicker": {
+    "toolbarAriaLabel": "Tipo de presa",
+    "clear": "Borrar",
+    "states": {
+      "starting": "Salida",
+      "hand": "Media",
+      "finish": "Final",
+      "foot": "Pie"
+    }
+  },
+  "directionPicker": {
+    "down": "Abajo"
+  },
+  "holdClassification": {
+    "drawerTitle": "Clasificación de presas",
+    "classifyHoldTitle": "Clasificar presa",
+    "loadingHolds": "Cargando presas...",
+    "emptyState": "No se encontraron presas para esta configuración de tabla.",
+    "progress": "Presa {{current}} de {{total}} ({{classified}} clasificadas)",
+    "complete": {
+      "title": "¡Clasificación completa!",
+      "subtitle": "Has clasificado {{classified}} de {{total}} presas. Puedes volver a pasar por este asistente cuando quieras para actualizar tus valoraciones."
+    },
+    "fields": {
+      "holdType": "Tipo de presa",
+      "handRating": "Valoración de mano (1-5)",
+      "footRating": "Valoración de pie (1-5)",
+      "pullDirection": "Dirección de tracción"
+    },
+    "hints": {
+      "handRating": "5 = Fácil de agarrar, 1 = Muy difícil",
+      "footRating": "5 = Fácil de pisar, 1 = Muy difícil",
+      "pullDirection": "Toca o arrastra para fijar la mejor dirección de tracción"
+    },
+    "actions": {
+      "previous": "Anterior",
+      "skip": "Saltar",
+      "finish": "Terminar"
+    },
+    "toast": {
+      "saveFailed": "No se pudo guardar la clasificación"
+    }
+  },
+  "moonboardImport": {
+    "card": {
+      "skipping": "Omitiendo",
+      "duplicate": "Omitiendo: ya existe",
+      "duplicateNamed": "Omitiendo: ya existe como \"{{name}}\"",
+      "removeAction": "Quitar",
+      "removeDescription": "Este bloque no se importará."
+    },
+    "bulk": {
+      "title": "Importar bloques de MoonBoard - {{layoutName}} @ {{angle}}°",
+      "loginRequired": "Inicia sesión para guardar bloques",
+      "loginRequiredTitle": "Inicio de sesión requerido",
+      "loginRequiredBody": "Inicia sesión para guardar bloques en la base de datos.",
+      "logIn": "Iniciar sesión",
+      "uploadPrompt": "Toca o arrastra capturas de pantalla a esta zona",
+      "uploadHelp": "Compatible con capturas de la app de MoonBoard. Suelta varios archivos para importar en lote.",
+      "processing": "Procesando capturas...",
+      "checkingDuplicates": "Comprobando los bloques importados con problemas de MoonBoard existentes...",
+      "reviewBeforeSaving": "Revisa los bloques de abajo. Puedes editar o quitar cualquiera antes de guardar.",
+      "saveAll": "Guardar todos ({{count}})",
+      "clearAndRestart": "Limpiar y empezar de nuevo",
+      "contributeImages": "Contribuir con imágenes para mejorar la precisión del OCR",
+      "tryAgain": "Reintentar",
+      "saveFailed": "No se pudieron guardar los bloques. Inténtalo de nuevo."
+    }
+  },
+  "moonboardEditModal": {
+    "title": "Editar bloque",
+    "nameLabel": "Nombre del bloque",
+    "nameRequired": "Introduce un nombre",
+    "save": "Guardar cambios",
+    "setter": "Aperturista: {{setter}}",
+    "grade": "Grado: {{grade}}",
+    "angle": "Ángulo: {{angle}}°",
+    "unknown": "Desconocido"
   }
 }

--- a/packages/web/i18n/locales/es/feed.json
+++ b/packages/web/i18n/locales/es/feed.json
@@ -11,5 +11,165 @@
     "sessions": "Sesiones",
     "proposals": "Propuestas",
     "comments": "Comentarios"
+  },
+  "activityFeed": {
+    "signInPrompt": "Inicia sesión para ver un feed de los escaladores que sigues."
+  },
+  "ascentsFeed": {
+    "attempts": "{{count}} intentos",
+    "deleteAscent": {
+      "title": "Eliminar ascenso",
+      "description": "¿Seguro? No se puede deshacer."
+    },
+    "mirrored": "Espejo",
+    "benchmark": "Referencia",
+    "setBy": "Por {{name}}",
+    "empty": "Aún no hay ascensos"
+  },
+  "betaVideos": {
+    "shareBetaFor": "Comparte beta para {{name}}",
+    "shareBetaVideo": "Comparte un vídeo de beta",
+    "shareBeta": "Compartir beta",
+    "dialogHelper": "Pega un enlace de reel o post para que otros vean tu beta.",
+    "addedToast": "Vídeo añadido al beta",
+    "addError": "No se pudo añadir el vídeo. Inténtalo de nuevo.",
+    "urlPlaceholder": "URL de Instagram o TikTok",
+    "urlLabel": "URL del vídeo de beta",
+    "urlLabelForClimb": "URL del vídeo de beta para {{name}}",
+    "defaultHelper": "Pega una URL pública de Instagram (reel/post) o TikTok para que otros vean tu beta.",
+    "cancel": "Cancelar",
+    "unableToLoad": "No se pudo cargar el vídeo",
+    "viewLink": "Ver",
+    "videoTitle": "Vídeo de beta",
+    "videoTitleByUser": "Vídeo de beta por {{name}}",
+    "modalTitle": "Vídeo de beta",
+    "modalTitleByUser": "Beta de @{{name}}",
+    "viewOnInstagram": "Ver en Instagram",
+    "showLess": "Ver menos",
+    "showMore_one": "Ver 1 vídeo más",
+    "showMore_other": "Ver {{count}} vídeos más",
+    "noVideosAvailable": "No hay vídeos de beta disponibles",
+    "angleSuffix": "{{angle}}°",
+    "unknownUser": "desconocido"
+  },
+  "commentFeed": {
+    "empty": "Sin comentarios todavía",
+    "commentedOn": "comentó en {{entity}}"
+  },
+  "emptyStates": {
+    "followClimbers": "Sigue a algunos escaladores para llenar esto",
+    "findClimbers": "Buscar escaladores",
+    "noRecentActivity": "Sin actividad reciente"
+  },
+  "errors": {
+    "loadFeed": "No se pudo cargar la actividad. Inténtalo de nuevo.",
+    "loadActivity": "No se pudo cargar la actividad",
+    "loadComments": "No se pudieron cargar los comentarios. Inténtalo de nuevo.",
+    "loadProposals": "No se pudieron cargar las propuestas. Inténtalo de nuevo."
+  },
+  "feedCommentButton": {
+    "commentsTitle": "Comentarios"
+  },
+  "feedItemComment": {
+    "commented": "comentó"
+  },
+  "feedItemNewClimb": {
+    "createdClimb": "creó un nuevo bloque"
+  },
+  "followerCount": {
+    "followingLabel": "siguiendo"
+  },
+  "freezeDialog": {
+    "reasonLabel": "Motivo (opcional)",
+    "reasonPlaceholder": "¿Por qué congelar/descongelar este bloque?"
+  },
+  "freezeIndicator": {
+    "frozen": "Este bloque está congelado y no acepta nuevas propuestas.",
+    "reasonPrefix": "Motivo: {{reason}}"
+  },
+  "newClimbFeed": {
+    "title": "Nuevos bloques",
+    "errorLoad": "No se pudieron cargar los bloques. Inténtalo de nuevo.",
+    "empty": "Aún no hay bloques en este layout. ¡Sé el primero!"
+  },
+  "proposalCard": {
+    "quotedReason": "“{{reason}}”",
+    "support": "Apoyar",
+    "oppose": "Oponerse",
+    "approve": "Aprobar",
+    "reject": "Rechazar",
+    "deleteProposal": "Eliminar propuesta",
+    "deleteDialog": {
+      "title": "Eliminar propuesta aceptada",
+      "description": "Esto revertirá los efectos de esta propuesta (p. ej., cambio de grado, estado de referencia/clásico) y la eliminará permanentemente. No se puede deshacer."
+    }
+  },
+  "proposalFeed": {
+    "empty": "Sin propuestas todavía"
+  },
+  "proposalSection": {
+    "title": "Propuestas de la comunidad",
+    "noOpen": "No hay propuestas abiertas"
+  },
+  "proposalVoteBar": {
+    "approved": "Aprobada",
+    "rejected": "Rechazada",
+    "votesNeeded": "{{current}} / {{required}} votos necesarios",
+    "opposed": "{{count}} en contra"
+  },
+  "search": {
+    "minCharsHint": "Escribe al menos 2 caracteres para buscar",
+    "noBoards": "No hay tablas para \"{{query}}\"",
+    "noGyms": "No hay gimnasios para \"{{query}}\"",
+    "noPlaylists": "No hay listas para \"{{query}}\"",
+    "noUsers": "No hay usuarios ni setters para \"{{query}}\"",
+    "climbCountOne": "{{count}} bloque",
+    "climbCountMany": "{{count}} bloques"
+  },
+  "sessionFeedCard": {
+    "climbCountOne": "{{count}} bloque",
+    "climbCountMany": "{{count}} bloques"
+  },
+  "sessionSummary": {
+    "completed": "Sesión completada"
+  },
+  "socialFeedItem": {
+    "climbed": "escaló"
+  },
+  "subscribeButton": {
+    "signInPrompt": "Inicia sesión para gestionar las suscripciones",
+    "subscribed": "Suscrito a nuevos bloques",
+    "unsubscribed": "Suscripción cancelada",
+    "updateFailed": "No se pudo actualizar la suscripción"
+  },
+  "userDrawer": {
+    "signIn": "Iniciar sesión",
+    "signInModalTitle": "Inicia sesión en Boardsesh",
+    "signInModalDescription": "Inicia sesión para guardar favoritos, registrar ascensos y más.",
+    "changeBoard": "Cambiar tabla",
+    "devUrl": "URL de dev",
+    "development": "Desarrollo",
+    "classifyHolds": "Clasificar presas",
+    "myPlaylists": "Mis listas",
+    "recentSessions": "Sesiones recientes",
+    "help": "Ayuda",
+    "about": "Sobre",
+    "rateBoardsesh": "Valorar Boardsesh",
+    "reportBug": "Reportar un bug",
+    "logout": "Cerrar sesión"
+  },
+  "userSearch": {
+    "ascentsThisMonth": "{{count}} ascensos este mes",
+    "climbsSetOne": "{{count}} bloque creado",
+    "climbsSetMany": "{{count}} bloques creados",
+    "climbCountOne": "{{count}} bloque",
+    "climbCountMany": "{{count}} bloques"
+  },
+  "userSmartCard": {
+    "followerOne": "{{count}} seguidor",
+    "followerMany": "{{count}} seguidores",
+    "following": "{{count}} siguiendo",
+    "distinctClimbOne": "{{count}} bloque distinto",
+    "distinctClimbMany": "{{count}} bloques distintos"
   }
 }

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -186,5 +186,19 @@
       "addedPartial": "Se añadieron {{added}} bloques. No se pudieron rellenar {{failed}} huecos.",
       "failed": "No se pudo generar la playlist. No se encontraron bloques adecuados."
     }
+  },
+  "bottomTabBar": {
+    "home": "Inicio",
+    "climb": "Vías",
+    "discover": "Descubre",
+    "feed": "Actividad",
+    "create": "Crear",
+    "you": "Tú",
+    "youSignInTitle": "Inicia sesión para ver tu progreso",
+    "youSignInDescription": "Inicia sesión para registrar tus estadísticas, sesiones y logbook.",
+    "selectBoardForPlaylist": "Selecciona un tablero antes de crear una playlist",
+    "boardDetailsMissing": "No se pueden determinar los datos del tablero para crear la playlist",
+    "createdPlaylistToast": "Playlist «{{name}}» creada",
+    "createPlaylistFailed": "No se pudo crear la playlist"
   }
 }

--- a/packages/web/i18n/locales/es/profile.json
+++ b/packages/web/i18n/locales/es/profile.json
@@ -70,7 +70,136 @@
     "noClimbingData": "Sin datos de escalada en este periodo"
   },
   "filter": {
-    "pageTitle": "Estadísticas"
+    "pageTitle": "Estadísticas",
+    "drawer": {
+      "title": "Filtros",
+      "board": "Board",
+      "timeRange": "Rango de tiempo",
+      "from": "Desde",
+      "to": "Hasta"
+    }
+  },
+  "analytics": {
+    "noData": "Sin datos analíticos disponibles todavía. Los datos se recopilan durante la sincronización.",
+    "ascentsOverTime": "Ascensos a lo largo del tiempo",
+    "qualityOverTime": "Calidad a lo largo del tiempo"
+  },
+  "logbook": {
+    "section": {
+      "noAscentsLogged": "Sin encadenes registrados para este bloque"
+    },
+    "crew": {
+      "signInPrompt": "Inicia sesión para ver la bitácora de tu crew para este bloque",
+      "loadError": "No se pudo cargar la bitácora de tu crew. Inténtalo de nuevo en un rato.",
+      "noneYet": "Nadie de tu crew ha registrado este bloque todavía"
+    },
+    "entry": {
+      "mirroredTag": "Reflejado",
+      "attemptsLabel": "Intentos: {{count}}"
+    },
+    "form": {
+      "ascent": "Encadene",
+      "attempt": "Intento",
+      "boulder": "Bloque",
+      "dateAndTime": "Fecha y hora",
+      "angle": "Ángulo",
+      "attempts": "Intentos",
+      "quality": "Calidad",
+      "difficulty": "Dificultad",
+      "notes": "Notas",
+      "video": "Vídeo",
+      "videoPlaceholder": "URL de Instagram o TikTok",
+      "videoHelper": "Pega un enlace de Instagram o TikTok para que otros vean tu beta. (Opcional)",
+      "mirrored": "Reflejado",
+      "submit": "Enviar",
+      "cancel": "Cancelar"
+    },
+    "feed": {
+      "deleteSwipeLabel": "Eliminar",
+      "cancelEditing": "Cancelar edición",
+      "saveEdit": "Guardar",
+      "moreActions": "Más acciones",
+      "editLog": "Editar registro",
+      "deleteLog": "Eliminar registro",
+      "postToInstagram": "Publicar en Instagram",
+      "linkInstagramPost": "Vincular publicación de Instagram",
+      "stars": "estrellas",
+      "user": "usuario",
+      "grade": "grado",
+      "tries": "intentos",
+      "selectGrade": "Selecciona el grado registrado",
+      "status": {
+        "flash": "Flash",
+        "send": "Encadene",
+        "attempt": "Intento"
+      },
+      "snackbar": {
+        "boardsLinkMissing": "No se encontró la tabla enlazada — mostrando todas tus entradas.",
+        "deleteFailed": "No se pudo eliminar la marca",
+        "tickDeleted": "Marca eliminada",
+        "undo": "Deshacer"
+      }
+    },
+    "search": {
+      "placeholder": "Busca bloques o notas",
+      "openFilters": "Abrir filtros",
+      "search": "Buscar",
+      "gradeRange": "Rango de grados",
+      "sort": "Ordenar",
+      "clearAll": "Limpiar todo",
+      "filterCount_one": "filtro activo",
+      "filterCount_other": "filtros activos",
+      "resultType": {
+        "includeSends": "Incluir encadenes",
+        "includeAttempts": "Incluir intentos",
+        "flashOnly": "Solo flash",
+        "benchmarkOnly": "Solo benchmark"
+      },
+      "dateAngle": {
+        "dateRange": "Rango de fechas",
+        "startDate": "Fecha de inicio",
+        "endDate": "Fecha de fin",
+        "wallAngleRange": "Rango de ángulo de la pared ({{min}}°–{{max}}°)"
+      },
+      "sortFields": {
+        "date": "Fecha",
+        "climbName": "Nombre del bloque",
+        "loggedGrade": "Grado registrado",
+        "consensusGrade": "Grado consensuado",
+        "attemptCount": "Intentos"
+      },
+      "sortDirection": {
+        "desc": "Desc"
+      }
+    },
+    "instagram": {
+      "back": "Atrás",
+      "title": "Publicar en Instagram",
+      "subtitle": "Comparte tu encadene y vincúlalo aquí.",
+      "betaLoadFailed": "No se pudieron cargar los vídeos de beta.",
+      "retry": "Reintentar",
+      "steps": {
+        "copy": "Copia el pie de foto y abre Instagram.",
+        "paste": "Pega el pie de foto al crear tu publicación.",
+        "comeBack": "Cuando tu publicación esté en vivo, vuelve aquí.",
+        "pasteLink": "Pega el enlace de Instagram para mostrar aquí tu vídeo de encadene."
+      },
+      "addLinkSubmit": "Añadir enlace de Instagram",
+      "shareYourBeta": "Comparte tu vídeo de beta",
+      "shareYourBetaBody": "Copiamos el pie de foto, abrimos Instagram y luego pegas el enlace final en Boardsesh.",
+      "howItWorks": "Cómo funciona",
+      "caption": "Pie de foto",
+      "copyAndOpen": "Copiar y abrir Instagram",
+      "pasteLinkTitle": "Pega tu enlace de Instagram",
+      "pasteLinkBody": "Cuando tu publicación esté en vivo, pega el enlace del reel o post aquí para que Boardsesh muestre tu vídeo de encadene.",
+      "pasteLinkHelper": "Pega la URL del reel o post de Instagram.",
+      "existingBetaVideos": "Vídeos de beta existentes",
+      "snackbar": {
+        "copyFailed": "No se pudo copiar el pie de foto. Inténtalo de nuevo.",
+        "openFailed": "No se pudo abrir Instagram. Ábrelo manualmente y pega el pie de foto copiado.",
+        "copied": "Pie de foto copiado. Instagram debería abrirse a continuación."
+      }
+    }
   },
   "setter": {
     "notFoundTitle": "Aperturista no encontrado",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -205,6 +205,26 @@
   },
   "queueBar": {
     "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
+    "shellMessage": "Sin bloque seleccionado",
+    "startSesh": "Empezar sesh",
+    "linkCopied": "¡Enlace copiado!",
+    "shareFailed": "Error al compartir",
+    "leaveFailed": "No se pudo salir de la sesión. Inténtalo de nuevo.",
+    "cancelReconnect": "Cancelar",
+    "tickError": "No se pudo guardar tu marca. Inténtalo otra vez.",
+    "tickCommentPlaceholder": "Comentario...",
+    "tickCommentAria": "Comentario de marca",
+    "tickAttemptLabel": "intento",
+    "reconnect": {
+      "connectionError": "Error de conexión – reintentando…",
+      "reconnecting": "Reconectando…"
+    },
+    "tickBar": {
+      "collapse": "Contraer",
+      "expand": "Expandir",
+      "collapseAria": "Contraer barra de marca",
+      "expandAria": "Expandir barra de marca"
+    },
     "ariaLabels": {
       "leaveSession": "Salir de la sesión",
       "keepReconnecting": "Seguir reconectando",
@@ -219,10 +239,45 @@
     "title": "Cola",
     "clearTitle": "Vaciar cola",
     "clearDescription": "¿Seguro que quieres vaciar la cola?",
-    "clearConfirm": "Vaciar"
+    "clearConfirm": "Vaciar",
+    "clear": "Vaciar",
+    "removeItems_one": "Eliminar {{count}} elemento",
+    "removeItems_other": "Eliminar {{count}} elementos"
   },
   "queueList": {
     "editClimb": "Editar este bloque",
-    "addedViaBluetooth": "Añadido por Bluetooth"
+    "addedViaBluetooth": "Añadido por Bluetooth",
+    "suggestionsHeader": "Sugerencias",
+    "endMessage": "Eso es todo por ahora"
+  },
+  "queueProvider": {
+    "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
+  },
+  "playView": {
+    "yourAscents_one": "Tu ascenso ({{count}})",
+    "yourAscents_other": "Tus ascensos ({{count}})",
+    "triesCount_one": "{{count}} intento",
+    "triesCount_other": "{{count}} intentos",
+    "tickError": "No se pudo guardar tu marca — guardada como borrador",
+    "closeAria": "Cerrar",
+    "noClimbSelected": "Ningún bloque seleccionado",
+    "browseClimbs": "Ver bloques",
+    "actionBar": {
+      "climbActionsAria": "Acciones del bloque",
+      "openQueueAria": "Abrir cola"
+    },
+    "tickFab": {
+      "logAscentAria": "Registrar ascenso"
+    },
+    "tickBar": {
+      "commentPlaceholder": "Comentario...",
+      "commentAria": "Comentario de marca",
+      "closeAria": "Cerrar barra de marca",
+      "collapseAria": "Contraer barra de marca",
+      "expandAria": "Expandir barra de marca",
+      "attemptLabel": "intento",
+      "logAttemptAria": "Registrar intento",
+      "saveTickAria": "Guardar marca"
+    }
   }
 }

--- a/packages/web/i18n/locales/es/settings.json
+++ b/packages/web/i18n/locales/es/settings.json
@@ -267,5 +267,93 @@
     "saving": "Guardando en Apple Health…",
     "saved": "Guardado en Apple Health",
     "retry": "Guardar en Apple Health (reintentar)"
+  },
+  "feedbackDialog": {
+    "titleRating": "Valora Boardsesh",
+    "titleBug": "Reportar un fallo",
+    "submitRating": "Enviar",
+    "submitBug": "Enviar reporte",
+    "successRating": "Gracias — registrado.",
+    "successBug": "Fallo registrado — gracias.",
+    "errorRating": "No se pudo enviar — guardamos tus comentarios.",
+    "closeAria": "Cerrar"
+  },
+  "feedbackForm": {
+    "missingHeading": "¿Qué falta?",
+    "compactPlaceholder": "Cuéntanos qué te ayudaría",
+    "skip": "Omitir",
+    "sendAria": "Enviar",
+    "cancel": "Cancelar",
+    "saveDefault": "Guardar",
+    "bugPlaceholder": "¿Qué estabas haciendo? ¿Qué esperabas y qué viste?",
+    "ratingPlaceholder": "¿Qué piensas?",
+    "remainingChars": "Faltan {{count}} caracteres",
+    "nextAria": "Siguiente"
+  },
+  "feedbackBanner": {
+    "successToast": "Gracias — registrado.",
+    "errorToast": "No se pudo enviar — guardamos tu valoración.",
+    "dismissAria": "Descartar"
+  },
+  "shakeToReport": {
+    "disabledToast": "Sacudir para reportar desactivado. Toca tu avatar arriba para enviar comentarios.",
+    "dontShowAgain": "No mostrar de nuevo"
+  },
+  "storeReview": {
+    "title": "Ayuda a otros a descubrir Boardsesh",
+    "body": "Gracias por la valoración. ¿Dejarías también una reseña rápida en tu tienda de apps? Es lo mejor que puedes hacer para ayudar a otros escaladores a encontrarnos.",
+    "notNow": "Ahora no",
+    "leaveReview": "Dejar reseña"
+  },
+  "sessionProvider": {
+    "deepLinkError": "El inicio de sesión con Google, Apple o Facebook puede no funcionar. Prueba a reiniciar la app."
+  },
+  "onboarding": {
+    "skipTour": "Saltar tour",
+    "finish": "Finalizar",
+    "next": "Siguiente",
+    "stepProgress": "{{current}} de {{total}}"
+  },
+  "devUrlDialog": {
+    "title": "URL de desarrollo",
+    "intro": "Apunta el WebView a un origen diferente. La app se reiniciará al guardar.",
+    "urlLabel": "URL del servidor",
+    "useProduction": "Usar producción",
+    "currentlyOverriding": "Actualmente apunta a: {{url}}",
+    "cancel": "Cancelar",
+    "clearOverride": "Quitar override",
+    "save": "Guardar y reiniciar",
+    "restarting": "Reiniciando…",
+    "validation": {
+      "enterUrl": "Introduce una URL",
+      "mustBeHttp": "La URL debe empezar por http:// o https://",
+      "invalid": "URL no válida",
+      "generic": "Algo salió mal"
+    }
+  },
+  "boardConfigMismatch": {
+    "title": "La configuración del tablero no coincide",
+    "intro": "Nuestros registros muestran que este tablero tiene una configuración diferente a la que tienes seleccionada.",
+    "currentLabel": "<strong>Tienes configurado:</strong>",
+    "recordedLabel": "<strong>Registrado para este controlador:</strong>",
+    "cancel": "Cancelar",
+    "connectAnyway": "Conectar igualmente",
+    "switchToCorrect": "Cambiar a la configuración correcta"
+  },
+  "devicePicker": {
+    "title": "Selecciona tu tablero",
+    "scanning": "Buscando tableros cercanos…",
+    "lastConnected": "Último tablero conectado",
+    "unknownDevice": "Dispositivo desconocido",
+    "lastConnectedAt": "Conectado por última vez {{time}}",
+    "cancel": "Cancelar"
+  },
+  "bluetoothMismatch": {
+    "switchNoAngleToast": "No se pudo cambiar — abre una vía con un ángulo concreto primero.",
+    "switchUrlFailedToast": "No se pudo cambiar a esa configuración. Prueba Conectar igualmente."
+  },
+  "auroraImport": {
+    "unlinkSuccessToast": "Cuenta desvinculada",
+    "uploadAriaLabel": "Subir archivo JSON exportado de Aurora"
   }
 }


### PR DESCRIPTION
## Summary

- Removes 577 of 619 `i18n-ignore-next-line` markers introduced by the static i18n check (PR #1820), wrapping each site in `t(…)` / `<Trans>` and adding both the EN and ES catalog entries.
- New keys land in `feed` (~73), `profile` (~73), `climbs` (~133), `boards` (~75), `session` (~38), `settings` (~60), `playlists` (~12), and `auth` (~2). All new EN keys have matching ES.
- The remaining 42 markers (15 files) stay ignored with a `-- reason` suffix on each: OG images (brand text), `components/brand/logo.tsx` (brand), `/development/*` (internal tooling), `/docs/*` (API/GraphQL/Swagger reference), and `legal/legal-content.tsx` (contact email).

## Mechanical follow-ups bundled in

- `tick-icon.tsx`: widen `TickButtonWithLabel.label` from a discriminated union to `string` — the prop is already treated as opaque rendered text.
- 40 unit-test files now mock `react-i18next` via the existing `tFromCatalog` helper so EN catalog values resolve at test time and existing English assertions keep working.
- `climbs.json` drawer copy normalised to sentence case to match the rest of the catalog (`Sign In Required` → `Sign in required`, etc.).
- `board-config-mismatch-dialog.test.tsx` mock upgraded to resolve `<Trans i18nKey="…" />` so its `<strong>`-tagged copy renders.

## Test plan

- [x] `vp run check:i18n` — 391 files scanned, 0 violations, 0 stale markers
- [x] `bunx tsc --noEmit` (packages/web) — clean
- [x] `vp test --project web` — 3991/3991 passing
- [x] EN/ES key parity preserved (279 pre-existing `marketing.*` gaps unchanged; no new gaps)
- [ ] Manual smoke at `/` and `/es/` for high-traffic pages (climb detail with comments, logbook, queue, settings, board entity) — recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)