### PR TITLE
Fix #1851: rapid playlist taps over-decrement climbCount

### DIFF
--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -319,6 +319,96 @@ describe('useClimbActionsData', () => {
     });
   });
 
+  it('rapid addToPlaylist taps converge to a single climbCount increment (#1851)', async () => {
+    mockRequest.mockResolvedValueOnce({ favorites: [] });
+    mockRequest.mockResolvedValueOnce({
+      allUserPlaylists: [{ uuid: 'pl-1', name: 'Test', climbCount: 2 }],
+    });
+    mockRequest.mockResolvedValueOnce({ playlistsForClimbs: [] });
+
+    const wrapper = createQueryWrapper();
+    const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.playlistsProviderProps.isLoading).toBe(false);
+    });
+
+    // Three rapid taps — server is idempotent so all three resolve successfully.
+    mockRequest.mockResolvedValue({ addClimbToPlaylist: { success: true } });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.playlistsProviderProps.addToPlaylist('pl-1', 'climb-1', 40),
+        result.current.playlistsProviderProps.addToPlaylist('pl-1', 'climb-1', 40),
+        result.current.playlistsProviderProps.addToPlaylist('pl-1', 'climb-1', 40),
+      ]);
+    });
+
+    // climbCount must end at 3, not 5 — the optimistic update is gated on actual transition.
+    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(playlist?.climbCount).toBe(3);
+    expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(true);
+  });
+
+  it('rapid removeFromPlaylist taps converge to a single climbCount decrement (#1851)', async () => {
+    mockRequest.mockResolvedValueOnce({ favorites: [] });
+    mockRequest.mockResolvedValueOnce({
+      allUserPlaylists: [{ uuid: 'pl-1', name: 'Test', climbCount: 5 }],
+    });
+    mockRequest.mockResolvedValueOnce({
+      playlistsForClimbs: [{ climbUuid: 'climb-1', playlistUuids: ['pl-1'] }],
+    });
+
+    const wrapper = createQueryWrapper();
+    const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(true);
+    });
+
+    mockRequest.mockResolvedValue({ removeClimbFromPlaylist: { success: true } });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.playlistsProviderProps.removeFromPlaylist('pl-1', 'climb-1'),
+        result.current.playlistsProviderProps.removeFromPlaylist('pl-1', 'climb-1'),
+        result.current.playlistsProviderProps.removeFromPlaylist('pl-1', 'climb-1'),
+      ]);
+    });
+
+    // climbCount must end at 4, not 2 — the second and third tap see membership already removed.
+    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(playlist?.climbCount).toBe(4);
+    expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(false);
+  });
+
+  it('addToPlaylist rolls back membership and climbCount when the request fails', async () => {
+    mockRequest.mockResolvedValueOnce({ favorites: [] });
+    mockRequest.mockResolvedValueOnce({
+      allUserPlaylists: [{ uuid: 'pl-1', name: 'Test', climbCount: 2 }],
+    });
+    mockRequest.mockResolvedValueOnce({ playlistsForClimbs: [] });
+
+    const wrapper = createQueryWrapper();
+    const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.playlistsProviderProps.isLoading).toBe(false);
+    });
+
+    mockRequest.mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      await expect(result.current.playlistsProviderProps.addToPlaylist('pl-1', 'climb-1', 40)).rejects.toThrow(
+        'network down',
+      );
+    });
+
+    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(playlist?.climbCount).toBe(2);
+    expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1') ?? false).toBe(false);
+  });
+
   it('createPlaylist sends mutation and updates cache', async () => {
     mockRequest.mockResolvedValueOnce({ favorites: [] });
     mockRequest.mockResolvedValueOnce({ allUserPlaylists: [] });

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -409,6 +409,35 @@ describe('useClimbActionsData', () => {
     expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1') ?? false).toBe(false);
   });
 
+  it('removeFromPlaylist rolls back membership and climbCount when the request fails', async () => {
+    mockRequest.mockResolvedValueOnce({ favorites: [] });
+    mockRequest.mockResolvedValueOnce({
+      allUserPlaylists: [{ uuid: 'pl-1', name: 'Test', climbCount: 5 }],
+    });
+    mockRequest.mockResolvedValueOnce({
+      playlistsForClimbs: [{ climbUuid: 'climb-1', playlistUuids: ['pl-1'] }],
+    });
+
+    const wrapper = createQueryWrapper();
+    const { result } = renderHook(() => useClimbActionsData(defaultOptions), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(true);
+    });
+
+    mockRequest.mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      await expect(result.current.playlistsProviderProps.removeFromPlaylist('pl-1', 'climb-1')).rejects.toThrow(
+        'network down',
+      );
+    });
+
+    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(playlist?.climbCount).toBe(5);
+    expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(true);
+  });
+
   it('createPlaylist sends mutation and updates cache', async () => {
     mockRequest.mockResolvedValueOnce({ favorites: [] });
     mockRequest.mockResolvedValueOnce({ allUserPlaylists: [] });

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -344,9 +344,10 @@ describe('useClimbActionsData', () => {
       ]);
     });
 
