### PR TITLE
chore(db): tighten autovacuum on board_climbs / board_climb_stats

### DIFF
--- a/packages/db/drizzle/0086_tune_search_autovacuum.sql
+++ b/packages/db/drizzle/0086_tune_search_autovacuum.sql
@@ -1,0 +1,17 @@
+-- board_climb_stats: continuously updated by Aurora syncs as people log ascents.
+-- Tighten autovacuum so the visibility map stays fresh enough for the
+-- ascents-DESC search query to use a true Index Only Scan (no heap fetches).
+-- Default 0.2/0.1 scale factors mean autovacuum waits for ~120K dead tuples
+-- before firing on this ~600K-row table; 0.02/0.01 brings that to ~12K dead.
+ALTER TABLE board_climb_stats SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_analyze_scale_factor = 0.01
+);
+--> statement-breakpoint
+-- board_climbs: lower modification rate (mostly inserts on new climbs +
+-- denormalized-column backfills). 0.05/0.02 gives autovacuum a tighter trigger
+-- than the default without making it run constantly.
+ALTER TABLE board_climbs SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1777941719782,
       "tag": "0085_productive_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1777953600000,
+      "tag": "0086_tune_search_autovacuum",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #1969. Production `EXPLAIN (ANALYZE, BUFFERS)` for the climb search query shows `Heap Fetches: 22` on what should be a pure Index Only Scan over `board_climb_stats_ascents_covering_idx`:

```
->  Index Only Scan using board_climb_stats_ascents_covering_idx on public.board_climb_stats
      Index Cond: ((board_type = 'kilter'::text) AND (angle = 40))
      Heap Fetches: 22
```

22 of 22 lookups fall back to a heap probe — the table's **visibility map is stale**. Postgres rebuilds the visibility map only during VACUUM. Investigation:

- `pg_stat_user_tables.last_vacuum`, `last_autovacuum`, `last_analyze`, `last_autoanalyze` are all `NULL` for both tables.
- Autovacuum is on cluster-wide but uses default scale factors (0.2 / 0.1). With ~600K rows in `board_climb_stats`, autovacuum waits for ~120K dead tuples before firing — too lax for a hot read table that's continuously updated by Aurora syncs.

## Change

Lower per-table autovacuum scale factors via storage parameters:

| Table | vacuum scale | analyze scale | Vacuum trigger | Analyze trigger |
|---|---|---|---|---|
| `board_climb_stats` | 0.02 | 0.01 | ~12K dead tuples | ~6K modified |
| `board_climbs` | 0.05 | 0.02 | ~24K dead tuples | ~10K modified |

Defaults remain in place cluster-wide. Storage parameters are catalog-only — no data impact, takes a brief AccessExclusiveLock on each table to update `pg_class.reloptions`.

This is a hand-written migration because `drizzle-kit generate` doesn't model PostgreSQL storage parameters in the schema (same precedent as `0013_add_heatmap_indexes.sql` for materialized views).

## Expected impact

Cold-cache search query: ~3.5 ms → < 1 ms once the visibility map is fresh (heap probes were the dominant cost in the post-#1969 plan). Planner also gets accurate row estimates across all queries against these tables, not just search.

## Optional one-time bootstrap

`VACUUM` cannot run inside the migration's transaction, so a fresh visibility map won't be rebuilt by the migration itself — autovacuum will pick the tables up within an hour or so once the new thresholds are active. For an immediate effect, run once after deploy from a writable Railway connection:

```sql
VACUUM (ANALYZE) board_climb_stats;
VACUUM (ANALYZE) board_climbs;
```

## Test plan

- [ ] Verify locally: `vp run db:migrate`, then `SELECT relname, reloptions FROM pg_class WHERE relname IN ('board_climbs','board_climb_stats')` — expect the new storage params on both rows. (Already done; both rows show the expected reloptions.)
- [ ] Capture production `EXPLAIN (ANALYZE, BUFFERS)` baseline before deploy showing `Heap Fetches: 22`.
- [ ] Post-deploy: run the optional `VACUUM (ANALYZE)` above, then re-run the same `EXPLAIN`. Expect `Heap Fetches: 0` and `Execution Time` < 1 ms.
- [ ] Over 24h: monitor `pg_stat_user_tables` for these tables. `last_autovacuum`/`last_autoanalyze` should update regularly (every few hours rather than never), and `n_dead_tup` should stay below ~12K for `board_climb_stats`.
- [ ] Watch Railway Postgres I/O metrics — tighter autovacuum means more frequent (but still throttled) runs. If autovacuum cost limits become a problem we can raise `autovacuum_vacuum_cost_limit` per-table; not expected at this scale.

## Rollback

```sql
ALTER TABLE board_climb_stats RESET (autovacuum_vacuum_scale_factor, autovacuum_analyze_scale_factor);
ALTER TABLE board_climbs RESET (autovacuum_vacuum_scale_factor, autovacuum_analyze_scale_factor);
```

Or revert this PR. Tables fall back to cluster-wide defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)