### PR TITLE
fix(aurora-sync): surface real Postgres errors + lock in per-user fault isolation

### DIFF
--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -7,6 +7,8 @@ type SyncRunnerPrivates = {
   updateCredentialStatus: (userId: string, boardType: string, status: string, error?: string | null) => Promise<void>;
   syncSingleCredential: (cred: ReturnType<typeof createCredential>) => Promise<void>;
   maybeRunSharedSync: (boardType: AuroraBoardName, token: string, userId: string) => Promise<void>;
+  getActiveCredentials: () => Promise<Array<ReturnType<typeof createCredential>>>;
+  getNextCredentialToSync: () => Promise<ReturnType<typeof createCredential> | null>;
 };
 
 const { mockDecrypt, mockEncrypt, mockSignIn, mockSyncSharedData } = vi.hoisted(() => ({
@@ -95,7 +97,11 @@ describe('SyncRunner login failure handling', () => {
   });
 });
 
-function createCredential() {
+function createCredential(overrides: Partial<ReturnType<typeof baseCredential>> = {}) {
+  return { ...baseCredential(), ...overrides };
+}
+
+function baseCredential() {
   return {
     userId: 'user-123',
     boardType: 'decoy',
@@ -183,5 +189,73 @@ describe('SyncRunner shared-sync per-board throttle', () => {
     await runnerPrivates.maybeRunSharedSync('decoy', 'tok', 'u2');
 
     expect(mockSyncSharedData).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SyncRunner per-user fault isolation', () => {
+  it('continues syncing remaining users when one user throws a SQL error', async () => {
+    vi.useFakeTimers();
+    try {
+      const runner = new SyncRunner();
+      const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+      const credA = createCredential({ userId: 'user-A' });
+      const credB = createCredential({ userId: 'user-B' });
+      const credC = createCredential({ userId: 'user-C' });
+
+      vi.spyOn(runnerPrivates, 'getActiveCredentials').mockResolvedValue([credA, credB, credC]);
+
+      const dbError = new Error(
+        'Database error [code=23503 constraint=board_walls_layout_fk table=board_walls]: detail=Key not present',
+      );
+      const syncSingle = vi.spyOn(runnerPrivates, 'syncSingleCredential').mockImplementation(async (cred) => {
+        if (cred.userId === 'user-B') throw dbError;
+      });
+
+      const syncPromise = runner.syncAllUsers();
+      // syncAllUsers sleeps 10s after each successful credential — fast-forward through them
+      await vi.runAllTimersAsync();
+      const summary = await syncPromise;
+
+      expect(syncSingle).toHaveBeenCalledTimes(3);
+      expect(summary.total).toBe(3);
+      expect(summary.successful).toBe(2);
+      expect(summary.failed).toBe(1);
+      expect(summary.errors).toEqual([
+        {
+          userId: 'user-B',
+          boardType: 'decoy',
+          error: dbError.message,
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('syncNextUser does not throw on a SQL error and reports it in the summary', async () => {
+    const runner = new SyncRunner();
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    const cred = createCredential({ userId: 'user-X' });
+    vi.spyOn(runnerPrivates, 'getNextCredentialToSync').mockResolvedValue(cred);
+
+    const dbError = new Error('Database error [code=23503 constraint=board_walls_user_fk table=board_walls]');
+    vi.spyOn(runnerPrivates, 'syncSingleCredential').mockRejectedValue(dbError);
+
+    const summary = await runner.syncNextUser();
+
+    expect(summary).toEqual({
+      total: 1,
+      successful: 0,
+      failed: 1,
+      errors: [
+        {
+          userId: 'user-X',
+          boardType: 'decoy',
+          error: dbError.message,
+        },
+      ],
+    });
   });
 });

--- a/packages/aurora-sync/src/sync/db-error.test.ts
+++ b/packages/aurora-sync/src/sync/db-error.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { formatDbError } from './db-error';
+
+function makePostgresError(fields: Record<string, string>): Error {
+  const err = new Error(fields.message ?? 'pg error');
+  Object.assign(err, fields);
+  return err;
+}
+
+function makeDrizzleQueryError(query: string, params: unknown[], cause: Error): Error {
+  const err = new Error(`Failed query: ${query}\nparams: ${params.join(',')}`);
+  Object.assign(err, { query, params, cause });
+  return err;
+}
+
+describe('formatDbError', () => {
+  it('returns message for a plain Error with no cause', () => {
+    expect(formatDbError(new Error('something broke'))).toBe('something broke');
+  });
+
+  it('stringifies non-Error throws', () => {
+    expect(formatDbError('boom')).toBe('boom');
+    expect(formatDbError(42)).toBe('42');
+    expect(formatDbError(undefined)).toBe('undefined');
+  });
+
+  it('extracts PostgresError fields from a DrizzleQueryError cause', () => {
+    const cause = makePostgresError({
+      code: '23503',
+      severity: 'ERROR',
+      constraint_name: 'board_walls_layout_fk',
+      table_name: 'board_walls',
+      column_name: 'layout_id',
+      schema_name: 'public',
+      detail: 'Key (board_type, layout_id)=(tension, 10) is not present in table "board_layouts".',
+      hint: 'Make sure the layout exists.',
+      message: 'insert or update on table "board_walls" violates foreign key constraint "board_walls_layout_fk"',
+    });
+    const wrapped = makeDrizzleQueryError('insert into "board_walls" ...', ['tension', 10], cause);
+
+    const formatted = formatDbError(wrapped);
+
+    expect(formatted).toContain('code=23503');
+    expect(formatted).toContain('severity=ERROR');
+    expect(formatted).toContain('constraint=board_walls_layout_fk');
+    expect(formatted).toContain('table=board_walls');
+    expect(formatted).toContain('column=layout_id');
+    expect(formatted).toContain('schema=public');
+    expect(formatted).toContain(
+      'detail=Key (board_type, layout_id)=(tension, 10) is not present in table "board_layouts".',
+    );
+    expect(formatted).toContain('hint=Make sure the layout exists.');
+    expect(formatted).toContain('message=insert or update on table "board_walls"');
+    // Drizzle wrapper noise should NOT leak through
+    expect(formatted).not.toContain('Failed query:');
+  });
+
+  it('extracts fields when the PostgresError is the top-level error', () => {
+    const direct = makePostgresError({
+      code: '23505',
+      severity: 'ERROR',
+      constraint_name: 'board_users_pkey',
+      table_name: 'board_users',
+      detail: 'Key (board_type, id)=(kilter, 1) already exists.',
+      message: 'duplicate key value violates unique constraint "board_users_pkey"',
+    });
+
+    const formatted = formatDbError(direct);
+
+    expect(formatted).toContain('code=23505');
+    expect(formatted).toContain('constraint=board_users_pkey');
+    expect(formatted).toContain('table=board_users');
+    expect(formatted).toContain('detail=Key (board_type, id)=(kilter, 1) already exists.');
+  });
+
+  it('caps output length at ~2000 chars even with a huge detail field', () => {
+    const cause = makePostgresError({
+      code: '23503',
+      severity: 'ERROR',
+      detail: 'x'.repeat(5000),
+      message: 'huge detail',
+    });
+
+    const formatted = formatDbError(cause);
+
+    expect(formatted.length).toBeLessThanOrEqual(2000);
+    // truncation marker
+    expect(formatted.endsWith('…')).toBe(true);
+  });
+});

--- a/packages/aurora-sync/src/sync/db-error.ts
+++ b/packages/aurora-sync/src/sync/db-error.ts
@@ -1,0 +1,58 @@
+const MAX_LENGTH = 2000;
+
+const POSTGRES_FIELDS = [
+  ['code', 'code'],
+  ['severity', 'severity'],
+  ['constraint_name', 'constraint'],
+  ['table_name', 'table'],
+  ['column_name', 'column'],
+  ['schema_name', 'schema'],
+] as const;
+
+type ErrorWithCause = { cause?: unknown };
+
+function looksLikePostgresError(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.code === 'string' && typeof v.severity === 'string';
+}
+
+function pickPostgresError(error: unknown): Record<string, unknown> | null {
+  if (looksLikePostgresError(error)) return error;
+  const cause = (error as ErrorWithCause)?.cause;
+  if (looksLikePostgresError(cause)) return cause;
+  return null;
+}
+
+function truncate(value: string): string {
+  return value.length <= MAX_LENGTH ? value : `${value.slice(0, MAX_LENGTH - 1)}…`;
+}
+
+export function formatDbError(error: unknown): string {
+  const pgError = pickPostgresError(error);
+
+  if (!pgError) {
+    if (error instanceof Error) return truncate(error.message);
+    return truncate(String(error));
+  }
+
+  const tags = POSTGRES_FIELDS.flatMap(([field, label]) => {
+    const value = pgError[field];
+    return typeof value === 'string' && value.length > 0 ? [`${label}=${value}`] : [];
+  });
+
+  const parts: string[] = [];
+  if (tags.length > 0) parts.push(`Database error [${tags.join(' ')}]`);
+  else parts.push('Database error');
+
+  const detail = pgError.detail;
+  if (typeof detail === 'string' && detail.length > 0) parts.push(`detail=${detail}`);
+
+  const hint = pgError.hint;
+  if (typeof hint === 'string' && hint.length > 0) parts.push(`hint=${hint}`);
+
+  const message = pgError.message;
+  if (typeof message === 'string' && message.length > 0) parts.push(`message=${message}`);
+
+  return truncate(parts.join(': '));
+}

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -7,6 +7,7 @@ import { UNIFIED_TABLES } from '../db/table-select';
 import { boardseshTicks, playlists, playlistClimbs, playlistOwnership } from '@boardsesh/db/schema/app';
 import { randomUUID } from 'crypto';
 import { convertQuality } from '@boardsesh/shared-schema';
+import { formatDbError } from './db-error';
 
 const BATCH_SIZE = 100;
 
@@ -552,18 +553,9 @@ export async function syncUserData(
           }
         });
       } catch (error) {
-        let errorMessage: string;
-        if (error instanceof Error) {
-          if (error.message.includes('violates foreign key constraint')) {
-            errorMessage = `FK constraint violation: ${error.message.split('violates foreign key constraint')[1]?.split('"')[1] || 'unknown'}`;
-          } else {
-            errorMessage = error.message.slice(0, 2000);
-          }
-        } else {
-          errorMessage = String(error).slice(0, 2000);
-        }
-        log(`Database error: ${errorMessage}`);
-        throw new Error(`Database error: ${errorMessage}`);
+        const formatted = formatDbError(error);
+        log(formatted);
+        throw new Error(formatted);
       }
 
       isComplete = syncResults._complete !== false;
@@ -581,8 +573,8 @@ export async function syncUserData(
 
     return totalResults;
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : JSON.stringify(error);
-    log(`Error syncing user data: ${errorMsg}`);
-    throw error instanceof Error ? error : new Error(`Sync error: ${errorMsg}`);
+    const formatted = formatDbError(error);
+    log(`Error syncing user data: ${formatted}`);
+    throw error instanceof Error ? error : new Error(formatted);
   }
 }


### PR DESCRIPTION
## Summary

- `aurora-sync` was logging FK violations as a generic `Database error: Failed query: ...` because the catch block only read drizzle's outer `error.message` wrapper. The actual `PostgresError` (with `code`, `constraint_name`, `table_name`, `detail`, etc.) lives on `error.cause`. Two failing tension users have been showing this useless error in the daemon logs since the Railway DB migration.
- Adds a `formatDbError` helper that walks `error.cause` and emits a structured one-liner. With it deployed to the systemd daemon, the same 2 failures now surface their real cause: `code=23503 constraint=board_walls_product_size_fk … detail=Key (board_type, product_size_id)=(tension, 10) is not present in table "board_product_sizes"` — i.e. tension `product_size_id=10` is missing from `board_product_sizes` (a separate data follow-up).
- Locks in per-user fault isolation with two regression tests so a future SQL error on one user can never halt the daemon.

## Changes

- **NEW** `packages/aurora-sync/src/sync/db-error.ts` — `formatDbError(error)` helper. Walks one level of `error.cause`; if it duck-types as a `PostgresError`, formats `code/severity/constraint/table/column/schema/detail/hint/message` into a single line, capped at 2000 chars.
- **NEW** `packages/aurora-sync/src/sync/db-error.test.ts` — 5 cases (plain Error, non-Error throws, drizzle-wrapped PostgresError, direct PostgresError, length cap).
- **MODIFIED** `packages/aurora-sync/src/sync/user-sync.ts` — both swallowing catch blocks (transaction-level and outer per-user) now use the helper. Drops the brittle `error.message.includes('violates foreign key constraint')` substring parser; SQLSTATE `23503` is the canonical signal.
- **MODIFIED** `packages/aurora-sync/src/runner/sync-runner.test.ts` — adds `describe('SyncRunner per-user fault isolation', …)` with two regression tests asserting that `syncAllUsers` continues past a SQL error from one user and `syncNextUser` returns a failure summary instead of throwing.

## Test plan

- [x] `vp test run --project aurora-sync` — 18/18 pass (5 new helper tests + 2 new fault-isolation tests + existing 11)
- [x] `vp run typecheck` — clean
- [x] End-to-end: triggered the `boardsesh-aurora-sync` systemd service against the Railway DB. 56/58 still succeed (logging change is non-behavioral); the 2 known-failing tension users now log the structured error including the FK constraint, schema, table and `detail` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)