### PR TITLE
Document GH issue fix workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,19 @@ Boardsesh is a monorepo containing a Next.js 16 application for controlling stan
 - No buzzwords. Concrete numbers and simple language.
 - No unnecessary check-ins. Default to action. Full autonomy except no data deletion without asking.
 
+## GitHub Issue Fix Workflow
+
+When fixing a GitHub issue, follow this sequence:
+
+1. **Work in a fresh git worktree branched off the latest `main`.** Fetch `origin/main` first; do not branch from whatever HEAD happens to be.
+2. **Plan the fix before implementing.** Produce an explicit plan of the change before writing code.
+3. **After implementing, make sure the pre-commit hook passes.** If it fails, fix the underlying issue rather than bypassing it (no `--no-verify`).
+4. **Start the dev server with `vp run dev`** so the user can test the fix in the browser.
+5. **Tell the user the dev server URL and the QA plan in a single message** as soon as the server is up. Report whatever URL the server actually prints (typically `http://localhost:3000`) alongside a concrete QA plan: the specific pages/flows to exercise, what correct behavior looks like, and any edge cases worth poking at. Don't split the URL and the QA plan across two messages.
+6. **Always open a PR** for the GitHub issue once the fix is implemented and validated.
+
+This applies to any request framed as "fix issue #N", "this GH issue", "the bug from <issue link>", or similar. It does not apply to ad-hoc edits or feature work the user requested directly without referencing an issue. If the user explicitly opts out of any step for a given task, respect that for the current task only — the default still holds next time.
+
 ## Database Hosting (Railway)
 
 We host PostgreSQL on Railway. **Treat Railway as a portable stepping stone, not a permanent marriage.** Railway is currently better gravity than Neon (simpler, less magical, closer to "Docker + Postgres") but it is still a platform. The whole point of leaving Neon was to escape platform gravity — don't accidentally re-create it.


### PR DESCRIPTION
## Summary
- Adds a new **GitHub Issue Fix Workflow** section to `CLAUDE.md` codifying how Claude should handle requests framed as "fix issue #N".
- Sequence: fresh worktree off latest `main` → plan → pre-commit must pass → `vp run dev` → share URL + QA plan in one message → always open a PR.
- Documents the carve-out: the workflow only kicks in for GH-issue-framed work, not ad-hoc edits, and per-task opt-outs don't change the default.

## Test plan
- [ ] Skim the rendered `CLAUDE.md` on GitHub to confirm the new section sits between *Project Rules* and *Database Hosting (Railway)*.
- [ ] Verify no other content was disturbed (single insertion, +13 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)