### PR TITLE
feat(admin): cohort retention dashboard at /admin/retention

### DIFF
--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Alert from '@mui/material/Alert';
+import MuiLink from '@mui/material/Link';
 import { useTranslation } from 'react-i18next';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -15,6 +16,7 @@ import { GET_MY_ROLES } from '@/app/lib/graphql/operations/proposals';
 import type { CommunityRoleAssignment } from '@boardsesh/shared-schema';
 import RoleManagement from '@/app/components/admin/role-management';
 import CommunitySettingsPanel from '@/app/components/admin/community-settings-panel';
+import LocaleLink from '@/app/components/i18n/locale-link';
 
 export default function AdminPage() {
   const { t } = useTranslation('admin');
@@ -63,9 +65,19 @@ export default function AdminPage() {
 
   return (
     <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
-      <Typography variant="h5" sx={{ fontWeight: 700, mb: 3, color: themeTokens.neutral[800] }}>
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: themeTokens.neutral[800] }}>
         {t('title')}
       </Typography>
+      <Box sx={{ mb: 3 }}>
+        <MuiLink
+          component={LocaleLink}
+          href="/admin/retention"
+          underline="hover"
+          sx={{ color: themeTokens.colors.primary }}
+        >
+          {t('nav.retention')}
+        </MuiLink>
+      </Box>
 
       <Box sx={{ borderBottom: 1, borderColor: themeTokens.neutral[200], mb: 3 }}>
         <Tabs value={tab} onChange={(_, v) => setTab(v)}>

--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { sql } from 'drizzle-orm';
+import Container from '@mui/material/Container';
+import Alert from '@mui/material/Alert';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { dbz, executeRows } from '@/app/lib/db/db';
+import { checkAdmin } from '@/app/lib/admin/check-admin';
+import RetentionDashboard, { type RetentionRow } from './retention-dashboard';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  const { t, locale } = await getServerTranslation('admin');
+  return createNoIndexMetadata({
+    title: t('metadata.retention.title'),
+    description: t('metadata.retention.description'),
+    path: '/admin/retention',
+    locale,
+  });
+}
+
+type RawRetentionRow = {
+  cohort_week: string;
+  signups: number;
+  d1_count: number;
+  d3_count: number;
+  d7_count: number;
+  d30_count: number;
+  activated_count: number;
+  d1_pct: string | null;
+  d3_pct: string | null;
+  d7_pct: string | null;
+  d30_pct: string | null;
+  activation_pct: string | null;
+};
+
+async function fetchRetention(): Promise<RetentionRow[]> {
+  // Cohort = week-of-signup (UTC). Activity = at least one boardsesh tick.
+  // Window capped at 180 days. D7/D30 columns are NULL'd for cohorts younger
+  // than the window so the UI can render a placeholder instead of 0%.
+  const rows = await executeRows<RawRetentionRow>(
+    dbz,
+    sql`
+      WITH signup_cohorts AS (
+        SELECT
+          id AS user_id,
+          (date_trunc('week', created_at AT TIME ZONE 'UTC'))::date AS cohort_week,
+          created_at
+        FROM users
+        WHERE created_at >= NOW() - INTERVAL '180 days'
+      ),
+      ticks_by_user AS (
+        SELECT
+          sc.user_id,
+          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '1 day')  AS active_d1,
+          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '3 days') AS active_d3,
+          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '7 days') AS active_d7,
+          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '30 days') AS active_d30,
+          BOOL_OR(TRUE) AS ever_active
+        FROM signup_cohorts sc
+        JOIN boardsesh_ticks t
+          ON t.user_id = sc.user_id
+         AND t.climbed_at >= sc.created_at
+        GROUP BY sc.user_id
+      ),
+      cohort_rollup AS (
+        SELECT
+          sc.cohort_week,
+          COUNT(*)::int AS signups,
+          COUNT(*) FILTER (WHERE tbu.active_d1)::int AS d1_count,
+          COUNT(*) FILTER (WHERE tbu.active_d3)::int AS d3_count,
+          COUNT(*) FILTER (WHERE tbu.active_d7)::int AS d7_count,
+          COUNT(*) FILTER (WHERE tbu.active_d30)::int AS d30_count,
+          COUNT(*) FILTER (WHERE tbu.ever_active)::int AS activated_count
+        FROM signup_cohorts sc
+        LEFT JOIN ticks_by_user tbu USING (user_id)
+        GROUP BY sc.cohort_week
+      )
+      SELECT
+        to_char(cohort_week, 'YYYY-MM-DD') AS cohort_week,
+        signups,
+        d1_count,
+        d3_count,
+        d7_count,
+        d30_count,
+        activated_count,
+        ROUND(100.0 * d1_count  / NULLIF(signups, 0), 1) AS d1_pct,
+        ROUND(100.0 * d3_count  / NULLIF(signups, 0), 1) AS d3_pct,
+        CASE WHEN cohort_week + INTERVAL '7 days'  <= CURRENT_DATE
+             THEN ROUND(100.0 * d7_count  / NULLIF(signups, 0), 1) END AS d7_pct,
+        CASE WHEN cohort_week + INTERVAL '30 days' <= CURRENT_DATE
+             THEN ROUND(100.0 * d30_count / NULLIF(signups, 0), 1) END AS d30_pct,
+        ROUND(100.0 * activated_count / NULLIF(signups, 0), 1) AS activation_pct
+      FROM cohort_rollup
+      ORDER BY cohort_week DESC;
+    `,
+  );
+
+  const toNumberOrNull = (value: string | null): number | null => (value === null ? null : Number(value));
+
+  return rows.map((row) => ({
+    cohortWeek: row.cohort_week,
+    signups: row.signups,
+    d1Count: row.d1_count,
+    d3Count: row.d3_count,
+    d7Count: row.d7_count,
+    d30Count: row.d30_count,
+    activatedCount: row.activated_count,
+    d1Pct: toNumberOrNull(row.d1_pct),
+    d3Pct: toNumberOrNull(row.d3_pct),
+    d7Pct: toNumberOrNull(row.d7_pct),
+    d30Pct: toNumberOrNull(row.d30_pct),
+    activationPct: toNumberOrNull(row.activation_pct),
+  }));
+}
+
+export default async function AdminRetentionPage() {
+  const access = await checkAdmin();
+  const locale = await getLocale();
+  const { t } = await getServerTranslation('admin');
+
+  if (!access.authenticated) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="warning">{t('auth.signInRequired')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  if (!access.isAdmin) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="error">{t('auth.noAccess')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  const rows = await fetchRetention();
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+      <RetentionDashboard rows={rows} />
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/admin/retention/retention-dashboard.tsx
+++ b/packages/web/app/admin/retention/retention-dashboard.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import MuiLink from '@mui/material/Link';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { useTranslation } from 'react-i18next';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export type RetentionRow = {
+  cohortWeek: string;
+  signups: number;
+  d1Count: number;
+  d3Count: number;
+  d7Count: number;
+  d30Count: number;
+  activatedCount: number;
+  d1Pct: number | null;
+  d3Pct: number | null;
+  d7Pct: number | null;
+  d30Pct: number | null;
+  activationPct: number | null;
+};
+
+type RetentionDashboardProps = {
+  rows: RetentionRow[];
+};
+
+function formatPct(value: number | null, placeholder: string): string {
+  if (value === null) return placeholder;
+  return `${value.toFixed(1)}%`;
+}
+
+export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
+  const { t } = useTranslation('admin');
+  const placeholder = t('retention.table.notReady');
+
+  const chartRows = [...rows].reverse().filter((row) => row.d7Pct !== null);
+  const chartCategories = chartRows.map((row) => row.cohortWeek);
+  const chartValues = chartRows.map((row) => row.d7Pct ?? 0);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+      <Box sx={{ mb: 3 }}>
+        <MuiLink component={LocaleLink} href="/admin" underline="hover" sx={{ color: themeTokens.colors.primary }}>
+          {t('retention.back')}
+        </MuiLink>
+      </Box>
+
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: themeTokens.neutral[800] }}>
+        {t('retention.heading')}
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 1, color: themeTokens.neutral[700] }}>
+        {t('retention.subheading')}
+      </Typography>
+      <Typography variant="caption" sx={{ display: 'block', mb: 3, color: themeTokens.neutral[600] }}>
+        {t('retention.definitions')}
+      </Typography>
+
+      {chartRows.length > 0 && (
+        <Paper sx={{ p: 2, mb: 3 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1, color: themeTokens.neutral[800] }}>
+            {t('retention.chart.title')}
+          </Typography>
+          <Box sx={{ height: 240 }}>
+            <BarChart
+              series={[
+                {
+                  data: chartValues,
+                  label: t('retention.chart.label'),
+                  color: themeTokens.colors.primary,
+                },
+              ]}
+              xAxis={[
+                {
+                  data: chartCategories,
+                  scaleType: 'band' as const,
+                  tickLabelStyle: { fontSize: 10, angle: -45, textAnchor: 'end' },
+                },
+              ]}
+              yAxis={[{ min: 0, max: 100 }]}
+              height={240}
+              margin={{ top: 8, bottom: 56, left: 32, right: 8 }}
+              hideLegend
+              borderRadius={4}
+            />
+          </Box>
+        </Paper>
+      )}
+
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('retention.table.cohortWeek')}</TableCell>
+              <TableCell align="right">{t('retention.table.signups')}</TableCell>
+              <TableCell align="right">{t('retention.table.activated')}</TableCell>
+              <TableCell align="right">{t('retention.table.d1')}</TableCell>
+              <TableCell align="right">{t('retention.table.d3')}</TableCell>
+              <TableCell align="right">{t('retention.table.d7')}</TableCell>
+              <TableCell align="right">{t('retention.table.d30')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ color: themeTokens.neutral[600] }}>
+                  {t('retention.table.empty')}
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((row) => (
+              <TableRow key={row.cohortWeek}>
+                <TableCell>{row.cohortWeek}</TableCell>
+                <TableCell align="right">{row.signups}</TableCell>
+                <TableCell align="right">{formatPct(row.activationPct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d1Pct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d3Pct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d7Pct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d30Pct, placeholder)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Container>
+  );
+}

--- a/packages/web/app/lib/admin/check-admin.ts
+++ b/packages/web/app/lib/admin/check-admin.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import { getServerSession } from 'next-auth/next';
+import { eq, and } from 'drizzle-orm';
+import { authOptions } from '@/app/lib/auth/auth-options';
+import { getDb } from '@/app/lib/db/db';
+import { communityRoles } from '@/app/lib/db/schema';
+
+export type AdminCheck = { authenticated: false } | { authenticated: true; userId: string; isAdmin: boolean };
+
+export async function checkAdmin(): Promise<AdminCheck> {
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id;
+  if (!userId) return { authenticated: false };
+
+  const rows = await getDb()
+    .select({ id: communityRoles.id })
+    .from(communityRoles)
+    .where(and(eq(communityRoles.userId, userId), eq(communityRoles.role, 'admin')))
+    .limit(1);
+
+  return { authenticated: true, userId, isAdmin: rows.length > 0 };
+}

--- a/packages/web/i18n/locales/en-US/admin.json
+++ b/packages/web/i18n/locales/en-US/admin.json
@@ -3,6 +3,10 @@
     "admin": {
       "title": "Admin Panel",
       "description": "Boardsesh admin panel"
+    },
+    "retention": {
+      "title": "Retention",
+      "description": "Cohort retention dashboard"
     }
   },
   "title": "Admin Panel",
