### PR TITLE
Memoize queue drawer handler and add queue-button tests

### DIFF
--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
@@ -1,0 +1,410 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { dispatchOpenSeshSettingsDrawer } from '@/app/components/sesh-settings/sesh-settings-drawer-event';
+import QueueControlBar from '../queue-control-bar';
+
+// -- All mocks before imports --
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockGetPreference = vi.fn().mockResolvedValue(null);
+const mockSetPreference = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+}));
+
+let mockQueueContext: Record<string, unknown> = {};
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueContext: () => mockQueueContext,
+  useQueueData: () => mockQueueContext,
+  useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({
+    currentClimb: mockQueueContext.currentClimb,
+  }),
+  useQueueList: () => ({
+    queue: mockQueueContext.queue,
+    suggestedClimbs: [],
+  }),
+  useSessionData: () => ({
+    viewOnlyMode: mockQueueContext.viewOnlyMode ?? false,
+    isSessionActive: !!mockQueueContext.sessionId,
+    sessionId: mockQueueContext.sessionId ?? null,
+    sessionSummary: null,
+    sessionGoal: null,
+    connectionState: mockQueueContext.connectionState ?? 'idle',
+    canMutate: mockQueueContext.canMutate ?? true,
+    isDisconnected: mockQueueContext.isDisconnected ?? false,
+    users: mockQueueContext.users ?? [],
+    clientId: null,
+    isLeader: true,
+    isBackendMode: false,
+    hasConnected: true,
+    connectionError: null,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/1/1/1/40',
+  useParams: () => ({
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '1',
+    set_ids: '1',
+    angle: '40',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', props, children),
+}));
+
+vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
+  useCardSwipeNavigation: () => ({
+    swipeHandlers: {},
+    swipeOffset: 0,
+    isAnimating: false,
+    navigateToNext: vi.fn(),
+    navigateToPrev: vi.fn(),
+    peekIsNext: true,
+    exitOffset: 0,
+    enterDirection: null,
+    clearEnterAnimation: vi.fn(),
+  }),
+  EXIT_DURATION: 300,
+  SNAP_BACK_DURATION: 200,
+  ENTER_ANIMATION_DURATION: 300,
+}));
+
+vi.mock('@/app/hooks/use-color-mode', () => ({
+  useColorMode: () => ({ mode: 'light' }),
+}));
+
+vi.mock('@/app/lib/grade-colors', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getGradeTintColor: () => null,
+  };
+});
+
+vi.mock('@/app/components/climb-card/climb-thumbnail', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-thumbnail' }),
+}));
+
+vi.mock('@/app/components/climb-card/climb-title', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-title' }),
+}));
+
+vi.mock('@/app/components/queue-control/queue-list', () => ({
+  default: React.forwardRef(() => React.createElement('div', { 'data-testid': 'queue-list' })),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'queue-drawer', 'data-open': open ? 'true' : 'false' }, children),
+}));
+
+vi.mock('@/app/components/queue-control/next-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'next-climb' }),
+}));
+
+vi.mock('@/app/components/queue-control/previous-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'prev-climb' }),
+}));
+
+vi.mock('@/app/components/logbook/tick-button', () => ({
+  TickButton: (props: { onActivateTickBar?: () => void; tickBarActive?: boolean }) =>
+    React.createElement('button', {
+      'data-testid': 'tick-button',
+      onClick: props.onActivateTickBar,
+      'data-tick-active': props.tickBarActive,
+    }),
+}));
+
+vi.mock('@/app/components/board-page/share-button', () => ({
+  ShareBoardButton: () => null,
+}));
+
+vi.mock('@/app/components/play-view/play-view-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/onboarding/onboarding-tour-events', () => ({
+  TOUR_CLOSE_PLAY_VIEW_EVENT: 'onboarding:close-play-view',
+}));
+
+vi.mock('@/app/components/ui/confirm-popover', () => ({
+  ConfirmPopover: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+let mockPersistentSessionState: Record<string, unknown> = {
+  activeSession: null,
+  localBoardDetails: null,
+  localCurrentClimbQueueItem: null,
+  session: null,
+  users: [],
+};
+vi.mock('@/app/components/persistent-session/persistent-session-context', () => ({
+  usePersistentSessionState: () => mockPersistentSessionState,
+}));
+
+vi.mock('@/app/components/board-bluetooth-control/bluetooth-context', () => ({
+  useBluetoothContext: () => ({
+    isConnected: false,
+    isConnecting: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    sendLedUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ logbook: [] }),
+}));
+
+vi.mock('@/app/components/logbook/quick-tick-bar', () => ({
+  QuickTickBar: React.forwardRef((_props: unknown, _ref: unknown) =>
+    React.createElement('div', { 'data-testid': 'quick-tick-bar' }),
+  ),
+}));
+
+vi.mock('@/app/hooks/use-tick-save', () => ({
+  hasPriorHistoryForClimb: () => false,
+}));
+
+vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/sesh-settings/sesh-settings-drawer-event', () => ({
+  dispatchOpenSeshSettingsDrawer: vi.fn(),
+}));
+
+vi.mock('@/app/lib/session-utils', () => ({
+  generateSessionName: () => 'Test Session',
+}));
+
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: () => null,
+}));
+
+vi.mock('@/app/lib/share-utils', () => ({
+  shareWithFallback: vi.fn(),
+}));
+
+// jsdom doesn't provide window.matchMedia — stub it before the component
+// accesses it (the swipe-hint effect calls matchMedia on mount).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Import after mocks
+
+const mockClimb = {
+  uuid: 'climb-1',
+  setter_username: 'setter1',
+  name: 'Test Climb',
+  description: '',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: '7',
+  quality_average: '3.5',
+  stars: 3,
+  difficulty_error: '',
+  mirrored: false,
+  benchmark_difficulty: null,
+  userAscents: 0,
+  userAttempts: 0,
+};
+
+const makeQueueItem = (uuid: string) => ({
+  uuid,
+  climb: { ...mockClimb, uuid: `climb-${uuid}` },
+  addedBy: 'user-1',
+  suggested: false,
+});
+
+const baseQueueContext = {
+  queue: [makeQueueItem('item-1')],
+  currentClimbQueueItem: makeQueueItem('item-1'),
+  currentClimb: mockClimb,
+  climbSearchResults: [],
+  suggestedClimbs: [],
+  isFetchingClimbs: false,
+  isFetchingNextPage: false,
+  hasDoneFirstFetch: true,
+  viewOnlyMode: false,
+  parsedParams: { board_name: 'kilter', layout_id: '1', size_id: '1', set_ids: ['1'], angle: '40' },
+  connectionState: 'connected',
+  sessionId: 'session-1',
+  canMutate: true,
+  isDisconnected: false,
+  users: [],
+  endSession: vi.fn(),
+  disconnect: vi.fn(),
+  addToQueue: vi.fn(),
+  removeFromQueue: vi.fn(),
+  setCurrentClimb: vi.fn(),
+  setCurrentClimbQueueItem: vi.fn(),
+  setClimbSearchParams: vi.fn(),
+  setCountSearchParams: vi.fn(),
+  mirrorClimb: vi.fn(),
+  fetchMoreClimbs: vi.fn(),
+  getNextClimbQueueItem: vi.fn().mockReturnValue(null),
+  getPreviousClimbQueueItem: vi.fn().mockReturnValue(null),
+  setQueue: vi.fn(),
+};
+
+const defaultProps = {
+  angle: '40' as unknown as number,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+};
+
+const activeSessionState = {
+  activeSession: {
+    sessionId: 'session-1',
+    sessionName: 'Test Session',
+    startedAt: new Date('2025-01-01').toISOString(),
+  },
+  localBoardDetails: null,
+  localCurrentClimbQueueItem: null,
+  session: { id: 'session-1', name: 'Test Session', startedAt: new Date('2025-01-01').toISOString() },
+  users: [],
+};
+
+describe('QueueControlBar queue button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = { ...baseQueueContext };
+    mockPersistentSessionState = {
+      activeSession: null,
+      localBoardDetails: null,
+      localCurrentClimbQueueItem: null,
+      session: null,
+      users: [],
+    };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('opens the queue drawer when clicked', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(screen.getByTestId('queue-drawer').getAttribute('data-open')).toBe('false');
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open queue'));
+    });
+
+    expect(screen.getByTestId('queue-drawer').getAttribute('data-open')).toBe('true');
+  });
+
+  it('stopPropagation prevents the parent session header from opening sesh settings', async () => {
+    mockPersistentSessionState = activeSessionState;
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open queue'));
+    });
+
+    expect(dispatchOpenSeshSettingsDrawer).not.toHaveBeenCalled();
+    // And the queue drawer did open, confirming the click landed on the button.
+    expect(screen.getByTestId('queue-drawer').getAttribute('data-open')).toBe('true');
+  });
+
+  it('badge shows the queue count when items are queued', async () => {
+    mockQueueContext = {
+      ...baseQueueContext,
+      queue: [makeQueueItem('item-1'), makeQueueItem('item-2'), makeQueueItem('item-3')],
+    };
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    const badge = screen.getByLabelText('Open queue').querySelector('.MuiBadge-badge');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toBe('3');
+  });
+
+  it('badge content is 0 (and rendered invisible) when queue is empty', async () => {
+    mockQueueContext = { ...baseQueueContext, queue: [] };
+
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    const badge = screen.getByLabelText('Open queue').querySelector('.MuiBadge-badge');
+    expect(badge).toBeTruthy();
+    // MUI renders `badgeContent={0}` literally; `invisible={true}` hides it via CSS
+    // (no public class name in v6+), so we assert on the bound count, not visibility.
+    expect(badge!.textContent).toBe('0');
+  });
+
+  it('mini bar collapses (loses sessionHeaderExpanded) when tick mode activates', async () => {
+    const { container } = render(<QueueControlBar {...defaultProps} />);
+    await act(async () => {});
+
+    const wrapper = container.querySelector('[class*="sessionHeaderWrapper"]');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper!.getAttribute('class')).toMatch(/sessionHeaderExpanded/);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('tick-button'));
+    });
+
+    expect(wrapper!.getAttribute('class')).not.toMatch(/sessionHeaderExpanded/);
+  });
+});

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -855,30 +855,39 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     offlineBannerText = 'Offline. Changes will sync when you reconnect.';
   }
 