-    // climbCount must end at 3, not 5 — the optimistic update is gated on actual transition.
-    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
-    expect(playlist?.climbCount).toBe(3);
+    // Starting count is 2; only the first tap performs an effective add (2 + 1 = 3).
+    // Without the membership gate, all three taps would each apply +1 (2 + 3 = 5).
+    const addedPlaylist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(addedPlaylist?.climbCount).toBe(3);
     expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(true);
   });
 
@@ -376,9 +377,10 @@ describe('useClimbActionsData', () => {
       ]);
     });
 
-    // climbCount must end at 4, not 2 — the second and third tap see membership already removed.
-    const playlist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
-    expect(playlist?.climbCount).toBe(4);
+    // Starting count is 5; only the first tap performs an effective remove (5 - 1 = 4).
+    // Without the membership gate, all three taps would each apply -1 (5 - 3 = 2).
+    const removedPlaylist = result.current.playlistsProviderProps.playlists.find((p) => p.uuid === 'pl-1');
+    expect(removedPlaylist?.climbCount).toBe(4);
     expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-1')).toBe(false);
   });
 

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -53,6 +53,13 @@ const hasMapSizeChanged = (prev: Map<string, Set<string>>, next: Map<string, Set
 const EMPTY_SET = new Set<string>();
 const EMPTY_MAP = new Map<string, Set<string>>();
 
+type AddPlaylistVars = { playlistId: string; climbUuid: string; climbAngle: number };
+type RemovePlaylistVars = { playlistId: string; climbUuid: string };
+// onError reverses only its own optimistic write (gated on `membershipChanged`)
+// rather than restoring a snapshot, so a concurrent mutation's optimistic state
+// is preserved if its onMutate ran between this mutation's onMutate and onError.
+type PlaylistMutationContext = { membershipChanged: boolean };
+
 export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: UseClimbActionsDataOptions) {
   const { t } = useTranslation('climbs');
   const { token, isAuthenticated, isLoading: isAuthLoading } = useWsAuthToken();
@@ -233,29 +240,25 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
   // Optimistic updates run inside onMutate so the second of two rapid taps
   // sees the cache state from the first — the count delta is gated on whether
   // membership actually transitioned, so redundant requests are no-ops on the count.
-  type AddPlaylistVars = { playlistId: string; climbUuid: string; climbAngle: number };
-  type RemovePlaylistVars = { playlistId: string; climbUuid: string };
-  type PlaylistMutationContext = {
-    prevMem: Map<string, Set<string>> | undefined;
-    prevPlaylists: Playlist[] | undefined;
-    membershipChanged: boolean;
-  };
-
   const addPlaylistMutation = useMutation<unknown, Error, AddPlaylistVars, PlaylistMutationContext>({
     mutationKey: ['addToPlaylist'],
     mutationFn: async ({ playlistId, climbUuid, climbAngle }) => {
-      const r = playlistRef.current;
-      if (!r.token) throw new Error('Not authenticated');
-      const client = createGraphQLHttpClient(r.token);
+      const { token: latestToken } = playlistRef.current;
+      if (!latestToken) throw new Error('Not authenticated');
+      const client = createGraphQLHttpClient(latestToken);
       return client.request<AddClimbToPlaylistMutationResponse>(ADD_CLIMB_TO_PLAYLIST, {
         input: { playlistId, climbUuid, angle: climbAngle },
       });
     },
     onMutate: async ({ playlistId, climbUuid }) => {
-      const r = playlistRef.current;
-      await r.cancelMemFetches();
-      const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey);
-      const prevPlaylists = r.queryClient.getQueryData<Playlist[]>(r.playlistsQueryKey);
+      const {
+        cancelMemFetches: latestCancelMemFetches,
+        queryClient: latestQueryClient,
+        memAccKey: latestMemAccKey,
+        playlistsQueryKey: latestPlaylistsQueryKey,
+      } = playlistRef.current;
+      await latestCancelMemFetches();
+      const prevMem = latestQueryClient.getQueryData<Map<string, Set<string>>>(latestMemAccKey);
       const currentSet = prevMem?.get(climbUuid) ?? EMPTY_SET;
       const alreadyMember = currentSet.has(playlistId);
       if (!alreadyMember) {
@@ -263,46 +266,58 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
         const nextSet = new Set(currentSet);
         nextSet.add(playlistId);
         updatedMem.set(climbUuid, nextSet);
-        r.queryClient.setQueryData(r.memAccKey, updatedMem);
-        r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
+        latestQueryClient.setQueryData(latestMemAccKey, updatedMem);
+        latestQueryClient.setQueryData<Playlist[]>(latestPlaylistsQueryKey, (prev) =>
           prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount + 1 } : p)),
         );
       }
