### PR TITLE
Keep screen awake during an active session

### DIFF
--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -3,7 +3,8 @@
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { PartyProfileProvider } from '../party-manager/party-profile-context';
-import { PersistentSessionProvider, usePersistentSession } from '../persistent-session';
+import { PersistentSessionProvider, usePersistentSession, usePersistentSessionState } from '../persistent-session';
+import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { QueueBridgeProvider, useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
 import { useCurrentClimb, useQueueList } from '../graphql-queue';
 import QueueControlBar from '../queue-control/queue-control-bar';
@@ -63,6 +64,7 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
                   <RootBottomBar boardConfigs={boardConfigs} />
                   <RootSessionSummaryDialog />
                   <RootSeshSettingsDrawer />
+                  <SessionWakeLock />
                 </ProfileHeaderShareProvider>
               </StatsFilterBridgeProvider>
             </SearchDrawerBridgeProvider>
@@ -71,6 +73,17 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
       </PersistentSessionProvider>
     </PartyProfileProvider>
   );
+}
+
+/**
+ * Holds a screen wake lock while a party session is active so the device
+ * (especially Android) doesn't sleep mid-session and break the WebSocket
+ * or Bluetooth connection.
+ */
+function SessionWakeLock() {
+  const { activeSession } = usePersistentSessionState();
+  useWakeLock(activeSession !== null);
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Mounts a `SessionWakeLock` component inside `PersistentSessionWrapper` that calls the existing `useWakeLock(activeSession !== null)` hook.
- On Android (Capacitor) this routes through `@capacitor-community/keep-awake`; on the web it uses `navigator.wakeLock.request('screen')`. Both are already wired up — no new dependency, no settings UI.
- Lock is held only while a party session is active, and the existing `visibilitychange` handler re-acquires it when the app comes back to the foreground.

## Why

When the device sleeps mid-session, the WebView is suspended and the WebSocket / Bluetooth connections drop. Users have to unlock and reconnect just to see the next climb. Holding a screen wake lock for the duration of an active session makes the foreground app behave the way climbers expect at the wall.

## Known caveat

The native `KeepAwake` plugin is a single global flag (no reference counting). If both Bluetooth and a session hold a lock and one of them releases first, the screen can sleep until the next foreground event. This is pre-existing behaviour (already true for the Bluetooth + play-drawer pair) and is not made worse by this PR. A small reference-counter inside `use-wake-lock.ts` is the obvious follow-up if we want to harden it.

## Test plan

- [ ] Web (desktop Chrome / Android Chrome): join a session, confirm a "screen" wake lock is held in DevTools → Application → Background services. End the session, confirm it's released.
- [ ] Native Android: set device screen-timeout to 15s. With no session, screen sleeps at 15s. Join a session, leave the app idle in the foreground >15s — screen stays on. End the session — screen sleeps at next idle window.
- [ ] Native Android: background the app during a session, then foreground it — wake lock is re-acquired (existing `visibilitychange` handler).
- [ ] `vp check` and `vp run typecheck:web` pass in CI.

https://claude.ai/code/session_01JyToL8C7Khjjgp9v5jRRGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyToL8C7Khjjgp9v5jRRGL)_