### PR TITLE
i18n: preload missing namespaces in page providers

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -89,7 +89,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session']}>
+    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed']}>
       <div
         style={{
           minHeight: '100dvh',

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -60,7 +60,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session']}>
+    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed']}>
       <div
         style={{
           minHeight: '100dvh',

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
   ]);
 
   return (
-    <I18nProvider locale={locale} namespaces={['marketing', 'boards']}>
+    <I18nProvider locale={locale} namespaces={['marketing', 'boards', 'climbs', 'profile', 'feed']}>
       <HomePageContent boardConfigs={boardConfigs} initialPopularConfigs={popularConfigs} />
     </I18nProvider>
   );

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -21,7 +21,7 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
   const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
 
   return (
-    <I18nProvider locale={locale} namespaces={['playlists']}>
+    <I18nProvider locale={locale} namespaces={['playlists', 'climbs', 'feed']}>
       <div className={styles.pageContainer}>
         <PlaylistDetailContent playlistUuid={playlist_uuid} initialMyBoards={initialMyBoards} />
       </div>

--- a/packages/web/app/playlists/page.tsx
+++ b/packages/web/app/playlists/page.tsx
@@ -33,7 +33,7 @@ export default async function PlaylistsPage() {
   const lcpPreloadUrl = getPlaylistLcpPreloadUrl(initialPlaylists?.[0] ?? initialDiscoverPlaylists?.popular?.[0]);
 
   return (
-    <I18nProvider locale={locale} namespaces={['playlists']}>
+    <I18nProvider locale={locale} namespaces={['playlists', 'climbs', 'feed']}>
       {lcpPreloadUrl && <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />}
       <div className={styles.pageContainer}>
         <LibraryPageContent

--- a/packages/web/app/you/layout.tsx
+++ b/packages/web/app/you/layout.tsx
@@ -16,7 +16,7 @@ export default async function YouLayout({ children }: { children: React.ReactNod
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['you', 'profile']}>
+    <I18nProvider locale={locale} namespaces={['you', 'profile', 'climbs', 'boards', 'feed']}>
       <Box className={styles.layout}>
         <Box component="main" className={styles.content}>
           <YouTabBar />


### PR DESCRIPTION
## Summary

Fix the burst of `Missing i18n key` Sentry warnings (BOARDSESH-3*, BOARDSESH-4*, BOARDSESH-5*) reported across `/`, `/es`, `/playlists`, `/you/sessions`, `/you/logbook`, `/b/:board_slug/:angle/list`, and the deep `[board_name]/[layout_id]/...` routes.

## Root cause

The keys all exist in the catalogs (verified in both `en-US` and `es`). The `missingKeyHandler` (`packages/web/app/lib/i18n/missing-key-reporter.ts`) fires because the namespaces aren't in the SSR-rendered resource bundle. When a client component calls `useTranslation('profile' | 'climbs' | 'boards' | 'feed')` on a page whose `I18nProvider` doesn't preload that namespace, react-i18next dynamically imports it via `resourcesToBackend` — and during the brief window before the bundle resolves, every `t()` call falls through to `missingKeyHandler` with `saveMissing: true`.

For pluralized keys (e.g. `climbs:angleSelector.sends`, `feed:sessionFeedCard.climbCount_*`) the missing handler fires on the suffixed lookup (`_one`/`_other`) or on the base key when `count` is undefined, both of which are also resolved by adding the namespace.

## Fix

Add the missing namespaces to the `I18nProvider` for each affected route so SSR ships them and they're hydrated on first render:

| Route | Added |
| --- | --- |
| `/` (home) | `climbs`, `profile`, `feed` |
| `/playlists` (+ `[playlist_uuid]`) | `climbs`, `feed` |
| `/you/*` layout | `climbs`, `boards`, `feed` |
| `/b/[board_slug]/[angle]` layout | `boards`, `profile`, `feed` |
| `/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]` layout | `boards`, `profile`, `feed` |

## Test plan

- [ ] Load `/` and `/es` in production build; confirm no new `Missing i18n key` events for `profile:logbook.form.*`, `climbs:card.*`, `climbs:actions.*`, `climbs:board.*`, `boards:boardSwitchConfirm.*`
- [ ] Load `/playlists` and `/es/playlists`; confirm no warnings for `climbs:search.*` or `feed:search.*`
- [ ] Load `/you/sessions` and `/you/logbook`; confirm no warnings for `feed:sessionFeedCard.*`, `feed:emptyStates.*`, `climbs:*`, `boards:boardFilterStrip.*`
- [ ] Load `/b/:board_slug/:angle/list`; confirm no warnings for `boards:discovery.*`, `boards:boardSearchDrawer.*`, `boards:zoomableBoard.reset`, `boards:boardSearchMap.myLocation`
- [ ] Load `/:board_name/:layout_id/:size_id/:set_ids/:angle/list`; confirm no warning for `climbs:angleSelector.sends`

https://claude.ai/code/session_01BxcJQJyMPs9KFfSvAerALU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxcJQJyMPs9KFfSvAerALU)_