-  const openQueueDrawer = () => setActiveDrawer('queue');
-  const queueIconButton = (
-    <div
-      className={styles.queueIconWrapper}
-      onClick={(e) => {
-        e.stopPropagation();
-        openQueueDrawer();
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
+  const openQueueDrawer = useCallback(() => setActiveDrawer('queue'), []);
+  const queueIconButton = useMemo(
+    () => (
+      <div
+        className={styles.queueIconWrapper}
+        onClick={(e) => {
           e.stopPropagation();
           openQueueDrawer();
-        }
-      }}
-      role="button"
-      tabIndex={0}
-      aria-label={t('common:ariaLabels.openQueue')}
-    >
-      <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
-        <Badge badgeContent={queue.length} max={99} color="primary" invisible={queue.length === 0} sx={QUEUE_BADGE_SX}>
-          <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
-        </Badge>
-      </IconButton>
-    </div>
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.stopPropagation();
+            openQueueDrawer();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={t('common:ariaLabels.openQueue')}
+      >
+        <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
+          <Badge
+            badgeContent={queue.length}
+            max={99}
+            color="primary"
+            invisible={queue.length === 0}
+            sx={QUEUE_BADGE_SX}
+          >
+            <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
+          </Badge>
+        </IconButton>
+      </div>
+    ),
+    [openQueueDrawer, queue.length, t],
   );
 
   return (

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -285,6 +285,43 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   const nextClimb = useMemo(() => getNextClimbQueueItem(), [getNextClimbQueueItem]);
   const previousClimb = useMemo(() => getPreviousClimbQueueItem(), [getPreviousClimbQueueItem]);
+
+  // Declared up here (above the `isReconnecting` early return below) so the
+  // hook order stays stable across renders.
+  const openQueueDrawer = useCallback(() => setActiveDrawer('queue'), []);
+  const queueIconButton = useMemo(
+    () => (
+      <div
+        className={styles.queueIconWrapper}
+        onClick={(e) => {
+          e.stopPropagation();
+          openQueueDrawer();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.stopPropagation();
+            openQueueDrawer();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={t('common:ariaLabels.openQueue')}
+      >
+        <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
+          <Badge
+            badgeContent={queue.length}
+            max={99}
+            color="primary"
+            invisible={queue.length === 0}
+            sx={QUEUE_BADGE_SX}
+          >
+            <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
+          </Badge>
+        </IconButton>
+      </div>
+    ),
+    [openQueueDrawer, queue.length, t],
+  );
   const shouldNavigate = isViewPage || isPlayPage;
 
   // Build URL for a climb item (for navigation on view/play pages)
@@ -854,41 +891,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   } else {
     offlineBannerText = 'Offline. Changes will sync when you reconnect.';
   }
-
-  const openQueueDrawer = useCallback(() => setActiveDrawer('queue'), []);
-  const queueIconButton = useMemo(
-    () => (
-      <div
-        className={styles.queueIconWrapper}
-        onClick={(e) => {
-          e.stopPropagation();
-          openQueueDrawer();
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.stopPropagation();
-            openQueueDrawer();
-          }
-        }}
-        role="button"
-        tabIndex={0}
-        aria-label={t('common:ariaLabels.openQueue')}
-      >
-        <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
-          <Badge
-            badgeContent={queue.length}
-            max={99}
-            color="primary"
-            invisible={queue.length === 0}
-            sx={QUEUE_BADGE_SX}
-          >
-            <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
-          </Badge>
-        </IconButton>
-      </div>
-    ),
-    [openQueueDrawer, queue.length, t],
-  );
 
   return (
     <div id="onboarding-queue-bar" className={`queue-bar-shadow ${styles.queueBar}`} data-testid="queue-control-bar">


### PR DESCRIPTION
## Summary

Addresses two review comments on the recent "move queue button into the session mini bar" change.

- **Memoize the handler.** `openQueueDrawer` was a plain arrow function recreated on every render (and so was the derived `queueIconButton` JSX). Wrap them in `useCallback` / `useMemo` to match the pattern every other handler in `queue-control-bar.tsx` uses (`handleCloseDrawer`, `handleThumbnailClick`, etc.).
- **Add tests for the new queue button.** The previous PR removed 6 queue-button tests from `global-header.test.tsx` but added zero replacements. New file `queue-control-bar-queue-button.test.tsx` covers: click opens the queue drawer, `stopPropagation` prevents the parent session-header click from firing, the badge reflects queue length (3 items vs. 0 items), and the mini bar collapses (`sessionHeaderExpanded` class drops) when tick mode activates.

## Test plan

- [x] `vp test --project web packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx` — 5/5 pass
- [x] `vp test --project web packages/web/app/components/queue-control/` — 207/207 pass (no regressions)
- [x] `vp test --project web packages/web/app/components/global-header/` — 37/37 pass
- [x] `vp run typecheck:web`
- [x] `vp lint` and `vp fmt --check` on the two modified files

https://claude.ai/code/session_01526bqYw3TwqSChhD9hXwnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01526bqYw3TwqSChhD9hXwnM)_