-      return { prevMem, prevPlaylists, membershipChanged: !alreadyMember };
+      return { membershipChanged: !alreadyMember };
     },
-    onError: (_err, _vars, context) => {
+    onError: (_err, { playlistId, climbUuid }, context) => {
       if (!context?.membershipChanged) return;
-      const r = playlistRef.current;
-      // setQueryData treats undefined as a no-op, so use removeQueries to roll back
-      // to a "no data" state when the snapshot was undefined.
-      if (context.prevMem === undefined) {
-        r.queryClient.removeQueries({ queryKey: r.memAccKey, exact: true });
-      } else {
-        r.queryClient.setQueryData(r.memAccKey, context.prevMem);
-      }
-      if (context.prevPlaylists === undefined) {
-        r.queryClient.removeQueries({ queryKey: r.playlistsQueryKey, exact: true });
-      } else {
-        r.queryClient.setQueryData(r.playlistsQueryKey, context.prevPlaylists);
-      }
+      // Reverse only the specific optimistic write made in onMutate, so a concurrent
+      // mutation's optimistic state (which may have run between our onMutate and onError)
+      // is preserved. Restoring a full snapshot would clobber it.
+      const {
+        queryClient: latestQueryClient,
+        memAccKey: latestMemAccKey,
+        playlistsQueryKey: latestPlaylistsQueryKey,
+      } = playlistRef.current;
+      latestQueryClient.setQueryData<Map<string, Set<string>>>(latestMemAccKey, (current) => {
+        if (!current) return current;
+        const climbSet = current.get(climbUuid);
+        if (!climbSet?.has(playlistId)) return current;
+        const updated = new Map(current);
+        const nextSet = new Set(climbSet);
+        nextSet.delete(playlistId);
+        updated.set(climbUuid, nextSet);
+        return updated;
+      });
+      latestQueryClient.setQueryData<Playlist[]>(latestPlaylistsQueryKey, (current) =>
+        current?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: Math.max(0, p.climbCount - 1) } : p)),
+      );
     },
   });
 
   const removePlaylistMutation = useMutation<unknown, Error, RemovePlaylistVars, PlaylistMutationContext>({
     mutationKey: ['removeFromPlaylist'],
     mutationFn: async ({ playlistId, climbUuid }) => {
-      const r = playlistRef.current;
-      if (!r.token) throw new Error('Not authenticated');
-      const client = createGraphQLHttpClient(r.token);
+      const { token: latestToken } = playlistRef.current;
+      if (!latestToken) throw new Error('Not authenticated');
+      const client = createGraphQLHttpClient(latestToken);
       return client.request<RemoveClimbFromPlaylistMutationResponse>(REMOVE_CLIMB_FROM_PLAYLIST, {
         input: { playlistId, climbUuid },
       });
     },
     onMutate: async ({ playlistId, climbUuid }) => {
-      const r = playlistRef.current;
-      await r.cancelMemFetches();
-      const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey);
-      const prevPlaylists = r.queryClient.getQueryData<Playlist[]>(r.playlistsQueryKey);
+      const {
+        cancelMemFetches: latestCancelMemFetches,
+        queryClient: latestQueryClient,
+        memAccKey: latestMemAccKey,
+        playlistsQueryKey: latestPlaylistsQueryKey,
+      } = playlistRef.current;
+      await latestCancelMemFetches();
+      const prevMem = latestQueryClient.getQueryData<Map<string, Set<string>>>(latestMemAccKey);
       const currentSet = prevMem?.get(climbUuid);
       const wasMember = currentSet?.has(playlistId) ?? false;
       if (wasMember) {
@@ -310,28 +325,33 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
         const nextSet = new Set(currentSet);
         nextSet.delete(playlistId);
         updatedMem.set(climbUuid, nextSet);
-        r.queryClient.setQueryData(r.memAccKey, updatedMem);
-        r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
+        latestQueryClient.setQueryData(latestMemAccKey, updatedMem);
+        latestQueryClient.setQueryData<Playlist[]>(latestPlaylistsQueryKey, (prev) =>
           prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: Math.max(0, p.climbCount - 1) } : p)),
         );
       }
