### PR TITLE
Match queue icon in climb actions to other queue buttons

### DIFF
--- a/packages/web/app/components/climb-actions/actions/go-to-queue-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/go-to-queue-action.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import QueueMusicOutlined from '@mui/icons-material/QueueMusicOutlined';
+import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalQueueActions } from '../../graphql-queue';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
@@ -26,7 +26,7 @@ export function GoToQueueAction({
     [onGoToQueue],
   );
 
-  const icon = <QueueMusicOutlined sx={{ fontSize: iconSize }} />;
+  const icon = <FormatListBulletedOutlined sx={{ fontSize: iconSize }} />;
 
   return buildActionResult({
     key: 'goToQueue',


### PR DESCRIPTION
Fixes #1844

## Summary

The "Go to Queue" action in the climb actions menu used `QueueMusicOutlined`, while every other open-queue affordance in the app uses `FormatListBulletedOutlined`:

- `play-view-drawer.tsx`
- `queue-control-bar.tsx`
- `bottom-tab-bar.tsx`

Swapping the climb-action icon to match makes the "open the queue" affordance visually consistent across the app.

## Test plan

- [ ] Open a climb's actions and verify the "Go to Queue" button shows the same list-bulleted icon as the queue button in the bottom tab bar, queue control bar, and play view drawer.
- [ ] Confirm the action still navigates to / opens the queue.

https://claude.ai/code/session_01YaSWSuusaCmAg22YmJJq8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaSWSuusaCmAg22YmJJq8a)_