### PR TITLE
Add ROADMAP.md and surface it from README + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 [Join us on Discord](https://discord.gg/YXA8GsXfQK)
 
+# Where work is tracked
+
+The live roadmap lives on a single public GitHub project: [Boardsesh Roadmap](https://github.com/orgs/boardsesh/projects/3). Every issue sits in **Now**, **Next**, **Later**, or **Done**, and big multi-issue features carry an `Initiative` tag you can filter on. New issues you open land in **Later** by default — we'll triage from there.
+
+Big features also get a **tracking issue** that lists their sub-issues in the order they should land. See [#1773 (Recently Climbed & Display Mode)](https://github.com/boardsesh/boardsesh/issues/1773) for the canonical pattern; copy the shape if you're proposing a similarly-sized change.
+
+See [ROADMAP.md](./ROADMAP.md) for the full picture.
+
 # Getting Started
 
 ## How to get everything going

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Boardsesh is a unified experience that works across different board types, helpi
 
 Boardsesh is completely open source under the Apache license. You can view the code, contribute features, report bugs, or fork it entirely to run your own instance.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup instructions.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup instructions and [ROADMAP.md](./ROADMAP.md) for what's coming next.
 
 ## API Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ Current initiatives:
 - **MoonBoard support** — feature parity with Kilter/Tension. [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22MoonBoard+support%22)
 - **BLE / device picker** — Bluetooth UX, mismatch handling, [ESP32 emulator](CONTRIBUTING.md#testing-ble-end-to-end-with-an-esp32). [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22BLE+%2F+device+picker%22)
 - **OG smartlinks & SEO** — [docs/og-smartlinks-roadmap.md](docs/og-smartlinks-roadmap.md) · [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22OG+smartlinks+%26+SEO%22)
-- **Aurora migration** — decoupling from the Aurora API. [docs/aurora-sync.md](docs/aurora-sync.md), [docs/neon-migration.md](docs/neon-migration.md)
+- **Aurora migration** — decoupling from the Aurora API. [docs/aurora-sync.md](docs/aurora-sync.md)
 
 A new initiative gets its own `Initiative` tag on the board once it has a tracking issue and a design doc under `docs/`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# Boardsesh Roadmap
+
+The live, up-to-date roadmap is on GitHub Projects:
+
+**[github.com/orgs/boardsesh/projects/3](https://github.com/orgs/boardsesh/projects/3)**
+
+The board is public — no GitHub login needed to read it.
+
+## How we plan
+
+Every issue is in one of four columns:
+
+- **Now** — actively being worked on. PRs landing this week or next.
+- **Next** — queued for the next month or two.
+- **Later** — wanted, scoped, but not scheduled. New issues land here by default.
+- **Done** — recently shipped. Items sit here for a while before getting archived.
+
+Anyone can [open an issue](https://github.com/boardsesh/boardsesh/issues/new). It will land in **Later** automatically; we'll triage it onto **Next** or **Now** as we plan.
+
+## Big initiatives
+
+Multi-issue features get an `Initiative` tag on the board so you can filter the roadmap to one theme. They also get a **tracking issue** that lists every sub-issue in the order they should land — see [#1773](https://github.com/boardsesh/boardsesh/issues/1773) for the canonical example.
+
+Initiatives that are big enough to ship in **phases** also get one [milestone](https://github.com/boardsesh/boardsesh/milestones) per phase, so you can see progress per checkpoint. Initiatives that ship as a single deliverable get a single milestone.
+
+Current initiatives:
+
+- **Recently Climbed & Display Mode** — gym TV kiosk + recent-climbs feed. Tracking issue [#1773](https://github.com/boardsesh/boardsesh/issues/1773) · [design doc](docs/recently-climbed-display-mode.md) · [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22Display+Mode%22) · [milestone](https://github.com/boardsesh/boardsesh/milestone/10)
+- **Mobile app** — Capacitor app + offline-first refactor (vite migration, refdata, mutation queue). [docs/mobile-app-plan.md](docs/mobile-app-plan.md), [docs/ios-app-store-publishing-plan.md](docs/ios-app-store-publishing-plan.md) · [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22Mobile+app%22) · phase milestones [0a Hosting](https://github.com/boardsesh/boardsesh/milestone/1) · [0b GraphQL](https://github.com/boardsesh/boardsesh/milestone/2) · [0c Auth](https://github.com/boardsesh/boardsesh/milestone/3) · [1 Vite migration](https://github.com/boardsesh/boardsesh/milestone/4) · [2 Capacitor bundle](https://github.com/boardsesh/boardsesh/milestone/5) · [3 Refdata SQLite](https://github.com/boardsesh/boardsesh/milestone/6) · [4 User cache](https://github.com/boardsesh/boardsesh/milestone/7) · [5 Mutation queue](https://github.com/boardsesh/boardsesh/milestone/8) · [6 Polish](https://github.com/boardsesh/boardsesh/milestone/9)
+- **MoonBoard support** — feature parity with Kilter/Tension. [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22MoonBoard+support%22)
+- **BLE / device picker** — Bluetooth UX, mismatch handling, [ESP32 emulator](CONTRIBUTING.md#testing-ble-end-to-end-with-an-esp32). [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22BLE+%2F+device+picker%22)
+- **OG smartlinks & SEO** — [docs/og-smartlinks-roadmap.md](docs/og-smartlinks-roadmap.md) · [board filter](https://github.com/orgs/boardsesh/projects/3/views/1?filterQuery=initiative%3A%22OG+smartlinks+%26+SEO%22)
+- **Aurora migration** — decoupling from the Aurora API. [docs/aurora-sync.md](docs/aurora-sync.md), [docs/neon-migration.md](docs/neon-migration.md)
+
+A new initiative gets its own `Initiative` tag on the board once it has a tracking issue and a design doc under `docs/`.
+
+## Want to help?
+
+Issues tagged [`good first issue`](https://github.com/boardsesh/boardsesh/labels/good%20first%20issue) and [`help wanted`](https://github.com/boardsesh/boardsesh/labels/help%20wanted) are the easiest places to start. Drop into [Discord](https://discord.gg/YXA8GsXfQK) if you want to claim one — we'll make sure no one else is already on it and answer any setup questions.


### PR DESCRIPTION
## Summary

- Adds `ROADMAP.md` at repo root pointing at the (now public) org Project [#3 Boardsesh Roadmap](https://github.com/orgs/boardsesh/projects/3) and explaining the Now / Next / Later / Done convention.
- README links to the roadmap from the "Open Source" section.
- CONTRIBUTING gains a "Where work is tracked" section above Getting Started, including the tracking-issue pattern (canonical: #1773).

## Context

Cleaning up the GitHub side of planning so contributors and sponsors have one place to look:

- 4 org Projects → 1 (renamed, public, with `Now / Next / Later / Done` and an `Initiative` field).
- 11 phase/area/umbrella labels → milestones + Initiative tags. The 9 mobile-app `phase:*` labels became per-phase milestones (#1–#9), `area:display-mode` became milestone #10, and the `mobile-app-plan` umbrella label became `Initiative = Mobile app` on the board.

This PR is the **docs** half of that cleanup. The Project / milestone / label changes are already live on GitHub.

## Test plan

- [ ] ROADMAP.md renders correctly on github.com (links resolve, project board is readable while logged out)
- [ ] README "Open Source" section links to ROADMAP
- [ ] CONTRIBUTING "Where work is tracked" appears above "Getting Started"
- [ ] No accidental changes to other docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)