### PR TITLE
feat(admin/retention): add 'any activity' retention alongside ticks

### DIFF
--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -35,14 +35,27 @@ type RawRetentionRow = {
   d7_pct: string | null;
   d30_pct: string | null;
   activation_pct: string | null;
+  d1_any_count: number;
+  d3_any_count: number;
+  d7_any_count: number;
+  d30_any_count: number;
+  activated_any_count: number;
+  d1_any_pct: string | null;
+  d3_any_pct: string | null;
+  d7_any_pct: string | null;
+  d30_any_pct: string | null;
+  activation_any_pct: string | null;
 };
 
 async function fetchRetention(): Promise<RetentionRow[]> {
-  // Cohort = week-of-signup (UTC). Activity = at least one boardsesh tick
-  // that originated in Boardsesh (aurora_id IS NULL — i.e. not synced in
-  // from Aurora). Window capped at 180 days. D7/D30 columns are NULL'd for
-  // cohorts younger than the window so the UI can render a placeholder
-  // instead of 0%.
+  // Cohort = week-of-signup (UTC). Two parallel "active" definitions:
+  //   1. Tick activity: at least one boardsesh tick (aurora_id IS NULL —
+  //      not synced in from Aurora). This is the original metric.
+  //   2. Any activity: a UNION ALL of every user-attributable timestamp
+  //      we record — ticks, party sessions, favorites/playlists/pins/follows,
+  //      comments/votes/proposals/feedback. Captures returners who don't tick.
+  // Window capped at 180 days. D7/D30 columns are NULL'd for cohorts younger
+  // than the window so the UI can render a placeholder instead of 0%.
   const rows = await executeRows<RawRetentionRow>(
     dbz,
     sql`
@@ -69,6 +82,49 @@ async function fetchRetention(): Promise<RetentionRow[]> {
          AND t.aurora_id IS NULL
         GROUP BY sc.user_id
       ),
+      activity_events AS (
+        SELECT user_id, climbed_at AS ts FROM boardsesh_ticks WHERE aurora_id IS NULL
+        UNION ALL
+        SELECT created_by_user_id AS user_id, created_at AS ts FROM board_sessions WHERE created_by_user_id IS NOT NULL
+        UNION ALL
+        SELECT user_id, joined_at AS ts FROM board_session_participants
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM user_favorites
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM playlist_ownership
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM user_playlist_pins
+        UNION ALL
+        SELECT follower_id AS user_id, created_at AS ts FROM user_follows
+        UNION ALL
+        SELECT follower_id AS user_id, created_at AS ts FROM playlist_follows
+        UNION ALL
+        SELECT follower_id AS user_id, created_at AS ts FROM setter_follows
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM new_climb_subscriptions
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM comments
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM votes
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM proposal_votes
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM app_feedback WHERE user_id IS NOT NULL
+      ),
+      activity_by_user AS (
+        SELECT
+          sc.user_id,
+          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '1 day')  AS active_d1,
+          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '3 days') AS active_d3,
+          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '7 days') AS active_d7,
+          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '30 days') AS active_d30,
+          BOOL_OR(TRUE) AS ever_active
+        FROM signup_cohorts sc
+        JOIN activity_events ae
+          ON ae.user_id = sc.user_id
+         AND ae.ts >= sc.created_at
+        GROUP BY sc.user_id
+      ),
       cohort_rollup AS (
         SELECT
           sc.cohort_week,
@@ -77,9 +133,15 @@ async function fetchRetention(): Promise<RetentionRow[]> {
           COUNT(*) FILTER (WHERE tbu.active_d3)::int AS d3_count,
           COUNT(*) FILTER (WHERE tbu.active_d7)::int AS d7_count,
           COUNT(*) FILTER (WHERE tbu.active_d30)::int AS d30_count,
-          COUNT(*) FILTER (WHERE tbu.ever_active)::int AS activated_count
+          COUNT(*) FILTER (WHERE tbu.ever_active)::int AS activated_count,
+          COUNT(*) FILTER (WHERE abu.active_d1)::int AS d1_any_count,
+          COUNT(*) FILTER (WHERE abu.active_d3)::int AS d3_any_count,
+          COUNT(*) FILTER (WHERE abu.active_d7)::int AS d7_any_count,
+          COUNT(*) FILTER (WHERE abu.active_d30)::int AS d30_any_count,
+          COUNT(*) FILTER (WHERE abu.ever_active)::int AS activated_any_count
         FROM signup_cohorts sc
         LEFT JOIN ticks_by_user tbu USING (user_id)
+        LEFT JOIN activity_by_user abu USING (user_id)
         GROUP BY sc.cohort_week
       )
       SELECT
@@ -96,7 +158,19 @@ async function fetchRetention(): Promise<RetentionRow[]> {
              THEN ROUND(100.0 * d7_count  / NULLIF(signups, 0), 1) END AS d7_pct,
         CASE WHEN cohort_week + INTERVAL '30 days' <= CURRENT_DATE
              THEN ROUND(100.0 * d30_count / NULLIF(signups, 0), 1) END AS d30_pct,
-        ROUND(100.0 * activated_count / NULLIF(signups, 0), 1) AS activation_pct
+        ROUND(100.0 * activated_count / NULLIF(signups, 0), 1) AS activation_pct,
+        d1_any_count,
+        d3_any_count,
+        d7_any_count,
+        d30_any_count,
+        activated_any_count,
+        ROUND(100.0 * d1_any_count  / NULLIF(signups, 0), 1) AS d1_any_pct,
+        ROUND(100.0 * d3_any_count  / NULLIF(signups, 0), 1) AS d3_any_pct,
+        CASE WHEN cohort_week + INTERVAL '7 days'  <= CURRENT_DATE
+             THEN ROUND(100.0 * d7_any_count  / NULLIF(signups, 0), 1) END AS d7_any_pct,
+        CASE WHEN cohort_week + INTERVAL '30 days' <= CURRENT_DATE
+             THEN ROUND(100.0 * d30_any_count / NULLIF(signups, 0), 1) END AS d30_any_pct,
+        ROUND(100.0 * activated_any_count / NULLIF(signups, 0), 1) AS activation_any_pct
       FROM cohort_rollup
       ORDER BY cohort_week DESC;
     `,
@@ -117,6 +191,16 @@ async function fetchRetention(): Promise<RetentionRow[]> {
     d7Pct: toNumberOrNull(row.d7_pct),
     d30Pct: toNumberOrNull(row.d30_pct),
     activationPct: toNumberOrNull(row.activation_pct),
+    d1AnyCount: row.d1_any_count,
+    d3AnyCount: row.d3_any_count,
+    d7AnyCount: row.d7_any_count,
+    d30AnyCount: row.d30_any_count,
+    activatedAnyCount: row.activated_any_count,
+    d1AnyPct: toNumberOrNull(row.d1_any_pct),
+    d3AnyPct: toNumberOrNull(row.d3_any_pct),
+    d7AnyPct: toNumberOrNull(row.d7_any_pct),
+    d30AnyPct: toNumberOrNull(row.d30_any_pct),
+    activationAnyPct: toNumberOrNull(row.activation_any_pct),
   }));
 }
 

