### PR TITLE
Let multiple vp run dev instances coexist via per-port distDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ packages/web/e2e/screenshots/
 
 # next.js
 .next/
+# Per-port distDir created by dev-orchestrator when running multiple
+# `vp run dev` instances side-by-side (each gets its own build cache and
+# next-dev lock).
+.next-*/
 out/
 
 # production

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -7,6 +7,10 @@ const withVercelToolbar = createWithVercelToolbar();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // Honour NEXT_DIST_DIR so the dev orchestrator can give each parallel
+  // `vp run dev` instance its own build cache + next-dev lock; falls back to
+  // the canonical `.next` when the env var is unset (every other context).
+  ...(process.env.NEXT_DIST_DIR ? { distDir: process.env.NEXT_DIST_DIR } : {}),
   typescript: {
     // ignoreBuildErrors: true,
   },

--- a/scripts/dev-orchestrator.ts
+++ b/scripts/dev-orchestrator.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
-import { mkdirSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { createConnection, createServer } from 'node:net';
 import { homedir } from 'node:os';
 import { createInterface } from 'node:readline/promises';
@@ -60,6 +60,40 @@ const processes: { backend: ProcessRef; web: ProcessRef } = {
 };
 
 let backendHealthy = false;
+
+// When we run a non-default distDir, Next.js writes the new path into
+// packages/web/tsconfig.json's `include` array on first compile. That file
+// is checked in, so the side effect would dirty the working tree on every
+// parallel-dev start. Snapshot the original bytes here and restore on
+// shutdown so the pollution stays scoped to the running process.
+type TsconfigSnapshot = { path: string; content: string };
+let tsconfigSnapshot: TsconfigSnapshot | null = null;
+
+function snapshotTsconfig(): void {
+  const path = join(ROOT_DIR, 'packages/web/tsconfig.json');
+  try {
+    tsconfigSnapshot = { path, content: readFileSync(path, 'utf8') };
+  } catch (error) {
+    console.warn(
+      '[dev] Could not snapshot packages/web/tsconfig.json — Next.js may leave per-port paths behind:',
+      error,
+    );
+  }
+}
+
+function restoreTsconfig(): void {
+  if (!tsconfigSnapshot) return;
+  const { path, content } = tsconfigSnapshot;
+  try {
+    const current = readFileSync(path, 'utf8');
+    if (current !== content) {
+      writeFileSync(path, content);
+      console.info('[dev] Reverted packages/web/tsconfig.json (Next.js had auto-added per-port type paths)');
+    }
+  } catch (error) {
+    console.warn('[dev] Could not restore packages/web/tsconfig.json:', error);
+  }
+}
 
 function parseCliOptions(args: string[]): CliOptions {
   let qaNotesFilePath: string | null = null;
@@ -475,6 +509,16 @@ function startWeb(
 ): ReturnType<typeof spawn> {
   console.info(`[dev] Starting web on port ${port}...`);
 
+  // Each parallel dev instance needs its own distDir; otherwise `next dev`
+  // refuses to start with "Unable to acquire lock at .next/dev/lock". The
+  // canonical `.next` is reserved for the default-port instance so existing
+  // tooling (vercel deploys, debuggers attached to .next/...) keeps working;
+  // any auto-incremented or explicit non-default port gets `.next-<port>`.
+  const distDir = port === DEFAULT_WEB_PORT ? undefined : `.next-${port}`;
+  if (distDir) {
+    console.info(`[dev] Using distDir ${distDir} (per-port to avoid next-dev lock collision)`);
+  }
+
   const webProcess = spawn('bun', ['run', 'dev'], {
     cwd: join(ROOT_DIR, 'packages/web'),
     stdio: ['inherit', 'inherit', 'inherit'],
@@ -486,6 +530,7 @@ function startWeb(
       ...(devBuildMetadata.branchName ? { BOARDSESH_DEV_BRANCH_NAME: devBuildMetadata.branchName } : {}),
       ...(devBuildMetadata.qaNotes ? { BOARDSESH_DEV_QA_NOTES: devBuildMetadata.qaNotes } : {}),
       ...(devBuildMetadata.qaNotesFilePath ? { BOARDSESH_DEV_QA_NOTES_FILE: devBuildMetadata.qaNotesFilePath } : {}),
+      ...(distDir ? { NEXT_DIST_DIR: distDir } : {}),
       ...(tls
         ? {
             DEV_HTTPS_CERT_FILE: tls.certFile,
@@ -539,6 +584,11 @@ async function shutdown() {
   if (processes.web.process && !processes.web.process.killed) {
     processes.web.process.kill('SIGKILL');
   }
+
+  // Best-effort revert of any tsconfig.json edits Next.js made for our
+  // per-port distDir. Skipped if the orchestrator is SIGKILL'd; users can
+  // recover with `git checkout -- packages/web/tsconfig.json`.
+  restoreTsconfig();
 
   process.exit(0);
 }
@@ -596,6 +646,13 @@ async function main(): Promise<void> {
     console.info(`[dev] QA notes: ${devBuildMetadata.qaNotesFilePath}`);
   }
   console.info();
+
+  // Only snapshot tsconfig if we're going to use a per-port distDir; the
+  // canonical-port instance lets Next manage `.next/types` in tsconfig as
+  // it always has.
+  if (webPort !== DEFAULT_WEB_PORT) {
+    snapshotTsconfig();
+  }
 
   processes.backend.process = startBackend(backendPort, tls, devDbEnv);
 


### PR DESCRIPTION
## Summary

`next dev` writes a lock at `<distDir>/dev/lock` and refuses to start a second instance sharing the same distDir. The orchestrator already auto-picks free ports, but a second `vp run dev` from the same worktree still failed at this lock because both shared `.next/`.

This PR has the orchestrator pass `NEXT_DIST_DIR=.next-<port>` to the web spawn whenever it picks (or is told to use) a non-default port. The canonical port keeps `.next/` so existing tooling — vercel deploys, debuggers, the already-set tsconfig include paths — keeps working unchanged.

## Changes

- `next.config.mjs` — honour `NEXT_DIST_DIR` when set; falls back to `.next` otherwise (build/CI/single-instance dev unchanged).
- `scripts/dev-orchestrator.ts` — set `NEXT_DIST_DIR=.next-<port>` for non-default ports. Snapshot `packages/web/tsconfig.json` on startup and restore it on shutdown to undo Next.js's auto-rewrite (it adds `<distDir>/types/**/*.ts` to the `include` array).
- `.gitignore` — also ignore `.next-*/` so the per-port build dirs aren't tracked.

## Caveat

Next.js's tsconfig auto-rewrite is a side effect of `next dev` — there's no flag to disable it. The snapshot/restore handles graceful exits (SIGINT/SIGTERM); a SIGKILL still leaks the edits. Recovery is one command: `git checkout -- packages/web/tsconfig.json`. This is documented in the orchestrator code.

## Test plan

- [x] Single-instance `vp run dev` unchanged (port 3000 → distDir `.next`, no tsconfig snapshot taken).
- [x] Forced `PORT=3009 vp run dev` while another instance held `.next/dev/lock` — second instance starts cleanly using `.next-3009`.
- [x] Watched tsconfig.json mutate during startup (Next adds `.next-3009/types/**/*.ts`), then SIGTERM'd the orchestrator and confirmed `git diff packages/web/tsconfig.json` is empty afterwards.
- [x] `vp check` passes on all modified files.
- [x] `vp run typecheck:web` passes (no impact from the conditional `distDir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)