### PR TITLE
Add create-playlist FAB to Discover page

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import React, { useState, useCallback, useContext } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import MuiButton from '@mui/material/Button';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -27,12 +22,10 @@ import {
   generateSizeSlug,
   generateSetSlug,
   searchParamsToUrlParams,
-  getContextAwarePlaylistUrl,
   getPlaylistsBasePath,
 } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useColorMode } from '@/app/hooks/use-color-mode';
-import { PlaylistsContext } from '../climb-actions/playlists-batch-context';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { usePersistentSessionState } from '../persistent-session';
 import { getLastUsedBoard } from '@/app/lib/last-used-board-db';
@@ -43,24 +36,15 @@ import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import { useSession } from 'next-auth/react';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
-import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import type { StoredBoardConfig } from '@/app/lib/saved-boards-db';
-import { isValidHexColor } from '@/app/lib/color-utils';
 import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
 
 type Tab = 'home' | 'climbs' | 'library' | 'feed' | 'create' | 'you';
-type PendingCreateAction = 'climb' | 'playlist' | null;
 
 type BottomTabBarProps = {
   boardDetails?: BoardDetails | null;
   angle?: number;
   boardConfigs?: BoardConfigData;
-};
-
-type SelectedBoardContext = {
-  boardName: string;
-  layoutId: number;
-  angle: number;
 };
 
 const getActiveTab = (pathname: string): Tab => {
@@ -70,19 +54,6 @@ const getActiveTab = (pathname: string): Tab => {
   if (pathname.startsWith('/you')) return 'you';
   if (pathname.startsWith('/playlists') || pathname.includes('/playlists')) return 'library';
   return 'climbs';
-};
-
-const INITIAL_PLAYLIST_FORM = { name: '', description: '', color: '' };
-
-const getBoardContextFromSelector = (config?: StoredBoardConfig): SelectedBoardContext | null => {
-  if (!config || typeof config.layoutId !== 'number' || config.layoutId <= 0) {
-    return null;
-  }
-  return {
-    boardName: config.board,
-    layoutId: config.layoutId,
-    angle: config.angle ?? 40,
-  };
 };
 
 const listUrlToCreateUrl = (url: string): string => {
@@ -104,24 +75,15 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const { t } = useTranslation('playlists');
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
-  const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
-  const [isCreatePlaylistRendered, setIsCreatePlaylistRendered] = useState(false);
-  const [isCreatingPlaylist, setIsCreatingPlaylist] = useState(false);
   const { openAuthModal } = useAuthModal();
   const [isBoardSelectorOpen, setIsBoardSelectorOpen] = useState(false);
   const [isBoardSelectorRendered, setIsBoardSelectorRendered] = useState(false);
   const [isCustomBoardOpen, setIsCustomBoardOpen] = useState(false);
   const [isCustomBoardRendered, setIsCustomBoardRendered] = useState(false);
-  const [pendingCreateAction, setPendingCreateAction] = useState<PendingCreateAction>(null);
-  const [selectedBoardContext, setSelectedBoardContext] = useState<SelectedBoardContext | null>(null);
-  const [playlistFormValues, setPlaylistFormValues] = useState(INITIAL_PLAYLIST_FORM);
-  const [playlistFormErrors, setPlaylistFormErrors] = useState<Record<string, string>>({});
+  const [isPendingCreateClimb, setIsPendingCreateClimb] = useState(false);
 
   // Stable callbacks for drawer unmount-after-close-animation pattern.
   // Avoids invalidating MUI's SlideProps memo on every parent render.
-  const handleCreatePlaylistTransitionEnd = useCallback((open: boolean) => {
-    if (!open) setIsCreatePlaylistRendered(false);
-  }, []);
   const handleCustomBoardTransitionEnd = useCallback((open: boolean) => {
     if (!open) setIsCustomBoardRendered(false);
   }, []);
@@ -134,10 +96,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const guardBoardSwitch = useBoardSwitchGuard();
 
   const { data: session } = useSession();
-
-  // Playlist context may be absent at root-level routes; use a local fallback for create flow.
-  const playlistsContext = useContext(PlaylistsContext);
-  const { showMessage } = useSnackbar();
+  const isAuthenticated = !!session?.user?.id;
 
   // Use the active queue's board details as a fallback when no boardDetails prop
   const { activeSession, localBoardDetails, localCurrentClimbQueueItem } = usePersistentSessionState();
@@ -150,23 +109,9 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     (activeSession ? activeSession.parsedParams.angle : undefined) ??
     localCurrentClimbQueueItem?.climb?.angle ??
     0;
-  const playlistBoardName = effectiveBoardDetails?.board_name ?? selectedBoardContext?.boardName ?? '';
-  const playlistLayoutId = effectiveBoardDetails?.layout_id ?? selectedBoardContext?.layoutId ?? 0;
-  const playlistAngle = effectiveAngle ?? selectedBoardContext?.angle ?? 0;
-
-  const { playlistsProviderProps } = useClimbActionsData({
-    boardName: playlistBoardName,
-    layoutId: playlistLayoutId,
-    angle: playlistAngle,
-    climbUuids: [],
-  });
-  const createPlaylist = playlistsContext?.createPlaylist ?? playlistsProviderProps.createPlaylist;
-  const isAuthenticated = playlistsContext?.isAuthenticated ?? playlistsProviderProps.isAuthenticated;
-  const canCreatePlaylistHere = !!playlistBoardName && playlistLayoutId > 0;
 
   // Determine active tab from pathname
-  const activeTabFromPath = getActiveTab(pathname);
-  const activeTab = isCreatePlaylistOpen ? 'create' : activeTabFromPath;
+  const activeTab = getActiveTab(pathname);
 
   // Build URLs using effective board details
   // If we're on a /b/ slug route, preserve the slug URL format
@@ -209,15 +154,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     return null;
   })();
 
