### PR TITLE
Improve form label contrast in dark mode

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -329,9 +329,19 @@ html[data-theme='dark'] .MuiOutlinedInput-root.Mui-focused {
   background-color: var(--input-bg-focused);
 }
 
-html[data-theme='dark'] .MuiSelect-icon,
-html[data-theme='dark'] .MuiInputLabel-root {
+html[data-theme='dark'] .MuiSelect-icon {
   color: var(--neutral-500);
+}
+
+/* Floating MUI label sits inside the white input at rest, then floats up
+   over the dark page background when shrunk. Use a dark color at rest so
+   it reads on white, and a light color when shrunk so it reads on dark. */
+html[data-theme='dark'] .MuiInputLabel-root {
+  color: var(--neutral-100);
+}
+
+html[data-theme='dark'] .MuiInputLabel-root.MuiInputLabel-shrink {
+  color: var(--neutral-700);
 }
 
 html[data-theme='dark'] .MuiInputLabel-root.Mui-focused {

--- a/packages/web/app/components/search-drawer/accordion-search-form.module.css
+++ b/packages/web/app/components/search-drawer/accordion-search-form.module.css
@@ -33,7 +33,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.6px;
-  color: var(--neutral-400, #9ca3af);
+  color: var(--neutral-500, #6b7280);
   margin-bottom: 2px;
 }
 

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -345,7 +345,12 @@ const darkComponents: Components<Theme> = {
   MuiInputLabel: {
     styleOverrides: {
       root: {
-        color: themeTokens.neutral[500],
+        // Resting label sits inside the white input — needs dark text.
+        color: themeTokens.neutral[700],
+        // Shrunk label floats over the dark page bg — needs light text.
+        '&.MuiInputLabel-shrink': {
+          color: darkTokens.neutral[700],
+        },
         '&.Mui-focused': {
           color: themeTokens.colors.primary,
         },
@@ -362,7 +367,13 @@ const darkComponents: Components<Theme> = {
           color: themeTokens.neutral[800],
         },
         '& .MuiInputLabel-root': {
-          color: themeTokens.neutral[500],
+          color: themeTokens.neutral[700],
+        },
+        '& .MuiInputLabel-root.MuiInputLabel-shrink': {
+          color: darkTokens.neutral[700],
+        },
+        '& .MuiInputLabel-root.Mui-focused': {
+          color: themeTokens.colors.primary,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Fixes #1842 — floating MUI labels and the accordion search form's static field labels were illegible in dark mode because mid-gray text sat across the boundary between the dark page background and the intentionally-white input surface.
- `MuiInputLabel` (dark theme only) now uses a dark color at rest inside the white input and a light color when shrunk over the dark page bg; focused state keeps the rose accent.
- `.fieldLabel` in the accordion search form now reads `--neutral-500`, which is theme-aware (`#6B7280` in light, `#B3B3B3` in dark) and stays readable in both modes.
- Inputs themselves stay white in dark mode (project rule preserved).

## Test plan

- [ ] `vp check` and `vp run typecheck:web` pass on the branch
- [ ] In dark mode, the climb search filter drawer (`Climb Name`, `Setter`, `Min Ascents`, etc.) reads clearly against the dark page background
- [ ] In dark mode, board/layout/size selectors (`BoardConfigSelects`) — empty + unfocused: label inside white input is dark gray; filled or focused: label floats up and reads as light gray (or rose if focused)
- [ ] Settings → Controllers and any board create/edit form: same floating-label behavior
- [ ] Light mode: no visual regression on the same screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)