### PR TITLE
i18n: add French (fr) locale + dropdown language picker

### DIFF
--- a/packages/web/app/__tests__/i18n-catalog-completeness.test.ts
+++ b/packages/web/app/__tests__/i18n-catalog-completeness.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_LOCALE } from '@/app/lib/i18n/config';
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'i18n', 'locales');
+
+// Locales we ship and own end-to-end. Community-maintained locales (e.g. `es`)
+// are intentionally allowed to have gaps — i18next falls back to English. New
+// owned locales must stay at full parity so a missing key surfaces here, not
+// in production as silently-English copy.
+const STRICTLY_ENFORCED_LOCALES = ['fr'] as const;
+
+type Catalog = Record<string, unknown>;
+
+function loadCatalog(locale: string, namespace: string): Catalog {
+  return JSON.parse(readFileSync(join(LOCALES_DIR, locale, namespace), 'utf8'));
+}
+
+function collectKeys(node: unknown, prefix = ''): string[] {
+  if (node === null || typeof node !== 'object') {
+    return [prefix];
+  }
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(node)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    keys.push(...collectKeys(value, next));
+  }
+  return keys;
+}
+
+const namespaces = readdirSync(join(LOCALES_DIR, DEFAULT_LOCALE)).filter((file) => file.endsWith('.json'));
+
+describe('i18n catalog completeness', () => {
+  for (const locale of STRICTLY_ENFORCED_LOCALES) {
+    describe(locale, () => {
+      it.each(namespaces)('%s ships the same key set as en-US', (namespace) => {
+        const expected = new Set(collectKeys(loadCatalog(DEFAULT_LOCALE, namespace)));
+        const actual = new Set(collectKeys(loadCatalog(locale, namespace)));
+        const missing = [...expected].filter((key) => !actual.has(key));
+        const extra = [...actual].filter((key) => !expected.has(key));
+        expect({ namespace, missing, extra }).toEqual({ namespace, missing: [], extra: [] });
+      });
+    });
+  }
+});