--- a/packages/web/app/admin/retention/retention-dashboard.tsx
+++ b/packages/web/app/admin/retention/retention-dashboard.tsx
@@ -30,6 +30,16 @@ export type RetentionRow = {
   d7Pct: number | null;
   d30Pct: number | null;
   activationPct: number | null;
+  d1AnyCount: number;
+  d3AnyCount: number;
+  d7AnyCount: number;
+  d30AnyCount: number;
+  activatedAnyCount: number;
+  d1AnyPct: number | null;
+  d3AnyPct: number | null;
+  d7AnyPct: number | null;
+  d30AnyPct: number | null;
+  activationAnyPct: number | null;
 };
 
 type RetentionDashboardProps = {
@@ -45,9 +55,10 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
   const { t } = useTranslation('admin');
   const placeholder = t('retention.table.notReady');
 
-  const chartRows = [...rows].reverse().filter((row) => row.d7Pct !== null);
+  const chartRows = [...rows].reverse().filter((row) => row.d7Pct !== null || row.d7AnyPct !== null);
   const chartCategories = chartRows.map((row) => row.cohortWeek);
-  const chartValues = chartRows.map((row) => row.d7Pct ?? 0);
+  const chartTickValues = chartRows.map((row) => row.d7Pct ?? 0);
+  const chartAnyValues = chartRows.map((row) => row.d7AnyPct ?? 0);
 
   return (
     <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
@@ -72,13 +83,18 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
           <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1, color: themeTokens.neutral[800] }}>
             {t('retention.chart.title')}
           </Typography>
