### PR TITLE
fix(android): revert @capacitor/keyboard to fix screen collapse (#1808)

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-geolocation')
-    implementation project(':capacitor-keyboard')
 
 }
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -22,6 +22,3 @@ project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/
 
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')
-
-include ':capacitor-keyboard'
-project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -15,7 +15,6 @@
         "@capacitor/core": "^8",
         "@capacitor/geolocation": "8.1.0",
         "@capacitor/ios": "^8",
-        "@capacitor/keyboard": "^8",
         "@capacitor/motion": "^8",
       },
       "devDependencies": {
@@ -46,8 +45,6 @@
     "@capacitor/geolocation": ["@capacitor/geolocation@8.1.0", "", { "dependencies": { "@capacitor/synapse": "^1.0.4" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-dHeGuVlT3ELxxn8WaoRsGjfx8tmziaC0ZuaKhUBCoKFjOue4fAnmLczCMQsYW7OykgiyBh0pirNPwWZ0/LXB7Q=="],
 
     "@capacitor/ios": ["@capacitor/ios@8.3.0", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-5Rtwv8SITKlYTt8lAZG+khnVIdzPtqbocH3eP+JkEmX1vpSMwx4TOKtT8OBz8gpQ+pUJDRp7DBYOv3U6l/obCw=="],
-
-    "@capacitor/keyboard": ["@capacitor/keyboard@8.0.3", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ=="],
 
     "@capacitor/motion": ["@capacitor/motion@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-eCTe9+ZSVw2dQLQLvq5vfp2GGnMmsAy5jn4boKB93CHEenD9ZZojXZYJn1u4zUWhfj9cGXSxu+2j7WaQbkMlPg=="],
 

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -23,13 +23,17 @@ const config: CapacitorConfig = {
     SystemBars: {
       insetsHandling: 'disable',
     },
-    // Resize the Android WebView when the soft keyboard opens so 100dvh/100%
-    // layouts (e.g. the climb-name filter drawer) shrink to fit above it,
-    // matching how mobile Chrome behaves natively.
-    Keyboard: {
-      resize: 'native',
-      resizeOnFullScreen: true,
-    },
+    // Do not install @capacitor/keyboard or set a `Keyboard` plugin config
+    // here. @capacitor-community/safe-area pads the WebView decorView by
+    // imeInsets.bottom on Chromium >= 140 with viewport-fit=cover, so the
+    // keyboard already lifts content as expected. Combined with
+    // `interactiveWidget: 'resizes-visual'` (packages/web/app/layout.tsx) and
+    // `100dvh` drawers, this matches mobile Chrome. Adding @capacitor/keyboard
+    // with `resize: 'native'` plus `windowSoftInputMode="adjustResize"` (PRs
+    // #1796 + commit 6e748c0d5) physically shrinks the WebView when the IME
+    // opens, collapsing the dvh-based layout on top of a fixed-height bottom
+    // bar — see #1808. The safe-area plugin also explicitly logs an error if
+    // `Keyboard.resizeOnFullScreen: true` is set.
   },
 };
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,7 +19,6 @@
     "@capacitor/core": "^8",
     "@capacitor/geolocation": "8.1.0",
     "@capacitor/ios": "^8",
-    "@capacitor/keyboard": "^8",
     "@capacitor/motion": "^8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Reverts the runtime / native pieces of commit `6e748c0d5` ("fix(mobile): resize Android WebView when soft keyboard opens"):

- Drops `@capacitor/keyboard` from `mobile/package.json` + `bun.lock`.
- Removes its registration from `capacitor.build.gradle` and `capacitor.settings.gradle`.
- Removes the `Keyboard:` plugin block from `capacitor.config.ts`.
- Removes `android:windowSoftInputMode="adjustResize"` from `AndroidManifest.xml`.
- Adds an inline `Do-not-add-this-back` comment in `capacitor.config.ts` documenting why.

Closes #1808.

## Why this is the right shape

`6e748c0d5` set `Keyboard.resize: 'native'` + `windowSoftInputMode="adjustResize"` so Android would physically shrink the WebView when the soft keyboard opened. That made `100dvh`-based layout tokens (header, body, drawers) collapse on top of the fixed-height `145px` bottom bar — exactly what's pictured in #1808.

`@capacitor-community/safe-area@^8` already handles soft-keyboard layout on Chromium ≥ 140 with `viewport-fit=cover`: it pads the WebView decorView by `imeInsets.bottom` while the IME is visible. Combined with `interactiveWidget: 'resizes-visual'` (already on the root viewport in `packages/web/app/layout.tsx`), Chromium shrinks the *visual* viewport so `100dvh` drawers still fit above the keyboard, while the *layout* viewport stays full-height — matching mobile Chrome web. The safe-area plugin source also explicitly logs an error if `Keyboard.resizeOnFullScreen: true` is set, which 6e748c0d5 added anyway.

## Relationship to PR #1798

This PR carries forward the same code-level revert that PR #1798 proposed. #1798 is stuck on a stale May-1 branch whose `docs/mobile-app-plan.md` conflicts with `main`'s current v9.0 rewrite. Rather than resolve that conflict against an unrelated docs rewrite, this PR replaces the docs note with a tighter inline comment in `capacitor.config.ts` so the warning lives next to the code someone might be tempted to edit. #1798 can be closed in favour of this one.

## Test plan

- [ ] Build and install on an Android device: `cd mobile && bun install && bunx cap sync android && bunx cap run android`. The `bun install` step is required because `@capacitor/keyboard` was removed from `package.json` / `bun.lock`.
- [ ] **#1808 repro**: focus any text input on Android (climb name filter, login email, comment box). Verify the header height stays constant, content doesn't squash, the bottom bar stays anchored, and the focused input is visible above the keyboard.
- [ ] **Original "black gap" check** (the bug `6e748c0d5` was originally trying to fix): open the board search drawer and focus the climb-name filter at `app/components/board-search-drawer/board-search-drawer.tsx:180`. The drawer should fit above the keyboard with no black gap. (`@capacitor-community/safe-area` is responsible here.)
- [ ] **Comment form** + **Login screen**: focus the inputs; surrounding UI should not collapse.
- [ ] **iOS smoke test**: focus an input. No iOS behavior change is expected — the removed plugin config is Android-only and iOS uses `contentInset: 'never'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)