### PR TITLE
i18n: switch manual plural ternaries to i18next plural keys

### DIFF
--- a/packages/web/app/components/activity-feed/session-feed-card.tsx
+++ b/packages/web/app/components/activity-feed/session-feed-card.tsx
@@ -305,9 +305,7 @@ export default function SessionFeedCard({ session }: SessionFeedCardProps) {
                 {boardTypes.map((bt) => bt.charAt(0).toUpperCase() + bt.slice(1)).join(', ')}
               </Typography>
               <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                {tickCount === 1
-                  ? t('sessionFeedCard.climbCountOne', { count: tickCount })
-                  : t('sessionFeedCard.climbCountMany', { count: tickCount })}
+                {t('sessionFeedCard.climbCount', { count: tickCount })}
               </Typography>
             </Box>
           )}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -248,8 +248,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     if (!sessionShareUrl) return;
     await shareWithFallback({
       url: sessionShareUrl,
-      title: 'Join my climbing session',
-      text: 'Jump in and climb with me on Boardsesh',
+      title: t('settings.share.shareTitle'),
+      text: t('settings.share.shareText'),
       trackingEvent: 'Session Shared',
       trackingProps: { sessionId: activeSession?.sessionId ?? '' },
       onClipboardSuccess: () => showMessage(t('queueBar.linkCopied'), 'success'),

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -75,7 +75,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
     },
     ref,
   ) => {
-    const { t } = useTranslation('climbs');
+    const { t } = useTranslation(['climbs', 'session']);
     const currentClimbUuid = useCurrentClimbUuid();
     const { queue, suggestedClimbs } = useQueueList();
     const { hasMoreResults, isFetchingClimbs, isFetchingNextPage } = useSearchData();

--- a/packages/web/app/components/social/comment-list.tsx
+++ b/packages/web/app/components/social/comment-list.tsx
@@ -139,9 +139,7 @@ export default function CommentList({ entityType, entityId, refreshKey = 0, curr
       {totalCount > 0 && (
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
           <MuiTypography variant="caption" color="text.secondary">
-            {totalCount === 1
-              ? t('comment.countOne', { count: totalCount })
-              : t('comment.countMany', { count: totalCount })}
+            {t('comment.count', { count: totalCount })}
           </MuiTypography>
           <ToggleButtonGroup value={sortBy} exclusive onChange={handleSortChange} size="small">
             <ToggleButton value="new" sx={{ textTransform: 'none', px: 1, py: 0.25, fontSize: 12 }}>

--- a/packages/web/app/components/social/playlist-search-results.tsx
+++ b/packages/web/app/components/social/playlist-search-results.tsx
@@ -133,10 +133,7 @@ export default function PlaylistSearchResults({ query, authToken }: PlaylistSear
                 {playlist.name}
               </Typography>
               <Typography variant="body2" color="text.secondary" noWrap>
-                {playlist.creatorName} ·{' '}
-                {playlist.climbCount === 1
-                  ? t('search.climbCountOne', { count: playlist.climbCount })
-                  : t('search.climbCountMany', { count: playlist.climbCount })}
+                {playlist.creatorName} · {t('search.climbCount', { count: playlist.climbCount })}
               </Typography>
             </Box>
             <Chip label={playlist.boardType} size="small" variant="outlined" sx={{ flexShrink: 0 }} />

--- a/packages/web/app/components/social/user-search-results.tsx
+++ b/packages/web/app/components/social/user-search-results.tsx
@@ -140,9 +140,7 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
                       )}
                       {result.setter && (
                         <Typography variant="caption" component="span" color="text.secondary">
-                          {result.setter.climbCount === 1
-                            ? t('userSearch.climbsSetOne', { count: result.setter.climbCount })
-                            : t('userSearch.climbsSetMany', { count: result.setter.climbCount })}
+                          {t('userSearch.climbsSet', { count: result.setter.climbCount })}
                         </Typography>
                       )}
                     </Box>
@@ -184,9 +182,7 @@ export default function UserSearchResults({ query, authToken }: UserSearchResult
                   secondary={
                     <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
                       <Typography variant="caption" component="span" color="text.secondary">
-                        {result.setter.climbCount === 1
-                          ? t('userSearch.climbCountOne', { count: result.setter.climbCount })
-                          : t('userSearch.climbCountMany', { count: result.setter.climbCount })}
+                        {t('userSearch.climbCount', { count: result.setter.climbCount })}
                       </Typography>
                       {result.setter.boardTypes.map((bt) => (
                         <Chip

--- a/packages/web/app/components/social/user-smart-card.tsx
+++ b/packages/web/app/components/social/user-smart-card.tsx
@@ -162,9 +162,7 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
               </div>
 
               <Typography variant="caption" component="span" color="text.secondary">
-                {profile.followerCount === 1
-                  ? t('userSmartCard.followerOne', { count: profile.followerCount })
-                  : t('userSmartCard.followerMany', { count: profile.followerCount })}
+                {t('userSmartCard.follower', { count: profile.followerCount })}
                 {' · '}
                 {t('userSmartCard.following', { count: profile.followingCount })}
               </Typography>
@@ -190,9 +188,7 @@ export default function UserSmartCard({ userId, refreshKey = 0 }: UserSmartCardP
           {gradeBars.length > 0 && (
             <div className={styles.chartSection}>
               <Typography variant="caption" component="span" color="text.secondary" className={styles.chartLabel}>
-                {totalClimbs === 1
-                  ? t('userSmartCard.distinctClimbOne', { count: totalClimbs })
-                  : t('userSmartCard.distinctClimbMany', { count: totalClimbs })}
+                {t('userSmartCard.distinctClimb', { count: totalClimbs })}
               </Typography>
 
               <div className={styles.gradeBarContainer}>

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -116,8 +116,8 @@
     "reply": "Reply",
     "showRepliesOne": "Show 1 reply",
     "showRepliesMany": "Show {{count}} replies",
-    "countOne": "{{count}} comment",
-    "countMany": "{{count}} comments",
+    "count_one": "{{count}} comment",
+    "count_other": "{{count}} comments",
     "sort": {
       "new": "New",
       "top": "Top",

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -123,12 +123,12 @@
     "noGyms": "No gyms found for \"{{query}}\"",
     "noPlaylists": "No playlists found for \"{{query}}\"",
     "noUsers": "No users or setters found for \"{{query}}\"",
-    "climbCountOne": "{{count}} climb",
-    "climbCountMany": "{{count}} climbs"
+    "climbCount_one": "{{count}} climb",
+    "climbCount_other": "{{count}} climbs"
   },
   "sessionFeedCard": {
-    "climbCountOne": "{{count}} climb",
-    "climbCountMany": "{{count}} climbs"
+    "climbCount_one": "{{count}} climb",
+    "climbCount_other": "{{count}} climbs"
   },
   "sessionSummary": {
     "completed": "Session completed"
@@ -160,16 +160,16 @@
   },
   "userSearch": {
     "ascentsThisMonth": "{{count}} ascents this month",
-    "climbsSetOne": "{{count}} climb set",
-    "climbsSetMany": "{{count}} climbs set",
-    "climbCountOne": "{{count}} climb",
-    "climbCountMany": "{{count}} climbs"
+    "climbsSet_one": "{{count}} climb set",
+    "climbsSet_other": "{{count}} climbs set",
+    "climbCount_one": "{{count}} climb",
+    "climbCount_other": "{{count}} climbs"
   },
   "userSmartCard": {
-    "followerOne": "{{count}} follower",
-    "followerMany": "{{count}} followers",
+    "follower_one": "{{count}} follower",
+    "follower_other": "{{count}} followers",
     "following": "{{count}} following",
-    "distinctClimbOne": "{{count}} distinct climb",
-    "distinctClimbMany": "{{count}} distinct climbs"
+    "distinctClimb_one": "{{count}} distinct climb",
+    "distinctClimb_other": "{{count}} distinct climbs"
   }
 }

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -108,8 +108,8 @@
     "reply": "Responder",
     "showRepliesOne": "Mostrar 1 respuesta",
     "showRepliesMany": "Mostrar {{count}} respuestas",
-    "countOne": "{{count}} comentario",
-    "countMany": "{{count}} comentarios",
+    "count_one": "{{count}} comentario",
+    "count_other": "{{count}} comentarios",
     "sort": {
       "new": "Nuevos",
       "top": "Top",

--- a/packages/web/i18n/locales/es/feed.json
+++ b/packages/web/i18n/locales/es/feed.json
@@ -123,12 +123,12 @@
     "noGyms": "No hay gimnasios para \"{{query}}\"",
     "noPlaylists": "No hay listas para \"{{query}}\"",
     "noUsers": "No hay usuarios ni setters para \"{{query}}\"",
-    "climbCountOne": "{{count}} bloque",
-    "climbCountMany": "{{count}} bloques"
+    "climbCount_one": "{{count}} bloque",
+    "climbCount_other": "{{count}} bloques"
   },
   "sessionFeedCard": {
-    "climbCountOne": "{{count}} bloque",
-    "climbCountMany": "{{count}} bloques"
+    "climbCount_one": "{{count}} bloque",
+    "climbCount_other": "{{count}} bloques"
   },
   "sessionSummary": {
     "completed": "Sesión completada"
@@ -160,16 +160,16 @@
   },
   "userSearch": {
     "ascentsThisMonth": "{{count}} ascensos este mes",
-    "climbsSetOne": "{{count}} bloque creado",
-    "climbsSetMany": "{{count}} bloques creados",
-    "climbCountOne": "{{count}} bloque",
-    "climbCountMany": "{{count}} bloques"
+    "climbsSet_one": "{{count}} bloque creado",
+    "climbsSet_other": "{{count}} bloques creados",
+    "climbCount_one": "{{count}} bloque",
+    "climbCount_other": "{{count}} bloques"
   },
   "userSmartCard": {
-    "followerOne": "{{count}} seguidor",
-    "followerMany": "{{count}} seguidores",
+    "follower_one": "{{count}} seguidor",
+    "follower_other": "{{count}} seguidores",
     "following": "{{count}} siguiendo",
-    "distinctClimbOne": "{{count}} bloque distinto",
-    "distinctClimbMany": "{{count}} bloques distintos"
+    "distinctClimb_one": "{{count}} bloque distinto",
+    "distinctClimb_other": "{{count}} bloques distintos"
   }
 }


### PR DESCRIPTION
## Summary

- Convert 7 hand-rolled `count === 1 ? t('keyOne') : t('keyMany')` ternaries to a single `t('key', { count })` call, and rename the corresponding catalog entries from `*One`/`*Many` to `*_one`/`*_other` so i18next's CLDR plural rules apply (the binary form silently breaks for Slavic, Arabic, etc.). Pattern matches the pre-existing `addedToQueue_one`/`addedToQueue_other` keys.
- Replace two hardcoded share strings in `queue-control-bar.tsx` (`'Join my climbing session'` / `'Jump in and climb with me on Boardsesh'`) with the existing `t('settings.share.shareTitle')` / `t('settings.share.shareText')` keys from `session.json`. The component already calls `useTranslation('session')`, so no catalog edits were needed.
- Declare `session` explicitly in `queue-list.tsx`'s `useTranslation` (`useTranslation(['climbs', 'session'])`) so the existing `t('session:queueList.*')` calls don't rely on another component preloading the namespace higher in the tree.

## Files changed

Component call sites:
- `packages/web/app/components/activity-feed/session-feed-card.tsx`
- `packages/web/app/components/social/comment-list.tsx`
- `packages/web/app/components/social/playlist-search-results.tsx`
- `packages/web/app/components/social/user-search-results.tsx`
- `packages/web/app/components/social/user-smart-card.tsx`
- `packages/web/app/components/queue-control/queue-control-bar.tsx`
- `packages/web/app/components/queue-control/queue-list.tsx`

Catalog renames (`*One`/`*Many` → `*_one`/`*_other`):
- `packages/web/i18n/locales/en-US/feed.json` — `search.climbCount`, `sessionFeedCard.climbCount`, `userSearch.climbsSet`, `userSearch.climbCount`, `userSmartCard.follower`, `userSmartCard.distinctClimb`
- `packages/web/i18n/locales/en-US/common.json` — `comment.count`
- `packages/web/i18n/locales/es/feed.json` — same keys
- `packages/web/i18n/locales/es/common.json` — `comment.count`

Out of scope: unrelated `*One`/`*Many` keys (e.g. `comment.showRepliesOne`/`showRepliesMany`) — leaving those for a follow-up.

## Test plan

- [x] `vp run check:i18n` passes (no hardcoded user-facing strings)
- [x] `vp lint` — 0 errors
- [x] `vp run typecheck:web` — 0 errors
- [x] `vp fmt --check` on changed files — clean
- [ ] Manual smoke (en-US and `/es/`):
  - [ ] Activity feed card: 1 climb / 5 climbs ↔ 1 bloque / 5 bloques
  - [ ] Comment list header: 1 comment / 2 comments ↔ 1 comentario / 2 comentarios
  - [ ] User search & playlist search results: climb-count and "climbs set" counters render with correct singular/plural
  - [ ] User smart card: follower count and distinct-climb count render correctly
  - [ ] Party session share button: system share sheet shows translated title/text
  - [ ] Queue list with suggestions: `Suggestions` header and `That's all for now` end message render via `session:` namespace


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbcZB9di8u2cpwJGA7wCGx)_