### PR TITLE
feat(analytics): add PostHog dual-write alongside Vercel Analytics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,6 +225,7 @@
         "next-auth": "^4.24.13",
         "nodemailer": "^8.0.1",
         "pg": "^8.19.0",
+        "posthog-js-lite": "^4.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -237,6 +238,7 @@
         "undici": "^7.22.0",
         "use-debounce": "^10.1.0",
         "uuid": "^13.0.0",
+        "web-vitals": "^4.2.4",
         "ws": "^8.19.0",
         "yup": "^1.7.1",
         "zod": "^4.3.6",
@@ -973,6 +975,10 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@posthog/core": ["@posthog/core@1.28.3", "", { "dependencies": { "@posthog/types": "1.372.9" } }, "sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw=="],
+
+    "@posthog/types": ["@posthog/types@1.372.9", "", {}, "sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA=="],
 
     "@powersync/common": ["@powersync/common@1.51.0", "", { "dependencies": { "event-iterator": "^2.0.0" } }, "sha512-nee5QQhPK8qLQFeocr/HDFCasdwIXhy16w29VPYOkKCed3ry5wKM9gDSh6L7E12D2rjfLrH1Z/e/uWeTC3oqfQ=="],
 
@@ -2648,6 +2654,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "posthog-js-lite": ["posthog-js-lite@4.6.18", "", { "dependencies": { "@posthog/core": "1.28.3" } }, "sha512-LDKZvvIi2SOnTWbO223E6FssBfqtBm+MbpiLzkDL+I/oFKLAZOuxCQcER/ZxLxoRz68xY8reBdVJbNZRaYWfJg=="],
+
     "preact": ["preact@10.11.3", "", {}, "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="],
 
     "preact-render-to-string": ["preact-render-to-string@5.2.3", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA=="],
@@ -3043,6 +3051,8 @@
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.24.5", "", {}, "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w=="],
+
+    "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 

--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -20,6 +20,12 @@ NEXTAUTH_URL=http://localhost:3000
 # For production, set this via your deployment platform's environment variables (e.g., Vercel)
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
 
+# PostHog (production only — wrapper hostname-gates to *.boardsesh.com,
+# so dev/preview never initialises the client even if the key is set).
+# Set NEXT_PUBLIC_POSTHOG_KEY in the Vercel production environment.
+# NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # S3 Storage Configuration (optional, for production)
 # When these are set, avatar uploads go to S3 instead of local disk
 # AWS_ACCESS_KEY_ID=your_access_key

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -8,7 +8,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-view-content.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-view-content.tsx
@@ -9,7 +9,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { FavoriteOutlined, SentimentDissatisfiedOutlined, MoreVertOutlined, AddOutlined } from '@mui/icons-material';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/layout-client.tsx
@@ -7,7 +7,7 @@ import Badge from '@mui/material/Badge';
 import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { DeleteOutlined } from '@mui/icons-material';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useTranslation } from 'react-i18next';
 import type { BoardDetails } from '@/app/lib/types';
 import dynamic from 'next/dynamic';

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import MuiButton from '@mui/material/Button';
 import { useSearchParams } from 'next/navigation';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import type { Climb, BoardDetails, Angle } from '@/app/lib/types';

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/layout-client.tsx
@@ -5,7 +5,7 @@ import Badge from '@mui/material/Badge';
 import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { DeleteOutlined } from '@mui/icons-material';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useTranslation } from 'react-i18next';
 import type { BoardDetails } from '@/app/lib/types';
 

