### PR TITLE
feat(lights): add disco mode that strobes the climb's holds

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -43,10 +43,12 @@ type BluetoothContextValue = {
   /** Board configuration for the current route — exposed so light-show
    * features (party mode) can read holdsData and edge bounds. */
   boardDetails: BoardDetails;
-  /** True while a non-queue light show (e.g. party mode) is driving the
-   * board. The auto-sender stops emitting queue frames during this. */
-  partyActive: boolean;
-  setPartyActive: (active: boolean) => void;
+  /** Which non-queue light show is driving the board, if any. The
+   * auto-sender stops emitting queue frames whenever this is non-'off'.
+   * 'glyphs' spells BOARDSESH across the wall; 'disco' strobes the
+   * current climb's holds through random role colours. */
+  partyMode: 'off' | 'glyphs' | 'disco';
+  setPartyMode: (mode: 'off' | 'glyphs' | 'disco') => void;
   isBluetoothSupported: boolean;
   isIOS: boolean;
 };
@@ -142,14 +144,14 @@ export function BluetoothProvider({
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('settings');
 
-  const [partyActive, setPartyActive] = useState(false);
+  const [partyMode, setPartyMode] = useState<'off' | 'glyphs' | 'disco'>('off');
   const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
 
-  // Stop the party loop the moment the board disconnects so a reconnect
-  // doesn't immediately resume an orphaned interval in the drawer.
+  // Stop any active light show the moment the board disconnects so a
+  // reconnect doesn't immediately resume an orphaned interval in the drawer.
   useEffect(() => {
-    if (!isConnected && partyActive) setPartyActive(false);
-  }, [isConnected, partyActive]);
+    if (!isConnected && partyMode !== 'off') setPartyMode('off');
+  }, [isConnected, partyMode]);
 
   // Both `[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...` and
   // `/b/{slug}/{angle}/...` routes carry `[angle]` as a dynamic segment.
@@ -347,8 +349,8 @@ export function BluetoothProvider({
       sendFramesToBoard,
       clearBoard,
       boardDetails,
-      partyActive,
-      setPartyActive,
+      partyMode,
+      setPartyMode,
       isBluetoothSupported,
       isIOS,
     }),
