### PR TITLE
Move queue button into the session mini bar

### DIFF
--- a/packages/web/app/components/global-header/__tests__/global-header.test.tsx
+++ b/packages/web/app/components/global-header/__tests__/global-header.test.tsx
@@ -48,36 +48,6 @@ vi.mock('@/app/components/search-drawer/search-drawer-bridge-context', () => ({
   useSearchDrawerBridge: () => mockBridgeState,
 }));
 
-let mockQueueList: { queue: Array<{ uuid: string }>; suggestedClimbs: unknown[] } = {
-  queue: [],
-  suggestedClimbs: [],
-};
-vi.mock('@/app/components/graphql-queue', () => ({
-  useQueueList: () => mockQueueList,
-}));
-
-let mockQueueBridgeBoardInfo: {
-  boardDetails: { board_name: string } | null;
-  angle: number;
-  hasActiveQueue: boolean;
-  isHydrated: boolean;
-} = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: false };
-vi.mock('@/app/components/queue-control/queue-bridge-board-info-context', () => ({
-  useQueueBridgeBoardInfo: () => mockQueueBridgeBoardInfo,
-}));
-
-// `next/dynamic` is used at module top to lazy-load QueueDrawer; intercept it
-// so the loader returns the mock synchronously (otherwise the lazy boundary
-// never resolves under the test renderer). vi.hoisted lets the vi.mock factory
-// reference the component despite mock-call hoisting.
-const { mockQueueDrawer } = vi.hoisted(() => ({
-  mockQueueDrawer: ({ open }: { open: boolean }) =>
-    open ? React.createElement('div', { 'data-testid': 'queue-drawer' }) : null,
-}));
-vi.mock('next/dynamic', () => ({
-  default: () => mockQueueDrawer,
-}));
-
 vi.mock('@/app/components/search-drawer/unified-search-drawer', () => ({
   default: ({ open, defaultCategory }: { open: boolean; onClose: () => void; defaultCategory: string }) =>
     open ? <div data-testid="unified-search-drawer" data-category={defaultCategory} /> : null,
@@ -191,8 +161,6 @@ describe('GlobalHeader', () => {
       setNameFilter: null,
       hasActiveNonNameFilters: false,
     };
-    mockQueueList = { queue: [], suggestedClimbs: [] };
-    mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: false };
   });
 
   it('renders user drawer and search input', () => {
@@ -376,16 +344,13 @@ describe('GlobalHeader', () => {
     expect(screen.getByPlaceholderText('Search climbs...')).toBeTruthy();
   });
 
-  it('renders filter and queue buttons on board list routes pre-hydration (disabled)', () => {
+  it('renders the filter button disabled on board list routes pre-hydration', () => {
     mockPathname = '/b/test-board/40/list';
-    // Bridge not yet registered, queue not hydrated — both buttons render
-    // but should be disabled so taps don't silently no-op.
     render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
     const filterButton = screen.getByLabelText('Open filters') as HTMLButtonElement;
-    const queueButton = screen.getByLabelText('Open queue') as HTMLButtonElement;
     expect(filterButton.disabled).toBe(true);
-    expect(queueButton.disabled).toBe(true);
+    expect(screen.queryByLabelText('Open queue')).toBeNull();
   });
 
   it('shows generic placeholder on non-list routes when the bridge is inactive', () => {
@@ -589,92 +554,6 @@ describe('GlobalHeader', () => {
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
       expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Queue button (climb list page)
-  // -----------------------------------------------------------------------
-  describe('queue button on climb list page', () => {
-    const listPathname = '/b/test-board/40/list';
-
-    beforeEach(() => {
-      mockPathname = listPathname;
-    });
-
-    it('does not render on non-list routes', () => {
-      mockPathname = '/you';
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      expect(screen.queryByLabelText('Open queue')).toBeNull();
-    });
-
-    it('renders disabled when the queue bridge has not hydrated', () => {
-      mockQueueBridgeBoardInfo = {
-        boardDetails: { board_name: 'kilter' },
-        angle: 40,
-        hasActiveQueue: false,
-        isHydrated: false,
-      };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
-      expect(button.disabled).toBe(true);
-    });
-
-    it('renders disabled when boardDetails is null even after hydration', () => {
-      mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: true };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
-      expect(button.disabled).toBe(true);
-    });
-
-    it('renders enabled when hydrated and boardDetails is present', () => {
-      mockQueueBridgeBoardInfo = {
-        boardDetails: { board_name: 'kilter' },
-        angle: 40,
-        hasActiveQueue: true,
-        isHydrated: true,
-      };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      const button = screen.getByLabelText('Open queue') as HTMLButtonElement;
-      expect(button.disabled).toBe(false);
-    });
-
-    it('opens the queue drawer when the enabled button is clicked', () => {
-      mockQueueBridgeBoardInfo = {
-        boardDetails: { board_name: 'kilter' },
-        angle: 40,
-        hasActiveQueue: true,
-        isHydrated: true,
-      };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      expect(screen.queryByTestId('queue-drawer')).toBeNull();
-      fireEvent.click(screen.getByLabelText('Open queue'));
-      expect(screen.getByTestId('queue-drawer')).toBeTruthy();
-    });
-
-    it('does not open the drawer if click somehow fires while disabled', () => {
-      // boardDetails is null so the button is disabled and handleOpenQueue
-      // bails early — defensive against any path where the visual disabled
-      // state is bypassed (e.g. assistive tooling).
-      mockQueueBridgeBoardInfo = { boardDetails: null, angle: 0, hasActiveQueue: false, isHydrated: true };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      fireEvent.click(screen.getByLabelText('Open queue'));
-      expect(screen.queryByTestId('queue-drawer')).toBeNull();
-    });
-
-    it('shows the queue count badge when items are queued', () => {
-      mockQueueBridgeBoardInfo = {
-        boardDetails: { board_name: 'kilter' },
-        angle: 40,
-        hasActiveQueue: true,
-        isHydrated: true,
-      };
-      mockQueueList = {
-        queue: [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }],
-        suggestedClimbs: [],
-      };
-      render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
-      expect(screen.getByText('3')).toBeTruthy();
     });
   });
 });

--- a/packages/web/app/components/global-header/global-header.tsx
+++ b/packages/web/app/components/global-header/global-header.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useCallback, useRef } from 'react';
-import dynamic from 'next/dynamic';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
@@ -9,7 +8,6 @@ import InputAdornment from '@mui/material/InputAdornment';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import ClearOutlined from '@mui/icons-material/ClearOutlined';
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined';
-import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
 import IosShareOutlined from '@mui/icons-material/IosShare';
 import NotificationsOutlined from '@mui/icons-material/NotificationsOutlined';
@@ -33,14 +31,10 @@ import { useTranslation } from 'react-i18next';
 import { useStatsFilterBridge } from '@/app/components/stats-filter-bridge/stats-filter-bridge-context';
 import { useProfileHeaderShare } from '@/app/components/profile-header-bridge/profile-header-bridge-context';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-board-info-context';
-import { useQueueList } from '@/app/components/graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
 import styles from './global-header.module.css';
 
 const BADGE_SMALL_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
-
-const QueueDrawer = dynamic(() => import('@/app/components/play-view/queue-drawer'), { ssr: false });
 
 /** Route prefix → translation key for pages that show a simple title header instead of the default search/sesh header */
 const TITLE_HEADER_PAGES: Record<string, string> = {
@@ -168,8 +162,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   const { t } = useTranslation('common');
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchRendered, setSearchRendered] = useState(false);
-  const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [isQueueRendered, setIsQueueRendered] = useState(false);
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
 
@@ -183,8 +175,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   } = useSearchDrawerBridge();
   const statsFilterBridge = useStatsFilterBridge();
   const profileHeaderShare = useProfileHeaderShare();
-  const { boardDetails, isHydrated: isQueueBridgeHydrated } = useQueueBridgeBoardInfo();
-  const { queue } = useQueueList();
   const pathname = usePathnameWithoutLocale();
   const inputRef = useRef<HTMLInputElement>(null);
   const profileHeaderConfig = getProfileHeaderConfig(pathname, t);
@@ -193,20 +183,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
   // MUI Modal/Portal/FocusTrap infrastructure on every parent re-render.
   const handleSearchTransitionEnd = useCallback((open: boolean) => {
     if (!open) setSearchRendered(false);
-  }, []);
-
-  const handleOpenQueue = useCallback(() => {
-    if (!boardDetails) return;
-    setIsQueueRendered(true);
-    setIsQueueOpen(true);
-  }, [boardDetails]);
-
-  const handleCloseQueue = useCallback(() => {
-    setIsQueueOpen(false);
-  }, []);
-
-  const handleQueueTransitionEnd = useCallback((open: boolean) => {
-    if (!open) setIsQueueRendered(false);
   }, []);
 
   const handleShareOwnProfile = useCallback(() => {
@@ -463,27 +439,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
             {nonNameFiltersActive && <span className={styles.filterActiveIndicator} />}
           </div>
         )}
-
-        {isClimbListPage && (
-          <div className={styles.iconButtonWrapper}>
-            <IconButton
-              onClick={handleOpenQueue}
-              aria-label={t('ariaLabels.openQueue')}
-              size="small"
-              disabled={!isQueueBridgeHydrated || !boardDetails}
-            >
-              <Badge
-                badgeContent={queue.length}
-                max={99}
-                color="primary"
-                invisible={queue.length === 0}
-                sx={BADGE_SMALL_SX}
-              >
-                <FormatListBulletedOutlined />
-              </Badge>
-            </IconButton>
-          </div>
-        )}
       </header>
 
       {searchRendered && (
@@ -492,15 +447,6 @@ export default function GlobalHeader({ boardConfigs }: GlobalHeaderProps) {
           onClose={() => setSearchOpen(false)}
           onTransitionEnd={handleSearchTransitionEnd}
           defaultCategory={isOnBoardRoute ? 'climbs' : 'boards'}
-        />
-      )}
-
-      {isQueueRendered && boardDetails && (
-        <QueueDrawer
-          open={isQueueOpen}
-          onClose={handleCloseQueue}
-          onTransitionEnd={handleQueueTransitionEnd}
-          boardDetails={boardDetails}
         />
       )}
     </>

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -194,6 +194,15 @@
   flex-shrink: 0;
 }
 
+/* Queue icon — clickable area for opening the queue drawer */
+.queueIconWrapper {
+  cursor: pointer;
+  touch-action: manipulation;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
 /* Expandable participant bar — same CSS grid collapse as tick row */
 .participantBar {
   display: grid;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -15,6 +15,7 @@ import SyncOutlined from '@mui/icons-material/SyncOutlined';
 import CloudOffOutlined from '@mui/icons-material/CloudOffOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import OpenInFullOutlined from '@mui/icons-material/OpenInFullOutlined';
+import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import { track } from '@vercel/analytics';
 import { useQueueActions, useCurrentClimb, useQueueList, useSessionData } from '../graphql-queue';
 import NextClimbButton from './next-climb-button';
@@ -84,6 +85,8 @@ export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
 export { PLAY_DRAWER_EVENT, dispatchOpenPlayDrawer } from './play-drawer-event';
 
 const QUEUE_DRAWER_STYLES = { wrapper: { height: '70%' }, body: { padding: 0 } } as const;
+
+const QUEUE_BADGE_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
 
 const TICK_BADGE_SX = {
   '& .MuiBadge-badge': {
@@ -852,6 +855,32 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     offlineBannerText = 'Offline. Changes will sync when you reconnect.';
   }
 
+  const openQueueDrawer = () => setActiveDrawer('queue');
+  const queueIconButton = (
+    <div
+      className={styles.queueIconWrapper}
+      onClick={(e) => {
+        e.stopPropagation();
+        openQueueDrawer();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.stopPropagation();
+          openQueueDrawer();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={t('common:ariaLabels.openQueue')}
+    >
+      <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
+        <Badge badgeContent={queue.length} max={99} color="primary" invisible={queue.length === 0} sx={QUEUE_BADGE_SX}>
+          <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
+        </Badge>
+      </IconButton>
+    </div>
+  );
+
   return (
     <div id="onboarding-queue-bar" className={`queue-bar-shadow ${styles.queueBar}`} data-testid="queue-control-bar">
       {/* Main Control Bar */}
@@ -950,6 +979,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       )}
                     </div>
                   )}
+                  {queueIconButton}
                 </div>
               ) : (
                 <div
@@ -967,6 +997,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 >
                   <PlayCircleOutlineOutlined sx={{ fontSize: 16, opacity: 0.7 }} />
                   <span className={styles.sessionName}>{t('queueBar.startSesh')}</span>
+                  {queueIconButton}
                 </div>
               )}
               {/* Expandable participant bar — only for active sessions with participants */}


### PR DESCRIPTION
## Summary

- Adds a queue icon button (with count badge) to the session mini bar inside the queue control bar — right of the AvatarGroup. It opens the queue via the `setActiveDrawer('queue')` flow that's already wired up in `queue-control-bar.tsx`.
- Removes the duplicate queue button, `QueueDrawer` dynamic import, queue state, and queue handlers from `global-header.tsx`. The notification button still uses `Badge` / `BADGE_SMALL_SX`, so those stay.
- The new button is always visible in the session header across all three states (active session with participants, active solo, no active session), so queue access is one tap away from the persistent bottom bar regardless of route — instead of being scoped to the climb list header.
- Cleans up the now-redundant `next/dynamic` mock and queue-button tests in `global-header.test.tsx`; replaces the old "filter and queue buttons pre-hydration" assertion with a filter-only equivalent that also asserts the queue button is gone from the header.

## Notes

- Reuses the existing `t('common:ariaLabels.openQueue')` translation key — no catalog changes.
- Uses the `themeTokens.badge.small` token to match the existing badge sizing.
- `e.stopPropagation()` on the new wrapper prevents the queue tap from bubbling into the parent `.sessionHeader` onClick (which opens the sesh-settings drawer or the start-sesh drawer).

## Test plan

- [ ] `vp check` clean
- [ ] `vp run typecheck:web` clean
- [ ] `vp test --project web` passes
- [ ] On the climb list page, the global header right side shows only the filter icon and search input — no queue icon
- [ ] Queue icon visible in the queue control bar's session mini bar in all three states (active+participants → right of AvatarGroup, active solo → right of session name, no session → right of "Start Sesh")
- [ ] Tapping the queue icon opens the existing SwipeableDrawer with the queue list and scrolls to the current climb
- [ ] Tapping the queue icon does NOT open the sesh-settings drawer (active session) or the start-sesh drawer (no session)
- [ ] Badge count tracks queue length, hidden when empty, capped at 99+
- [ ] Activating tick mode collapses the session mini bar (and the queue button with it) via the existing grid transition

https://claude.ai/code/session_01W53GD8txy4bdoFa5gBMUMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01W53GD8txy4bdoFa5gBMUMN)_