### PR TITLE
Aurora shared-sync piggyback + denormalized-column backfill fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,6 @@ curl -fsSL https://vite.plus | bash
 # .env.local contains generic config (tracked in git)
 # .env.development.local contains secrets (NOT tracked in git)
 
-# For shared sync to work, add Aurora API tokens to packages/web/.env.development.local:
-KILTER_SYNC_TOKEN=your_kilter_token_here
-TENSION_SYNC_TOKEN=your_tension_token_here
-
 # Note: VERCEL_URL is automatically set by Vercel for deployments
 # For local development, the app defaults to http://localhost:3000
 

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -294,11 +294,7 @@ export class SyncRunner {
     await this.maybeRunSharedSync(boardType, token, cred.userId);
   }
 
-  private async maybeRunSharedSync(
-    boardType: AuroraBoardName,
-    token: string,
-    userId: string,
-  ): Promise<void> {
+  private async maybeRunSharedSync(boardType: AuroraBoardName, token: string, userId: string): Promise<void> {
     const cooldownMs = this.getSharedSyncCooldownMs();
     const lastRunAt = this.lastSharedSyncAt.get(boardType);
     const now = Date.now();

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { notifications, setterFollows, userBoardMappings, userFollows } from '@boardsesh/db/schema';
 import type { SyncData } from '../api/sync-api-types';
 import type { SyncOptions } from '../api/types';
 
@@ -31,7 +32,7 @@ vi.mock('drizzle-orm/postgres-js', async () => {
   };
 });
 
-import { syncSharedData } from './shared-sync';
+import { createSetterSyncNotifications, syncSharedData } from './shared-sync';
 
 /**
  * Minimal db shim. Drizzle's query builder is fluent — every call returns
@@ -92,9 +93,15 @@ describe('syncSharedData loop', () => {
 
   it('keeps looping while _complete is false', async () => {
     mockSharedSync
-      .mockResolvedValueOnce(partial({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-01-01 00:00:00' }] }))
-      .mockResolvedValueOnce(partial({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-02-01 00:00:00' }] }))
-      .mockResolvedValueOnce(complete({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-03-01 00:00:00' }] }));
+      .mockResolvedValueOnce(
+        partial({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-01-01 00:00:00' }] }),
+      )
+      .mockResolvedValueOnce(
+        partial({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-02-01 00:00:00' }] }),
+      )
+      .mockResolvedValueOnce(
+        complete({ shared_syncs: [{ table_name: 'climbs', last_synchronized_at: '2026-03-01 00:00:00' }] }),
+      );
 
     await syncSharedData(fakePostgresClient(), 'decoy', 'token');
 
@@ -136,9 +143,7 @@ describe('syncSharedData cursor merge', () => {
     // tables, with `climbs` advanced to 2026-04-01 and the rest at the
     // default floor (2024-05-01) since the in-memory map was seeded empty.
     const secondCallOptions = mockSharedSync.mock.calls[1][1] as SyncOptions;
-    const cursors = new Map(
-      (secondCallOptions.sharedSyncs ?? []).map((s) => [s.table_name, s.last_synchronized_at]),
-    );
+    const cursors = new Map((secondCallOptions.sharedSyncs ?? []).map((s) => [s.table_name, s.last_synchronized_at]));
     expect(cursors.get('climbs')).toBe('2026-04-01 00:00:00');
     expect(cursors.get('products')).toBe('2024-05-01 00:00:00.000000');
     expect(cursors.get('holes')).toBe('2024-05-01 00:00:00.000000');
@@ -196,3 +201,118 @@ describe('syncSharedData cursor merge', () => {
 function fakePostgresClient(): never {
   return {} as never;
 }
+
+type FollowerRow = { followerId: string; setterUsername: string };
+type MappingRow = { userId: string; boardUsername: string };
+type UserFollowRow = { followerId: string; followingId: string };
+type CapturedInsert = { table: unknown; rows: Array<Record<string, unknown>> };
+
+/**
+ * DB shim tailored to `createSetterSyncNotifications`. Returns seeded rows
+ * for the three SELECT call shapes the function makes (setterFollows,
+ * userBoardMappings, userFollows) and captures every insert chunk so tests
+ * can assert on chunking and per-row payloads.
+ */
+function createNotificationDbShim(opts: {
+  setterFollowsRows?: FollowerRow[];
+  userBoardMappingsRows?: MappingRow[];
+  userFollowsRows?: UserFollowRow[];
+}) {
+  const inserts: CapturedInsert[] = [];
+  const followerSeed = opts.setterFollowsRows ?? [];
+  const mappingSeed = opts.userBoardMappingsRows ?? [];
+  const userFollowSeed = opts.userFollowsRows ?? [];
+
+  const db = {
+    select(_cols: unknown) {
+      return {
+        from(table: unknown) {
+          let rows: unknown[];
+          if (table === setterFollows) rows = followerSeed;
+          else if (table === userBoardMappings) rows = mappingSeed;
+          else if (table === userFollows) rows = userFollowSeed;
+          else rows = [];
+
+          // Drizzle's chain is `.from(table).where(cond)` (awaited at the end).
+          // `createSetterSyncNotifications` always calls `.where()`, so we
+          // don't need to make `.from()` itself thenable.
+          return {
+            where: (_cond: unknown) => Promise.resolve(rows),
+          };
+        },
+      };
+    },
+    insert(table: unknown) {
+      return {
+        values: async (rows: Array<Record<string, unknown>>) => {
+          inserts.push({ table, rows });
+        },
+      };
+    },
+  };
+
+  type DbArg = Parameters<typeof createSetterSyncNotifications>[0];
+  return { db: db as unknown as DbArg, inserts };
+}
+
+describe('createSetterSyncNotifications', () => {
+  it('chunks notification inserts when followers exceed BATCH_SIZE', async () => {
+    const followers: FollowerRow[] = Array.from({ length: 2500 }, (_, i) => ({
+      followerId: `user-${i}`,
+      setterUsername: 'setter-a',
+    }));
+    const { db, inserts } = createNotificationDbShim({ setterFollowsRows: followers });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [{ uuid: 'climb-1', setterUsername: 'setter-a', layoutId: 1 }],
+      () => {},
+    );
+
+    const notificationInserts = inserts.filter((i) => i.table === notifications);
+    expect(notificationInserts).toHaveLength(3);
+    expect(notificationInserts.map((i) => i.rows.length)).toEqual([1000, 1000, 500]);
+
+    const allRows = notificationInserts.flatMap((i) => i.rows);
+    expect(allRows).toHaveLength(2500);
+    const uuids = new Set(allRows.map((row) => row.uuid));
+    expect(uuids.size).toBe(2500);
+  });
+
+  it('uses the first climb uuid as entityId when a setter has multiple new climbs', async () => {
+    const followers: FollowerRow[] = Array.from({ length: 50 }, (_, i) => ({
+      followerId: `user-${i}`,
+      setterUsername: 'setter-a',
+    }));
+    const { db, inserts } = createNotificationDbShim({ setterFollowsRows: followers });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [
+        { uuid: 'c1', setterUsername: 'setter-a', layoutId: 1 },
+        { uuid: 'c2', setterUsername: 'setter-a', layoutId: 1 },
+        { uuid: 'c3', setterUsername: 'setter-a', layoutId: 1 },
+      ],
+      () => {},
+    );
+
+    const allRows = inserts.filter((i) => i.table === notifications).flatMap((i) => i.rows);
+    expect(allRows).toHaveLength(50);
+    expect(allRows.every((row) => row.entityId === 'c1')).toBe(true);
+  });
+
+  it('skips setters with zero followers', async () => {
+    const { db, inserts } = createNotificationDbShim({ setterFollowsRows: [] });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [{ uuid: 'climb-1', setterUsername: 'setter-a', layoutId: 1 }],
+      () => {},
+    );
+
+    expect(inserts.filter((i) => i.table === notifications)).toHaveLength(0);
+  });
+});

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -408,12 +408,7 @@ async function upsertAttempts(db: DrizzleDb, board: AuroraBoardName, data: Attem
   });
 }
 