@@ -360,8 +362,8 @@ export function BluetoothProvider({
       sendFramesToBoard,
       clearBoard,
       boardDetails,
-      partyActive,
-      setPartyActive,
+      partyMode,
+      setPartyMode,
       isBluetoothSupported,
       isIOS,
     ],
@@ -428,7 +430,7 @@ export function BluetoothProvider({
 
   return (
     <BluetoothContext.Provider value={value}>
-      {isConnected && !partyActive && (
+      {isConnected && partyMode === 'off' && (
         <BluetoothAutoSender sendFramesToBoard={sendFramesToBoard} layoutName={boardDetails.layout_name ?? ''} />
       )}
       {activePickerState && (

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -9,26 +9,49 @@ import ListItemText from '@mui/material/ListItemText';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import Celebration from '@mui/icons-material/Celebration';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
+import AutoAwesome from '@mui/icons-material/AutoAwesome';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
+import { useCurrentClimb } from '../graphql-queue';
 import { STATE_TO_PRIMARY_CODE } from '../board-renderer/types';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { GLYPHS, PARTY_LETTERS, buildPartyFrames, mapGlyphToHolds } from './party-glyphs';
 
 const PARTY_TICK_MS = 600;
+const DISCO_TICK_MS = 450;
 
 type LightControlDrawerProps = {
   open: boolean;
   onClose: () => void;
 };
 
+/**
+ * Pull just the placement IDs out of a frame string like "p123r42p55r43".
+ * Empty / malformed frames return [], so the disco effect no-ops gracefully
+ * when the climb has no lit holds.
+ */
+function extractPlacementIds(frames: string): number[] {
+  if (!frames) return [];
+  const ids: number[] = [];
+  for (const segment of frames.split('p')) {
+    if (!segment) continue;
+    const placementStr = segment.split('r')[0];
+    const placementId = Number(placementStr);
+    if (Number.isFinite(placementId)) ids.push(placementId);
+  }
+  return ids;
+}
+
 export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, onClose }) => {
   const { t } = useTranslation('common');
   const { showMessage } = useSnackbar();
-  const { isConnected, sendFramesToBoard, clearBoard, boardDetails, partyActive, setPartyActive } =
-    useBluetoothContext();
+  const { isConnected, sendFramesToBoard, clearBoard, boardDetails, partyMode, setPartyMode } = useBluetoothContext();
+  const { currentClimbQueueItem } = useCurrentClimb();
 
   const isMoonboard = boardDetails.board_name === 'moonboard';
+  const climbFrames = currentClimbQueueItem?.climb.frames ?? '';
+  const climbMirrored = !!currentClimbQueueItem?.climb.mirrored;
+  const hasClimbLoaded = climbFrames.length > 0;
 
   // Pre-snap each unique letter's bitmap to hold IDs once per board config —
   // the snap is deterministic so we don't need to re-run it every tick.
@@ -46,7 +69,7 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
   // Cycle through the letters of "BOARDSESH", rotating through the board's
   // available role colours so each letter is visually distinct.
   useEffect(() => {
-    if (!partyActive || !isConnected || isMoonboard) return;
+    if (partyMode !== 'glyphs' || !isConnected || isMoonboard) return;
 
     const stateCodes = Object.values(STATE_TO_PRIMARY_CODE[boardDetails.board_name] ?? {}).filter(
       (code): code is number => typeof code === 'number',
@@ -64,24 +87,51 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     sendCurrentLetter();
     const intervalId = window.setInterval(sendCurrentLetter, PARTY_TICK_MS);
     return () => window.clearInterval(intervalId);
-  }, [partyActive, isConnected, isMoonboard, boardDetails.board_name, lettersToHoldIds, sendFramesToBoard]);
+  }, [partyMode, isConnected, isMoonboard, boardDetails.board_name, lettersToHoldIds, sendFramesToBoard]);
 
-  // When the user stops party mode, the wall would otherwise stay frozen on
-  // the last letter — clear it once so the board returns to a blank state.
-  const wasPartyActiveRef = useRef(partyActive);
+  // Disco mode: keep the current climb's lit holds, but reroll each hold's
+  // colour every tick. The placement IDs come straight from the climb's
+  // frames string so swapping climbs while the disco is running picks up
+  // the new holds on the next tick.
   useEffect(() => {
-    if (wasPartyActiveRef.current && !partyActive && isConnected) {
+    if (partyMode !== 'disco' || !isConnected) return;
+
+    const stateCodes = Object.values(STATE_TO_PRIMARY_CODE[boardDetails.board_name] ?? {}).filter(
+      (code): code is number => typeof code === 'number',
+    );
+    if (stateCodes.length === 0) return;
+
+    const placementIds = extractPlacementIds(climbFrames);
+    if (placementIds.length === 0) return;
+
+    const sendDiscoFrame = () => {
+      const frames = placementIds
+        .map((id) => `p${id}r${stateCodes[Math.floor(Math.random() * stateCodes.length)]}`)
+        .join('');
+      void sendFramesToBoard(frames, climbMirrored);
+    };
+    sendDiscoFrame();
+    const intervalId = window.setInterval(sendDiscoFrame, DISCO_TICK_MS);
+    return () => window.clearInterval(intervalId);
+  }, [partyMode, isConnected, boardDetails.board_name, climbFrames, climbMirrored, sendFramesToBoard]);
+
+  // When any light show stops, the wall would otherwise stay frozen on the
+  // last frame — clear it once so the board returns to a blank state. The
+  // queue auto-sender resumes on the next render and repaints the climb.
+  const lastPartyModeRef = useRef(partyMode);
+  useEffect(() => {
+    if (lastPartyModeRef.current !== 'off' && partyMode === 'off' && isConnected) {
       void clearBoard();
     }
-    wasPartyActiveRef.current = partyActive;
-  }, [partyActive, isConnected, clearBoard]);
+    lastPartyModeRef.current = partyMode;
+  }, [partyMode, isConnected, clearBoard]);
 
   const handleClearAll = async () => {
-    // When party is active, the stop-party effect already issues a
-    // clearBoard() once partyActive flips false — calling clearBoard()
+    // When a light show is active, the stop effect already issues a
+    // clearBoard() once partyMode flips off — calling clearBoard()
     // here too would double up the BLE write for one tap.
-    if (partyActive) {
-      setPartyActive(false);
+    if (partyMode !== 'off') {
+      setPartyMode('off');
       return;
     }
     const result = await clearBoard();
@@ -95,7 +145,15 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
       showMessage(t('lightControl.partyUnsupported'), 'info');
       return;
     }
-    setPartyActive(!partyActive);
+    setPartyMode(partyMode === 'glyphs' ? 'off' : 'glyphs');
+  };
+
+  const handleDiscoToggle = () => {
+    if (!hasClimbLoaded) {
+      showMessage(t('lightControl.discoNeedsClimb'), 'info');
+      return;
+    }
+    setPartyMode(partyMode === 'disco' ? 'off' : 'disco');
   };
 
   return (
@@ -107,10 +165,17 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
           </ListItemIcon>
           <ListItemText primary={t('lightControl.turnOffAll')} />
         </ListItemButton>
-        <ListItemButton onClick={handlePartyToggle} disabled={!isConnected || isMoonboard}>
-          <ListItemIcon>{partyActive ? <StopCircleOutlined /> : <Celebration />}</ListItemIcon>
+        <ListItemButton onClick={handleDiscoToggle} disabled={!isConnected || !hasClimbLoaded}>
+          <ListItemIcon>{partyMode === 'disco' ? <StopCircleOutlined /> : <AutoAwesome />}</ListItemIcon>
           <ListItemText
-            primary={partyActive ? t('lightControl.stopParty') : t('lightControl.partyMode')}
+            primary={partyMode === 'disco' ? t('lightControl.stopDisco') : t('lightControl.discoMode')}
+            secondary={!hasClimbLoaded ? t('lightControl.discoNeedsClimb') : undefined}
+          />
+        </ListItemButton>
+        <ListItemButton onClick={handlePartyToggle} disabled={!isConnected || isMoonboard}>
+          <ListItemIcon>{partyMode === 'glyphs' ? <StopCircleOutlined /> : <Celebration />}</ListItemIcon>
+          <ListItemText
+            primary={partyMode === 'glyphs' ? t('lightControl.stopParty') : t('lightControl.partyMode')}
             secondary={isMoonboard ? t('lightControl.partyUnsupported') : undefined}
           />
         </ListItemButton>

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -14,6 +14,9 @@
     "partyMode": "Party mode",
     "stopParty": "Stop party",
     "partyUnsupported": "Party mode isn't available on this board",
+    "discoMode": "Disco the climb",
+    "stopDisco": "Stop disco",
+    "discoNeedsClimb": "Load a climb to start the disco",
     "clearFailed": "Couldn't clear the board"
   },
   "actions": {


### PR DESCRIPTION
## Summary
- Adds a second light show in the long-press lightbulb drawer: **Disco the climb** — keeps the current climb's lit holds but rerolls each hold's color every 450ms from the board's role palette.
- Refactors `BluetoothContext.partyActive: boolean` → `partyMode: 'off' | 'glyphs' | 'disco'` so the existing BOARDSESH-letter party mode and the new disco mode share one auto-sender gate and stay mutually exclusive.
- Disco mode reacts to the current climb's `frames` string, so swapping climbs mid-disco picks up the new holds on the next tick. Disabled when no climb is loaded; surfaces a snackbar hint via the new `lightControl.discoNeedsClimb` string.

## How it works
- Placement IDs are extracted from `currentClimbQueueItem.climb.frames` (`p{id}r{role}` segments).
- Each tick, every placement gets a random role code from `STATE_TO_PRIMARY_CODE[boardName]` (Kilter: green/cyan/magenta/orange; Tension/Decoy/Touchstone/Grasshopper: green/blue/red/magenta).
- Frames are sent through the existing `sendFramesToBoard()` pipeline with the climb's `mirrored` flag, so the BLE write path is unchanged.
- When `partyMode` flips back to `'off'` the drawer issues one `clearBoard()`; the auto-sender remounts on the next render and repaints the climb in its normal colors.

## Test plan
- [ ] Connect to a Kilter board, load a climb, long-press the lightbulb. Expect three rows: "Turn off all lights", "Disco the climb", "Party mode".
- [ ] Tap **Disco the climb** → climb's lit holds should cycle random colors at ~450ms.
- [ ] Tap **Stop disco** → board clears once, then the climb's normal colors come back.
- [ ] With disco running, tap **Party mode** → disco stops, BOARDSESH letters take over (only one show at a time).
- [ ] Open the drawer with no climb loaded → "Disco the climb" is disabled with the "Load a climb to start the disco" hint.
- [ ] Start disco → swipe to a different climb in the queue → expect: disco continues, now strobing the new climb's holds.
- [ ] Start disco → tap lightbulb to disconnect → expect: disco state resets to off automatically; reconnecting does not auto-resume disco.
- [ ] Repeat happy path on Tension. MoonBoard "Party mode" remains disabled; verify Disco behavior on MoonBoard (palette is smaller, visual variety will be lower).

🤖 Generated with [Claude Code](https://claude.com/claude-code)