### PR TITLE
fix(i18n): preload login + global namespaces, report missing keys to Sentry

### DIFF
--- a/packages/web/app/components/providers/__tests__/auth-modal-provider.test.tsx
+++ b/packages/web/app/components/providers/__tests__/auth-modal-provider.test.tsx
@@ -62,11 +62,11 @@ describe('AuthModalProvider', () => {
     expect(result.current.openAuthModal).toEqual(expect.any(Function));
   });
 
-  it('opens AuthModal with provided config', async () => {
+  it('opens AuthModal with provided config', () => {
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await result.current.openAuthModal({
+    act(() => {
+      result.current.openAuthModal({
         title: 'Test Title',
         description: 'Test description',
       });
@@ -78,21 +78,21 @@ describe('AuthModalProvider', () => {
     expect(props.description).toBe('Test description');
   });
 
-  it('opens AuthModal with default config when no args provided', async () => {
+  it('opens AuthModal with default config when no args provided', () => {
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await result.current.openAuthModal();
+    act(() => {
+      result.current.openAuthModal();
     });
 
     expect(lastAuthModalProps().open).toBe(true);
   });
 
-  it('closes AuthModal on close callback', async () => {
+  it('closes AuthModal on close callback', () => {
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await result.current.openAuthModal({ title: 'Test' });
+    act(() => {
+      result.current.openAuthModal({ title: 'Test' });
     });
     expect(lastAuthModalProps().open).toBe(true);
 
@@ -102,12 +102,12 @@ describe('AuthModalProvider', () => {
     expect(lastAuthModalProps().open).toBe(false);
   });
 
-  it('calls onSuccess callback and closes modal on success', async () => {
+  it('calls onSuccess callback and closes modal on success', () => {
     const onSuccess = vi.fn();
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await result.current.openAuthModal({ title: 'Test', onSuccess });
+    act(() => {
+      result.current.openAuthModal({ title: 'Test', onSuccess });
     });
     expect(lastAuthModalProps().open).toBe(true);
 
@@ -119,12 +119,12 @@ describe('AuthModalProvider', () => {
     expect(lastAuthModalProps().open).toBe(false);
   });
 
-  it('onSuccess still fires even if onClose is called first (AuthModal calls onClose before onSuccess)', async () => {
+  it('onSuccess still fires even if onClose is called first (AuthModal calls onClose before onSuccess)', () => {
     const onSuccess = vi.fn();
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await result.current.openAuthModal({ title: 'Test', onSuccess });
+    act(() => {
+      result.current.openAuthModal({ title: 'Test', onSuccess });
     });
 
     // AuthModal internally calls onClose() then onSuccess?.() on successful login
@@ -138,14 +138,12 @@ describe('AuthModalProvider', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('latest openAuthModal call wins when called multiple times', async () => {
+  it('latest openAuthModal call wins when called multiple times', () => {
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
-    await act(async () => {
-      await Promise.all([
-        result.current.openAuthModal({ title: 'First' }),
-        result.current.openAuthModal({ title: 'Second' }),
-      ]);
+    act(() => {
+      result.current.openAuthModal({ title: 'First' });
+      result.current.openAuthModal({ title: 'Second' });
     });
 
     const props = lastAuthModalProps();
@@ -153,13 +151,13 @@ describe('AuthModalProvider', () => {
     expect(props.title).toBe('Second');
   });
 
-  it('does not mount AuthModal until first open', async () => {
+  it('does not mount AuthModal until first open', () => {
     const { result } = renderHook(() => useAuthModal(), { wrapper });
 
     expect(mockAuthModal).not.toHaveBeenCalled();
 
-    await act(async () => {
-      await result.current.openAuthModal();
+    act(() => {
+      result.current.openAuthModal();
     });
 
     expect(mockAuthModal).toHaveBeenCalled();
@@ -172,9 +170,9 @@ describe('AuthModalProvider', () => {
     expect(lastAuthModalProps().open).toBe(false);
   });
 
-  it('works with default context outside provider (noop)', async () => {
+  it('works with default context outside provider (noop)', () => {
     const { result } = renderHook(() => useAuthModal());
-    // Should not throw - just resolves to a noop promise
-    await expect(result.current.openAuthModal()).resolves.toBeUndefined();
+    // Should not throw — the default-context implementation is a no-op.
+    expect(() => result.current.openAuthModal()).not.toThrow();
   });
 });

--- a/packages/web/app/components/providers/__tests__/auth-modal-provider.test.tsx
+++ b/packages/web/app/components/providers/__tests__/auth-modal-provider.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { AuthModalProvider, useAuthModal } from '../auth-modal-provider';
 
-const { mockAuthModal, loadNamespaces } = vi.hoisted(() => ({
+const { mockAuthModal } = vi.hoisted(() => ({
   mockAuthModal: vi.fn(
     ({
       open,
@@ -31,18 +31,10 @@ const { mockAuthModal, loadNamespaces } = vi.hoisted(() => ({
         </div>
       ) : null,
   ),
-  loadNamespaces: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@/app/components/auth/auth-modal', () => ({
   default: mockAuthModal,
-}));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: { loadNamespaces, language: 'en-US' },
-  }),
 }));
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -159,18 +151,6 @@ describe('AuthModalProvider', () => {
     const props = lastAuthModalProps();
     expect(props.open).toBe(true);
     expect(props.title).toBe('Second');
-  });
-
-  it('defers loading the auth namespace until first open', async () => {
-    const { result } = renderHook(() => useAuthModal(), { wrapper });
-
-    expect(loadNamespaces).not.toHaveBeenCalled();
-
-    await act(async () => {
-      await result.current.openAuthModal();
-    });
-
-    expect(loadNamespaces).toHaveBeenCalledWith('auth');
   });
 
   it('does not mount AuthModal until first open', async () => {

--- a/packages/web/app/components/providers/auth-modal-provider.tsx
+++ b/packages/web/app/components/providers/auth-modal-provider.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import AuthModal from '@/app/components/auth/auth-modal';
 
 type AuthModalConfig = {
@@ -21,26 +20,17 @@ const AuthModalContext = createContext<AuthModalContextValue>({
 export const useAuthModal = () => useContext(AuthModalContext);
 
 export function AuthModalProvider({ children }: { children: React.ReactNode }) {
-  const { i18n } = useTranslation();
   const [open, setOpen] = useState(false);
   const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
   const [config, setConfig] = useState<AuthModalConfig>({});
   const onSuccessRef = useRef<(() => void) | undefined>(undefined);
 
-  const openAuthModal = useCallback(
-    async (cfg: AuthModalConfig = {}) => {
-      onSuccessRef.current = cfg.onSuccess;
-      setConfig({ title: cfg.title, description: cfg.description });
-      // Lazy-load the auth namespace so unrelated pages don't ship auth.json.
-      // resourcesToBackend (see lib/i18n/client.tsx) resolves this with a
-      // dynamic JSON import; mounting the modal before the load resolves would
-      // flash bare keys for one render tick.
-      await i18n.loadNamespaces('auth');
-      setHasOpenedOnce(true);
-      setOpen(true);
-    },
-    [i18n],
-  );
+  const openAuthModal = useCallback(async (cfg: AuthModalConfig = {}) => {
+    onSuccessRef.current = cfg.onSuccess;
+    setConfig({ title: cfg.title, description: cfg.description });
+    setHasOpenedOnce(true);
+    setOpen(true);
+  }, []);
 
   const handleClose = useCallback(() => {
     setOpen(false);

--- a/packages/web/app/components/providers/auth-modal-provider.tsx
+++ b/packages/web/app/components/providers/auth-modal-provider.tsx
@@ -10,11 +10,11 @@ type AuthModalConfig = {
 };
 
 type AuthModalContextValue = {
-  openAuthModal: (config?: AuthModalConfig) => Promise<void>;
+  openAuthModal: (config?: AuthModalConfig) => void;
 };
 
 const AuthModalContext = createContext<AuthModalContextValue>({
-  openAuthModal: () => Promise.resolve(),
+  openAuthModal: () => {},
 });
 
 export const useAuthModal = () => useContext(AuthModalContext);
@@ -25,7 +25,7 @@ export function AuthModalProvider({ children }: { children: React.ReactNode }) {
   const [config, setConfig] = useState<AuthModalConfig>({});
   const onSuccessRef = useRef<(() => void) | undefined>(undefined);
 
-  const openAuthModal = useCallback(async (cfg: AuthModalConfig = {}) => {
+  const openAuthModal = useCallback((cfg: AuthModalConfig = {}) => {
     onSuccessRef.current = cfg.onSuccess;
     setConfig({ title: cfg.title, description: cfg.description });
     setHasOpenedOnce(true);

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -76,7 +76,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
               <ColorModeProvider>
-                <I18nProvider locale={locale} namespaces={['common', 'playlists', 'session']}>
+                <I18nProvider
+                  locale={locale}
+                  namespaces={['common', 'playlists', 'session', 'auth', 'errors', 'settings']}
+                >
                   <SnackbarProvider>
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>

--- a/packages/web/app/lib/i18n/__tests__/missing-key-reporter.test.ts
+++ b/packages/web/app/lib/i18n/__tests__/missing-key-reporter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { reportMissingI18nKey, __resetMissingI18nKeyReporterForTests } from '../missing-key-reporter';
+
+const captureMessage = vi.hoisted(() => vi.fn());
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage,
+}));
+
+describe('reportMissingI18nKey', () => {
+  beforeEach(() => {
+    captureMessage.mockClear();
+    __resetMissingI18nKeyReporterForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('no-ops outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    reportMissingI18nKey({ lngs: ['en-US'], ns: 'auth', key: 'login.title' });
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('forwards to Sentry in production with namespace + locale tags', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    reportMissingI18nKey({
+      lngs: ['es', 'en-US'],
+      ns: 'auth',
+      key: 'login.placeholders.email',
+      fallbackValue: 'Email',
+    });
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage).toHaveBeenCalledWith('Missing i18n key: auth:login.placeholders.email', {
+      level: 'warning',
+      tags: { i18n_namespace: 'auth', i18n_locale: 'es' },
+      extra: {
+        i18n_key: 'login.placeholders.email',
+        i18n_locales: ['es', 'en-US'],
+        i18n_fallback: 'Email',
+      },
+    });
+  });
+
+  it('dedupes repeated reports of the same key', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const args = { lngs: ['en-US'], ns: 'auth', key: 'login.title' };
+    reportMissingI18nKey(args);
+    reportMissingI18nKey(args);
+    reportMissingI18nKey(args);
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports distinct keys separately', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    reportMissingI18nKey({ lngs: ['en-US'], ns: 'auth', key: 'a' });
+    reportMissingI18nKey({ lngs: ['en-US'], ns: 'auth', key: 'b' });
+    reportMissingI18nKey({ lngs: ['es'], ns: 'auth', key: 'a' });
+
+    expect(captureMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to "unknown" locale tag when lngs is empty', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    reportMissingI18nKey({ lngs: [], ns: 'common', key: 'foo' });
+
+    expect(captureMessage).toHaveBeenCalledWith(
+      'Missing i18n key: common:foo',
+      expect.objectContaining({ tags: { i18n_namespace: 'common', i18n_locale: 'unknown' } }),
+    );
+  });
+});

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -5,6 +5,7 @@ import i18next, { type i18n } from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { DEFAULT_LOCALE, DEFAULT_NAMESPACE, SUPPORTED_LOCALES, type Locale } from './config';
+import { reportMissingI18nKey } from './missing-key-reporter';
 
 // Module-level singleton. The language switcher routes via `next/link` so the
 // browser navigates to the new locale's URL — that re-runs the server pipeline,
@@ -46,6 +47,10 @@ function getClientInstance(locale: Locale, resources: Record<string, Record<stri
       resources: { [locale]: resources },
       interpolation: { escapeValue: false },
       returnNull: false,
+      saveMissing: true,
+      missingKeyHandler: (lngs, ns, key, fallbackValue) => {
+        reportMissingI18nKey({ lngs, ns, key, fallbackValue });
+      },
     });
   clientInstance = instance;
   return instance;

--- a/packages/web/app/lib/i18n/missing-key-reporter.ts
+++ b/packages/web/app/lib/i18n/missing-key-reporter.ts
@@ -8,6 +8,13 @@ export function reportMissingI18nKey(args: {
   key: string;
   fallbackValue?: unknown;
 }) {
+  // Sentry's `enabled` flag (instrumentation-client.ts / sentry.server.config.ts)
+  // already gates the network call, but skip the work in non-production
+  // environments so dev/preview/test runs don't pay the dedupe + payload cost
+  // and so a future SDK misconfiguration can't accidentally ship missing-key
+  // events from local builds.
+  if (process.env.NODE_ENV !== 'production') return;
+
   const dedupeKey = `${args.lngs.join(',')}|${args.ns}|${args.key}`;
   if (reported.has(dedupeKey)) return;
   reported.add(dedupeKey);
@@ -24,4 +31,10 @@ export function reportMissingI18nKey(args: {
       i18n_fallback: args.fallbackValue,
     },
   });
+}
+
+// Test-only hook: clears the per-process dedupe Set so unit tests can
+// exercise the "first hit" path repeatedly without import-order coupling.
+export function __resetMissingI18nKeyReporterForTests() {
+  reported.clear();
 }

--- a/packages/web/app/lib/i18n/missing-key-reporter.ts
+++ b/packages/web/app/lib/i18n/missing-key-reporter.ts
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/nextjs';
+
+const reported = new Set<string>();
+
+export function reportMissingI18nKey(args: {
+  lngs: readonly string[];
+  ns: string;
+  key: string;
+  fallbackValue?: unknown;
+}) {
+  const dedupeKey = `${args.lngs.join(',')}|${args.ns}|${args.key}`;
+  if (reported.has(dedupeKey)) return;
+  reported.add(dedupeKey);
+
+  Sentry.captureMessage(`Missing i18n key: ${args.ns}:${args.key}`, {
+    level: 'warning',
+    tags: {
+      i18n_namespace: args.ns,
+      i18n_locale: args.lngs[0] ?? 'unknown',
+    },
+    extra: {
+      i18n_key: args.key,
+      i18n_locales: args.lngs,
+      i18n_fallback: args.fallbackValue,
+    },
+  });
+}

--- a/packages/web/app/lib/i18n/server.ts
+++ b/packages/web/app/lib/i18n/server.ts
@@ -5,6 +5,7 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next/initReactI18next';
 import { DEFAULT_LOCALE, DEFAULT_NAMESPACE, SUPPORTED_LOCALES, type Locale, type SeedNamespace } from './config';
 import { getLocale } from './get-locale';
+import { reportMissingI18nKey } from './missing-key-reporter';
 
 const resourceLoader = resourcesToBackend(
   (locale: string, namespace: string) => import(`../../../i18n/locales/${locale}/${namespace}.json`),
@@ -28,6 +29,10 @@ const initI18nForRequest = cache(async (locale: Locale, namespacesKey: string): 
       ns: namespaces,
       interpolation: { escapeValue: false },
       returnNull: false,
+      saveMissing: true,
+      missingKeyHandler: (lngs, ns, key, fallbackValue) => {
+        reportMissingI18nKey({ lngs, ns, key, fallbackValue });
+      },
     });
   return instance;
 });


### PR DESCRIPTION
## Summary

The login modal could render raw i18n keys (e.g. `login.placeholders.email`, `modal.title`) on first paint. Root cause: the modal lives in `AuthModalProvider` mounted at the root layout and uses `useTranslation('auth')`, but the root `<I18nProvider>` only pre-loaded `['common', 'playlists', 'session']`. The provider's compensating `await i18n.loadNamespaces('auth')` could resolve before `resourcesToBackend`'s dynamic JSON import was registered with the singleton, flashing bare keys for one render tick.

The same gap existed for any other client widget mounted at root that uses a non-pre-loaded namespace. Sweep found two more:

- `SessionProviderWrapper` (`packages/web/app/components/providers/session-provider.tsx:16`) → `useTranslation('settings')`
- `OnboardingTourOverlay` (`packages/web/app/components/onboarding/onboarding-tour-overlay.tsx:163`) → `useTranslation('settings')`

We also had no telemetry for missing keys, so this kind of bug only surfaced via user reports.

### Changes

- **`packages/web/app/layout.tsx`** — root `<I18nProvider>` now pre-loads `['common', 'playlists', 'session', 'auth', 'errors', 'settings']`. `errors` added because error UIs are cross-cutting; `settings` covers the two root widgets above; `auth` fixes the original bug.
- **`packages/web/app/components/providers/auth-modal-provider.tsx`** — drop the redundant `await i18n.loadNamespaces('auth')` and the now-unused `useTranslation` import; the namespace is pre-loaded.
- **`packages/web/app/lib/i18n/missing-key-reporter.ts`** *(new)* — wraps `Sentry.captureMessage` with locale/namespace tags, per-process dedupe (`Set` keyed by `lngs|ns|key`), severity `warning`. No-ops in dev/preview because Sentry's existing `enabled` flag gates the call.
- **`packages/web/app/lib/i18n/client.tsx`** + **`packages/web/app/lib/i18n/server.ts`** — wire `saveMissing: true` and `missingKeyHandler` into both inits so any future gap shows up in Sentry.

Per-route layouts/pages (`/admin`, `/you`, `/auth/login`, etc.) already wrap their own `<I18nProvider>` with the right namespaces — left untouched.

## Test plan

- [x] `vp check` — only formatting issues are pre-existing in generated/doc files I didn't touch
- [x] `vp run typecheck:web` — passes (also runs the production build)
- [ ] Manually click any "Log in" trigger on the running dev server and confirm modal renders strings on first paint, including under DevTools "Slow 4G"
- [ ] Visit `/es/`, repeat — no raw keys (English fallback for any missing Spanish strings is fine)
- [ ] Visit `/auth/login`, `/auth/error`, `/auth/verify-request` — page-level auth flows still translate
- [ ] After deploy, confirm "Missing i18n key" warnings in Sentry are tagged with `i18n_namespace` / `i18n_locale` and respect dedupe (no event-storm on a list page)

https://claude.ai/code/session_01Job458Q2dw2ZWkSGp3v5xP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Job458Q2dw2ZWkSGp3v5xP)_