### PR TITLE
fix(i18n): preload feed namespace on profile page for FollowerCount

### DIFF
--- a/packages/web/app/profile/[user_id]/page.tsx
+++ b/packages/web/app/profile/[user_id]/page.tsx
@@ -91,7 +91,7 @@ export default async function ProfilePage({ params }: PageProps) {
   const locale = await getLocale();
 
   return (
-    <I18nProvider locale={locale} namespaces={['profile']}>
+    <I18nProvider locale={locale} namespaces={['profile', 'feed']}>
       <ProfilePageContent
         userId={user_id}
         initialProfile={initialProfile}


### PR DESCRIPTION
## Summary

- The profile page's `I18nProvider` only preloaded the `profile` namespace
- `FollowerCount` component uses `useTranslation('feed')`, so the `feed` namespace was never available on the profile route
- This caused `feed:followerCount.followingLabel` to be missing at runtime, producing the warning on `/profile/:user_id`

## Fix

Added `'feed'` to the `namespaces` array in `app/profile/[user_id]/page.tsx` so the `feed` catalog is server-side rendered and available to `FollowerCount` before hydration.

## Test plan

- [ ] Visit `/profile/:user_id` and confirm no `Missing i18n key: feed:followerCount.followingLabel` warning in the console
- [ ] Verify the follower/following counts render correctly in English and Spanish

https://claude.ai/code/session_01SsU2capUFRSiPDhhcPfidF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsU2capUFRSiPDhhcPfidF)_