### PR TITLE
feat(playlists/library): infinite scroll on Discover slider

### DIFF
--- a/packages/web/app/hooks/use-discover-playlists.ts
+++ b/packages/web/app/hooks/use-discover-playlists.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { executeGraphQL } from '@/app/lib/graphql/client';
+import {
+  DISCOVER_PLAYLISTS,
+  type DiscoverablePlaylist,
+  type DiscoverPlaylistsInput,
+  type DiscoverPlaylistsQueryResponse,
+} from '@/app/lib/graphql/operations/playlists';
+
+type UseDiscoverPlaylistsOptions = {
+  /** Optional board filter. Changing it resets pagination for both streams. */
+  boardType?: string;
+  /** Optional layout filter. Changing it resets pagination for both streams. */
+  layoutId?: number;
+  /** Page size per stream per request. Defaults to 10 (matches the existing UX). */
+  pageSize?: number;
+  /** SSR-provided initial data. When supplied, the first page fetch is skipped. */
+  initialData?: { popular: DiscoverablePlaylist[]; recent: DiscoverablePlaylist[] };
+  /** Whether the SSR popular slice has more pages. Pass through the server's
+   *  hasMore so the IntersectionObserver doesn't fire a redundant first
+   *  request just to learn there's nothing more. */
+  initialPopularHasMore?: boolean;
+  /** Same as `initialPopularHasMore`, but for the recent stream. */
+  initialRecentHasMore?: boolean;
+};
+
+type UseDiscoverPlaylistsResult = {
+  popular: DiscoverablePlaylist[];
+  recent: DiscoverablePlaylist[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  hasError: boolean;
+  loadMore: () => void;
+  refetch: () => void;
+};
+
+/**
+ * Fetches the public Discover playlists (popular + recent), paginated.
+ * Sibling of `useUserPlaylists` for the same `PlaylistScrollSection` slider:
+ *  - Two parallel page cursors, one per sort. `hasMore` is the OR.
+ *  - On `loadMore`, fetches the next page of *only* the streams that still
+ *    have more — exhausted streams are left untouched.
+ *  - Filter (boardType/layoutId) changes reset both cursors and refetch
+ *    page 0 of each.
+ *  - Three consecutive loadMore failures freeze the hook to prevent the
+ *    IntersectionObserver in PlaylistScrollSection from retrying forever.
+ */
+export function useDiscoverPlaylists({
+  boardType,
+  layoutId,
+  pageSize = 10,
+  initialData,
+  initialPopularHasMore,
+  initialRecentHasMore,
+}: UseDiscoverPlaylistsOptions): UseDiscoverPlaylistsResult {
+  const hasInitialData = initialData != null;
+  const [popular, setPopular] = useState<DiscoverablePlaylist[]>(hasInitialData ? initialData.popular : []);
+  const [recent, setRecent] = useState<DiscoverablePlaylist[]>(hasInitialData ? initialData.recent : []);
+  const [isLoading, setIsLoading] = useState(!hasInitialData);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [popularHasMore, setPopularHasMore] = useState(hasInitialData ? (initialPopularHasMore ?? false) : false);
+  const [recentHasMore, setRecentHasMore] = useState(hasInitialData ? (initialRecentHasMore ?? false) : false);
+  const [hasError, setHasError] = useState(false);
+
+  // SSR delivers page 0 for both streams; the next loadMore() must request
+  // page 1, not page 0 again (which would duplicate the SSR rows).
+  const popularPageRef = useRef(hasInitialData ? 1 : 0);
+  const recentPageRef = useRef(hasInitialData ? 1 : 0);
+  const popularHasMoreRef = useRef(popularHasMore);
+  const recentHasMoreRef = useRef(recentHasMore);
+  const isFetchingRef = useRef(false);
+  const loadMoreFailCountRef = useRef(0);
+
+  const fetchPages = useCallback(
+    async (popularPage: number, recentPage: number, isInitial: boolean) => {
+      if (isFetchingRef.current) return;
+      isFetchingRef.current = true;
+
+      if (isInitial) {
+        setIsLoading(true);
+      } else {
+        setIsLoadingMore(true);
+      }
+
+      // Initial load always pulls both streams. Subsequent loadMore calls
+      // skip a stream once it's exhausted so we don't waste requests.
+      const wantPopular = isInitial || popularHasMoreRef.current;
+      const wantRecent = isInitial || recentHasMoreRef.current;
+
+      const baseInput: DiscoverPlaylistsInput = {
+        pageSize,
+        ...(boardType !== undefined && { boardType }),
+        ...(layoutId !== undefined && { layoutId }),
+      };
+
+      try {
+        const [popularRes, recentRes] = await Promise.all([
+          wantPopular
+            ? executeGraphQL<DiscoverPlaylistsQueryResponse, { input: DiscoverPlaylistsInput }>(DISCOVER_PLAYLISTS, {
+                input: { ...baseInput, sortBy: 'popular', page: popularPage },
+              })
+            : Promise.resolve(null),
+          wantRecent
+            ? executeGraphQL<DiscoverPlaylistsQueryResponse, { input: DiscoverPlaylistsInput }>(DISCOVER_PLAYLISTS, {
+                input: { ...baseInput, sortBy: 'recent', page: recentPage },
+              })
+            : Promise.resolve(null),
+        ]);
+
+        if (popularRes) {
+          const { playlists: nextPopular, hasMore: more } = popularRes.discoverPlaylists;
+          setPopular((prev) => (isInitial ? nextPopular : [...prev, ...nextPopular]));
+          setPopularHasMore(more);
+          popularHasMoreRef.current = more;
+          popularPageRef.current = popularPage + 1;
+        }
+        if (recentRes) {
+          const { playlists: nextRecent, hasMore: more } = recentRes.discoverPlaylists;
+          setRecent((prev) => (isInitial ? nextRecent : [...prev, ...nextRecent]));
+          setRecentHasMore(more);
+          recentHasMoreRef.current = more;
+          recentPageRef.current = recentPage + 1;
+        }
+        loadMoreFailCountRef.current = 0;
+        setHasError(false);
+      } catch (err) {
+        console.error('Failed to fetch discover playlists:', err);
+        if (isInitial) {
+          setHasError(true);
+        } else {
+          loadMoreFailCountRef.current += 1;
+          if (loadMoreFailCountRef.current >= 3) {
+            setPopularHasMore(false);
+            setRecentHasMore(false);
+            popularHasMoreRef.current = false;
+            recentHasMoreRef.current = false;
+          }
+        }
+      } finally {
+        if (isInitial) {
+          setIsLoading(false);
+        } else {
+          setIsLoadingMore(false);
+        }
+        isFetchingRef.current = false;
+      }
+    },
+    [boardType, layoutId, pageSize],
+  );
+
+  // Reset + re-fetch when filters change. Skip the very first run if SSR
+  // already populated initialData for the current filter.
+  const skipFirstFetchRef = useRef(hasInitialData);
+  useEffect(() => {
+    if (skipFirstFetchRef.current) {
+      skipFirstFetchRef.current = false;
+      return;
+    }
+    setPopular([]);
+    setRecent([]);
+    popularPageRef.current = 0;
+    recentPageRef.current = 0;
+    popularHasMoreRef.current = false;
+    recentHasMoreRef.current = false;
+    setPopularHasMore(false);
+    setRecentHasMore(false);
+    void fetchPages(0, 0, true);
+  }, [fetchPages]);
+
+  const loadMore = useCallback(() => {
+    if (isFetchingRef.current) return;
+    if (!popularHasMoreRef.current && !recentHasMoreRef.current) return;
+    void fetchPages(popularPageRef.current, recentPageRef.current, false);
+  }, [fetchPages]);
+
+  const refetch = useCallback(() => {
+    popularPageRef.current = 0;
+    recentPageRef.current = 0;
+    popularHasMoreRef.current = false;
+    recentHasMoreRef.current = false;
+    void fetchPages(0, 0, true);
+  }, [fetchPages]);
+
+  return {
+    popular,
+    recent,
+    isLoading,
+    isLoadingMore,
+    hasMore: popularHasMore || recentHasMore,
+    hasError,
+    loadMore,
+    refetch,
+  };
+}

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -127,10 +127,17 @@ export async function cachedUserSessionGroupedFeed(authToken: string, userId: st
 
 /**
  * Server-side cached fetch of discover playlists (public, no auth needed).
+ *
+ * Surfaces per-stream `hasMore` + `totalCount` so the client hook can seed
+ * pagination state without firing a redundant first request.
  */
 export async function cachedDiscoverPlaylists(input: { boardType?: string; layoutId?: number } = {}): Promise<{
   popular: DiscoverablePlaylist[];
   recent: DiscoverablePlaylist[];
+  popularHasMore: boolean;
+  recentHasMore: boolean;
+  popularTotalCount: number;
+  recentTotalCount: number;
 } | null> {
   const { DISCOVER_PLAYLISTS } = await import('@/app/lib/graphql/operations/playlists');
   type Response = DiscoverPlaylistsQueryResponse;
@@ -151,6 +158,10 @@ export async function cachedDiscoverPlaylists(input: { boardType?: string; layou
     return {
       popular: popularRes.discoverPlaylists.playlists,
       recent: recentRes.discoverPlaylists.playlists,
+      popularHasMore: popularRes.discoverPlaylists.hasMore,
+      recentHasMore: recentRes.discoverPlaylists.hasMore,
+      popularTotalCount: popularRes.discoverPlaylists.totalCount,
+      recentTotalCount: recentRes.discoverPlaylists.totalCount,
     };
   } catch {
     return null;

--- a/packages/web/app/playlists/__tests__/library-page-content.test.tsx
+++ b/packages/web/app/playlists/__tests__/library-page-content.test.tsx
@@ -285,7 +285,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[board]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
         boardSlug={board.slug}
       />,
@@ -306,7 +306,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
       />,
     );
@@ -326,7 +326,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
       />,
     );
@@ -348,7 +348,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
       />,
     );
@@ -374,7 +374,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
       />,
     );
 
@@ -395,7 +395,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[board]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
         boardSlug={board.slug}
         createSource="board-slug-playlists-fab"
@@ -413,7 +413,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[board]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
         boardSlug={board.slug}
       />,
@@ -435,7 +435,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[board]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
         boardSlug="kilter-route"
       />,
@@ -453,7 +453,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={[]}
         initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
       />,
     );
