### PR TITLE
fix(i18n): resolve userDrawer keys from common namespace

### DIFF
--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -268,12 +268,12 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                     onClick={() => {
                       handleClose();
                       openAuthModal({
-                        title: t('feed:userDrawer.signInModalTitle'),
-                        description: t('feed:userDrawer.signInModalDescription'),
+                        title: t('userDrawer.signInModalTitle'),
+                        description: t('userDrawer.signInModalDescription'),
                       });
                     }}
                   >
-                    {t('feed:userDrawer.signIn')}
+                    {t('userDrawer.signIn')}
                   </MuiButton>
                 </>
               )}
@@ -295,7 +295,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemIcon}>
                   <SwapHorizOutlined />
                 </span>
-                <span className={styles.menuItemLabel}>{t('feed:userDrawer.changeBoard')}</span>
+                <span className={styles.menuItemLabel}>{t('userDrawer.changeBoard')}</span>
               </button>
 
               {session?.user && (
@@ -334,7 +334,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <BuildOutlined />
                   </span>
-                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.devUrl')}</span>
+                  <span className={styles.menuItemLabel}>{t('userDrawer.devUrl')}</span>
                 </button>
               )}
 
@@ -343,7 +343,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <DeveloperBoardOutlined />
                   </span>
-                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.development')}</span>
+                  <span className={styles.menuItemLabel}>{t('userDrawer.development')}</span>
                 </LocaleLink>
               )}
 
@@ -359,7 +359,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <GpsFixedOutlined />
                   </span>
-                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.classifyHolds')}</span>
+                  <span className={styles.menuItemLabel}>{t('userDrawer.classifyHolds')}</span>
                 </button>
               )}
 
@@ -367,7 +367,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 <span className={styles.menuItemIcon}>
                   <LocalOfferOutlined />
                 </span>
-                <span className={styles.menuItemLabel}>{t('feed:userDrawer.myPlaylists')}</span>
+                <span className={styles.menuItemLabel}>{t('userDrawer.myPlaylists')}</span>
               </LocaleLink>
             </nav>
 
@@ -376,7 +376,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <>
                 <div className={styles.divider} />
                 <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.sectionLabel}>
-                  {t('feed:userDrawer.recentSessions')}
+                  {t('userDrawer.recentSessions')}
                 </MuiTypography>
                 {recentSessions.slice(0, 5).map((storedSession) => (
                   <button
@@ -414,14 +414,14 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <HelpOutlineOutlined />
               </span>
-              <span className={styles.menuItemLabel}>{t('feed:userDrawer.help')}</span>
+              <span className={styles.menuItemLabel}>{t('userDrawer.help')}</span>
             </LocaleLink>
 
             <LocaleLink href="/about" className={styles.menuItem} onClick={handleClose}>
               <span className={styles.menuItemIcon}>
                 <InfoOutlined />
               </span>
-              <span className={styles.menuItemLabel}>{t('feed:userDrawer.about')}</span>
+              <span className={styles.menuItemLabel}>{t('userDrawer.about')}</span>
             </LocaleLink>
 
             <button
@@ -435,7 +435,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <StarBorderOutlined />
               </span>
-              <span className={styles.menuItemLabel}>{t('feed:userDrawer.rateBoardsesh')}</span>
+              <span className={styles.menuItemLabel}>{t('userDrawer.rateBoardsesh')}</span>
             </button>
 
             <button
@@ -449,7 +449,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
               <span className={styles.menuItemIcon}>
                 <BugReportOutlined />
               </span>
-              <span className={styles.menuItemLabel}>{t('feed:userDrawer.reportBug')}</span>
+              <span className={styles.menuItemLabel}>{t('userDrawer.reportBug')}</span>
             </button>
 
             {/* Logout */}
@@ -460,7 +460,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                   <span className={styles.menuItemIcon}>
                     <LogoutOutlined />
                   </span>
-                  <span className={styles.menuItemLabel}>{t('feed:userDrawer.logout')}</span>
+                  <span className={styles.menuItemLabel}>{t('userDrawer.logout')}</span>
                 </button>
               </>
             )}

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -82,6 +82,22 @@
     "ariaCreateBoard": "Create a board",
     "empty": "No boards yet. Create one from the board selector to get started."
   },
