### PR TITLE
Fix #1849: marquee long climb names when active

### DIFF
--- a/packages/backend/src/events/notification-worker.ts
+++ b/packages/backend/src/events/notification-worker.ts
@@ -328,7 +328,9 @@ export class NotificationWorker {
     entityId: string,
     intervalMinutes: number,
   ): Promise<boolean> {
-    const rows = await executeRows<unknown>(db, sql`
+    const rows = await executeRows<unknown>(
+      db,
+      sql`
       SELECT 1 FROM notifications
       WHERE actor_id = ${actorId}
         AND recipient_id = ${recipientId}
@@ -336,7 +338,8 @@ export class NotificationWorker {
         AND entity_id = ${entityId}
         AND created_at > NOW() - make_interval(mins => ${intervalMinutes})
       LIMIT 1
-    `);
+    `,
+    );
     return rows.length > 0;
   }
 

--- a/packages/backend/src/graphql/resolvers/board/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board/queries.ts
@@ -30,14 +30,17 @@ export const boardQueries: Pick<QueryResolvers, 'grades' | 'angles'> = {
   angles: async (_, { boardName, layoutId }) => {
     validateInput(BoardNameSchema, boardName, 'boardName');
 
-    const result = await executeRows<{ angle: number }>(db, sql`
+    const result = await executeRows<{ angle: number }>(
+      db,
+      sql`
       SELECT DISTINCT pa.angle
       FROM board_products_angles pa
       JOIN board_layouts l
         ON l.board_type = pa.board_type AND l.product_id = pa.product_id
       WHERE l.board_type = ${boardName} AND l.id = ${layoutId}
       ORDER BY pa.angle ASC
-    `);
+    `,
+    );
 
     return result.map((r) => ({ angle: r.angle }));
   },

--- a/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
@@ -153,7 +153,9 @@ export async function findMoonBoardDuplicateMatches(
       uniqueSignatures.map((signature) => sql`${signature}`),
       sql`, `,
     );
-    const exactMatchRows = await executeRows<DuplicateLookupRow>(db, sql`
+    const exactMatchRows = await executeRows<DuplicateLookupRow>(
+      db,
+      sql`
       SELECT
         ${dbSchema.boardClimbs.uuid} AS uuid,
         ${dbSchema.boardClimbs.name} AS name,
@@ -184,7 +186,8 @@ export async function findMoonBoardDuplicateMatches(
         ',' ORDER BY ${dbSchema.boardClimbHolds.holdId}
       ) IN (${signatureValues})
       ORDER BY COALESCE(${dbSchema.boardClimbStats.ascensionistCount}, 0) DESC, ${dbSchema.boardClimbs.uuid} ASC
-    `);
+    `,
+    );
 
     for (const row of exactMatchRows) {
       const next = {
@@ -198,7 +201,9 @@ export async function findMoonBoardDuplicateMatches(
       }
     }
 
-    const legacyRows = await executeRows<LegacyDuplicateLookupRow>(db, sql`
+    const legacyRows = await executeRows<LegacyDuplicateLookupRow>(
+      db,
+      sql`
       SELECT
         ${dbSchema.boardClimbs.uuid} AS uuid,
         ${dbSchema.boardClimbs.name} AS name,
@@ -221,7 +226,8 @@ export async function findMoonBoardDuplicateMatches(
             AND legacy_holds.climb_uuid = ${dbSchema.boardClimbs.uuid}
         )
       ORDER BY COALESCE(${dbSchema.boardClimbStats.ascensionistCount}, 0) DESC, ${dbSchema.boardClimbs.uuid} ASC
-    `);
+    `,
+    );
 
     for (const row of legacyRows) {
       const signature = buildMoonBoardHoldSignatureFromFrames(row.frames);

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -146,7 +146,9 @@ export const socialCommentQueries = {
     const totalCount = Number(countResult[0]?.count || 0);
 
     // Main query — LEFT JOIN vote_counts instead of LATERAL JOIN subqueries
-    const rawRows = await executeRows<CommentRow>(db, sql`
+    const rawRows = await executeRows<CommentRow>(
+      db,
+      sql`
       SELECT
         c."id",
         c."uuid",
@@ -190,7 +192,8 @@ export const socialCommentQueries = {
       ORDER BY ${orderByClause}
       LIMIT ${limit}
       OFFSET ${offset}
-    `);
+    `,
+    );
 
     const comments = rawRows.map(mapCommentRow);
 
@@ -256,7 +259,9 @@ export const socialCommentQueries = {
 
     const distinctClause = boardTypeFilter ? sql`DISTINCT ON (c."id")` : sql``;
 
-    const rawRows = await executeRows<CommentRow>(db, sql`
+    const rawRows = await executeRows<CommentRow>(
+      db,
+      sql`
       SELECT ${distinctClause}
         c."id",
         c."uuid",
@@ -301,7 +306,8 @@ export const socialCommentQueries = {
       ORDER BY ${boardTypeFilter ? sql`c."id",` : sql``} c."created_at" DESC
       LIMIT ${limit + 1}
       OFFSET ${offset}
-    `);
+    `,
+    );
 
     const hasMore = rawRows.length > limit;
     const resultRows = hasMore ? rawRows.slice(0, limit) : rawRows;

--- a/packages/backend/src/graphql/resolvers/social/notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/notifications.ts
@@ -69,7 +69,9 @@ export const socialNotificationQueries = {
         totalCount: string;
         unreadCount: string;
       }
-    >(db, sql`
+    >(
+      db,
+      sql`
       SELECT
         n."uuid",
         n."type",
@@ -95,7 +97,8 @@ export const socialNotificationQueries = {
       ORDER BY n."created_at" DESC
       LIMIT ${limit}
       OFFSET ${offset}
-    `);
+    `,
+    );
 
     const notifications = rows.map(mapNotificationRow);
     const totalCount = rows.length > 0 ? Number(rows[0].totalCount) : 0;
@@ -135,7 +138,9 @@ export const socialNotificationQueries = {
       totalGroupCount: string;
     };
 
-    const rows = await executeRows<GroupedRow>(db, sql`
+    const rows = await executeRows<GroupedRow>(
+      db,
+      sql`
       WITH all_groups AS (
         SELECT
           n."type",
@@ -176,7 +181,8 @@ export const socialNotificationQueries = {
           LEFT JOIN "user_profiles" up ON up."user_id" = aid.id
         ) as "actorAvatarUrls"
       FROM paged p
-    `);
+    `,
+    );
 
     // Total group count from window function (same value on every row)
     const totalCount = rows.length > 0 ? Number(rows[0].totalGroupCount) : 0;

--- a/packages/backend/src/graphql/resolvers/social/proposals/grade-analysis.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/grade-analysis.ts
@@ -24,13 +24,16 @@ export async function analyzeGradeOutlier(
       angle: number;
       display_difficulty: number;
       ascensionist_count: number;
-    }>(db, sql`
+    }>(
+      db,
+      sql`
       SELECT angle, display_difficulty, ascensionist_count
       FROM board_climb_stats
       WHERE climb_uuid = ${climbUuid}
         AND board_type = ${boardType}
       ORDER BY angle
-    `);
+    `,
+    );
     if (!rows || rows.length < 2) return null;
 
     // Find the current angle's data

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -17,11 +17,14 @@ async function main() {
 
   // Check how many unassigned ticks exist
   const { count: unassignedCount = 0 } =
-    (await executeFirstRow<{ count: number }>(db, sql`
+    (await executeFirstRow<{ count: number }>(
+      db,
+      sql`
     SELECT COUNT(*) AS count
     FROM boardsesh_ticks
     WHERE session_id IS NULL AND inferred_session_id IS NULL
-  `)) ?? {};
+  `,
+    )) ?? {};
 
   console.info(`Found ${unassignedCount} unassigned ticks`);
 
@@ -50,17 +53,21 @@ async function main() {
   // Migrate orphaned votes/comments with "ug:" entity IDs
   console.info('\n=== Migrating orphaned ug: entity references ===');
 
-  const voteResult =
-    (await executeFirstRow<{ count: number }>(db, sql`
+  const voteResult = (await executeFirstRow<{ count: number }>(
+    db,
+    sql`
     SELECT COUNT(*) AS count FROM vote_counts
     WHERE entity_type = 'session' AND entity_id LIKE 'ug:%'
-  `)) ?? { count: 0 };
+  `,
+  )) ?? { count: 0 };
 
-  const commentResult =
-    (await executeFirstRow<{ count: number }>(db, sql`
+  const commentResult = (await executeFirstRow<{ count: number }>(
+    db,
+    sql`
     SELECT COUNT(*) AS count FROM comments
     WHERE entity_type = 'session' AND entity_id LIKE 'ug:%'
-  `)) ?? { count: 0 };
+  `,
+  )) ?? { count: 0 };
 
   console.info(`Found ${voteResult.count} orphaned vote_counts, ${commentResult.count} orphaned comments`);
 
@@ -72,11 +79,14 @@ async function main() {
 
   // Verify final state
   const { count: remaining = 0 } =
-    (await executeFirstRow<{ count: number }>(db, sql`
+    (await executeFirstRow<{ count: number }>(
+      db,
+      sql`
     SELECT COUNT(*) AS count
     FROM boardsesh_ticks
     WHERE session_id IS NULL AND inferred_session_id IS NULL
-  `)) ?? {};
+  `,
+    )) ?? {};
 
   console.info(`\n=== Final state: ${remaining} unassigned ticks remaining ===`);
 

--- a/packages/db/scripts/analyze-climbs.ts
+++ b/packages/db/scripts/analyze-climbs.ts
@@ -218,11 +218,14 @@ async function main() {
       name: string;
       full_name: string;
       product_id: number;
-    }>(db, sql`
+    }>(
+      db,
+      sql`
       SELECT board_type, id, name, full_name, product_id
       FROM board_placement_roles
       ORDER BY board_type, id
-    `);
+    `,
+    );
 
     let unmappedCount = 0;
     for (const role of dbRoles) {
@@ -244,19 +247,25 @@ async function main() {
     for (const board of boards) {
       console.info(`\n=== Analyzing ${board} climbs ===\n`);
 
-      const climbs = await executeRows<ClimbRow>(db, sql`
+      const climbs = await executeRows<ClimbRow>(
+        db,
+        sql`
         SELECT uuid, board_type, name, setter_username, frames, is_listed
         FROM board_climbs
         WHERE board_type = ${board}
-      `);
+      `,
+      );
 
       // Gather ascensionist counts for affected climbs
-      const statsRows = await executeRows<StatsRow>(db, sql`
+      const statsRows = await executeRows<StatsRow>(
+        db,
+        sql`
         SELECT climb_uuid, COALESCE(SUM(ascensionist_count), 0) as total_ascents
         FROM board_climb_stats
         WHERE board_type = ${board}
         GROUP BY climb_uuid
-      `);
+      `,
+      );
 
       const statsMap = new Map(statsRows.map((s) => [s.climb_uuid, Number(s.total_ascents)]));
 
@@ -321,7 +330,9 @@ async function main() {
 
     // Summary of all unknown role codes across all climbs
     console.info('\n=== Unknown role codes summary ===\n');
-    const allUnknown = await executeRows<{ board_type: string; role_code: number; climb_count: string }>(db, sql`
+    const allUnknown = await executeRows<{ board_type: string; role_code: number; climb_count: string }>(
+      db,
+      sql`
       SELECT board_type,
         (regexp_matches(frames, 'r(-?\d+)', 'g'))[1]::int as role_code,
         count(*) as climb_count
@@ -329,7 +340,8 @@ async function main() {
       WHERE frames IS NOT NULL AND frames != ''
       GROUP BY board_type, role_code
       ORDER BY board_type, role_code
-    `);
+    `,
+    );
 
     let anyUnknown = false;
     for (const row of allUnknown) {

--- a/packages/db/scripts/analyze-led-mapping.ts
+++ b/packages/db/scripts/analyze-led-mapping.ts
@@ -77,17 +77,23 @@ async function main() {
         );
 
     // Get product sizes from DB for display
-    const sizeRows = await executeRows<{ id: number; name: string }>(db, sql`
+    const sizeRows = await executeRows<{ id: number; name: string }>(
+      db,
+      sql`
       SELECT id, name FROM board_product_sizes ORDER BY board_type, id
-    `);
+    `,
+    );
     const sizeNames = new Map(sizeRows.map((s) => [s.id, s.name]));
 
     // Get set-to-layout-size mappings
-    const setRows = await executeRows<SetRow>(db, sql`
+    const setRows = await executeRows<SetRow>(
+      db,
+      sql`
       SELECT layout_id, product_size_id, set_id
       FROM board_product_sizes_layouts_sets
       ORDER BY layout_id, product_size_id, set_id
-    `);
+    `,
+    );
     const setsForConfig = new Map<string, number[]>();
     for (const row of setRows) {
       const key = `${row.layout_id}-${row.product_size_id}`;
@@ -120,7 +126,9 @@ async function main() {
         const sizeKeys = layoutSizeKeys.filter((k) => k.startsWith(`${layoutId}-`)).map((k) => Number(k.split('-')[1]));
 
         // Fetch ALL climbs for this board/layout once (reused across sizes)
-        const climbs = await executeRows<ClimbRow>(db, sql`
+        const climbs = await executeRows<ClimbRow>(
+          db,
+          sql`
           SELECT uuid, board_type, layout_id, name, setter_username, frames,
                  is_listed, required_set_ids, compatible_size_ids,
                  edge_left, edge_right, edge_bottom, edge_top
@@ -129,15 +137,19 @@ async function main() {
             AND layout_id = ${layoutId}
             AND frames IS NOT NULL
             AND frames != ''
-        `);
+        `,
+        );
 
         // Fetch ascensionist counts
-        const statsRows = await executeRows<StatsRow>(db, sql`
+        const statsRows = await executeRows<StatsRow>(
+          db,
+          sql`
           SELECT climb_uuid, COALESCE(SUM(ascensionist_count), 0) as total_ascents
           FROM board_climb_stats
           WHERE board_type = ${boardName}
           GROUP BY climb_uuid
-        `);
+        `,
+        );
         const statsMap = new Map(statsRows.map((s) => [s.climb_uuid, Number(s.total_ascents)]));
 
         for (const sizeId of sizeKeys) {

--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
@@ -30,14 +30,17 @@ type WarmTarget = {
 
 async function getAnglesForLayout(boardName: AuroraBoardName, layoutId: number): Promise<number[]> {
   // Same query used by packages/backend/src/graphql/resolvers/board/queries.ts:44-50
-  const result = await executeRows<{ angle: number }>(db, sql`
+  const result = await executeRows<{ angle: number }>(
+    db,
+    sql`
     SELECT DISTINCT pa.angle
     FROM board_products_angles pa
     JOIN board_layouts l
       ON l.board_type = pa.board_type AND l.product_id = pa.product_id
     WHERE l.board_type = ${boardName} AND l.id = ${layoutId}
     ORDER BY pa.angle ASC
-  `);
+  `,
+  );
   return result.map((row) => Number(row.angle));
 }
 

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -35,7 +35,8 @@ export async function GET(request: NextRequest) {
     const sql = getReadPool();
     const [summary, gradeRows] = await Promise.all([
       getProfileOgSummary(userId),
-      rowsFromResult<{ difficulty: number; cnt: number }>(await sql`
+      rowsFromResult<{ difficulty: number; cnt: number }>(
+        await sql`
         SELECT difficulty, COUNT(DISTINCT climb_uuid) as cnt
         FROM boardsesh_ticks
         WHERE user_id = ${userId}
@@ -43,7 +44,8 @@ export async function GET(request: NextRequest) {
           AND difficulty IS NOT NULL
         GROUP BY difficulty
         ORDER BY difficulty
-      `),
+      `,
+      ),
     ]);
     const dbMs = performance.now() - dbT0;
 

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -38,7 +38,9 @@ export async function GET(request: NextRequest) {
       executeRows<{
         difficulty: number;
         cnt: number;
-      }>(dbz, sql`
+      }>(
+        dbz,
+        sql`
         SELECT bt.difficulty, COUNT(*) as cnt
         FROM boardsesh_ticks bt
         JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
@@ -47,7 +49,8 @@ export async function GET(request: NextRequest) {
           AND bt.difficulty IS NOT NULL
         GROUP BY bt.difficulty
         ORDER BY bt.difficulty
-      `),
+      `,
+      ),
     ]);
     const dbMs = performance.now() - dbT0;
     const gradeRows = gradeResult;

--- a/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
+++ b/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
@@ -7,13 +7,15 @@ export async function GET(req: Request, props: { params: Promise<{ board_name: s
   const { /*board_name,*/ layout_id } = params;
 
   try {
-    const angles = rowsFromResult<{ angle: number }>(await sql`
+    const angles = rowsFromResult<{ angle: number }>(
+      await sql`
       SELECT angle
       FROM kilter_products_angles
       JOIN layouts ON layouts.product_id = products_angles.product_id
       WHERE layouts.id = ${layout_id}
       ORDER BY angle ASC
-    `);
+    `,
+    );
     return NextResponse.json(angles);
   } catch {
     return NextResponse.json({ error: 'Failed to fetch angles' }, { status: 500 });

--- a/packages/web/app/components/climb-card/__tests__/marquee-text.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/marquee-text.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import MarqueeText from '../marquee-text';
+
+const setElementWidth = (
+  element: HTMLElement,
+  { scrollWidth, clientWidth }: { scrollWidth: number; clientWidth: number },
+) => {
+  Object.defineProperty(element, 'scrollWidth', { configurable: true, value: scrollWidth });
+  Object.defineProperty(element, 'clientWidth', { configurable: true, value: clientWidth });
+};
+
+describe('MarqueeText', () => {
+  let resizeCallbacks: ResizeObserverCallback[] = [];
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    resizeCallbacks = [];
+    class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallbacks.push(cb);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+    vi.restoreAllMocks();
+  });
+
+  const renderMarquee = (props: { active: boolean }) => {
+    const { container } = render(
+      <MarqueeText active={props.active}>
+        <span data-testid="content">Some long climb name that overflows</span>
+      </MarqueeText>,
+    );
+    const outer = container.firstElementChild as HTMLElement;
+    const inner = outer.firstElementChild as HTMLElement;
+    return { outer, inner };
+  };
+
+  const triggerMeasurement = () => {
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
+    });
+  };
+
+  it('uses the static (ellipsis) class when text fits', () => {
+    const { outer, inner } = renderMarquee({ active: true });
+    setElementWidth(outer, { scrollWidth: 200, clientWidth: 200 });
+    setElementWidth(inner, { scrollWidth: 200, clientWidth: 200 });
+    triggerMeasurement();
+
+    expect(inner.className).toContain('innerStatic');
+    expect(inner.className).not.toContain('innerScrolling');
+    // Style vars are not set when not scrolling
+    expect(inner.style.getPropertyValue('--marquee-distance')).toBe('');
+  });
+
+  it('uses the scrolling class and sets CSS vars when active and text overflows', () => {
+    const { outer, inner } = renderMarquee({ active: true });
+    // Inner content is wider than the outer container by 80px
+    setElementWidth(outer, { clientWidth: 100, scrollWidth: 100 });
+    setElementWidth(inner, { scrollWidth: 180, clientWidth: 180 });
+    triggerMeasurement();
+
+    expect(inner.className).toContain('innerScrolling');
+    expect(inner.className).not.toContain('innerStatic');
+    expect(inner.style.getPropertyValue('--marquee-distance')).toBe('80px');
+    expect(inner.style.getPropertyValue('--marquee-duration')).not.toBe('');
+  });
+
+  it('does not animate when active is false, even if text would overflow', () => {
+    const { outer, inner } = renderMarquee({ active: false });
+    setElementWidth(outer, { clientWidth: 100, scrollWidth: 100 });
+    setElementWidth(inner, { scrollWidth: 180, clientWidth: 180 });
+    // The component should not have registered an observer at all when inactive.
+    expect(resizeCallbacks).toHaveLength(0);
+
+    expect(inner.className).toContain('innerStatic');
+    expect(inner.className).not.toContain('innerScrolling');
+    expect(inner.style.getPropertyValue('--marquee-distance')).toBe('');
+  });
+
+  it('falls back to static when overflow becomes zero on a later measurement', () => {
+    const { outer, inner } = renderMarquee({ active: true });
+
+    // First measurement: overflow > 0 → scrolling.
+    setElementWidth(outer, { clientWidth: 100, scrollWidth: 100 });
+    setElementWidth(inner, { scrollWidth: 180, clientWidth: 180 });
+    triggerMeasurement();
+    expect(inner.className).toContain('innerScrolling');
+
+    // Second measurement: container grew to fit → static.
+    setElementWidth(outer, { clientWidth: 200, scrollWidth: 200 });
+    setElementWidth(inner, { scrollWidth: 180, clientWidth: 180 });
+    triggerMeasurement();
+    expect(inner.className).toContain('innerStatic');
+    expect(inner.className).not.toContain('innerScrolling');
+  });
+});

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -625,7 +625,7 @@ const ClimbListItem: React.FC<ClimbListItemProps> = React.memo(
 
             {/* Center: Name, stars, setter, colorized grade */}
             <div style={centerStyle}>
-              <ClimbTitle climb={climb} {...resolvedTitleProps} />
+              <ClimbTitle climb={climb} {...resolvedTitleProps} isActive={selected} />
               {centerBottomSlot}
             </div>
 

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
 import ClimbIcons from './climb-icons';
+import MarqueeText from './marquee-text';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { formatSends, formatQuality } from '@/app/lib/format-climb-stats';
@@ -54,6 +55,9 @@ export type ClimbTitleProps = {
   /** When provided, replaces the computed subtitle in `gradePosition='right'` mode.
    *  Used by logbook items to show ascent-specific info (time ago, status, etc.). */
   subtitleOverride?: React.ReactNode;
+  /** When true, the climb name marquees if it overflows. Used for the "active" climb
+   *  (selected list item, current queue climb, drawer/detail header). */
+  isActive?: boolean;
 };
 
 // --- Static sx objects hoisted to module scope (no reactive deps) ---
@@ -184,6 +188,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     favorited = false,
     isNoMatch = false,
     subtitleOverride,
+    isActive = false,
   }) => {
     const { t } = useTranslation('climbs');
     const isDark = useIsDarkMode();
@@ -259,10 +264,12 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     };
 
     const nameElement = (
-      <Typography variant="body2" component="span" sx={nameSx}>
-        {climb.name}
-        <ClimbIcons benchmarkDifficulty={climb.benchmark_difficulty} isNoMatch={resolvedIsNoMatch} />
-      </Typography>
+      <MarqueeText active={isActive}>
+        <Typography variant="body2" component="span" sx={nameSx}>
+          {climb.name}
+          <ClimbIcons benchmarkDifficulty={climb.benchmark_difficulty} isNoMatch={resolvedIsNoMatch} />
+        </Typography>
+      </MarqueeText>
     );
 
     const gradeElement = (
@@ -425,7 +432,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
         prev.gradePosition === next.gradePosition &&
         prev.favorited === next.favorited &&
         prev.isNoMatch === next.isNoMatch &&
-        prev.subtitleOverride === next.subtitleOverride
+        prev.subtitleOverride === next.subtitleOverride &&
+        prev.isActive === next.isActive
       );
     }
 
@@ -458,7 +466,8 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
       prev.gradePosition === next.gradePosition &&
       prev.favorited === next.favorited &&
       prev.isNoMatch === next.isNoMatch &&
-      prev.subtitleOverride === next.subtitleOverride
+      prev.subtitleOverride === next.subtitleOverride &&
+      prev.isActive === next.isActive
     );
   },
 );

--- a/packages/web/app/components/climb-card/drawer-climb-header.tsx
+++ b/packages/web/app/components/climb-card/drawer-climb-header.tsx
@@ -24,6 +24,7 @@ export default function DrawerClimbHeader({ climb, boardDetails }: DrawerClimbHe
         gradePosition="right"
         titleFontSize={themeTokens.typography.fontSize.xl}
         showSetterInfo
+        isActive
       />
     </div>
   );

--- a/packages/web/app/components/climb-card/marquee-text.module.css
+++ b/packages/web/app/components/climb-card/marquee-text.module.css
@@ -1,0 +1,48 @@
+.outer {
+  display: block;
+  overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.inner {
+  display: inline-block;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.innerStatic {
+  composes: inner;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.innerScrolling {
+  composes: inner;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .innerScrolling {
+    overflow: visible;
+    text-overflow: clip;
+    animation: marqueeScroll var(--marquee-duration, 12s) ease-in-out infinite;
+    will-change: transform;
+  }
+
+  @keyframes marqueeScroll {
+    0%,
+    12% {
+      transform: translateX(0);
+    }
+    48%,
+    60% {
+      transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
+    }
+    96%,
+    100% {
+      transform: translateX(0);
+    }
+  }
+}

--- a/packages/web/app/components/climb-card/marquee-text.tsx
+++ b/packages/web/app/components/climb-card/marquee-text.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import styles from './marquee-text.module.css';
+
+type MarqueeTextProps = {
+  /** Slow horizontal scroll when content overflows. When false, render plain ellipsis. */
+  active: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+const PIXELS_PER_SECOND = 30;
+const MIN_DURATION_S = 8;
+const MAX_DURATION_S = 24;
+const TRAILING_BUFFER_PX = 8;
+
+const useIsoLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const MarqueeText: React.FC<MarqueeTextProps> = ({ active, className, children }) => {
+  const outerRef = useRef<HTMLSpanElement | null>(null);
+  const innerRef = useRef<HTMLSpanElement | null>(null);
+  const [overflowPx, setOverflowPx] = useState(0);
+
+  useIsoLayoutEffect(() => {
+    if (!active) {
+      setOverflowPx(0);
+      return;
+    }
+    const outer = outerRef.current;
+    const inner = innerRef.current;
+    if (!outer || !inner || typeof ResizeObserver === 'undefined') return;
+
+    const measure = () => {
+      const overflow = inner.scrollWidth - outer.clientWidth;
+      setOverflowPx(overflow > 0 ? overflow : 0);
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(outer);
+    observer.observe(inner);
+    return () => observer.disconnect();
+  }, [active, children]);
+
+  const isScrolling = active && overflowPx > 0;
+  const durationS = isScrolling
+    ? Math.min(MAX_DURATION_S, Math.max(MIN_DURATION_S, overflowPx / PIXELS_PER_SECOND + 6))
+    : 0;
+
+  const innerStyle = isScrolling
+    ? ({
+        ['--marquee-distance' as string]: `${overflowPx + TRAILING_BUFFER_PX}px`,
+        ['--marquee-duration' as string]: `${durationS}s`,
+      } as React.CSSProperties)
+    : undefined;
+
+  return (
+    <span ref={outerRef} className={`${styles.outer}${className ? ` ${className}` : ''}`}>
+      <span ref={innerRef} className={isScrolling ? styles.innerScrolling : styles.innerStatic} style={innerStyle}>
+        {children}
+      </span>
+    </span>
+  );
+};
+
+export default MarqueeText;

--- a/packages/web/app/components/climb-card/marquee-text.tsx
+++ b/packages/web/app/components/climb-card/marquee-text.tsx
@@ -13,7 +13,6 @@ type MarqueeTextProps = {
 const PIXELS_PER_SECOND = 30;
 const MIN_DURATION_S = 8;
 const MAX_DURATION_S = 24;
-const TRAILING_BUFFER_PX = 8;
 
 const useIsoLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -50,7 +49,7 @@ const MarqueeText: React.FC<MarqueeTextProps> = ({ active, className, children }
 
   const innerStyle = isScrolling
     ? ({
-        ['--marquee-distance' as string]: `${overflowPx + TRAILING_BUFFER_PX}px`,
+        ['--marquee-distance' as string]: `${overflowPx}px`,
         ['--marquee-duration' as string]: `${durationS}s`,
       } as React.CSSProperties)
     : undefined;

--- a/packages/web/app/components/climb-detail/climb-detail-header.tsx
+++ b/packages/web/app/components/climb-detail/climb-detail-header.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import ClimbIcons from '@/app/components/climb-card/climb-icons';
+import MarqueeText from '@/app/components/climb-card/marquee-text';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { formatSends } from '@/app/lib/format-climb-stats';
@@ -102,21 +103,20 @@ export default function ClimbDetailHeader({ climb, communityGrade }: ClimbDetail
         }}
       >
         {/* Name row */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px', maxWidth: '100%' }}>
-          <Typography
-            variant="body1"
-            component="span"
-            sx={{
-              fontSize: themeTokens.typography.fontSize.lg,
-              fontWeight: themeTokens.typography.fontWeight.bold,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {climb.name}
-            <ClimbIcons benchmarkDifficulty={climb.benchmark_difficulty} isNoMatch={!!climb.is_no_match} />
-          </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px', maxWidth: '100%', minWidth: 0 }}>
+          <MarqueeText active>
+            <Typography
+              variant="body1"
+              component="span"
+              sx={{
+                fontSize: themeTokens.typography.fontSize.lg,
+                fontWeight: themeTokens.typography.fontWeight.bold,
+              }}
+            >
+              {climb.name}
+              <ClimbIcons benchmarkDifficulty={climb.benchmark_difficulty} isNoMatch={!!climb.is_no_match} />
+            </Typography>
+          </MarqueeText>
         </Box>
 
         {/* Details row: quality + setter */}

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1224,7 +1224,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                           cursor: tickBarActive ? 'default' : undefined,
                         }}
                       >
-                        <ClimbTitle climb={displayedClimb} gradePosition="right" showSetterInfo />
+                        <ClimbTitle climb={displayedClimb} gradePosition="right" showSetterInfo isActive />
                       </div>
 
                       {/* Peek text — shows next/previous climb sliding in from the edge */}

--- a/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
+++ b/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
@@ -101,7 +101,9 @@ export const getHoldHeatmapData = async (
 
       // Query for user ascents and attempts per hold in parallel
       const [userAscentsQuery, userAttemptsQuery] = await Promise.all([
-        executeRows<{ hold_id: number; user_ascents: number }>(db, sql`
+        executeRows<{ hold_id: number; user_ascents: number }>(
+          db,
+          sql`
           SELECT ch.hold_id, COUNT(*) as user_ascents
           FROM ${boardseshTicks} t
           JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
@@ -110,8 +112,11 @@ export const getHoldHeatmapData = async (
             AND t.angle = ${params.angle}
             AND t.status IN ('flash', 'send')
           GROUP BY ch.hold_id
-        `),
-        executeRows<{ hold_id: number; user_attempts: number }>(db, sql`
+        `,
+        ),
+        executeRows<{ hold_id: number; user_attempts: number }>(
+          db,
+          sql`
           SELECT ch.hold_id, SUM(t.attempt_count) as user_attempts
           FROM ${boardseshTicks} t
           JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
@@ -119,7 +124,8 @@ export const getHoldHeatmapData = async (
             AND t.board_type = ${params.board_name}
             AND t.angle = ${params.angle}
           GROUP BY ch.hold_id
-        `),
+        `,
+        ),
       ]);
 
       // Convert results to Maps for easier lookup

--- a/packages/web/app/lib/graphql/generated/index.ts
+++ b/packages/web/app/lib/graphql/generated/index.ts
@@ -1,1 +1,1 @@
-export * from "./gql";
+export * from './gql';

--- a/packages/web/app/lib/seo/__tests__/dynamic-og-data.test.ts
+++ b/packages/web/app/lib/seo/__tests__/dynamic-og-data.test.ts
@@ -27,7 +27,7 @@ vi.mock('@/app/lib/board-utils', () => ({
 // tagged template) for replica-tolerant reads. Mock both onto the existing
 // `executeMock` and a fresh tagged-template fake.
 const mockSqlTag = vi.fn();
-const rowsFromResultMock = <T,>(result: unknown): T[] => {
+const rowsFromResultMock = <T>(result: unknown): T[] => {
   if (Array.isArray(result)) return result as T[];
   throw new TypeError('Expected postgres-js query result to be a row array');
 };
@@ -37,7 +37,7 @@ vi.mock('@/app/lib/db/db', () => ({
   dbzRead: { execute: executeMock },
   getReadPool: () => mockSqlTag,
   rowsFromResult: rowsFromResultMock,
-  executeRows: async <T,>(conn: { execute: (query: unknown) => Promise<unknown> }, query: unknown) =>
+  executeRows: async <T>(conn: { execute: (query: unknown) => Promise<unknown> }, query: unknown) =>
     rowsFromResultMock<T>(await conn.execute(query)),
 }));
 

--- a/packages/web/app/lib/seo/dynamic-og-data.ts
+++ b/packages/web/app/lib/seo/dynamic-og-data.ts
@@ -29,7 +29,8 @@ export const getProfileOgSummary = cache(async (userId: string): Promise<Profile
     display_name: string | null;
     avatar_url: string | null;
     version_at: string | Date | null;
-  }>(await rawSql`
+  }>(
+    await rawSql`
     SELECT
       u.name,
       u.image,
@@ -44,7 +45,8 @@ export const getProfileOgSummary = cache(async (userId: string): Promise<Profile
     LEFT JOIN user_profiles p ON p.user_id = u.id
     WHERE u.id = ${userId}
     LIMIT 1
-  `);
+  `,
+  );
 
   const row = rows[0];
   if (!row) {
@@ -71,7 +73,9 @@ export const getSetterOgSummary = cache(async (username: string): Promise<Setter
     display_name: string | null;
     avatar_url: string | null;
     version_at: string | Date | null;
-  }>(dbz, drizzleSql`
+  }>(
+    dbz,
+    drizzleSql`
     SELECT
       profile.name,
       profile.display_name,
@@ -111,7 +115,8 @@ export const getSetterOgSummary = cache(async (username: string): Promise<Setter
       WHERE ubm.board_username = ${username}
       LIMIT 1
     ) AS profile ON true
-  `);
+  `,
+  );
 
   const row = result[0];
 
@@ -312,7 +317,9 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
     layout_id: number | null;
     size_id: number | null;
     set_ids: string | null;
-  }>(dbz, drizzleSql`
+  }>(
+    dbz,
+    drizzleSql`
     SELECT
       bs.name,
       COALESCE(
@@ -347,7 +354,8 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
     LEFT JOIN user_boards ub ON ub.id = bs.board_id
     WHERE bs.id = ${sessionId}
     LIMIT 1
-  `);
+  `,
+  );
 
   if (partySessionResult[0]) {
     sessionType = 'party';
@@ -364,7 +372,9 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
       layout_id: number | null;
       size_id: number | null;
       set_ids: string | null;
-    }>(dbz, drizzleSql`
+    }>(
+      dbz,
+      drizzleSql`
       SELECT
         s.name,
         COALESCE(
@@ -388,7 +398,8 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
       LEFT JOIN user_profiles up ON up.user_id = s.user_id
       WHERE s.id = ${sessionId}
       LIMIT 1
-    `);
+    `,
+    );
 
     if (inferredSessionResult[0]) {
       sessionType = 'inferred';
@@ -421,14 +432,19 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
   const [participantCountResult, participantResult, totalSendsResult, gradeResult, boardInfo] = await Promise.all([
     executeRows<{
       participant_count: number;
-    }>(dbz, drizzleSql`
+    }>(
+      dbz,
+      drizzleSql`
       SELECT COUNT(DISTINCT bt.user_id)::int as participant_count
       FROM boardsesh_ticks bt
       WHERE ${tickWhereClause}
-    `),
+    `,
+    ),
     executeRows<{
       display_name: string;
-    }>(dbz, drizzleSql`
+    }>(
+      dbz,
+      drizzleSql`
       SELECT DISTINCT
         COALESCE(up.display_name, u.name, 'Climber') as display_name
       FROM boardsesh_ticks bt
@@ -436,19 +452,25 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
       LEFT JOIN user_profiles up ON up.user_id = bt.user_id
       WHERE ${tickWhereClause}
       LIMIT 6
-    `),
+    `,
+    ),
     executeRows<{
       total_sends: number;
-    }>(dbz, drizzleSql`
+    }>(
+      dbz,
+      drizzleSql`
       SELECT COUNT(*)::int as total_sends
       FROM boardsesh_ticks bt
       WHERE ${tickWhereClause}
         AND bt.status IN ('flash', 'send')
-    `),
+    `,
+    ),
     executeRows<{
       difficulty: number;
       cnt: number;
-    }>(dbz, drizzleSql`
+    }>(
+      dbz,
+      drizzleSql`
       SELECT
         COALESCE(bt.difficulty, ROUND(bcs.display_difficulty)::int) as difficulty,
         COUNT(*) as cnt
@@ -462,7 +484,8 @@ export const getSessionOgSummary = cache(async (sessionId: string): Promise<Sess
         AND COALESCE(bt.difficulty, ROUND(bcs.display_difficulty)::int) IS NOT NULL
       GROUP BY COALESCE(bt.difficulty, ROUND(bcs.display_difficulty)::int)
       ORDER BY COALESCE(bt.difficulty, ROUND(bcs.display_difficulty)::int)
-    `),
+    `,
+    ),
     resolveSessionBoardInfo({
       boardPath: sessionRow.board_path,
       boardSlug: sessionRow.board_slug,
@@ -517,7 +540,8 @@ export const getPlaylistOgSummary = cache(async (playlistUuid: string): Promise<
     board_type: string;
     climb_count: number;
     version_at: string | Date | null;
-  }>(await rawSql`
+  }>(
+    await rawSql`
     SELECT
       p.name,
       p.description,
@@ -530,7 +554,8 @@ export const getPlaylistOgSummary = cache(async (playlistUuid: string): Promise<
     FROM playlists p
     WHERE p.uuid = ${playlistUuid}
     LIMIT 1
-  `);
+  `,
+  );
 
   const row = rows[0];
   if (!row) {


### PR DESCRIPTION
## Summary

- Long climb names get clipped to ellipsis on narrow viewports — the user can't read the full name. When a climb is the user's focus (selected list item, current climb in the queue control bar, drawer or detail header), the name now slowly scrolls back and forth so the full name is readable.
- Inactive list items keep the existing ellipsis. Reduced-motion users keep the ellipsis everywhere.
- Centralized in a new `MarqueeText` wrapper used by `ClimbTitle` (name only) and the climb detail header.

## What changed

- New `packages/web/app/components/climb-card/marquee-text.tsx` (+ CSS module). Outer wrapper clips overflow; inner wrapper measures `scrollWidth − clientWidth` via `ResizeObserver`. When `active && overflow > 0`, applies a CSS keyframe animation with pauses at each end. When `active=false`, falls back to plain ellipsis. Animation gated on `prefers-reduced-motion: no-preference`.
- `ClimbTitle` gets an `isActive` prop (default `false`) and wraps the name `<Typography>` with `MarqueeText`. Subtitles stay ellipsis.
- Threaded `isActive` through the four call sites:
  - `climb-list-item.tsx` — `isActive={selected}` (the selection store already drives this)
  - `queue-control-bar.tsx` — `isActive` on the live current climb (peek climb stays static — it's a transient swipe artifact)
  - `drawer-climb-header.tsx` — always `isActive`
  - `climb-detail-header.tsx` — wraps the name `<Typography>` with `<MarqueeText active>` directly (this header doesn't use `ClimbTitle`)

## Test plan

- [ ] Browse climbs at iPhone-12 viewport. Confirm unselected list items keep ellipsis.
- [ ] Tap a climb with a long name → the selected (highlighted) item slowly scrolls left, pauses, scrolls back, pauses, repeats.
- [ ] Open the queue control bar with a long-named current climb → name marquees at the top of the play view. Swipe to next/prev → marquee restarts on the new name.
- [ ] Tap the `…` (three-dots) menu on a long-named climb in any list → the drawer header's name marquees.
- [ ] Open a climb detail view → centered name marquees.
- [ ] Enable "Reduce motion" (DevTools → Rendering → emulate `prefers-reduced-motion: reduce`) → marquees go static, ellipsis restored everywhere.
- [ ] Confirm climbs with short names don't animate (no overflow, no measurement-driven scrolling).

Closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)