### PR TITLE
Drop Android pre-launch countdown — app is live on Google Play

### DIFF
--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -238,15 +238,9 @@ describe('HomePageContent', () => {
       mockIsNativeApp.mockReturnValue(false);
       mockIsCapacitorWebView.mockReturnValue(false);
       mockWaitForCapacitor.mockResolvedValue(false);
-      // Freeze Date so pre-/post-launch assertions don't drift once real
-      // time passes ANDROID_LAUNCH_DATE. `toFake: ['Date']` keeps
-      // setTimeout/setInterval real so waitFor still works.
-      vi.useFakeTimers({ toFake: ['Date'] });
-      vi.setSystemTime(new Date('2026-04-17T00:00:00Z'));
     });
 
     afterEach(() => {
-      vi.useRealTimers();
       if (originalUA) {
         Object.defineProperty(window.navigator, 'userAgent', originalUA);
       }
@@ -261,24 +255,13 @@ describe('HomePageContent', () => {
       expect(screen.getByText(/Lights up holds on your board straight from your phone/i)).toBeTruthy();
     });
 
-    it('shows the Android pre-launch sideload CTA on Android UA', async () => {
-      setUserAgent(ANDROID_UA);
-      render(<HomePageContent {...defaultProps} />);
-      await waitFor(() => {
-        expect(screen.getByText(/Android app is almost here/i)).toBeTruthy();
-      });
-      expect(screen.getByText(/Tap to sideload the preview build/i)).toBeTruthy();
-    });
-
-    it('switches to the Google Play CTA on Android once the launch date has passed', async () => {
-      vi.setSystemTime(new Date('2026-05-05T00:00:00Z'));
+    it('shows the Google Play CTA on Android UA', async () => {
       setUserAgent(ANDROID_UA);
       render(<HomePageContent {...defaultProps} />);
       await waitFor(() => {
         expect(screen.getByText(/Now on Google Play/i)).toBeTruthy();
       });
-      expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
-      expect(screen.queryByText(/Tap to sideload the preview build/i)).toBeNull();
+      expect(screen.getByText(/Get the Boardsesh app/i)).toBeTruthy();
     });
 
     it('hides the install card once running in the native Capacitor app', async () => {
@@ -286,7 +269,7 @@ describe('HomePageContent', () => {
       render(<HomePageContent {...defaultProps} />);
       await waitFor(() => {
         expect(screen.queryByText(/Get the Boardsesh app/i)).toBeNull();
-        expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
+        expect(screen.queryByText(/Now on Google Play/i)).toBeNull();
       });
     });
 
@@ -305,7 +288,7 @@ describe('HomePageContent', () => {
       render(<HomePageContent {...defaultProps} />);
       await waitFor(() => {
         // Card must not render since we now know we're native.
-        expect(screen.queryByText(/Android app is almost here/i)).toBeNull();
+        expect(screen.queryByText(/Now on Google Play/i)).toBeNull();
       });
       expect(mockWaitForCapacitor).toHaveBeenCalledTimes(1);
     });

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -19,8 +19,7 @@ import AndroidOutlined from '@mui/icons-material/AndroidOutlined';
 import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
 import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
-import { IOS_APP_STORE_URL, ANDROID_PLAY_STORE_URL, ANDROID_SIDELOAD_URL } from '@/app/lib/store-urls';
-import { useCountdown } from '@/app/lib/hooks/use-countdown';
+import { IOS_APP_STORE_URL, ANDROID_PLAY_STORE_URL } from '@/app/lib/store-urls';
 import { useSession } from 'next-auth/react';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useTranslation } from 'react-i18next';
@@ -161,8 +160,6 @@ function OnboardingCard({ icon, title, description, onClick, accent = 'action' }
   );
 }
 
-const ANDROID_LAUNCH_DATE = new Date('2026-05-03T00:00:00Z');
-
 type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
 
 function InstallAppShadowCard() {
@@ -194,34 +191,19 @@ function InstallAppShadowCard() {
 
 function InstallAppCard({ platform }: { platform: InstallPlatform }) {
   const { t } = useTranslation('marketing');
-  const isAndroid = platform === 'android-web';
-  const { days, hours, minutes, seconds, done } = useCountdown(ANDROID_LAUNCH_DATE, isAndroid);
 
   if (platform === 'unknown') return <InstallAppShadowCard />;
   if (platform === 'native') return null;
 
-  if (isAndroid) {
-    if (done) {
-      return (
-        <OnboardingCard
-          icon={<AndroidOutlined />}
-          title={t('home.install.androidLiveTitle')}
-          description={t('home.install.androidLiveDescription')}
-          onClick={() => {
-            track('App Install Click', { platform: 'android', source: 'google-play' });
-            window.open(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
-          }}
-        />
-      );
-    }
+  if (platform === 'android-web') {
     return (
       <OnboardingCard
         icon={<AndroidOutlined />}
-        title={t('home.install.androidPreLaunchTitle')}
-        description={t('home.install.androidPreLaunchDescription', { days, hours, minutes, seconds })}
+        title={t('home.install.androidLiveTitle')}
+        description={t('home.install.androidLiveDescription')}
         onClick={() => {
-          track('App Install Click', { platform: 'android', source: 'github-sideload' });
-          window.open(ANDROID_SIDELOAD_URL, '_blank', 'noopener,noreferrer');
+          track('App Install Click', { platform: 'android', source: 'google-play' });
+          window.open(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
         }}
       />
     );

--- a/packages/web/app/lib/store-urls.ts
+++ b/packages/web/app/lib/store-urls.ts
@@ -1,6 +1,5 @@
 export const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
 export const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
-export const ANDROID_SIDELOAD_URL = 'https://github.com/boardsesh/boardsesh/releases/latest';
 
 // Native scheme URLs — open the App Store / Play Store app directly and land on
 // the rate section, which https:// URLs cannot reliably do when surfaced via

--- a/packages/web/i18n/locales/en-US/marketing.json
+++ b/packages/web/i18n/locales/en-US/marketing.json
@@ -38,9 +38,7 @@
       "iosTitle": "Get the Boardsesh app",
       "iosDescription": "Lights up holds on your board straight from your phone",
       "androidLiveTitle": "Get the Boardsesh app",
-      "androidLiveDescription": "Now on Google Play",
-      "androidPreLaunchTitle": "Android app is almost here",
-      "androidPreLaunchDescription": "Landing in {{days}}d {{hours}}h {{minutes}}m {{seconds}}s. Tap to sideload the preview build."
+      "androidLiveDescription": "Now on Google Play"
     },
     "cards": {
       "tourTitle": "Take the tour",

--- a/packages/web/i18n/locales/es/marketing.json
+++ b/packages/web/i18n/locales/es/marketing.json
@@ -38,9 +38,7 @@
       "iosTitle": "Descarga la app de Boardsesh",
       "iosDescription": "Ilumina las presas de tu tabla directamente desde el móvil",
       "androidLiveTitle": "Descarga la app de Boardsesh",
-      "androidLiveDescription": "Ya disponible en Google Play",
-      "androidPreLaunchTitle": "La app de Android está al caer",
-      "androidPreLaunchDescription": "Llega en {{days}}d {{hours}}h {{minutes}}m {{seconds}}s. Toca para instalar la beta."
+      "androidLiveDescription": "Ya disponible en Google Play"
     },
     "cards": {
       "tourTitle": "Haz el tour",


### PR DESCRIPTION
## Summary
- Boardsesh for Android is now live at `https://play.google.com/store/apps/details?id=com.boardsesh.app`, so the home-screen install card always shows the Google Play CTA on Android web — no more launch-date gate or sideload fallback.
- Removed `ANDROID_LAUNCH_DATE`, the `useCountdown` integration, the GitHub sideload path, and the now-unused `ANDROID_SIDELOAD_URL` export plus the `androidPreLaunch*` i18n keys (en-US + es).
- Trimmed the corresponding pre-launch test cases in `home-page-content.test.tsx` and renamed the live case to "shows the Google Play CTA on Android UA".

## Test plan
- [ ] `vp run typecheck:web`
- [ ] `vp test --project web -- home-page-content`
- [ ] Manual: load `/` on an Android UA and confirm the install card opens `play.google.com/store/apps/details?id=com.boardsesh.app`.
- [ ] Manual: load `/` on iOS Safari UA and confirm the iOS App Store CTA still renders.

https://claude.ai/code/session_01KvPVx67qFFEmNiQe3d1Dew

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvPVx67qFFEmNiQe3d1Dew)_