### PR TITLE
Attach ticks to the named board they were climbed on (#1843)

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, isNull } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext, TickStatus } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -294,9 +294,37 @@ export const tickMutations = {
     const now = new Date().toISOString();
     const climbedAt = new Date(validatedInput.climbedAt).toISOString();
 
-    // Resolve board ID from board config if provided
+    // Resolve board ID. Prefer the explicit boardUuid coming from a named-board
+    // route (`/b/<slug>/...`) so ticks attach to that exact board entity even
+    // when the climber doesn't own it (e.g. a seeded gym board owned by the
+    // system user). Fall back to the user-owned config lookup for the legacy
+    // `/[board_name]/[layout_id]/...` route, which doesn't reference a
+    // specific board entity.
     let boardId: number | null = null;
-    if (validatedInput.layoutId && validatedInput.sizeId && validatedInput.setIds) {
+    if (validatedInput.boardUuid) {
+      const [board] = await db
+        .select({
+          id: dbSchema.userBoards.id,
+          ownerId: dbSchema.userBoards.ownerId,
+          isPublic: dbSchema.userBoards.isPublic,
+        })
+        .from(dbSchema.userBoards)
+        .where(and(eq(dbSchema.userBoards.uuid, validatedInput.boardUuid), isNull(dbSchema.userBoards.deletedAt)))
+        .limit(1);
+
+      if (!board) {
+        throw new GraphQLError('Board not found', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+
+      // Don't let a client write ticks against someone else's private board.
+      // Public boards (including seeded gym boards) and the climber's own
+      // boards are both fine.
+      if (!board.isPublic && board.ownerId !== userId) {
+        throw new GraphQLError('Cannot tick on a private board', { extensions: { code: 'FORBIDDEN' } });
+      }
+
+      boardId = board.id;
+    } else if (validatedInput.layoutId && validatedInput.sizeId && validatedInput.setIds) {
       boardId = await resolveBoardFromPath(
         userId,
         validatedInput.boardType,

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -39,6 +39,21 @@ export function videoUrlForTickStatus(status: TickStatus, videoUrl: string | nul
   }
 }
 
+// Hold-set IDs are stored and transported as a comma-separated string but the
+// order isn't part of the identity — `15,20` and `20,15` describe the same
+// configuration. Normalize before comparing so a client serializing in a
+// different order doesn't trip the boardUuid consistency check.
+export function normalizeSetIds(setIds: string): string {
+  return setIds
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map(Number)
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b)
+    .join(',');
+}
+
 export type ShortcodeConflict = { kind: 'none' } | { kind: 'same-climb' } | { kind: 'cross-climb'; climbName: string };
 
 // Looks up whether the same Instagram shortcode is already attached to any
@@ -307,6 +322,10 @@ export const tickMutations = {
           id: dbSchema.userBoards.id,
           ownerId: dbSchema.userBoards.ownerId,
           isPublic: dbSchema.userBoards.isPublic,
+          boardType: dbSchema.userBoards.boardType,
+          layoutId: dbSchema.userBoards.layoutId,
+          sizeId: dbSchema.userBoards.sizeId,
+          setIds: dbSchema.userBoards.setIds,
         })
         .from(dbSchema.userBoards)
         .where(and(eq(dbSchema.userBoards.uuid, validatedInput.boardUuid), isNull(dbSchema.userBoards.deletedAt)))
@@ -321,6 +340,34 @@ export const tickMutations = {
       // boards are both fine.
       if (!board.isPublic && board.ownerId !== userId) {
         throw new GraphQLError('Cannot tick on a private board', { extensions: { code: 'FORBIDDEN' } });
+      }
+
+      // Make sure the board the client is pointing at actually matches the
+      // tick payload. Without this, a client could attach a Kilter tick to
+      // any public Tension board (or any other config) and skew that board's
+      // ascent/climber stats — those aggregations key purely on `board_id`.
+      if (board.boardType !== validatedInput.boardType) {
+        throw new GraphQLError("Board type doesn't match tick payload", {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      if (validatedInput.layoutId !== undefined && Number(board.layoutId) !== validatedInput.layoutId) {
+        throw new GraphQLError("Board layout doesn't match tick payload", {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      if (validatedInput.sizeId !== undefined && Number(board.sizeId) !== validatedInput.sizeId) {
+        throw new GraphQLError("Board size doesn't match tick payload", {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      if (
+        validatedInput.setIds !== undefined &&
+        normalizeSetIds(board.setIds) !== normalizeSetIds(validatedInput.setIds)
+      ) {
+        throw new GraphQLError("Board hold sets don't match tick payload", {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
 
       boardId = board.id;

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@boardsesh/shared-schema';
-import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
+import { ExternalUUIDSchema, BoardNameSchema, UUIDSchema } from './primitives';
 
 /**
  * Tick status validation schema
@@ -29,6 +29,7 @@ export const SaveTickInputSchema = z
     layoutId: z.number().int().positive().optional(),
     sizeId: z.number().int().positive().optional(),
     setIds: z.string().min(1).optional(),
+    boardUuid: UUIDSchema.optional(),
     videoUrl: z.string().max(500).regex(BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE).optional().nullable(),
   })
   .refine(

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -763,6 +763,8 @@ input SaveTickInput {
   sizeId: Int
   "Set IDs for board resolution"
   setIds: String
+  "Specific board entity this tick is on. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board)."
+  boardUuid: String
   "Optional Instagram post or reel URL to attach as beta for the climb"
   videoUrl: String
 }

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3953,6 +3953,8 @@ export type SaveTickInput = {
   attemptCount: Scalars['Int']['input'];
   /** Board type */
   boardType: Scalars['String']['input'];
+  /** Specific board entity this tick is on. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board). */
+  boardUuid?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID */
   climbUuid: Scalars['String']['input'];
   /** When the climb was attempted (ISO 8601) */

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -109,6 +109,8 @@ export const ticksTypeDefs = /* GraphQL */ `
     sizeId: Int
     "Set IDs for board resolution"
     setIds: String
+    "Specific board entity this tick is on. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board)."
+    boardUuid: String
     "Optional Instagram post or reel URL to attach as beta for the climb"
     videoUrl: String
   }

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -57,6 +57,12 @@ export type SaveTickInput = {
   layoutId?: number;
   sizeId?: number;
   setIds?: string;
+  /**
+   * Specific board entity this tick is on. When provided, takes precedence
+   * over `(layoutId, sizeId, setIds)` resolution and lets ticks attach to a
+   * board the climber doesn't own (e.g. a seeded gym board).
+   */
+  boardUuid?: string;
   videoUrl?: string | null;
 };
 

--- a/packages/shared/board-react/src/board-provider.tsx
+++ b/packages/shared/board-react/src/board-provider.tsx
@@ -21,6 +21,13 @@ export type BoardContextType = {
    * yet" — mutations throw rather than send an empty boardType.
    */
   boardName: BoardName | null;
+  /**
+   * UUID of the active board entity when the user is on a named-board route
+   * (`/b/<slug>/...`). Null on the legacy config route, which doesn't
+   * reference a specific board entity, and on platforms that resolve the
+   * board by config alone.
+   */
+  boardUuid: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
@@ -41,7 +48,21 @@ export type BoardContextType = {
 
 const BoardContext = createContext<BoardContextType | undefined>(undefined);
 
-export function BoardProvider({ boardName, children }: { boardName: BoardName | null; children: ReactNode }) {
+export function BoardProvider({
+  boardName,
+  boardUuid,
+  children,
+}: {
+  boardName: BoardName | null;
+  /**
+   * Active board entity UUID. Set by named-board routes (`/b/<slug>/...`) so
+   * ticks attach to that exact board even when the climber doesn't own it
+   * (e.g. a seeded gym board). Omit on the legacy config route, which doesn't
+   * reference a specific board entity.
+   */
+  boardUuid?: string;
+  children: ReactNode;
+}) {
   const { isAuthenticated, isAuthLoading, resolveActiveSessionId } = useBoardAdapter();
   const [isInitialized, setIsInitialized] = useState(false);
   const [climbUuids, setClimbUuids] = useState<string[]>([]);
@@ -96,12 +117,20 @@ export function BoardProvider({ boardName, children }: { boardName: BoardName | 
     updateClimbMutateRef.current = updateClimbMutation.mutateAsync;
   });
 
+  // Mirror the active board uuid into a ref so the stable empty-dep saveTick
+  // callback always injects the latest value without taking boardUuid as a dep.
+  const boardUuidRef = useRef(boardUuid);
+  useEffect(() => {
+    boardUuidRef.current = boardUuid;
+  });
+
   const saveTick = useCallback(
     async (options: SaveTickOptions): Promise<void> => {
       const resolvedSessionId = options.sessionId ?? resolveActiveSessionId() ?? undefined;
       await saveTickMutateRef.current({
         ...options,
         sessionId: resolvedSessionId,
+        boardUuid: options.boardUuid ?? boardUuidRef.current,
       });
     },
     [resolveActiveSessionId],
@@ -118,6 +147,7 @@ export function BoardProvider({ boardName, children }: { boardName: BoardName | 
   const value = useMemo<BoardContextType>(
     () => ({
       boardName,
+      boardUuid: boardUuid ?? null,
       isAuthenticated,
       isLoading: isAuthLoading,
       error: null,
@@ -131,6 +161,7 @@ export function BoardProvider({ boardName, children }: { boardName: BoardName | 
     }),
     [
       boardName,
+      boardUuid,
       isAuthenticated,
       isAuthLoading,
       isInitialized,

--- a/packages/shared/board-react/src/tick-helpers.ts
+++ b/packages/shared/board-react/src/tick-helpers.ts
@@ -18,6 +18,12 @@ export type SaveTickOptions = {
   layoutId?: number;
   sizeId?: number;
   setIds?: string;
+  /**
+   * Specific board entity this tick is on. When provided, takes precedence
+   * over `(layoutId, sizeId, setIds)` resolution and lets ticks attach to a
+   * board the climber doesn't own (e.g. a seeded gym board).
+   */
+  boardUuid?: string;
   videoUrl?: string;
 };
 

--- a/packages/shared/board-react/src/use-save-tick.ts
+++ b/packages/shared/board-react/src/use-save-tick.ts
@@ -75,6 +75,7 @@ export function useSaveTick(boardName: BoardName | null) {
           layoutId: options.layoutId,
           sizeId: options.sizeId,
           setIds: options.setIds,
+          boardUuid: options.boardUuid,
           videoUrl: options.videoUrl,
         },
       };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3950,6 +3950,8 @@ export type SaveTickInput = {
   attemptCount: Scalars['Int']['input'];
   /** Board type */
   boardType: Scalars['String']['input'];
+  /** Specific board entity this tick is on. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board). */
+  boardUuid?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID */
   climbUuid: Scalars['String']['input'];
   /** When the climb was attempted (ISO 8601) */

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -79,7 +79,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
           angle={angle}
           boardSlug={board.slug}
         />
-        <BoardProvider boardName={parsedParams.board_name}>
+        <BoardProvider boardName={parsedParams.board_name} boardUuid={board.uuid}>
           <BoardSessionBridge boardDetails={boardDetails} parsedParams={parsedParams}>
             <ConnectionSettingsProvider>
               <WebSocketConnectionProvider>

--- a/packages/web/app/components/board-page/__tests__/board-page-climbs-list.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/board-page-climbs-list.test.tsx
@@ -103,6 +103,7 @@ describe('BoardPageClimbsList logbook seed', () => {
     vi.clearAllMocks();
     mockUseOptionalBoardProvider.mockReturnValue({
       boardName: 'kilter',
+      boardUuid: null,
       isAuthenticated: true,
       isLoading: false,
       error: null,

--- a/packages/web/app/components/board-provider/board-provider-context.tsx
+++ b/packages/web/app/components/board-provider/board-provider-context.tsx
@@ -24,10 +24,26 @@ export type BoardContextType = Omit<SharedBoardContextType, 'boardName'> & { boa
 
 export { BoardContext };
 
-export function BoardProvider({ boardName, children }: { boardName: BoardName; children: ReactNode }) {
+export function BoardProvider({
+  boardName,
+  boardUuid,
+  children,
+}: {
+  boardName: BoardName;
+  /**
+   * Active board entity UUID. Set by named-board routes (`/b/<slug>/...`) so
+   * ticks attach to that exact board even when the climber doesn't own it
+   * (e.g. a seeded gym board). Omit on the legacy config route, which doesn't
+   * reference a specific board entity.
+   */
+  boardUuid?: string;
+  children: ReactNode;
+}) {
   return (
     <BoardAdapterWrapper>
-      <SharedBoardProvider boardName={boardName}>{children}</SharedBoardProvider>
+      <SharedBoardProvider boardName={boardName} boardUuid={boardUuid}>
+        {children}
+      </SharedBoardProvider>
     </BoardAdapterWrapper>
   );
 }

--- a/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
@@ -52,6 +52,7 @@ function createBoardContextValue({
   }
   return {
     boardName,
+    boardUuid: null,
     isAuthenticated: true,
     isLoading: false,
     error: null,

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -158,6 +158,7 @@ describe('useQueueDataFetching', () => {
       saveClimb: vi.fn(),
       updateClimb: vi.fn(),
       boardName: 'kilter',
+      boardUuid: null,
     });
 
     mockUseOptionalBoardProvider.mockReturnValue({
@@ -172,6 +173,7 @@ describe('useQueueDataFetching', () => {
       saveClimb: vi.fn(),
       updateClimb: vi.fn(),
       boardName: 'kilter',
+      boardUuid: null,
     });
 
     mockUseOptionalBoardProvider.mockReturnValue({
@@ -186,6 +188,7 @@ describe('useQueueDataFetching', () => {
       saveClimb: vi.fn(),
       updateClimb: vi.fn(),
       boardName: 'kilter',
+      boardUuid: null,
     });
 
     mockUseWsAuthToken.mockReturnValue({


### PR DESCRIPTION
## Summary

- Adds optional `boardUuid` to `SaveTickInput`. When the user is on a named-board route (`/b/<slug>/...`), `BoardProvider` carries the active board's UUID and injects it into every `saveTick` call (mirroring how `sessionId` is injected today).
- The resolver looks up `user_boards` by uuid and uses that id directly — no ownership check on the climber, just a public-or-owned guard so clients can't tick against someone else's private board.
- The legacy `/[board_name]/[layout_id]/...` config route is unchanged; it still falls back to `resolveBoardFromPath` because there's no specific board entity in scope.

Fixes #1843 — before this, `resolveBoardFromPath` only matched `user_boards` rows where `owner_id = userId`, so every tick on a seeded gym board (owned by the system user) landed with `board_id = NULL` and the map's ascent/climber counts always read 0.

## Test plan

- [ ] Sign in as `test@boardsesh.com` / `test`. Navigate to a seeded gym from the map drawer (Find a board) → drill into one of its boards. URL should be `/b/<slug>/<angle>/list`.
- [ ] Tick a climb. The `SaveTick` request should include `input.boardUuid`. Confirm in the DB: `select board_id from boardsesh_ticks where uuid = '<tick-uuid>'` returns a non-null id.
- [ ] Reopen the board's detail drawer → the Ascents / Climbers chips should reflect the new tick (1 / 1, or higher if you tick more). Same for the board card on the map carousel.
- [ ] Negative path: tick a climb from `/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list`. The `SaveTick` request should omit `boardUuid`; `boardId` resolves via the existing config-based fallback (your own board, or null).
- [ ] Spot-check unrelated tick paths still work: `logascent-form`, `quick-tick-bar` (queue/play views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)