### PR TITLE
Fix Postgres /dev/shm exhaustion on default ascents-DESC climb search

### DIFF
--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -68,21 +68,18 @@ export const searchClimbs = async (
   const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
   const isDraftsQuery = !!searchParams.onlyDrafts;
 
-  // For the default hot path (ascents DESC with stats filters active), drive from
-  // board_climb_stats so PostgreSQL reads the covering index in sorted order and
-  // stops after pageSize+1 qualifying rows — avoids scanning all 15K+ matching
-  // climbs just to sort and take 21.
+  // For ascents DESC (the default landing page sort), drive FROM board_climb_stats
+  // so PostgreSQL reads board_climb_stats_ascents_covering_idx in sorted order and
+  // stops after pageSize+1 qualifying rows. The LEFT JOIN alternative materializes
+  // the full join result and sorts it, which under concurrent load exhausts
+  // /dev/shm via parallel hash join + sort workers (each allocates a 16MB shared
+  // memory segment) and produces "could not resize shared memory segment" errors.
   //
-  // Only safe when stats filters are active (e.g., minAscents >= 1) because the
-  // INNER JOIN excludes climbs without stats rows. When stats filters are active,
-  // those climbs would be excluded by the WHERE clause anyway (NULL fails >= 1),
-  // making LEFT JOIN and INNER JOIN equivalent.
-  // When no stats filters are active, fall through to the LEFT JOIN path.
-  const hasStatsFilters = filters.getClimbStatsConditions().length > 0;
-  // projectsOnly includes climbs with NO stats row (ascents NULL), so the INNER-JOIN
-  // stats-driven path would drop exactly the climbs we want. Force the LEFT-JOIN path.
-  const useStatsDriven =
-    sortBy === 'ascents' && sortOrder === 'desc' && !isDraftsQuery && hasStatsFilters && !searchParams.projectsOnly;
+  // Climbs without a board_climb_stats row would only appear after every climb
+  // with any ascent (NULLS LAST), i.e. far past the first paginated page. Trading
+  // that long-tail visibility for an index-only plan is the right call for the
+  // hot path. Other sort orders, drafts, and projectsOnly still use the LEFT JOIN.
+  const useStatsDriven = sortBy === 'ascents' && sortOrder === 'desc' && !isDraftsQuery && !searchParams.projectsOnly;
 
   if (useStatsDriven) {
     return statsDrivenSearch(db, params, filters, page, pageSize);
@@ -93,12 +90,14 @@ export const searchClimbs = async (
 
 /**
  * Stats-driven search: FROM board_climb_stats INNER JOIN board_climbs.
- * PostgreSQL reads the stats covering index in ascensionist_count DESC order
- * and stops after pageSize+1 qualifying rows.
+ * PostgreSQL reads board_climb_stats_ascents_covering_idx in ascensionist_count
+ * DESC order and stops after pageSize+1 qualifying rows.
  *
- * Only used when stats filters are active (checked by caller), so the INNER JOIN
- * is equivalent to LEFT JOIN — climbs without stats would be excluded by stats
- * filters (e.g., minAscents >= 1) in the WHERE clause anyway.
+ * Trade-off vs LEFT JOIN: climbs that have no board_climb_stats row for the
+ * given (board_type, angle) are dropped. They would only appear after every
+ * climb that has any ascent (NULLS LAST) and so are unreachable through normal
+ * pagination anyway. The benefit is no Sort/Gather node, no /dev/shm pressure
+ * under concurrent load.
  *
  * All climb filters (including personal progress like hideCompleted) are in
  * the WHERE clause — not the JOIN ON — so they apply correctly to the result set.


### PR DESCRIPTION
## Summary

Production logs were showing recurring Postgres errors on the climb search query:

```
ERROR: could not resize shared memory segment "/PostgreSQL.X" to 16777216 bytes:
       No space left on device
STATEMENT:  select … from "board_climbs"
            left join "board_climb_stats" on (…)
            where (… is_listed = $5 and is_draft = $6 and frames_count = $7 …)
            order by "board_climb_stats"."ascensionist_count" DESC NULLS LAST,
                     "board_climbs"."uuid" desc limit $11
```

Even after bumping the host's `/dev/shm` to 1G, the error kept firing under concurrent load.

### Root cause

`searchClimbs` in `packages/db/src/queries/climbs/search-climbs.ts` only routed requests to the index-driven `statsDrivenSearch` path when *stats filters were active* (`hasStatsFilters`). The default board landing page (sort = ascents DESC, no min-ascents/grade/quality filter) therefore fell through to `standardSearch`, which:

1. Scans `board_climbs` with the layout/listed/draft filters (~15k+ rows).
2. LEFT JOINs against `board_climb_stats` for the angle.
3. Materializes the full join result and sorts by `board_climb_stats.ascensionist_count DESC NULLS LAST` — the existing covering index `board_climb_stats_ascents_covering_idx` (migration `0068`) cannot drive the order because the join is led by `board_climbs`.
4. Postgres parallelizes the hash join + sort. Each parallel worker allocates a 16 MB shared-memory segment in `/dev/shm`. Concurrent requests multiply that, exhausting `/dev/shm` even at 1G.

### Fix

Loosen the `useStatsDriven` gate so any `ascents DESC` request that isn't a drafts/projectsOnly query goes through `statsDrivenSearch`. That path drives FROM `board_climb_stats INNER JOIN board_climbs`, so Postgres reads `board_climb_stats_ascents_covering_idx` in sorted order and stops after `pageSize + 1` qualifying rows — no Sort node, no parallel gather, no `/dev/shm` pressure.

Trade-off: climbs without a `board_climb_stats` row for the angle are dropped. With `NULLS LAST` they would only appear after every climb that has any ascent — i.e. far past the first paginated page in practice. Other sort orders (`difficulty`, `quality`, `popular`, `creation`, `name`), drafts queries, and `projectsOnly` continue to use the LEFT JOIN.

No schema migration is needed — the covering index from `0068_add_search_performance_indexes.sql` already supports the index-driven plan.

## Test plan

- [ ] **Plan check (manual):** capture `EXPLAIN (ANALYZE, BUFFERS)` of the failing-shape query (default sort, no filters) before and after — should change from `Sort → Hash Left Join → Seq Scan` to `Limit → Nested Loop → Index Scan on board_climb_stats_ascents_covering_idx` with no `Sort`/`Gather`/`Parallel` nodes.
- [ ] **Default landing page:** open `http://localhost:3000/kilter/<layout>/<size>/<sets>/<angle>` (default sort = ascents DESC, no filters), confirm climbs render and pagination works (scroll to fetch page 2/3).
- [ ] **Sort regressions:** click through Difficulty, Quality, Popular, Creation, Name (asc + desc) — these still use `standardSearch`, confirm no rendering regression.
- [ ] **Stats filter behavior unchanged:** apply a min-ascents filter; behavior should be identical to before (already used `statsDrivenSearch`).
- [ ] **Drafts:** open the drafts view; should still use `standardSearch` and surface drafts that have no stats row.
- [ ] **Projects:** with `projectsOnly` enabled, climbs with no stats row should still appear.
- [ ] **Production observation:** after deploy, watch Railway logs for ~24h and confirm `could not resize shared memory segment` errors disappear on `board_climbs ↔ board_climb_stats` statements.

https://claude.ai/code/session_01R81b6qpcDEMaZoM7JYPvxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R81b6qpcDEMaZoM7JYPvxT)_