### PR TITLE
Fix FAB positioning, type scope, copy, and add missing create-flow tests

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -287,6 +287,31 @@ describe('BottomTabBar create flow', () => {
 
     expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('/create'));
   });
+
+  it('routes to /create (not /list) when board is selected via isCreateClimbFlow', () => {
+    // createClimbUrl is null (no boardDetails/angle); boardConfigs is set so the board selector opens
+    render(<BottomTabBar boardConfigs={boardConfigs} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(screen.getByTestId('drawer-Pick a board')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Board' }));
+
+    // Should navigate to the create path, not the list path the mock returns
+    const pushedUrl = mockPush.mock.calls[0][0] as string;
+    expect(pushedUrl).toContain('/create');
+    expect(pushedUrl).not.toContain('/list');
+  });
+
+  it('does nothing when createClimbUrl is null and boardConfigs is not provided', () => {
+    // No boardDetails, no boardConfigs — Create tab should not navigate or open any drawer
+    render(<BottomTabBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('drawer-Pick a board')).toBeNull();
+  });
 });
 
 describe('BottomTabBar You tab', () => {

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -1,10 +1,15 @@
 /* Library View Styles */
 
+/* Shared max-width token; also referenced by the FAB right-offset in library-page-content.tsx */
+:global(:root) {
+  --library-page-max-width: 800px;
+}
+
 .pageContainer {
   padding: 16px;
   min-height: 100vh;
   background-color: var(--neutral-50);
-  max-width: 800px;
+  max-width: var(--library-page-max-width);
   margin: 0 auto;
   padding-bottom: 96px;
 }

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -43,6 +43,8 @@ import styles from '@/app/components/library/library.module.css';
 
 type SelectedBoardForCreate = { boardType: string; layoutId: number };
 
+type PendingDrawerAction = { type: 'create'; context: SelectedBoardForCreate } | { type: 'custom' } | null;
+
 type LibraryPageContentProps = {
   /** When set, the page was rendered from a board route and this board is pre-selected. */
   boardSlug?: string;
@@ -282,7 +284,6 @@ export default function LibraryPageContent({
 
   // Pending action to fire once the currently-closing drawer finishes its
   // slide-out, so two drawers are never mounted-and-animating at once.
-  type PendingDrawerAction = { type: 'create'; context: SelectedBoardForCreate } | { type: 'custom' } | null;
   const [pendingDrawer, setPendingDrawer] = useState<PendingDrawerAction>(null);
 
   const openCreateDrawerFor = useCallback((boardType: string, layoutId: number) => {
@@ -518,10 +519,9 @@ export default function LibraryPageContent({
           aria-label={t('library.createFab.ariaLabel')}
           sx={{
             position: 'fixed',
-            // On wide viewports the page container is centred at max-width 800px
-            // (see library.module.css .pageContainer). Anchor the FAB to the right
-            // edge of that column so it doesn't drift to the browser edge.
-            right: `max(${themeTokens.spacing[4]}px, calc((100vw - 800px) / 2 + ${themeTokens.spacing[4]}px))`,
+            // Anchor the FAB to the right edge of .pageContainer (see --library-page-max-width
+            // in library.module.css) so it doesn't drift to the browser edge on wide viewports.
+            right: `max(${themeTokens.spacing[4]}px, calc((100vw - var(--library-page-max-width)) / 2 + ${themeTokens.spacing[4]}px))`,
             // --bottom-bar-height is set by persistent-session-wrapper after hydration with the
             // measured queue-control + tab-bar height; the 145px fallback matches the SSR estimate
             // declared in app/components/index.css and is what users see during first paint only.

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -28,7 +28,7 @@
     "createFab": {
       "ariaLabel": "Create playlist"
     },
-    "customUnavailable": "Custom boards aren't available here yet. Pick one of your boards or a popular config from the list.",
+    "customUnavailable": "Pick one of your boards or a popular config to get started.",
     "errors": {
       "loadTitle": "Unable to Load Library",
       "loadDescription": "There was an error loading your library. Please try again.",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **FAB positioning**: Replace hardcoded `800px` in the library page FAB's `right` offset with a `--library-page-max-width` CSS variable defined on `:root` in `library.module.css`. The `.pageContainer` now also uses the variable, so both share one source of truth and can't silently diverge if the container width changes.
- **Type scope**: Hoist `PendingDrawerAction` type alias from inside the component body to module scope alongside `SelectedBoardForCreate`.
- **Copy**: Rewrite `customUnavailable` i18n copy to lead with what the user can do ("Pick one of your boards or a popular config to get started.") rather than exposing an implementation detail ("aren't available here yet").
- **Tests**: Add two focused tests for the `handleCreateTab → board-selector → /create` flow — one asserting the create URL is used (not the list URL the board selector returns), and one asserting nothing happens when both `createClimbUrl` and `boardConfigs` are absent.

## Test plan

- [ ] Visit the library/playlists page on a wide viewport and confirm the FAB stays anchored to the right edge of the 800px column (not drifting to the browser edge)
- [ ] Confirm no visual regressions on the library page at narrow (mobile) and wide (desktop) widths
- [ ] On the bottom tab bar, click Create with no board context — confirm the board selector drawer opens and selecting a board navigates to `/create`
- [ ] Click Create when already on a board route — confirm it navigates directly to the create URL without opening a drawer
- [ ] Confirm the snackbar shown when custom boards are unavailable reads the new copy

https://claude.ai/code/session_01UUJEFytrhBskqjBgbNi8EP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUJEFytrhBskqjBgbNi8EP)_