### PR TITLE
fix(discover): wrap smart playlist route in layout that clears header and bottom bar

### DIFF
--- a/packages/web/app/discover/layout.tsx
+++ b/packages/web/app/discover/layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function DiscoverLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        minHeight: '100dvh',
+        paddingTop: 'var(--global-header-height)',
+        paddingBottom: 'var(--bottom-bar-height)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- The smart (generated) playlist detail page at `/discover/[smart_playlist]/[user_id]` was rendering its hero card **behind** the fixed global header and letting the climb list scroll **under** the bottom nav bar — the cause of both the "hero card below header" and "renders too big / awkward scrolling" bugs.
- Root cause: `packages/web/app/discover/` had no `layout.tsx`, so the route never received the `padding-top: var(--global-header-height)` / `padding-bottom: var(--bottom-bar-height)` wrapper that `packages/web/app/playlists/layout.tsx` provides for the regular and public playlist pages.
- Fix: add `packages/web/app/discover/layout.tsx` mirroring the playlists layout. No component or CSS changes were needed — `smart-playlist-content.tsx` already shares `playlist-view.module.css`, `PlaylistPreviewSquare`, `MultiboardClimbList`, and `BackButton` with `playlist-detail-content.tsx`.

## Test plan

- [ ] `vp run dev`, sign in as `test@boardsesh.com` / `test`.
- [ ] Open a generated playlist (e.g. `/discover/recent-sends/<userId>`) and confirm the hero card sits below the global header, not under it.
- [ ] Scroll the climb list to the bottom and confirm the last climb is fully visible above the bottom nav bar.
- [ ] Compare side-by-side with a regular playlist at `/playlists/<uuid>` — the chrome (back row, hero card, climbs section) should match.
- [ ] `vp check` and `vp run typecheck:web` pass.

https://claude.ai/code/session_0121oRfdxWRzDt3aHv9jxefm

---
_Generated by [Claude Code](https://claude.ai/code/session_0121oRfdxWRzDt3aHv9jxefm)_