### PR TITLE
Add top-level queue button to climb list header

### DIFF
--- a/packages/web/app/components/global-header/__tests__/global-header.test.tsx
+++ b/packages/web/app/components/global-header/__tests__/global-header.test.tsx
@@ -48,6 +48,36 @@ vi.mock('@/app/components/search-drawer/search-drawer-bridge-context', () => ({
   useSearchDrawerBridge: () => mockBridgeState,
 }));
 
+let mockQueueList: { queue: Array<{ uuid: string }>; suggestedClimbs: unknown[] } = {
+  queue: [],
+  suggestedClimbs: [],
+};
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueList: () => mockQueueList,
+}));
+
+let mockQueueBridgeBoardInfo: {
+  boardDetails: { board_name: string } | null;
+  angle: number;
+  hasActiveQueue: boolean;
+  isHydrated: boolean;
+} = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: false };
+vi.mock('@/app/components/queue-control/queue-bridge-board-info-context', () => ({
+  useQueueBridgeBoardInfo: () => mockQueueBridgeBoardInfo,
+}));
+
+// `next/dynamic` is used at module top to lazy-load QueueDrawer; intercept it
+// so the loader returns the mock synchronously (otherwise the lazy boundary
+// never resolves under the test renderer). vi.hoisted lets the vi.mock factory
+// reference the component despite mock-call hoisting.
+const { mockQueueDrawer } = vi.hoisted(() => ({
+  mockQueueDrawer: ({ open }: { open: boolean }) =>
+    open ? React.createElement('div', { 'data-testid': 'queue-drawer' }) : null,
+}));
+vi.mock('next/dynamic', () => ({
+  default: () => mockQueueDrawer,
+}));
+
 vi.mock('@/app/components/search-drawer/unified-search-drawer', () => ({
   default: ({ open, defaultCategory }: { open: boolean; onClose: () => void; defaultCategory: string }) =>
     open ? <div data-testid="unified-search-drawer" data-category={defaultCategory} /> : null,
@@ -161,6 +191,8 @@ describe('GlobalHeader', () => {
       setNameFilter: null,
       hasActiveNonNameFilters: false,
     };
+    mockQueueList = { queue: [], suggestedClimbs: [] };
+    mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: false };
   });
 
   it('renders user drawer and search input', () => {
@@ -223,6 +255,7 @@ describe('GlobalHeader', () => {
   // -----------------------------------------------------------------------
   describe('with search drawer bridge active (on board list page)', () => {
     beforeEach(() => {
+      mockPathname = '/b/test-board/40/list';
       mockBridgeState = {
         openClimbSearchDrawer: mockOpenClimbSearchDrawer,
         searchPillSummary: 'V5-V7 · Tall',
@@ -278,7 +311,10 @@ describe('GlobalHeader', () => {
       expect(searchWrapper).toBeTruthy();
     });
 
-    it('does not show filter button when bridge is inactive', () => {
+    it('renders the filter button disabled when the bridge is inactive on a list path', () => {
+      // Pathname-driven gate: the button renders on every list path so the
+      // SSR HTML matches the hydrated HTML; it's disabled until the bridge
+      // registers so taps don't silently no-op.
       mockBridgeState = {
         openClimbSearchDrawer: null,
         searchPillSummary: null,
@@ -290,7 +326,8 @@ describe('GlobalHeader', () => {
 
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      expect(screen.queryByLabelText('Open filters')).toBeNull();
+      const button = screen.getByLabelText('Open filters') as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
     });
 
     it('shows clear button when nameFilter has a value', () => {
@@ -328,16 +365,27 @@ describe('GlobalHeader', () => {
     });
   });
 
-  it('shows "Search climbs..." placeholder on board list routes before the bridge registers', () => {
+  it('shows "Search climbs..." placeholder on board list routes even before the bridge registers', () => {
+    // Pathname-derived gate: the SSR HTML must already match the hydrated
+    // copy on a list route, so the placeholder switches based on path,
+    // not bridge state.
     mockPathname = '/b/test-board/40/list';
 
-    // Bridge not registered yet — openClimbSearchDrawer is null
-    // but the pathname check in the component might not suffice;
-    // the real behavior is driven by the bridge state.
-    // With no bridge, non-list placeholder is shown
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-    expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Search climbs...')).toBeTruthy();
+  });
+
+  it('renders filter and queue buttons on board list routes pre-hydration (disabled)', () => {
+    mockPathname = '/b/test-board/40/list';
+    // Bridge not yet registered, queue not hydrated — both buttons render
+    // but should be disabled so taps don't silently no-op.
+    render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+
+    const filterButton = screen.getByLabelText('Open filters') as HTMLButtonElement;
+    const queueButton = screen.getByLabelText('Open queue') as HTMLButtonElement;
+    expect(filterButton.disabled).toBe(true);
+    expect(queueButton.disabled).toBe(true);
   });
 
   it('shows generic placeholder on non-list routes when the bridge is inactive', () => {
@@ -541,6 +589,92 @@ describe('GlobalHeader', () => {
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
       expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Queue button (climb list page)
+  // -----------------------------------------------------------------------
+  describe('queue button on climb list page', () => {
+    const listPathname = '/b/test-board/40/list';
+
+    beforeEach(() => {
+      mockPathname = listPathname;
+    });
+
+    it('does not render on non-list routes', () => {
+      mockPathname = '/you';
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      expect(screen.queryByLabelText('Open queue')).toBeNull();
+    });
+
+    it('renders disabled when the queue bridge has not hydrated', () => {
+      mockQueueBridgeBoardInfo = {
+        boardDetails: { board_name: 'kilter' },
+        angle: 40,
+        hasActiveQueue: false,
+        isHydrated: false,
+      };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+    });
+
+    it('renders disabled when boardDetails is null even after hydration', () => {
+      mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: true };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+    });
+
+    it('renders enabled when hydrated and boardDetails is present', () => {
+      mockQueueBridgeBoardInfo = {
+        boardDetails: { board_name: 'kilter' },
+        angle: 40,
+        hasActiveQueue: true,
+        isHydrated: true,
+      };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+    });
+
+    it('opens the queue drawer when the enabled button is clicked', () => {
+      mockQueueBridgeBoardInfo = {
+        boardDetails: { board_name: 'kilter' },
+        angle: 40,
+        hasActiveQueue: true,
+        isHydrated: true,
+      };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      expect(screen.queryByTestId('queue-drawer')).toBeNull();
+      fireEvent.click(screen.getByLabelText('Open queue'));
+      expect(screen.getByTestId('queue-drawer')).toBeTruthy();
+    });
+
+    it('does not open the drawer if click somehow fires while disabled', () => {
+      // boardDetails is null so the button is disabled and handleOpenQueue
+      // bails early — defensive against any path where the visual disabled
+      // state is bypassed (e.g. assistive tooling).
+      mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: true };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      fireEvent.click(screen.getByLabelText('Open queue'));
+      expect(screen.queryByTestId('queue-drawer')).toBeNull();
+    });
+
+    it('shows the queue count badge when items are queued', () => {
+      mockQueueBridgeBoardInfo = {
+        boardDetails: { board_name: 'kilter' },
+        angle: 40,
+        hasActiveQueue: true,
+        isHydrated: true,
+      };
+      mockQueueList = {
+        queue: [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }],
+        suggestedClimbs: [],
+      };
+      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
+      expect(screen.getByText('3')).toBeTruthy();
     });
   });
 });

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -39,7 +39,7 @@
   padding: 6px 0;
 }
 
-.filterButton {
+.iconButtonWrapper {
   position: relative;
   flex-shrink: 0;
 }

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -35,7 +35,10 @@ import { useProfileHeaderShare } from '@/app/components/profile-header-bridge/pr
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-board-info-context';
 import { useQueueList } from '@/app/components/graphql-queue';
+import { themeTokens } from '@/app/theme/theme-config';
 import styles from './global-header.module.css';
+
+const BADGE_SMALL_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
 
 const QueueDrawer = dynamic(() => import('@/app/components/play-view/queue-drawer'), { ssr: false });
 
@@ -180,7 +183,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   } = useSearchDrawerBridge();
   const statsFilterBridge = useStatsFilterBridge();
   const profileHeaderShare = useProfileHeaderShare();
-  const { boardDetails } = useQueueBridgeBoardInfo();
+  const { boardDetails, isHydrated: isQueueBridgeHydrated } = useQueueBridgeBoardInfo();
   const { queue } = useQueueList();
   const pathname = usePathnameWithoutLocale();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -193,9 +196,10 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   }, []);
 
   const handleOpenQueue = useCallback(() => {
+    if (!boardDetails) return;
     setIsQueueRendered(true);
     setIsQueueOpen(true);
-  }, []);
+  }, [boardDetails]);
 
   const handleCloseQueue = useCallback(() => {
     setIsQueueOpen(false);
@@ -242,12 +246,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
 
   const notificationButton = (
     <IconButton component={LocaleLink} href="/notifications" aria-label={t('ariaLabels.notifications')} size="small">
-      <Badge
-        badgeContent={notificationUnreadCount}
-        color="error"
-        max={99}
-        sx={{ '& .MuiBadge-badge': { fontSize: 10, height: 16, minWidth: 16 } }}
-      >
+      <Badge badgeContent={notificationUnreadCount} color="error" max={99} sx={BADGE_SMALL_SX}>
         <NotificationsOutlined />
       </Badge>
     </IconButton>
@@ -274,7 +273,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
         right={
           <div className={styles.headerActions}>
             {statsFilterBridge.isActive && (
-              <div className={styles.filterButton}>
+              <div className={styles.iconButtonWrapper}>
                 <IconButton
                   onClick={() => statsFilterBridge.openFilterDrawer?.()}
                   aria-label={t('ariaLabels.openStatsFilters')}
@@ -342,7 +341,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
         right={
           <div className={styles.headerActions}>
             {statsFilterBridge.isActive && (
-              <div className={styles.filterButton}>
+              <div className={styles.iconButtonWrapper}>
                 <IconButton
                   onClick={() => statsFilterBridge.openFilterDrawer?.()}
                   aria-label={t('ariaLabels.openStatsFilters')}
@@ -452,8 +451,13 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
         </div>
 
         {isClimbListPage && (
-          <div className={styles.filterButton}>
-            <IconButton onClick={handleFilterClick} aria-label={t('ariaLabels.openFilters')} size="small">
+          <div className={styles.iconButtonWrapper}>
+            <IconButton
+              onClick={handleFilterClick}
+              aria-label={t('ariaLabels.openFilters')}
+              size="small"
+              disabled={!useClimbSearchBridge}
+            >
               <FilterListOutlined />
             </IconButton>
             {nonNameFiltersActive && <span className={styles.filterActiveIndicator} />}
@@ -461,14 +465,19 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
         )}
 
         {isClimbListPage && (
-          <div className={styles.filterButton}>
-            <IconButton onClick={handleOpenQueue} aria-label={t('ariaLabels.openQueue')} size="small">
+          <div className={styles.iconButtonWrapper}>
+            <IconButton
+              onClick={handleOpenQueue}
+              aria-label={t('ariaLabels.openQueue')}
+              size="small"
+              disabled={!isQueueBridgeHydrated || !boardDetails}
+            >
               <Badge
                 badgeContent={queue.length}
                 max={99}
                 color="primary"
                 invisible={queue.length === 0}
-                sx={{ '& .MuiBadge-badge': { fontSize: 10, height: 16, minWidth: 16 } }}
+                sx={BADGE_SMALL_SX}
               >
                 <FormatListBulletedOutlined />
               </Badge>

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useRef } from 'react';
+import dynamic from 'next/dynamic';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
@@ -8,6 +9,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import ClearOutlined from '@mui/icons-material/ClearOutlined';
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
+import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
 import IosShareOutlined from '@mui/icons-material/IosShare';
 import NotificationsOutlined from '@mui/icons-material/NotificationsOutlined';
@@ -21,7 +23,7 @@ import { useSearchDrawerBridge } from '@/app/components/search-drawer/search-dra
 import UserDrawer from '@/app/components/user-drawer/user-drawer';
 import { useIsOnBoardRoute } from '@/app/components/persistent-session/persistent-session-context';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
-import { isBoardCreatePath } from '@/app/lib/board-route-paths';
+import { isBoardCreatePath, isBoardListPath } from '@/app/lib/board-route-paths';
 
 import TuneOutlined from '@mui/icons-material/TuneOutlined';
 import { usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
@@ -31,7 +33,11 @@ import { useTranslation } from 'react-i18next';
 import { useStatsFilterBridge } from '@/app/components/stats-filter-bridge/stats-filter-bridge-context';
 import { useProfileHeaderShare } from '@/app/components/profile-header-bridge/profile-header-bridge-context';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-board-info-context';
+import { useQueueList } from '@/app/components/graphql-queue';
 import styles from './global-header.module.css';
+
+const QueueDrawer = dynamic(() => import('@/app/components/play-view/queue-drawer'), { ssr: false });
 
 /** Route prefix → translation key for pages that show a simple title header instead of the default search/sesh header */
 const TITLE_HEADER_PAGES: Record<string, string> = {
@@ -159,6 +165,8 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const { t } = useTranslation('common');
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchRendered, setSearchRendered] = useState(false);
+  const [isQueueOpen, setIsQueueOpen] = useState(false);
+  const [isQueueRendered, setIsQueueRendered] = useState(false);
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
 
@@ -172,6 +180,8 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   } = useSearchDrawerBridge();
   const statsFilterBridge = useStatsFilterBridge();
   const profileHeaderShare = useProfileHeaderShare();
+  const { boardDetails } = useQueueBridgeBoardInfo();
+  const { queue } = useQueueList();
   const pathname = usePathnameWithoutLocale();
   const inputRef = useRef<HTMLInputElement>(null);
   const profileHeaderConfig = getProfileHeaderConfig(pathname, t);
@@ -180,6 +190,19 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   // MUI Modal/Portal/FocusTrap infrastructure on every parent re-render.
   const handleSearchTransitionEnd = useCallback((open: boolean) => {
     if (!open) setSearchRendered(false);
+  }, []);
+
+  const handleOpenQueue = useCallback(() => {
+    setIsQueueRendered(true);
+    setIsQueueOpen(true);
+  }, []);
+
+  const handleCloseQueue = useCallback(() => {
+    setIsQueueOpen(false);
+  }, []);
+
+  const handleQueueTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setIsQueueRendered(false);
   }, []);
 
   const handleShareOwnProfile = useCallback(() => {
@@ -353,12 +376,19 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   // Check if current page wants a simple title header
   const titleHeaderPage = Object.entries(TITLE_HEADER_PAGES).find(([prefix]) => pathname.startsWith(prefix));
 
+  // Pathname-derived gate: lets us SSR the filter and queue buttons before the
+  // board-route bridge injectors run on the client. The bridge callbacks
+  // (`openClimbSearchDrawer`, `boardDetails`) are still null on the server, so
+  // the click handlers no-op until hydration — but the icons themselves render
+  // in the initial HTML and don't pop in.
+  const isClimbListPage = isBoardListPath(pathname);
+
   // When the bridge is active (on a board list page), delegate to the board route's drawer
   const useClimbSearchBridge = openClimbSearchDrawer !== null;
 
   const handleSearchFocus = () => {
     // On non-list pages, the input acts as a fake search trigger
-    if (!useClimbSearchBridge) {
+    if (!isClimbListPage) {
       inputRef.current?.blur();
       setSearchRendered(true);
       setSearchOpen(true);
@@ -371,7 +401,7 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
     }
   };
 
-  const searchPlaceholder = useClimbSearchBridge ? t('header.searchClimbsPlaceholder') : t('header.searchPlaceholder');
+  const searchPlaceholder = isClimbListPage ? t('header.searchClimbsPlaceholder') : t('header.searchPlaceholder');
 
   // Simple title header for specific pages (back button + title, no search/sesh)
   if (titleHeaderPage) {
@@ -383,20 +413,20 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
       <header className={styles.header}>
         <UserDrawer boardConfigs={boardConfigs} />
 
-        <div id={useClimbSearchBridge ? 'onboarding-search-button' : undefined} className={styles.searchInput}>
+        <div id={isClimbListPage ? 'onboarding-search-button' : undefined} className={styles.searchInput}>
           <TextField
             inputRef={inputRef}
             placeholder={searchPlaceholder}
             variant="outlined"
             size="small"
             fullWidth
-            value={useClimbSearchBridge ? nameFilter : ''}
+            value={isClimbListPage ? nameFilter : ''}
             onChange={(e) => setNameFilter?.(e.target.value)}
             onFocus={handleSearchFocus}
             aria-label={t('ariaLabels.searchClimbsByName')}
             slotProps={{
               input: {
-                readOnly: !useClimbSearchBridge,
+                readOnly: !isClimbListPage,
                 startAdornment: (
                   <InputAdornment position="start">
                     <SearchOutlined sx={{ fontSize: 18 }} />
@@ -421,12 +451,28 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
           />
         </div>
 
-        {useClimbSearchBridge && (
+        {isClimbListPage && (
           <div className={styles.filterButton}>
             <IconButton onClick={handleFilterClick} aria-label={t('ariaLabels.openFilters')} size="small">
               <FilterListOutlined />
             </IconButton>
             {nonNameFiltersActive && <span className={styles.filterActiveIndicator} />}
+          </div>
+        )}
+
+        {isClimbListPage && (
+          <div className={styles.filterButton}>
+            <IconButton onClick={handleOpenQueue} aria-label={t('ariaLabels.openQueue')} size="small">
+              <Badge
+                badgeContent={queue.length}
+                max={99}
+                color="primary"
+                invisible={queue.length === 0}
+                sx={{ '& .MuiBadge-badge': { fontSize: 10, height: 16, minWidth: 16 } }}
+              >
+                <FormatListBulletedOutlined />
+              </Badge>
+            </IconButton>
           </div>
         )}
       </header>
@@ -437,6 +483,15 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
           onClose={() => setSearchOpen(false)}
           onTransitionEnd={handleSearchTransitionEnd}
           defaultCategory={isOnBoardRoute ? 'climbs' : 'boards'}
+        />
+      )}
+
+      {isQueueRendered && boardDetails && (
+        <QueueDrawer
+          open={isQueueOpen}
+          onClose={handleCloseQueue}
+          onTransitionEnd={handleQueueTransitionEnd}
+          boardDetails={boardDetails}
         />
       )}
     </>

--- a/packages/web/app/components/library/logbook-search-form.tsx
+++ b/packages/web/app/components/library/logbook-search-form.tsx
@@ -356,7 +356,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                   },
                 }}
               />
-              <div className={headerStyles.filterButton}>
+              <div className={headerStyles.iconButtonWrapper}>
                 <IconButton onClick={openDrawer} aria-label={t('logbook.search.openFilters')} size="small">
                   <FilterListOutlined />
                 </IconButton>

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -167,6 +167,13 @@ export const themeTokens = {
     disabled: 0.5, // Disabled/unsupported state
   },
 
+  // Badge sizing — applied via sx={{ '& .MuiBadge-badge': themeTokens.badge.small }}
+  // on counter badges (notification count, queue count) so the small-format
+  // visual stays consistent across the app.
+  badge: {
+    small: { fontSize: 10, height: 16, minWidth: 16 },
+  },
+
   // Layout constants
   layout: {
     /** CSS height value for a spacer that prevents the bottom nav bar from covering content on mobile Safari.

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -44,6 +44,7 @@
     "search": "Search",
     "clearSearch": "Clear search",
     "openFilters": "Open filters",
+    "openQueue": "Open queue",
     "openStatsFilters": "Open stats filters",
     "shareProfile": "Share profile",
     "settings": "Settings",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -44,6 +44,7 @@
     "search": "Rechercher",
     "clearSearch": "Effacer la recherche",
     "openFilters": "Ouvrir les filtres",
+    "openQueue": "Ouvrir la file d'attente",
     "openStatsFilters": "Ouvrir les filtres de statistiques",
     "shareProfile": "Partager le profil",
     "settings": "Paramètres",


### PR DESCRIPTION
## Summary

- Adds a queue (`FormatListBulletedOutlined`) button to the global header on board list pages, immediately to the right of the filter button. Tapping it opens the same `QueueDrawer` the per-climb three-dot menu's "Go to Queue" action opens, with a live count badge driven by `useQueueList()`.
- Gates the filter and queue buttons on a pathname check (`isBoardListPath`) instead of the bridge state, so both icons — and the matching "Search climbs..." placeholder + editable input — render in the SSR HTML rather than popping in on hydration.
- Lazy-loads `QueueDrawer` via `next/dynamic({ ssr: false })` so the drawer tree only enters the bundle when a list page is visible, and unmounts after close (mirrors the existing `searchRendered` pattern).

Fixes #1844.

## Test plan
- [ ] Open a board list page (e.g. `/kilter/8/15/15,16,17,18/40/list`) and confirm both the filter and queue icons are present in the page's view-source HTML before JS executes.
- [ ] With an empty queue, badge is invisible. Add a climb (swipe right or "Add to queue") — badge increments live.
- [ ] Tap the queue icon — `QueueDrawer` opens. Open it via the per-climb three-dot menu — same drawer, same items.
- [ ] Reorder/remove inside the drawer, close, reopen via the header button — state persists.
- [ ] Navigate to `/you`, `/playlists`, etc. — both filter and queue icons disappear, header reverts to non-list copy.
- [ ] Mobile viewport (iPhone SE width): two icons fit alongside the search input without overflow.
- [ ] Dark mode: icon and badge are legible.
- [ ] Desktop ≥768px: existing right-hand sider with its Queue tab still works; both surfaces reflect the same queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)