### PR TITLE
fix: remove unused errors namespace from root layout and isolate test reset hook

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <ColorModeProvider>
                 <I18nProvider
                   locale={locale}
-                  namespaces={['common', 'playlists', 'session', 'auth', 'errors', 'settings']}
+                  namespaces={['common', 'playlists', 'session', 'auth', 'settings']}
                 >
                   <SnackbarProvider>
                     <AuthModalProvider>

--- a/packages/web/app/lib/i18n/__tests__/missing-key-reporter.test.ts
+++ b/packages/web/app/lib/i18n/__tests__/missing-key-reporter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { reportMissingI18nKey, __resetMissingI18nKeyReporterForTests } from '../missing-key-reporter';
+import { reportMissingI18nKey } from '../missing-key-reporter';
+import { __resetMissingI18nKeyReporterForTests } from '../missing-key-reporter.test-utils';
 
 const captureMessage = vi.hoisted(() => vi.fn());
 

--- a/packages/web/app/lib/i18n/missing-key-reporter.test-utils.ts
+++ b/packages/web/app/lib/i18n/missing-key-reporter.test-utils.ts
@@ -1,0 +1,3 @@
+// Re-exports the test-only reset hook so test files can import from a
+// clearly test-scoped module rather than directly from the production file.
+export { __resetMissingI18nKeyReporterForTests } from './missing-key-reporter';

--- a/packages/web/app/lib/i18n/missing-key-reporter.ts
+++ b/packages/web/app/lib/i18n/missing-key-reporter.ts
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
 
+// Process-global on the server: dedupes across all requests for the lifetime of
+// the Node.js process. A server restart resets the set, so a missing key that
+// fired before a deploy will re-fire once after restart (expect a brief Sentry
+// spike per cold start around deployments).
 const reported = new Set<string>();
 
 export function reportMissingI18nKey(args: {


### PR DESCRIPTION
## Summary

- Remove `errors` from the root `I18nProvider` namespaces in `layout.tsx` — no root-level component uses it, so it was unnecessary bundle weight loaded on every page
- Create `missing-key-reporter.test-utils.ts` that re-exports `__resetMissingI18nKeyReporterForTests`, so tests import from a clearly test-scoped module rather than directly from the production file
- Add a comment on the process-global `reported` Set documenting the known server-restart/cold-start Sentry spike behaviour

## Test plan

- [ ] Verify pages that use the `errors` namespace (page-level components) still load translations correctly — they load the namespace themselves via their own providers, not from the root
- [ ] Run `vp test --project web` to confirm the missing-key-reporter tests still pass with the updated import path

https://claude.ai/code/session_01E5ReVr7XExX1Mkce7Q2u3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5ReVr7XExX1Mkce7Q2u3k)_