-      return { prevMem, prevPlaylists, membershipChanged: wasMember };
+      return { membershipChanged: wasMember };
     },
-    onError: (_err, _vars, context) => {
+    onError: (_err, { playlistId, climbUuid }, context) => {
       if (!context?.membershipChanged) return;
-      const r = playlistRef.current;
-      // setQueryData treats undefined as a no-op, so use removeQueries to roll back
-      // to a "no data" state when the snapshot was undefined.
-      if (context.prevMem === undefined) {
-        r.queryClient.removeQueries({ queryKey: r.memAccKey, exact: true });
-      } else {
-        r.queryClient.setQueryData(r.memAccKey, context.prevMem);
-      }
-      if (context.prevPlaylists === undefined) {
-        r.queryClient.removeQueries({ queryKey: r.playlistsQueryKey, exact: true });
-      } else {
-        r.queryClient.setQueryData(r.playlistsQueryKey, context.prevPlaylists);
-      }
+      const {
+        queryClient: latestQueryClient,
+        memAccKey: latestMemAccKey,
+        playlistsQueryKey: latestPlaylistsQueryKey,
+      } = playlistRef.current;
+      latestQueryClient.setQueryData<Map<string, Set<string>>>(latestMemAccKey, (current) => {
+        if (!current) return current;
+        const climbSet = current.get(climbUuid) ?? EMPTY_SET;
+        if (climbSet.has(playlistId)) return current;
+        const updated = new Map(current);
+        const nextSet = new Set(climbSet);
+        nextSet.add(playlistId);
+        updated.set(climbUuid, nextSet);
+        return updated;
+      });
+      latestQueryClient.setQueryData<Playlist[]>(latestPlaylistsQueryKey, (current) =>
+        current?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount + 1 } : p)),
+      );
     },
   });
 

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -312,7 +312,7 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
         updatedMem.set(climbUuid, nextSet);
         r.queryClient.setQueryData(r.memAccKey, updatedMem);
         r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
-          prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount - 1 } : p)),
+          prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: Math.max(0, p.climbCount - 1) } : p)),
         );
       }
       return { prevMem, prevPlaylists, membershipChanged: wasMember };

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -230,45 +230,122 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
     layoutId,
   };
 