-          <Box sx={{ height: 240 }}>
+          <Box sx={{ height: 280 }}>
             <BarChart
               series={[
                 {
-                  data: chartValues,
+                  data: chartTickValues,
                   label: t('retention.chart.label'),
                   color: themeTokens.colors.primary,
+                },
+                {
+                  data: chartAnyValues,
+                  label: t('retention.chart.labelAny'),
+                  color: themeTokens.colors.success,
                 },
               ]}
               xAxis={[
@@ -89,9 +105,8 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
                 },
               ]}
               yAxis={[{ min: 0, max: 100 }]}
-              height={240}
-              margin={{ top: 8, bottom: 56, left: 32, right: 8 }}
-              hideLegend
+              height={280}
+              margin={{ top: 24, bottom: 56, left: 32, right: 8 }}
               borderRadius={4}
             />
           </Box>
@@ -102,9 +117,28 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
         <Table size="small">
           <TableHead>
             <TableRow>
-              <TableCell>{t('retention.table.cohortWeek')}</TableCell>
-              <TableCell align="right">{t('retention.table.signups')}</TableCell>
-              <TableCell align="right">{t('retention.table.activated')}</TableCell>
+              <TableCell rowSpan={2}>{t('retention.table.cohortWeek')}</TableCell>
+              <TableCell align="right" rowSpan={2}>
+                {t('retention.table.signups')}
+              </TableCell>
+              <TableCell align="center" colSpan={5} sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                {t('retention.table.groupTicks')}
+              </TableCell>
+              <TableCell align="center" colSpan={5} sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                {t('retention.table.groupAny')}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell align="right" sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                {t('retention.table.activated')}
+              </TableCell>
+              <TableCell align="right">{t('retention.table.d1')}</TableCell>
+              <TableCell align="right">{t('retention.table.d3')}</TableCell>
+              <TableCell align="right">{t('retention.table.d7')}</TableCell>
+              <TableCell align="right">{t('retention.table.d30')}</TableCell>
+              <TableCell align="right" sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                {t('retention.table.activated')}
+              </TableCell>
               <TableCell align="right">{t('retention.table.d1')}</TableCell>
               <TableCell align="right">{t('retention.table.d3')}</TableCell>
               <TableCell align="right">{t('retention.table.d7')}</TableCell>
