### PR TITLE
chore(search): stabilise empty holdsFilter ref, cover move-handle drag

### DIFF
--- a/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
@@ -352,4 +352,31 @@ describe('ClimbSearchForm — drag handles', () => {
     // from endDrag (while keeping it in handleEnable) would fail here.
     expect(dragCall?.holdsFilter).toEqual({ 101: { STARTING: 'include' } });
   });
+
+  it('dragging the move handle translates the zone and prunes holds outside the new box', () => {
+    const startZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
+    mockUISearchParams = {
+      ...DEFAULT_SEARCH_PARAMS,
+      holdsFilter: filterAllThreeHolds,
+      zoneBox: startZone,
+    };
+    render(<ClimbSearchForm boardDetails={boardDetails} />);
+
+    const moveHandle = screen.getByTestId('zone-handle-move');
+
+    // Centre starts at grid (72, 78) → SVG (540, 585). Drag to grid (82, 88) → SVG (615, 510).
+    fireEvent.pointerDown(moveHandle, { clientX: 540, clientY: 585, pointerId: 1 });
+    fireEvent.pointerMove(moveHandle, { clientX: 615, clientY: 510, pointerId: 1 });
+    fireEvent.pointerUp(moveHandle, { clientX: 615, clientY: 510, pointerId: 1 });
+
+    const dragCall = mockUpdateFilters.mock.calls.at(-1)?.[0] as
+      | { zoneBox: ZoneBox; holdsFilter: HoldsFilter }
+      | undefined;
+    expect(dragCall).toBeDefined();
+    // Move-mode translates both edges on each axis by the same delta — width
+    // (86) and height (94) are preserved, unlike the SE-corner case.
+    expect(dragCall?.zoneBox).toEqual({ edgeLeft: 39, edgeRight: 125, edgeBottom: 41, edgeTop: 135 });
+    // Hold 101 at grid (60, 80) is still inside; the two outer holds are pruned.
+    expect(dragCall?.holdsFilter).toEqual({ 101: { STARTING: 'include' } });
+  });
 });

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -57,6 +57,10 @@ const HANDLE_OPACITY = 0.95;
 const RECT_FILL_OPACITY = 0.18;
 const RECT_STROKE_OPACITY = 0.9;
 
+// Stable empty fallback so the ref-syncing effect doesn't re-run every
+// render when the URL has no holds filter set.
+const EMPTY_HOLDS_FILTER: HoldsFilter = Object.freeze({}) as HoldsFilter;
+
 const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
   const { t } = useTranslation('climbs');
   const { uiSearchParams, updateFilters } = useUISearchParams();
@@ -137,7 +141,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
     [dims],
   );
 
-  const holdsFilter: HoldsFilter = uiSearchParams.holdsFilter || {};
+  const holdsFilter: HoldsFilter = uiSearchParams.holdsFilter ?? EMPTY_HOLDS_FILTER;
 
   // Latest-known holdsFilter snapshot for prune calculations during a drag.
   // The tap-a-hold path calls `updateFilters({ holdsFilter })` which is
@@ -302,14 +306,11 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
   // unreliable once `setPointerCapture` re-routes the move/up events to
   // the captured handle. Binding the handlers to each handle makes the
   // capture self-contained.
-  const dragHandlers = useMemo(
-    () => ({
-      onPointerMove: handlePointerMove,
-      onPointerUp: endDrag,
-      onPointerCancel: endDrag,
-    }),
-    [endDrag, handlePointerMove],
-  );
+  const dragHandlers = {
+    onPointerMove: handlePointerMove,
+    onPointerUp: endDrag,
+    onPointerCancel: endDrag,
+  };
 
   const rectSvg = useMemo(() => {
     if (!localZone) return null;


### PR DESCRIPTION
## Summary

Three small follow-ups from a code-review pass on `climb-search-form.tsx`:

- **Stabilise the empty `holdsFilter` reference.** `uiSearchParams.holdsFilter || {}` allocated a fresh `{}` every render, so the `useEffect(..., [holdsFilter])` that syncs `holdsFilterRef.current` re-ran on every render when no filter was set. Replaced with a frozen module-level `EMPTY_HOLDS_FILTER` and `??` so the reference stays stable across renders.
- **Drop the unnecessary `dragHandlers` `useMemo`.** The object was only spread into JSX (`{...dragHandlers}` on the move handle and the four corner handles) and was not a dependency of any hook, so the memoization saved nothing. Replaced with a plain object literal; the per-handle wiring comment above it stays.
- **Add a move-handle drag test.** The drag suite already covered the SE-corner path end-to-end but not the centre/move handle. Added a sibling test that asserts the move-mode translation preserves the zone's width/height and prunes out-of-zone holds, mirroring the SE-corner test's structure.

No documented systems are affected (WebSocket / design-guideline docs untouched), so no doc updates.

## Test plan

- [x] `vp test run packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx` — 9/9 pass (8 existing + the new move-handle test).
- [x] `vp run typecheck` — clean.
- [x] `vp check packages/web/app/components/search-drawer/climb-search-form.tsx packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx` — format + lint + types clean on the touched files.
- [ ] Manual smoke (optional): draw a zone in the search drawer and drag the centre handle; confirm the zone translates without resizing and that holds outside the new box drop from the include/exclude chips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnkbNjaKCFE58HMpoSH2yZ)_