### PR TITLE
Auto-bump iOS / Android marketing version from store API

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -63,11 +63,21 @@ jobs:
         working-directory: mobile
         run: bunx cap sync android
 
-      - name: Set version code
+      - name: Set version code and version name
         working-directory: mobile/android
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          BUILD_GRADLE_PATH: ${{ github.workspace }}/mobile/android/app/build.gradle
         run: |
           sed -Ei "s/^([[:space:]]*)versionCode[[:space:]]*=.*$/\\1versionCode = ${{ github.run_number }}/" app/build.gradle
           echo "Version code set to ${{ github.run_number }}"
+          if [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            VERSION_NAME_NEXT=$(node "$GITHUB_WORKSPACE/mobile/scripts/next-android-version-name.mjs")
+            sed -Ei "s/^([[:space:]]*)versionName[[:space:]]*=.*$/\\1versionName = \"$VERSION_NAME_NEXT\"/" app/build.gradle
+            echo "Version name set to $VERSION_NAME_NEXT"
+          else
+            echo "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON not set; leaving versionName unchanged."
+          fi
 
       - name: Build debug APK
         working-directory: mobile/android

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -73,6 +73,10 @@ jobs:
           echo "Version code set to ${{ github.run_number }}"
           if [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]; then
             VERSION_NAME_NEXT=$(node "$GITHUB_WORKSPACE/mobile/scripts/next-android-version-name.mjs")
+            if ! [[ "$VERSION_NAME_NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Refusing to apply unexpected versionName value: '$VERSION_NAME_NEXT'"
+              exit 1
+            fi
             sed -Ei "s/^([[:space:]]*)versionName[[:space:]]*=.*$/\\1versionName = \"$VERSION_NAME_NEXT\"/" app/build.gradle
             echo "Version name set to $VERSION_NAME_NEXT"
           else

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -117,6 +117,10 @@ jobs:
           fi
           export APP_STORE_CONNECT_API_KEY_PATH="$HOME/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
           MARKETING_VERSION_NEXT=$(node "$GITHUB_WORKSPACE/mobile/scripts/next-ios-marketing-version.mjs")
+          if ! [[ "$MARKETING_VERSION_NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to apply unexpected MARKETING_VERSION value: '$MARKETING_VERSION_NEXT'"
+            exit 1
+          fi
           agvtool new-marketing-version "$MARKETING_VERSION_NEXT"
           echo "Marketing version set to $MARKETING_VERSION_NEXT"
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -102,6 +102,24 @@ jobs:
           echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode \
             > ~/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
 
+      - name: Set marketing version from latest App Store release
+        working-directory: mobile/ios/App
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_APP_ID: ${{ vars.APP_STORE_APP_ID }}
+          PBXPROJ_PATH: ${{ github.workspace }}/mobile/ios/App/App.xcodeproj/project.pbxproj
+        run: |
+          if [ -z "$APP_STORE_APP_ID" ]; then
+            echo "APP_STORE_APP_ID repo variable is not set; skipping marketing version bump."
+            echo "Set it under repo Settings -> Secrets and variables -> Actions -> Variables."
+            exit 0
+          fi
+          export APP_STORE_CONNECT_API_KEY_PATH="$HOME/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          MARKETING_VERSION_NEXT=$(node "$GITHUB_WORKSPACE/mobile/scripts/next-ios-marketing-version.mjs")
+          agvtool new-marketing-version "$MARKETING_VERSION_NEXT"
+          echo "Marketing version set to $MARKETING_VERSION_NEXT"
+
       - name: Archive
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}

--- a/mobile/scripts/next-android-version-name.mjs
+++ b/mobile/scripts/next-android-version-name.mjs
@@ -17,21 +17,16 @@
 import { createSign } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import {
+  base64url,
+  die,
+  highestVersion,
+  normalize,
+  pickNextVersion,
+  requireEnv,
+} from './version-utils.mjs';
 
-function die(message) {
-  process.stderr.write(`next-android-version-name: ${message}\n`);
-  process.exit(1);
-}
-
-function requireEnv(name) {
-  const value = process.env[name];
-  if (!value) die(`missing required env var ${name}`);
-  return value;
-}
-
-function base64url(input) {
-  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
-}
+const SCRIPT = 'next-android-version-name';
 
 function signServiceAccountJwt({ clientEmail, privateKey }) {
   const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
@@ -61,38 +56,17 @@ async function exchangeJwtForAccessToken(jwt) {
   });
   if (!response.ok) {
     const body = await response.text();
-    die(`OAuth2 token exchange failed: ${response.status} ${response.statusText}\n${body}`);
+    die(SCRIPT, `OAuth2 token exchange failed: ${response.status} ${response.statusText}\n${body}`);
   }
   const json = await response.json();
-  if (!json.access_token) die(`OAuth2 response missing access_token: ${JSON.stringify(json)}`);
+  if (!json.access_token) die(SCRIPT, `OAuth2 response missing access_token: ${JSON.stringify(json)}`);
   return json.access_token;
-}
-
-function normalize(version) {
-  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
-  while (parts.length < 3) parts.push(0);
-  return parts.join('.');
-}
-
-function compareVersions(left, right) {
-  const lp = left.split('.').map(Number);
-  const rp = right.split('.').map(Number);
-  for (let index = 0; index < 3; index += 1) {
-    if (lp[index] !== rp[index]) return lp[index] - rp[index];
-  }
-  return 0;
-}
-
-function bumpPatch(version) {
-  const parts = version.split('.').map(Number);
-  parts[2] += 1;
-  return parts.join('.');
 }
 
 function readCurrentVersionName(buildGradlePath) {
   const contents = readFileSync(buildGradlePath, 'utf8');
   const match = contents.match(/versionName\s*=?\s*"([^"]+)"/);
-  if (!match) die(`could not find versionName in ${buildGradlePath}`);
+  if (!match) die(SCRIPT, `could not find versionName in ${buildGradlePath}`);
   return normalize(match[1]);
 }
 
@@ -105,10 +79,10 @@ async function fetchLatestProductionVersionName({ accessToken, packageName }) {
   const editResponse = await fetch(`${baseUrl}/edits`, { method: 'POST', headers });
   if (!editResponse.ok) {
     const body = await editResponse.text();
-    die(`Play Developer API edits.insert failed: ${editResponse.status} ${editResponse.statusText}\n${body}`);
+    die(SCRIPT, `Play Developer API edits.insert failed: ${editResponse.status} ${editResponse.statusText}\n${body}`);
   }
   const { id: editId } = await editResponse.json();
-  if (!editId) die('Play Developer API returned no edit id');
+  if (!editId) die(SCRIPT, 'Play Developer API returned no edit id');
 
   try {
     const trackResponse = await fetch(`${baseUrl}/edits/${editId}/tracks/production`, { headers });
@@ -116,6 +90,7 @@ async function fetchLatestProductionVersionName({ accessToken, packageName }) {
     if (!trackResponse.ok) {
       const body = await trackResponse.text();
       die(
+        SCRIPT,
         `Play Developer API tracks.get failed: ${trackResponse.status} ${trackResponse.statusText}\n${body}`,
       );
     }
@@ -123,22 +98,14 @@ async function fetchLatestProductionVersionName({ accessToken, packageName }) {
     const releases = (track.releases ?? []).filter((release) =>
       release.status === 'completed' || release.status === 'inProgress',
     );
-    if (releases.length === 0) return null;
-
-    const versionNames = releases
-      .map((release) => release.name)
-      .filter((name) => typeof name === 'string' && name.length > 0)
-      .map(normalize);
-    if (versionNames.length === 0) return null;
-
-    return versionNames.sort(compareVersions).at(-1);
+    return highestVersion(releases.map((release) => release.name));
   } finally {
     await fetch(`${baseUrl}/edits/${editId}`, { method: 'DELETE', headers }).catch(() => {});
   }
 }
 
 async function main() {
-  const serviceAccountJson = requireEnv('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON');
+  const serviceAccountJson = requireEnv(SCRIPT, 'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON');
   const packageName = process.env.ANDROID_PACKAGE_NAME ?? 'com.boardsesh.app';
   const buildGradlePath = resolve(process.env.BUILD_GRADLE_PATH ?? 'mobile/android/app/build.gradle');
 
@@ -148,10 +115,10 @@ async function main() {
   try {
     serviceAccount = JSON.parse(serviceAccountJson);
   } catch (error) {
-    die(`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not valid JSON: ${error.message}`);
+    die(SCRIPT, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not valid JSON: ${error.message}`);
   }
   if (!serviceAccount.client_email || !serviceAccount.private_key) {
-    die('service account JSON missing client_email or private_key');
+    die(SCRIPT, 'service account JSON missing client_email or private_key');
   }
 
   const jwt = signServiceAccountJwt({
@@ -167,16 +134,10 @@ async function main() {
     `play production version: ${releasedVersion ?? '(none — no production release yet)'}\n`,
   );
 
-  let nextVersion;
-  if (!releasedVersion) {
-    nextVersion = sourceVersion;
-  } else {
-    const candidate = bumpPatch(releasedVersion);
-    nextVersion = compareVersions(sourceVersion, candidate) > 0 ? sourceVersion : candidate;
-  }
+  const nextVersion = pickNextVersion(sourceVersion, releasedVersion);
 
   process.stderr.write(`next versionName: ${nextVersion}\n`);
   process.stdout.write(`${nextVersion}\n`);
 }
 
-main().catch((error) => die(error.stack ?? String(error)));
+main().catch((error) => die(SCRIPT, error.stack ?? String(error)));

--- a/mobile/scripts/next-android-version-name.mjs
+++ b/mobile/scripts/next-android-version-name.mjs
@@ -20,6 +20,7 @@ import { resolve } from 'node:path';
 import {
   base64url,
   die,
+  failAndExit,
   highestVersion,
   normalize,
   pickNextVersion,
@@ -89,14 +90,11 @@ async function fetchLatestProductionVersionName({ accessToken, packageName }) {
     if (trackResponse.status === 404) return null;
     if (!trackResponse.ok) {
       const body = await trackResponse.text();
-      die(
-        SCRIPT,
-        `Play Developer API tracks.get failed: ${trackResponse.status} ${trackResponse.statusText}\n${body}`,
-      );
+      die(SCRIPT, `Play Developer API tracks.get failed: ${trackResponse.status} ${trackResponse.statusText}\n${body}`);
     }
     const track = await trackResponse.json();
-    const releases = (track.releases ?? []).filter((release) =>
-      release.status === 'completed' || release.status === 'inProgress',
+    const releases = (track.releases ?? []).filter(
+      (release) => release.status === 'completed' || release.status === 'inProgress',
     );
     return highestVersion(releases.map((release) => release.name));
   } finally {
@@ -130,9 +128,7 @@ async function main() {
   const releasedVersion = await fetchLatestProductionVersionName({ accessToken, packageName });
 
   process.stderr.write(`source versionName: ${sourceVersion}\n`);
-  process.stderr.write(
-    `play production version: ${releasedVersion ?? '(none — no production release yet)'}\n`,
-  );
+  process.stderr.write(`play production version: ${releasedVersion ?? '(none — no production release yet)'}\n`);
 
   const nextVersion = pickNextVersion(sourceVersion, releasedVersion);
 
@@ -140,4 +136,4 @@ async function main() {
   process.stdout.write(`${nextVersion}\n`);
 }
 
-main().catch((error) => die(SCRIPT, error.stack ?? String(error)));
+main().catch((error) => failAndExit(SCRIPT, error));

--- a/mobile/scripts/next-android-version-name.mjs
+++ b/mobile/scripts/next-android-version-name.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Compute the next Android versionName for a Play Store build.
+//
+// Mints an OAuth2 access token from a Google service account, queries the
+// Play Developer API for the production track's most recent release, and
+// prints the next versionName to stdout. Designed to be invoked from
+// .github/workflows/android-release.yml; runs anywhere with Node + the
+// service account JSON in env.
+//
+// Inputs (env):
+//   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON   Service account JSON (raw text)
+//   ANDROID_PACKAGE_NAME (optional)    Defaults to com.boardsesh.app
+//   BUILD_GRADLE_PATH (optional)       Defaults to mobile/android/app/build.gradle
+//
+// Output: prints "<major>.<minor>.<patch>" to stdout. Diagnostics go to stderr.
+
+import { createSign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function die(message) {
+  process.stderr.write(`next-android-version-name: ${message}\n`);
+  process.exit(1);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) die(`missing required env var ${name}`);
+  return value;
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function signServiceAccountJwt({ clientEmail, privateKey }) {
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64url(
+    JSON.stringify({
+      iss: clientEmail,
+      scope: 'https://www.googleapis.com/auth/androidpublisher',
+      aud: 'https://oauth2.googleapis.com/token',
+      iat: now,
+      exp: now + 60 * 60,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = createSign('RSA-SHA256').update(signingInput).sign(privateKey);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+async function exchangeJwtForAccessToken(jwt) {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }).toString(),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    die(`OAuth2 token exchange failed: ${response.status} ${response.statusText}\n${body}`);
+  }
+  const json = await response.json();
+  if (!json.access_token) die(`OAuth2 response missing access_token: ${JSON.stringify(json)}`);
+  return json.access_token;
+}
+
+function normalize(version) {
+  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
+  while (parts.length < 3) parts.push(0);
+  return parts.join('.');
+}
+
+function compareVersions(left, right) {
+  const lp = left.split('.').map(Number);
+  const rp = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (lp[index] !== rp[index]) return lp[index] - rp[index];
+  }
+  return 0;
+}
+
+function bumpPatch(version) {
+  const parts = version.split('.').map(Number);
+  parts[2] += 1;
+  return parts.join('.');
+}
+
+function readCurrentVersionName(buildGradlePath) {
+  const contents = readFileSync(buildGradlePath, 'utf8');
+  const match = contents.match(/versionName\s*=?\s*"([^"]+)"/);
+  if (!match) die(`could not find versionName in ${buildGradlePath}`);
+  return normalize(match[1]);
+}
+
+async function fetchLatestProductionVersionName({ accessToken, packageName }) {
+  const headers = { Authorization: `Bearer ${accessToken}` };
+  const baseUrl = `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${encodeURIComponent(
+    packageName,
+  )}`;
+
+  const editResponse = await fetch(`${baseUrl}/edits`, { method: 'POST', headers });
+  if (!editResponse.ok) {
+    const body = await editResponse.text();
+    die(`Play Developer API edits.insert failed: ${editResponse.status} ${editResponse.statusText}\n${body}`);
+  }
+  const { id: editId } = await editResponse.json();
+  if (!editId) die('Play Developer API returned no edit id');
+
+  try {
+    const trackResponse = await fetch(`${baseUrl}/edits/${editId}/tracks/production`, { headers });
+    if (trackResponse.status === 404) return null;
+    if (!trackResponse.ok) {
+      const body = await trackResponse.text();
+      die(
+        `Play Developer API tracks.get failed: ${trackResponse.status} ${trackResponse.statusText}\n${body}`,
+      );
+    }
+    const track = await trackResponse.json();
+    const releases = (track.releases ?? []).filter((release) =>
+      release.status === 'completed' || release.status === 'inProgress',
+    );
+    if (releases.length === 0) return null;
+
+    const versionNames = releases
+      .map((release) => release.name)
+      .filter((name) => typeof name === 'string' && name.length > 0)
+      .map(normalize);
+    if (versionNames.length === 0) return null;
+
+    return versionNames.sort(compareVersions).at(-1);
+  } finally {
+    await fetch(`${baseUrl}/edits/${editId}`, { method: 'DELETE', headers }).catch(() => {});
+  }
+}
+
+async function main() {
+  const serviceAccountJson = requireEnv('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON');
+  const packageName = process.env.ANDROID_PACKAGE_NAME ?? 'com.boardsesh.app';
+  const buildGradlePath = resolve(process.env.BUILD_GRADLE_PATH ?? 'mobile/android/app/build.gradle');
+
+  const sourceVersion = readCurrentVersionName(buildGradlePath);
+
+  let serviceAccount;
+  try {
+    serviceAccount = JSON.parse(serviceAccountJson);
+  } catch (error) {
+    die(`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not valid JSON: ${error.message}`);
+  }
+  if (!serviceAccount.client_email || !serviceAccount.private_key) {
+    die('service account JSON missing client_email or private_key');
+  }
+
+  const jwt = signServiceAccountJwt({
+    clientEmail: serviceAccount.client_email,
+    privateKey: serviceAccount.private_key,
+  });
+  const accessToken = await exchangeJwtForAccessToken(jwt);
+
+  const releasedVersion = await fetchLatestProductionVersionName({ accessToken, packageName });
+
+  process.stderr.write(`source versionName: ${sourceVersion}\n`);
+  process.stderr.write(
+    `play production version: ${releasedVersion ?? '(none — no production release yet)'}\n`,
+  );
+
+  let nextVersion;
+  if (!releasedVersion) {
+    nextVersion = sourceVersion;
+  } else {
+    const candidate = bumpPatch(releasedVersion);
+    nextVersion = compareVersions(sourceVersion, candidate) > 0 ? sourceVersion : candidate;
+  }
+
+  process.stderr.write(`next versionName: ${nextVersion}\n`);
+  process.stdout.write(`${nextVersion}\n`);
+}
+
+main().catch((error) => die(error.stack ?? String(error)));

--- a/mobile/scripts/next-ios-marketing-version.mjs
+++ b/mobile/scripts/next-ios-marketing-version.mjs
@@ -20,21 +20,17 @@
 import { createSign } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import {
+  base64url,
+  compareVersions,
+  die,
+  highestVersion,
+  normalize,
+  pickNextVersion,
+  requireEnv,
+} from './version-utils.mjs';
 
-function die(message) {
-  process.stderr.write(`next-ios-marketing-version: ${message}\n`);
-  process.exit(1);
-}
-
-function requireEnv(name) {
-  const value = process.env[name];
-  if (!value) die(`missing required env var ${name}`);
-  return value;
-}
-
-function base64url(input) {
-  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
-}
+const SCRIPT = 'next-ios-marketing-version';
 
 function signJwt({ keyId, issuerId, privateKey }) {
   const header = base64url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }));
@@ -54,35 +50,14 @@ function signJwt({ keyId, issuerId, privateKey }) {
   return `${signingInput}.${base64url(signature)}`;
 }
 
-function normalize(version) {
-  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
-  while (parts.length < 3) parts.push(0);
-  return parts.join('.');
-}
-
-function compareVersions(left, right) {
-  const lp = left.split('.').map(Number);
-  const rp = right.split('.').map(Number);
-  for (let index = 0; index < 3; index += 1) {
-    if (lp[index] !== rp[index]) return lp[index] - rp[index];
-  }
-  return 0;
-}
-
-function bumpPatch(version) {
-  const parts = version.split('.').map(Number);
-  parts[2] += 1;
-  return parts.join('.');
-}
-
 function readCurrentMarketingVersion(pbxprojPath) {
   const contents = readFileSync(pbxprojPath, 'utf8');
   const matches = [...contents.matchAll(/MARKETING_VERSION\s*=\s*([0-9.]+)\s*;/g)].map((match) => match[1]);
-  if (matches.length === 0) die(`could not find MARKETING_VERSION in ${pbxprojPath}`);
+  if (matches.length === 0) die(SCRIPT, `could not find MARKETING_VERSION in ${pbxprojPath}`);
   const unique = [...new Set(matches.map(normalize))];
   if (unique.length > 1) {
     process.stderr.write(
-      `next-ios-marketing-version: warning — multiple MARKETING_VERSION values in pbxproj (${unique.join(
+      `${SCRIPT}: warning — multiple MARKETING_VERSION values in pbxproj (${unique.join(
         ', ',
       )}); using the highest\n`,
     );
@@ -91,24 +66,28 @@ function readCurrentMarketingVersion(pbxprojPath) {
 }
 
 async function fetchLatestReleasedVersion({ appId, jwt }) {
+  // Fetch all READY_FOR_SALE versions and sort with compareVersions ourselves;
+  // the API does not order by semver so a naive `limit=1` can miss the highest.
   const url = `https://api.appstoreconnect.apple.com/v1/apps/${encodeURIComponent(
     appId,
-  )}/appStoreVersions?filter%5BappStoreState%5D=READY_FOR_SALE&limit=1`;
+  )}/appStoreVersions?filter%5BappStoreState%5D=READY_FOR_SALE&limit=200`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${jwt}` } });
   if (!response.ok) {
     const body = await response.text();
-    die(`App Store Connect lookup failed: ${response.status} ${response.statusText}\n${body}`);
+    die(SCRIPT, `App Store Connect lookup failed: ${response.status} ${response.statusText}\n${body}`);
   }
   const json = await response.json();
-  const released = json?.data?.[0]?.attributes?.versionString;
-  return released ? normalize(released) : null;
+  const versionStrings = (json?.data ?? [])
+    .map((entry) => entry?.attributes?.versionString)
+    .filter(Boolean);
+  return highestVersion(versionStrings);
 }
 
 async function main() {
-  const keyId = requireEnv('APP_STORE_CONNECT_API_KEY_ID');
-  const issuerId = requireEnv('APP_STORE_CONNECT_ISSUER_ID');
-  const keyPath = requireEnv('APP_STORE_CONNECT_API_KEY_PATH');
-  const appId = requireEnv('APP_STORE_APP_ID');
+  const keyId = requireEnv(SCRIPT, 'APP_STORE_CONNECT_API_KEY_ID');
+  const issuerId = requireEnv(SCRIPT, 'APP_STORE_CONNECT_ISSUER_ID');
+  const keyPath = requireEnv(SCRIPT, 'APP_STORE_CONNECT_API_KEY_PATH');
+  const appId = requireEnv(SCRIPT, 'APP_STORE_APP_ID');
   const pbxprojPath = resolve(
     process.env.PBXPROJ_PATH ?? 'mobile/ios/App/App.xcodeproj/project.pbxproj',
   );
@@ -122,16 +101,10 @@ async function main() {
   process.stderr.write(`source MARKETING_VERSION: ${sourceVersion}\n`);
   process.stderr.write(`store READY_FOR_SALE version: ${releasedVersion ?? '(none — no public release yet)'}\n`);
 
-  let nextVersion;
-  if (!releasedVersion) {
-    nextVersion = sourceVersion;
-  } else {
-    const candidate = bumpPatch(releasedVersion);
-    nextVersion = compareVersions(sourceVersion, candidate) > 0 ? sourceVersion : candidate;
-  }
+  const nextVersion = pickNextVersion(sourceVersion, releasedVersion);
 
   process.stderr.write(`next marketing version: ${nextVersion}\n`);
   process.stdout.write(`${nextVersion}\n`);
 }
 
-main().catch((error) => die(error.stack ?? String(error)));
+main().catch((error) => die(SCRIPT, error.stack ?? String(error)));

--- a/mobile/scripts/next-ios-marketing-version.mjs
+++ b/mobile/scripts/next-ios-marketing-version.mjs
@@ -24,6 +24,7 @@ import {
   base64url,
   compareVersions,
   die,
+  failAndExit,
   highestVersion,
   normalize,
   pickNextVersion,
@@ -44,9 +45,7 @@ function signJwt({ keyId, issuerId, privateKey }) {
     }),
   );
   const signingInput = `${header}.${payload}`;
-  const signature = createSign('SHA256')
-    .update(signingInput)
-    .sign({ key: privateKey, dsaEncoding: 'ieee-p1363' });
+  const signature = createSign('SHA256').update(signingInput).sign({ key: privateKey, dsaEncoding: 'ieee-p1363' });
   return `${signingInput}.${base64url(signature)}`;
 }
 
@@ -57,9 +56,7 @@ function readCurrentMarketingVersion(pbxprojPath) {
   const unique = [...new Set(matches.map(normalize))];
   if (unique.length > 1) {
     process.stderr.write(
-      `${SCRIPT}: warning — multiple MARKETING_VERSION values in pbxproj (${unique.join(
-        ', ',
-      )}); using the highest\n`,
+      `${SCRIPT}: warning — multiple MARKETING_VERSION values in pbxproj (${unique.join(', ')}); using the highest\n`,
     );
   }
   return unique.sort(compareVersions).at(-1);
@@ -77,9 +74,7 @@ async function fetchLatestReleasedVersion({ appId, jwt }) {
     die(SCRIPT, `App Store Connect lookup failed: ${response.status} ${response.statusText}\n${body}`);
   }
   const json = await response.json();
-  const versionStrings = (json?.data ?? [])
-    .map((entry) => entry?.attributes?.versionString)
-    .filter(Boolean);
+  const versionStrings = (json?.data ?? []).map((entry) => entry?.attributes?.versionString).filter(Boolean);
   return highestVersion(versionStrings);
 }
 
@@ -88,9 +83,7 @@ async function main() {
   const issuerId = requireEnv(SCRIPT, 'APP_STORE_CONNECT_ISSUER_ID');
   const keyPath = requireEnv(SCRIPT, 'APP_STORE_CONNECT_API_KEY_PATH');
   const appId = requireEnv(SCRIPT, 'APP_STORE_APP_ID');
-  const pbxprojPath = resolve(
-    process.env.PBXPROJ_PATH ?? 'mobile/ios/App/App.xcodeproj/project.pbxproj',
-  );
+  const pbxprojPath = resolve(process.env.PBXPROJ_PATH ?? 'mobile/ios/App/App.xcodeproj/project.pbxproj');
 
   const sourceVersion = readCurrentMarketingVersion(pbxprojPath);
 
@@ -107,4 +100,4 @@ async function main() {
   process.stdout.write(`${nextVersion}\n`);
 }
 
-main().catch((error) => die(SCRIPT, error.stack ?? String(error)));
+main().catch((error) => failAndExit(SCRIPT, error));

--- a/mobile/scripts/next-ios-marketing-version.mjs
+++ b/mobile/scripts/next-ios-marketing-version.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Compute the next iOS marketing version for a TestFlight/App Store build.
+//
+// Reads the latest publicly-released version from App Store Connect and the
+// current MARKETING_VERSION committed in the Xcode project, then prints the
+// next version to stdout. Designed to be invoked from
+// .github/workflows/ios-testflight.yml and to run cross-platform for local
+// dry-runs (only Node + standard library are required).
+//
+// Inputs (env):
+//   APP_STORE_CONNECT_API_KEY_ID       Apple API key id (e.g. ABC1234567)
+//   APP_STORE_CONNECT_ISSUER_ID        Apple issuer uuid
+//   APP_STORE_CONNECT_API_KEY_PATH     Path to the .p8 private key
+//   APP_STORE_APP_ID                   Numeric App Store app id
+//   PBXPROJ_PATH (optional)            Defaults to
+//                                      mobile/ios/App/App.xcodeproj/project.pbxproj
+//
+// Output: prints "<major>.<minor>.<patch>" to stdout. All diagnostics go to stderr.
+
+import { createSign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function die(message) {
+  process.stderr.write(`next-ios-marketing-version: ${message}\n`);
+  process.exit(1);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) die(`missing required env var ${name}`);
+  return value;
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function signJwt({ keyId, issuerId, privateKey }) {
+  const header = base64url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64url(
+    JSON.stringify({
+      iss: issuerId,
+      iat: now,
+      exp: now + 15 * 60,
+      aud: 'appstoreconnect-v1',
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = createSign('SHA256')
+    .update(signingInput)
+    .sign({ key: privateKey, dsaEncoding: 'ieee-p1363' });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+function normalize(version) {
+  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
+  while (parts.length < 3) parts.push(0);
+  return parts.join('.');
+}
+
+function compareVersions(left, right) {
+  const lp = left.split('.').map(Number);
+  const rp = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (lp[index] !== rp[index]) return lp[index] - rp[index];
+  }
+  return 0;
+}
+
+function bumpPatch(version) {
+  const parts = version.split('.').map(Number);
+  parts[2] += 1;
+  return parts.join('.');
+}
+
+function readCurrentMarketingVersion(pbxprojPath) {
+  const contents = readFileSync(pbxprojPath, 'utf8');
+  const matches = [...contents.matchAll(/MARKETING_VERSION\s*=\s*([0-9.]+)\s*;/g)].map((match) => match[1]);
+  if (matches.length === 0) die(`could not find MARKETING_VERSION in ${pbxprojPath}`);
+  const unique = [...new Set(matches.map(normalize))];
+  if (unique.length > 1) {
+    process.stderr.write(
+      `next-ios-marketing-version: warning — multiple MARKETING_VERSION values in pbxproj (${unique.join(
+        ', ',
+      )}); using the highest\n`,
+    );
+  }
+  return unique.sort(compareVersions).at(-1);
+}
+
+async function fetchLatestReleasedVersion({ appId, jwt }) {
+  const url = `https://api.appstoreconnect.apple.com/v1/apps/${encodeURIComponent(
+    appId,
+  )}/appStoreVersions?filter%5BappStoreState%5D=READY_FOR_SALE&limit=1`;
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${jwt}` } });
+  if (!response.ok) {
+    const body = await response.text();
+    die(`App Store Connect lookup failed: ${response.status} ${response.statusText}\n${body}`);
+  }
+  const json = await response.json();
+  const released = json?.data?.[0]?.attributes?.versionString;
+  return released ? normalize(released) : null;
+}
+
+async function main() {
+  const keyId = requireEnv('APP_STORE_CONNECT_API_KEY_ID');
+  const issuerId = requireEnv('APP_STORE_CONNECT_ISSUER_ID');
+  const keyPath = requireEnv('APP_STORE_CONNECT_API_KEY_PATH');
+  const appId = requireEnv('APP_STORE_APP_ID');
+  const pbxprojPath = resolve(
+    process.env.PBXPROJ_PATH ?? 'mobile/ios/App/App.xcodeproj/project.pbxproj',
+  );
+
+  const sourceVersion = readCurrentMarketingVersion(pbxprojPath);
+
+  const privateKey = readFileSync(keyPath, 'utf8');
+  const jwt = signJwt({ keyId, issuerId, privateKey });
+  const releasedVersion = await fetchLatestReleasedVersion({ appId, jwt });
+
+  process.stderr.write(`source MARKETING_VERSION: ${sourceVersion}\n`);
+  process.stderr.write(`store READY_FOR_SALE version: ${releasedVersion ?? '(none — no public release yet)'}\n`);
+
+  let nextVersion;
+  if (!releasedVersion) {
+    nextVersion = sourceVersion;
+  } else {
+    const candidate = bumpPatch(releasedVersion);
+    nextVersion = compareVersions(sourceVersion, candidate) > 0 ? sourceVersion : candidate;
+  }
+
+  process.stderr.write(`next marketing version: ${nextVersion}\n`);
+  process.stdout.write(`${nextVersion}\n`);
+}
+
+main().catch((error) => die(error.stack ?? String(error)));

--- a/mobile/scripts/version-utils.mjs
+++ b/mobile/scripts/version-utils.mjs
@@ -1,8 +1,17 @@
 // Shared helpers for the iOS / Android marketing-version computation scripts.
 // Kept zero-dependency so callers can run on any Node 18+ runtime.
 
+// Throws rather than calling process.exit() so that `finally` blocks (e.g. the
+// Play edit cleanup) still run when a failure happens mid-request. The script
+// entrypoints catch this and exit non-zero via failAndExit().
 export function die(scriptName, message) {
-  process.stderr.write(`${scriptName}: ${message}\n`);
+  throw new Error(`${scriptName}: ${message}`);
+}
+
+// Top-level error handler for the entrypoints. Prints to stderr and exits 1,
+// after any in-flight `finally` cleanup has already run.
+export function failAndExit(scriptName, error) {
+  process.stderr.write(`${error?.stack ?? error?.message ?? `${scriptName}: ${String(error)}`}\n`);
   process.exit(1);
 }
 
@@ -17,7 +26,11 @@ export function base64url(input) {
 }
 
 export function normalize(version) {
-  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
+  const parts = String(version)
+    .trim()
+    .split('.')
+    .slice(0, 3)
+    .map((part) => Number.parseInt(part, 10) || 0);
   while (parts.length < 3) parts.push(0);
   return parts.join('.');
 }
@@ -49,9 +62,7 @@ export function pickNextVersion(sourceVersion, releasedVersion) {
 // Picks the highest version from a list (after normalising). Returns null if
 // the list is empty after filtering.
 export function highestVersion(versions) {
-  const normalised = versions
-    .filter((value) => typeof value === 'string' && value.length > 0)
-    .map(normalize);
+  const normalised = versions.filter((value) => typeof value === 'string' && value.length > 0).map(normalize);
   if (normalised.length === 0) return null;
   return normalised.sort(compareVersions).at(-1);
 }

--- a/mobile/scripts/version-utils.mjs
+++ b/mobile/scripts/version-utils.mjs
@@ -1,0 +1,57 @@
+// Shared helpers for the iOS / Android marketing-version computation scripts.
+// Kept zero-dependency so callers can run on any Node 18+ runtime.
+
+export function die(scriptName, message) {
+  process.stderr.write(`${scriptName}: ${message}\n`);
+  process.exit(1);
+}
+
+export function requireEnv(scriptName, name) {
+  const value = process.env[name];
+  if (!value) die(scriptName, `missing required env var ${name}`);
+  return value;
+}
+
+export function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+export function normalize(version) {
+  const parts = String(version).trim().split('.').slice(0, 3).map((part) => Number.parseInt(part, 10) || 0);
+  while (parts.length < 3) parts.push(0);
+  return parts.join('.');
+}
+
+export function compareVersions(left, right) {
+  const lp = left.split('.').map(Number);
+  const rp = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (lp[index] !== rp[index]) return lp[index] - rp[index];
+  }
+  return 0;
+}
+
+export function bumpPatch(version) {
+  const parts = version.split('.').map(Number);
+  parts[2] += 1;
+  return parts.join('.');
+}
+
+// Computes the next marketing version given the value committed in source
+// and the most recent publicly-released version (or null if the store has
+// no public release yet).
+export function pickNextVersion(sourceVersion, releasedVersion) {
+  if (!releasedVersion) return sourceVersion;
+  const candidate = bumpPatch(releasedVersion);
+  return compareVersions(sourceVersion, candidate) > 0 ? sourceVersion : candidate;
+}
+
+// Picks the highest version from a list (after normalising). Returns null if
+// the list is empty after filtering.
+export function highestVersion(versions) {
+  const normalised = versions
+    .filter((value) => typeof value === 'string' && value.length > 0)
+    .map(normalize);
+  if (normalised.length === 0) return null;
+  return normalised.sort(compareVersions).at(-1);
+}

--- a/mobile/scripts/version-utils.test.mjs
+++ b/mobile/scripts/version-utils.test.mjs
@@ -1,0 +1,101 @@
+// Run with: node --test mobile/scripts/version-utils.test.mjs
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  bumpPatch,
+  compareVersions,
+  highestVersion,
+  normalize,
+  pickNextVersion,
+} from './version-utils.mjs';
+
+describe('normalize', () => {
+  it('pads 2-segment versions to 3 segments', () => {
+    assert.equal(normalize('1.2'), '1.2.0');
+  });
+
+  it('passes 3-segment versions through unchanged', () => {
+    assert.equal(normalize('1.2.3'), '1.2.3');
+  });
+
+  it('truncates extra segments', () => {
+    assert.equal(normalize('1.2.3.4'), '1.2.3');
+  });
+
+  it('treats non-numeric segments as zero', () => {
+    assert.equal(normalize('1.x.3'), '1.0.3');
+  });
+
+  it('handles leading/trailing whitespace', () => {
+    assert.equal(normalize('  1.2  '), '1.2.0');
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders by numeric value, not lexicographically', () => {
+    assert.ok(compareVersions('1.10.0', '1.9.0') > 0, '1.10.0 should rank higher than 1.9.0');
+    assert.ok(compareVersions('1.2.10', '1.2.9') > 0, '1.2.10 should rank higher than 1.2.9');
+  });
+
+  it('returns 0 for equal versions', () => {
+    assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
+  });
+
+  it('compares major before minor before patch', () => {
+    assert.ok(compareVersions('2.0.0', '1.99.99') > 0);
+    assert.ok(compareVersions('1.5.0', '1.4.99') > 0);
+  });
+});
+
+describe('bumpPatch', () => {
+  it('increments only the patch segment', () => {
+    assert.equal(bumpPatch('1.2.3'), '1.2.4');
+    assert.equal(bumpPatch('1.0.0'), '1.0.1');
+  });
+});
+
+describe('highestVersion', () => {
+  it('returns null for empty input', () => {
+    assert.equal(highestVersion([]), null);
+  });
+
+  it('filters out non-string values', () => {
+    assert.equal(highestVersion([null, undefined, '']), null);
+  });
+
+  it('picks the highest version after normalisation', () => {
+    assert.equal(highestVersion(['1.2', '1.10.0', '1.9.0']), '1.10.0');
+  });
+});
+
+describe('pickNextVersion', () => {
+  it('returns source unchanged when the store has no release', () => {
+    assert.equal(pickNextVersion('1.2.0', null), '1.2.0');
+  });
+
+  it('bumps patch when source matches store (cold start)', () => {
+    assert.equal(pickNextVersion('1.2.0', '1.2.0'), '1.2.1');
+  });
+
+  it('respects source when it is ahead of store', () => {
+    assert.equal(pickNextVersion('2.0.0', '1.2.0'), '2.0.0');
+  });
+
+  it('bumps from store when store has skipped ahead', () => {
+    assert.equal(pickNextVersion('1.2.0', '1.3.0'), '1.3.1');
+  });
+
+  it('keeps idempotent next-version across reruns until store moves', () => {
+    // First run: source 1.2.0, store 1.2.0 -> 1.2.1
+    const first = pickNextVersion('1.2.0', '1.2.0');
+    // Re-run before promotion: store still 1.2.0, source still 1.2.0 -> 1.2.1 again
+    const second = pickNextVersion('1.2.0', '1.2.0');
+    assert.equal(first, second);
+  });
+
+  it('handles double-digit version segments correctly', () => {
+    assert.equal(pickNextVersion('1.9.0', '1.10.0'), '1.10.1');
+  });
+});

--- a/mobile/scripts/version-utils.test.mjs
+++ b/mobile/scripts/version-utils.test.mjs
@@ -3,13 +3,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import {
-  bumpPatch,
-  compareVersions,
-  highestVersion,
-  normalize,
-  pickNextVersion,
-} from './version-utils.mjs';
+import { bumpPatch, compareVersions, highestVersion, normalize, pickNextVersion } from './version-utils.mjs';
 
 describe('normalize', () => {
   it('pads 2-segment versions to 3 segments', () => {


### PR DESCRIPTION
## Summary

Both release workflows now query their respective store APIs at build time to derive the next user-visible version. After a release ships on the App Store or Play Store, the next main build automatically increments past it, so we no longer queue a second build under the same `1.2` / `1.1` once an earlier one has been promoted.

- **iOS** (`.github/workflows/ios-testflight.yml`): new step calls App Store Connect (`/v1/apps/{id}/appStoreVersions?filter[appStoreState]=READY_FOR_SALE`) using the existing `.p8` key and runs `agvtool new-marketing-version` before the archive step.
- **Android** (`.github/workflows/android-release.yml`): the existing "Set version code" step is extended to also query the Play Developer API edits/tracks endpoint and `sed` the new `versionName` into `app/build.gradle`.
- Build numbers (`CURRENT_PROJECT_VERSION` / `versionCode`) continue to come from `github.run_number` — only the marketing version is new.
- Logic: `next = max(source, bumpPatch(latest_released))`. If the store has no public release yet, source ships unchanged. The bump is **ephemeral** in CI — we do not commit it back, matching how `versionCode` already works.
- Reuses existing auth in both workflows. No new secrets.
- Helper logic lives in two zero-dependency Node scripts under `mobile/scripts/`, so the same lookup can be run locally for debugging.

## Required before merging

The iOS path needs a new repository **variable** (not a secret — the App Store app id is public):

- `vars.APP_STORE_APP_ID` — the numeric App Store id (the digits in the App Store Connect URL, e.g. `1234567890`).

If unset, the iOS step prints a notice and skips the bump; the build proceeds with whatever's committed in `pbxproj`.

## Notes

- iOS and Android stay independent — each app tracks its own marketing version. Source files are currently `MARKETING_VERSION = 1.2` (iOS) and `versionName = "1.1"` (Android). Both will normalize to 3-segment (`1.2.0`, `1.1.0`) on the next bump and continue from there.
- Edge cases covered: cold start, source ahead of store, store skipped ahead, repeated builds before a promotion, legacy 2-segment store strings, double-digit minor versions (`1.10.0` vs `1.9.0`). Verified with an inline test pass against the bump helpers.
- API failures fail the workflow loud rather than silently falling back — a stale upload would be rejected later by the store anyway, and a re-run is cheap.

## Test plan

- [ ] Set `vars.APP_STORE_APP_ID` in repo settings.
- [ ] Trigger `ios-testflight.yml` via `workflow_dispatch`; check the "Set marketing version" step output and confirm the resulting TestFlight build shows the bumped marketing version + run-number build number.
- [ ] Trigger `android-release.yml` via `workflow_dispatch`; confirm the Play Console internal track shows the bumped `versionName`.
- [ ] Re-run each workflow without a new store release and confirm the same next version is computed (idempotent until the store moves).
- [ ] Once a real release ships, confirm the next main build picks up the next bump automatically.

https://claude.ai/code/session_01NVnVe8ucnzWdNXNg5RCar2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVnVe8ucnzWdNXNg5RCar2)_