--- a/packages/web/app/__tests__/page-seo-metadata.test.ts
+++ b/packages/web/app/__tests__/page-seo-metadata.test.ts
@@ -49,9 +49,10 @@ describe('page metadata exports', () => {
 
     expect(aboutMetadata.title).toBe('About | Boardsesh');
     expect(aboutMetadata.alternates?.canonical).toBe('/about');
-    expect(aboutMetadata.alternates?.languages).toMatchObject({
+    expect(aboutMetadata.alternates?.languages).toEqual({
       'en-US': '/about',
       es: '/es/about',
+      fr: '/fr/about',
       'x-default': '/about',
     });
     expect(aboutMetadata.openGraph?.url).toBe('/about');

--- a/packages/web/app/components/i18n/compact-language-switcher.tsx
+++ b/packages/web/app/components/i18n/compact-language-switcher.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import React, { Suspense } from 'react';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import React, { Suspense, useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import {
   DEFAULT_LOCALE,
   LOCALE_COOKIE,
@@ -19,51 +23,73 @@ import { localeHref, stripLocalePrefix } from '@/app/lib/i18n/locale-href';
 const FLAGS: Record<Locale, string> = {
   'en-US': '🇺🇸',
   es: '🇪🇸',
+  fr: '🇫🇷',
 };
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
 const flagSx = { fontSize: 20, lineHeight: 1 };
-
-function nextLocaleAfter(current: Locale): Locale {
-  const idx = SUPPORTED_LOCALES.indexOf(current);
-  return SUPPORTED_LOCALES[(idx + 1) % SUPPORTED_LOCALES.length];
-}
+const menuFlagSx = { fontSize: 18, lineHeight: 1, minWidth: 24 };
 
 type LabelProps = {
   ariaLabel: string;
   flag: string;
 };
 
-function CompactLanguageSwitcherInner({
-  ariaLabelTemplate,
-  switchToTemplate,
-}: {
-  ariaLabelTemplate: (label: string) => string;
-  switchToTemplate: (label: string) => string;
-}) {
-  const router = useRouter();
+function CompactLanguageSwitcherInner({ ariaLabelTemplate }: { ariaLabelTemplate: (label: string) => string }) {
   const pathname = usePathname() ?? '/';
   const searchParams = useSearchParams();
   const { i18n } = useTranslation('common');
   const current: Locale = isSupportedLocale(i18n.language) ? i18n.language : DEFAULT_LOCALE;
-  const next = nextLocaleAfter(current);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = anchorEl !== null;
 
-  const handleClick = () => {
+  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = (next: Locale) => {
+    handleClose();
+    if (next === current) {
+      return;
+    }
     document.cookie = `${LOCALE_COOKIE}=${next}; path=/; max-age=${ONE_YEAR_SECONDS}; samesite=lax`;
-    void i18n.changeLanguage(next);
     const basePath = stripLocalePrefix(pathname, current);
     const target = localeHref(basePath, next);
     const query = searchParams?.toString();
-    router.push(query ? `${target}?${query}` : target);
+    window.location.assign(query ? `${target}?${query}` : target);
   };
 
   return (
-    <Tooltip title={switchToTemplate(LOCALE_LABELS[next])}>
-      <IconButton onClick={handleClick} aria-label={ariaLabelTemplate(LOCALE_LABELS[current])} size="small">
-        <Box component="span" sx={flagSx} aria-hidden>
-          {FLAGS[current]}
-        </Box>
-      </IconButton>
-    </Tooltip>
+    <>
+      <Tooltip title={LOCALE_LABELS[current]}>
+        <IconButton
+          onClick={handleOpen}
+          aria-label={ariaLabelTemplate(LOCALE_LABELS[current])}
+          aria-haspopup="menu"
+          aria-expanded={open ? true : undefined}
+          size="small"
+        >
+          <Box component="span" sx={flagSx} aria-hidden>
+            {FLAGS[current]}
+          </Box>
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {SUPPORTED_LOCALES.map((locale) => (
+          <MenuItem key={locale} selected={locale === current} onClick={() => handleSelect(locale)}>
+            <ListItemIcon>
+              <Box component="span" sx={menuFlagSx} aria-hidden>
+                {FLAGS[locale]}
+              </Box>
+            </ListItemIcon>
+            <ListItemText>{LOCALE_LABELS[locale]}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
   );
 }
 
@@ -78,15 +104,9 @@ function CompactLanguageSwitcherFallback({ ariaLabel, flag }: LabelProps) {
 }
 
 export default function CompactLanguageSwitcher() {
-  // Resolve translations at the parent so the Suspense fallback (which can't
-  // call hooks during the suspended render) still announces in the user's
-  // active language. The fallback shows for ~one tick while useSearchParams
-  // resolves; resolved labels prevent screen readers from reading English
-  // chrome on a Spanish page.
   const { i18n, t } = useTranslation('common');
   const fallbackLocale: Locale = isSupportedLocale(i18n.language) ? i18n.language : DEFAULT_LOCALE;
   const ariaLabelTemplate = (label: string) => t('languageSwitcher.ariaLabelWithCurrent', { language: label });
-  const switchToTemplate = (label: string) => t('languageSwitcher.switchTo', { language: label });
 
   return (
     <Suspense
@@ -97,7 +117,7 @@ export default function CompactLanguageSwitcher() {
         />
       }
     >
-      <CompactLanguageSwitcherInner ariaLabelTemplate={ariaLabelTemplate} switchToTemplate={switchToTemplate} />
+      <CompactLanguageSwitcherInner ariaLabelTemplate={ariaLabelTemplate} />
     </Suspense>
   );
 }

--- a/packages/web/app/components/i18n/language-switcher.tsx
+++ b/packages/web/app/components/i18n/language-switcher.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { Suspense } from 'react';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { type SelectChangeEvent } from '@mui/material/Select';
@@ -16,7 +16,6 @@ import {
 import { localeHref, stripLocalePrefix } from '@/app/lib/i18n/locale-href';
 
 function LanguageSwitcherInner() {
-  const router = useRouter();
   const pathname = usePathname() ?? '/';
   // useSearchParams forces the consumer into a client-rendered Suspense
   // boundary; the wrapper below provides it.
@@ -32,7 +31,7 @@ function LanguageSwitcherInner() {
     const basePath = stripLocalePrefix(pathname, currentLocale);
     const target = localeHref(basePath, next);
     const query = searchParams?.toString();
-    router.push(query ? `${target}?${query}` : target);
+    window.location.assign(query ? `${target}?${query}` : target);
   };
 
   return (

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ['en-US', 'es'] as const;
+export const SUPPORTED_LOCALES = ['en-US', 'es', 'fr'] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = 'en-US';
@@ -6,16 +6,19 @@ export const DEFAULT_LOCALE: Locale = 'en-US';
 export const LOCALE_HTML_LANG: Record<Locale, string> = {
   'en-US': 'en',
   es: 'es',
+  fr: 'fr',
 };
 
 export const LOCALE_OG: Record<Locale, string> = {
   'en-US': 'en_US',
   es: 'es_ES',
+  fr: 'fr_FR',
 };
 
 export const LOCALE_LABELS: Record<Locale, string> = {
   'en-US': 'English',
   es: 'Español',
+  fr: 'Français',
 };
 
 export const DEFAULT_NAMESPACE = 'common';

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -1,12 +1,12 @@
 {
   "languageSwitcher": {
     "ariaLabel": "Language",
-    "ariaLabelWithCurrent": "Language: {{language}}",
-    "switchTo": "Switch to {{language}}"
+    "ariaLabelWithCurrent": "Language: {{language}}"
   },
   "languages": {
     "en-US": "English",
-    "es": "Español"
+    "es": "Español",
+    "fr": "Français"
   },
   "lightControl": {
     "title": "Lights",

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -1,12 +1,12 @@
 {
   "languageSwitcher": {
     "ariaLabel": "Idioma",
-    "ariaLabelWithCurrent": "Idioma: {{language}}",
-    "switchTo": "Cambiar a {{language}}"
+    "ariaLabelWithCurrent": "Idioma: {{language}}"
   },
   "languages": {
     "en-US": "English",
-    "es": "Español"
+    "es": "Español",
+    "fr": "Français"
   },
   "actions": {
     "yes": "Sí",

--- a/packages/web/i18n/locales/fr/admin.json
+++ b/packages/web/i18n/locales/fr/admin.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "admin": {
+      "title": "Panneau d'administration",
+      "description": "Panneau d'administration Boardsesh"
+    }
+  },
+  "title": "Panneau d'administration",
+  "auth": {
+    "signInRequired": "Veuillez vous connecter pour accéder au panneau d'administration.",
+    "noAccess": "Vous n'avez pas accès à l'administration."
+  },
+  "tabs": {
+    "roles": "Rôles",
+    "settings": "Paramètres"
+  },
+  "roles": {
+    "heading": "Rôles de la communauté",
+    "grant": "Attribuer un rôle",
+    "table": {
+      "user": "Utilisateur",
+      "role": "Rôle",
+      "board": "Mur",
+      "grantedBy": "Attribué par",
+      "date": "Date",
+      "actions": "Actions"
+    },
+    "labels": {
+      "admin": "Admin",
+      "leader": "Responsable",
+      "global": "Global",
+      "fallbackUserInitial": "U",
+      "fallbackEmpty": "-"
+    },
+    "empty": "Aucun rôle attribué pour le moment",
+    "dialog": {
+      "title": "Attribuer un rôle",
+      "search": {
+        "label": "Rechercher un utilisateur",
+        "placeholder": "Saisissez un nom pour rechercher..."
+      },
+      "fallbackUserInitial": "U",
+      "change": "Modifier",
+      "roleLabel": "Rôle",
+      "boardTypeLabel": "Type de mur (facultatif)",
+      "boardTypeOptions": {
+        "global": "Global (tous les murs)",
+        "kilter": "Kilter",
+        "tension": "Tension"
+      },
+      "roleOptions": {
+        "communityLeader": "Responsable de communauté",
+        "admin": "Admin"
+      },
+      "cancel": "Annuler",
+      "submit": "Attribuer"
+    },
+    "snackbar": {
+      "granted": "Rôle attribué",
+      "grantFailed": "Échec de l'attribution du rôle",
+      "revoked": "Rôle révoqué",
+      "revokeFailed": "Échec de la révocation du rôle"
+    }
+  },
+  "settings": {
+    "heading": "Paramètres de la communauté",
+    "scope": {
+      "label": "Portée",
+      "options": {
+        "global": "Global",
+        "board": "Mur",
+        "climb": "Voie"
+      },
+      "boardTypeLabel": "Type de mur",
+      "boardTypePlaceholder": "kilter, tension",
+      "climbUuidLabel": "UUID de la voie",
+      "climbUuidPlaceholder": "UUID de la voie"
+    },
+    "table": {
+      "setting": "Paramètre",
+      "description": "Description",
+      "value": "Valeur"
+    },
+    "rows": {
+      "approvalThreshold": {
+        "label": "Seuil d'approbation",
+        "description": "Votes pondérés requis pour l'approbation automatique"
+      },
+      "outlierMinAscents": {
+        "label": "Ascensions min. pour valeurs aberrantes",
+        "description": "Ascensions min. pour la détection des valeurs aberrantes"
+      },
+      "outlierGradeDiff": {
+        "label": "Écart de cotation aberrant",
+        "description": "Seuil d'écart de cotation pour valeur aberrante"
+      },
+      "adminVoteWeight": {
+        "label": "Poids du vote admin",
+        "description": "Multiplicateur de poids du vote pour les admins"
+      },
+      "leaderVoteWeight": {
+        "label": "Poids du vote responsable",
+        "description": "Multiplicateur de poids du vote pour les responsables"
+      }
+    },
+    "save": "Tout enregistrer",
+    "saving": "Enregistrement...",
+    "snackbar": {
+      "saved_one": "{{count}} paramètre enregistré",
+      "saved_other": "{{count}} paramètres enregistrés",
+      "saveFailed": "Échec de l'enregistrement des paramètres"
+    }
+  }
+}

--- a/packages/web/i18n/locales/fr/aurora.json
+++ b/packages/web/i18n/locales/fr/aurora.json
@@ -1,0 +1,54 @@
+{
+  "metadata": {
+    "migration": {
+      "title": "Migrer depuis l'ancienne app Kilter",
+      "description": "Migrez vos données du mur Kilter vers Boardsesh après l'arrêt du backend Aurora."
+    }
+  },
+  "migration": {
+    "whatHappened": {
+      "title": "Ce qui s'est passé",
+      "lead": "Le backend Aurora Kilter a disparu. Vos playlists, votre carnet et vos voies en brouillon partent avec lui, sauf si vous les exportez.",
+      "body": "Le 25 mars, l'app du mur Kilter a soudainement disparu, Aurora ayant arrêté son backend Kilter sans préavis. En réaction, Kilter a sorti précipitamment sa propre app, encore en bêta. Le résultat de cette bataille entre les deux entités : c'est le client qui en fait les frais. Pour en savoir plus, lisez :",
+      "articleTitle": "L'app du mur Kilter vient de disparaître sans avertissement. Voici ce qui s'est vraiment passé.",
+      "articleDescription": "Pendant des années, le mur d'entraînement le plus populaire de l'escalade a été en guerre avec son développeur d'app. Maintenant, ce sont les grimpeurs qui en paient le prix.",
+      "articleSource": "climbing.com",
+      "articleAlt": "L'app du mur Kilter vient de disparaître sans avertissement",
+      "ledRisk": "Ce risque lié à un fournisseur unique est devenu évident il y a 2 ans, quand il était impossible d'acheter un kit LED pour vos prises Kilter à cause d'un litige juridique en cours entre Kilter et Aurora.",
+      "boardseshIntroPrefix": "Pour supprimer ce risque, ",
+      "boardseshLink": "Boardsesh",
+      "boardseshIntroSuffix": " a été créé comme alternative open-source à toutes les apps de murs d'escalade. Boardsesh dispose de sa propre copie des bases de données de voies et prendra à terme en charge tous les murs. Il peut facilement être auto-hébergé et proposera une fonction d'export de vos données."
+    },
+    "howToMigrate": {
+      "title": "Comment migrer",
+      "step1": {
+        "title": "Demandez l'export de vos données",
+        "body": "Envoyez un e-mail à Aurora pour demander un export de vos données. Vous recevrez un fichier JSON contenant vos ascensions, tentatives et circuits.",
+        "cta": "Écrire à peter@auroraclimbing.com"
+      },
+      "step2": {
+        "title": "Créez un compte Boardsesh",
+        "signedInAs": "Connecté en tant que {{email}}",
+        "body": "Créez un compte ou connectez-vous afin que nous puissions accueillir vos données quelque part.",
+        "cta": "Se connecter ou créer un compte",
+        "modalTitle": "Connectez-vous pour migrer vos données",
+        "modalDescription": "Créez un compte ou connectez-vous pour importer vos données Aurora."
+      },
+      "step3": {
+        "title": "Importez vos données",
+        "signInFirst": "Connectez-vous d'abord pour importer vos données.",
+        "body": "Le backend Kilter étant hors service, seul l'import JSON est disponible pour Kilter. Pour Tension, lier votre compte synchronisera automatiquement vos données toutes les 12 heures pour que vous ayez toujours une sauvegarde."
+      },
+      "step4": {
+        "title": "Votre profil Boardsesh",
+        "signInFirst": "Connectez-vous d'abord pour voir votre profil."
+      }
+    },
+    "getHelp": {
+      "title": "Obtenir de l'aide",
+      "body": "Boardsesh est open source. Signalez des bugs, demandez des fonctionnalités, ou demandez simplement de l'aide.",
+      "discord": "Discord — Rejoignez-nous pour de l'aide et des discussions",
+      "github": "GitHub — github.com/boardsesh/boardsesh"
+    }
+  }
+}

--- a/packages/web/i18n/locales/fr/auth.json
+++ b/packages/web/i18n/locales/fr/auth.json
@@ -1,0 +1,112 @@
+{
+  "metadata": {
+    "login": {
+      "title": "Connexion",
+      "description": "Connectez-vous ou créez un compte sur Boardsesh"
+    },
+    "error": {
+      "title": "Erreur d'authentification",
+      "description": "Une erreur s'est produite lors de l'authentification"
+    },
+    "verifyRequest": {
+      "title": "Vérifier l'adresse e-mail",
+      "description": "Vérifiez votre adresse e-mail"
+    }
+  },
+  "login": {
+    "header": "Bienvenue",
+    "subtitle": "Connectez-vous ou créez un compte pour continuer",
+    "tabs": {
+      "signIn": "Connexion",
+      "signUp": "Créer un compte"
+    },
+    "fields": {
+      "name": "Nom",
+      "email": "E-mail",
+      "password": "Mot de passe",
+      "confirmPassword": "Confirmer le mot de passe"
+    },
+    "placeholders": {
+      "name": "Votre nom (facultatif)",
+      "email": "votre@email.com",
+      "password": "Mot de passe",
+      "passwordWithMin": "Mot de passe (8 caractères minimum)",
+      "confirmPassword": "Confirmer le mot de passe"
+    },
+    "validation": {
+      "emailRequired": "Veuillez saisir votre e-mail",
+      "emailInvalid": "Veuillez saisir un e-mail valide",
+      "passwordRequired": "Veuillez saisir votre mot de passe",
+      "passwordRequiredCreate": "Veuillez saisir un mot de passe",
+      "passwordTooShort": "Le mot de passe doit comporter au moins 8 caractères",
+      "confirmPasswordRequired": "Veuillez confirmer votre mot de passe",
+      "passwordsMismatch": "Les mots de passe ne correspondent pas",
+      "nameTooLong": "Le nom doit comporter moins de 100 caractères"
+    },
+    "submit": {
+      "signIn": "Connexion",
+      "signUp": "Créer un compte"
+    },
+    "divider": "ou",
+    "providers": {
+      "google": "Continuer avec Google",
+      "apple": "Continuer avec Apple",
+      "facebook": "Continuer avec Facebook"
+    },
+    "toasts": {
+      "invalidCredentials": "E-mail ou mot de passe incorrect",
+      "authFailed": "Échec de l'authentification. Veuillez réessayer.",
+      "loggedIn": "Connexion réussie",
+      "verified": "E-mail vérifié ! Vous pouvez maintenant vous connecter.",
+      "registrationFailed": "Échec de l'inscription",
+      "registrationFailedRetry": "Échec de l'inscription. Veuillez réessayer.",
+      "checkEmail": "Veuillez consulter votre e-mail pour vérifier votre compte",
+      "accountCreated": "Compte créé ! Connexion en cours...",
+      "loginAfterCreate": "Veuillez vous connecter avec votre compte"
+    }
+  },
+  "error": {
+    "header": "Erreur d'authentification",
+    "title": "Erreur d'authentification",
+    "back": "Retour à la connexion",
+    "messages": {
+      "Configuration": "Un problème de configuration du serveur est survenu.",
+      "AccessDenied": "Accès refusé. Vous n'avez pas l'autorisation de vous connecter.",
+      "Verification": "Le lien de vérification a expiré ou est invalide.",
+      "OAuthSignin": "Erreur lors du démarrage du processus de connexion. Veuillez réessayer.",
+      "OAuthCallback": "Erreur lors de la finalisation de la connexion. Veuillez réessayer.",
+      "OAuthCreateAccount": "Impossible de créer un compte avec ce fournisseur.",
+      "EmailCreateAccount": "Impossible de créer un compte par e-mail.",
+      "Callback": "Erreur dans le rappel d'authentification.",
+      "OAuthAccountNotLinked": "Cet e-mail est déjà associé à un autre compte. Veuillez vous connecter avec votre méthode initiale.",
+      "SessionRequired": "Vous devez être connecté pour accéder à cette page.",
+      "default": "Une erreur d'authentification inattendue est survenue."
+    }
+  },
+  "verifyRequest": {
+    "header": "Vérification de l'e-mail",
+    "title": "Consultez votre boîte de réception",
+    "description": "Nous vous avons envoyé un lien de vérification. Cliquez sur le lien dans votre e-mail pour vérifier votre compte.",
+    "resendPlaceholder": "Saisissez votre e-mail pour renvoyer",
+    "resend": "Renvoyer l'e-mail de vérification",
+    "back": "Retour à la connexion",
+    "messages": {
+      "EmailNotVerified": "Veuillez vérifier votre e-mail avant de vous connecter.",
+      "InvalidToken": "Le lien de vérification est invalide. Veuillez en demander un nouveau.",
+      "TokenExpired": "Le lien de vérification a expiré. Veuillez en demander un nouveau.",
+      "TooManyAttempts": "Trop de tentatives de vérification. Veuillez attendre une minute et réessayer."
+    },
+    "toasts": {
+      "sent": "E-mail de vérification envoyé ! Consultez votre boîte de réception.",
+      "failed": "Échec de l'envoi de l'e-mail de vérification"
+    }
+  },
+  "modal": {
+    "title": "Connectez-vous pour conserver votre progression",
+    "description": "Votre carnet, vos playlists et vos abonnements restent associés à votre compte."
+  },
+  "nativeStart": {
+    "invalidProvider": "Fournisseur de connexion invalide",
+    "signingIn": "Connexion en cours..."
+  }
+}

--- a/packages/web/i18n/locales/fr/boards.json
+++ b/packages/web/i18n/locales/fr/boards.json
@@ -1,0 +1,287 @@
+{
+  "discovery": {
+    "section": {
+      "nearby": "Boards près de chez vous"
+    },
+    "findNearby": {
+      "loading": "Recherche de boards…",
+      "geoDenied": "Localisation indisponible",
+      "error": "Échec du chargement des boards à proximité",
+      "noResults": "Aucun board à proximité",
+      "idle": "Trouver à proximité"
+    },
+    "search": {
+      "ariaLabel": "Rechercher un board",
+      "label": "Rechercher"
+    },
+    "custom": {
+      "ariaLabel": "Créer un board personnalisé",
+      "label": "Board personnalisé"
+    },
+    "create": {
+      "defaultLabel": "Nouveau board"
+    },
+    "bluetooth": {
+      "scanning": "Recherche en cours…",
+      "boardsFound": "Boards trouvés",
+      "noBoardsFound": "Aucun board trouvé",
+      "unavailable": "Bluetooth indisponible",
+      "idle": "Démarrage rapide"
+    }
+  },
+  "boardEntity": {
+    "notFound": "Board introuvable",
+    "chips": {
+      "unlisted": "Non répertorié",
+      "locationHidden": "Emplacement masqué"
+    },
+    "tabs": {
+      "leaderboard": "Classement",
+      "comments": "Commentaires"
+    },
+    "actions": {
+      "addToGym": "Ajouter à la salle",
+      "edit": "Modifier",
+      "delete": "Supprimer"
+    },
+    "stats": {
+      "ascents": "ascensions",
+      "climbers": "grimpeurs",
+      "followers": "abonnés",
+      "comments": "commentaires"
+    },
+    "delete": {
+      "title": "Supprimer le board",
+      "confirm": "Supprimer « {{name}} » ? Cette action est irréversible.",
+      "cancel": "Annuler",
+      "delete": "Supprimer"
+    },
+    "snackbar": {
+      "deleted": "Board supprimé",
+      "deleteFailed": "Échec de la suppression du board",
+      "linkedToGym": "Board lié à la salle",
+      "unlinkedFromGym": "Board dissocié de la salle",
+      "linkFailed": "Échec de l'association du board à la salle"
+    },
+    "comments": {
+      "title": "Discussion sur le board"
+    },
+    "follow": {
+      "entityLabel": "board"
+    }
+  },
+  "boardForm": {
+    "create": {
+      "submit": "Créer le board",
+      "authRequired": "Vous devez être connecté pour créer un board",
+      "errorMessage": "Échec de la création du board. Il existe peut-être déjà pour cette configuration.",
+      "nameRequired": "Le nom du board est obligatoire",
+      "createdNamed": "Board « {{name}} » créé !",
+      "namePlaceholder": "ex. Home Board, nom de la salle",
+      "locationPlaceholder": "ex. ville, nom de la salle"
+    },
+    "fields": {
+      "name": "Nom du board",
+      "slug": "Slug d'URL",
+      "description": "Description",
+      "location": "Emplacement",
+      "serialNumber": "Numéro de série du contrôleur",
+      "defaultAngle": "Inclinaison par défaut",
+      "angleAdjustable": "Inclinaison réglable",
+      "isPublic": "Board public",
+      "unlisted": "Non répertorié",
+      "hideLocation": "Masquer des boards à proximité",
+      "isOwned": "Je possède ce board",
+      "layout": "Disposition",
+      "size": "Taille",
+      "holdSets": "Jeux de prises"
+    },
+    "placeholders": {
+      "description": "Description facultative",
+      "serialNumber": "ex. ABC-12345"
+    },
+    "helperText": {
+      "unlisted": "Masqué des résultats de recherche mais accessible via un lien direct",
+      "hideLocation": "Masqué des recherches de boards à proximité, sauf si vous suivez la personne qui cherche"
+    },
+    "alerts": {
+      "configEditable": "Vous pouvez modifier la disposition du board car aucune voie n'a encore été enregistrée."
+    }
+  },
+  "editBoard": {
+    "title": "Modifier le board",
+    "submitLabel": "Enregistrer les modifications",
+    "snackbar": {
+      "updated": "Board mis à jour !",
+      "updateFailed": "Échec de la mise à jour du board"
+    }
+  },
+  "editGym": {
+    "title": "Modifier la salle",
+    "submitLabel": "Enregistrer les modifications",
+    "snackbar": {
+      "updated": "Salle mise à jour !",
+      "updateFailed": "Échec de la mise à jour de la salle"
+    }
+  },
+  "mapLocationPicker": {
+    "locationDisplay": "Emplacement : {{lat}}, {{lng}}",
+    "setOnMap": "Définir l'emplacement sur la carte",
+    "searchPlaceholder": "Rechercher une adresse ou une ville...",
+    "myLocation": "Ma position",
+    "helpText": "Cliquez sur la carte pour définir l'emplacement de votre board, ou faites glisser le repère pour ajuster"
+  },
+  "boardLeaderboard": {
+    "empty": "Aucune activité pour cette période.",
+    "period": {
+      "week": "Semaine",
+      "month": "Mois",
+      "year": "Année",
+      "all": "Toujours"
+    },
+    "columns": {
+      "climber": "Grimpeur",
+      "sends": "Réussites",
+      "flashes": "Flashs",
+      "hardest": "Plus dur"
+    }
+  },
+  "boardHeatmap": {
+    "loading": "Chargement de la carte de chaleur...",
+    "legend": {
+      "low": "Faible ({{value}})",
+      "mid": "Moyen ({{value}})",
+      "high": "Élevé ({{value}})"
+    }
+  },
+  "boardConfigSelects": {
+    "board": "Board",
+    "layout": "Disposition",
+    "size": "Taille",
+    "holdSets": "Jeux de prises",
+    "angle": "Inclinaison"
+  },
+  "boardFilterStrip": {
+    "all": "Tous",
+    "allBoards": "Tous les boards"
+  },
+  "boardSwitchConfirm": {
+    "session": {
+      "title": "Quitter votre session ?",
+      "body": "Vous êtes en session sur {{lockedLabel}}. Passer à {{targetLabel}} déconnecte votre board mais maintient la session active."
+    },
+    "connection": {
+      "title": "Déconnecter votre board ?",
+      "body": "Votre {{lockedLabel}} est encore connecté. Passer à {{targetLabel}} le déconnecte."
+    },
+    "stay": "Rester",
+    "switch": "Changer de board"
+  },
+  "boardSearchDrawer": {
+    "title": "Trouver un board",
+    "searchPlaceholder": "Rechercher des boards par nom ou emplacement",
+    "clear": "Effacer",
+    "radiusInfo": "Affichage des boards dans un rayon de {{radiusKm}} km autour du centre de la carte",
+    "empty": "Aucun board dans cette zone. Déplacez la carte ou dézoomez pour en trouver d'autres.",
+    "emptyWithQuery": "Aucun board ne correspond à « {{query}} » ici. Essayez de dézoomer ou de chercher ailleurs.",
+    "open": "Ouvrir"
+  },
+  "boardSearchMap": {
+    "myLocation": "Ma position"
+  },
+  "zoomableBoard": {
+    "reset": "Réinitialiser"
+  },
+  "zoomHint": {
+    "pinchToZoom": "Pincez pour zoomer"
+  },
+  "gymMemberManagement": {
+    "removeConfirm": "Retirer ce membre de la salle ?",
+    "empty": "Aucun membre pour le moment",
+    "unknownUser": "Utilisateur inconnu",
+    "loadMore": "Charger plus ({{count}} sur {{total}})",
+    "snackbar": {
+      "removed": "Membre retiré",
+      "removeFailed": "Échec du retrait du membre"
+    }
+  },
+  "gymSelector": {
+    "loading": "Chargement des salles...",
+    "linkToGym": "Associer à une salle",
+    "noGym": "Aucune salle",
+    "createNew": "Créer"
+  },
+  "selectorDrawer": {
+    "customTitle": "Board personnalisé",
+    "createTitle": "Créer un board",
+    "createButton": "Créer un board",
+    "quickSession": "Session rapide",
+    "configSection": {
+      "label": "Configuration du board",
+      "title": "Configuration du board",
+      "defaultSummary": "Sélectionner un board"
+    }
+  },
+  "gymEntity": {
+    "notFound": "Salle introuvable",
+    "tabs": {
+      "members": "Membres",
+      "comments": "Commentaires"
+    },
+    "actions": {
+      "edit": "Modifier",
+      "delete": "Supprimer"
+    },
+    "stats": {
+      "boards": "boards",
+      "members": "membres",
+      "followers": "abonnés",
+      "comments": "commentaires"
+    },
+    "delete": {
+      "title": "Supprimer la salle",
+      "confirm": "Supprimer « {{name}} » ? Cette action est irréversible.",
+      "cancel": "Annuler",
+      "delete": "Supprimer"
+    },
+    "snackbar": {
+      "deleted": "Salle supprimée",
+      "deleteFailed": "Échec de la suppression de la salle"
+    },
+    "comments": {
+      "title": "Discussion sur la salle"
+    },
+    "follow": {
+      "entityLabel": "salle"
+    }
+  },
+  "gymForm": {
+    "fields": {
+      "name": "Nom de la salle",
+      "slug": "Slug d'URL",
+      "description": "Description",
+      "address": "Adresse",
+      "contactEmail": "E-mail de contact",
+      "contactPhone": "Téléphone de contact",
+      "isPublic": "Salle publique"
+    },
+    "placeholders": {
+      "name": "ex. Boulder World, The Climbing Factory",
+      "description": "Description facultative",
+      "address": "ex. 123 rue Principale, ville",
+      "contactEmail": "E-mail de contact facultatif",
+      "contactPhone": "Téléphone de contact facultatif"
+    },
+    "actions": {
+      "cancel": "Annuler"
+    },
+    "create": {
+      "title": "Créer une salle",
+      "submit": "Créer la salle",
+      "authRequired": "Vous devez être connecté pour créer une salle",
+      "errorMessage": "Échec de la création de la salle",
+      "nameRequired": "Le nom de la salle est obligatoire",
+      "createdNamed": "Salle « {{name}} » créée !"
+    }
+  }
+}

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -1,0 +1,508 @@
+{
+  "metadata": {
+    "boardHome": {
+      "title": "{{boardName}} sur Boardsesh",
+      "description": "Parcourez les voies et les sessions sur {{boardName}}",
+      "fallbackTitle": "Board introuvable"
+    },
+    "list": {
+      "title": "Voies {{boardName}} à {{angle}}°",
+      "description": "Parcourez les voies sur {{boardName}} à {{angle}}°",
+      "fallbackTitle": "Voies",
+      "fallbackDescription": "Parcourez les voies"
+    },
+    "view": {
+      "title": "{{climbName}} - {{grade}}",
+      "description": "{{climbName}} - {{grade}} par {{setter}}. Qualité : {{quality}}/5. Ascensions : {{ascents}}",
+      "imageAlt": "{{climbName}} - {{grade}} sur le board {{boardName}}",
+      "fallbackTitle": "Voie",
+      "fallbackDescription": "Voir les détails de la voie et les vidéos beta"
+    },
+    "play": {
+      "title": "{{climbName}} - {{grade}} | Mode Play",
+      "description": "{{climbName}} - {{grade}} par {{setter}}. Qualité : {{quality}}/5. Ascensions : {{ascents}}",
+      "fallbackTitle": "Play",
+      "fallbackDescription": "Grimpez une voie sur votre board"
+    },
+    "create": {
+      "title": "Créer une voie",
+      "description": "Ouvrez une nouvelle voie sur votre board"
+    },
+    "import": {
+      "title": "Importer des voies",
+      "description": "Importez des voies MoonBoard depuis des captures d'écran"
+    },
+    "liked": {
+      "title": "Voies aimées",
+      "description": "Voies que vous avez aimées"
+    },
+    "logbook": {
+      "title": "Carnet",
+      "description": "Votre historique de grimpe pour ce board"
+    }
+  },
+  "list": {
+    "empty": {
+      "title": "Aucune voie ne correspond à vos filtres",
+      "subtitle": "Assouplissez les filtres et réessayez"
+    },
+    "loading": "Chargement des voies...",
+    "loadMore": "Charger plus",
+    "noMore": "Plus de voies",
+    "viewMode": {
+      "list": "Vue liste",
+      "grid": "Vue grille"
+    },
+    "biggerBoard": {
+      "title": "Ne rentre pas sur votre board",
+      "description": "Celle-ci dépasse les bords de votre mur. Il vous faudra une plus grande taille pour l'enchaîner."
+    },
+    "sort": {
+      "label": "Trier",
+      "ascents": "Ascensions",
+      "popular": "Populaires",
+      "difficulty": "Difficulté",
+      "name": "Nom",
+      "quality": "Qualité",
+      "creation": "Création",
+      "ascending": "Asc",
+      "descending": "Desc"
+    }
+  },
+  "header": {
+    "backToList": "Retour à la liste des voies",
+    "createNewClimb": "Créer une nouvelle voie"
+  },
+  "share": {
+    "title": "{{climbName}} sur Boardsesh",
+    "text": "Découvrez {{climbName}} sur Boardsesh",
+    "actionLabel": "Partager",
+    "actionText": "Découvrez « {{climbName}} » ({{difficulty}}) sur Boardsesh",
+    "linkCopied": "Lien copié",
+    "shareFailed": "Échec du partage"
+  },
+  "board": {
+    "connect": "Se connecter au board",
+    "disconnect": "Se déconnecter du board",
+    "connectError": "Connexion au board impossible. Vérifiez que le Bluetooth est activé et que le board est à proximité.",
+    "lightingUnavailable": "Éclairage du board indisponible",
+    "lightingUnavailableIos": "Safari ne prend pas en charge le Bluetooth. Utilisez l'app Boardsesh pour allumer les prises sur votre board.",
+    "lightingUnavailableBrowser": "Ce navigateur ne prend pas en charge le Bluetooth. Passez à Chrome pour allumer les prises sur votre board.",
+    "dismiss": "Ignorer",
+    "getApp": "Obtenir l'app"
+  },
+  "angleSelector": {
+    "selectAngle": "Choisir l'inclinaison",
+    "loadingStats": "Chargement des stats...",
+    "noData": "Aucune donnée",
+    "sends_one": "{{count}} enchaînement",
+    "sends_other": "{{count}} enchaînements"
+  },
+  "search": {
+    "drawerTitle": "Recherche et filtres",
+    "categories": {
+      "climbs": "Voies",
+      "boards": "Boards",
+      "gyms": "Salles",
+      "users": "Utilisateurs",
+      "playlists": "Playlists"
+    },
+    "placeholders": {
+      "boards": "Rechercher des boards...",
+      "gyms": "Rechercher des salles...",
+      "users": "Rechercher des grimpeurs...",
+      "playlists": "Rechercher des playlists...",
+      "climbs": "Rechercher des voies...",
+      "setters": "Rechercher des ouvreurs..."
+    },
+    "fields": {
+      "climbName": "Nom de la voie",
+      "gradeRange": "Plage de cotation",
+      "minGrade": "Min",
+      "maxGrade": "Max",
+      "setter": "Ouvreur",
+      "minAscents": "Ascensions min",
+      "minRating": "Note min",
+      "any": "Toutes",
+      "tallClimbsOnly": "Voies hautes uniquement",
+      "tallClimbsTooltip": "Afficher uniquement les voies qui utilisent les prises des 8 rangées du bas (disponible uniquement sur les boards 10x12)",
+      "gradeAccuracy": "Précision de la cotation",
+      "somewhatAccurate": "Plutôt précise (<0.2)",
+      "veryAccurate": "Très précise (<0.1)",
+      "extremelyAccurate": "Extrêmement précise (<0.05)",
+      "classicsOnly": "Classiques uniquement"
+    },
+    "panels": {
+      "quality": "Qualité",
+      "status": "Statut d'ascension",
+      "progress": "Progression",
+      "holds": "Prises",
+      "holdsTitle": "Rechercher par prise",
+      "anyDefault": "Toutes",
+      "allClimbs": "Toutes les voies"
+    },
+    "status": {
+      "any": "Toutes",
+      "established": "Établies",
+      "establishedTooltip": "Voies avec 2 ascensions ou plus",
+      "projects": "Projets",
+      "projectsTooltip": "Voies sans aucune ascension enregistrée",
+      "myDrafts": "Mes brouillons",
+      "myDraftsSignedOut": "Mes brouillons (connexion)",
+      "signInToFilterDrafts": "Connectez-vous pour filtrer par vos brouillons.",
+      "signInModalTitle": "Connectez-vous à Boardsesh",
+      "signInModalDescription": "Connectez-vous pour parcourir vos voies en brouillon."
+    },
+    "progress": {
+      "signInTitle": "Connectez-vous pour filtrer par vos données",
+      "signInBody": "Connectez-vous pour filtrer les voies selon votre historique d'essais et de réussites.",
+      "signInModalTitle": "Connectez-vous à Boardsesh",
+      "signInModalDescription": "Créez un compte pour filtrer par votre progression et enregistrer vos favorites.",
+      "hideAttempted": "Masquer essayées",
+      "hideCompleted": "Masquer enchaînées",
+      "onlyAttempted": "Essayées uniquement",
+      "onlyCompleted": "Enchaînées uniquement"
+    },
+    "actions": {
+      "search": "Rechercher",
+      "clearAll": "Tout effacer",
+      "signIn": "Se connecter"
+    },
+    "results": {
+      "count": "résultats"
+    },
+    "setters": {
+      "loading": "Chargement...",
+      "openDropdown": "Ouvrez le menu pour voir les ouvreurs",
+      "noSetters": "Aucun ouvreur trouvé"
+    },
+    "holds": {
+      "tapTo": "Appuyez pour :",
+      "include": "Inclure",
+      "exclude": "Exclure",
+      "included": "{{count}} incluses",
+      "excluded": "{{count}} exclues"
+    },
+    "sortToggle": "Trier"
+  },
+  "statsFilter": {
+    "drawerTitle": "Filtres",
+    "fields": {
+      "board": "Board",
+      "timeRange": "Période",
+      "from": "Du",
+      "to": "Au"
+    }
+  },
+  "create": {
+    "auth": {
+      "signInTitle": "Connectez-vous pour enregistrer votre voie",
+      "signInDescription": "Créez un compte ou connectez-vous pour enregistrer votre voie sur le board.",
+      "signInAria": "Se connecter pour enregistrer",
+      "logInTitle": "Connectez-vous pour enregistrer votre voie",
+      "logInAria": "Se connecter pour enregistrer",
+      "editLockedTitle": "Les voies publiées ne peuvent être modifiées que pendant 24 heures après leur première publication.",
+      "editLockedAria": "Fenêtre de modification fermée",
+      "savedTitle": "Enregistrée",
+      "savedAria": "Enregistrée"
+    },
+    "clear": {
+      "title": "Effacer la voie",
+      "description": "Cela effacera toutes les prises et réinitialisera le formulaire. Êtes-vous sûr ?",
+      "tooltip": "Effacer toutes les prises"
+    }
+  },
+  "actions": {
+    "playlist": {
+      "toast": {
+        "added": "Ajoutée à la playlist",
+        "removed": "Retirée de la playlist",
+        "addFailed": "Échec de l'ajout à la playlist",
+        "removeFailed": "Échec du retrait de la playlist",
+        "createdNamed": "Playlist « {{name}} » créée",
+        "createFailed": "Échec de la création de la playlist"
+      },
+      "validation": {
+        "nameRequired": "Veuillez saisir un nom de playlist",
+        "nameTooLong": "Nom trop long",
+        "descriptionTooLong": "Description trop longue"
+      },
+      "auth": {
+        "title": "Connectez-vous pour créer des playlists",
+        "description": "Connectez-vous pour organiser vos voies en playlists personnalisées."
+      },
+      "popover": {
+        "title": "Ajouter à la playlist",
+        "empty": "Aucune playlist pour l'instant",
+        "createFirst": "Créer votre première playlist",
+        "createNew": "Créer une nouvelle playlist",
+        "signInBlurb": "Connectez-vous pour créer et gérer des playlists"
+      },
+      "create": {
+        "nameLabel": "Nom de la playlist",
+        "namePlaceholder": "ex. Réglettes dures",
+        "descriptionLabel": "Description (optionnelle)",
+        "descriptionPlaceholder": "Description optionnelle...",
+        "colorLabel": "Couleur (optionnelle)",
+        "submit": "Créer"
+      }
+    },
+    "tick": {
+      "drawer": {
+        "signInRequired": "Connexion requise",
+        "selectBoard": "Choisir le board",
+        "logAscent": "Enregistrer l'ascension",
+        "signInToRecord": "Connectez-vous pour enregistrer des ticks",
+        "createAccountBlurb": "Créez un compte Boardsesh pour enregistrer vos voies et suivre votre progression.",
+        "signIn": "Se connecter",
+        "orLogInOfficialApp": "Ou enregistrez votre tick dans l'app officielle :",
+        "openInApp": "Ouvrir dans l'app",
+        "alwaysOpenInApp": "Toujours ouvrir dans l'app",
+        "authModalTitle": "Connectez-vous pour enregistrer des ticks",
+        "authModalDescription": "Créez un compte pour enregistrer vos voies et suivre votre progression.",
+        "mirroredTooltip": "Cliquez sur l'étiquette pour indiquer si vous avez enchaîné cette voie en miroir",
+        "whichBoard": "Sur quel board avez-vous grimpé ?"
+      }
+    },
+    "navigation": {
+      "nextClimb": "Voie suivante",
+      "previousClimb": "Voie précédente"
+    },
+    "mirror": {
+      "label": {
+        "mirrored": "En miroir",
+        "mirror": "Miroir"
+      },
+      "tooltip": {
+        "mirrored": "En miroir (cliquez pour réinitialiser)",
+        "mirror": "Mettre la voie en miroir"
+      }
+    },
+    "favorite": {
+      "label": {
+        "favorited": "Favorite",
+        "favorite": "Favori"
+      },
+      "tooltip": {
+        "add": "Ajouter aux favoris",
+        "remove": "Retirer des favoris"
+      },
+      "auth": {
+        "title": "Connectez-vous pour enregistrer vos favoris",
+        "descriptionWithName": "Connectez-vous pour ajouter « {{climbName}} » à vos favoris.",
+        "description": "Connectez-vous pour ajouter des voies à vos favoris."
+      },
+      "toast": {
+        "updateFailed": "Échec de la mise à jour du favori. Veuillez réessayer.",
+        "saveFailed": "Échec de l'enregistrement du favori. Veuillez réessayer."
+      }
+    }
+  },
+  "card": {
+    "title": {
+      "noClimbSelected": "Aucune voie sélectionnée",
+      "project": "projet",
+      "projectAtAngle": "projet @ {{angle}}°",
+      "draftBy": "Brouillon de {{name}}",
+      "by": "Par {{name}}",
+      "byWithSends": "Par {{name}} - {{sends}}"
+    },
+    "list": {
+      "moreActions": "Plus d'actions",
+      "tickError": "Tick non enregistré — sauvegardé en brouillon"
+    },
+    "detailHeader": {
+      "project": "projet",
+      "unknownSetter": "Ouvreur inconnu"
+    }
+  },
+  "detail": {
+    "sections": {
+      "beta": "Beta",
+      "logbook": "Votre carnet",
+      "logbookEmpty": "Aucune ascension",
+      "crewLogbook": "Carnet du crew",
+      "crewLogbookSummary": "Voir les enchaînements de votre crew",
+      "community": "Communauté",
+      "communitySummary": "Votes, commentaires, propositions",
+      "analytics": "Statistiques",
+      "analyticsSummary": "Ascensions, tendances de qualité"
+    }
+  },
+  "multiboardList": {
+    "noClimbsFound": "Aucune voie trouvée",
+    "popular": "Populaires",
+    "new": "Nouvelles",
+    "count_one": "{{count}} voie",
+    "count_other": "{{count}} voies"
+  },
+  "tick": {
+    "controls": {
+      "selectGrade": "Choisir la cotation enregistrée",
+      "userByline": "utilisateur",
+      "starsLabel": "étoiles",
+      "triesLabel": "essais",
+      "starRating": "Note en étoiles",
+      "noRating": "Pas de note",
+      "gradeOverride": "Cotation personnalisée",
+      "clearGradeOverride": "Effacer la cotation personnalisée",
+      "attemptCount": "Nombre d'essais"
+    },
+    "bar": {
+      "logAscent": "Enregistrer l'ascension",
+      "logAttempt": "Enregistrer l'essai",
+      "cancel": "Annuler"
+    }
+  },
+  "liked": {
+    "heroTitle": "Voies aimées",
+    "heroSubtitle": "Vos voies favorites",
+    "signInRequired": "Connexion requise",
+    "signInBody": "Veuillez vous connecter pour voir vos voies aimées.",
+    "actionsAriaLabel": "Actions",
+    "queueAll": "Tout mettre en file",
+    "adding": "Ajout en cours...",
+    "noClimbsToAdd": "Aucune voie à ajouter",
+    "addedToQueue_one": "{{count}} voie ajoutée à la file",
+    "addedToQueue_other": "{{count}} voies ajoutées à la file",
+    "addToQueueFailed": "Échec de l'ajout des voies à la file",
+    "loadFailed": "Échec du chargement des voies aimées",
+    "emptyState": "Pas encore de voies aimées. Mettez un cœur sur des voies pour les voir ici !"
+  },
+  "moonboard": {
+    "invalidLayout": "Disposition MoonBoard invalide"
+  },
+  "createClimbForm": {
+    "draftBadge": "Brouillon",
+    "namePlaceholder": "Nom de la voie",
+    "descriptionPlaceholder": "Ajoutez du beta ou des notes sur votre voie...",
+    "openDrafts": "Ouvrir les brouillons",
+    "processing": "Traitement...",
+    "importFromScreenshot": "Importer depuis une capture d'écran",
+    "bulkImport": "Import en masse",
+    "dismiss": "Ignorer",
+    "alerts": {
+      "importFailed": "Échec de l'import : {{error}}",
+      "importWarnings": "Avertissements d'import :",
+      "checkingMoonBoardDuplicate": "Vérification que cette voie MoonBoard n'existe pas déjà..."
+    },
+    "clear": {
+      "title": "Effacer la voie",
+      "description": "Cela effacera toutes les prises et réinitialisera le formulaire. Êtes-vous sûr ?",
+      "confirm": "Effacer",
+      "tooltip": "Effacer toutes les prises"
+    },
+    "settings": {
+      "tooltip": "Paramètres de la voie",
+      "title": "Paramètres de la voie"
+    },
+    "fields": {
+      "name": "Nom",
+      "holds": "Prises",
+      "angle": "Inclinaison",
+      "grade": "Cotation",
+      "gradeNone": "Aucune",
+      "benchmark": "Référence",
+      "description": "Description (optionnelle)"
+    },
+    "holds": {
+      "starting": "Départ",
+      "start": "Départ",
+      "hand": "Main",
+      "finish": "Arrivée",
+      "total": "Total"
+    },
+    "validation": {
+      "needsStartFinish": "Une voie valide nécessite au moins 1 prise de départ et 1 prise d'arrivée"
+    }
+  },
+  "draftsDrawer": {
+    "title": "Brouillons",
+    "count_one": "{{count}} brouillon",
+    "count_other": "{{count}} brouillons",
+    "loadError": "Impossible de charger vos brouillons. Réessayez.",
+    "empty": {
+      "title": "Pas encore de brouillons",
+      "subtitle": "Enregistrez une voie en brouillon pour la reprendre plus tard."
+    }
+  },
+  "holdTypePicker": {
+    "toolbarAriaLabel": "Type de prise",
+    "clear": "Effacer",
+    "states": {
+      "starting": "Départ",
+      "hand": "Milieu",
+      "finish": "Arrivée",
+      "foot": "Pied"
+    }
+  },
+  "directionPicker": {
+    "down": "Bas"
+  },
+  "holdClassification": {
+    "drawerTitle": "Classification des prises",
+    "classifyHoldTitle": "Classifier la prise",
+    "loadingHolds": "Chargement des prises...",
+    "emptyState": "Aucune prise trouvée pour cette configuration de board.",
+    "progress": "Prise {{current}} sur {{total}} ({{classified}} classifiées)",
+    "complete": {
+      "title": "Classification terminée !",
+      "subtitle": "Vous avez classifié {{classified}} prises sur {{total}}. Vous pouvez relancer cet assistant à tout moment pour mettre à jour vos évaluations."
+    },
+    "fields": {
+      "holdType": "Type de prise",
+      "handRating": "Note main (1-5)",
+      "footRating": "Note pied (1-5)",
+      "pullDirection": "Direction de traction"
+    },
+    "hints": {
+      "handRating": "5 = Facile à saisir, 1 = Très difficile",
+      "footRating": "5 = Facile à poser le pied, 1 = Très difficile",
+      "pullDirection": "Cliquez ou glissez pour définir la meilleure direction de traction"
+    },
+    "actions": {
+      "previous": "Précédent",
+      "skip": "Passer",
+      "finish": "Terminer"
+    },
+    "toast": {
+      "saveFailed": "Échec de l'enregistrement de la classification"
+    }
+  },
+  "moonboardImport": {
+    "card": {
+      "skipping": "Ignorée",
+      "duplicate": "Ignorée : existe déjà",
+      "duplicateNamed": "Ignorée : existe déjà sous le nom « {{name}} »",
+      "removeAction": "Retirer",
+      "removeDescription": "Cette voie ne sera pas importée."
+    },
+    "bulk": {
+      "title": "Importer des voies MoonBoard - {{layoutName}} @ {{angle}}°",
+      "loginRequired": "Veuillez vous connecter pour enregistrer les voies",
+      "loginRequiredTitle": "Connexion requise",
+      "loginRequiredBody": "Veuillez vous connecter pour enregistrer les voies dans la base de données.",
+      "logIn": "Se connecter",
+      "uploadPrompt": "Cliquez ou glissez des fichiers de capture d'écran dans cette zone",
+      "uploadHelp": "Prise en charge des captures d'écran de l'app MoonBoard. Déposez plusieurs fichiers pour un import en masse.",
+      "processing": "Traitement des captures d'écran...",
+      "checkingDuplicates": "Vérification des voies importées par rapport aux problèmes MoonBoard existants...",
+      "reviewBeforeSaving": "Vérifiez les voies ci-dessous. Vous pouvez en modifier ou en retirer avant d'enregistrer.",
+      "saveAll": "Tout enregistrer ({{count}})",
+      "clearAndRestart": "Effacer et recommencer",
+      "contributeImages": "Contribuez des images pour améliorer la précision de l'OCR",
+      "tryAgain": "Réessayer",
+      "saveFailed": "Échec de l'enregistrement des voies. Veuillez réessayer."
+    }
+  },
+  "moonboardEditModal": {
+    "title": "Modifier la voie",
+    "nameLabel": "Nom de la voie",
+    "nameRequired": "Veuillez saisir un nom",
+    "save": "Enregistrer les modifications",
+    "setter": "Ouvreur : {{setter}}",
+    "grade": "Cotation : {{grade}}",
+    "angle": "Inclinaison : {{angle}}°",
+    "unknown": "Inconnu"
+  }
+}

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -1,0 +1,218 @@
+{
+  "languageSwitcher": {
+    "ariaLabel": "Langue",
+    "ariaLabelWithCurrent": "Langue : {{language}}",
+    "switchTo": "Passer en {{language}}"
+  },
+  "languages": {
+    "en-US": "English",
+    "es": "Español"
+  },
+  "lightControl": {
+    "title": "Lumières",
+    "turnOffAll": "Éteindre toutes les lumières",
+    "partyMode": "Mode soirée",
+    "stopParty": "Arrêter la soirée",
+    "partyUnsupported": "Le mode soirée n'est pas disponible sur ce board",
+    "clearFailed": "Impossible d'éteindre le board"
+  },
+  "actions": {
+    "yes": "Oui",
+    "no": "Non",
+    "ok": "OK",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "back": "Retour",
+    "next": "Suivant",
+    "done": "Terminé",
+    "retry": "Réessayer",
+    "loadMore": "Charger plus",
+    "loading": "Chargement...",
+    "share": "Partager",
+    "copy": "Copier",
+    "submit": "Envoyer",
+    "clear": "Effacer",
+    "remove": "Retirer"
+  },
+  "ariaLabels": {
+    "close": "Fermer",
+    "back": "Retour",
+    "menu": "Menu",
+    "search": "Rechercher",
+    "clearSearch": "Effacer la recherche",
+    "openFilters": "Ouvrir les filtres",
+    "openStatsFilters": "Ouvrir les filtres de statistiques",
+    "shareProfile": "Partager le profil",
+    "settings": "Paramètres",
+    "notifications": "Notifications",
+    "searchClimbsByName": "Rechercher des voies par nom",
+    "userMenu": "Menu utilisateur",
+    "toggleDarkMode": "Activer/désactiver le mode sombre"
+  },
+  "boardSelector": {
+    "title": "Choisir un board"
+  },
+  "header": {
+    "you": "Vous",
+    "profile": "Profil",
+    "statistics": "Statistiques",
+    "sessions": "Sessions",
+    "createdClimbs": "Voies créées",
+    "auroraMigration": "Migration Aurora",
+    "searchPlaceholder": "Que voulez-vous grimper ?",
+    "searchClimbsPlaceholder": "Rechercher des voies..."
+  },
+  "share": {
+    "profileTitle": "Profil de grimpeur de {{name}}",
+    "profileText": "Découvrez le profil de grimpeur de {{name}} sur Boardsesh",
+    "fallbackName": "Mon",
+    "viewedFallbackName": "Grimpeur",
+    "linkCopied": "Lien copié dans le presse-papiers !",
+    "shareFailed": "Échec du partage"
+  },
+  "myBoards": {
+    "title": "Mes boards",
+    "findBoard": "Trouver un board",
+    "boardDetail": "Board",
+    "searchPlaceholder": "Rechercher par nom ou emplacement...",
+    "ariaFindBoard": "Trouver un board",
+    "ariaCreateBoard": "Créer un board",
+    "empty": "Aucun board pour le moment. Créez-en un depuis le sélecteur de board pour commencer."
+  },
+  "loading": {
+    "messages": [
+      "Préparation de votre board...",
+      "Configuration des voies...",
+      "Préparation du mur...",
+      "Chargement des jeux de prises...",
+      "Presque prêt à grimper...",
+      "Allumage des LED...",
+      "Synchronisation de la configuration du board...",
+      "Calibrage des cotations...",
+      "Mise en jambes...",
+      "Vérification de l'état des voies..."
+    ]
+  },
+  "emptyState": {
+    "default": "Aucune donnée"
+  },
+  "comment": {
+    "placeholder": "Ajouter un commentaire...",
+    "replyPlaceholder": "Écrire une réponse...",
+    "thoughtsPlaceholder": "Partagez votre avis...",
+    "shortPlaceholder": "Commentaire...",
+    "submit": "Publier",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "signInPrompt": "Connectez-vous pour laisser un commentaire.",
+    "discussionTitle": "Discussion",
+    "empty": "Aucun commentaire pour le moment. Lancez la conversation.",
+    "deleted": "[supprimé]",
+    "edited": "(modifié)",
+    "userFallback": "Utilisateur",
+    "reply": "Répondre",
+    "showRepliesOne": "Afficher 1 réponse",
+    "showRepliesMany": "Afficher {{count}} réponses",
+    "countOne": "{{count}} commentaire",
+    "countMany": "{{count}} commentaires",
+    "sort": {
+      "new": "Récents",
+      "top": "Top",
+      "controversial": "Controversés",
+      "hot": "Populaires"
+    },
+    "delete": {
+      "title": "Supprimer le commentaire",
+      "description": "Voulez-vous vraiment supprimer ce commentaire ? Cette action est irréversible.",
+      "confirm": "Supprimer",
+      "editAria": "Modifier le commentaire",
+      "deleteAria": "Supprimer le commentaire"
+    },
+    "errors": {
+      "post": "Échec de la publication du commentaire",
+      "update": "Échec de la mise à jour du commentaire",
+      "delete": "Échec de la suppression du commentaire",
+      "reply": "Échec de la publication de la réponse",
+      "loadReplies": "Échec du chargement des réponses"
+    }
+  },
+  "vote": {
+    "upvote": "Voter pour",
+    "downvote": "Voter contre",
+    "like": "J'aime",
+    "unlike": "Je n'aime plus",
+    "signInPrompt": "Connectez-vous pour voter",
+    "failed": "Échec du vote"
+  },
+  "proposal": {
+    "trigger": "Proposer une modification",
+    "drawerTitle": "Créer une proposition",
+    "submit": "Créer la proposition",
+    "submitting": "Création...",
+    "cancel": "Annuler",
+    "types": {
+      "grade": "Cotation",
+      "classic": "Classique",
+      "benchmark": "Référence"
+    },
+    "fields": {
+      "angle": "Inclinaison",
+      "proposedGrade": "Cotation proposée",
+      "proposedStatus": "Statut proposé",
+      "reasonLabel": "Motif (facultatif)",
+      "reasonPlaceholder": "Pourquoi pensez-vous que cette modification est nécessaire ?",
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "hints": {
+      "classic": "Les propositions classiques s'appliquent à toutes les inclinaisons.",
+      "benchmark": "Les propositions de référence sont par inclinaison."
+    },
+    "outlierWarning": "La cotation à cette inclinaison semble aberrante par rapport aux inclinaisons voisines. Cette proposition pourra être approuvée automatiquement si elle correspond aux données voisines.",
+    "validation": {
+      "signIn": "Connectez-vous pour créer des propositions",
+      "signInToVote": "Connectez-vous pour voter sur les propositions",
+      "missingValue": "Veuillez saisir une valeur proposée",
+      "sameGrade": "La cotation proposée est identique à la cotation actuelle",
+      "noData": "Échec de la création de la proposition : aucune donnée renvoyée",
+      "failed": "Échec de la création de la proposition",
+      "failedToVote": "Échec du vote",
+      "failedToResolve": "Échec de la résolution de la proposition",
+      "failedToDelete": "Échec de la suppression de la proposition"
+    },
+    "created": "Proposition créée"
+  },
+  "follow": {
+    "follow": "Suivre",
+    "following": "Suivi",
+    "unfollow": "Ne plus suivre"
+  },
+  "feedback": {
+    "title": "Vous aimez Boardsesh ?"
+  },
+  "betaVideos": {
+    "empty": "Aucune vidéo de beta pour le moment"
+  },
+  "moonboardImport": {
+    "removeConfirmTitle": "Retirer cette voie ?"
+  },
+  "ascents": {
+    "deleteTitle": "Supprimer l'ascension",
+    "deleteDescription": "Êtes-vous sûr ? Cette action est irréversible.",
+    "statusFlash": "flash",
+    "statusSend": "réussite",
+    "statusAttempt": "essai",
+    "flashed_one": "Flashée",
+    "flashed_other": "{{count}} flashs",
+    "sent_one": "Réussie",
+    "sent_other": "{{count}} réussites",
+    "attempts_one": "1 essai",
+    "attempts_other": "{{count}} essais"
+  },
+  "board": {
+    "resetZoom": "Réinitialiser le zoom"
+  }
+}

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -1,12 +1,12 @@
 {
   "languageSwitcher": {
     "ariaLabel": "Langue",
-    "ariaLabelWithCurrent": "Langue : {{language}}",
-    "switchTo": "Passer en {{language}}"
+    "ariaLabelWithCurrent": "Langue : {{language}}"
   },
   "languages": {
     "en-US": "English",
-    "es": "Español"
+    "es": "Español",
+    "fr": "Français"
   },
   "lightControl": {
     "title": "Lumières",

--- a/packages/web/i18n/locales/fr/errors.json
+++ b/packages/web/i18n/locales/fr/errors.json
@@ -1,0 +1,16 @@
+{
+  "globalError": {
+    "title": "Quelque chose s'est mal passé",
+    "subtitle": "Essayez de recharger pour repartir du bon pied",
+    "reload": "Recharger l'app"
+  },
+  "notFound": {
+    "title": "Page introuvable",
+    "subtitle": "On dirait que cette page n'existe pas.",
+    "goHome": "Retour à Boardsesh"
+  },
+  "boundary": {
+    "title": "Quelque chose a planté",
+    "retry": "Réessayer"
+  }
+}

--- a/packages/web/i18n/locales/fr/feed.json
+++ b/packages/web/i18n/locales/fr/feed.json
@@ -1,0 +1,175 @@
+{
+  "metadata": {
+    "feed": {
+      "title": "Fil d'actualité",
+      "description": "Consultez l'activité d'escalade des grimpeurs que vous suivez."
+    }
+  },
+  "title": "Fil d'actualité",
+  "tabs": {
+    "label": "Onglets du fil",
+    "sessions": "Sessions",
+    "proposals": "Propositions",
+    "comments": "Commentaires"
+  },
+  "activityFeed": {
+    "signInPrompt": "Connectez-vous pour voir un fil personnalisé des grimpeurs que vous suivez."
+  },
+  "ascentsFeed": {
+    "attempts": "{{count}} essais",
+    "deleteAscent": {
+      "title": "Supprimer l'ascension",
+      "description": "Êtes-vous sûr ? Cette action est irréversible."
+    },
+    "mirrored": "Inversée",
+    "benchmark": "Référence",
+    "setBy": "Ouverte par {{name}}",
+    "empty": "Aucune ascension enregistrée pour le moment"
+  },
+  "betaVideos": {
+    "shareBetaFor": "Partager la beta pour {{name}}",
+    "shareBetaVideo": "Partager une vidéo beta",
+    "shareBeta": "Partager la beta",
+    "dialogHelper": "Collez le lien d'un reel ou d'une publication pour montrer votre beta aux autres.",
+    "addedToast": "Vidéo ajoutée à la beta",
+    "addError": "Impossible d'ajouter la vidéo. Réessayez.",
+    "urlPlaceholder": "URL Instagram ou TikTok",
+    "urlLabel": "URL de la vidéo beta",
+    "urlLabelForClimb": "URL de la vidéo beta pour {{name}}",
+    "defaultHelper": "Collez l'URL d'un reel/post Instagram public ou d'une vidéo TikTok pour montrer votre beta.",
+    "cancel": "Annuler",
+    "unableToLoad": "Impossible de charger la vidéo",
+    "viewLink": "Voir",
+    "videoTitle": "Vidéo beta",
+    "videoTitleByUser": "Vidéo beta par {{name}}",
+    "modalTitle": "Vidéo beta",
+    "modalTitleByUser": "Beta par @{{name}}",
+    "viewOnInstagram": "Voir sur Instagram",
+    "showLess": "Afficher moins",
+    "showMore_one": "Afficher 1 vidéo de plus",
+    "showMore_other": "Afficher {{count}} vidéos de plus",
+    "noVideosAvailable": "Aucune vidéo beta disponible",
+    "angleSuffix": "{{angle}}°",
+    "unknownUser": "inconnu"
+  },
+  "commentFeed": {
+    "empty": "Aucun commentaire pour le moment",
+    "commentedOn": "a commenté {{entity}}"
+  },
+  "emptyStates": {
+    "followClimbers": "Suivez des grimpeurs pour remplir cette section",
+    "findClimbers": "Trouver des grimpeurs",
+    "noRecentActivity": "Aucune activité récente"
+  },
+  "errors": {
+    "loadFeed": "Échec du chargement du fil d'actualité. Veuillez réessayer.",
+    "loadActivity": "Échec du chargement du fil d'actualité",
+    "loadComments": "Échec du chargement des commentaires. Veuillez réessayer.",
+    "loadProposals": "Échec du chargement des propositions. Veuillez réessayer."
+  },
+  "feedCommentButton": {
+    "commentsTitle": "Commentaires"
+  },
+  "feedItemComment": {
+    "commented": "a commenté"
+  },
+  "feedItemNewClimb": {
+    "createdClimb": "a créé une nouvelle voie"
+  },
+  "followerCount": {
+    "followingLabel": "abonnements"
+  },
+  "freezeDialog": {
+    "reasonLabel": "Raison (facultative)",
+    "reasonPlaceholder": "Pourquoi geler/dégeler cette voie ?"
+  },
+  "freezeIndicator": {
+    "frozen": "Cette voie est gelée et ne reçoit plus de nouvelles propositions.",
+    "reasonPrefix": "Raison : {{reason}}"
+  },
+  "newClimbFeed": {
+    "title": "Nouvelles voies",
+    "errorLoad": "Échec du chargement des voies. Veuillez réessayer.",
+    "empty": "Aucune voie pour ce layout. Soyez le premier à en ouvrir une !"
+  },
+  "proposalCard": {
+    "quotedReason": "« {{reason}} »",
+    "support": "Soutenir",
+    "oppose": "S'opposer",
+    "approve": "Approuver",
+    "reject": "Rejeter",
+    "deleteProposal": "Supprimer la proposition",
+    "deleteDialog": {
+      "title": "Supprimer la proposition acceptée",
+      "description": "Cela annulera les effets de cette proposition (par ex. changement de cotation, statut référence/classique) et la supprimera définitivement. Cette action est irréversible."
+    }
+  },
+  "proposalFeed": {
+    "empty": "Aucune proposition pour le moment"
+  },
+  "proposalSection": {
+    "title": "Propositions de la communauté",
+    "noOpen": "Aucune proposition ouverte"
+  },
+  "proposalVoteBar": {
+    "approved": "Approuvée",
+    "rejected": "Rejetée",
+    "votesNeeded": "{{current}} / {{required}} votes requis",
+    "opposed": "{{count}} contre"
+  },
+  "search": {
+    "minCharsHint": "Tapez au moins 2 caractères pour rechercher",
+    "noBoards": "Aucun board trouvé pour « {{query}} »",
+    "noGyms": "Aucune salle trouvée pour « {{query}} »",
+    "noPlaylists": "Aucune playlist trouvée pour « {{query}} »",
+    "noUsers": "Aucun utilisateur ou ouvreur trouvé pour « {{query}} »",
+    "climbCountOne": "{{count}} voie",
+    "climbCountMany": "{{count}} voies"
+  },
+  "sessionFeedCard": {
+    "climbCountOne": "{{count}} voie",
+    "climbCountMany": "{{count}} voies"
+  },
+  "sessionSummary": {
+    "completed": "Session terminée"
+  },
+  "socialFeedItem": {
+    "climbed": "a grimpé"
+  },
+  "subscribeButton": {
+    "signInPrompt": "Veuillez vous connecter pour gérer les abonnements",
+    "subscribed": "Abonné aux nouvelles voies",
+    "unsubscribed": "Désabonné des nouvelles voies",
+    "updateFailed": "Impossible de mettre à jour l'abonnement"
+  },
+  "userDrawer": {
+    "signIn": "Se connecter",
+    "signInModalTitle": "Se connecter à Boardsesh",
+    "signInModalDescription": "Connectez-vous pour enregistrer vos favoris, journaliser vos ascensions et plus encore.",
+    "changeBoard": "Changer de board",
+    "devUrl": "URL de dev",
+    "development": "Développement",
+    "classifyHolds": "Classer les prises",
+    "myPlaylists": "Mes playlists",
+    "recentSessions": "Sessions récentes",
+    "help": "Aide",
+    "about": "À propos",
+    "rateBoardsesh": "Noter Boardsesh",
+    "reportBug": "Signaler un bug",
+    "logout": "Se déconnecter"
+  },
+  "userSearch": {
+    "ascentsThisMonth": "{{count}} ascensions ce mois-ci",
+    "climbsSetOne": "{{count}} voie ouverte",
+    "climbsSetMany": "{{count}} voies ouvertes",
+    "climbCountOne": "{{count}} voie",
+    "climbCountMany": "{{count}} voies"
+  },
+  "userSmartCard": {
+    "followerOne": "{{count}} abonné",
+    "followerMany": "{{count}} abonnés",
+    "following": "{{count}} abonnements",
+    "distinctClimbOne": "{{count}} voie distincte",
+    "distinctClimbMany": "{{count}} voies distinctes"
+  }
+}

--- a/packages/web/i18n/locales/fr/marketing.json
+++ b/packages/web/i18n/locales/fr/marketing.json
@@ -1,0 +1,547 @@
+{
+  "metadata": {
+    "home": {
+      "title": "Boardsesh - Entraînez-vous plus malin sur votre board d'escalade",
+      "description": "Suivez vos sends sur Kilter, Tension et MoonBoard. Une seule app pour vos boards.",
+      "ogDescription": "Compatible avec Kilter, Tension et MoonBoard. Suivez vos sessions, pilotez les LEDs, grimpez ensemble."
+    },
+    "about": {
+      "title": "À propos",
+      "description": "Une seule app pour chaque board d'escalade. Open source, portée par la communauté."
+    },
+    "help": {
+      "title": "Aide",
+      "description": "Découvrez les fonctionnalités de Boardsesh : heatmap, mode party, générateur de playlists et bien plus."
+    },
+    "docs": {
+      "title": "Documentation API",
+      "description": "Documentation des API REST et WebSocket de Boardsesh - intégration des boards d'entraînement interactifs"
+    },
+    "legal": {
+      "title": "Politique légale et de propriété intellectuelle",
+      "description": "Politique légale et de propriété intellectuelle de Boardsesh, incluant notre position sur les données de voies, l'interopérabilité et l'usage des marques."
+    },
+    "privacy": {
+      "title": "Politique de confidentialité",
+      "description": "Politique de confidentialité de Boardsesh - comment nous gérons vos données."
+    }
+  },
+  "home": {
+    "hero": {
+      "title": "Au mur !",
+      "subtitle": "Suivez vos sends sur Kilter, Tension et MoonBoard.",
+      "ctaStart": "Commencer à grimper",
+      "ctaContinue": "Continuer à grimper"
+    },
+    "onboardingHeader": "Personnalisez",
+    "install": {
+      "iosTitle": "Installer l'app Boardsesh",
+      "iosDescription": "Allume les prises de votre board directement depuis votre téléphone",
+      "androidLiveTitle": "Installer l'app Boardsesh",
+      "androidLiveDescription": "Disponible sur Google Play",
+      "androidPreLaunchTitle": "L'app Android arrive bientôt",
+      "androidPreLaunchDescription": "Sortie dans {{days}}j {{hours}}h {{minutes}}m {{seconds}}s. Touchez pour installer la version preview."
+    },
+    "cards": {
+      "tourTitle": "Faites le tour",
+      "tourDescription": "Une minute pour découvrir la file d'attente, le suivi et les sessions entre potes",
+      "auroraTitle": "Vous arrivez de Kilter ?",
+      "auroraDescription": "Importez votre carnet et votre historique en une étape",
+      "crewTitle": "Trouvez votre crew",
+      "crewDescription": "Suivez vos amis et voyez ce qu'ils grimpent",
+      "playlistTitle": "Préparez une playlist",
+      "playlistDescription": "Alignez vos voies avant d'arriver à la salle",
+      "bluetoothTitle": "Connectez votre board",
+      "bluetoothDescription": "Appairez en Bluetooth et allumez votre prochaine voie",
+      "discordTitle": "Rejoignez le crew sur Discord",
+      "discordDescription": "Partagez la beta, signalez des bugs et façonnez la suite"
+    },
+    "feed": {
+      "callout": "Vos amis grimpent.",
+      "cta": "Voir le feed"
+    }
+  },
+  "about": {
+    "headerTitle": "À propos",
+    "hero": {
+      "title": "Suivez, entraînez-vous et grimpez ensemble",
+      "subtitle": "Une seule app pour chaque board d'escalade"
+    },
+    "vision": {
+      "title": "Notre vision",
+      "p1": "Kilter, Tension, MoonBoard, Decoy, Grasshopper. Chaque board a son app et son écosystème fermé. Votre entraînement ne devrait pas être prisonnier de l'un d'entre eux.",
+      "p2": "Boardsesh fonctionne avec tous, pour que vous puissiez juste grimper."
+    },
+    "features": {
+      "title": "Ce que Boardsesh propose",
+      "queueLabel": "Gestion de la file.",
+      "queueDescription": "Passez chacun votre tour sans le « c'est à qui ? » embarrassant",
+      "partyLabel": "Mode Party.",
+      "partyDescription": "Partagez une session et grimpez ensemble en temps réel",
+      "multiBoardLabel": "Multi-board.",
+      "multiBoardDescription": "Compatible avec Kilter, Tension, MoonBoard et d'autres",
+      "communityLabel": "Porté par la communauté.",
+      "communityDescription": "Construit et amélioré par des grimpeurs",
+      "selfHostedLabel": "Auto-hébergeable.",
+      "selfHostedDescription": "Lancez votre propre instance si ça vous tente"
+    },
+    "openSource": {
+      "title": "Open Source",
+      "body": "Boardsesh est open source sous licence Apache. Parcourez le code, envoyez une PR, ouvrez un bug ou forkez le projet entier.",
+      "cta": "Voir sur GitHub →"
+    },
+    "api": {
+      "title": "Documentation API",
+      "body": "Envie de construire avec les données d'escalade ? L'API est publique. Régalez-vous.",
+      "cta": "Explorer la documentation API →"
+    },
+    "community": {
+      "title": "Rejoignez la communauté",
+      "body": "Que vous codiez, ouvriez des voies ou vouliez juste nous dire ce qui cloche, on vous écoute."
+    },
+    "legalLink": "Politique légale et de propriété intellectuelle",
+    "footer": "Fait par des grimpeurs. Ouvert à tous."
+  },
+  "legal": {
+    "headerTitle": "Mentions légales",
+    "intro": {
+      "title": "Politique légale et de propriété intellectuelle",
+      "p1": "Boardsesh est une alternative gratuite, open source et communautaire pour parcourir et interagir avec les boards d'entraînement à LED standardisés (Kilter Board, Tension Board, MoonBoard et autres). Le projet est non commercial et entièrement maintenu par des bénévoles.",
+      "p2": "Nous pensons que les grimpeurs doivent être libres de choisir comment ils interagissent avec le matériel qu'ils ont acheté, et que les données créées par la communauté doivent rester accessibles à la communauté."
+    },
+    "climbData": {
+      "title": "Notre position sur les données de voies",
+      "facts": {
+        "title": "Les voies sont des données factuelles",
+        "p1": "Une voie sur un board standardisé est une liste de positions de prises sur une disposition fixe et standardisée (ex. : « départ sur A5, utilise B12, C3, D18, arrivée sur K11 »), associée à une cotation et un angle de mur. C'est de l'information factuelle et fonctionnelle — comparable à une position d'échecs, à un ensemble de coordonnées GPS ou à un numéro de téléphone — et non une œuvre de création originale.",
+        "p2": "Selon le droit d'auteur américain, les faits ne sont pas protégeables par le copyright (<em>Feist Publications, Inc. v. Rural Telephone Service Co.</em>, 499 U.S. 340 (1991)). Un board standardisé avec un nombre fini de prises (typiquement 200 à 500) produit des définitions de voies intrinsèquement contraintes, factuelles et fonctionnelles."
+      },
+      "community": {
+        "title": "La base de données est créée par la communauté",
+        "p1": "Les bases de données de voies de ces boards sont presque entièrement composées de contenu généré par les utilisateurs. Ce sont les grimpeurs qui créent et soumettent les voies. Les fabricants de boards n'ont pas écrit ce contenu — ils fournissent une plateforme de soumission et d'affichage.",
+        "p2": "La position de licence varie selon le fabricant, mais en aucun cas un fabricant ne possède les données de voies de la communauté :",
+        "aurora": "<strong>Aurora Climbing</strong> (Kilter Board, Tension Board, et autres) : les conditions d'utilisation d'Aurora leur accordent une « licence perpétuelle, sans restriction, illimitée, non exclusive et irrévocable » sur le contenu soumis par les utilisateurs. Surtout, cette licence est <strong>non exclusive</strong> — elle ne transfère pas la propriété à Aurora, et n'empêche pas le créateur original (ou des tiers) d'utiliser, collecter ou présenter de manière indépendante les mêmes données factuelles.",
+        "moonLabel": "Moon Climbing (MoonBoard) :",
+        "moonBody": "À la date du dernier examen des documents juridiques publics de Moon Climbing (février 2026), Moon Climbing n'a pas de conditions d'utilisation spécifiques à son app, pas de contrat utilisateur final, ni de licence de contenu contribué régissant l'app MoonBoard ou sa base de données de voies. En l'absence d'un tel accord, Moon Climbing n'a aucune revendication contractuelle sur les voies créées et soumises par ses utilisateurs."
+      },
+      "compilation": {
+        "title": "Les bases de données exhaustives ne bénéficient que d'une faible protection",
+        "body": "Même lorsqu'un agencement de base de données pourrait bénéficier d'une protection ténue par le copyright en tant que compilation, la Cour suprême américaine a jugé que cette protection ne s'étend qu'à la sélection ou à l'arrangement créatif — et non aux faits sous-jacents. Une base de données qui collecte exhaustivement toutes les soumissions des utilisateurs sans curation éditoriale (comme le font ces plateformes) est analogue à un annuaire téléphonique alphabétique, que la Cour a jugé non protégeable dans <em>Feist</em>."
+      }
+    },
+    "attribution": {
+      "title": "Attribution et respect des créateurs",
+      "intro": "Nous respectons la communauté de l'escalade et les personnes qui créent des voies.",
+      "item1": "Lorsque les informations sur le créateur d'une voie sont disponibles, nous l'attribuons par son nom d'utilisateur.",
+      "item2": "Nous ne revendiquons pas la paternité des voies que nous n'avons pas créées.",
+      "item3Start": "Si vous êtes le créateur d'une voie et souhaitez qu'elle soit retirée, veuillez",
+      "item3Link": "ouvrir un ticket",
+      "item3End": "ou nous contacter, et nous donnerons suite à votre demande rapidement."
+    },
+    "interop": {
+      "title": "Interopérabilité et compatibilité matérielle",
+      "intro": "Ce projet fournit des logiciels et des conceptions matérielles compatibles avec les boards d'escalade standardisés. Les grimpeurs qui ont acheté ces boards ont le droit d'utiliser des logiciels et contrôleurs tiers avec leur propre matériel.",
+      "software": {
+        "title": "Interopérabilité logicielle",
+        "body": "Notre app communique avec les contrôleurs des boards via des protocoles Bluetooth standards. Le protocole de communication Bluetooth utilisé par ces boards n'est pas chiffré et repose sur du matériel courant (LEDs adressables WS2812B pilotées par des contrôleurs Bluetooth standards). Implémenter une interface Bluetooth compatible à des fins d'interopérabilité est bien établi comme légal en droit américain et européen (<em>Sega Enterprises Ltd. v. Accolade, Inc.</em>, 977 F.2d 1510 (9th Cir. 1992) ; Directive UE 2009/24/CE, Article 6)."
+      },
+      "controller": {
+        "title": "Contrôleur open source",
+        "p1": "Ce projet propose également des conceptions matérielles et de firmware open source pour le contrôleur. Le contrôleur est une implémentation indépendante et originale qui communique en utilisant le même protocole Bluetooth que les contrôleurs officiels. Il est construit sur des composants courants (microcontrôleurs standards et LEDs WS2812B) et n'incorpore aucun firmware, code ou conception matérielle propriétaire d'un fabricant de boards. Aucun brevet connu ne couvre les systèmes de contrôleurs LED utilisés par les fabricants de boards actuels.",
+        "p2": "Notre contrôleur est conçu pour être interopérable avec le logiciel de ce projet et, à la discrétion de l'utilisateur, avec les apps officielles des fabricants. Toute interopérabilité de ce type est initiée par l'utilisateur final sur son propre matériel."
+      }
+    },
+    "trademark": {
+      "title": "Usage des marques",
+      "body": "Nous utilisons les noms de boards et de produits (par exemple « Kilter Board », « MoonBoard », « Tension Board ») uniquement pour décrire la compatibilité matérielle et l'interopérabilité. Ces noms sont des marques déposées de leurs propriétaires respectifs. Ce projet n'est pas affilié, approuvé ou sponsorisé par Aurora Climbing, Moon Climbing ou tout autre fabricant de board."
+    },
+    "dmca": {
+      "title": "DMCA et demandes de retrait",
+      "intro": "Nous prenons les questions de propriété intellectuelle au sérieux. Si vous estimez qu'un contenu de ce projet enfreint vos droits d'auteur, veuillez nous contacter avec les informations suivantes :",
+      "item1": "Identification de l'œuvre protégée que vous estimez enfreinte.",
+      "item2": "Identification du contenu que vous jugez contrefaisant, avec assez de détails pour que nous puissions le localiser.",
+      "item3": "Vos coordonnées (nom, adresse, e-mail, téléphone).",
+      "item4": "Une déclaration selon laquelle vous croyez de bonne foi que cet usage n'est pas autorisé par le titulaire des droits, son agent ou la loi.",
+      "item5": "Une déclaration, sous peine de parjure, que les informations de votre notification sont exactes et que vous êtes le titulaire des droits ou autorisé à agir en son nom.",
+      "review1": "Nous examinerons toutes les demandes valides rapidement et de bonne foi. Nous pouvons également déposer une contre-notification si nous estimons qu'une demande de retrait repose sur une mauvaise identification du contenu ou une mauvaise compréhension du droit.",
+      "contactLabel": "Contact :"
+    },
+    "community": {
+      "title": "Un mot à la communauté",
+      "p1": "La communauté de l'escalade a une longue tradition de partage ouvert de la beta. Ce projet existe dans cet esprit. Nous ne cherchons pas à nuire à une entreprise — nous voulons offrir aux grimpeurs de meilleurs outils pour interagir avec du matériel qu'ils possèdent déjà et des données qu'ils ont contribué à créer.",
+      "p2": "Les fabricants continuent de bénéficier de cet écosystème. Notre projet stimule la demande pour leurs produits physiques (prises, boards, panneaux) là où ils apportent une vraie valeur. Nous pensons simplement que les grimpeurs méritent un choix dans leur manière d'interagir avec leur matériel.",
+      "p3": "Si vous êtes fabricant de boards et souhaitez discuter d'une collaboration ou exprimer des inquiétudes, nous accueillons un dialogue ouvert. N'hésitez pas à nous contacter."
+    },
+    "thirdParty": {
+      "title": "Mentions tierces",
+      "iconLabel": "Icône Personne qui tombe",
+      "iconFrom": "depuis",
+      "fontAwesomeLink": "Font Awesome Free 6.7.2",
+      "byAuthor": "par @fontawesome.",
+      "licenseLabel": "Licence :",
+      "licenseLink": "CC BY 4.0",
+      "copyright": ". Copyright 2024 Fonticons, Inc."
+    },
+    "footer": "Ce document est fourni à titre informatif et ne constitue pas un avis juridique. Dernière mise à jour : 02-08-2026"
+  },
+  "help": {
+    "headerTitle": "Aide",
+    "hero": {
+      "title": "Comment pouvons-nous vous aider ?",
+      "subtitle": "Découvrez les fonctionnalités de Boardsesh et tirez le meilleur de vos sessions"
+    },
+    "sections": {
+      "visualization": { "label": "Visualisation et analyse" },
+      "collaboration": { "label": "Sessions et collaboration" },
+      "training": { "label": "Entraînement et workouts" },
+      "search": { "label": "Recherche et découverte" },
+      "connectivity": { "label": "Sync et connectivité" }
+    },
+    "heatmap": {
+      "q": "Comment utiliser la heatmap ?",
+      "imgAlt": "Visualisation de la heatmap",
+      "intro": "La heatmap montre les schémas d'utilisation des prises sur l'ensemble des voies, ce qui aide à identifier les prises populaires et les opportunités d'entraînement.",
+      "accessLabel": "Pour accéder à la heatmap :",
+      "access1": "Ouvrez le tiroir de recherche et déployez la section « Prises »",
+      "access2": "Cliquez sur le bouton « Afficher la heatmap »",
+      "access3": "Le board affichera un dégradé de couleurs allant du vert (faible utilisation) au rouge (forte utilisation)",
+      "modesLabel": "Modes de couleur disponibles :",
+      "modes": {
+        "ascentsLabel": "Ascensions :",
+        "ascentsBody": "Popularité globale basée sur le total des sends",
+        "startLabel": "Prises de départ :",
+        "startBody": "Positions de départ courantes",
+        "handFootLabel": "Prises mains/pieds :",
+        "handFootBody": "Utilisation par type de membre",
+        "finishLabel": "Prises d'arrivée :",
+        "finishBody": "Positions de top courantes"
+      },
+      "outro": "Utilisez les interrupteurs pour afficher/masquer les numéros des prises et inclure/exclure les prises de pied."
+    },
+    "holdClassification": {
+      "q": "Comment classifier les prises de mon board ?",
+      "imgAlt": "Assistant de classification des prises",
+      "intro": "La classification des prises vous permet de créer vos propres notations pour chaque prise de votre board, vous aidant à comprendre vos points forts et à trouver des voies adaptées.",
+      "attrsLabel": "Attributs de classification :",
+      "attrs": {
+        "holdTypeLabel": "Type de prise :",
+        "holdTypeBody": "Bac, Plat, Pince, Réglette ou Trou",
+        "handRatingLabel": "Note main :",
+        "handRatingBody": "Échelle de difficulté de 1 à 5 pour l'usage à la main",
+        "footRatingLabel": "Note pied :",
+        "footRatingBody": "Échelle de difficulté de 1 à 5 pour l'usage au pied",
+        "pullDirectionLabel": "Direction de traction :",
+        "pullDirectionBody": "Angle optimal de traction de 0 à 360"
+      },
+      "outro": "Les classifications sont personnelles et stockées dans votre compte, ce qui vous permet de construire au fil du temps une compréhension sur mesure de votre board."
+    },
+    "partyMode": {
+      "q": "Comment démarrer une session collaborative ?",
+      "imgAlt": "Session active en mode party",
+      "intro": "Le mode Party permet à plusieurs grimpeurs de partager une file d'attente et de se relayer sur le board en temps réel.",
+      "startLabel": "Pour démarrer une session :",
+      "start1": "Touchez l'icône ampoule dans la barre de file en bas",
+      "start2": "Allez à l'onglet « Démarrer la session » et connectez-vous si ce n'est pas déjà fait",
+      "start3": "Cliquez sur « Démarrer le mode Party » pour créer une nouvelle session",
+      "start4": "Partagez la session avec vos amis via QR code ou lien",
+      "joinLabel": "Pour rejoindre une session :",
+      "join": {
+        "qrLabel": "Scanner le QR code :",
+        "qrBody": "L'hôte de la session peut afficher un QR code que les autres peuvent scanner avec l'appareil photo de leur téléphone",
+        "shareLabel": "Partager le lien :",
+        "shareBody": "Copiez et partagez l'URL de la session — toute personne avec le lien peut rejoindre",
+        "idLabel": "Saisir l'ID de session :",
+        "idBody": "Allez à l'onglet « Rejoindre la session » et collez soit l'URL complète, soit juste l'ID de la session"
+      },
+      "featuresLabel": "Fonctionnalités de session :",
+      "feature1": "Synchronisation en temps réel de la file sur tous les appareils",
+      "feature2": "Plusieurs utilisateurs peuvent ajouter/retirer des voies",
+      "feature3": "Le leader de la session contrôle l'affichage du board",
+      "feature4": "Passage automatique du leadership si le leader actuel se déconnecte",
+      "feature5": "La session persiste à travers les rafraîchissements de page et les reconnexions"
+    },
+    "queueManagement": {
+      "q": "Comment gérer la file de voies ?",
+      "imgAlt": "Gestion de la file",
+      "intro": "La file vous permet d'organiser les voies de votre session, que vous grimpiez seul ou à plusieurs.",
+      "actionsLabel": "Actions sur la file :",
+      "actions": {
+        "addLabel": "Ajouter des voies :",
+        "addBody": "Double-touchez n'importe quelle voie de la liste pour l'ajouter à votre file",
+        "reorderLabel": "Réorganiser :",
+        "reorderBody": "Glissez-déposez les voies pour changer l'ordre",
+        "currentLabel": "Définir l'actuelle :",
+        "currentBody": "Cliquez sur une voie pour la rendre active",
+        "removeLabel": "Retirer :",
+        "removeBody": "Cliquez sur la croix d'une voie de la file",
+        "mirrorLabel": "Miroir :",
+        "mirrorBody": "Activez le mode miroir pour un entraînement bilatéral"
+      },
+      "outro": "La file se synchronise automatiquement avec les membres de la party et persiste hors-ligne pour des sessions sans interruption."
+    },
+    "playlistGenerator": {
+      "q": "Comment générer une playlist d'entraînement ?",
+      "intro": "Le générateur de playlist crée des workouts structurés adaptés à vos objectifs.",
+      "typesLabel": "Types de workout :",
+      "types": {
+        "volumeLabel": "Volume :",
+        "volumeBody": "Beaucoup de répétitions à une cotation constante pour l'endurance",
+        "pyramidLabel": "Pyramide :",
+        "pyramidBody": "Montée jusqu'à une cotation maximale, puis redescente",
+        "ladderLabel": "Échelle :",
+        "ladderBody": "Progression par paliers à travers des cotations croissantes",
+        "gradeFocusLabel": "Focus cotation :",
+        "gradeFocusBody": "Travail concentré sur une seule cotation cible"
+      },
+      "optionsLabel": "Options de configuration :",
+      "option1": "Style d'échauffement (Standard, Étendu ou Aucun)",
+      "option2": "Choix de la cotation cible",
+      "option3": "Biais de voie (Inconnues, Tentées ou Toutes)",
+      "option4": "Filtres de nombre minimum d'ascensions/de note",
+      "option5": "Nombre de voies par section"
+    },
+    "mirroring": {
+      "q": "Comment mettre une voie en miroir ?",
+      "intro": "Le miroir d'une voie inverse toutes les prises sur le côté opposé du board, parfait pour un entraînement de force bilatéral.",
+      "howLabel": "Pour mettre une voie en miroir :",
+      "step1": "Trouvez la voie que vous voulez inverser",
+      "step2": "Cherchez l'icône de bascule miroir dans les actions de la voie",
+      "step3": "Activez-la pour inverser la voie horizontalement",
+      "outro": "Quand vous êtes connecté en Bluetooth, le board LED affiche automatiquement le motif inversé. Cette fonctionnalité est disponible sur les boards compatibles comme le Kilter Homewall."
+    },
+    "searchFilters": {
+      "q": "Quels filtres de recherche sont disponibles ?",
+      "imgAlt": "Filtres de recherche",
+      "basicLabel": "Filtres de recherche basiques :",
+      "basic": {
+        "nameLabel": "Nom de voie :",
+        "nameBody": "Recherche par titre de voie",
+        "gradeLabel": "Plage de cotation :",
+        "gradeBody": "Définissez les cotations minimale et maximale",
+        "setterLabel": "Ouvreur :",
+        "setterBody": "Filtrer par créateur de voie",
+        "minAscentsLabel": "Ascensions min :",
+        "minAscentsBody": "Afficher uniquement les voies populaires",
+        "minRatingLabel": "Note min :",
+        "minRatingBody": "Filtrer par note de qualité",
+        "classicsLabel": "Classiques uniquement :",
+        "classicsBody": "Afficher seulement les voies classées classiques"
+      },
+      "personalLabel": "Filtres de progression personnelle",
+      "personalRequires": "(connexion requise) :",
+      "personalImgAlt": "Filtres de progression personnelle",
+      "personal1": "Masquer les voies réussies",
+      "personal2": "Masquer les voies tentées",
+      "personal3": "Afficher uniquement les voies tentées",
+      "personal4": "Afficher uniquement les voies réussies"
+    },
+    "searchByHold": {
+      "q": "Comment chercher par prises spécifiques ?",
+      "imgAlt": "Recherche par prise",
+      "intro": "La recherche par prise vous permet de trouver des voies qui utilisent (ou évitent) des prises spécifiques du board.",
+      "howLabel": "Pour rechercher par prises :",
+      "step1": "Ouvrez le tiroir de recherche et déployez la section « Prises »",
+      "step2": "Sélectionnez le mode « Inclure » ou « Exclure » dans le menu déroulant",
+      "step3": "Touchez les prises sur le board pour les sélectionner",
+      "step4": "Les résultats se mettent à jour automatiquement à mesure que vous sélectionnez",
+      "includeLabel": "Mode Inclure :",
+      "includeBody": "Les voies doivent utiliser les prises sélectionnées",
+      "excludeLabel": "Mode Exclure :",
+      "excludeBody": "Les voies ne doivent pas utiliser les prises sélectionnées"
+    },
+    "bluetooth": {
+      "q": "Comment connecter les LEDs de mon board ?",
+      "intro": "Boardsesh utilise Web Bluetooth pour piloter le système LED de votre board directement depuis le navigateur.",
+      "requirementsLabel": "Prérequis :",
+      "req1": "Navigateur Chrome (recommandé) ou autre navigateur compatible Web Bluetooth",
+      "req2": "Utilisateurs iOS : utilisez l'app Boardsesh (Safari ne supporte pas Web Bluetooth)",
+      "req3": "Bluetooth activé sur votre appareil",
+      "req4": "Board allumé et à portée",
+      "connectLabel": "Pour vous connecter :",
+      "connect1": "Touchez l'icône ampoule dans la barre de file",
+      "connect2": "Sélectionnez votre board dans la liste des appareils",
+      "connect3": "Une fois connecté, les LEDs affichent automatiquement la voie en cours",
+      "outro": "La connexion supporte les motifs en miroir et se met à jour automatiquement quand vous changez de voie."
+    },
+    "userSync": {
+      "q": "Comment synchroniser avec mon compte Kilter/Tension ?",
+      "imgAlt": "Paramètres de compte Aurora",
+      "intro": "Liez votre compte Aurora (Kilter ou Tension) pour synchroniser votre historique et votre progression.",
+      "linkLabel": "Pour lier votre compte :",
+      "link1": "Ouvrez le menu (touchez votre avatar) et allez dans Paramètres",
+      "link2": "Trouvez la section « Comptes Aurora »",
+      "link3": "Saisissez vos identifiants Kilter ou Tension",
+      "link4": "Cliquez sur « Lier le compte »",
+      "syncsLabel": "Ce qui est synchronisé :",
+      "syncs1": "Historique des ascensions (voies réussies)",
+      "syncs2": "Tentatives",
+      "syncs3": "Circuits/playlists",
+      "outro": "Les modifications se synchronisent dans les deux sens, donc les ascensions enregistrées dans Boardsesh apparaîtront dans les apps officielles."
+    },
+    "logbook": {
+      "q": "Comment suivre mes voies ?",
+      "imgAlt": "Détail de voie avec actions",
+      "intro": "Suivez votre progression en escalade en enregistrant vos ascensions et vos tentatives.",
+      "fromLabel": "Depuis n'importe quelle voie :",
+      "actions": {
+        "tickLabel": "Tentative :",
+        "tickBody": "Enregistre une tentative sur la voie",
+        "logLabel": "Enregistrer une ascension :",
+        "logBody": "Marque la voie comme réussie (send)",
+        "favoriteLabel": "Favori :",
+        "favoriteBody": "Sauvegardez des voies pour y accéder rapidement"
+      },
+      "outro": "Votre carnet se synchronise avec les comptes Aurora liés et peut être filtré dans les résultats de recherche pour trouver de nouveaux défis ou reprendre d'anciens projets."
+    },
+    "offline": {
+      "q": "Boardsesh fonctionne-t-il hors-ligne ?",
+      "intro": "Oui ! Boardsesh est conçu pour fonctionner de manière fiable même avec une connectivité intermittente.",
+      "worksLabel": "Ce qui fonctionne hors-ligne :",
+      "works1": "Votre file persiste localement via IndexedDB",
+      "works2": "Les jetons de session sont mis en cache pour une reconnexion rapide",
+      "works3": "Les données de profil sont stockées localement",
+      "works4": "Le contrôle Bluetooth des LEDs fonctionne indépendamment",
+      "outro": "Quand la connectivité est rétablie, toute modification en attente se synchronise automatiquement en arrière-plan."
+    }
+  },
+  "docs": {
+    "loading": "Chargement de la documentation…",
+    "headerTitle": "Documentation API",
+    "headerSubtitle": "Référence complète des API REST et WebSocket de Boardsesh",
+    "tabs": {
+      "overview": "Aperçu",
+      "rest": "API REST",
+      "graphql": "Schéma GraphQL",
+      "websocket": "Guide WebSocket"
+    },
+    "overview": {
+      "title": "Aperçu de l'API Boardsesh",
+      "intro": "Boardsesh fournit deux API complémentaires pour interagir avec les boards d'entraînement interactifs (Kilter, Tension) :",
+      "rest": {
+        "title": "API REST",
+        "intro": "Utilisez l'API REST pour des opérations sans état comme la recherche de voies, la récupération de la configuration du board et l'authentification utilisateur. L'API REST est idéale pour :",
+        "feature1": "Récupérer les données et statistiques de voies",
+        "feature2": "Inscription et authentification des utilisateurs",
+        "feature3": "Gestion de profil",
+        "feature4": "Intégration avec la plateforme Aurora",
+        "baseUrlLabel": "URL de base :"
+      },
+      "ws": {
+        "title": "API GraphQL WebSocket",
+        "intro": "Utilisez l'API WebSocket pour les fonctionnalités temps réel comme les sessions party et la synchronisation de file. L'API GraphQL fournit :",
+        "feature1": "Mises à jour de file en temps réel via les subscriptions",
+        "feature2": "Gestion de session (créer, rejoindre, quitter)",
+        "feature3": "Collaboration multi-utilisateur",
+        "feature4": "Toutes les fonctionnalités de l'API REST via queries/mutations",
+        "endpointLabel": "Endpoint :",
+        "endpointSuffix": "(via le protocole graphql-ws)"
+      },
+      "auth": {
+        "title": "Authentification",
+        "restLabel": "API REST :",
+        "restBody": "Utilise les cookies de session NextAuth. Authentifiez-vous via les endpoints",
+        "restBodyEnd": ".",
+        "wsLabel": "API WebSocket :",
+        "wsBody": "Obtenez un jeton JWT depuis",
+        "wsBodyEnd": "et incluez-le dans les paramètres de connexion :"
+      },
+      "rateLimit": {
+        "title": "Limitation de débit",
+        "body": "Les endpoints d'authentification sont limités en débit pour prévenir les abus. Les en-têtes de limite sont inclus dans les réponses. Les endpoints de lecture publics ont des limites généreuses."
+      }
+    },
+    "ws": {
+      "title": "Guide de connexion WebSocket",
+      "introStart": "L'API WebSocket de Boardsesh utilise le protocole",
+      "introEnd": "pour les subscriptions GraphQL en temps réel.",
+      "connection": {
+        "title": "Configuration de la connexion"
+      },
+      "session": {
+        "title": "Gestion des sessions",
+        "body": "Les sessions sont l'unité centrale de collaboration. Les utilisateurs rejoignent des sessions pour partager une file de voies."
+      },
+      "delta": {
+        "title": "Synchronisation delta",
+        "body": "Lors d'une reconnexion, utilisez la sync delta pour vous remettre à jour sans transfert d'état complet :"
+      },
+      "connectionHandling": {
+        "title": "Gestion de la connexion",
+        "body": "La connexion WebSocket peut être interrompue par des changements réseau. Implémentez une logique de reconnexion avec les options de retry de graphql-ws et utilisez la sync delta pour maintenir la cohérence d'état."
+      }
+    }
+  },
+  "privacy": {
+    "title": "Politique de confidentialité",
+    "lastUpdated": "Dernière mise à jour : avril 2026",
+    "intro1": "Boardsesh est une app open source pour piloter les boards d'entraînement (Kilter, Tension, MoonBoard) en Bluetooth. Cette politique explique quelles données nous collectons, pourquoi, et ce que nous en faisons.",
+    "intro2": "La version courte : nous collectons uniquement ce qui est nécessaire au fonctionnement de l'app. Nous ne vendons pas vos données, nous n'affichons pas de publicités, et nous n'utilisons pas de pisteurs tiers.",
+    "collect": {
+      "title": "Ce que nous collectons",
+      "accountLabel": "Informations de compte.",
+      "accountBody": "Quand vous créez un compte, nous stockons votre adresse e-mail et votre nom d'utilisateur. Votre e-mail sert à l'authentification. Votre nom d'utilisateur est affiché sur votre profil et visible par les autres utilisateurs dans les sessions Mode Party et les fonctionnalités sociales.",
+      "activityLabel": "Activité de grimpe.",
+      "activityBody": "Quand vous enregistrez un send ou une tentative, nous stockons les détails de la voie, la cotation, la date et toutes les notes que vous ajoutez. Cela alimente votre carnet et le suivi de progression.",
+      "locationLabel": "Localisation.",
+      "locationBody": "Si vous accordez la permission de localisation, nous utilisons votre position approximative pour vous aider à découvrir des sessions Mode Party à proximité. Nous ne suivons pas votre position en arrière-plan et ne stockons pas d'historique de localisation.",
+      "analyticsLabel": "Analytique.",
+      "analyticsBody": "Nous utilisons Vercel Analytics pour collecter des données anonymes de pages vues et de performance. Cela nous aide à comprendre quelles fonctionnalités sont utilisées et où l'app est lente. Ces données ne sont pas liées à votre compte."
+    },
+    "bluetooth": {
+      "title": "Bluetooth",
+      "body": "Boardsesh utilise Bluetooth Low Energy (BLE) pour se connecter au contrôleur LED de votre board. La connexion Bluetooth sert exclusivement à envoyer des commandes d'éclairage des prises au board. Aucune donnée personnelle n'est transmise par Bluetooth. L'app ne lit pas de données depuis le board, en dehors de l'identification basique de l'appareil lors de l'appairage."
+    },
+    "location": {
+      "title": "Données de localisation",
+      "body1": "L'accès à la localisation est optionnel. Lorsqu'il est accordé, il sert un seul objectif : rendre votre session Mode Party visible aux grimpeurs à proximité. Votre localisation n'est partagée avec le serveur que pendant qu'une session Mode Party est active. Nous ne stockons pas votre historique de localisation, ne construisons pas de profil de localisation et ne partageons pas de données de localisation en dehors de la fonctionnalité de découverte de sessions party.",
+      "body2": "Vous pouvez révoquer la permission de localisation à tout moment dans les paramètres de votre appareil. L'app fonctionne pleinement sans elle."
+    },
+    "thirdParty": {
+      "title": "Services tiers",
+      "vercelLabel": "Vercel.",
+      "vercelBody": "Nous utilisons Vercel pour l'hébergement et l'analytique. Vercel traite les requêtes pour servir l'app et collecte des métriques d'utilisation anonymes. Voir ",
+      "vercelLink": "la politique de confidentialité de Vercel",
+      "auroraLabel": "API Aurora Climbing.",
+      "auroraBody": "Si vous liez votre compte Aurora Climbing (utilisé par les boards Kilter et Tension), nous synchronisons vos données de voies avec les serveurs d'Aurora afin que votre carnet reste cohérent entre les apps. Cette synchronisation n'a lieu que lorsque vous l'initiez. Voir ",
+      "auroraLink": "Aurora Climbing",
+      "auroraBodyEnd": " pour leurs pratiques de données."
+    },
+    "sharing": {
+      "title": "Partage de données",
+      "body1": "Nous ne vendons pas vos données. Nous n'affichons pas de publicités. Nous ne partageons pas vos informations avec des marketeurs tiers ou des courtiers en données. Les seules données partagées en externe sont celles décrites ci-dessus (hébergement/analytique Vercel, sync Aurora Climbing si vous l'activez).",
+      "body2": "Les autres utilisateurs de Boardsesh peuvent voir votre nom d'utilisateur, votre profil et vos voies enregistrées si vous participez à des fonctionnalités sociales comme le Mode Party. C'est visible dans l'app et fait partie du fonctionnement du produit."
+    },
+    "retention": {
+      "title": "Conservation des données",
+      "body": "Nous conservons les données de votre compte et votre historique de voies tant que votre compte est actif. Si vous arrêtez d'utiliser Boardsesh, vos données restent jusqu'à ce que vous supprimiez votre compte."
+    },
+    "deletion": {
+      "title": "Suppression du compte",
+      "intro": "Vous pouvez supprimer votre compte et toutes les données associées à tout moment. Il y a deux façons de le faire :",
+      "inApp": "Dans l'app :",
+      "inAppBody": " Allez dans Paramètres, descendez tout en bas et touchez Supprimer le compte. Une confirmation vous sera demandée avant toute suppression.",
+      "onWeb": "Sur le web :",
+      "onWebBody": " Connectez-vous sur ",
+      "onWebLink": "boardsesh.com/settings",
+      "onWebBodyEnd": " et descendez tout en bas de la page pour trouver le même bouton Supprimer le compte.",
+      "permanent": "La suppression est immédiate et définitive. Une fois confirmée, nous retirons de nos serveurs votre adresse e-mail, votre nom d'utilisateur, vos entrées de carnet, vos données de file et l'historique de vos sessions party. Cela ne peut pas être annulé."
+    },
+    "children": {
+      "title": "Enfants",
+      "body": "Boardsesh ne s'adresse pas aux enfants de moins de 13 ans. Nous ne collectons pas sciemment d'informations personnelles auprès d'enfants de moins de 13 ans. Si vous pensez qu'un enfant de moins de 13 ans a créé un compte, contactez-nous et nous le supprimerons."
+    },
+    "changes": {
+      "title": "Modifications de cette politique",
+      "body": "Si nous modifions cette politique de confidentialité, nous mettrons à jour cette page avec le nouveau texte et la date de « dernière mise à jour ». Pour les changements significatifs, nous pourrons aussi vous notifier dans l'app."
+    },
+    "contact": {
+      "title": "Contact",
+      "body1Start": "Des questions sur cette politique ou vos données ? Écrivez-nous à ",
+      "body1Email": "support@boardsesh.com",
+      "body1End": ".",
+      "body2Start": "Boardsesh est open source. Vous pouvez voir exactement quelles données l'app collecte et comment elles sont traitées en lisant le code source sur ",
+      "body2Link": "GitHub",
+      "body2End": "."
+    }
+  }
+}

--- a/packages/web/i18n/locales/fr/notifications.json
+++ b/packages/web/i18n/locales/fr/notifications.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "notifications": {
+      "title": "Notifications",
+      "description": "Tes notifications sur Boardsesh"
+    }
+  },
+  "title": "Notifications",
+  "empty": "Rien pour l'instant",
+  "markAllRead": "Tout marquer comme lu",
+  "actorSummary": {
+    "fallback": "Quelqu'un",
+    "secondaryFallback": "quelqu'un",
+    "two": "{{first}} et {{second}}",
+    "many": "{{first}} et {{count}} autres",
+    "manyOne": "{{first}} et 1 autre"
+  },
+  "items": {
+    "newFollower": "{{actor}} a commencé à te suivre",
+    "commentReplyWithBody": "{{actor}} a répondu : « {{body}} »",
+    "commentReply": "{{actor}} a répondu à ton commentaire",
+    "commentOnTickWithBody": "{{actor}} a commenté : « {{body}} »",
+    "commentOnTick": "{{actor}} a commenté ton ascension",
+    "commentOnClimbWithBody": "{{actor}} a commenté : « {{body}} »",
+    "commentOnClimb": "{{actor}} a commenté une voie",
+    "voteOnTick": "{{actor}} a aimé ton ascension",
+    "voteOnComment": "{{actor}} a aimé ton commentaire",
+    "proposalCreated": "{{actor}} a créé une nouvelle proposition",
+    "proposalApproved": "La proposition de {{actor}} a été approuvée",
+    "proposalRejected": "La proposition de {{actor}} a été rejetée",
+    "proposalVote": "{{actor}} a voté sur ta proposition",
+    "newClimb": "{{actor}} a créé une nouvelle voie",
+    "newClimbsSyncedSetter": "{{setter}} a ouvert de nouvelles voies",
+    "newClimbsSynced": "{{actor}} a ouvert de nouvelles voies",
+    "default": "Tu as une nouvelle notification"
+  },
+  "time": {
+    "justNow": "à l'instant",
+    "minutes": "{{count}} min",
+    "hours": "{{count}} h",
+    "days": "{{count}} j"
+  }
+}

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -1,0 +1,204 @@
+{
+  "metadata": {
+    "library": {
+      "title": "Découvrir des playlists d'escalade",
+      "description": "Découvrez des playlists d'escalade publiques et gérez les vôtres après vous être connecté."
+    },
+    "detail": {
+      "fallbackTitle": "Playlist",
+      "fallbackDescription": "Playlist d'escalade sur Boardsesh"
+    }
+  },
+  "library": {
+    "signInBanner": {
+      "title": "Connectez-vous pour utiliser votre bibliothèque",
+      "description": "Suivez vos ascensions et gérez vos playlists.",
+      "cta": "Se connecter",
+      "modalTitle": "Se connecter à Boardsesh",
+      "modalDescription": "Connectez-vous pour suivre vos voies et gérer vos playlists."
+    },
+    "sections": {
+      "jumpBackIn": "Reprendre",
+      "discover": "Découvrir"
+    },
+    "empty": {
+      "title": "Aucune playlist pour le moment",
+      "description": "Créez votre première playlist en ajoutant des voies depuis la liste."
+    },
+    "errors": {
+      "loadTitle": "Impossible de charger la bibliothèque",
+      "loadDescription": "Une erreur est survenue lors du chargement de votre bibliothèque. Veuillez réessayer.",
+      "loadFailed": "Échec du chargement de votre bibliothèque",
+      "tryAgain": "Réessayer"
+    }
+  },
+  "detail": {
+    "share": "Partager la playlist",
+    "actions": "Actions de la playlist",
+    "menu": {
+      "generate": "Générer",
+      "edit": "Modifier",
+      "delete": "Supprimer"
+    },
+    "visibility": {
+      "public": "Public",
+      "private": "Privé"
+    },
+    "shareText": "Découvrez cette playlist d'escalade sur Boardsesh",
+    "shareFallbackTitle": "Playlist",
+    "shareSuccess": "Lien copié dans le presse-papiers !",
+    "shareError": "Échec du partage",
+    "deleted": "Playlist supprimée",
+    "deleteFailed": "Échec de la suppression de la playlist",
+    "discussion": "Discussion",
+    "empty": "Aucune voie dans cette playlist pour le moment",
+    "climbCount_one": "{{count}} voie",
+    "climbCount_other": "{{count}} voies",
+    "followerCount_one": "{{count}} abonné",
+    "followerCount_other": "{{count}} abonnés",
+    "errors": {
+      "notFoundTitle": "Playlist introuvable",
+      "notFoundDescription": "Cette playlist a peut-être été supprimée ou vous n'avez pas la permission de la consulter.",
+      "loadTitle": "Impossible de charger la playlist",
+      "loadDescription": "Une erreur est survenue lors du chargement de cette playlist. Veuillez réessayer.",
+      "loadFailed": "Échec du chargement de la playlist",
+      "notFound": "Playlist introuvable",
+      "tryAgain": "Réessayer"
+    }
+  },
+  "edit": {
+    "title": "Modifier la playlist",
+    "fields": {
+      "name": "Nom de la playlist",
+      "namePlaceholder": "ex. : Réglettes dures",
+      "description": "Description",
+      "descriptionPlaceholder": "Description facultative pour votre playlist...",
+      "color": "Couleur",
+      "icon": "Icône",
+      "removeIcon": "Supprimer",
+      "visibility": "Visibilité",
+      "publicHint": "Les playlists publiques sont visibles par toute personne disposant du lien",
+      "privateHint": "Les playlists privées ne sont visibles que par vous"
+    },
+    "actions": {
+      "cancel": "Annuler",
+      "save": "Enregistrer",
+      "saving": "Enregistrement..."
+    },
+    "validation": {
+      "nameRequired": "Veuillez saisir un nom de playlist",
+      "nameTooLong": "Le nom ne doit pas dépasser 100 caractères",
+      "descriptionTooLong": "La description ne doit pas dépasser 500 caractères"
+    },
+    "messages": {
+      "updated": "Playlist mise à jour avec succès",
+      "updateFailed": "Échec de la mise à jour de la playlist"
+    }
+  },
+  "create": {
+    "drawerTitle": "Créer une playlist",
+    "submit": "Créer",
+    "submitting": "Création...",
+    "fields": {
+      "name": "Nom",
+      "namePlaceholder": "ex. : Réglettes dures",
+      "description": "Description (facultative)",
+      "descriptionPlaceholder": "Description facultative...",
+      "color": "Couleur (facultative)"
+    }
+  },
+  "generator": {
+    "drawerTitle": "Générer une playlist",
+    "generatingTitle": "Génération...",
+    "optionsTitle": "Options",
+    "generatingProgress": "Ajout des voies... {{current}} / {{total}}",
+    "generate": "Générer",
+    "reset": "Réinitialiser",
+    "totals": {
+      "total": "Total",
+      "climbs_one": "{{count}} voie",
+      "climbs_other": "{{count}} voies"
+    },
+    "summaryRow_one": "{{count}} voie ({{range}})",
+    "summaryRow_other": "{{count}} voies ({{range}})",
+    "options": {
+      "warmUp": "Échauffement",
+      "targetGrade": "Cotation cible",
+      "minAscents": "Ascensions min.",
+      "minRating": "Note min.",
+      "climbBias": "Préférence de voie",
+      "tallClimbsLabel": "Voies hautes uniquement",
+      "tallClimbsTooltip": "Afficher uniquement les voies qui utilisent les prises des 8 rangées du bas (disponible uniquement sur les boards 10x12)",
+      "mainSetClimbs": "Voies de la série principale",
+      "mainSetVariability": "Variabilité de la série principale",
+      "numberOfSteps": "Nombre de paliers",
+      "climbsPerStep": "Voies par palier",
+      "numberOfClimbs": "Nombre de voies"
+    },
+    "warmUpOptions": {
+      "standard": "Standard",
+      "extended": "Prolongé",
+      "none": "Aucun"
+    },
+    "climbBiasOptions": {
+      "unfamiliar": "Inconnues",
+      "attempted": "Essayées",
+      "any": "Toutes"
+    },
+    "effortLevels": {
+      "moderate": "Modéré",
+      "challenging": "Difficile",
+      "veryDifficult": "Très difficile",
+      "maxEffort": "Effort maximal"
+    },
+    "workoutTypes": {
+      "volume": {
+        "name": "Volume",
+        "description": "Générer un entraînement à fort volume."
+      },
+      "pyramid": {
+        "name": "Pyramide",
+        "description": "Monter jusqu'à une cotation max puis redescendre."
+      },
+      "ladder": {
+        "name": "Échelle",
+        "description": "Progresser dans les cotations par paliers."
+      },
+      "gradeFocus": {
+        "name": "Cotation ciblée",
+        "description": "Choisissez une cotation et c'est parti !"
+      }
+    },
+    "sections": {
+      "warmUp": "Échauffement",
+      "increasing": "Montée",
+      "peak": "Pic",
+      "decreasing": "Descente",
+      "main": "Série principale"
+    },
+    "chart": {
+      "ariaLabel": "Aperçu de la distribution des cotations",
+      "configurePrompt": "Configurez les options pour prévisualiser"
+    },
+    "messages": {
+      "noClimbs": "Aucune voie à générer",
+      "addedAll": "{{count}} voies ajoutées à la playlist",
+      "addedPartial": "{{added}} voies ajoutées. {{failed}} emplacements n'ont pas pu être remplis.",
+      "failed": "Échec de la génération de la playlist. Aucune voie appropriée trouvée."
+    }
+  },
+  "bottomTabBar": {
+    "home": "Accueil",
+    "climb": "Grimper",
+    "discover": "Découvrir",
+    "feed": "Fil",
+    "create": "Créer",
+    "you": "Vous",
+    "youSignInTitle": "Connectez-vous pour voir votre progression",
+    "youSignInDescription": "Connectez-vous pour suivre vos statistiques d'escalade, vos sessions et votre carnet.",
+    "selectBoardForPlaylist": "Sélectionnez un board avant de créer une playlist",
+    "boardDetailsMissing": "Impossible de déterminer les détails du board pour créer la playlist",
+    "createdPlaylistToast": "Playlist « {{name}} » créée",
+    "createPlaylistFailed": "Échec de la création de la playlist"
+  }
+}

--- a/packages/web/i18n/locales/fr/profile.json
+++ b/packages/web/i18n/locales/fr/profile.json
@@ -1,0 +1,217 @@
+{
+  "metadata": {
+    "profile": {
+      "title": "{{name}}",
+      "description": "Profil d'escalade de {{name}} sur Boardsesh",
+      "fallbackTitle": "Profil",
+      "fallbackDescription": "Voir le profil et les statistiques d'escalade",
+      "notFoundTitle": "Profil introuvable",
+      "notFoundDescription": "Ce profil d'escalade est introuvable.",
+      "ogAlt": "Profil d'escalade de {{name}}"
+    },
+    "statistics": {
+      "title": "Statistiques"
+    },
+    "sessions": {
+      "title": "Sessions"
+    },
+    "climbs": {
+      "title": "Voies créées"
+    },
+    "setter": {
+      "title": "{{name}} - Ouvreur",
+      "description": "Voies créées par {{name}} sur Boardsesh",
+      "fallbackTitle": "Profil d'ouvreur",
+      "fallbackDescription": "Voir le profil d'ouvreur et ses voies sur Boardsesh",
+      "ogAlt": "Profil d'ouvreur de {{name}}"
+    }
+  },
+  "page": {
+    "lastThreeMonths": "3 derniers mois",
+    "activityChartLabel": "Activité des 3 derniers mois",
+    "displayNameFallback": "Grimpeur"
+  },
+  "nav": {
+    "statistics": {
+      "title": "Statistiques",
+      "subtitleSent": "{{count}} blocs réussis",
+      "subtitleEmpty": "Cotations, progression et plus encore"
+    },
+    "sessions": {
+      "title": "Sessions",
+      "subtitle": "Sessions et activité d'escalade"
+    },
+    "createdClimbs": {
+      "title": "Voies créées",
+      "subtitleOwn": "Voies que vous avez créées",
+      "subtitleOther": "Voies qu'iels ont créées"
+    }
+  },
+  "stats": {
+    "problems": "blocs",
+    "send": "réussite",
+    "flash": "flash",
+    "percentile": "Percentile",
+    "topPercent": "Top {{value}} %",
+    "moreSentThan": "Plus de blocs réussis que {{value}} % des grimpeurs",
+    "activity": "Activité",
+    "gradeDistribution": "Distribution des cotations",
+    "flashVsRedpoint": "Flash vs Après-travail",
+    "vPoints": "V-Points",
+    "vPointsTotal": "{{value}} au total",
+    "gradeDistributionAria": "Distribution des cotations entre les boards",
+    "weeklyAttemptsAria": "Essais hebdomadaires par difficulté",
+    "flashRedpointAria": "Flash vs après-travail par cotation",
+    "layoutTooltip": "{{name}} : {{count}} blocs ({{percentage}} %)"
+  },
+  "empty": {
+    "userNotFound": "Utilisateur introuvable",
+    "noAscentData": "Aucune donnée d'ascension pour cette période",
+    "noClimbingData": "Aucune donnée d'escalade pour cette période"
+  },
+  "filter": {
+    "pageTitle": "Statistiques",
+    "drawer": {
+      "title": "Filtres",
+      "board": "Board",
+      "timeRange": "Période",
+      "from": "Du",
+      "to": "Au"
+    }
+  },
+  "analytics": {
+    "noData": "Aucune donnée d'analyse disponible pour le moment. Les données sont collectées lors de la synchronisation.",
+    "ascentsOverTime": "Ascensions au fil du temps",
+    "qualityOverTime": "Qualité au fil du temps"
+  },
+  "logbook": {
+    "section": {
+      "noAscentsLogged": "Aucune ascension enregistrée pour cette voie"
+    },
+    "crew": {
+      "signInPrompt": "Connectez-vous pour voir le carnet de votre crew pour cette voie",
+      "loadError": "Impossible de charger le carnet de votre crew. Réessayez dans un instant.",
+      "noneYet": "Personne de votre crew n'a encore enregistré cette voie"
+    },
+    "entry": {
+      "mirroredTag": "Inversée",
+      "attemptsLabel": "Essais : {{count}}"
+    },
+    "form": {
+      "ascent": "Ascension",
+      "attempt": "Essai",
+      "boulder": "Bloc",
+      "dateAndTime": "Date et heure",
+      "angle": "Angle",
+      "attempts": "Essais",
+      "quality": "Qualité",
+      "difficulty": "Difficulté",
+      "notes": "Notes",
+      "video": "Vidéo",
+      "videoPlaceholder": "URL Instagram ou TikTok",
+      "videoHelper": "Collez un lien Instagram ou TikTok pour montrer votre beta. (Facultatif)",
+      "mirrored": "Inversée",
+      "submit": "Envoyer",
+      "cancel": "Annuler"
+    },
+    "feed": {
+      "deleteSwipeLabel": "Supprimer",
+      "cancelEditing": "Annuler la modification",
+      "saveEdit": "Enregistrer",
+      "moreActions": "Plus d'actions",
+      "editLog": "Modifier l'entrée",
+      "deleteLog": "Supprimer l'entrée",
+      "postToInstagram": "Publier sur Instagram",
+      "linkInstagramPost": "Lier la publication Instagram",
+      "stars": "étoiles",
+      "user": "utilisateur",
+      "grade": "cotation",
+      "tries": "essais",
+      "selectGrade": "Sélectionner la cotation enregistrée",
+      "status": {
+        "flash": "Flash",
+        "send": "Réussite",
+        "attempt": "Essai"
+      },
+      "snackbar": {
+        "boardsLinkMissing": "Impossible de trouver le board lié — affichage de toutes vos entrées.",
+        "deleteFailed": "Échec de la suppression du tick",
+        "tickDeleted": "Tick supprimé",
+        "undo": "Annuler"
+      }
+    },
+    "search": {
+      "placeholder": "Rechercher des voies ou des notes",
+      "openFilters": "Ouvrir les filtres",
+      "search": "Rechercher",
+      "gradeRange": "Plage de cotations",
+      "sort": "Trier",
+      "clearAll": "Tout effacer",
+      "filterCount_one": "filtre actif",
+      "filterCount_other": "filtres actifs",
+      "resultType": {
+        "includeSends": "Inclure les réussites",
+        "includeAttempts": "Inclure les essais",
+        "flashOnly": "Flash uniquement",
+        "benchmarkOnly": "Références uniquement"
+      },
+      "dateAngle": {
+        "dateRange": "Plage de dates",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "wallAngleRange": "Plage d'angle du mur ({{min}}°–{{max}}°)"
+      },
+      "sortFields": {
+        "date": "Date",
+        "climbName": "Nom de la voie",
+        "loggedGrade": "Cotation enregistrée",
+        "consensusGrade": "Cotation consensuelle",
+        "attemptCount": "Essais"
+      },
+      "sortDirection": {
+        "desc": "Décr."
+      }
+    },
+    "instagram": {
+      "back": "Retour",
+      "title": "Publier sur Instagram",
+      "subtitle": "Partagez votre ascension et reliez-la à Boardsesh.",
+      "betaLoadFailed": "Impossible de charger les vidéos beta.",
+      "retry": "Réessayer",
+      "steps": {
+        "copy": "Copiez la légende et ouvrez Instagram.",
+        "paste": "Collez la légende lors de la création de votre publication.",
+        "comeBack": "Une fois votre publication en ligne, revenez ici.",
+        "pasteLink": "Collez le lien Instagram pour que nous puissions afficher votre vidéo d'ascension ici."
+      },
+      "addLinkSubmit": "Ajouter le lien Instagram",
+      "shareYourBeta": "Partagez votre vidéo beta",
+      "shareYourBetaBody": "Nous copions la légende, ouvrons Instagram, et vous laissons coller le lien final dans Boardsesh.",
+      "howItWorks": "Comment ça marche",
+      "caption": "Légende",
+      "copyAndOpen": "Copier et ouvrir Instagram",
+      "pasteLinkTitle": "Collez votre lien Instagram",
+      "pasteLinkBody": "Quand votre publication est en ligne, collez le lien du reel ou de la publication ici pour que Boardsesh affiche votre vidéo d'ascension.",
+      "pasteLinkHelper": "Collez l'URL du reel ou de la publication Instagram en ligne.",
+      "existingBetaVideos": "Vidéos beta existantes",
+      "snackbar": {
+        "copyFailed": "Impossible de copier la légende. Réessayez.",
+        "openFailed": "Impossible d'ouvrir Instagram. Ouvrez-le manuellement et collez la légende copiée.",
+        "copied": "Légende copiée. Instagram devrait s'ouvrir."
+      }
+    }
+  },
+  "setter": {
+    "notFoundTitle": "Ouvreur introuvable",
+    "notFoundMessage": "Ce profil d'ouvreur n'existe peut-être pas ou a été supprimé.",
+    "shareAriaLabel": "Partager le profil d'ouvreur",
+    "shareTitle": "{{name}} - Ouvreur",
+    "shareText": "Découvrez les voies de {{name}} sur Boardsesh",
+    "linkCopied": "Lien copié dans le presse-papiers !",
+    "shareFailed": "Échec du partage",
+    "follower_one": "abonné",
+    "follower_other": "abonnés",
+    "climb_one": "voie",
+    "climb_other": "voies"
+  }
+}

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -1,0 +1,283 @@
+{
+  "metadata": {
+    "detail": {
+      "title": "Session de grimpe",
+      "description": "Session de grimpe sur Boardsesh",
+      "notFoundTitle": "Session introuvable",
+      "notFoundDescription": "Cette session n'existe pas ou est terminée."
+    },
+    "join": {
+      "title": "Rejoindre la session",
+      "description": "Rejoins une session de grimpe sur Boardsesh",
+      "headlineWithLeader": "Rejoins {{name}} sur le mur",
+      "headlineDefault": "Rejoins la crew sur le mur",
+      "descriptionDefault": "Saute dans cette session de grimpe sur Boardsesh. Monte sur le mur.",
+      "descriptionLive": "{{sessionName}} est en direct sur Boardsesh. Monte sur le mur.",
+      "descriptionBoardWithSends_one": "{{boardInfo}}. {{count}} enchaînement jusqu'ici{{gradeSummary}}. Monte sur le mur.",
+      "descriptionBoardWithSends_other": "{{boardInfo}}. {{count}} enchaînements jusqu'ici{{gradeSummary}}. Monte sur le mur.",
+      "descriptionBoardNoSends": "{{boardInfo}}. Aucun enchaînement pour l'instant. Monte sur le mur.",
+      "boardAtAngle": "{{boardLabel}} à {{angle}}°",
+      "gradeOn": " en {{grade}}",
+      "gradeRange": " de {{first}} à {{last}}"
+    }
+  },
+  "detail": {
+    "title": "Session",
+    "subtitleSends_one": "{{count}} enchaînement",
+    "subtitleSends_other": "{{count}} enchaînements",
+    "participantsClimbing": "{{names}} grimpent sur Boardsesh",
+    "sessionNameOnBoardsesh": "{{name}} sur Boardsesh",
+    "host": "Hôte : {{name}}",
+    "participants": "Participants",
+    "climbs": "Voies",
+    "climbsCount": "Voies ({{count}})",
+    "duration": "Durée",
+    "startedAt": "Démarrée {{time}}",
+    "empty": "Aucun enchaînement pour l'instant",
+    "endSession": "Terminer la session",
+    "leaveSession": "Quitter la session",
+    "share": "Partager la session",
+    "shareTitle": "Session de grimpe",
+    "shareText": "Regarde cette session de grimpe sur Boardsesh",
+    "shareSuccess": "Lien copié dans le presse-papiers !",
+    "shareError": "Échec du partage",
+    "comments": "Commentaires",
+    "deleteAscent": "Supprimer l'ascension",
+    "deleteAscentConfirm": "Tu es sûr ? Cette action est irréversible.",
+    "delete": "Supprimer",
+    "climberFallback": "Grimpeur",
+    "unknownClimb": "Voie inconnue",
+    "anonymous": "Anonyme",
+    "attemptOnNth": "au {{ordinal}} essai",
+    "totalAttempts": "{{count}} au total",
+    "attemptCount_one": "{{count}} essai",
+    "attemptCount_other": "{{count}} essais",
+    "ordinalFirst": "{{n}}er",
+    "ordinalSecond": "{{n}}e",
+    "ordinalThird": "{{n}}e",
+    "ordinalDefault": "{{n}}e",
+    "joiningSession": "Connexion à la session…",
+    "sessionNotesPlaceholder": "Notes ou objectif de session…",
+    "noClimbsYet": "Aucune voie pour l'instant",
+    "logSomeClimbs": "Enregistre quelques voies pour voir la répartition par cotation",
+    "climbsLogged_one": "{{count}} voie enregistrée",
+    "climbsLogged_other": "{{count}} voies enregistrées",
+    "gradesCount_one": "{{count}} cotation",
+    "gradesCount_other": "{{count}} cotations",
+    "gradeDistribution": "Répartition des cotations",
+    "gradesClimbedThisSession": "Cotations grimpées cette session",
+    "sessionGradeDistribution": "Répartition des cotations de la session",
+    "sections": {
+      "invite": "Inviter",
+      "inviteTitle": "Invite la crew à rejoindre",
+      "inviteSummary": "Partage le lien ou le QR code",
+      "activity": "Activité",
+      "analytics": "Statistiques"
+    },
+    "sendsCount_one": "{{count}} enchaînement",
+    "sendsCount_other": "{{count}} enchaînements",
+    "flashesCount_one": "{{count}} flash",
+    "flashesCount_other": "{{count}} flashs",
+    "attemptsCount_one": "{{count}} essai",
+    "attemptsCount_other": "{{count}} essais",
+    "climbCount_one": "{{count}} voie",
+    "climbCount_other": "{{count}} voies",
+    "hardestLabel": "Plus dure : {{grade}}",
+    "notFound": {
+      "title": "Session introuvable",
+      "subtitle": "Cette session est introuvable. Elle a peut-être été supprimée.",
+      "back": "Retour à Boardsesh"
+    },
+    "userSearch": {
+      "title": "Ajouter un grimpeur",
+      "placeholder": "Rechercher par nom…",
+      "noUsersFound": "Aucun utilisateur trouvé"
+    }
+  },
+  "join": {
+    "title": "Rejoindre la session",
+    "subtitle": "Monte sur le mur",
+    "description": "Tu as été invité à une session de grimpe.",
+    "joinButton": "Rejoindre la session",
+    "joining": "Connexion à la session…",
+    "leaderName": "Animée par {{name}}",
+    "scanQr": "Ou scanne un QR code de l'hôte",
+    "enterId": "Ou colle un identifiant de session",
+    "errors": {
+      "notFound": "Session introuvable",
+      "ended": "Cette session est terminée",
+      "joinFailed": "Impossible de rejoindre la session"
+    }
+  },
+  "settings": {
+    "drawerTitle": "Paramètres de la session",
+    "fallbackTitle": "Session",
+    "partyMode": {
+      "label": "Mode session",
+      "subtitle": "Partage ta file d'attente avec la crew"
+    },
+    "name": "Nom de la session",
+    "namePlaceholder": "Sesh du vendredi soir",
+    "color": "Couleur de la session",
+    "leader": "Animateur de la session",
+    "leaveSession": "Quitter la session",
+    "endSession": "Terminer la session",
+    "stopSession": "Arrêter la session",
+    "dismiss": "Fermer",
+    "loadFailed": "Impossible de charger tous les détails de la session. Les stats en direct continueront dès que possible.",
+    "endSessionConfirm": {
+      "title": "Terminer cette session ?",
+      "description": "Ta crew sera déconnectée.",
+      "confirm": "Terminer",
+      "cancel": "Annuler"
+    },
+    "share": {
+      "shareTitle": "Rejoins ma session de grimpe",
+      "shareText": "Saute dedans et grimpe avec moi sur Boardsesh",
+      "shareLink": "Partager le lien de la session",
+      "shareLinkPreview": "Partager le lien de la session (aperçu)",
+      "linkCopied": "Lien copié !",
+      "shareError": "Échec du partage",
+      "showQr": "Afficher le QR code",
+      "hideQr": "Masquer le QR code",
+      "showQrPreview": "Afficher le QR code (aperçu)",
+      "inviteCopy": "Embarque ta crew en partageant ce lien ou en scannant le QR code",
+      "inviteCopyPreview": "Partage ce lien ou ce QR code avec ta crew et ils apparaîtront en direct."
+    }
+  },
+  "creation": {
+    "title": "Lancer une session",
+    "subtitle": "Grimpez ensemble en temps réel",
+    "drawerTitle": "Lancer la session",
+    "create": "Lancer la session",
+    "creating": "Lancement…",
+    "submitDefault": "Sesh",
+    "dialogTitle": "Créer une session",
+    "dialogSubmit": "Créer la session",
+    "started": "Session lancée !",
+    "selectBoardWarning": "Sélectionne d'abord un board",
+    "boardsNearYou": "Boards près de toi",
+    "loggedInBlurb": "Suis tes voies et invite d'autres grimpeurs à rejoindre.",
+    "anonymousBlurb": "Saute dedans sans compte. Connecte-toi plus tard pour sauvegarder ta progression.",
+    "signInForMore": "Connecte-toi pour plus de fonctionnalités",
+    "signInModalTitle": "Connecte-toi pour sauvegarder ta session",
+    "signInModalDescription": "Tes enchaînements ne disparaîtront pas en fermant l'onglet.",
+    "form": {
+      "sessionNameLabel": "Nom de la session",
+      "sessionNamePlaceholder": "ex. Projet du mardi",
+      "sessionGoalLabel": "Objectif de la session",
+      "sessionGoalPlaceholder": "ex. Enchaîner du V5 aujourd'hui",
+      "sessionGoalHelper": "{{count}}/500",
+      "sessionColor": "Couleur de la session",
+      "discoverableLabel": "Visible par les grimpeurs à proximité",
+      "discoverableDescription": "Les autres à proximité pourront trouver et rejoindre ta session",
+      "permanentLabel": "Session permanente (ne se terminera pas automatiquement)"
+    },
+    "errors": {
+      "createFailed": "Échec du lancement de la session"
+    }
+  },
+  "summary": {
+    "title": "Résumé de la session",
+    "dialogTitle": "Résumé de la session",
+    "totalClimbs": "Total des voies",
+    "sends": "Enchaînements",
+    "attempts": "Essais",
+    "duration": "Durée",
+    "hardestSend": "Enchaînement le plus dur :",
+    "shareSummary": "Partager le résumé",
+    "goal": "Objectif :",
+    "gradeDistribution": "Répartition des cotations",
+    "participants": "Participants",
+    "anonymous": "Anonyme",
+    "participantStats": "{{sends}} enchaînements / {{attempts}} essais",
+    "done": "Terminé",
+    "saveToAppleHealth": "Enregistrer dans Apple Santé",
+    "savingToAppleHealth": "Enregistrement dans Apple Santé…",
+    "savedToAppleHealth": "Enregistré dans Apple Santé",
+    "saveToAppleHealthRetry": "Enregistrer dans Apple Santé (réessayer)",
+    "minutes": "{{count}} min",
+    "hours": "{{count}} h",
+    "hoursAndMinutes": "{{hours}} h {{mins}} min"
+  },
+  "overview": {
+    "goal": "Objectif : {{goal}}"
+  },
+  "queueBar": {
+    "cancelReconnectConfirm": "Annuler quittera la session. C'est ce que tu veux ?",
+    "shellMessage": "Aucune voie sélectionnée",
+    "startSesh": "Lancer la sesh",
+    "linkCopied": "Lien copié !",
+    "shareFailed": "Échec du partage",
+    "leaveFailed": "Impossible de quitter la session. Réessaie.",
+    "cancelReconnect": "Annuler",
+    "tickError": "Impossible d'enregistrer ton tick. Réessaie.",
+    "tickCommentPlaceholder": "Commentaire…",
+    "tickCommentAria": "Commentaire du tick",
+    "tickAttemptLabel": "essai",
+    "reconnect": {
+      "connectionError": "Erreur de connexion – nouvelle tentative…",
+      "reconnecting": "Reconnexion…"
+    },
+    "tickBar": {
+      "collapse": "Réduire",
+      "expand": "Développer",
+      "collapseAria": "Réduire la barre de tick",
+      "expandAria": "Développer la barre de tick"
+    },
+    "ariaLabels": {
+      "leaveSession": "Quitter la session",
+      "keepReconnecting": "Continuer à reconnecter",
+      "dismissOfflineNotice": "Fermer l'avis hors ligne",
+      "shareSessionLink": "Partager le lien de la session",
+      "closeTickBar": "Fermer la barre de tick",
+      "enterPlayMode": "Passer en mode jeu",
+      "logAttempt": "Enregistrer un essai"
+    }
+  },
+  "queueDrawer": {
+    "title": "File d'attente",
+    "clearTitle": "Vider la file d'attente",
+    "clearDescription": "Tu veux vraiment vider tous les éléments de la file d'attente ?",
+    "clearConfirm": "Vider",
+    "clear": "Vider",
+    "removeItems_one": "Retirer {{count}} élément",
+    "removeItems_other": "Retirer {{count}} éléments"
+  },
+  "queueList": {
+    "editClimb": "Modifier cette voie",
+    "addedViaBluetooth": "Ajoutée via Bluetooth",
+    "suggestionsHeader": "Suggestions",
+    "endMessage": "C'est tout pour l'instant"
+  },
+  "queueProvider": {
+    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes voies."
+  },
+  "playView": {
+    "yourAscents_one": "Ton ascension ({{count}})",
+    "yourAscents_other": "Tes ascensions ({{count}})",
+    "triesCount_one": "{{count}} essai",
+    "triesCount_other": "{{count}} essais",
+    "tickError": "Impossible d'enregistrer ton tick — sauvegardé en brouillon",
+    "closeAria": "Fermer",
+    "noClimbSelected": "Aucune voie sélectionnée",
+    "browseClimbs": "Parcourir les voies",
+    "actionBar": {
+      "climbActionsAria": "Actions de la voie",
+      "openQueueAria": "Ouvrir la file d'attente"
+    },
+    "tickFab": {
+      "logAscentAria": "Enregistrer une ascension"
+    },
+    "tickBar": {
+      "commentPlaceholder": "Commentaire…",
+      "commentAria": "Commentaire du tick",
+      "closeAria": "Fermer la barre de tick",
+      "collapseAria": "Réduire la barre de tick",
+      "expandAria": "Développer la barre de tick",
+      "attemptLabel": "essai",
+      "logAttemptAria": "Enregistrer un essai",
+      "saveTickAria": "Enregistrer le tick"
+    }
+  }
+}

--- a/packages/web/i18n/locales/fr/settings.json
+++ b/packages/web/i18n/locales/fr/settings.json
@@ -1,0 +1,359 @@
+{
+  "metadata": {
+    "settings": {
+      "title": "Paramètres",
+      "description": "Gérez votre compte Boardsesh, votre profil et vos préférences"
+    }
+  },
+  "title": "Paramètres",
+  "loading": {
+    "profileError": "Échec du chargement du profil"
+  },
+  "profile": {
+    "title": "Profil",
+    "subtitle": "Personnalisez votre apparence sur Boardsesh",
+    "avatar": {
+      "label": "Avatar",
+      "upload": "Téléverser",
+      "change": "Modifier",
+      "remove": "Supprimer",
+      "hint": "JPG, PNG, GIF ou WebP. Jusqu'à 10 Mo — compression automatique."
+    },
+    "displayName": {
+      "label": "Nom d'affichage",
+      "placeholder": "Saisissez votre nom d'affichage"
+    },
+    "instagram": {
+      "label": "Profil Instagram",
+      "placeholder": "https://instagram.com/username"
+    },
+    "email": {
+      "label": "E-mail",
+      "help": "L'e-mail ne peut pas être modifié"
+    },
+    "save": "Enregistrer les modifications",
+    "saved": "Paramètres enregistrés avec succès",
+    "saveError": "Échec de l'enregistrement des paramètres",
+    "validation": {
+      "displayNameTooLong": "Le nom d'affichage doit comporter moins de 100 caractères",
+      "invalidInstagramUrl": "Veuillez saisir une URL de profil Instagram valide",
+      "invalidImageType": "Seules les images JPG, PNG, GIF et WebP sont autorisées",
+      "imageTooLarge": "L'image doit être inférieure à 10 Mo",
+      "compressionFailed": "Compression impossible — essayez une image plus petite"
+    },
+    "avatarUploadFailed": "Échec du téléversement de l'avatar"
+  },
+  "preferences": {
+    "title": "Préférences d'affichage",
+    "subtitle": "Personnalisez l'affichage des cotations et autres données",
+    "gradeFormat": {
+      "label": "Format d'affichage des cotations",
+      "vGrade": "Cotation V (V3, V6, ...)",
+      "font": "Font (6A, 7C+, ...)"
+    },
+    "appleHealth": {
+      "label": "Apple Health",
+      "switchLabel": "Enregistrer automatiquement les sessions dans Apple Health",
+      "subtitle": "Désactivez cette option pour n'enregistrer les sessions que lorsque vous appuyez sur le bouton Enregistrer dans Apple Health."
+    }
+  },
+  "logbook": {
+    "title": "Votre carnet",
+    "subtitle": "Consultez et filtrez vos voies enregistrées"
+  },
+  "deleteAccount": {
+    "title": "Supprimer le compte",
+    "warning": "Supprimez définitivement votre compte et toutes les données associées. Cette action est irréversible.",
+    "button": "Supprimer le compte",
+    "dialog": {
+      "title": "Supprimer votre compte ?",
+      "warning": "Cette action est définitive. Votre profil, vos brouillons de voies, votre carnet et toutes les autres données seront supprimés et ne pourront pas être récupérés.",
+      "checking": "Vérification de vos voies...",
+      "publishedClimbs_one": "Vous avez <strong>{{count}}</strong> voie publiée qui sera conservée après la suppression.",
+      "publishedClimbs_other": "Vous avez <strong>{{count}}</strong> voies publiées qui seront conservées après la suppression.",
+      "removeSetterName": "Retirer mon nom d'ouvreur des voies publiées",
+      "confirmInstruction": "Saisissez <strong>DELETE</strong> pour confirmer.",
+      "confirmPlaceholder": "DELETE",
+      "cancel": "Annuler",
+      "confirm": "Supprimer mon compte"
+    },
+    "error": "Échec de la suppression du compte. Veuillez réessayer."
+  },
+  "password": {
+    "enabledTitle": "Connexion par e-mail et mot de passe",
+    "enabledDescription": "La connexion par mot de passe est activée pour {{email}}",
+    "title": "Connexion par e-mail et mot de passe",
+    "description": "Définissez un mot de passe pour vous connecter avec votre adresse e-mail. Cela est utile pour les navigateurs qui ne prennent pas en charge la connexion Google (par exemple, l'application Boardsesh iOS).",
+    "linkedProviderInfo_one": "Vous êtes actuellement connecté avec {{providers}}. Définir un mot de passe n'affectera pas votre connexion {{providers}}.",
+    "linkedProviderInfo_other": "Vous êtes actuellement connecté avec {{providers}}. Définir un mot de passe n'affectera pas votre connexion sociale.",
+    "passwordLabel": "Mot de passe",
+    "passwordPlaceholder": "Mot de passe (min. 8 caractères)",
+    "confirmLabel": "Confirmer le mot de passe",
+    "confirmPlaceholder": "Confirmez le mot de passe",
+    "submit": "Définir le mot de passe",
+    "success": "Mot de passe défini ! Vous pouvez maintenant vous connecter avec votre e-mail et votre mot de passe.",
+    "validation": {
+      "enterPassword": "Veuillez saisir un mot de passe",
+      "tooShort": "Le mot de passe doit comporter au moins 8 caractères",
+      "tooLong": "Le mot de passe doit comporter moins de 128 caractères",
+      "confirmRequired": "Veuillez confirmer votre mot de passe",
+      "mismatch": "Les mots de passe ne correspondent pas",
+      "saveError": "Échec de la définition du mot de passe",
+      "retryError": "Échec de la définition du mot de passe. Veuillez réessayer."
+    }
+  },
+  "controllers": {
+    "title": "Contrôleurs ESP32",
+    "subtitle": "Enregistrez des appareils ESP32 pour contrôler votre board via un pont Bluetooth. Cela vous permet d'utiliser BoardSesh avec les applications officielles Kilter/Tension.",
+    "empty": "Aucun contrôleur enregistré. Ajoutez un ESP32 pour utiliser BoardSesh avec les applications officielles.",
+    "add": "Ajouter un contrôleur",
+    "card": {
+      "unnamed": "Contrôleur sans nom",
+      "board": "Board :",
+      "layout": "Layout :",
+      "layoutValue": "{{layoutId}} / Taille {{sizeId}}",
+      "lastSeen": "Vu pour la dernière fois :",
+      "delete": "Supprimer le contrôleur",
+      "deleteConfirm": {
+        "title": "Supprimer le contrôleur",
+        "description": "Voulez-vous vraiment supprimer ce contrôleur ? Cette action est irréversible.",
+        "ok": "Oui, supprimer",
+        "cancel": "Annuler"
+      }
+    },
+    "status": {
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "neverConnected": "Jamais connecté",
+      "never": "Jamais",
+      "justNow": "À l'instant",
+      "minutesAgo_one": "il y a {{count}} minute",
+      "minutesAgo_other": "il y a {{count}} minutes",
+      "hoursAgo_one": "il y a {{count}} heure",
+      "hoursAgo_other": "il y a {{count}} heures"
+    },
+    "register": {
+      "title": "Enregistrer un contrôleur ESP32",
+      "description": "Enregistrez un nouveau contrôleur ESP32 pour recevoir les commandes LED de BoardSesh. Vous recevrez une clé API à configurer sur l'appareil.",
+      "nameLabel": "Nom du contrôleur (facultatif)",
+      "namePlaceholder": "ex. Board du salon",
+      "boardLabel": "Type de board",
+      "layoutLabel": "Layout",
+      "sizeLabel": "Taille",
+      "setsLabel": "Sets de prises",
+      "submit": "Enregistrer le contrôleur",
+      "submitting": "Enregistrement...",
+      "registerError": "Échec de l'enregistrement du contrôleur"
+    },
+    "apiKey": {
+      "title": "Contrôleur enregistré",
+      "warningTitle": "Enregistrez cette clé API maintenant !",
+      "warning": "C'est la seule fois où vous verrez cette clé. Si vous la perdez, vous devrez supprimer et réenregistrer le contrôleur.",
+      "registered": "Votre contrôleur <strong>{{name}}</strong> a été enregistré.",
+      "instruction": "Saisissez cette clé API dans la configuration de votre ESP32 :",
+      "copy": "Copier la clé API",
+      "done": "Terminé",
+      "copySuccess": "Clé API copiée dans le presse-papiers",
+      "copyError": "Échec de la copie — veuillez sélectionner et copier manuellement"
+    },
+    "deleteSuccess": "Contrôleur supprimé avec succès",
+    "deleteError": "Échec de la suppression du contrôleur"
+  },
+  "aurora": {
+    "title": "Comptes de board",
+    "subtitle": "Liez vos comptes de board pour importer vos données Aurora dans Boardsesh, ou importez à partir d'un fichier d'export JSON. Nous synchroniserons automatiquement votre carnet, vos ascensions et vos voies DEPUIS Aurora toutes les 12 heures. Les données créées dans Boardsesh restent locales et ne sont pas renvoyées vers Aurora.",
+    "card": {
+      "boardSuffix": "Board",
+      "username": "Nom d'utilisateur :",
+      "lastSynced": "Dernière synchronisation :",
+      "never": "Jamais",
+      "kilterShutdown": "Le backend Kilter a été arrêté. Vous pouvez importer vos données à l'aide d'un fichier d'export JSON Aurora, ou envoyer un e-mail à Aurora Climbing pour demander un export de vos données.",
+      "notConnected": "Non connecté. Liez votre compte {{boardName}} pour importer vos données Aurora, ou importez à partir d'un fichier d'export JSON.",
+      "link": "Lier",
+      "import": "Importer",
+      "requestData": "Demander vos données",
+      "unlink": "Délier",
+      "unlinkConfirm": {
+        "title": "Supprimer le lien du compte",
+        "description": "Voulez-vous vraiment délier votre compte {{boardName}} ?",
+        "ok": "Oui, délier"
+      }
+    },
+    "status": {
+      "connected": "Connecté",
+      "error": "Erreur",
+      "expired": "Expiré",
+      "syncing": "Synchronisation"
+    },
+    "unsynced": {
+      "title_one": "{{count}} élément en attente de synchronisation",
+      "title_other": "{{count}} éléments en attente de synchronisation",
+      "ascents_one": "{{count}} ascension",
+      "ascents_other": "{{count}} ascensions",
+      "climbs_one": "{{count}} voie",
+      "climbs_other": "{{count}} voies"
+    },
+    "linkDialog": {
+      "title": "Lier le compte {{boardName}}",
+      "description": "Saisissez votre nom d'utilisateur et votre mot de passe {{boardName}} Board pour importer vos données Aurora. Vos identifiants sont chiffrés et stockés en toute sécurité. Les données se synchronisent toutes les 12 heures.",
+      "usernameLabel": "Nom d'utilisateur",
+      "usernamePlaceholder": "Saisissez votre nom d'utilisateur",
+      "passwordLabel": "Mot de passe",
+      "passwordPlaceholder": "Saisissez votre mot de passe",
+      "submit": "Lier le compte",
+      "submitting": "Liaison en cours...",
+      "linkError": "Échec de la liaison du compte",
+      "linkSuccess": "Compte {{boardName}} lié. Vos données apparaîtront dans les 12 heures."
+    },
+    "unlinkSuccess": "Compte délié avec succès",
+    "unlinkError": "Échec de la déliaison du compte",
+    "import": {
+      "steps": {
+        "climbs": "Importation des brouillons de voies",
+        "resolving": "Résolution des noms de voies",
+        "dedup": "Vérification des doublons",
+        "ascents": "Importation des ascensions",
+        "attempts": "Importation des essais",
+        "circuits": "Importation des circuits",
+        "sessions": "Construction des sessions"
+      },
+      "fileLabel": "Téléverser le fichier d'export JSON Aurora",
+      "tooLarge": "Le fichier est trop volumineux (max 200 Mo). Veuillez vérifier que vous avez sélectionné le bon fichier.",
+      "parseError": "Échec de l'analyse du fichier JSON. Veuillez vérifier le format du fichier.",
+      "readError": "Échec de la lecture du fichier. Veuillez réessayer.",
+      "interrupted": "L'importation a été interrompue. Le serveur a peut-être expiré. Vos données ont peut-être été partiellement importées.",
+      "interruptedShort": "Importation interrompue",
+      "failed": "Échec de l'importation",
+      "successCount": "{{count}} éléments importés avec succès",
+      "dialog": {
+        "previewTitle": "Importer les données Aurora",
+        "importingTitle": "Importation des données Aurora...",
+        "completeTitle": "Importation terminée",
+        "errorTitle": "Échec de l'importation",
+        "previewIntro": "Importer les données de <strong>{{username}}</strong> vers <strong>{{boardName}}</strong> :",
+        "draftClimbs": "{{count}} brouillons de voies",
+        "ascents": "{{count}} ascensions",
+        "attempts": "{{count}} essais",
+        "circuits": "{{count}} circuits",
+        "previewNote": "Les voies seront associées par nom. Celles qui ne pourront pas être associées seront signalées après l'importation. Réimporter le même fichier ne créera pas de doublons.",
+        "cancel": "Annuler",
+        "confirm": "Importer",
+        "close": "Fermer",
+        "errorTitleShort": "Échec de l'importation"
+      },
+      "results": {
+        "draftClimbs": "Brouillons de voies",
+        "draftClimbsSummary": "{{imported}} importées, {{skipped}} ignorées, {{failed}} échouées",
+        "ascents": "Ascensions",
+        "ascentsSummary": "{{imported}} importées, {{skipped}} ignorées (déjà existantes), {{failed}} non associées",
+        "attempts": "Essais",
+        "attemptsSummary": "{{imported}} importés, {{skipped}} ignorés (déjà existants), {{failed}} non associés",
+        "circuits": "Circuits",
+        "circuitsSummary": "{{imported}} importés, {{skipped}} ignorés, {{failed}} échoués",
+        "unresolvedTitle_one": "{{count}} voie n'a pas pu être associée",
+        "unresolvedTitle_other": "{{count}} voies n'ont pas pu être associées",
+        "unresolvedMore": "...et {{count}} de plus"
+      }
+    },
+    "kilterEmail": {
+      "subject": "Données Kilterboard",
+      "namePlaceholder": "[VOTRE NOM]",
+      "emailPlaceholder": "[VOTRE E-MAIL]",
+      "body": "Bonjour !\n\nJe suis un ancien utilisateur de l'application. Je me demandais si je pouvais obtenir une copie de mes données afin de conserver mes carnets et autres données pour mon suivi personnel.\n\nMon nom d'utilisateur est {{name}}, et cela devrait être sous cet e-mail ({{email}}).\n\nMerci !\n\n{{name}}"
+    }
+  },
+  "healthkit": {
+    "save": "Enregistrer dans Apple Health",
+    "saving": "Enregistrement dans Apple Health…",
+    "saved": "Enregistré dans Apple Health",
+    "retry": "Enregistrer dans Apple Health (réessayer)"
+  },
+  "feedbackDialog": {
+    "titleRating": "Noter Boardsesh",
+    "titleBug": "Signaler un bug",
+    "submitRating": "Envoyer",
+    "submitBug": "Envoyer le rapport de bug",
+    "successRating": "Merci — enregistré.",
+    "successBug": "Bug enregistré — merci.",
+    "errorRating": "Échec de l'envoi — nous conserverons votre retour.",
+    "closeAria": "Fermer"
+  },
+  "feedbackForm": {
+    "missingHeading": "Qu'est-ce qui manque ?",
+    "compactPlaceholder": "Dites-nous ce qui pourrait aider",
+    "skip": "Passer",
+    "sendAria": "Envoyer",
+    "cancel": "Annuler",
+    "saveDefault": "Enregistrer",
+    "bugPlaceholder": "Que faisiez-vous ? Qu'attendiez-vous et qu'avez-vous vu ?",
+    "ratingPlaceholder": "Qu'avez-vous en tête ?",
+    "remainingChars": "Encore {{count}} caractères",
+    "nextAria": "Suivant"
+  },
+  "feedbackBanner": {
+    "successToast": "Merci — enregistré.",
+    "errorToast": "Échec de l'envoi — nous conserverons votre note.",
+    "dismissAria": "Ignorer"
+  },
+  "shakeToReport": {
+    "disabledToast": "Secouer pour signaler désactivé. Touchez votre avatar en haut pour envoyer un retour.",
+    "dontShowAgain": "Ne plus afficher"
+  },
+  "storeReview": {
+    "title": "Aidez les autres à découvrir Boardsesh",
+    "body": "Merci pour votre note. Pourriez-vous aussi laisser un avis rapide sur votre app store ? C'est la meilleure chose que vous puissiez faire pour aider d'autres grimpeurs à nous trouver.",
+    "notNow": "Pas maintenant",
+    "leaveReview": "Laisser un avis"
+  },
+  "sessionProvider": {
+    "deepLinkError": "La connexion avec Google, Apple ou Facebook peut ne pas fonctionner. Essayez de redémarrer l'application."
+  },
+  "onboarding": {
+    "skipTour": "Passer la visite",
+    "finish": "Terminer",
+    "next": "Suivant",
+    "stepProgress": "{{current}} sur {{total}}"
+  },
+  "devUrlDialog": {
+    "title": "URL de dev",
+    "intro": "Pointez la WebView vers une autre origine. L'application redémarrera après l'enregistrement.",
+    "urlLabel": "URL du serveur",
+    "useProduction": "Utiliser la production",
+    "currentlyOverriding": "Remplacement actuel par : {{url}}",
+    "cancel": "Annuler",
+    "clearOverride": "Effacer le remplacement",
+    "save": "Enregistrer et redémarrer",
+    "restarting": "Redémarrage…",
+    "validation": {
+      "enterUrl": "Saisissez une URL",
+      "mustBeHttp": "L'URL doit commencer par http:// ou https://",
+      "invalid": "URL non valide",
+      "generic": "Une erreur s'est produite"
+    }
+  },
+  "boardConfigMismatch": {
+    "title": "La configuration du board ne correspond pas",
+    "intro": "Nos enregistrements indiquent que ce board a une configuration différente de celle que vous avez configurée.",
+    "currentLabel": "<strong>Vous êtes configuré pour :</strong>",
+    "recordedLabel": "<strong>Enregistré pour ce contrôleur :</strong>",
+    "cancel": "Annuler",
+    "connectAnyway": "Connecter quand même",
+    "switchToCorrect": "Passer à la bonne configuration"
+  },
+  "devicePicker": {
+    "title": "Sélectionnez votre board",
+    "scanning": "Recherche de boards à proximité…",
+    "lastConnected": "Dernier board connecté",
+    "unknownDevice": "Appareil inconnu",
+    "lastConnectedAt": "Dernière connexion {{time}}",
+    "cancel": "Annuler"
+  },
+  "bluetoothMismatch": {
+    "switchNoAngleToast": "Impossible de changer — ouvrez d'abord une voie à un angle spécifique.",
+    "switchUrlFailedToast": "Impossible de passer à la configuration de ce board. Essayez Connecter quand même."
+  },
+  "auroraImport": {
+    "unlinkSuccessToast": "Compte délié avec succès",
+    "uploadAriaLabel": "Téléverser le fichier d'export JSON Aurora"
+  }
+}

--- a/packages/web/i18n/locales/fr/you.json
+++ b/packages/web/i18n/locales/fr/you.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "dashboard": {
+      "title": "Vous",
+      "description": "Votre tableau de bord d'escalade sur Boardsesh"
+    },
+    "logbook": {
+      "title": "Carnet",
+      "description": "Votre carnet d'escalade sur Boardsesh"
+    },
+    "sessions": {
+      "title": "Sessions",
+      "description": "Vos sessions d'escalade sur Boardsesh"
+    }
+  },
+  "tabs": {
+    "progress": "Progression",
+    "sessions": "Sessions",
+    "logbook": "Carnet"
+  },
+  "progress": {
+    "title": "Progression"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds full French (\`fr\`) translations for all 15 i18n namespaces (~3,160 keys)
- Registers \`fr\` in \`SUPPORTED_LOCALES\` so middleware, sitemap, and hreflang alternates pick it up automatically
- Replaces the cycle-button compact language switcher with a real MUI \`Menu\` dropdown listing every locale with its flag + label
- Both switchers now hard-reload (\`window.location.assign\`) instead of \`router.push\`, so server components and the i18next instance fully rebootstrap when the user changes language

## Test plan

- [ ] \`/\` renders English chrome
- [ ] \`/es/\` regression — Spanish chrome unchanged
- [ ] \`/fr/\` renders French copy across home, about, settings, climb view, drawer
- [ ] User-drawer flag opens a menu with three options + check on current locale
- [ ] Selecting French triggers a full document request (Network tab) and lands at \`/fr/\` with path + query preserved
- [ ] \`view-source:/fr/about\` shows hreflang \`fr\`, \`en-US\`, \`es\`, and \`x-default\`
- [ ] \`/sitemap.xml\` includes \`/fr/\` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)