-  const getPlaylistUrl = useCallback(
-    (playlistUuid: string) => {
-      return getContextAwarePlaylistUrl(pathname, playlistUuid);
-    },
-    [pathname],
-  );
-
   const handleHomeTab = () => {
-    setIsCreatePlaylistOpen(false);
     router.push('/');
     track('Bottom Tab Bar', { tab: 'home' });
   };
@@ -233,8 +170,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       !pathname.startsWith('/notifications'));
 
   const handleClimbsTab = async () => {
-    setIsCreatePlaylistOpen(false);
-
     let url: string | null = null;
 
     if (isOnBoardPage) {
@@ -299,7 +234,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const playlistsUrl = getPlaylistsBasePath(pathname);
 
   const handleLibraryTab = () => {
-    setIsCreatePlaylistOpen(false);
     const currentUrl = pathname + (typeof window !== 'undefined' ? window.location.search : '');
     if (playlistsUrl !== currentUrl) {
       router.push(playlistsUrl);
@@ -308,14 +242,12 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   };
 
   const handleFeedTab = () => {
-    setIsCreatePlaylistOpen(false);
     router.push('/feed');
     track('Bottom Tab Bar', { tab: 'feed' });
   };
 
   const handleYouTab = () => {
-    setIsCreatePlaylistOpen(false);
-    if (!isAuthenticated || !session?.user?.id) {
+    if (!isAuthenticated) {
       openAuthModal({
         title: t('bottomTabBar.youSignInTitle'),
         description: t('bottomTabBar.youSignInDescription'),
@@ -330,7 +262,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   };
 
   const handleCreateTab = () => {
-    setIsCreatePlaylistOpen(false);
     track('Bottom Tab Bar', { tab: 'create' });
     // Go directly to create climb, skip the drawer
     if (createClimbUrl) {
@@ -338,7 +269,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       return;
     }
     if (boardConfigs) {
-      setPendingCreateAction('climb');
+      setIsPendingCreateClimb(true);
       setIsBoardSelectorRendered(true);
       setIsBoardSelectorOpen(true);
     }
@@ -369,26 +300,9 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
 
   const handleBoardSelected = useCallback(
     (url: string, config?: StoredBoardConfig) => {
-      const selectedContext = getBoardContextFromSelector(config);
-      if (selectedContext) {
-        setSelectedBoardContext(selectedContext);
-      }
-
-      if (pendingCreateAction === 'climb') {
+      if (isPendingCreateClimb) {
         router.push(listUrlToCreateUrl(url));
-        setPendingCreateAction(null);
-        return;
-      }
-
-      if (pendingCreateAction === 'playlist') {
-        if (!selectedContext) {
-          showMessage(t('bottomTabBar.boardDetailsMissing'), 'error');
-          setPendingCreateAction(null);
-          return;
-        }
-        setIsCreatePlaylistRendered(true);
-        setIsCreatePlaylistOpen(true);
-        setPendingCreateAction(null);
+        setIsPendingCreateClimb(false);
         return;
       }
 
@@ -404,7 +318,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         router.push(url);
       }
     },
-    [pendingCreateAction, router, showMessage, guardBoardSwitch, t],
+    [isPendingCreateClimb, router, guardBoardSwitch],
   );
 
   const handleDiscoveryBoardClick = useCallback(
@@ -460,75 +374,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     },
     [handleBoardSelected],
   );
-
-  const validatePlaylistForm = useCallback((): boolean => {
-    const errors: Record<string, string> = {};
-    if (!playlistFormValues.name.trim()) {
-      errors.name = t('climbs:actions.playlist.validation.nameRequired');
-    } else if (playlistFormValues.name.length > 100) {
-      errors.name = t('climbs:actions.playlist.validation.nameTooLong');
-    }
-    if (playlistFormValues.description.length > 500) {
-      errors.description = t('climbs:actions.playlist.validation.descriptionTooLong');
-    }
-    setPlaylistFormErrors(errors);
-    return Object.keys(errors).length === 0;
-  }, [playlistFormValues, t]);
-
-  const handleCreatePlaylist = useCallback(async () => {
-    if (!validatePlaylistForm() || !createPlaylist) {
-      return;
-    }
-
-    if (!canCreatePlaylistHere) {
-      showMessage(t('bottomTabBar.selectBoardForPlaylist'), 'error');
-      return;
-    }
-
-    try {
-      setIsCreatingPlaylist(true);
-
-      // Extract and validate hex color
-      let colorHex: string | undefined;
-      if (playlistFormValues.color && isValidHexColor(playlistFormValues.color)) {
-        colorHex = playlistFormValues.color;
-      }
-
-      const newPlaylist = await createPlaylist(
-        playlistFormValues.name,
-        playlistFormValues.description,
-        colorHex,
-        undefined,
-      );
-
-      showMessage(t('bottomTabBar.createdPlaylistToast', { name: playlistFormValues.name }), 'success');
-      track('Create Playlist', {
-        boardName: playlistBoardName || 'unknown',
-        playlistName: playlistFormValues.name,
-        source: 'bottom-tab-bar',
-      });
-
-      setPlaylistFormValues(INITIAL_PLAYLIST_FORM);
-      setPlaylistFormErrors({});
-      setIsCreatePlaylistOpen(false);
-
-      // Navigate to the new playlist
-      router.push(getPlaylistUrl(newPlaylist.uuid));
-    } catch {
-      showMessage(t('bottomTabBar.createPlaylistFailed'), 'error');
-    } finally {
-      setIsCreatingPlaylist(false);
-    }
-  }, [
-    validatePlaylistForm,
-    createPlaylist,
-    canCreatePlaylistHere,
-    playlistFormValues,
-    playlistBoardName,
-    router,
-    getPlaylistUrl,
-    showMessage,
-  ]);
 
   return (
     <>
@@ -592,83 +437,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         />
       </BottomNavigation>
 
-      {/* Create Playlist Drawer */}
-      {isCreatePlaylistRendered && (
-        <SwipeableDrawer
-          title={t('create.drawerTitle')}
-          placement="bottom"
-          open={isCreatePlaylistOpen}
-          onClose={() => {
-            setIsCreatePlaylistOpen(false);
-            setPlaylistFormValues(INITIAL_PLAYLIST_FORM);
-            setPlaylistFormErrors({});
-          }}
-          onTransitionEnd={handleCreatePlaylistTransitionEnd}
-          styles={{
-            wrapper: { height: 'auto' },
-            body: { padding: themeTokens.spacing[4] },
-          }}
-          extra={
-            <MuiButton variant="contained" onClick={handleCreatePlaylist} disabled={isCreatingPlaylist}>
-              {isCreatingPlaylist ? t('create.submitting') : t('create.submit')}
-            </MuiButton>
-          }
-        >
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box>
-              <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                {t('create.fields.name')}
-              </Typography>
-              <TextField
-                placeholder={t('create.fields.namePlaceholder')}
-                autoFocus
-                fullWidth
-                size="small"
-                value={playlistFormValues.name}
-                onChange={(e) => {
-                  setPlaylistFormValues((prev) => ({ ...prev, name: e.target.value }));
-                  setPlaylistFormErrors((prev) => ({ ...prev, name: '' }));
-                }}
-                error={!!playlistFormErrors.name}
-                helperText={playlistFormErrors.name}
-              />
-            </Box>
-            <Box>
-              <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                {t('create.fields.description')}
-              </Typography>
-              <TextField
-                placeholder={t('create.fields.descriptionPlaceholder')}
-                multiline
-                rows={2}
-                fullWidth
-                size="small"
-                slotProps={{ htmlInput: { maxLength: 500 } }}
-                value={playlistFormValues.description}
-                onChange={(e) => {
-                  setPlaylistFormValues((prev) => ({ ...prev, description: e.target.value }));
-                  setPlaylistFormErrors((prev) => ({ ...prev, description: '' }));
-                }}
-                error={!!playlistFormErrors.description}
-                helperText={playlistFormErrors.description}
-              />
-            </Box>
-            <Box>
-              <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                {t('create.fields.color')}
-              </Typography>
-              <TextField
-                type="color"
-                value={playlistFormValues.color || '#000000'}
-                onChange={(e) => setPlaylistFormValues((prev) => ({ ...prev, color: e.target.value }))}
-                size="small"
-                sx={{ width: 80 }}
-              />
-            </Box>
-          </Box>
-        </SwipeableDrawer>
-      )}
-
       {/* Board Selector Drawer */}
       {isBoardSelectorRendered && (
         <SwipeableDrawer
@@ -677,7 +445,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           open={isBoardSelectorOpen}
           onClose={() => {
             setIsBoardSelectorOpen(false);
-            setPendingCreateAction(null);
+            setIsPendingCreateClimb(false);
           }}
           onTransitionEnd={handleBoardSelectorTransitionEnd}
         >

--- a/packages/web/app/components/library/create-playlist-drawer.tsx
+++ b/packages/web/app/components/library/create-playlist-drawer.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import React, { useCallback, useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { track } from '@vercel/analytics';
+import MuiButton from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+import { PlaylistsContext } from '@/app/components/climb-actions/playlists-batch-context';
+import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
+import { isValidHexColor } from '@/app/lib/color-utils';
+import type { Playlist } from '@/app/lib/graphql/operations/playlists';
+
+const INITIAL_FORM = { name: '', description: '', color: '' };
+
+type CreatePlaylistDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  boardName: string;
+  layoutId: number;
+  angle: number;
+  /** Analytics source label (e.g. "discover-fab", "library-empty-state"). */
+  source: string;
+  onCreated?: (playlist: Playlist) => void;
+};
+
+export default function CreatePlaylistDrawer({
+  open,
+  onClose,
+  boardName,
+  layoutId,
+  angle,
+  source,
+  onCreated,
+}: CreatePlaylistDrawerProps) {
+  const { t } = useTranslation('playlists');
+  const { showMessage } = useSnackbar();
+
+  const [formValues, setFormValues] = useState(INITIAL_FORM);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRendered, setIsRendered] = useState(open);
+
+  const playlistsContext = useContext(PlaylistsContext);
+  const { playlistsProviderProps } = useClimbActionsData({
+    boardName,
+    layoutId,
+    angle,
+    climbUuids: [],
+  });
+  const createPlaylist = playlistsContext?.createPlaylist ?? playlistsProviderProps.createPlaylist;
+
+  const canSubmit = !!boardName && layoutId > 0;
+
+  // Mount lazily and keep mounted during close transition.
+  if (open && !isRendered) {
+    setIsRendered(true);
+  }
+
+  const handleTransitionEnd = useCallback((isOpen: boolean) => {
+    if (!isOpen) setIsRendered(false);
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const errors: Record<string, string> = {};
+    if (!formValues.name.trim()) {
+      errors.name = t('climbs:actions.playlist.validation.nameRequired');
+    } else if (formValues.name.length > 100) {
+      errors.name = t('climbs:actions.playlist.validation.nameTooLong');
+    }
+    if (formValues.description.length > 500) {
+      errors.description = t('climbs:actions.playlist.validation.descriptionTooLong');
+    }
+    setFormErrors(errors);
+    return Object.keys(errors).length === 0;
+  }, [formValues, t]);
+
+  const resetAndClose = useCallback(() => {
+    setFormValues(INITIAL_FORM);
+    setFormErrors({});
+    onClose();
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!validate()) return;
+
+    if (!canSubmit) {
+      showMessage(t('bottomTabBar.selectBoardForPlaylist'), 'error');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const colorHex = isValidHexColor(formValues.color) ? formValues.color : undefined;
+
+      const newPlaylist = await createPlaylist(formValues.name, formValues.description, colorHex, undefined);
+
+      showMessage(t('bottomTabBar.createdPlaylistToast', { name: formValues.name }), 'success');
+      track('Create Playlist', {
+        boardName,
+        playlistName: formValues.name,
+        source,
+      });
+
+      setFormValues(INITIAL_FORM);
+      setFormErrors({});
+      onClose();
+      onCreated?.(newPlaylist);
+    } catch {
+      showMessage(t('bottomTabBar.createPlaylistFailed'), 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [validate, canSubmit, formValues, createPlaylist, showMessage, t, boardName, source, onClose, onCreated]);
+
+  if (!isRendered) return null;
+
+  return (
+    <SwipeableDrawer
+      title={t('create.drawerTitle')}
+      placement="bottom"
+      open={open}
+      onClose={resetAndClose}
+      onTransitionEnd={handleTransitionEnd}
+      styles={{
+        wrapper: { height: 'auto' },
+        body: { padding: themeTokens.spacing[4] },
+      }}
+      extra={
+        <MuiButton variant="contained" onClick={handleSubmit} disabled={isSubmitting}>
+          {isSubmitting ? t('create.submitting') : t('create.submit')}
+        </MuiButton>
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            {t('create.fields.name')}
+          </Typography>
+          <TextField
+            placeholder={t('create.fields.namePlaceholder')}
+            autoFocus
+            fullWidth
+            size="small"
+            value={formValues.name}
+            onChange={(event) => {
+              setFormValues((prev) => ({ ...prev, name: event.target.value }));
+              setFormErrors((prev) => ({ ...prev, name: '' }));
+            }}
+            error={!!formErrors.name}
+            helperText={formErrors.name}
+          />
+        </Box>
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            {t('create.fields.description')}
+          </Typography>
+          <TextField
+            placeholder={t('create.fields.descriptionPlaceholder')}
+            multiline
+            rows={2}
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { maxLength: 500 } }}
+            value={formValues.description}
+            onChange={(event) => {
+              setFormValues((prev) => ({ ...prev, description: event.target.value }));
+              setFormErrors((prev) => ({ ...prev, description: '' }));
+            }}
+            error={!!formErrors.description}
+            helperText={formErrors.description}
+          />
+        </Box>
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            {t('create.fields.color')}
+          </Typography>
+          <TextField
+            type="color"
+            value={formValues.color || '#000000'}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, color: event.target.value }))}
+            size="small"
+            sx={{ width: 80 }}
+          />
+        </Box>
+      </Box>
+    </SwipeableDrawer>
+  );
+}

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -2,8 +2,9 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import MuiButton from '@mui/material/Button';
+import Fab from '@mui/material/Fab';
 import Typography from '@mui/material/Typography';
-import { LabelOutlined, LoginOutlined, SentimentDissatisfiedOutlined } from '@mui/icons-material';
+import { AddOutlined, LabelOutlined, LoginOutlined, SentimentDissatisfiedOutlined } from '@mui/icons-material';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
@@ -24,13 +25,24 @@ import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-br
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { findMatchingBoard } from '@/app/lib/find-matching-board';
 import { deriveIsAuthenticated } from '@/app/lib/derive-auth-status';
-import type { UserBoard } from '@boardsesh/shared-schema';
+import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import PlaylistCardGrid from '@/app/components/library/playlist-card-grid';
 import PlaylistScrollSection from '@/app/components/library/playlist-scroll-section';
 import PlaylistCard from '@/app/components/library/playlist-card';
 import BoardFilterStrip from '@/app/components/board-scroll/board-filter-strip';
+import BoardDiscoveryScroll from '@/app/components/board-scroll/board-discovery-scroll';
+import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
+import CreatePlaylistDrawer from '@/app/components/library/create-playlist-drawer';
 import styles from '@/app/components/library/library.module.css';
+
+type CreateBoardContext = {
+  boardName: string;
+  layoutId: number;
+  angle: number;
+};
 
 type LibraryPageContentProps = {
   /** When set, the page was rendered from a board route and this board is pre-selected. */
@@ -252,6 +264,62 @@ export default function LibraryPageContent({
     [boardSlug, playlistsBasePath, router],
   );
 
+  // Create-playlist FAB flow
+  const [createBoardContext, setCreateBoardContext] = useState<CreateBoardContext | null>(null);
+  const [isCreateDrawerOpen, setIsCreateDrawerOpen] = useState(false);
+  const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
+  const [isBoardPickerRendered, setIsBoardPickerRendered] = useState(false);
+
+  const handleCreatePlaylistClick = useCallback(() => {
+    if (selectedBoard) {
+      setCreateBoardContext({
+        boardName: selectedBoard.boardType,
+        layoutId: selectedBoard.layoutId,
+        angle: selectedBoard.angle,
+      });
+      setIsCreateDrawerOpen(true);
+      return;
+    }
+    setIsBoardPickerRendered(true);
+    setIsBoardPickerOpen(true);
+  }, [selectedBoard]);
+
+  const handlePickerBoardClick = useCallback((board: UserBoard) => {
+    setCreateBoardContext({
+      boardName: board.boardType,
+      layoutId: board.layoutId,
+      angle: board.angle,
+    });
+    setIsBoardPickerOpen(false);
+    setIsCreateDrawerOpen(true);
+  }, []);
+
+  const handlePickerConfigClick = useCallback((config: PopularBoardConfig) => {
+    setCreateBoardContext({
+      boardName: config.boardType,
+      layoutId: config.layoutId,
+      angle: getDefaultAngleForBoard(config.boardType),
+    });
+    setIsBoardPickerOpen(false);
+    setIsCreateDrawerOpen(true);
+  }, []);
+
+  const handlePickerCustomClick = useCallback(() => {
+    // The custom-board flow lives elsewhere (board selector drawer); close the picker.
+    setIsBoardPickerOpen(false);
+  }, []);
+
+  const handlePickerTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setIsBoardPickerRendered(false);
+  }, []);
+
+  const handlePlaylistCreated = useCallback(
+    (playlist: Playlist) => {
+      router.push(getPlaylistUrl(playlist.uuid));
+    },
+    [router, getPlaylistUrl],
+  );
+
   // Error state (only for authenticated users with fetch errors)
   if (isAuthenticated && error) {
     return (
@@ -375,6 +443,53 @@ export default function LibraryPageContent({
             />
           ))}
         </PlaylistScrollSection>
+      )}
+
+      {/* Create Playlist FAB (authenticated users only) */}
+      {isAuthenticated && (
+        <Fab
+          color="primary"
+          aria-label={t('library.createFab.ariaLabel')}
+          onClick={handleCreatePlaylistClick}
+          sx={{
+            position: 'fixed',
+            right: themeTokens.spacing[4],
+            bottom: `calc(var(--tab-bar-safe-area-padding, 0px) + 88px)`,
+            zIndex: 1000,
+          }}
+        >
+          <AddOutlined />
+        </Fab>
+      )}
+
+      {/* Board picker drawer (only when no board is filter-selected) */}
+      {isBoardPickerRendered && (
+        <SwipeableDrawer
+          title={t('common:boardSelector.title')}
+          placement="bottom"
+          open={isBoardPickerOpen}
+          onClose={() => setIsBoardPickerOpen(false)}
+          onTransitionEnd={handlePickerTransitionEnd}
+        >
+          <BoardDiscoveryScroll
+            onBoardClick={handlePickerBoardClick}
+            onConfigClick={handlePickerConfigClick}
+            onCustomClick={handlePickerCustomClick}
+          />
+        </SwipeableDrawer>
+      )}
+
+      {/* Create Playlist Drawer */}
+      {createBoardContext && (
+        <CreatePlaylistDrawer
+          open={isCreateDrawerOpen}
+          onClose={() => setIsCreateDrawerOpen(false)}
+          boardName={createBoardContext.boardName}
+          layoutId={createBoardContext.layoutId}
+          angle={createBoardContext.angle}
+          source="discover-fab"
+          onCreated={handlePlaylistCreated}
+        />
       )}
     </>
   );

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -23,7 +23,10 @@
     },
     "empty": {
       "title": "No playlists yet",
-      "description": "Create your first playlist by adding climbs from the climb list."
+      "description": "Tap the + button to line up your first set of climbs."
+    },
+    "createFab": {
+      "ariaLabel": "Create playlist"
     },
     "errors": {
       "loadTitle": "Unable to Load Library",


### PR DESCRIPTION
## Summary

- Adds a Floating Action Button to `/playlists` (and the per-board variants) for creating a new playlist — restoring an entry point that was lost when the bottom tab bar's Create button was repurposed for create-climb in #1432.
- Extracts the existing playlist-creation form into a reusable `CreatePlaylistDrawer` component and removes the now-unreachable inline drawer + state from `BottomTabBar`.
- When the "All boards" filter is active, tapping the FAB opens a board picker first (via `BoardDiscoveryScroll`) so the new playlist gets a valid board context.

Fixes #1535.

## Test plan

- [ ] Sign in, visit `/playlists` — FAB visible bottom-right, doesn't overlap the bottom tab bar.
- [ ] With a board filter selected, tap the FAB → drawer opens immediately, fill in name (and optional description/color), submit → snackbar confirms and routes to the new playlist.
- [ ] With "All boards" filter, tap the FAB → board picker opens, pick a board → drawer opens for that board → create succeeds.
- [ ] Visit `/b/<slug>/<angle>/playlists` and a deep-route playlist page — FAB is present and creates against the route's board.
- [ ] Sign out — FAB is hidden.
- [ ] Empty state copy mentions the + button.
- [ ] Bottom tab bar's Create button still routes straight to climb create on a board page (unchanged behavior).
- [ ] Validation: empty name → error; >100-char name → error; >500-char description → error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)