### PR TITLE
i18n: fix fr catalog gaps from plural-format and userDrawer refactors

### DIFF
--- a/packages/web/app/lib/i18n/__tests__/locale.test.ts
+++ b/packages/web/app/lib/i18n/__tests__/locale.test.ts
@@ -11,7 +11,7 @@ describe('isSupportedLocale', () => {
   });
 
   it('rejects unsupported strings, null, and undefined', () => {
-    expect(isSupportedLocale('fr')).toBe(false);
+    expect(isSupportedLocale('de')).toBe(false);
     expect(isSupportedLocale('en')).toBe(false); // we use 'en-US', not 'en'
     expect(isSupportedLocale('es-MX')).toBe(false);
     expect(isSupportedLocale('')).toBe(false);

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -82,6 +82,22 @@
     "ariaCreateBoard": "Créer un board",
     "empty": "Aucun board pour le moment. Créez-en un depuis le sélecteur de board pour commencer."
   },
+  "userDrawer": {
+    "signIn": "Se connecter",
+    "signInModalTitle": "Se connecter à Boardsesh",
+    "signInModalDescription": "Connectez-vous pour enregistrer vos favoris, journaliser vos ascensions et plus encore.",
+    "changeBoard": "Changer de board",
+    "devUrl": "URL de dev",
+    "development": "Développement",
+    "classifyHolds": "Classer les prises",
+    "myPlaylists": "Mes playlists",
+    "recentSessions": "Sessions récentes",
+    "help": "Aide",
+    "about": "À propos",
+    "rateBoardsesh": "Noter Boardsesh",
+    "reportBug": "Signaler un bug",
+    "logout": "Se déconnecter"
+  },
   "loading": {
     "messages": [
       "Préparation de votre board...",
@@ -116,8 +132,8 @@
     "reply": "Répondre",
     "showRepliesOne": "Afficher 1 réponse",
     "showRepliesMany": "Afficher {{count}} réponses",
-    "countOne": "{{count}} commentaire",
-    "countMany": "{{count}} commentaires",
+    "count_one": "{{count}} commentaire",
+    "count_other": "{{count}} commentaires",
     "sort": {
       "new": "Récents",
       "top": "Top",

--- a/packages/web/i18n/locales/fr/feed.json
+++ b/packages/web/i18n/locales/fr/feed.json
@@ -123,12 +123,12 @@
     "noGyms": "Aucune salle trouvée pour « {{query}} »",
     "noPlaylists": "Aucune playlist trouvée pour « {{query}} »",
     "noUsers": "Aucun utilisateur ou ouvreur trouvé pour « {{query}} »",
-    "climbCountOne": "{{count}} voie",
-    "climbCountMany": "{{count}} voies"
+    "climbCount_one": "{{count}} voie",
+    "climbCount_other": "{{count}} voies"
   },
   "sessionFeedCard": {
-    "climbCountOne": "{{count}} voie",
-    "climbCountMany": "{{count}} voies"
+    "climbCount_one": "{{count}} voie",
+    "climbCount_other": "{{count}} voies"
   },
   "sessionSummary": {
     "completed": "Session terminée"
@@ -142,34 +142,18 @@
     "unsubscribed": "Désabonné des nouvelles voies",
     "updateFailed": "Impossible de mettre à jour l'abonnement"
   },
-  "userDrawer": {
-    "signIn": "Se connecter",
-    "signInModalTitle": "Se connecter à Boardsesh",
-    "signInModalDescription": "Connectez-vous pour enregistrer vos favoris, journaliser vos ascensions et plus encore.",
-    "changeBoard": "Changer de board",
-    "devUrl": "URL de dev",
-    "development": "Développement",
-    "classifyHolds": "Classer les prises",
-    "myPlaylists": "Mes playlists",
-    "recentSessions": "Sessions récentes",
-    "help": "Aide",
-    "about": "À propos",
-    "rateBoardsesh": "Noter Boardsesh",
-    "reportBug": "Signaler un bug",
-    "logout": "Se déconnecter"
-  },
   "userSearch": {
     "ascentsThisMonth": "{{count}} ascensions ce mois-ci",
-    "climbsSetOne": "{{count}} voie ouverte",
-    "climbsSetMany": "{{count}} voies ouvertes",
-    "climbCountOne": "{{count}} voie",
-    "climbCountMany": "{{count}} voies"
+    "climbsSet_one": "{{count}} voie ouverte",
+    "climbsSet_other": "{{count}} voies ouvertes",
+    "climbCount_one": "{{count}} voie",
+    "climbCount_other": "{{count}} voies"
   },
   "userSmartCard": {
-    "followerOne": "{{count}} abonné",
-    "followerMany": "{{count}} abonnés",
+    "follower_one": "{{count}} abonné",
+    "follower_other": "{{count}} abonnés",
     "following": "{{count}} abonnements",
-    "distinctClimbOne": "{{count}} voie distincte",
-    "distinctClimbMany": "{{count}} voies distinctes"
+    "distinctClimb_one": "{{count}} voie distincte",
+    "distinctClimb_other": "{{count}} voies distinctes"
   }
 }


### PR DESCRIPTION
## Summary
- Rename fr plural keys (`*One`/`*Many`) to i18next-native `_one`/`_other` so `count`-style lookups resolve in French instead of silently falling back to English.
- Move `userDrawer.*` from `fr/feed.json` to `fr/common.json` to match the post-merge English layout (commit 7800ddfac moved the keys but fr was untouched).
- Update `locale.test.ts` to stop asserting `'fr'` is unsupported now that French is shipped — replaced with `'de'`.

These are the three pre-existing failures on main from the recently-merged French i18n PR (#1836) crossing with the userDrawer/plural follow-ups:
- `i18n-catalog-completeness.test.ts > fr > common.json`
- `i18n-catalog-completeness.test.ts > fr > feed.json`
- `locale.test.ts > rejects unsupported strings`

The E2E shard 3 notifications-bell timeout is unrelated and looks like a flake in the existing race-prone navigation assertion (the spec already has `// races with NextLink's own pushState in practice`); leaving that alone.

## Test plan
- [x] `vp test run --project web` (4013/4013 pass)
- [x] `vp check` clean for the touched files (only unrelated generated/docs files have pre-existing format drift on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)