@@ -114,7 +148,7 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
           <TableBody>
             {rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={7} align="center" sx={{ color: themeTokens.neutral[600] }}>
+                <TableCell colSpan={12} align="center" sx={{ color: themeTokens.neutral[600] }}>
                   {t('retention.table.empty')}
                 </TableCell>
               </TableRow>
@@ -123,11 +157,20 @@ export default function RetentionDashboard({ rows }: RetentionDashboardProps) {
               <TableRow key={row.cohortWeek}>
                 <TableCell>{row.cohortWeek}</TableCell>
                 <TableCell align="right">{row.signups}</TableCell>
-                <TableCell align="right">{formatPct(row.activationPct, placeholder)}</TableCell>
+                <TableCell align="right" sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                  {formatPct(row.activationPct, placeholder)}
+                </TableCell>
                 <TableCell align="right">{formatPct(row.d1Pct, placeholder)}</TableCell>
                 <TableCell align="right">{formatPct(row.d3Pct, placeholder)}</TableCell>
                 <TableCell align="right">{formatPct(row.d7Pct, placeholder)}</TableCell>
                 <TableCell align="right">{formatPct(row.d30Pct, placeholder)}</TableCell>
+                <TableCell align="right" sx={{ borderLeft: `1px solid ${themeTokens.neutral[300]}` }}>
+                  {formatPct(row.activationAnyPct, placeholder)}
+                </TableCell>
+                <TableCell align="right">{formatPct(row.d1AnyPct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d3AnyPct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d7AnyPct, placeholder)}</TableCell>
+                <TableCell align="right">{formatPct(row.d30AnyPct, placeholder)}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/packages/web/i18n/locales/en-US/admin.json
+++ b/packages/web/i18n/locales/en-US/admin.json
@@ -23,12 +23,14 @@
   },
   "retention": {
     "heading": "User retention",
-    "subheading": "Of users who signed up in week W, how many returned to log a tick within N days.",
-    "definitions": "Cohort = signup week (UTC). Activity = at least one tick logged in Boardsesh (Aurora-imported ticks excluded). D7 = active within 7 days of signup. Cohorts younger than the window show —.",
+    "subheading": "Of users who signed up in week W, how many came back within N days — both as ticks (climbs logged) and as any in-app activity.",
+    "definitions": "Cohort = signup week (UTC). Ticks = at least one climb logged in Boardsesh (Aurora-imported ticks excluded). Any activity = a tick, party-session host or join, favorite, playlist (created or pinned), follow (user, setter, or playlist), new-climb subscription, comment, vote, proposal vote, or feedback submission. D7 = active within 7 days of signup. Cohorts younger than the window show —.",
     "back": "Back to admin",
     "table": {
       "cohortWeek": "Cohort week",
       "signups": "Signups",
+      "groupTicks": "Ticks",
+      "groupAny": "Any activity",
       "activated": "Activated",
       "d1": "D1",
       "d3": "D3",
@@ -39,7 +41,8 @@
     },
     "chart": {
       "title": "D7 retention by cohort week",
-      "label": "D7 %"
+      "label": "Ticks",
+      "labelAny": "Any activity"
     }
   },
   "roles": {


### PR DESCRIPTION
## Summary

The retention dashboard at `/admin/retention` previously defined "active" as "logged a tick." Many real users sign up and never tick — they browse climbs, build playlists, join party sessions, comment, follow setters, etc. Treating those users as churned understates retention.

This PR adds a parallel "any activity" cohort metric that runs side-by-side with the existing tick metric, so we can see the gap between "users who came back to log climbs" and "users who came back to do anything at all."

### What counts as "any activity"

A `UNION ALL` of every user-attributable timestamp in the schema, joined to the same signup-cohort window the tick query already uses:

- **Climb log**: `boardsesh_ticks.climbed_at` (Aurora-imported ticks excluded, same as before)
- **Party sessions**: `board_sessions.created_at` (host) + `board_session_participants.joined_at`
- **Curation**: `user_favorites`, `playlist_ownership`, `user_playlist_pins`, `user_follows`, `playlist_follows`, `setter_follows`, `new_climb_subscriptions`
- **Social writes**: `comments`, `votes`, `proposal_votes`, `app_feedback`

Tables with nullable user FKs (`board_sessions.created_by_user_id`, `app_feedback.user_id`) are filtered with `WHERE user_id IS NOT NULL` in the union.

### UI

- Table now has two parallel column groups — **Ticks** and **Any activity** — each with Activated/D1/D3/D7/D30. A vertical divider separates the two groups.
- D7 bar chart now plots both series per cohort week so the gap is visible at a glance (legend re-enabled).
- `retention.definitions` updated to enumerate what counts toward the broader metric.

### Files changed

- `packages/web/app/admin/retention/page.tsx` — extended SQL with `activity_events` and `activity_by_user` CTEs; added `*_any_count` / `*_any_pct` to the projection and mapper.
- `packages/web/app/admin/retention/retention-dashboard.tsx` — extended `RetentionRow` with `*Any` fields; restructured table head with two grouped column sets; added second BarChart series.
- `packages/web/i18n/locales/en-US/admin.json` — added `groupTicks`, `groupAny`, `chart.labelAny`, updated `definitions` and `subheading`. Spanish catalog falls back to English.

No schema changes, no migrations.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp lint packages/web/app/admin/retention/` — 0 warnings, 0 errors
- [x] `vp fmt --check` on all three modified files — passes
- [ ] **Browser QA was not possible in the agent sandbox** (no Docker daemon → no dev DB). Reviewer should run `vp run dev`, sign in as admin, open `/admin/retention`, and confirm:
  - The original tick columns match what was on the page before this PR (sanity check on the SQL refactor).
  - For every cohort, the "Any activity" percentages are ≥ the matching "Ticks" percentages (a tick is itself one of the union inputs, so any-activity must dominate).
  - Cohorts that previously showed 0% tick retention but had favorites / session joins / playlist activity now show non-zero "Any activity" retention.
  - D7 chart renders two coloured series with a legend.
- [ ] Spot-check one user in `dbz`: pick a recent signup with no ticks but with a `user_favorites` or `board_session_participants` row inside the D7 window — confirm they roll up into `activated_any_count` / `d7_any_count`.

https://claude.ai/code/session_01XJmhRnznw7VF1jZZHv8uQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJmhRnznw7VF1jZZHv8uQg)_