### PR TITLE
Auto-install dependencies on new git worktrees

### DIFF
--- a/.vite-hooks/post-checkout
+++ b/.vite-hooks/post-checkout
@@ -1,0 +1,38 @@
+prev_head="$1"
+new_head="$2"
+branch_flag="$3"
+
+# Only act on branch-style checkouts (worktree add, clone, branch switch).
+# File checkouts (e.g. `git checkout -- some/file`) pass branch_flag=0.
+[ "$branch_flag" = "1" ] || exit 0
+
+repo_root=$(git rev-parse --show-toplevel) || exit 0
+cd "$repo_root" || exit 0
+
+# Skip if deps already present — only act on fresh worktrees / clones.
+if [ -d node_modules ] && [ -d packages/web/node_modules ]; then
+  exit 0
+fi
+
+echo "==> New worktree detected at $repo_root"
+
+if ! command -v vp >/dev/null 2>&1; then
+  echo "==> Installing Vite+ (vp)..."
+  if ! curl -fsSL https://vite.plus | bash; then
+    echo "!! Vite+ install failed — run \`curl -fsSL https://vite.plus | bash\` manually, then \`vp install\`." >&2
+    exit 0
+  fi
+  export PATH="$HOME/.local/bin:$HOME/.vite-plus/bin:$HOME/.bun/bin:$PATH"
+  if ! command -v vp >/dev/null 2>&1; then
+    echo "!! vp installed but not on PATH — add the install dir to PATH and run \`vp install\` manually." >&2
+    exit 0
+  fi
+fi
+
+echo "==> Installing dependencies (vp install)..."
+if ! vp install; then
+  echo "!! vp install failed — fix the issue and rerun \`vp install\` in $repo_root." >&2
+  exit 0
+fi
+
+echo "==> Worktree ready."


### PR DESCRIPTION
## Summary

- Adds a `.vite-hooks/post-checkout` hook that runs `vp install` whenever a new git worktree (or fresh clone) lands without `node_modules`. Bootstraps Vite+ via `curl -fsSL https://vite.plus | bash` if `vp` isn't already on `PATH`.
- Branch switches between existing worktrees stay no-op — the hook short-circuits when `node_modules` and `packages/web/node_modules` are already present, so it only fires on truly fresh checkouts.
- Failures (curl install or `vp install`) are loud but non-fatal: the hook prints a clear message and exits 0 so a transient issue doesn't leave the worktree unable to commit.

Note: for this hook to fire, `core.hooksPath` must point at `.vite-hooks/_` (the Vite+ default). If your local repo has a stale `core.hooksPath` override, run `git config --unset core.hooksPath && vp config` in the main worktree.

## Test plan

- [ ] In a clone with this branch checked out: `git worktree add ../bsesh-test -b test-hook` and confirm `==> New worktree detected ... ==> Installing dependencies (vp install)...` runs and `node_modules` ends up populated.
- [ ] From an existing worktree with deps installed: `git checkout main` (or any branch switch) — confirm hook is silent (no install kicked off).
- [ ] Temporarily mask `vp` from `PATH` (e.g. `PATH=/usr/bin:/bin git worktree add ...`) and confirm the curl-install branch fires before `vp install` runs.
- [ ] Cleanup: `git worktree remove ../bsesh-test && git branch -D test-hook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)