+  "userDrawer": {
+    "signIn": "Sign in",
+    "signInModalTitle": "Sign in to Boardsesh",
+    "signInModalDescription": "Sign in to save favorites, log ascents, and more.",
+    "changeBoard": "Change board",
+    "devUrl": "Dev URL",
+    "development": "Development",
+    "classifyHolds": "Classify holds",
+    "myPlaylists": "My playlists",
+    "recentSessions": "Recent sessions",
+    "help": "Help",
+    "about": "About",
+    "rateBoardsesh": "Rate Boardsesh",
+    "reportBug": "Report a bug",
+    "logout": "Log out"
+  },
   "loading": {
     "messages": [
       "Setting up your board...",

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -142,22 +142,6 @@
     "unsubscribed": "Unsubscribed from new climbs",
     "updateFailed": "Couldn't update subscription"
   },
-  "userDrawer": {
-    "signIn": "Sign in",
-    "signInModalTitle": "Sign in to Boardsesh",
-    "signInModalDescription": "Sign in to save favorites, log ascents, and more.",
-    "changeBoard": "Change board",
-    "devUrl": "Dev URL",
-    "development": "Development",
-    "classifyHolds": "Classify holds",
-    "myPlaylists": "My playlists",
-    "recentSessions": "Recent sessions",
-    "help": "Help",
-    "about": "About",
-    "rateBoardsesh": "Rate Boardsesh",
-    "reportBug": "Report a bug",
-    "logout": "Log out"
-  },
   "userSearch": {
     "ascentsThisMonth": "{{count}} ascents this month",
     "climbsSetOne": "{{count}} climb set",

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -74,6 +74,22 @@
     "ariaCreateBoard": "Crear tabla",
     "empty": "Aún no tienes tablas. Crea una desde el selector de tablas."
   },
+  "userDrawer": {
+    "signIn": "Iniciar sesión",
+    "signInModalTitle": "Inicia sesión en Boardsesh",
+    "signInModalDescription": "Inicia sesión para guardar favoritos, registrar ascensos y más.",
+    "changeBoard": "Cambiar tabla",
+    "devUrl": "URL de dev",
+    "development": "Desarrollo",
+    "classifyHolds": "Clasificar presas",
+    "myPlaylists": "Mis listas",
+    "recentSessions": "Sesiones recientes",
+    "help": "Ayuda",
+    "about": "Sobre",
+    "rateBoardsesh": "Valorar Boardsesh",
+    "reportBug": "Reportar un bug",
+    "logout": "Cerrar sesión"
+  },
   "loading": {
     "messages": [
       "Preparando tu tabla...",

--- a/packages/web/i18n/locales/es/feed.json
+++ b/packages/web/i18n/locales/es/feed.json
@@ -142,22 +142,6 @@
     "unsubscribed": "Suscripción cancelada",
     "updateFailed": "No se pudo actualizar la suscripción"
   },
-  "userDrawer": {
-    "signIn": "Iniciar sesión",
-    "signInModalTitle": "Inicia sesión en Boardsesh",
-    "signInModalDescription": "Inicia sesión para guardar favoritos, registrar ascensos y más.",
-    "changeBoard": "Cambiar tabla",
-    "devUrl": "URL de dev",
-    "development": "Desarrollo",
-    "classifyHolds": "Clasificar presas",
-    "myPlaylists": "Mis listas",
-    "recentSessions": "Sesiones recientes",
-    "help": "Ayuda",
-    "about": "Sobre",
-    "rateBoardsesh": "Valorar Boardsesh",
-    "reportBug": "Reportar un bug",
-    "logout": "Cerrar sesión"
-  },
   "userSearch": {
     "ascentsThisMonth": "{{count}} ascensos este mes",
     "climbsSetOne": "{{count}} bloque creado",


### PR DESCRIPTION
## Summary

The user drawer (opened from the global header / sidebar / queue control area) was rendering raw translation keys — `userDrawer.changeBoard`, `userDrawer.myPlaylists`, `userDrawer.help`, `userDrawer.about`, `userDrawer.rateBoardsesh`, `userDrawer.reportBug`, etc. — instead of translated copy.

**Cause:** `user-drawer.tsx` calls `useTranslation('common')` but the 14 menu strings were authored as `t('feed:userDrawer.*')`. The `feed` namespace isn't in the root layout's pre-loaded set (`['common', 'playlists', 'session']` in `app/layout.tsx`), so the lookups fell back to the key. Sibling keys without a namespace prefix (`myBoards.title`, `ariaLabels.settings`) translated fine because they live in `common`.

**Fix:** The user drawer is shared chrome and conceptually belongs alongside the rest of `common`. Moved the `userDrawer` block (14 keys, with all existing Spanish translations) from `feed.json` to `common.json` for both locales, and dropped the `feed:` prefix from every `t()` call in `user-drawer.tsx`. No layout, namespace-config, or `feed.json` reorganisation needed beyond the move.

Files changed:
- `packages/web/i18n/locales/en-US/common.json` — added `userDrawer` block
- `packages/web/i18n/locales/en-US/feed.json` — removed `userDrawer` block
- `packages/web/i18n/locales/es/common.json` — added `userDrawer` block (Spanish copy preserved verbatim)
- `packages/web/i18n/locales/es/feed.json` — removed `userDrawer` block
- `packages/web/app/components/user-drawer/user-drawer.tsx` — 14 `t()` calls now reference `userDrawer.*` instead of `feed:userDrawer.*`

## Test plan

- [x] `vp run check:i18n` — no hardcoded strings (391 .tsx files scanned, OK)
- [x] `vp run typecheck:web` — passes (also exercises the dependency build chain)
- [ ] Manual: open the user drawer in `/` (English) and `/es/` (Spanish), confirm Change board / My playlists / Help / About / Rate Boardsesh / Report a bug all render translated copy in both locales
- [ ] Manual: trigger the sign-in modal (signed-out state) and the logout entry (signed-in state) to confirm the remaining `userDrawer.*` keys (`signIn`, `signInModalTitle`, `signInModalDescription`, `logout`) also resolve

https://claude.ai/code/session_016mjT4BtRKnyPG4NqoKCLDj

---
_Generated by [Claude Code](https://claude.ai/code/session_016mjT4BtRKnyPG4NqoKCLDj)_