### PR TITLE
fix(db): placeholder for tension product_size_id=10 (unblocks 2 user syncs)

### DIFF
--- a/packages/db/drizzle/0085_placeholder_tension_size_10.sql
+++ b/packages/db/drizzle/0085_placeholder_tension_size_10.sql
@@ -1,0 +1,35 @@
+-- Two production users have walls referencing (board_type='tension', product_size_id=10)
+-- but Aurora introduced this size after the last time it landed in our shared seed.
+-- Our shared-sync (packages/web/app/lib/data-sync/aurora/shared-sync.ts) does NOT include
+-- 'product_sizes' in TABLES_TO_PROCESS, so the Vercel cron will never insert it on its own.
+--
+-- Insert a placeholder so those users' walls (and the rest of their sync data) can land.
+-- Once shared-sync starts processing product_sizes, an upsert will overwrite this with
+-- the canonical row from Aurora.
+INSERT INTO "board_product_sizes" (
+    "board_type",
+    "id",
+    "product_id",
+    "name",
+    "description",
+    "edge_left",
+    "edge_right",
+    "edge_bottom",
+    "edge_top",
+    "image_filename",
+    "position",
+    "is_listed"
+) VALUES (
+    'tension',
+    10,
+    5,
+    'Unknown size (placeholder; Aurora-side size not yet synced)',
+    '',
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    NULL,
+    FALSE
+) ON CONFLICT ("board_type", "id") DO NOTHING;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1777496789115,
       "tag": "0084_new_mysterio",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1777893101247,
+      "tag": "0085_placeholder_tension_size_10",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two production users are stuck on a `board_walls_product_size_fk` violation — their walls reference `(board_type='tension', product_size_id=10)`, but `board_product_sizes` only has IDs 1–9 for tension. Aurora introduced this size on their side; our shared-sync excludes `'product_sizes'` from `TABLES_TO_PROCESS` (`packages/web/app/lib/data-sync/aurora/shared-sync.ts:47`), so the Vercel cron fetches the row and silently drops it. The row has never landed on our side and won't until that exclusion is changed.

This PR inserts a placeholder so those users' full sync (walls + ascents + bids + tags + everything else in their per-user transaction) can complete. The placeholder uses `product_id=5` (Tension Board 2 — matches the failing walls' `product_id`), degenerate edges (0/0/0/0), and `is_listed=FALSE` so it stays hidden from any product-size picker UI.

`ON CONFLICT (board_type, id) DO NOTHING` makes it idempotent. Once `product_sizes` becomes a processed table in shared-sync, an upsert will replace this stub with the canonical Aurora row.

Discovered via the structured DB-error logging added in #1951 — before that, all we saw was `Database error: Failed query: ...` with no constraint or detail.

## Changes

- **NEW** `packages/db/drizzle/0085_placeholder_tension_size_10.sql` — single `INSERT … ON CONFLICT DO NOTHING`.
- **MODIFIED** `packages/db/drizzle/meta/_journal.json` — adds the corresponding entry (idx 85).

## Test plan

- [x] `vp run boardsesh-monorepo#db:migrate` against the local dev DB applies the migration cleanly (`✅ Migrations completed successfully`).
- [x] Verified via direct `SELECT … WHERE board_type='tension' AND id=10` that the placeholder row landed with the expected fields.
- [ ] After deploy: re-run `boardsesh-aurora-sync.service` and confirm `d585457a-…` and `2064e822-…` (both tension) now appear in the success list.
- [ ] Future: when shared-sync starts processing `product_sizes`, confirm an upsert replaces this placeholder with the real Aurora row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)