### PR TITLE
i18n: install Intl.PluralRules polyfill + preload climbs at root

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -221,6 +221,7 @@
         "i18next": "^23.16.8",
         "i18next-resources-to-backend": "^1.2.1",
         "idb": "^8.0.3",
+        "intl-pluralrules": "^2.0.1",
         "iron-session": "^8.0.4",
         "leaflet": "^1.9.4",
         "next": "^16.1.6",
@@ -2265,6 +2266,8 @@
     "inquirer": ["inquirer@8.2.7", "", { "dependencies": { "@inquirer/external-editor": "^1.0.0", "ansi-escapes": "^4.2.1", "chalk": "^4.1.1", "cli-cursor": "^3.1.0", "cli-width": "^3.0.0", "figures": "^3.0.0", "lodash": "^4.17.21", "mute-stream": "0.0.8", "ora": "^5.4.1", "run-async": "^2.4.0", "rxjs": "^7.5.5", "string-width": "^4.1.0", "strip-ansi": "^6.0.0", "through": "^2.3.6", "wrap-ansi": "^6.0.1" } }, "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "intl-pluralrules": ["intl-pluralrules@2.0.1", "", {}, "sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg=="],
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <ColorModeProvider>
                 <I18nProvider
                   locale={locale}
-                  namespaces={['common', 'playlists', 'session', 'auth', 'settings', 'boards']}
+                  namespaces={['common', 'playlists', 'session', 'auth', 'settings', 'boards', 'climbs']}
                 >
                   <SnackbarProvider>
                     <AuthModalProvider>

--- a/packages/web/app/lib/i18n/__tests__/plurals.test.ts
+++ b/packages/web/app/lib/i18n/__tests__/plurals.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, beforeAll } from 'vite-plus/test';
+import 'intl-pluralrules';
+import i18next from 'i18next';
+
+// Validates that i18next v23's CLDR plural resolver (`compatibilityJSON: 'v4'`,
+// the default) maps `count` to the correct `_one` / `_other` suffix for each
+// supported locale. The polyfill import above is a no-op on Node 22 (which
+// ships native `Intl.PluralRules`) but ensures the test file exercises the
+// same code path the browser bundle uses — so a regression that strips the
+// polyfill would still surface here if it ever broke locale registration.
+//
+// Catches: accidental `compatibilityJSON: 'v3'` reverts, missing `_one`/
+// `_other` siblings in catalogs, and runtime environments where plural rules
+// aren't registered.
+
+describe('i18next plural resolution', () => {
+  beforeAll(async () => {
+    await i18next.init({
+      lng: 'en-US',
+      fallbackLng: 'en-US',
+      supportedLngs: ['en-US', 'es', 'fr'],
+      resources: {
+        'en-US': {
+          translation: {
+            climb_one: '{{count}} climb',
+            climb_other: '{{count}} climbs',
+          },
+        },
+        es: {
+          translation: {
+            climb_one: '{{count}} bloque',
+            climb_other: '{{count}} bloques',
+          },
+        },
+        fr: {
+          translation: {
+            climb_one: '{{count}} bloc',
+            climb_other: '{{count}} blocs',
+          },
+        },
+      },
+      interpolation: { escapeValue: false },
+    });
+  });
+
+  it.each([
+    ['en-US', 1, '1 climb'],
+    ['en-US', 2, '2 climbs'],
+    ['en-US', 0, '0 climbs'],
+    ['es', 1, '1 bloque'],
+    ['es', 2, '2 bloques'],
+    ['fr', 1, '1 bloc'],
+    ['fr', 2, '2 blocs'],
+    // French treats 0 as singular (`one`), unlike English/Spanish — this
+    // catches anyone who hardcodes `count !== 1 → other` instead of using
+    // `Intl.PluralRules`.
+    ['fr', 0, '0 bloc'],
+  ])('resolves %s count=%i to "%s"', async (locale, count, expected) => {
+    const t = await i18next.changeLanguage(locale);
+    expect(t('climb', { count })).toBe(expected);
+  });
+});

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+// Polyfill `Intl.PluralRules` for older browsers / WebViews (e.g. iOS 12,
+// older Bluefy builds). i18next v23 uses CLDR plural rules via
+// `Intl.PluralRules` — without this, environments that lack the API silently
+// fall through to the base key (issue #1852).
+import 'intl-pluralrules';
 import React, { useMemo } from 'react';
 import i18next, { type i18n } from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -70,6 +70,7 @@
     "i18next": "^23.16.8",
     "i18next-resources-to-backend": "^1.2.1",
     "idb": "^8.0.3",
+    "intl-pluralrules": "^2.0.1",
     "iron-session": "^8.0.4",
     "leaflet": "^1.9.4",
     "next": "^16.1.6",


### PR DESCRIPTION
## Summary
Fixes: #1852.

- **Polyfill `Intl.PluralRules`** for older browsers / WebViews (iOS 12, older Bluefy). PR #1835 switched catalogs to CLDR `*_one`/`*_other` form, which i18next v23 resolves via `Intl.PluralRules`. Side-effect import in `packages/web/app/lib/i18n/client.tsx` (no-op when the native API exists). Server is unchanged — Node 22 has full ICU.
- **Add `climbs` to the root layout's preloaded namespaces** (`packages/web/app/layout.tsx`). The root mounts `PersistentSessionWrapper` → `QueueControlBar`, which renders climb-related children (`tick-action`, `climb-title`, `board-page/header`, etc.) that call `useTranslation('climbs')`. Without the bundle in root, those keys race the lazy load on non-board routes — Sentry has been firing `Missing i18n key: climbs:*` warnings on `/auth/native-start` (BOARDSESH-3F/3G/3H/3K/3M/3P/3R/3S/3T/3V/3W/3X) and `/b/:board_slug/:angle/list` (BOARDSESH-54). Same pattern as 9b1a94e4e (boards preload).
- **New unit test** `packages/web/app/lib/i18n/__tests__/plurals.test.ts` locking in singular/plural resolution for en-US, es, fr — including French's `0 → one` rule, which catches anyone who hand-codes `count !== 1` instead of using CLDR.

## Out of scope (follow-up)
The two screenshots in #1852 (`sessionFeedCard.climbCount`, `onboarding.skipTour`) likely won't be fully closed by this PR. Both keys exist in their catalogs and both namespaces are already preloaded on the routes where they render, yet they still showed raw keys. Most plausible cause: a first-render-before-`init`-resolves race in `getClientInstance` (`client.tsx:38`). Worth a separate PR — the fix (Suspense-aware loading or blocking render on init) is non-trivial and orthogonal to the polyfill question.

## Test plan
- [x] `vp run typecheck:web` — 0 errors
- [x] `vp lint` on changed files — 0 errors (1 pre-existing warning untouched)
- [x] `vp fmt --check` on changed files — clean
- [x] `vp test run --project web` — 4025/4025 passing (includes new `plurals.test.ts`)
- [x] `vp run check:i18n` — clean
- [ ] Post-deploy: watch Sentry — BOARDSESH-3F..3X and 54 should auto-resolve
- [ ] Manual smoke: `/auth/native-start?provider=google` and `/b/<slug>/<angle>/list` show no `i18next::translator: missingKey` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)