### PR TITLE
Drive MUI InputLabel color from theme only (drop global CSS override)

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -333,21 +333,6 @@ html[data-theme='dark'] .MuiSelect-icon {
   color: var(--neutral-500);
 }
 
-/* Floating MUI label sits inside the white input at rest, then floats up
-   over the dark page background when shrunk. Use a dark color at rest so
-   it reads on white, and a light color when shrunk so it reads on dark. */
-html[data-theme='dark'] .MuiInputLabel-root {
-  color: var(--neutral-100);
-}
-
-html[data-theme='dark'] .MuiInputLabel-root.MuiInputLabel-shrink {
-  color: var(--neutral-700);
-}
-
-html[data-theme='dark'] .MuiInputLabel-root.Mui-focused {
-  color: var(--color-primary);
-}
-
 html[data-theme='dark'] .MuiOutlinedInput-input::placeholder {
   color: var(--neutral-500);
   opacity: 1;


### PR DESCRIPTION
## Summary

Resolves a CSS-vs-emotion specificity conflict on the resting `MuiInputLabel` color in dark mode flagged by Claude Review.

The resting label color was being set in two places with different values:

- `packages/web/app/components/index.css:339-341` → `var(--neutral-100)` = `#222222` in dark mode
- `packages/web/app/theme/mui-theme.ts:347-349` → `themeTokens.neutral[700]` = `#374151`

The shrunk and focused values agreed across both files, so only the resting state was actually conflicting. Whichever rule "won" depended on cascade order between the global stylesheet and emotion's runtime style injection — brittle and unpredictable.

## Change

Removed the dark-mode `.MuiInputLabel-root` block from `packages/web/app/components/index.css` (the `/* Floating MUI label … */` comment plus three rules covering resting / shrunk / focused). The dark-theme `MuiInputLabel.styleOverrides` block already living in `mui-theme.ts:345-359` covers all three states with semantically equivalent values, so it becomes the single source of truth — consistent with the project rule of driving component styling from theme tokens rather than global CSS overrides.

Net effect on visible color: resting label in dark mode goes from `#222222` to `#374151` (the value mui-theme.ts already intended). Both sit on the white-in-dark-mode input surface and pass AA contrast; the difference is barely perceptible. Shrunk (`#E5E7EB`) and focused (`#8C4A52`) values are unchanged.

## Test plan

- [ ] `vp check` passes
- [ ] `vp run typecheck` passes
- [ ] Dark mode: resting label on an empty `TextField` reads cleanly on the white input surface
- [ ] Dark mode: floating/shrunk label reads cleanly against the dark page background once a field has content or is focused
- [ ] Dark mode: focused label is the brand primary (`#8C4A52`)
- [ ] Light mode: no visual regression on any input label state
- [ ] DevTools spot-check on a resting label in dark mode: computed `color` is `rgb(55, 65, 81)` and the matching rule comes from an emotion `<style>` tag, not `index.css`
- [ ] QA across `MuiTextField`, `MuiSelect`, and `MuiAutocomplete` (e.g. settings/auth forms, board search, queue search)


---
_Generated by [Claude Code](https://claude.ai/code/session_017VS3HhcdNTCkZebmyQGZE4)_