-async function upsertClimbStats(
-  db: DrizzleDb,
-  board: AuroraBoardName,
-  data: ClimbStats[],
-  writeHistory: boolean,
-) {
+async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: ClimbStats[], writeHistory: boolean) {
   const climbStatsSchema = UNIFIED_TABLES.climbStats;
   const climbStatHistorySchema = UNIFIED_TABLES.climbStatsHistory;
 
@@ -462,12 +457,7 @@ async function isClimbStatsHistorySnapshotDue(db: DrizzleDb, board: AuroraBoardN
   const rows = await db
     .select({ lastSynchronizedAt: sharedSyncsSchema.lastSynchronizedAt })
     .from(sharedSyncsSchema)
-    .where(
-      and(
-        eq(sharedSyncsSchema.boardType, board),
-        eq(sharedSyncsSchema.tableName, HISTORY_CURSOR_TABLE_NAME),
-      ),
-    );
+    .where(and(eq(sharedSyncsSchema.boardType, board), eq(sharedSyncsSchema.tableName, HISTORY_CURSOR_TABLE_NAME)));
   if (rows.length === 0) return true;
 
   const raw = rows[0].lastSynchronizedAt;
@@ -884,7 +874,7 @@ export async function syncSharedData(
  * Create batched notifications for setter followers when new climbs are synced.
  * Mirrors the behavior previously in the web shared-sync route.
  */
-async function createSetterSyncNotifications(
+export async function createSetterSyncNotifications(
   db: DrizzleDb,
   boardName: AuroraBoardName,
   newClimbs: NewClimbInfo[],

--- a/packages/db/scripts/backfill-required-set-ids.ts
+++ b/packages/db/scripts/backfill-required-set-ids.ts
@@ -1,12 +1,17 @@
 /**
- * Backfill NULL required_set_ids and compatible_size_ids on board_climbs.
+ * Backfill required_set_ids and compatible_size_ids on board_climbs.
  *
- * Finds all climbs where either denormalized column is NULL, then calls
- * populateDenormalizedColumns() in batches. Safe to re-run — only touches
- * rows that still have NULL values.
+ * Default mode finds climbs where either denormalized column is NULL and
+ * populates them in batches. With --all, recomputes both columns for every
+ * climb of the targeted board(s) regardless of NULL state — useful after
+ * Aurora introduces a new layout / product size, since existing climbs'
+ * compatible_size_ids arrays won't include the new IDs until recomputed.
+ *
+ * Both modes call populateDenormalizedColumns() in batches and are safe to
+ * re-run (idempotent).
  *
  * Usage:
- *   bun run packages/db/scripts/backfill-required-set-ids.ts [--board kilter] [--batch-size 500] [--dry-run]
+ *   bun run packages/db/scripts/backfill-required-set-ids.ts [--board kilter] [--batch-size 500] [--all] [--dry-run]
  */
 
 import { sql } from 'drizzle-orm';
@@ -18,31 +23,42 @@ const args = process.argv.slice(2);
 const boardFilter = args.includes('--board') ? args[args.indexOf('--board') + 1] : undefined;
 const batchSize = args.includes('--batch-size') ? Number(args[args.indexOf('--batch-size') + 1]) : 500;
 const dryRun = args.includes('--dry-run');
+const all = args.includes('--all');
 
 async function main() {
   const { db, close } = createScriptDb();
 
   try {
-    // Find board types that have NULL denormalized columns
-    const boardTypes = await executeRows<{ board_type: string; null_count: string }>(db, sql`
-      SELECT board_type, COUNT(*) as null_count
+    // Discover boards eligible for backfill. In --all mode this counts every
+    // climb (sans NULL filter) so progress reporting reflects the full pass.
+    const nullPredicate = all ? sql`` : sql`(required_set_ids IS NULL OR compatible_size_ids IS NULL) AND`;
+    const heading = all ? 'Eligible climbs (full recompute):' : 'Climbs with NULL denormalized columns:';
+    const emptyMessage = all
+      ? 'No eligible climbs found. Nothing to do.'
+      : 'No climbs with NULL denormalized columns found. Nothing to do.';
+
+    const boardTypes = await executeRows<{ board_type: string; eligible_count: string }>(
+      db,
+      sql`
+      SELECT board_type, COUNT(*) as eligible_count
       FROM board_climbs
-      WHERE (required_set_ids IS NULL OR compatible_size_ids IS NULL)
-        AND frames IS NOT NULL
+      WHERE ${nullPredicate}
+        frames IS NOT NULL
         AND frames != ''
         AND board_type != 'moonboard'
       GROUP BY board_type
       ORDER BY board_type
-    `);
+    `,
+    );
 
     if (boardTypes.length === 0) {
-      console.info('No climbs with NULL denormalized columns found. Nothing to do.');
+      console.info(emptyMessage);
       return;
     }
 
-    console.info('Climbs with NULL denormalized columns:');
+    console.info(heading);
     for (const bt of boardTypes) {
-      console.info(`  ${bt.board_type}: ${Number(bt.null_count).toLocaleString()}`);
+      console.info(`  ${bt.board_type}: ${Number(bt.eligible_count).toLocaleString()}`);
     }
     console.info('');
 
@@ -54,39 +70,89 @@ async function main() {
     for (const bt of boardTypes) {
       if (boardFilter && bt.board_type !== boardFilter) continue;
 
-      const totalNull = Number(bt.null_count);
+      const totalEligible = Number(bt.eligible_count);
       let processed = 0;
 
-      console.info(`\nBackfilling ${bt.board_type} (${totalNull.toLocaleString()} climbs)...`);
+      console.info(`\nBackfilling ${bt.board_type} (${totalEligible.toLocaleString()} climbs)...`);
 
-      while (true) {
-        // Fetch a batch of UUIDs with NULL denormalized columns
-        const batchRows = await executeRows<{ uuid: string }>(db, sql`
-          SELECT uuid
-          FROM board_climbs
-          WHERE board_type = ${bt.board_type}
-            AND (required_set_ids IS NULL OR compatible_size_ids IS NULL)
-            AND frames IS NOT NULL
-            AND frames != ''
-          LIMIT ${batchSize}
-        `);
+      if (all) {
+        // Keyset pagination by uuid — there's no shrinking predicate to
+        // exclude already-processed rows, so iterate through the whole table
+        // in stable order and advance the cursor each batch.
+        let cursor = '';
+        while (true) {
+          const batchRows = await executeRows<{ uuid: string }>(
+            db,
+            sql`
+            SELECT uuid
+            FROM board_climbs
+            WHERE board_type = ${bt.board_type}
+              AND uuid > ${cursor}
+              AND frames IS NOT NULL
+              AND frames != ''
+            ORDER BY uuid
+            LIMIT ${batchSize}
+          `,
+          );
 
-        const uuids = batchRows.map((r) => r.uuid);
-        if (uuids.length === 0) break;
+          const uuids = batchRows.map((r) => r.uuid);
+          if (uuids.length === 0) break;
 
-        await populateDenormalizedColumns(db, bt.board_type, uuids);
-        processed += uuids.length;
+          await populateDenormalizedColumns(db, bt.board_type, uuids);
+          processed += uuids.length;
+          cursor = uuids[uuids.length - 1];
 
-        const pct = totalNull > 0 ? ((processed / totalNull) * 100).toFixed(1) : '100';
-        console.info(`  ${processed.toLocaleString()} / ${totalNull.toLocaleString()} (${pct}%)`);
+          const pct = totalEligible > 0 ? ((processed / totalEligible) * 100).toFixed(1) : '100';
+          console.info(`  ${processed.toLocaleString()} / ${totalEligible.toLocaleString()} (${pct}%)`);
+
+          if (uuids.length < batchSize) break;
+        }
+      } else {
+        while (true) {
+          // Fetch a batch of UUIDs with NULL denormalized columns. The NULL
+          // predicate doubles as the termination condition — once
+          // populateDenormalizedColumns flips the columns NOT NULL, those
+          // rows drop out of the result set.
+          const batchRows = await executeRows<{ uuid: string }>(
+            db,
+            sql`
+            SELECT uuid
+            FROM board_climbs
+            WHERE board_type = ${bt.board_type}
+              AND (required_set_ids IS NULL OR compatible_size_ids IS NULL)
+              AND frames IS NOT NULL
+              AND frames != ''
+            LIMIT ${batchSize}
+          `,
+          );
+
+          const uuids = batchRows.map((r) => r.uuid);
+          if (uuids.length === 0) break;
+
+          await populateDenormalizedColumns(db, bt.board_type, uuids);
+          processed += uuids.length;
+
+          const pct = totalEligible > 0 ? ((processed / totalEligible) * 100).toFixed(1) : '100';
+          console.info(`  ${processed.toLocaleString()} / ${totalEligible.toLocaleString()} (${pct}%)`);
+        }
       }
 
       console.info(`  Done — ${processed.toLocaleString()} climbs updated.`);
     }
 
-    // Verify
+    if (all) {
+      // The NULL-count verification is meaningless after --all: by definition
+      // every eligible climb just had its columns recomputed from current
+      // dependency state, so any remaining NULLs are the rows
+      // populateDenormalizedColumns chose not to update (e.g. climbs with
+      // unparseable frames). The per-board "Done" lines above are the summary.
+      return;
+    }
+
     console.info('\nVerification:');
-    const remaining = await executeRows<{ board_type: string; remaining: string }>(db, sql`
+    const remaining = await executeRows<{ board_type: string; remaining: string }>(
+      db,
+      sql`
       SELECT board_type, COUNT(*) as remaining
       FROM board_climbs
       WHERE (required_set_ids IS NULL OR compatible_size_ids IS NULL)
@@ -95,7 +161,8 @@ async function main() {
         AND board_type != 'moonboard'
       GROUP BY board_type
       ORDER BY board_type
-    `);
+    `,
+    );
 
     if (remaining.length === 0) {
       console.info('  All denormalized columns populated.');


### PR DESCRIPTION
## Summary

Moves the shared-sync from the Vercel cron into the per-user Aurora daemon (the bulk of this branch), plus two follow-ups from review and a related fix to the denormalized-column backfill script.

### Per-user shared-sync piggyback (existing commits)

- Drop the Vercel `/api/internal/shared-sync/<board>` cron and per-board sync tokens; the daemon reuses each user's just-refreshed Aurora token.
- Per-board cooldown to avoid duplicate work when many users sync within the same window.
- Chunk shared-sync upserts (1000 rows/statement) and merge cursors across batches so a multi-batch run doesn't reset progress.
- Floor missing cursors at 2024-05-01 (not 1970) so a fresh DB doesn't ask Aurora for ancient history.
- Weekly `board_climb_stats_history` snapshot cursor and chunked setter-follower notifications.

### Review follow-ups (`a7254a3ba`)

- Drop the stale `KILTER_SYNC_TOKEN` / `TENSION_SYNC_TOKEN` setup block from CLAUDE.md.
- Export `createSetterSyncNotifications` and add three tests covering the chunked-insert path the existing suite couldn't reach: 2500-follower chunking with unique UUIDs, first-climb `entityId` across multiple new climbs, and zero-followers no-op.
- Cosmetic reformat from `vp check --fix`.

Cooldown-on-failure follow-up tracked separately as #1976 (transient Aurora 5xx currently locks out the per-board sync for the full hour).

### Denormalized-column backfill (`1679994fd`)

Adds an `--all` flag to `packages/db/scripts/backfill-required-set-ids.ts` that recomputes `required_set_ids` and `compatible_size_ids` for every eligible climb, not just rows where the columns are NULL. Needed after Aurora ships a new layout / product size: existing climbs the shared sync didn't re-touch keep stale `compatible_size_ids` arrays that don't include the new IDs until forced to recompute. With `--all`, iteration switches to keyset pagination by `uuid` and the trailing NULL-count verification is skipped. Default behaviour is unchanged.

Specifically motivated by the new 2026 Tension layout — pre-2024 Tension climbs Aurora considers untouched still have `compatible_size_ids` arrays from before the new product sizes existed.

## Test plan

- [ ] `vp test --project aurora-sync` — all 25 tests pass (was 22)
- [ ] `vp run typecheck` — clean
- [ ] `vp check` — clean for files in this PR
- [ ] Backfill script smoke test: `bun packages/db/scripts/backfill-required-set-ids.ts --board tension --all --dry-run` reports the expected total climb count without writing
- [ ] Backfill script default mode unchanged: `bun packages/db/scripts/backfill-required-set-ids.ts --dry-run` only counts NULL-column rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)