### PR TITLE
test: cover userBoardMappings/userFollows paths and harden insert shim

### DIFF
--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -244,8 +244,13 @@ function createNotificationDbShim(opts: {
     },
     insert(table: unknown) {
       return {
-        values: async (rows: Array<Record<string, unknown>>) => {
+        values: (rows: Array<Record<string, unknown>>) => {
           inserts.push({ table, rows });
+          const noop = () => Promise.resolve();
+          return Object.assign(Promise.resolve(), {
+            onConflictDoNothing: noop,
+            onConflictDoUpdate: noop,
+          });
         },
       };
     },
@@ -314,5 +319,69 @@ describe('createSetterSyncNotifications', () => {
     );
 
     expect(inserts.filter((i) => i.table === notifications)).toHaveLength(0);
+  });
+
+  it('creates notifications for users who follow a linked board account', async () => {
+    const { db, inserts } = createNotificationDbShim({
+      setterFollowsRows: [],
+      userBoardMappingsRows: [{ userId: 'linked-user-1', boardUsername: 'setter-a' }],
+      userFollowsRows: [
+        { followerId: 'follower-x', followingId: 'linked-user-1' },
+        { followerId: 'follower-y', followingId: 'linked-user-1' },
+      ],
+    });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [{ uuid: 'climb-1', setterUsername: 'setter-a', layoutId: 1 }],
+      () => {},
+    );
+
+    const allRows = inserts.filter((i) => i.table === notifications).flatMap((i) => i.rows);
+    expect(allRows).toHaveLength(2);
+    const recipientIds = new Set(allRows.map((row) => row.recipientId));
+    expect(recipientIds.has('follower-x')).toBe(true);
+    expect(recipientIds.has('follower-y')).toBe(true);
+  });
+
+  it('deduplicates recipients who follow the setter both directly and via linked account', async () => {
+    const { db, inserts } = createNotificationDbShim({
+      setterFollowsRows: [{ followerId: 'shared-follower', setterUsername: 'setter-a' }],
+      userBoardMappingsRows: [{ userId: 'linked-user-1', boardUsername: 'setter-a' }],
+      userFollowsRows: [{ followerId: 'shared-follower', followingId: 'linked-user-1' }],
+    });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [{ uuid: 'climb-1', setterUsername: 'setter-a', layoutId: 1 }],
+      () => {},
+    );
+
+    const allRows = inserts.filter((i) => i.table === notifications).flatMap((i) => i.rows);
+    expect(allRows).toHaveLength(1);
+    expect(allRows[0].recipientId).toBe('shared-follower');
+  });
+
+  it('does not reach userFollows when no setters have linked board accounts', async () => {
+    // userBoardMappings returns nothing → linkedUserIds is empty → the
+    // userFollows query is skipped entirely; userFollowsRows are unreachable.
+    const { db, inserts } = createNotificationDbShim({
+      setterFollowsRows: [{ followerId: 'direct-follower', setterUsername: 'setter-a' }],
+      userBoardMappingsRows: [],
+      userFollowsRows: [{ followerId: 'indirect-follower', followingId: 'some-user' }],
+    });
+
+    await createSetterSyncNotifications(
+      db,
+      'decoy',
+      [{ uuid: 'climb-1', setterUsername: 'setter-a', layoutId: 1 }],
+      () => {},
+    );
+
+    const allRows = inserts.filter((i) => i.table === notifications).flatMap((i) => i.rows);
+    expect(allRows).toHaveLength(1);
+    expect(allRows[0].recipientId).toBe('direct-follower');
   });
 });

--- a/packages/db/scripts/backfill-required-set-ids.ts
+++ b/packages/db/scripts/backfill-required-set-ids.ts
@@ -31,7 +31,6 @@ async function main() {
   try {
     // Discover boards eligible for backfill. In --all mode this counts every
     // climb (sans NULL filter) so progress reporting reflects the full pass.
-    const nullPredicate = all ? sql`` : sql`(required_set_ids IS NULL OR compatible_size_ids IS NULL) AND`;
     const heading = all ? 'Eligible climbs (full recompute):' : 'Climbs with NULL denormalized columns:';
     const emptyMessage = all
       ? 'No eligible climbs found. Nothing to do.'
@@ -39,16 +38,26 @@ async function main() {
 
     const boardTypes = await executeRows<{ board_type: string; eligible_count: string }>(
       db,
-      sql`
-      SELECT board_type, COUNT(*) as eligible_count
-      FROM board_climbs
-      WHERE ${nullPredicate}
-        frames IS NOT NULL
-        AND frames != ''
-        AND board_type != 'moonboard'
-      GROUP BY board_type
-      ORDER BY board_type
-    `,
+      all
+        ? sql`
+        SELECT board_type, COUNT(*) as eligible_count
+        FROM board_climbs
+        WHERE frames IS NOT NULL
+          AND frames != ''
+          AND board_type != 'moonboard'
+        GROUP BY board_type
+        ORDER BY board_type
+      `
+        : sql`
+        SELECT board_type, COUNT(*) as eligible_count
+        FROM board_climbs
+        WHERE (required_set_ids IS NULL OR compatible_size_ids IS NULL)
+          AND frames IS NOT NULL
+          AND frames != ''
+          AND board_type != 'moonboard'
+        GROUP BY board_type
+        ORDER BY board_type
+      `,
     );
 
     if (boardTypes.length === 0) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add three new tests to `createSetterSyncNotifications` that seed `userBoardMappingsRows` and `userFollowsRows`, exercising the previously untested linked-account notification path, deduplication of recipients who appear in both `setterFollows` and `userFollows`, and the early-exit guard when no board account mappings exist
- Harden the `createNotificationDbShim` insert shim so `values()` returns a thenable that also exposes `onConflictDoNothing` / `onConflictDoUpdate` — chaining either method after `.values()` no longer throws at runtime
- Replace the fragile empty `sql`` `` predicate in `backfill-required-set-ids.ts` with two explicit conditional query branches, making the `--all` mode intent unambiguous and removing the implicit empty-fragment interpolation trick

## Test plan

- [ ] CI passes: `aurora-sync` vitest suite includes the three new tests and all pass
- [ ] Verify `createSetterSyncNotifications` linked-account test: seed a mapping `setter-a → linked-user-1` and two `userFollows` rows; confirm two notifications are created
- [ ] Verify deduplication test: same follower in both `setterFollows` and `userFollows`; confirm only one notification row
- [ ] Verify early-exit test: empty `userBoardMappings`; confirm only direct `setterFollows` recipients get notifications
- [ ] Backfill script: `--all` and default mode both produce valid SQL (covered by existing manual test plan in the doc-comment)

https://claude.ai/code/session_01QYAVw5pRJR66xD9Cf2BwTs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYAVw5pRJR66xD9Cf2BwTs)_