--- a/packages/web/app/components/analytics-client.tsx
+++ b/packages/web/app/components/analytics-client.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from 'web-vitals';
+import { pageview, track } from '@/app/lib/analytics';
+
+function reportVital(metric: Metric): void {
+  track('$web_vitals', {
+    metric: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    delta: metric.delta,
+    id: metric.id,
+    navigationType: metric.navigationType,
+  });
+}
+
+export default function AnalyticsClient() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const vitalsRegistered = useRef(false);
+
+  useEffect(() => {
+    if (vitalsRegistered.current) return;
+    vitalsRegistered.current = true;
+    onCLS(reportVital);
+    onFCP(reportVital);
+    onINP(reportVital);
+    onLCP(reportVital);
+    onTTFB(reportVital);
+  }, []);
+
+  useEffect(() => {
+    if (!pathname) return;
+    const search = searchParams?.toString();
+    const url = search ? `${pathname}?${search}` : pathname;
+    pageview(url);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -7,7 +7,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import {

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import Instagram from '@mui/icons-material/Instagram';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import { isInstagramUrl, isTikTokUrl } from '@/app/lib/beta-video-url';
 import TikTokIcon from './tiktok-icon';

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-i18next', () => ({
 
 // Mock dependencies before importing the module
 const mockTrack = vi.fn();
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -82,7 +82,7 @@ vi.mock('@/app/components/providers/snackbar-provider', () => ({
   useSnackbar: () => ({ showMessage: mockShowMessage }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'next/navigation';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useBoardBluetooth } from './use-board-bluetooth';
 import { useCurrentClimb } from '../graphql-queue';

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import * as Sentry from '@sentry/nextjs';
 import type { BoardDetails } from '@/app/lib/types';
 import { getAuroraBluetoothPacket, parseApiLevel, parseSerialNumber, type LedColorOverrides } from './bluetooth-aurora';

--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/app/hooks/use-is-dark-mode', () => ({
   useIsDarkMode: () => false,
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -9,7 +9,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useQuery } from '@tanstack/react-query';
 import { ANGLES } from '@/app/lib/board-data';

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -8,7 +8,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import { usePathname } from 'next/navigation';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import dynamic from 'next/dynamic';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';

--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -40,7 +40,7 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -12,7 +12,7 @@ import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import DynamicFeedOutlined from '@mui/icons-material/DynamicFeedOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import {
   constructClimbListWithSlugs,

--- a/packages/web/app/components/climb-actions/__tests__/action-labels-and-colors.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/action-labels-and-colors.test.tsx
@@ -66,7 +66,7 @@ vi.mock('next-auth/react', () => ({
   useSession: () => mockUseSession(),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/__tests__/playlist-selection-content.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/playlist-selection-content.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/app/components/providers/auth-modal-provider', () => ({
   useAuthModal: () => ({ openAuthModal: vi.fn() }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
@@ -116,7 +116,7 @@ vi.mock('@/app/hooks/use-always-tick-in-app', () => ({
 }));
 
 const mockTrack = vi.fn();
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 

--- a/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
+++ b/packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts
@@ -12,7 +12,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 const mockTrack = vi.fn();
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 

--- a/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/fork-action.test.ts
@@ -5,7 +5,7 @@ import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
 // Mock dependencies before importing the module
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/playlist-action.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@/app/components/providers/auth-modal-provider', () => ({
   useAuthModal: () => ({ openAuthModal: mockOpenAuthModal }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
@@ -5,7 +5,7 @@ import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
 // Mock dependencies before importing the module
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
+++ b/packages/web/app/components/climb-actions/actions/__tests__/view-details-action.test.ts
@@ -5,7 +5,7 @@ import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
 // Mock dependencies before importing the module
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/climb-actions/actions/favorite-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/favorite-action.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback } from 'react';
 import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
 import Favorite from '@mui/icons-material/Favorite';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useTranslation } from 'react-i18next';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useFavorite } from '../use-favorite';

--- a/packages/web/app/components/climb-actions/actions/fork-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/fork-action.tsx
@@ -6,7 +6,7 @@ import { ActionTooltip } from '../action-tooltip';
 import CallSplitOutlined from '@mui/icons-material/CallSplitOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import LocaleLink from '@/app/components/i18n/locale-link';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useSession } from 'next-auth/react';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { constructCreateClimbUrl } from '@/app/lib/url-utils';

--- a/packages/web/app/components/climb-actions/actions/mirror-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/mirror-action.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react';
 import MuiButton from '@mui/material/Button';
 import { ActionTooltip } from '../action-tooltip';
 import SwapHorizOutlined from '@mui/icons-material/SwapHorizOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalQueueActions, useOptionalQueueData } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/open-in-app-action.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { buildActionResult, buildUnavailableResult, computeActionDisplay } from '../action-view-renderer';

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -15,7 +15,7 @@ import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { usePlaylists } from '../use-playlists';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';

--- a/packages/web/app/components/climb-actions/actions/queue-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/queue-action.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalQueueActions } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/actions/set-active-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/set-active-action.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalQueueActions, useOptionalQueueData } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -15,7 +15,7 @@ import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalBoardProvider, BoardProvider } from '../../board-provider/board-provider-context';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { LogAscentForm } from '../../logbook/logascent-form';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/actions/view-details-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/view-details-action.tsx
@@ -5,7 +5,7 @@ import MuiButton from '@mui/material/Button';
 import { ActionTooltip } from '../action-tooltip';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import LocaleLink from '@/app/components/i18n/locale-link';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -5,7 +5,7 @@ import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
 import Favorite from '@mui/icons-material/Favorite';
 import Tooltip from '@mui/material/Tooltip';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useFavorite } from './use-favorite';
 import type { BoardName } from '@/app/lib/types';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';

--- a/packages/web/app/components/climb-actions/playlist-selection-content.tsx
+++ b/packages/web/app/components/climb-actions/playlist-selection-content.tsx
@@ -11,7 +11,7 @@ import ListItem from '@mui/material/ListItem';
 import Stack from '@mui/material/Stack';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { usePlaylists } from './use-playlists';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import type { Playlist } from './playlists-batch-context';

--- a/packages/web/app/components/climb-actions/queue-button.tsx
+++ b/packages/web/app/components/climb-actions/queue-button.tsx
@@ -4,7 +4,7 @@ import React, { useState, useCallback } from 'react';
 import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import MuiTooltip from '@mui/material/Tooltip';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useQueueActions, useQueueList } from '../graphql-queue';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { themeTokens } from '@/app/theme/theme-config';

--- a/packages/web/app/components/climb-actions/use-climb-actions.ts
+++ b/packages/web/app/components/climb-actions/use-climb-actions.ts
@@ -4,7 +4,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { usePathname } from 'next/navigation';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useQueueActions } from '../graphql-queue';
 import { useFavorite } from './use-favorite';
 import { constructCreateClimbUrl, constructClimbInfoUrl, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';

--- a/packages/web/app/components/climb-card/climb-list-item.tsx
+++ b/packages/web/app/components/climb-card/climb-list-item.tsx
@@ -8,7 +8,7 @@ import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbThumbnail from './climb-thumbnail';
 import ClimbTitle, { type ClimbTitleProps } from './climb-title';

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -33,7 +33,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import HoldIndicator from './hold-indicator';
 import { usePathname } from 'next/navigation';
 import LocaleLink from '@/app/components/i18n/locale-link';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useSession } from 'next-auth/react';
 import BoardRenderer from '../board-renderer/board-renderer';
 import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';

--- a/packages/web/app/components/library/__tests__/create-playlist-drawer.test.tsx
+++ b/packages/web/app/components/library/__tests__/create-playlist-drawer.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/app/lib/graphql/client', () => ({
 }));
 
 const mockTrack = vi.fn();
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 

