### PR TITLE
ci: pin claude-code-action to v1.0.99

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.99
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.99
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

The Claude Code Review workflow has been failing on every PR with:

```
ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude.
```

`anthropics/claude-code-action@v1` resolves to `v1.0.100+`, which installs Claude Code 2.1.129 via the native installer. On stock GitHub Actions runners that installer reports success but leaves `/home/runner/.local/bin/claude` missing (you can see both warnings in the failed run logs: *"installMethod is native, but directory /home/runner/.local/bin does not exist"* / *"claude command not found at /home/runner/.local/bin/claude"*). The action then passes that bogus path to the SDK and errors out before posting a review.

This is tracked upstream as [anthropics/claude-code-action#1242](https://github.com/anthropics/claude-code-action/issues/1242). The documented workaround is to pin to `v1.0.99`, which lets the SDK fall back to its bundled platform binary (`@anthropic-ai/claude-agent-sdk-linux-x64`) instead of relying on the broken native install.

This change pins both action invocations:

- `.github/workflows/claude-code-review.yml` (the failing one)
- `.github/workflows/claude.yml` (uses the same action, would fail the same way next time `@claude` is mentioned)

## Test plan

- [ ] Open a no-op PR (or push to this branch) and confirm `Claude Code Review` posts a review comment instead of failing during the SDK step
- [ ] Mention `@claude` on a PR and confirm the `Claude Code` workflow runs end-to-end
- [ ] Once upstream cuts a release that re-fixes the native install (or restores the bundled-binary fallback), revert this pin back to `@v1`

https://claude.ai/code/session_01PpU9JWzZU8vn85vSFpoNNh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpU9JWzZU8vn85vSFpoNNh)_