### PR TITLE
Fix retention query bias and broaden activity coverage

### DIFF
--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -48,18 +48,28 @@ type RawRetentionRow = {
 };
 
 async function fetchRetention(): Promise<RetentionRow[]> {
-  // Cohort = week-of-signup (UTC). Two parallel "active" definitions:
+  // Cohort = week-of-signup (UTC, Monday-anchored). The d1/d3/d7/d30 columns
+  // here are an *early-activation funnel* — "did the user do action X within
+  // the first N days of signup?" — not classic Dn retention. By construction
+  // d1 ⊆ d3 ⊆ d7 ⊆ d30. Two parallel definitions of "active":
   //   1. Tick activity: at least one boardsesh tick (aurora_id IS NULL —
   //      not synced in from Aurora). This is the original metric.
   //   2. Any activity: a UNION ALL of every user-attributable timestamp
   //      we record — ticks, party sessions, favorites/playlists/pins/follows,
-  //      comments/votes/proposals/feedback. Captures returners who don't tick.
-  // Window capped at 180 days. D7/D30 columns are NULL'd for cohorts younger
-  // than the window so the UI can render a placeholder instead of 0%.
+  //      gym/board follows, controller/serial setup, comments/votes/
+  //      proposals/feedback. Captures returners who don't tick.
+  // Each Dn % is NULL'd until *every* user in the cohort has had a full N days
+  // to be active (cohort_week + N + 7, since the cohort spans Mon–Sun). The
+  // 211-day prefilter on UNION branches is 180-day cohort window + 30-day Dn
+  // window + 1-day slack; it lets the planner skip very old rows without
+  // changing semantics. Today timestamps are read in UTC to match the cohort.
   const rows = await executeRows<RawRetentionRow>(
     dbz,
     sql`
-      WITH signup_cohorts AS (
+      WITH today_utc AS (
+        SELECT (NOW() AT TIME ZONE 'UTC')::date AS d
+      ),
+      signup_cohorts AS (
         SELECT
           id AS user_id,
           (date_trunc('week', created_at AT TIME ZONE 'UTC'))::date AS cohort_week,
@@ -73,8 +83,7 @@ async function fetchRetention(): Promise<RetentionRow[]> {
           BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '1 day')  AS active_d1,
           BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '3 days') AS active_d3,
           BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '7 days') AS active_d7,
-          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '30 days') AS active_d30,
-          BOOL_OR(TRUE) AS ever_active
+          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '30 days') AS active_d30
         FROM signup_cohorts sc
         JOIN boardsesh_ticks t
           ON t.user_id = sc.user_id
@@ -83,33 +92,65 @@ async function fetchRetention(): Promise<RetentionRow[]> {
         GROUP BY sc.user_id
       ),
       activity_events AS (
-        SELECT user_id, climbed_at AS ts FROM boardsesh_ticks WHERE aurora_id IS NULL
+        SELECT user_id, climbed_at AS ts FROM boardsesh_ticks
+          WHERE aurora_id IS NULL AND climbed_at >= NOW() - INTERVAL '211 days'
         UNION ALL
-        SELECT created_by_user_id AS user_id, created_at AS ts FROM board_sessions WHERE created_by_user_id IS NOT NULL
+        SELECT created_by_user_id AS user_id, created_at AS ts FROM board_sessions
+          WHERE created_by_user_id IS NOT NULL AND created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, joined_at AS ts FROM board_session_participants
+          WHERE joined_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM user_favorites
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM playlist_ownership
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM user_playlist_pins
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT follower_id AS user_id, created_at AS ts FROM user_follows
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT follower_id AS user_id, created_at AS ts FROM playlist_follows
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT follower_id AS user_id, created_at AS ts FROM setter_follows
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM new_climb_subscriptions
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM comments
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM votes
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
         SELECT user_id, created_at AS ts FROM proposal_votes
+          WHERE created_at >= NOW() - INTERVAL '211 days'
         UNION ALL
-        SELECT user_id, created_at AS ts FROM app_feedback WHERE user_id IS NOT NULL
+        SELECT proposer_id AS user_id, created_at AS ts FROM climb_proposals
+          WHERE created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM gym_members
+          WHERE created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM gym_follows
+          WHERE created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM board_follows
+          WHERE created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM esp32_controllers
+          WHERE user_id IS NOT NULL AND created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM user_board_serials
+          WHERE created_at >= NOW() - INTERVAL '211 days'
+        UNION ALL
+        SELECT user_id, created_at AS ts FROM app_feedback
+          WHERE user_id IS NOT NULL AND created_at >= NOW() - INTERVAL '211 days'
       ),
       activity_by_user AS (
         SELECT
@@ -117,8 +158,7 @@ async function fetchRetention(): Promise<RetentionRow[]> {
           BOOL_OR(ae.ts <= sc.created_at + INTERVAL '1 day')  AS active_d1,
           BOOL_OR(ae.ts <= sc.created_at + INTERVAL '3 days') AS active_d3,
           BOOL_OR(ae.ts <= sc.created_at + INTERVAL '7 days') AS active_d7,
-          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '30 days') AS active_d30,
-          BOOL_OR(TRUE) AS ever_active
+          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '30 days') AS active_d30
         FROM signup_cohorts sc
         JOIN activity_events ae
           ON ae.user_id = sc.user_id
@@ -129,50 +169,55 @@ async function fetchRetention(): Promise<RetentionRow[]> {
         SELECT
           sc.cohort_week,
           COUNT(*)::int AS signups,
-          COUNT(*) FILTER (WHERE tbu.active_d1)::int AS d1_count,
-          COUNT(*) FILTER (WHERE tbu.active_d3)::int AS d3_count,
-          COUNT(*) FILTER (WHERE tbu.active_d7)::int AS d7_count,
+          COUNT(*) FILTER (WHERE tbu.active_d1)::int  AS d1_count,
+          COUNT(*) FILTER (WHERE tbu.active_d3)::int  AS d3_count,
+          COUNT(*) FILTER (WHERE tbu.active_d7)::int  AS d7_count,
           COUNT(*) FILTER (WHERE tbu.active_d30)::int AS d30_count,
-          COUNT(*) FILTER (WHERE tbu.ever_active)::int AS activated_count,
-          COUNT(*) FILTER (WHERE abu.active_d1)::int AS d1_any_count,
-          COUNT(*) FILTER (WHERE abu.active_d3)::int AS d3_any_count,
-          COUNT(*) FILTER (WHERE abu.active_d7)::int AS d7_any_count,
+          COUNT(*) FILTER (WHERE tbu.user_id IS NOT NULL)::int AS activated_count,
+          COUNT(*) FILTER (WHERE abu.active_d1)::int  AS d1_any_count,
+          COUNT(*) FILTER (WHERE abu.active_d3)::int  AS d3_any_count,
+          COUNT(*) FILTER (WHERE abu.active_d7)::int  AS d7_any_count,
           COUNT(*) FILTER (WHERE abu.active_d30)::int AS d30_any_count,
-          COUNT(*) FILTER (WHERE abu.ever_active)::int AS activated_any_count
+          COUNT(*) FILTER (WHERE abu.user_id IS NOT NULL)::int AS activated_any_count
         FROM signup_cohorts sc
         LEFT JOIN ticks_by_user tbu USING (user_id)
         LEFT JOIN activity_by_user abu USING (user_id)
         GROUP BY sc.cohort_week
       )
       SELECT
-        to_char(cohort_week, 'YYYY-MM-DD') AS cohort_week,
-        signups,
-        d1_count,
-        d3_count,
-        d7_count,
-        d30_count,
-        activated_count,
-        ROUND(100.0 * d1_count  / NULLIF(signups, 0), 1) AS d1_pct,
-        ROUND(100.0 * d3_count  / NULLIF(signups, 0), 1) AS d3_pct,
-        CASE WHEN cohort_week + INTERVAL '7 days'  <= CURRENT_DATE
-             THEN ROUND(100.0 * d7_count  / NULLIF(signups, 0), 1) END AS d7_pct,
-        CASE WHEN cohort_week + INTERVAL '30 days' <= CURRENT_DATE
-             THEN ROUND(100.0 * d30_count / NULLIF(signups, 0), 1) END AS d30_pct,
-        ROUND(100.0 * activated_count / NULLIF(signups, 0), 1) AS activation_pct,
-        d1_any_count,
-        d3_any_count,
-        d7_any_count,
-        d30_any_count,
-        activated_any_count,
-        ROUND(100.0 * d1_any_count  / NULLIF(signups, 0), 1) AS d1_any_pct,
-        ROUND(100.0 * d3_any_count  / NULLIF(signups, 0), 1) AS d3_any_pct,
-        CASE WHEN cohort_week + INTERVAL '7 days'  <= CURRENT_DATE
-             THEN ROUND(100.0 * d7_any_count  / NULLIF(signups, 0), 1) END AS d7_any_pct,
-        CASE WHEN cohort_week + INTERVAL '30 days' <= CURRENT_DATE
-             THEN ROUND(100.0 * d30_any_count / NULLIF(signups, 0), 1) END AS d30_any_pct,
-        ROUND(100.0 * activated_any_count / NULLIF(signups, 0), 1) AS activation_any_pct
-      FROM cohort_rollup
-      ORDER BY cohort_week DESC;
+        to_char(cr.cohort_week, 'YYYY-MM-DD') AS cohort_week,
+        cr.signups,
+        cr.d1_count,
+        cr.d3_count,
+        cr.d7_count,
+        cr.d30_count,
+        cr.activated_count,
+        CASE WHEN cr.cohort_week + INTERVAL '8 days'  <= today_utc.d
+             THEN ROUND(100.0 * cr.d1_count  / NULLIF(cr.signups, 0), 1) END AS d1_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '10 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d3_count  / NULLIF(cr.signups, 0), 1) END AS d3_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '14 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d7_count  / NULLIF(cr.signups, 0), 1) END AS d7_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '37 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d30_count / NULLIF(cr.signups, 0), 1) END AS d30_pct,
+        ROUND(100.0 * cr.activated_count / NULLIF(cr.signups, 0), 1) AS activation_pct,
+        cr.d1_any_count,
+        cr.d3_any_count,
+        cr.d7_any_count,
+        cr.d30_any_count,
+        cr.activated_any_count,
+        CASE WHEN cr.cohort_week + INTERVAL '8 days'  <= today_utc.d
+             THEN ROUND(100.0 * cr.d1_any_count  / NULLIF(cr.signups, 0), 1) END AS d1_any_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '10 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d3_any_count  / NULLIF(cr.signups, 0), 1) END AS d3_any_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '14 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d7_any_count  / NULLIF(cr.signups, 0), 1) END AS d7_any_pct,
+        CASE WHEN cr.cohort_week + INTERVAL '37 days' <= today_utc.d
+             THEN ROUND(100.0 * cr.d30_any_count / NULLIF(cr.signups, 0), 1) END AS d30_any_pct,
+        ROUND(100.0 * cr.activated_any_count / NULLIF(cr.signups, 0), 1) AS activation_any_pct
+      FROM cohort_rollup cr
+      CROSS JOIN today_utc
+      ORDER BY cr.cohort_week DESC;
     `,
   );
 


### PR DESCRIPTION
## Summary

Reviewed `/admin/retention` and fixed correctness and completeness issues in the cohort SQL at `packages/web/app/admin/retention/page.tsx`. The query was *structurally* sound (signup cohorts → activity CTE → bool_or per window → rollup) but was reporting biased numbers for the most-recent cohorts and missing several user-attributable activity tables.

### Fixes

- **D7/D30 (and now D1/D3) visibility threshold.** The CASE gate was `cohort_week + N days <= CURRENT_DATE`, which is the cohort's *Monday* — but the cohort spans Mon–Sun, so the user who signed up on Sunday hadn't had a full N days yet when the gate flipped. This systematically pulled recent D7/D30 % downward. Threshold is now `cohort_week + N + 7 days` (Sun + N).
- **Broaden the "any activity" UNION.** Added `climb_proposals` (creation — only `proposal_votes` was there), `gym_members`, `gym_follows`, `board_follows`, `esp32_controllers` (with `user_id IS NOT NULL`), and `user_board_serials`. The "any activity" metric exists to catch returners who don't tick; these are first-class engagement signals.
- **211-day prefilter on every UNION branch.** 180-day cohort + 30-day Dn + 1-day slack. Lets the planner skip ancient rows on every branch instead of scanning each table to completion.
- **UTC "today".** Replaced `CURRENT_DATE` with `(NOW() AT TIME ZONE 'UTC')::date` in a CTE, so the comparison matches `cohort_week`'s UTC anchor instead of the session-local date.
- **Dropped tautological `BOOL_OR(TRUE) AS ever_active`.** Replaced with `user_id IS NOT NULL` on the rollup — same semantics, less dead column.
- **Reframed comment block.** Flags that `d1..d30` are an *early-activation funnel* (cumulative from signup, so `d1 ⊆ d3 ⊆ d7 ⊆ d30`), not classic Dn retention. Avoids future misreads.

### Deferred (not in this PR)

- Renaming the columns / dashboard headers to make the activation-funnel semantics explicit, or adding a separate set of true Dn-retention windows. Bigger UX call — better as a follow-up once the numbers are correct.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp lint packages/web/app/admin/retention/page.tsx` — 0 errors
- [x] `vp fmt packages/web/app/admin/retention/page.tsx` — clean
- [ ] Sign in as admin in `vp run dev`, hit `/admin/retention`, sanity-check:
  - Most recent cohort no longer shows artificially-low D7/D30
  - Old cohorts (>37 days) still show D30%
  - "Any activity" counts ≥ tick counts in every cell
- [ ] Spot-check one cohort by hand in Drizzle Studio (`vp run db:studio`): pick a `cohort_week`, run the inner CTEs separately, confirm the bool_or windows match a user's signup → first activity gap.

https://claude.ai/code/session_01JaQ8d9v2cQ88JjMg4KuPBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaQ8d9v2cQ88JjMg4KuPBp)_