--- a/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-item.test.tsx
@@ -129,7 +129,7 @@ vi.mock('@/app/components/queue-control/play-drawer-event', () => ({
   dispatchOpenPlayDrawer: () => dispatchOpenPlayDrawerMock(),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/library/create-playlist-drawer.tsx
+++ b/packages/web/app/components/library/create-playlist-drawer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import MuiButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -26,7 +26,7 @@ import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import dynamic from 'next/dynamic';
 import { formatTickRelativeTime } from '@/app/lib/format-tick-time';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
 import { useOptionalQueueActions } from '@/app/components/graphql-queue';

--- a/packages/web/app/components/logbook/__tests__/inline-list-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/inline-list-tick-bar.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../board-provider/board-provider-context', () => ({
   }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar-grade-format.test.tsx
@@ -60,7 +60,7 @@ vi.mock('react-swipeable', () => ({
   useSwipeable: () => ({}),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/quick-tick-bar.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../board-provider/board-provider-context', () => ({
   }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../board-provider/board-provider-context', () => ({
   }),
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -17,7 +17,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { type TickStatus, useBoardProvider } from '../board-provider/board-provider-context';
 import { TENSION_KILTER_GRADES, ANGLES } from '@/app/lib/board-data';

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -13,7 +13,7 @@ import Stack from '@mui/material/Stack';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { LogAscentDrawer } from './log-ascent-drawer';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';

--- a/packages/web/app/components/onboarding/__tests__/onboarding-tour-provider.test.tsx
+++ b/packages/web/app/components/onboarding/__tests__/onboarding-tour-provider.test.tsx
@@ -26,7 +26,7 @@ vi.mock('next-auth/react', () => ({
   useSession: mockUseSession,
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: mockTrack,
 }));
 

--- a/packages/web/app/components/onboarding/onboarding-tour-provider.tsx
+++ b/packages/web/app/components/onboarding/onboarding-tour-provider.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { clearTourProgress, getTourProgress, saveOnboardingStatus, saveTourProgress } from '@/app/lib/onboarding-db';
 import { PLAY_DRAWER_EVENT } from '@/app/components/queue-control/play-drawer-event';
 import { dispatchClimbListSwipeHintReplay } from '@/app/components/board-page/swipe-hint-orchestrator';

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -70,7 +70,15 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
     if (sessionStatus === 'authenticated' && session?.user?.id) {
       const userId = session.user.id;
       if (lastAnalyticsDistinctId.current === userId) return;
-      if (lastAnalyticsDistinctId.current === profileId) {
+
+      if (lastAnalyticsDistinctId.current && lastAnalyticsDistinctId.current !== profileId) {
+        reset();
+      }
+      if (lastAnalyticsDistinctId.current !== profileId) {
+        identify(profileId);
+        lastAnalyticsDistinctId.current = profileId;
+      }
+      if (profileId !== userId) {
         alias(userId);
       }
       identify(userId, session.user.email ? { email: session.user.email } : undefined);

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { type PartyProfile, getPartyProfile, clearPartyProfile, ensurePartyProfile } from '@/app/lib/party-profile-db';
+import { alias, identify, reset } from '@/app/lib/analytics';
 
 type UserProfileData = {
   displayName: string | null;
@@ -28,6 +29,7 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
   const [userProfile, setUserProfile] = useState<UserProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { data: session, status: sessionStatus } = useSession();
+  const lastAnalyticsDistinctId = useRef<string | null>(null);
 
   // Load party profile on mount
   useEffect(() => {
@@ -55,6 +57,36 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
       mounted = false;
     };
   }, []);
+
+  // Wire PostHog identity so anonymous → authenticated cohorts merge for D30
+  // retention. The IndexedDB party-profile UUID is the anonymous distinct_id;
+  // on login we alias it to session.user.id then switch identity. PostHog
+  // server-side merges historical anonymous events into the authed user.
+  useEffect(() => {
+    if (sessionStatus === 'loading') return;
+    const profileId = profile?.id;
+    if (!profileId) return;
+
+    if (sessionStatus === 'authenticated' && session?.user?.id) {
+      const userId = session.user.id;
+      if (lastAnalyticsDistinctId.current === userId) return;
+      if (lastAnalyticsDistinctId.current === profileId) {
+        alias(userId);
+      }
+      identify(userId, session.user.email ? { email: session.user.email } : undefined);
+      lastAnalyticsDistinctId.current = userId;
+      return;
+    }
+
+    if (sessionStatus === 'unauthenticated') {
+      if (lastAnalyticsDistinctId.current === profileId) return;
+      if (lastAnalyticsDistinctId.current && lastAnalyticsDistinctId.current !== profileId) {
+        reset();
+      }
+      identify(profileId);
+      lastAnalyticsDistinctId.current = profileId;
+    }
+  }, [profile?.id, sessionStatus, session?.user?.id, session?.user?.email]);
 
   // Fetch custom user profile (displayName, avatarUrl) when authenticated
   useEffect(() => {

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import MuiBadge from '@mui/material/Badge';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -68,7 +68,7 @@ vi.mock('next/link', () => ({
     React.createElement('a', props, children),
 }));
 
-vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn() }));
 
 vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
   useCardSwipeNavigation: () => ({

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
@@ -74,7 +74,7 @@ vi.mock('next/link', () => ({
     React.createElement('a', props, children),
 }));
 
-vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn() }));
 
 vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
   useCardSwipeNavigation: () => ({

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
@@ -73,7 +73,7 @@ vi.mock('next/link', () => ({
     React.createElement('a', props, children),
 }));
 
-vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn() }));
 
 vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
   useCardSwipeNavigation: () => ({

--- a/packages/web/app/components/queue-control/next-climb-button.tsx
+++ b/packages/web/app/components/queue-control/next-climb-button.tsx
@@ -8,7 +8,7 @@ import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/li
 import type { BoardDetails } from '@/app/lib/types';
 import { useResolvedBoardDetails } from '@/app/hooks/use-resolved-board-details';
 import FastForwardOutlined from '@mui/icons-material/FastForwardOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import IconButton, { type IconButtonProps } from '@mui/material/IconButton';
 
 type NextClimbButtonProps = {

--- a/packages/web/app/components/queue-control/previous-climb-button.tsx
+++ b/packages/web/app/components/queue-control/previous-climb-button.tsx
@@ -8,7 +8,7 @@ import { useQueueActions, useSessionData } from '../graphql-queue';
 import { constructPlayUrlWithSlugs, getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import type { BoardDetails } from '@/app/lib/types';
 import { useResolvedBoardDetails } from '@/app/hooks/use-resolved-board-details';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import FastRewindOutlined from '@mui/icons-material/FastRewindOutlined';
 import IconButton, { type IconButtonProps } from '@mui/material/IconButton';
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -14,7 +14,7 @@ import SyncOutlined from '@mui/icons-material/SyncOutlined';
 import CloudOffOutlined from '@mui/icons-material/CloudOffOutlined';
 import OpenInFullOutlined from '@mui/icons-material/OpenInFullOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useQueueActions, useCurrentClimb, useQueueList, useSessionData } from '../graphql-queue';
 import NextClimbButton from './next-climb-button';
 import { usePathname, useParams, useSearchParams } from 'next/navigation';

--- a/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
+++ b/packages/web/app/components/queue-control/ui-searchparams-provider.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useState } from 'react';
 import type { SearchRequestPagination } from '@/lib/types';
 import { useDebouncedCallback } from 'use-debounce';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { useQueueActions, useSearchData } from '../graphql-queue';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import { incrementSearches, maybeFireFeedbackPromptEvent } from '@/app/lib/feedback-prompt-db';

--- a/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
@@ -35,7 +35,7 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/kilter/1/1/1/40/list',
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -30,7 +30,7 @@ import { constructBoardSlugListUrl, constructClimbListWithSlugs, tryConstructSlu
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import { setClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { useOnboardingTourOptional } from '@/app/components/onboarding/onboarding-tour-provider';
 import { TOUR_OPEN_START_SESH_EVENT } from '@/app/components/onboarding/onboarding-tour-events';

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -31,7 +31,7 @@ vi.mock('../use-confetti', () => ({
   useConfetti: () => mockFireConfetti,
 }));
 
-vi.mock('@vercel/analytics', () => ({
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 import type { Climb, BoardDetails, Angle } from '@/app/lib/types';
 import { useBoardProvider } from '../components/board-provider/board-provider-context';
 import type { LogbookEntry, TickStatus } from '@/app/hooks/use-logbook';

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,9 +1,10 @@
 // app/layout.tsx
-import React from 'react';
+import React, { Suspense } from 'react';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import ColorModeProvider from './components/providers/color-mode-provider';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import AnalyticsClient from './components/analytics-client';
 import SessionProviderWrapper from './components/providers/session-provider';
 import QueryClientProvider from './components/providers/query-client-provider';
 import { NavigationLoadingProvider } from './components/providers/navigation-loading-provider';
@@ -72,6 +73,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html lang={LOCALE_HTML_LANG[locale]} data-theme="dark" suppressHydrationWarning>
       <body suppressHydrationWarning>
         <Analytics />
+        <Suspense fallback={null}>
+          <AnalyticsClient />
+        </Suspense>
         <QueryClientProvider>
           <SessionProviderWrapper>
             <AppRouterCacheProvider>

--- a/packages/web/app/lib/__tests__/share-utils.test.ts
+++ b/packages/web/app/lib/__tests__/share-utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { shareWithFallback } from '../share-utils';
 
-// Mock @vercel/analytics
-vi.mock('@vercel/analytics', () => ({
+// Mock the analytics wrapper
+vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
 }));
 
@@ -169,7 +169,7 @@ describe('shareWithFallback', () => {
 
   describe('analytics tracking', () => {
     it('tracks native share method', async () => {
-      const { track } = await import('@vercel/analytics');
+      const { track } = await import('@/app/lib/analytics');
       const share = vi.fn().mockResolvedValue(undefined);
       const canShare = vi.fn().mockReturnValue(true);
       mockNavigator({ share, canShare } as unknown as Partial<Navigator>);
@@ -183,7 +183,7 @@ describe('shareWithFallback', () => {
     });
 
     it('tracks clipboard method on error-path fallback', async () => {
-      const { track } = await import('@vercel/analytics');
+      const { track } = await import('@/app/lib/analytics');
       const share = vi.fn().mockRejectedValue(new Error('Share failed'));
       const canShare = vi.fn().mockReturnValue(true);
       const writeText = vi.fn().mockResolvedValue(undefined);
@@ -202,7 +202,7 @@ describe('shareWithFallback', () => {
     });
 
     it('tracks clipboard method', async () => {
-      const { track } = await import('@vercel/analytics');
+      const { track } = await import('@/app/lib/analytics');
       const writeText = vi.fn().mockResolvedValue(undefined);
       mockNavigator({
         share: undefined,

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -28,7 +28,7 @@ function getPosthog(): PostHog | null {
     host,
     autocapture: false,
     captureHistoryEvents: false,
-    persistence: 'localStorage',
+    persistence: 'memory',
   });
 
   return posthogClient;
@@ -47,7 +47,7 @@ function sanitizeForPosthog(properties?: EventProperties): PosthogProperties | u
 
 export function track(name: string, properties?: EventProperties, options?: { flags?: FlagsDataInput }): void {
   if (process.env.NODE_ENV !== 'production') {
-    console.debug('[analytics] track', name, properties);
+    console.info('[analytics] track', name, properties);
   }
 
   vercelTrack(name, properties, options);

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -1,0 +1,86 @@
+import { track as vercelTrack } from '@vercel/analytics';
+import { PostHog } from 'posthog-js-lite';
+
+// Mirror @vercel/analytics' AllowedPropertyValues so existing call sites
+// type-check unchanged when they swap to this wrapper.
+type AllowedPropertyValues = string | number | boolean | null | undefined;
+type EventProperties = Record<string, AllowedPropertyValues>;
+type FlagsDataInput = Parameters<typeof vercelTrack>[2];
+
+let posthogClient: PostHog | null = null;
+let posthogInitAttempted = false;
+
+function getPosthog(): PostHog | null {
+  if (typeof window === 'undefined') return null;
+  if (posthogClient) return posthogClient;
+  if (posthogInitAttempted) return null;
+  posthogInitAttempted = true;
+
+  // Hostname-gate to production, mirroring Sentry. Dev/preview deploys stay
+  // out of the prod PostHog project.
+  if (!window.location.hostname.includes('boardsesh.com')) return null;
+
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) return null;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+
+  posthogClient = new PostHog(apiKey, {
+    host,
+    autocapture: false,
+    captureHistoryEvents: false,
+    persistence: 'localStorage',
+  });
+
+  return posthogClient;
+}
+
+type PosthogProperties = Record<string, string | number | boolean | null>;
+
+function sanitizeForPosthog(properties?: EventProperties): PosthogProperties | undefined {
+  if (!properties) return undefined;
+  const out: PosthogProperties = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+export function track(name: string, properties?: EventProperties, options?: { flags?: FlagsDataInput }): void {
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug('[analytics] track', name, properties);
+  }
+
+  vercelTrack(name, properties, options);
+
+  const posthog = getPosthog();
+  if (posthog) posthog.capture(name, sanitizeForPosthog(properties));
+}
+
+export function identify(distinctId: string, properties?: PosthogProperties): void {
+  const posthog = getPosthog();
+  if (!posthog) return;
+  posthog.identify(distinctId, properties);
+}
+
+// Sends a $create_alias event linking the current distinct_id to `newId`.
+// Use this on signup/login to merge the anonymous IndexedDB UUID into the
+// authenticated user UUID, then call identify(newId) to switch.
+export function alias(newId: string): void {
+  const posthog = getPosthog();
+  if (!posthog) return;
+  posthog.alias(newId);
+}
+
+export function reset(): void {
+  const posthog = getPosthog();
+  if (!posthog) return;
+  posthog.reset();
+}
+
+export function pageview(url: string): void {
+  const posthog = getPosthog();
+  if (!posthog) return;
+  posthog.capture('$pageview', { $current_url: url });
+}
+
+export type { AllowedPropertyValues };

--- a/packages/web/app/lib/queue-metrics.ts
+++ b/packages/web/app/lib/queue-metrics.ts
@@ -1,4 +1,4 @@
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 
 export type QueueOperation =
   | 'setCurrentClimbQueueItem'

--- a/packages/web/app/lib/rendering-metrics.ts
+++ b/packages/web/app/lib/rendering-metrics.ts
@@ -1,4 +1,4 @@
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 
 export type RenderContext = 'thumbnail' | 'card' | 'full-board' | 'feed';
 

--- a/packages/web/app/lib/share-utils.ts
+++ b/packages/web/app/lib/share-utils.ts
@@ -1,4 +1,4 @@
-import { track } from '@vercel/analytics';
+import { track } from '@/app/lib/analytics';
 
 type ShareOptions = {
   /** The full URL to share */

--- a/packages/web/i18n/locales/fr/admin.json
+++ b/packages/web/i18n/locales/fr/admin.json
@@ -3,6 +3,10 @@
     "admin": {
       "title": "Panneau d'administration",
       "description": "Panneau d'administration Boardsesh"
+    },
+    "retention": {
+      "title": "Rétention",
+      "description": "Tableau de bord de rétention par cohorte"
     }
   },
   "title": "Panneau d'administration",
@@ -13,6 +17,33 @@
   "tabs": {
     "roles": "Rôles",
     "settings": "Paramètres"
+  },
+  "nav": {
+    "retention": "Tableau de rétention"
+  },
+  "retention": {
+    "heading": "Rétention utilisateur",
+    "subheading": "Parmi les utilisateurs inscrits pendant la semaine W, combien reviennent dans les N jours, à la fois pour les ticks (blocs enregistrés) et pour toute activité dans l'application.",
+    "definitions": "Cohorte = semaine d'inscription (UTC). Ticks = au moins un bloc enregistré dans Boardsesh (ticks importés depuis Aurora exclus). Toute activité = tick, hôte ou participation à une session, favori, playlist (créée ou épinglée), abonnement (utilisateur, ouvreur ou playlist), abonnement nouveaux blocs, commentaire, vote, vote de proposition ou envoi de feedback. D7 = actif dans les 7 jours suivant l'inscription. Les cohortes plus récentes que la fenêtre affichent —.",
+    "back": "Retour à l'administration",
+    "table": {
+      "cohortWeek": "Semaine de cohorte",
+      "signups": "Inscriptions",
+      "groupTicks": "Ticks",
+      "groupAny": "Toute activité",
+      "activated": "Activés",
+      "d1": "D1",
+      "d3": "D3",
+      "d7": "D7",
+      "d30": "D30",
+      "notReady": "—",
+      "empty": "Aucune donnée de cohorte pour le moment."
+    },
+    "chart": {
+      "title": "Rétention D7 par semaine de cohorte",
+      "label": "Ticks",
+      "labelAny": "Toute activité"
+    }
   },
   "roles": {
     "heading": "Rôles de la communauté",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -77,6 +77,7 @@
     "next-auth": "^4.24.13",
     "nodemailer": "^8.0.1",
     "pg": "^8.19.0",
+    "posthog-js-lite": "^4.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -89,6 +90,7 @@
     "undici": "^7.22.0",
     "use-debounce": "^10.1.0",
     "uuid": "^13.0.0",
+    "web-vitals": "^4.2.4",
     "ws": "^8.19.0",
     "yup": "^1.7.1",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary

- Adds PostHog as a parallel analytics provider so `track()` calls fan out to **both** Vercel and PostHog. Vercel Analytics stays running for a 14-day dual-write window before we drop it in a follow-up PR.
- Unblocks D30 cohort retention dashboards by wiring `identify` / `alias` / `reset` in `party-profile-context.tsx` so anonymous IndexedDB UUIDs merge into authenticated user UUIDs.
- Removes one of several Vercel hosting lock-in vectors (per `docs/mobile-app-plan.md` Phase 0a).

## Why these choices

- **`posthog-js-lite` (~3KB)** — covers everything D30 retention needs (`identify`/`capture`/`alias`/`reset`). At 3KB no async-load/queue is needed. Swap to full `posthog-js` later is a one-line change inside the wrapper.
- **Hostname-gated to `*.boardsesh.com`** — mirrors Sentry's posture; dev/preview don't pollute the prod project.
- **Wrapper signature matches `@vercel/analytics`** — 44 call sites swap with import-path changes only, no signature changes.
- **Identity seam in `party-profile-context.tsx`** — single file solves anonymous → authed continuity. PostHog merges historical anonymous events into the authed user, preserving cohort day-0.

## Deferred (intentional)

- `posthog-node` for server-side capture
- Native `posthog-ios` / `posthog-android` SDKs (Capacitor WebView inherits `posthog-js-lite`)
- The existing `@vercel/analytics/server` call site in `packages/web/app/lib/climb-search-cache.server.ts`

Plan lives at `/home/developer/.claude/plans/we-want-to-migrate-luminous-bubble.md`.

## Activation

Set `NEXT_PUBLIC_POSTHOG_KEY` in Vercel **production** environment. Until that's set, the wrapper hostname-gates and PostHog stays a no-op — Vercel Analytics keeps working unchanged.

## Test plan

- [ ] CI green (lint, typecheck, web tests)
- [ ] After merge + env var set: confirm both `vitals.vercel-insights.com` and `us.i.posthog.com` requests fire on a real page load
- [ ] Trigger a `track()` call site (open a climb), verify the event lands in **both** PostHog Live Events and Vercel Analytics dashboards
- [ ] Identity smoke: open in incognito → PostHog Person view shows distinct_id = IndexedDB profile UUID. Sign in → \`\$create_alias\` event fires; Person view now shows merged identity with `session.user.id`. Sign out → next event uses a fresh distinct_id.
- [ ] Build the D30 cohort retention insight in PostHog and pin it. Cross-check against `/admin/retention` during the 14-day dual-write window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)