@@ -476,7 +476,7 @@ describe('LibraryPageContent FAB orchestration', () => {
       <LibraryPageContent
         initialMyBoards={null}
         initialPlaylists={null}
-        initialDiscoverPlaylists={{ popular: [], recent: [] }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
         boardConfigs={fakeBoardConfigs}
       />,
     );

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -11,8 +11,6 @@ import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import {
-  type DiscoverPlaylistsQueryResponse,
-  type DiscoverPlaylistsInput,
   type GetMySmartPlaylistCountsQueryResponse,
   type Playlist,
   type DiscoverablePlaylist,
@@ -20,12 +18,12 @@ import {
   type PinPlaylistMutationVariables,
   type UnpinPlaylistMutationResponse,
   type UnpinPlaylistMutationVariables,
-  DISCOVER_PLAYLISTS,
   PIN_PLAYLIST,
   UNPIN_PLAYLIST,
   GET_MY_SMART_PLAYLIST_COUNTS,
 } from '@/app/lib/graphql/operations/playlists';
 import { useUserPlaylists } from '@/app/hooks/use-user-playlists';
+import { useDiscoverPlaylists } from '@/app/hooks/use-discover-playlists';
 import { usePinnedPlaylists } from '@/app/hooks/use-pinned-playlists';
 import { SMART_PLAYLISTS, smartPlaylistHref } from '@/app/lib/smart-playlists';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -65,10 +63,16 @@ type LibraryPageContentProps = {
    *  carries hasMore + totalCount so the client hook can seed both correctly
    *  and avoid a redundant first fetch. */
   initialPlaylists?: { playlists: Playlist[]; totalCount: number; hasMore: boolean } | null;
-  /** SSR-fetched discover playlists for instant rendering. */
+  /** SSR-fetched discover playlists for instant rendering. The connection
+   *  shape carries per-stream hasMore + totalCount so the client hook can
+   *  seed both correctly and avoid a redundant first fetch. */
   initialDiscoverPlaylists?: {
     popular: DiscoverablePlaylist[];
     recent: DiscoverablePlaylist[];
+    popularHasMore: boolean;
+    recentHasMore: boolean;
+    popularTotalCount?: number;
+    recentTotalCount?: number;
   } | null;
   /** Board configuration data for the custom-board picker path. */
   boardConfigs?: BoardConfigData;
@@ -186,55 +190,27 @@ export default function LibraryPageContent({
     [pinnedPlaylists, pinnedSource],
   );
 
-  const [popularPlaylists, setPopularPlaylists] = useState<DiscoverablePlaylist[]>(
-    initialDiscoverPlaylists?.popular ?? [],
-  );
-  const [recentPlaylists, setRecentPlaylists] = useState<DiscoverablePlaylist[]>(
-    initialDiscoverPlaylists?.recent ?? [],
-  );
-  const [discoverLoading, setDiscoverLoading] = useState(!hasInitialDiscoverData);
+  // Discover playlists — paginated horizontal scroll. Reset on board filter
+  // change. Two parallel cursors (popular + recent) live inside the hook;
+  // exhausted streams stop pulling additional pages.
+  const {
+    popular: popularPlaylists,
+    recent: recentPlaylists,
+    isLoading: discoverLoading,
+    isLoadingMore: discoverLoadingMore,
+    hasMore: discoverHasMore,
+    loadMore: loadMoreDiscover,
+  } = useDiscoverPlaylists({
+    boardType: selectedBoard?.boardType,
+    layoutId: selectedBoard?.layoutId,
+    pageSize: 10,
+    initialData: hasInitialDiscoverData
+      ? { popular: initialDiscoverPlaylists.popular, recent: initialDiscoverPlaylists.recent }
+      : undefined,
+    initialPopularHasMore: hasInitialDiscoverData ? initialDiscoverPlaylists.popularHasMore : undefined,
+    initialRecentHasMore: hasInitialDiscoverData ? initialDiscoverPlaylists.recentHasMore : undefined,
+  });
   const error = playlistsHasError;
-
-  const hasDiscoverDataRef = useRef(hasInitialDiscoverData);
-
-  // Fetch discover playlists (works for both "All" and specific board)
-  const fetchDiscoverData = useCallback(async () => {
-    try {
-      // Only show loading if we don't already have data
-      if (!hasDiscoverDataRef.current) {
-        setDiscoverLoading(true);
-      }
-
-      const baseInput: DiscoverPlaylistsInput = {
-        pageSize: 10,
-        ...(selectedBoard && {
-          boardType: selectedBoard.boardType,
-          layoutId: selectedBoard.layoutId,
-        }),
-      };
-
-      const [popularRes, recentRes] = await Promise.all([
-        executeGraphQL<DiscoverPlaylistsQueryResponse, { input: DiscoverPlaylistsInput }>(DISCOVER_PLAYLISTS, {
-          input: { ...baseInput, sortBy: 'popular' },
-        }),
-        executeGraphQL<DiscoverPlaylistsQueryResponse, { input: DiscoverPlaylistsInput }>(DISCOVER_PLAYLISTS, {
-          input: { ...baseInput, sortBy: 'recent' },
-        }),
-      ]);
-
-      setPopularPlaylists(popularRes.discoverPlaylists.playlists);
-      setRecentPlaylists(recentRes.discoverPlaylists.playlists);
-      hasDiscoverDataRef.current = true;
-    } catch (err) {
-      console.error('Error fetching discover playlists:', err);
-    } finally {
-      setDiscoverLoading(false);
-    }
-  }, [selectedBoard]);
-
-  useEffect(() => {
-    void fetchDiscoverData();
-  }, [fetchDiscoverData]);
 
   // Pin / unpin a playlist. Optimistic refetch — wait for the mutation, then
   // re-pull both the pinned list (server source of truth) and the page-1 of
@@ -311,9 +287,8 @@ export default function LibraryPageContent({
   const handleBoardSelect = useCallback(
     (board: UserBoard | null) => {
       setSelectedBoard(board);
-      // useUserPlaylists / usePinnedPlaylists reset themselves on filter change.
-      // Discover keeps its skeletons on board flip via this ref.
-      hasDiscoverDataRef.current = false;
+      // useUserPlaylists / useDiscoverPlaylists / usePinnedPlaylists all reset
+      // themselves on filter change.
 
       // When rendered from a board route, switching boards navigates to the correct URL
       if (boardSlug || playlistsBasePath !== '/playlists') {
@@ -613,9 +588,17 @@ export default function LibraryPageContent({
         </PlaylistScrollSection>
       )}
 
-      {/* Discover */}
+      {/* Discover — paginated horizontal scroll, popular + recent streams
+          merged client-side. Same IntersectionObserver-driven loadMore as
+          "Jump Back In". */}
       {(discoverLoading || discoverItems.length > 0) && (
-        <PlaylistScrollSection title={t('library.sections.discover')} loading={discoverLoading}>
+        <PlaylistScrollSection
+          title={t('library.sections.discover')}
+          loading={discoverLoading}
+          onLoadMore={loadMoreDiscover}
+          hasMore={discoverHasMore}
+          isLoadingMore={discoverLoadingMore}
+        >
           {discoverItems.map((p, i) => (
             <PlaylistCard
               key={p.uuid}


### PR DESCRIPTION
## Summary

The Discover tab's two horizontal sliders are now aligned on infinite scroll:

- **Jump Back In** already paginated horizontally via `useUserPlaylists`.
- **Discover** previously fetched a fixed 10 popular + 10 recent and stopped — `PlaylistScrollSection` was rendered without `onLoadMore`/`hasMore`/`isLoadingMore`, so its right-edge `IntersectionObserver` short-circuited.

Both sliders now share the same loadMore protocol on the existing `PlaylistScrollSection`. The new sibling hook `useDiscoverPlaylists` mirrors the structure of `useUserPlaylists` but tracks two parallel page cursors (popular + recent) and only re-fetches the streams that still report `hasMore` — exhausted streams stop pulling pages. Reset semantics on `boardType` / `layoutId` change match the user-playlists hook.

The backend `discoverPlaylists` resolver already supported `page`/`pageSize`/`hasMore`/`totalCount`, so this is a client-only change. SSR (`cachedDiscoverPlaylists`) now surfaces per-stream `hasMore`/`totalCount` so the hook can seed without firing a redundant first request on hydration.

## Files

- `packages/web/app/hooks/use-discover-playlists.ts` (new)
- `packages/web/app/playlists/library-page-content.tsx` — drops the inline `fetchDiscoverData` + `useState` triplet and wires the new hook into the Discover slider
- `packages/web/app/lib/graphql/server-cached-client.ts` — `cachedDiscoverPlaylists` returns per-stream `hasMore` + `totalCount`
- `packages/web/app/playlists/__tests__/library-page-content.test.tsx` — seed shape widened to include `popularHasMore: false`, `recentHasMore: false`

## Why a parallel hook, not a generic abstraction?

`useUserPlaylists` is ~110 lines of mostly mechanical state machine. Forcing both a single-stream and a dual-stream caller through one generic `usePaginatedList<T>` would need stream-merging knobs that add more code than they save. The reuse is concentrated where it pays off: the `PlaylistScrollSection` component, the SSR seed shape, and the dedupe + own-creator filter in `getDiscoverPlaylists`.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp lint` on changed files — 0 warnings, 0 errors
- [x] `vp fmt --check` on changed files — clean
- [x] `vp test run --project web packages/web/app/playlists/__tests__/library-page-content.test.tsx` — 10/10 pass
- [x] `vp test run --project web` (whole suite) — 4115/4116 (single pre-existing French i18n gap for `metadata.retention.title`, unrelated)
- [ ] Manual QA via `vp run dev` against `http://localhost:3000/playlists` (couldn't run in the agent sandbox — Docker isn't available so the dev DB doesn't start; please verify locally):
  - Scroll the Discover slider toward the right edge while signed out. DevTools Network should show one paired `discoverPlaylists` POST per loadMore (popular + recent), `page: 1, 2, …`
  - Confirm "Jump Back In" doesn't refetch when the Discover sentinel hits the viewport
  - Change board in the BoardFilterStrip — Discover resets to skeletons and refetches page 0
  - Sign in as a user who owns a popular playlist — own-creator filter still removes them as new pages append
  - When one stream exhausts, only the still-paginating stream is requested in subsequent loadMores
  - Block the request three times via DevTools to confirm the 3-strike freeze still kicks in

https://claude.ai/code/session_01BEXF2icBsbMhEhYHCg4WBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEXF2icBsbMhEhYHCg4WBN)_