### PR TITLE
i18n: preload boards in root layout and guard angleSelector count

### DIFF
--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -169,7 +169,7 @@ export default function AngleSelector({
                     </Typography>
                   )}
                   <Typography variant="body2" component="span" color="text.secondary" sx={{ fontSize: 10 }}>
-                    {t('angleSelector.sends', { count: stats.ascensionist_count })}
+                    {t('angleSelector.sends', { count: stats.ascensionist_count ?? 0 })}
                   </Typography>
                 </Box>
               </Box>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <ColorModeProvider>
                 <I18nProvider
                   locale={locale}
-                  namespaces={['common', 'playlists', 'session', 'auth', 'settings']}
+                  namespaces={['common', 'playlists', 'session', 'auth', 'settings', 'boards']}
                 >
                   <SnackbarProvider>
                     <AuthModalProvider>


### PR DESCRIPTION
BoardSwitchConfirmProvider is rendered in the root layout via PersistentSessionWrapper and calls useTranslation('boards') on every render — so 'boards' must be in the root layout's preload list, not just in per-page providers.

For climbs:angleSelector.sends, when stats.ascensionist_count is null/undefined i18next skips pluralization and looks up the bare key (which doesn't exist; only sends_one/sends_other do). Default to 0 so the plural lookup always finds a match.