### PR TITLE
fix(admin/retention): exclude Aurora-imported ticks from activity signal

### DIFF
--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -38,9 +38,11 @@ type RawRetentionRow = {
 };
 
 async function fetchRetention(): Promise<RetentionRow[]> {
-  // Cohort = week-of-signup (UTC). Activity = at least one boardsesh tick.
-  // Window capped at 180 days. D7/D30 columns are NULL'd for cohorts younger
-  // than the window so the UI can render a placeholder instead of 0%.
+  // Cohort = week-of-signup (UTC). Activity = at least one boardsesh tick
+  // that originated in Boardsesh (aurora_id IS NULL — i.e. not synced in
+  // from Aurora). Window capped at 180 days. D7/D30 columns are NULL'd for
+  // cohorts younger than the window so the UI can render a placeholder
+  // instead of 0%.
   const rows = await executeRows<RawRetentionRow>(
     dbz,
     sql`
@@ -64,6 +66,7 @@ async function fetchRetention(): Promise<RetentionRow[]> {
         JOIN boardsesh_ticks t
           ON t.user_id = sc.user_id
          AND t.climbed_at >= sc.created_at
+         AND t.aurora_id IS NULL
         GROUP BY sc.user_id
       ),
       cohort_rollup AS (

--- a/packages/web/i18n/locales/en-US/admin.json
+++ b/packages/web/i18n/locales/en-US/admin.json
@@ -24,7 +24,7 @@
   "retention": {
     "heading": "User retention",
     "subheading": "Of users who signed up in week W, how many returned to log a tick within N days.",
-    "definitions": "Cohort = signup week (UTC). Activity = at least one logged tick. D7 = active within 7 days of signup. Cohorts younger than the window show —.",
+    "definitions": "Cohort = signup week (UTC). Activity = at least one tick logged in Boardsesh (Aurora-imported ticks excluded). D7 = active within 7 days of signup. Cohorts younger than the window show —.",
     "back": "Back to admin",
     "table": {
       "cohortWeek": "Cohort week",


### PR DESCRIPTION
Ticks pulled in from Aurora's API/JSON import shouldn't count as Boardsesh engagement — the user logged those climbs in Aurora's app, not ours. Filter on aurora_id IS NULL so retention reflects ticks logged through Boardsesh's own UI.

Caveat: the legacy /api/v1/.../proxy/saveAscent route also sets aurora_id at insert time, so any historical ticks created via that path will be excluded along with imports. The modern createTick GraphQL mutation correctly inserts with aurora_id = NULL.