@@ -13,6 +17,30 @@
   "tabs": {
     "roles": "Roles",
     "settings": "Settings"
+  },
+  "nav": {
+    "retention": "Retention dashboard"
+  },
+  "retention": {
+    "heading": "User retention",
+    "subheading": "Of users who signed up in week W, how many returned to log a tick within N days.",
+    "definitions": "Cohort = signup week (UTC). Activity = at least one logged tick. D7 = active within 7 days of signup. Cohorts younger than the window show —.",
+    "back": "Back to admin",
+    "table": {
+      "cohortWeek": "Cohort week",
+      "signups": "Signups",
+      "activated": "Activated",
+      "d1": "D1",
+      "d3": "D3",
+      "d7": "D7",
+      "d30": "D30",
+      "notReady": "—",
+      "empty": "No cohort data yet."
+    },
+    "chart": {
+      "title": "D7 retention by cohort week",
+      "label": "D7 %"
+    }
   },
   "roles": {
     "heading": "Community Roles",


### PR DESCRIPTION
## Why

Vercel Web Analytics can't compute D1/D3/D7/D30 user retention. Visitor IDs are hashed and reset every 24h by design, the dashboard has no cohort report, and even though the app already calls `track()` 100+ times, custom event properties aren't queryable by `userId` in the dashboard.

But the data is already in Postgres:
- `users.created_at` → signup cohort
- `boardsesh_ticks.climbed_at` → "did the user come back and actually climb" — the strongest engagement signal we have, and there's already a covering index on `(user_id, climbed_at)`

So no new tables, no new write-path, no SaaS dependency. Just read what's there.

## What

A new server-rendered admin sub-route at `/admin/retention`:

- Server-side admin gate: reads NextAuth session, queries `community_roles` for `role = 'admin'` via Drizzle (mirrors the existing client-side check at `app/admin/page.tsx`).
- One CTE-style SQL query joining `users` (cohort) → `boardsesh_ticks` (return signal) → cohort rollup with `FILTER` clauses for D1/D3/D7/D30 buckets.
- MUI table: `Cohort week | Signups | Activated | D1 | D3 | D7 | D30`
- `@mui/x-charts` `BarChart` showing D7 % across cohort weeks.
- Cohorts younger than the window render as `—` instead of misleading 0%.

## Definitions

- **Cohort**: signup week (UTC), `date_trunc('week', users.created_at AT TIME ZONE 'UTC')`. Weekly buckets — daily would be too noisy at the current user count.
- **Active**: at least one `boardsesh_ticks` row. Logging a tick is the cleanest "the user actually used the product" signal.
- **D7**: returned to log a tick at least once within 7 days of signup (cumulative window, not strict "active on day 7").
- **Activation**: % of signups who ever logged a tick — bonus signal from the same data.
- **Window**: capped at 180 days; founder can bump it later.

## Files

- `packages/web/app/admin/retention/page.tsx` — server component + SQL
- `packages/web/app/admin/retention/retention-dashboard.tsx` — client table + chart
- `packages/web/app/lib/admin/check-admin.ts` — reusable server-side admin check
- `packages/web/app/admin/page.tsx` — adds a link to the retention page below the title
- `packages/web/i18n/locales/en-US/admin.json` — new copy under `retention.*`, `nav.retention`, `metadata.retention.*`

## Test plan

- [ ] Sign in as an admin user, visit `/admin/retention`, confirm the cohort table renders with non-empty data from the seed DB.
- [ ] Spot-check one cohort by hand:
      `SELECT id, created_at FROM users WHERE date_trunc('week', created_at AT TIME ZONE 'UTC') = '<some week>';`
      then count those with at least one tick within 7 days. Compare to the dashboard.
- [ ] Recent cohorts (< 7 days old) show `—` for D7, not `0.0%`.
- [ ] Sign out → `/admin/retention` shows "sign in" alert. Sign in as non-admin → shows "no access" alert.
- [ ] `/es/admin/retention` keeps locale prefix on the "Back to admin" link.
- [ ] `vp check && vp run typecheck` pass in CI.

## Out of scope (follow-ups)

- Anonymous-user retention (those users only exist in IndexedDB)
- Engagement-based "active" definition (UNION over comments / votes / follows / playlist edits) as a UI toggle
- Strict day-N retention (active exactly on day N, not "within N days")
- Daily cohort granularity
- Move query into `packages/backend` GraphQL — aligns with the long-term "no REST in next.js" rule, but overkill for an admin-only read

https://claude.ai/code/session_01Jvb1pJXTjWZgxmFCw4xXQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jvb1pJXTjWZgxmFCw4xXQT)_