### PR TITLE
Fix 19 missing i18n key warnings reported by Sentry

### DIFF
--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -53,6 +53,7 @@ function getClientInstance(locale: Locale, resources: Record<string, Record<stri
       interpolation: { escapeValue: false },
       returnNull: false,
       saveMissing: true,
+      saveMissingPlurals: false,
       missingKeyHandler: (lngs, ns, key, fallbackValue) => {
         reportMissingI18nKey({ lngs, ns, key, fallbackValue });
       },

--- a/packages/web/app/lib/i18n/server.ts
+++ b/packages/web/app/lib/i18n/server.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import 'intl-pluralrules';
 import { cache } from 'react';
 import { createInstance, type i18n, type TFunction } from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
@@ -30,6 +31,7 @@ const initI18nForRequest = cache(async (locale: Locale, namespacesKey: string): 
       interpolation: { escapeValue: false },
       returnNull: false,
       saveMissing: true,
+      saveMissingPlurals: false,
       missingKeyHandler: (lngs, ns, key, fallbackValue) => {
         reportMissingI18nKey({ lngs, ns, key, fallbackValue });
       },

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -21,7 +21,7 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
   const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
 
   return (
-    <I18nProvider locale={locale} namespaces={['playlists', 'climbs', 'feed']}>
+    <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed', 'playlists']}>
       <div className={styles.pageContainer}>
         <PlaylistDetailContent playlistUuid={playlist_uuid} initialMyBoards={initialMyBoards} />
       </div>

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -217,6 +217,11 @@
       "editLockedAria": "Periodo de edición cerrado",
       "savedTitle": "Guardado",
       "savedAria": "Guardado"
+    },
+    "clear": {
+      "title": "Borrar bloque",
+      "description": "Esto borrará todas las presas y reiniciará el formulario. ¿Seguro?",
+      "tooltip": "Borrar todas las presas"
     }
   },
   "actions": {

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -36,6 +36,7 @@
     "search": "Buscar",
     "clearSearch": "Limpiar búsqueda",
     "openFilters": "Abrir filtros",
+    "openQueue": "Abrir cola",
     "openStatsFilters": "Abrir filtros de estadísticas",
     "shareProfile": "Compartir perfil",
     "settings": "Ajustes",


### PR DESCRIPTION
## Summary

Resolves the 19 `Missing i18n key` warnings currently firing in Sentry. Diagnosis split them into 4 root causes — only two are actual catalog gaps; the other two are wiring / config issues.

| # | Cause | Keys | Fix |
|---|---|---|---|
| 1 | `'profile'` (and `'boards'`/`'common'`/`'session'`) namespaces not preloaded on `/playlists/:playlist_uuid` | 14 — `profile:logbook.form.*` | Extend the `<I18nProvider namespaces=…>` list on `packages/web/app/playlists/[playlist_uuid]/page.tsx` to match the proven board-layout set. The keys already exist in both `en-US/profile.json` and `es/profile.json`; they were silently lazy-loading and racing the missing-key handler. |
| 2 | Spanish `climbs.json` missing the `create.clear` subtree | 3 — `climbs:create.clear.{title,description,tooltip}` | Add `clear` block to `packages/web/i18n/locales/es/climbs.json`, reusing translations that already exist verbatim in the same file's `createClimbForm.clear` block (lines 396-401). |
| 3 | Spanish `common.json` missing one aria-label | 1 — `common:ariaLabels.openQueue` | Add `"openQueue": "Abrir cola"` to the `ariaLabels` block. |
| 4 | i18next plural false positive | 1 — `climbs:angleSelector.sends` | Catalog already has `sends_one`/`sends_other` (correct ICU). With the default `saveMissingPlurals: true`, i18next fires `missingKeyHandler` for the base key in addition to the suffixed lookup. Set `saveMissingPlurals: false` on both client + server inits, and import `intl-pluralrules` on the server as a polyfill belt-and-suspenders. |

Net diff: 5 files, +10 / -1.

## Files touched

- `packages/web/i18n/locales/es/climbs.json` — added `create.clear.*`
- `packages/web/i18n/locales/es/common.json` — added `ariaLabels.openQueue`
- `packages/web/app/playlists/[playlist_uuid]/page.tsx` — extended `<I18nProvider namespaces=…>` to `['common', 'climbs', 'session', 'boards', 'profile', 'feed', 'playlists']`
- `packages/web/app/lib/i18n/client.tsx` — added `saveMissingPlurals: false`
- `packages/web/app/lib/i18n/server.ts` — added `saveMissingPlurals: false` and `import 'intl-pluralrules'`

## Test plan

This sandbox doesn't have `vp` installed (Vite+ install URL is firewalled), so local `vp check` / `vp run typecheck` couldn't run. CI will validate. JSON syntax of all touched catalog files was verified locally with `jq empty`.

- [ ] CI: `vp check` passes (lint + format).
- [ ] CI: `vp run typecheck:web` passes.
- [ ] CI: `vp run check:i18n` passes (no new untranslated strings).
- [ ] CI: i18n tests pass (`app/__tests__/i18n-catalog-completeness.test.ts`, `app/lib/i18n/__tests__/{plurals,missing-key-reporter}.test.ts` if present).
- [ ] Visit `http://localhost:3000/es/kilter/original/12x12-square/screw_bolt/0/create` — open the "clear holds" confirmation popover; title / description / tooltip render in Spanish.
- [ ] Visit `http://localhost:3000/es/b/the-climb-madrid-kilter-d4226f60/50/list` — queue button's `aria-label` reads "Abrir cola" in DevTools.
- [ ] Visit `http://localhost:3000/playlists/<some-uuid>` (standalone, no board prefix), open a climb's tick action, trigger Log Ascent drawer — form labels render in active locale; no `i18next::translator: missingKey` console warnings for `profile:logbook.form.*`.
- [ ] Visit `http://localhost:3000/b/<slug>/<angle>/list` — angle selector still renders "N sends" / "1 send"; no console warning for `angleSelector.sends`.
- [ ] Sentry post-deploy: filter by the four key-pattern groups; all four stop receiving new events after one full deploy cycle.

## Out of scope (filed as follow-ups)

- The catalog completeness test only strict-enforces `fr`. Extending strict enforcement to `es` would have caught categories 2 + 3 at CI time but requires auditing every existing es-vs-en gap; the team currently treats `es` as community-maintained.
- Other standalone (non-board-prefixed) routes that render climb actions (e.g. `/u/:user`, `/setter/:id`) may have the same Category 1 namespace gap; worth a separate audit.

https://claude.ai/code/session_01LkhaQmB6Rv357SRhDoFzj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkhaQmB6Rv357SRhDoFzj2)_