+  // Optimistic updates run inside onMutate so the second of two rapid taps
+  // sees the cache state from the first — the count delta is gated on whether
+  // membership actually transitioned, so redundant requests are no-ops on the count.
+  type AddPlaylistVars = { playlistId: string; climbUuid: string; climbAngle: number };
+  type RemovePlaylistVars = { playlistId: string; climbUuid: string };
+  type PlaylistMutationContext = {
+    prevMem: Map<string, Set<string>> | undefined;
+    prevPlaylists: Playlist[] | undefined;
+    membershipChanged: boolean;
+  };
+
+  const addPlaylistMutation = useMutation<unknown, Error, AddPlaylistVars, PlaylistMutationContext>({
+    mutationKey: ['addToPlaylist'],
+    mutationFn: async ({ playlistId, climbUuid, climbAngle }) => {
+      const r = playlistRef.current;
+      if (!r.token) throw new Error('Not authenticated');
+      const client = createGraphQLHttpClient(r.token);
+      return client.request<AddClimbToPlaylistMutationResponse>(ADD_CLIMB_TO_PLAYLIST, {
+        input: { playlistId, climbUuid, angle: climbAngle },
+      });
+    },
+    onMutate: async ({ playlistId, climbUuid }) => {
+      const r = playlistRef.current;
+      await r.cancelMemFetches();
+      const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey);
+      const prevPlaylists = r.queryClient.getQueryData<Playlist[]>(r.playlistsQueryKey);
+      const currentSet = prevMem?.get(climbUuid) ?? EMPTY_SET;
+      const alreadyMember = currentSet.has(playlistId);
+      if (!alreadyMember) {
+        const updatedMem = new Map(prevMem ?? new Map());
+        const nextSet = new Set(currentSet);
+        nextSet.add(playlistId);
+        updatedMem.set(climbUuid, nextSet);
+        r.queryClient.setQueryData(r.memAccKey, updatedMem);
+        r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
+          prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount + 1 } : p)),
+        );
+      }
+      return { prevMem, prevPlaylists, membershipChanged: !alreadyMember };
+    },
+    onError: (_err, _vars, context) => {
+      if (!context?.membershipChanged) return;
+      const r = playlistRef.current;
+      // setQueryData treats undefined as a no-op, so use removeQueries to roll back
+      // to a "no data" state when the snapshot was undefined.
+      if (context.prevMem === undefined) {
+        r.queryClient.removeQueries({ queryKey: r.memAccKey, exact: true });
+      } else {
+        r.queryClient.setQueryData(r.memAccKey, context.prevMem);
+      }
+      if (context.prevPlaylists === undefined) {
+        r.queryClient.removeQueries({ queryKey: r.playlistsQueryKey, exact: true });
+      } else {
+        r.queryClient.setQueryData(r.playlistsQueryKey, context.prevPlaylists);
+      }
+    },
+  });
+
+  const removePlaylistMutation = useMutation<unknown, Error, RemovePlaylistVars, PlaylistMutationContext>({
+    mutationKey: ['removeFromPlaylist'],
+    mutationFn: async ({ playlistId, climbUuid }) => {
+      const r = playlistRef.current;
+      if (!r.token) throw new Error('Not authenticated');
+      const client = createGraphQLHttpClient(r.token);
+      return client.request<RemoveClimbFromPlaylistMutationResponse>(REMOVE_CLIMB_FROM_PLAYLIST, {
+        input: { playlistId, climbUuid },
+      });
+    },
+    onMutate: async ({ playlistId, climbUuid }) => {
+      const r = playlistRef.current;
+      await r.cancelMemFetches();
+      const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey);
+      const prevPlaylists = r.queryClient.getQueryData<Playlist[]>(r.playlistsQueryKey);
+      const currentSet = prevMem?.get(climbUuid);
+      const wasMember = currentSet?.has(playlistId) ?? false;
+      if (wasMember) {
+        const updatedMem = new Map(prevMem ?? new Map());
+        const nextSet = new Set(currentSet);
+        nextSet.delete(playlistId);
+        updatedMem.set(climbUuid, nextSet);
+        r.queryClient.setQueryData(r.memAccKey, updatedMem);
+        r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
+          prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount - 1 } : p)),
+        );
+      }
+      return { prevMem, prevPlaylists, membershipChanged: wasMember };
+    },
+    onError: (_err, _vars, context) => {
+      if (!context?.membershipChanged) return;
+      const r = playlistRef.current;
+      // setQueryData treats undefined as a no-op, so use removeQueries to roll back
+      // to a "no data" state when the snapshot was undefined.
+      if (context.prevMem === undefined) {
+        r.queryClient.removeQueries({ queryKey: r.memAccKey, exact: true });
+      } else {
+        r.queryClient.setQueryData(r.memAccKey, context.prevMem);
+      }
+      if (context.prevPlaylists === undefined) {
+        r.queryClient.removeQueries({ queryKey: r.playlistsQueryKey, exact: true });
+      } else {
+        r.queryClient.setQueryData(r.playlistsQueryKey, context.prevPlaylists);
+      }
+    },
+  });
+
+  const addPlaylistMutateRef = useRef(addPlaylistMutation.mutateAsync);
+  addPlaylistMutateRef.current = addPlaylistMutation.mutateAsync;
+  const removePlaylistMutateRef = useRef(removePlaylistMutation.mutateAsync);
+  removePlaylistMutateRef.current = removePlaylistMutation.mutateAsync;
+
   const addToPlaylist = useCallback(async (playlistId: string, climbUuid: string, climbAngle: number) => {
-    const r = playlistRef.current;
-    if (!r.token) throw new Error('Not authenticated');
-    const client = createGraphQLHttpClient(r.token);
-    await client.request<AddClimbToPlaylistMutationResponse>(ADD_CLIMB_TO_PLAYLIST, {
-      input: { playlistId, climbUuid, angle: climbAngle },
-    });
-    await r.cancelMemFetches();
-    const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey) ?? new Map();
-    const updatedMem = new Map(prevMem);
-    const currentSet = new Set(updatedMem.get(climbUuid) || []);
-    currentSet.add(playlistId);
-    updatedMem.set(climbUuid, currentSet);
-    r.queryClient.setQueryData(r.memAccKey, updatedMem);
-    r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
-      prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: p.climbCount + 1 } : p)),
-    );
+    await addPlaylistMutateRef.current({ playlistId, climbUuid, climbAngle });
   }, []);
 
   const removeFromPlaylist = useCallback(async (playlistId: string, climbUuid: string) => {
-    const r = playlistRef.current;
-    if (!r.token) throw new Error('Not authenticated');
-    const client = createGraphQLHttpClient(r.token);
-    await client.request<RemoveClimbFromPlaylistMutationResponse>(REMOVE_CLIMB_FROM_PLAYLIST, {
-      input: { playlistId, climbUuid },
-    });
-    await r.cancelMemFetches();
-    const prevMem = r.queryClient.getQueryData<Map<string, Set<string>>>(r.memAccKey) ?? new Map();
-    const updatedMem = new Map(prevMem);
-    const currentPlaylists = updatedMem.get(climbUuid);
-    if (currentPlaylists) {
-      const next = new Set(currentPlaylists);
-      next.delete(playlistId);
-      updatedMem.set(climbUuid, next);
-    }
-    r.queryClient.setQueryData(r.memAccKey, updatedMem);
-    r.queryClient.setQueryData<Playlist[]>(r.playlistsQueryKey, (prev) =>
-      prev?.map((p) => (p.uuid === playlistId ? { ...p, climbCount: Math.max(0, p.climbCount - 1) } : p)),
-    );
+    await removePlaylistMutateRef.current({ playlistId, climbUuid });
   }, []);
 
   const createPlaylist = useCallback(


### PR DESCRIPTION
## Summary

- Fixes #1851 — tapping a playlist row 3× quickly would shift the displayed `climbCount` by 3 even though the server only applied one effective change.
- Root cause: `addToPlaylist` / `removeFromPlaylist` in `use-climb-actions-data.tsx` always applied `±1` to the cached count *after* the (idempotent) GraphQL request returned, regardless of whether the server actually changed state.
- Convert both to `useMutation` with optimistic updates in `onMutate` (mirroring the existing favorites pattern in the same file). The count delta is now gated on whether membership actually transitioned, so redundant rapid taps are no-ops on the count. `onError` rolls back from a snapshot.

## Test plan

- [x] `vp run typecheck:web`
- [x] `vp lint` clean on touched files
- [x] `vp test --project web run packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx` — 18/18 pass, including 3 new tests:
  - rapid 3× `addToPlaylist` converges to a single `+1`
  - rapid 3× `removeFromPlaylist` converges to a single `-1`
  - error path rolls back membership and `climbCount`
- [x] Consumer tests still pass (`playlist-action.test.tsx`, `use-playlists.test.ts`)
- [ ] Manual repro after merge: open a climb's playlist popover with the climb already in a playlist, tap the row 5× rapidly → count drops by exactly 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)