### PR TITLE
Add Sharma gym outreach email draft

### DIFF
--- a/marketing/outreach/sharma-gyms-email.md
+++ b/marketing/outreach/sharma-gyms-email.md
@@ -1,0 +1,59 @@
+# Sharma Climbing — gym outreach email
+
+Draft email for Sharma gym managers after an in-person conversation about putting
+up a banner or QR code near the Kilter / Tension boards.
+
+Voice and positioning follow the about page (`packages/web/i18n/locales/en-US/marketing.json`,
+`about.*`) and the trademark guidance in `LEGAL.md`. Keep it climber-talk, no
+buzzwords, and explicitly non-affiliated with Aurora / Moon / Tension.
+
+---
+
+**Subject:** Boardsesh — a free tool for your Kilter / Tension members
+
+Hi [Manager's name],
+
+Thanks again for the chat the other day — really appreciate you being open to this. Here's the rundown you asked for so you can decide what makes sense for a banner or QR code at the boards.
+
+**What Boardsesh is**
+
+Boardsesh is a free, open-source app for climbers who train on LED boards. It works with Kilter, Tension, and MoonBoard from a single login, so members don't have to juggle three separate apps. We're not affiliated with Aurora, Tension, or Moon — just a community project built by climbers.
+
+Site: https://www.boardsesh.com
+
+**Why members at Sharma might like it**
+
+- **Take turns without the "who's next?"** — a shared queue on everyone's phone, so the rotation runs itself.
+- **Climb together in real time** — Party Mode shares a session across phones; the next climb lights up for whoever's on the wall.
+- **Bring your logbook over from Kilter** — one-step migration, no lost history.
+- **Build a playlist before you show up** — line up your projects at home, send them at the gym.
+- **One login, every board** — Kilter, Tension, MoonBoard, more on the way.
+
+It's free, no ads, no paywall, and self-hostable if a gym ever wants to run its own instance.
+
+**What I'd suggest for the banner / QR**
+
+Happy to send over print-ready artwork in whatever size you want. The simplest version:
+
+- QR code linking to https://www.boardsesh.com
+- A short tagline. Some options that have worked well:
+  - _"One app for Kilter, Tension, and MoonBoard."_
+  - _"Queue up. Climb together. Free."_
+  - _"Get on the board — boardsesh.com"_
+
+If you'd rather point straight to your specific boards (e.g. the Kilter at a specific Sharma location), I can generate a deep link so the QR drops members right onto that board's page.
+
+**What I'd need from you**
+
+- Which locations are putting it up
+- Preferred size / format (poster, sticker, table tent, screen)
+- Whether you want a generic QR or per-location deep links
+
+I'll turn it around within a couple of days. And if any of your setters or coaches want a walk-through of the app, I'm happy to jump on a quick call or come by in person.
+
+Thanks again — stoked to have Sharma involved.
+
+Cheers,
+Alex
+Boardsesh
+https://www.boardsesh.com


### PR DESCRIPTION
## Summary

- Adds `marketing/outreach/sharma-gyms-email.md` — a draft email Alex can send to Sharma climbing gym managers after the in-person chat about putting up a banner / QR code at the Kilter and Tension boards.
- Voice follows the about-page copy in `packages/web/i18n/locales/en-US/marketing.json` (climber-talk, no buzzwords, active CTAs).
- Trademark wording follows `LEGAL.md` — explicit non-affiliation with Aurora / Moon / Tension, names used only to describe compatibility.

Creates the `marketing/outreach/` directory as the home for future gym / partner outreach drafts so they stay versioned and consistent.

## Test plan

- [ ] Read through the draft and tweak tone / specifics before sending
- [ ] Decide whether to keep all three tagline options or pick one
- [ ] Confirm the QR target URL (generic `boardsesh.com` vs. per-location deep link)

https://claude.ai/code/session_01VJwYSSL7iEN55FEfdqdAc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJwYSSL7iEN55FEfdqdAc9)_