### PR TITLE
Add horizontal padding to Start climbing drawer body

### DIFF
--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -369,7 +369,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
             paddingLeft: `${themeTokens.spacing[3]}px`,
             paddingRight: `${themeTokens.spacing[3]}px`,
           },
-          body: { padding: `${themeTokens.spacing[2]}px 0` },
+          body: { padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px` },
         }}
         footer={
           <Button


### PR DESCRIPTION
## Summary

- The Start climbing drawer body had `padding: 8px 0`, so form fields and blurb text ran flush against the drawer edges while the header kept its 12px horizontal indent.
- Switch the body to `8px 12px` (using `themeTokens.spacing[3]`) so body content lines up with the header.

Fixes #1839

## Test plan

- [ ] `vp run dev` and open `http://localhost:3000`
- [ ] Click "Start climbing" — confirm board picker, blurb, session-name field, color chips, and the submit button now have visible horizontal margin matching the drawer title
- [ ] `vp check` and `vp run typecheck:web`
- [ ] `vp test --project web` (existing `start-sesh-drawer.test.tsx` should still pass)

## Out of scope

`packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx:350` has the same `body: { padding: '8px 0' }` pattern and likely the same visual issue. The reporter only flagged the homepage popup, so that drawer is untouched here — open a follow-up if needed.

https://claude.ai/code/session_0189JMN2XRtTC7Ha8EkyEyyP

---
_Generated by [Claude Code](https://claude.ai/code/session_0189JMN2XRtTC7Ha8EkyEyyP)_