### PR TITLE
feat(bottom-tab-bar): liquid-glass pill + Feed folds into /you

### DIFF
--- a/marketing/outreach/sharma-gyms-email.md
+++ b/marketing/outreach/sharma-gyms-email.md
@@ -62,18 +62,19 @@ Alex
 Boardsesh
 https://www.boardsesh.com
 
---- 
+---
 
 ## Spanish version
 
 ---
+
 Hola,
 
 Como comenté el otro dia con [persona de contacto], estoy colaborando en una aplicación para Kilter y me gustaría poder un QR o un banner junto a la kilter.
 
 **Qué es Boardsesh?**
 
-Boardsesh es una aplicación gratuita y de código abierto para escaladores que entrenan en paneles LED. Funciona con Kilter, Tension y MoonBoard con un único inicio de sesión, por lo que los miembros no tienen que lidiar con tres aplicaciones distintas. 
+Boardsesh es una aplicación gratuita y de código abierto para escaladores que entrenan en paneles LED. Funciona con Kilter, Tension y MoonBoard con un único inicio de sesión, por lo que los miembros no tienen que lidiar con tres aplicaciones distintas.
 
 No estamos afiliados a Aurora, Tension, Moon, ni ninguna marca comercial solo somos un proyecto de código abierto creado por y para escaladores.
 

--- a/packages/web/app/__tests__/page-seo-metadata.test.ts
+++ b/packages/web/app/__tests__/page-seo-metadata.test.ts
@@ -6,13 +6,13 @@ vi.mock('next/headers', () => ({
 }));
 
 const aboutPage = await import('../about/page');
-const feedPage = await import('../feed/page');
+const youFeedPage = await import('../you/feed/page');
 const loginPage = await import('../auth/login/page');
 const playlistsPage = await import('../playlists/page');
 const settingsPage = await import('../settings/page');
 
 const aboutMetadata = await aboutPage.generateMetadata();
-const feedMetadata = await feedPage.generateMetadata();
+const youFeedMetadata = await youFeedPage.generateMetadata();
 const playlistsMetadata = await playlistsPage.generateMetadata();
 const settingsMetadata = await settingsPage.generateMetadata();
 
@@ -65,9 +65,9 @@ describe('page metadata exports', () => {
     expect(loginPage.metadata.robots).toEqual({ index: false, follow: true });
   });
 
-  it('keeps the activity feed indexable so it surfaces public climbing activity', () => {
-    expect(feedMetadata.robots).toBeUndefined();
-    expect(feedMetadata.alternates?.canonical).toBe('/feed');
+  it('keeps the activity feed (now nested under /you) noindex because it is auth-gated', () => {
+    expect(youFeedMetadata.robots).toEqual({ index: false, follow: true });
+    expect(youFeedMetadata.alternates?.canonical).toBe('/you/feed');
   });
 
   it('keeps the public playlists directory indexable because it exposes discoverable content', () => {

--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -363,15 +363,18 @@ describe('BottomTabBar You tab', () => {
     expect(youTab.classList.contains('Mui-selected')).toBe(false);
   });
 
-  it('Feed tab is selected when on /feed path', () => {
-    mockPathname = '/feed';
+  it('Feed tab is no longer rendered (folded into the You sub-tabs)', () => {
     render(<BottomTabBar boardConfigs={boardConfigs} />);
 
-    const feedTab = screen.getByRole('button', { name: 'Feed' });
-    expect(feedTab.classList.contains('Mui-selected')).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Feed' })).toBeNull();
+  });
+
+  it('You tab is selected when on /you/feed path (Feed lives under You)', () => {
+    mockPathname = '/you/feed';
+    render(<BottomTabBar boardConfigs={boardConfigs} />);
 
     const youTab = screen.getByRole('button', { name: 'You' });
-    expect(youTab.classList.contains('Mui-selected')).toBe(false);
+    expect(youTab.classList.contains('Mui-selected')).toBe(true);
   });
 
   it('Home tab is selected when on / path', () => {
@@ -418,12 +421,12 @@ describe('BottomTabBar locale-aware pathname matching', () => {
     mockLanguage = 'es';
   });
 
-  it('Feed tab is selected when on /es/feed', () => {
-    mockPathname = '/es/feed';
+  it('You tab is selected when on /es/you/feed (locale-prefixed feed)', () => {
+    mockPathname = '/es/you/feed';
     render(<BottomTabBar boardConfigs={boardConfigs} />);
 
-    const feedTab = screen.getByRole('button', { name: 'Feed' });
-    expect(feedTab.classList.contains('Mui-selected')).toBe(true);
+    const youTab = screen.getByRole('button', { name: 'You' });
+    expect(youTab.classList.contains('Mui-selected')).toBe(true);
   });
 
   it('You tab is selected when on /es/you', () => {

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,66 +1,39 @@
+/* Floating liquid-glass pill. Centered, lifted off the bottom, with safe-area
+   clearance so it doesn't collide with the iOS home indicator or Android
+   gesture-nav area. Native (Capacitor) and web both render the pill — no
+   edge-to-edge fallback. */
 .bottomBarWrapper {
-  --tab-bar-top-radius: 16px;
-  --tab-bar-bottom-radius: 16px;
-  --tab-bar-safe-area-padding: var(--safe-area-inset-bottom);
+  --tab-bar-safe-area-padding: 0px;
   --tab-bar-bottom-extension: 0px;
   position: fixed;
-  bottom: 0;
-  left: 2dvw;
-  right: 2dvw;
-  z-index: 10;
-  background: none;
-  border-radius: 16px;
-}
-
-/* In Capacitor native the tab bar sits edge-to-edge. Safe-area clearance
-   is already handled: on Android the @capacitor-community/safe-area plugin
-   pads the WebView decorView (Chromium < 140) or passes real insets through
-   to env() (Chromium 140+); on iOS WKWebView env() reports home-indicator
-   inset natively. --tab-bar-safe-area-padding (inherited from the base
-   .bottomBarWrapper rule above, which reads --safe-area-inset-bottom from
-   :root) therefore picks up the correct inset automatically — no extra
-   Android floor or native-specific override is needed here. */
-.nativeApp {
-  --tab-bar-top-radius: 0px;
-  --tab-bar-bottom-radius: 0px;
+  bottom: max(12px, env(safe-area-inset-bottom));
   left: 0;
   right: 0;
-  border-radius: 0;
+  padding-inline: 12px;
+  z-index: 10;
+  background: none;
+  pointer-events: none;
 }
 
+/* Children (BottomNavigation, QueueControlBar, banners) handle their own taps. */
+.bottomBarWrapper > * {
+  pointer-events: auto;
+}
+
+/* Native shells get the same pill but a slightly larger lift on Android, where
+   the gesture-nav area can be 24-48px above the WebView bottom. The
+   @capacitor-community/safe-area plugin populates env(safe-area-inset-bottom)
+   on Android via passed insets (Chromium 140+) or decorView padding (older);
+   on iOS WKWebView env() reports the home-indicator inset natively. */
+.nativeApp {
+  bottom: max(16px, env(safe-area-inset-bottom));
+}
+
+/* On desktop the pill stays centered and capped; the wrapper itself spans full
+   width but the BottomNavigation child sets max-width: min(560px, 100%). */
 @media (min-width: 768px) {
   .bottomBarWrapper {
-    left: 0;
-    right: 0;
-    padding-bottom: 16px;
-    border-radius: 0;
-  }
-}
-
-/* Mobile Safari renders a grey rectangle under the chrome when bottom: 0,
-   so keep the 2dvh offset. Instead of a separate ::after pseudo-element
-   (which creates a visible backdrop-filter seam), extend the BottomNavigation
-   below the wrapper via negative margin so the frosted glass is one element.
-   The wrapper has no overflow:hidden, so the child visually overflows to
-   cover the 2dvh gap plus any safe area beyond it.
-
-   Use raw env(safe-area-inset-bottom) here instead of the :root-defined
-   var(--safe-area-inset-bottom). iOS Safari resolves var()-of-env() to 0
-   inside nested calc/max in some contexts, which collapses the negative
-   bottom-extension and leaves the Safari URL-bar area uncovered (visible
-   body background, which is black in dark mode). env() is reliable here
-   because this block only matches iOS Safari. */
-@supports (-webkit-touch-callout: none) {
-  @media (hover: none) and (pointer: coarse) {
-    .bottomBarWrapper:not(.nativeApp) {
-      --tab-bar-top-radius: 0px;
-      --tab-bar-bottom-radius: 0px;
-      --tab-bar-safe-area-padding: max(2dvh, env(safe-area-inset-bottom, 0px));
-      --tab-bar-bottom-extension: calc(-1 * max(2dvh, env(safe-area-inset-bottom, 0px)));
-      bottom: 2dvh;
-      left: 0;
-      right: 0;
-      border-radius: 0;
-    }
+    bottom: 16px;
+    padding-inline: 24px;
   }
 }

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -6,7 +6,7 @@
   --tab-bar-safe-area-padding: 0px;
   --tab-bar-bottom-extension: 0px;
   position: fixed;
-  bottom: max(12px, env(safe-area-inset-bottom));
+  bottom: max(4px, env(safe-area-inset-bottom));
   left: 0;
   right: 0;
   padding-inline: 12px;
@@ -26,14 +26,14 @@
    on Android via passed insets (Chromium 140+) or decorView padding (older);
    on iOS WKWebView env() reports the home-indicator inset natively. */
 .nativeApp {
-  bottom: max(16px, env(safe-area-inset-bottom));
+  bottom: max(8px, env(safe-area-inset-bottom));
 }
 
 /* On desktop the pill stays centered and capped; the wrapper itself spans full
    width but the BottomNavigation child sets max-width: min(560px, 100%). */
 @media (min-width: 768px) {
   .bottomBarWrapper {
-    bottom: 16px;
+    bottom: 8px;
     padding-inline: 24px;
   }
 }

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -58,11 +58,13 @@ const getActiveTab = (pathname: string): Tab => {
 
 // Scroll-direction hook. Returns true while the user is scrolling *down* past
 // COLLAPSE_THRESHOLD; flips back to false on any upward scroll or when they're
-// near the top of the page (< NEAR_TOP_PX). Movement under MIN_DELTA is ignored
-// to keep the pill stable on tiny scroll jitter (iOS rubber-banding, etc.).
+// near the top of the page (< NEAR_TOP_PX). Movement under the threshold is
+// ignored to keep the pill stable on tiny scroll jitter (iOS rubber-banding,
+// etc.). Returns a setter so the component can also expand the pill manually
+// — first tap on a collapsed pill should expand instead of navigating.
 const COLLAPSE_THRESHOLD = 8;
 const NEAR_TOP_PX = 24;
-function useScrollCollapsed(): boolean {
+function useScrollCollapsed(): [boolean, (value: boolean) => void] {
   const [collapsed, setCollapsed] = useState(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -90,7 +92,7 @@ function useScrollCollapsed(): boolean {
       if (frame) window.cancelAnimationFrame(frame);
     };
   }, []);
-  return collapsed;
+  return [collapsed, setCollapsed];
 }
 
 const listUrlToCreateUrl = (url: string): string => {
@@ -112,7 +114,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const { t } = useTranslation('playlists');
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
-  const collapsed = useScrollCollapsed();
+  const [collapsed, setCollapsed] = useScrollCollapsed();
   const { openAuthModal } = useAuthModal();
 
   // Publish the collapsed state as a `data-` attribute on <html> so other
@@ -322,6 +324,15 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   };
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: Tab) => {
+    // First tap on a collapsed pill expands it instead of navigating.
+    // The user can't reliably hit a 14px icon in a 28px-tall chrome, so the
+    // tap is treated as "bring the chrome back" — they can then aim properly
+    // and tap again to navigate. Mirrors how Safari's collapsed URL bar
+    // expands on first tap before it accepts a target.
+    if (collapsed) {
+      setCollapsed(false);
+      return;
+    }
     switch (newValue) {
       case 'home':
         handleHomeTab();

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -114,6 +114,19 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const isDark = mode === 'dark';
   const collapsed = useScrollCollapsed();
   const { openAuthModal } = useAuthModal();
+
+  // Publish the collapsed state as a `data-` attribute on <html> so other
+  // floating UI (specifically the queue-control FAB cluster, portal-rendered
+  // outside this component's tree) can subscribe via plain CSS — no shared
+  // state, no measurement-based jitter. Binary toggle = single 200ms
+  // transition on the consumer side that matches the bar's own animation.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.dataset.tabBarCollapsed = collapsed ? 'true' : 'false';
+    return () => {
+      delete document.documentElement.dataset.tabBarCollapsed;
+    };
+  }, [collapsed]);
   const [isBoardSelectorOpen, setIsBoardSelectorOpen] = useState(false);
   const [isBoardSelectorRendered, setIsBoardSelectorRendered] = useState(false);
   const [isCustomBoardOpen, setIsCustomBoardOpen] = useState(false);

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
@@ -9,7 +9,6 @@ import HomeOutlined from '@mui/icons-material/HomeOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
-import DynamicFeedOutlined from '@mui/icons-material/DynamicFeedOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { track } from '@vercel/analytics';
@@ -24,7 +23,7 @@ import {
   searchParamsToUrlParams,
   getPlaylistsBasePath,
 } from '@/app/lib/url-utils';
-import { themeTokens } from '@/app/theme/theme-config';
+import { themeTokens, darkTokens } from '@/app/theme/theme-config';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { usePersistentSessionState } from '../persistent-session';
@@ -39,7 +38,7 @@ import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import type { StoredBoardConfig } from '@/app/lib/saved-boards-db';
 import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
 
-type Tab = 'home' | 'climbs' | 'library' | 'feed' | 'create' | 'you';
+type Tab = 'home' | 'climbs' | 'library' | 'create' | 'you';
 
 type BottomTabBarProps = {
   boardDetails?: BoardDetails | null;
@@ -50,12 +49,49 @@ type BottomTabBarProps = {
 const getActiveTab = (pathname: string): Tab => {
   if (pathname === '/') return 'home';
   if (pathname.endsWith('/create')) return 'create';
-  if (pathname.startsWith('/feed')) return 'feed';
+  // /you/feed (and any other /you/* sub-route) lights up the You tab.
   if (pathname.startsWith('/you')) return 'you';
   if (pathname.startsWith('/discover/')) return 'library';
   if (pathname.startsWith('/playlists') || pathname.includes('/playlists')) return 'library';
   return 'climbs';
 };
+
+// Scroll-direction hook. Returns true while the user is scrolling *down* past
+// COLLAPSE_THRESHOLD; flips back to false on any upward scroll or when they're
+// near the top of the page (< NEAR_TOP_PX). Movement under MIN_DELTA is ignored
+// to keep the pill stable on tiny scroll jitter (iOS rubber-banding, etc.).
+const COLLAPSE_THRESHOLD = 8;
+const NEAR_TOP_PX = 24;
+function useScrollCollapsed(): boolean {
+  const [collapsed, setCollapsed] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let lastY = window.scrollY;
+    let frame = 0;
+    const handle = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        const y = window.scrollY;
+        const delta = y - lastY;
+        if (y < NEAR_TOP_PX) {
+          setCollapsed(false);
+        } else if (delta > COLLAPSE_THRESHOLD) {
+          setCollapsed(true);
+        } else if (delta < -COLLAPSE_THRESHOLD) {
+          setCollapsed(false);
+        }
+        lastY = y;
+      });
+    };
+    window.addEventListener('scroll', handle, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', handle);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+  return collapsed;
+}
 
 const listUrlToCreateUrl = (url: string): string => {
   const [path, query = ''] = url.split('?');
@@ -76,6 +112,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const { t } = useTranslation('playlists');
   const { mode } = useColorMode();
   const isDark = mode === 'dark';
+  const collapsed = useScrollCollapsed();
   const { openAuthModal } = useAuthModal();
   const [isBoardSelectorOpen, setIsBoardSelectorOpen] = useState(false);
   const [isBoardSelectorRendered, setIsBoardSelectorRendered] = useState(false);
@@ -242,11 +279,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     track('Bottom Tab Bar', { tab: 'library' });
   };
 
-  const handleFeedTab = () => {
-    router.push('/feed');
-    track('Bottom Tab Bar', { tab: 'feed' });
-  };
-
   const handleYouTab = () => {
     if (!isAuthenticated || !session?.user?.id) {
       openAuthModal({
@@ -286,9 +318,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         break;
       case 'library':
         handleLibraryTab();
-        break;
-      case 'feed':
-        handleFeedTab();
         break;
       case 'create':
         handleCreateTab();
@@ -376,66 +405,75 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
     [handleBoardSelected],
   );
 
+  const glassSurface = isDark ? darkTokens.glass.surface : themeTokens.glass.surface;
+  const glassBorder = isDark ? darkTokens.glass.border : themeTokens.glass.border;
+  const glassHighlight = isDark ? darkTokens.glass.highlight : themeTokens.glass.highlight;
+  const glassBlur = isDark ? themeTokens.glass.blur.strong : themeTokens.glass.blur.soft;
+  const glassShadow = isDark ? darkTokens.shadows.lg : themeTokens.shadows.lg;
+
   return (
     <>
       <BottomNavigation
         data-testid="bottom-tab-bar"
+        data-collapsed={collapsed ? 'true' : 'false'}
         value={activeTab}
         onChange={handleTabChange}
-        showLabels
+        showLabels={!collapsed}
         sx={{
-          background: isDark ? 'rgba(26, 26, 26, 0.7)' : 'rgba(255, 255, 255, 0.3)',
-          WebkitBackdropFilter: isDark ? 'blur(20px)' : 'blur(5px)',
-          backdropFilter: isDark ? 'blur(20px)' : 'blur(5px)',
-          borderRadius: `var(--tab-bar-top-radius, ${themeTokens.borderRadius.xl}px) var(--tab-bar-top-radius, ${themeTokens.borderRadius.xl}px) var(--tab-bar-bottom-radius, ${themeTokens.borderRadius.xl}px) var(--tab-bar-bottom-radius, ${themeTokens.borderRadius.xl}px)`,
-          pt: `${themeTokens.spacing[2]}px`,
-          pb: `calc(${themeTokens.spacing[2]}px + var(--tab-bar-safe-area-padding, 0px))`,
+          // Liquid-glass pill: layered translucent fill + top-edge highlight + hairline border.
+          background: `${glassHighlight}, ${glassSurface}`,
+          WebkitBackdropFilter: `blur(${glassBlur}) saturate(180%)`,
+          backdropFilter: `blur(${glassBlur}) saturate(180%)`,
+          border: `1px solid ${glassBorder}`,
+          boxShadow: glassShadow,
+          borderRadius: `${themeTokens.borderRadius.full}px`,
+          // Smoothly animate every collapse property at once.
+          transition: `min-height ${themeTokens.transitions.normal}, padding ${themeTokens.transitions.normal}, max-width ${themeTokens.transitions.normal}, opacity ${themeTokens.transitions.normal}, transform ${themeTokens.transitions.normal}`,
+          pt: `${collapsed ? 0 : themeTokens.spacing[2]}px`,
+          pb: `calc(${collapsed ? 0 : themeTokens.spacing[2]}px + var(--tab-bar-safe-area-padding, 0px))`,
+          px: `${collapsed ? themeTokens.spacing[1] : themeTokens.spacing[2]}px`,
           mb: 'var(--tab-bar-bottom-extension, 0px)',
+          minHeight: collapsed ? 28 : 64,
           height: 'auto',
-          '@media (min-width: 768px)': {
-            maxWidth: 480,
-            mx: 'auto',
-            boxShadow: themeTokens.shadows.lg,
-            border: `1px solid var(--neutral-200)`,
+          mx: 'auto',
+          maxWidth: collapsed ? 220 : 'min(560px, 100%)',
+          // When collapsed, the whole pill recedes — smaller, lower-contrast,
+          // mirrors the Safari chrome shrink so the user knows it's still
+          // there but is out of the way.
+          opacity: collapsed ? themeTokens.opacity.subtle : 1,
+          '& .MuiBottomNavigationAction-root': {
+            minWidth: collapsed ? 32 : 'auto',
+            maxWidth: collapsed ? 32 : undefined,
+            padding: collapsed ? '0 2px' : undefined,
+            minHeight: collapsed ? 24 : undefined,
+            transition: `min-width ${themeTokens.transitions.normal}, padding ${themeTokens.transitions.normal}`,
+          },
+          '& .MuiBottomNavigationAction-label': {
+            transition: `opacity ${themeTokens.transitions.normal}`,
+            opacity: collapsed ? 0 : 1,
+            display: collapsed ? 'none' : undefined,
+          },
+          '& .MuiSvgIcon-root': {
+            transition: `font-size ${themeTokens.transitions.normal}`,
+            fontSize: collapsed ? 14 : 20,
           },
         }}
       >
-        <BottomNavigationAction
-          label={t('bottomTabBar.home')}
-          icon={<HomeOutlined sx={{ fontSize: 20 }} />}
-          value="home"
-          sx={actionSx}
-        />
+        <BottomNavigationAction label={t('bottomTabBar.home')} icon={<HomeOutlined />} value="home" sx={actionSx} />
         <BottomNavigationAction
           label={t('bottomTabBar.climb')}
-          icon={<FormatListBulletedOutlined sx={{ fontSize: 20 }} />}
+          icon={<FormatListBulletedOutlined />}
           value="climbs"
           sx={actionSx}
         />
         <BottomNavigationAction
           label={t('bottomTabBar.discover')}
-          icon={<LocalOfferOutlined sx={{ fontSize: 20 }} />}
+          icon={<LocalOfferOutlined />}
           value="library"
           sx={actionSx}
         />
-        <BottomNavigationAction
-          label={t('bottomTabBar.feed')}
-          icon={<DynamicFeedOutlined sx={{ fontSize: 20 }} />}
-          value="feed"
-          sx={actionSx}
-        />
-        <BottomNavigationAction
-          label={t('bottomTabBar.create')}
-          icon={<AddOutlined sx={{ fontSize: 20 }} />}
-          value="create"
-          sx={actionSx}
-        />
-        <BottomNavigationAction
-          label={t('bottomTabBar.you')}
-          icon={<PersonOutlined sx={{ fontSize: 20 }} />}
-          value="you"
-          sx={actionSx}
-        />
+        <BottomNavigationAction label={t('bottomTabBar.create')} icon={<AddOutlined />} value="create" sx={actionSx} />
+        <BottomNavigationAction label={t('bottomTabBar.you')} icon={<PersonOutlined />} value="you" sx={actionSx} />
       </BottomNavigation>
 
       {/* Board Selector Drawer */}

--- a/packages/web/app/components/global-header/__tests__/global-header.test.tsx
+++ b/packages/web/app/components/global-header/__tests__/global-header.test.tsx
@@ -548,12 +548,12 @@ describe('GlobalHeader', () => {
     });
   });
 
-  describe('on /feed page', () => {
-    it('renders search bar (default header)', () => {
-      mockPathname = '/feed';
+  describe('on /you/feed page', () => {
+    it('uses the /you child header (no search bar)', () => {
+      mockPathname = '/you/feed';
       render(<GlobalHeader boardConfigs={mockBoardConfigs} />);
 
-      expect(screen.getByPlaceholderText('What do you want to climb?')).toBeTruthy();
+      expect(screen.queryByPlaceholderText('What do you want to climb?')).toBeNull();
     });
   });
 });

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -127,6 +127,10 @@
      (measurement jitters during URL-bar moves on Android). Update here if
      the tab bar's content height changes. */
   --bottom-tab-bar-height: 59px;
+  /* Collapsed pill height — used while scrolling down (Safari-chrome shrink).
+     The tab bar publishes `data-tab-bar-collapsed` on <html>; consumers (FAB
+     cluster, peek snackbar) override their `bottom` against this value. */
+  --bottom-tab-bar-height-collapsed: 28px;
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -1,14 +1,17 @@
 /* FAB cluster: thumbnail FAB on left, tick FAB on right.
-   Anchored above the bottom tab bar via the published --bottom-bar-height
-   variable, which the bottom-bar wrapper updates continuously as it
-   collapses/expands. The cluster's `bottom` therefore tracks the bar's
-   real-time height — no separate `transition: bottom` needed, otherwise
-   the eased `bottom` would desync from the wrapper's actual motion and
-   the FABs would appear to drift independently of the bar.
 
-   The cluster is purely a fade in/out: the bar visibly slides away above
-   it to reveal the FABs already in place. The 80ms delay on the entrance
-   keeps it from crossfading with the bar's exit. */
+   Anchored at a fixed offset above the bottom tab bar's expanded content
+   height. We can't measure the wrapper live (continuous height tracking
+   compounds with Android URL-bar movement and the queue-control-bar's
+   grid-row collapse into visible jitter — abandoned that approach
+   intentionally). Instead, we react to a binary signal: the bottom tab
+   bar publishes its collapsed state as `data-tab-bar-collapsed` on
+   <html>, and we override `bottom` via a single CSS rule below. One
+   200ms transition matches the tab-bar pill's own animation.
+
+   The cluster's opacity is also a fade in/out: the bar visibly slides
+   away above it to reveal the FABs already in place. The 80ms delay on
+   the entrance keeps it from crossfading with the bar's exit. */
 .fabRoot {
   position: fixed;
   left: 0;
@@ -31,7 +34,17 @@
   gap: 12px;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 220ms ease-out 80ms;
+  transition:
+    opacity 220ms ease-out 80ms,
+    bottom 200ms ease;
+}
+
+/* Tab bar collapsed: pill shrinks to --bottom-tab-bar-height-collapsed, so the
+   FAB cluster drops with it and reclaims the space the labels used to occupy.
+   Single transition on `bottom` (declared above) matches the bar's own
+   collapse timing. */
+:root[data-tab-bar-collapsed='true'] .fabRoot {
+  bottom: calc(var(--bottom-tab-bar-height-collapsed) + env(safe-area-inset-bottom, 0px) + var(--spacing-2));
 }
 
 .fabRootVisible {
@@ -127,7 +140,9 @@
   /* Same fixed anchor as the FAB cluster (above the small-FAB row + gap).
      46px = small FAB diameter (mirrored from SMALL_FAB_SIZE in
      queue-control-fab.tsx); --spacing-3 is the visual gap between the
-     small-FAB row and the snackbar pill above it. */
+     small-FAB row and the snackbar pill above it. A
+     `:root[data-tab-bar-collapsed='true']` rule below tracks the bar
+     when it collapses, animated by the existing `transition: bottom`. */
   bottom: calc(
     var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px +
       var(--spacing-3)
@@ -149,6 +164,13 @@
   font-size: 14px;
   line-height: 1.25;
   text-align: center;
+}
+
+:root[data-tab-bar-collapsed='true'] .peekSnackbar {
+  bottom: calc(
+    var(--bottom-tab-bar-height-collapsed) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px +
+      var(--spacing-3)
+  );
 }
 
 /* Exit phase: paired ease-in animation (incoming items decelerate, outgoing

--- a/packages/web/app/feed/feed-page-content.tsx
+++ b/packages/web/app/feed/feed-page-content.tsx
@@ -26,6 +26,7 @@ type FeedPageContentProps = {
   initialFeedResult?: SessionFeedResult | null;
   isAuthenticatedSSR?: boolean;
   initialMyBoards?: UserBoard[] | null;
+  basePath?: string;
 };
 
 export default function FeedPageContent({
@@ -34,6 +35,7 @@ export default function FeedPageContent({
   initialFeedResult,
   isAuthenticatedSSR,
   initialMyBoards,
+  basePath = '/feed',
 }: FeedPageContentProps) {
   const { t } = useTranslation('feed');
   const { status } = useSession();
@@ -70,9 +72,9 @@ export default function FeedPageContent({
         params.delete(key);
       }
       const qs = params.toString();
-      router.push(qs ? `/feed?${qs}` : '/feed', { scroll: false });
+      router.push(qs ? `${basePath}?${qs}` : basePath, { scroll: false });
     },
-    [router, searchParams],
+    [router, searchParams, basePath],
   );
 
   const handleTabChange = (_: React.SyntheticEvent, value: FeedTab) => {

--- a/packages/web/app/feed/feed-server-data.ts
+++ b/packages/web/app/feed/feed-server-data.ts
@@ -1,0 +1,42 @@
+import { getServerAuthToken } from '../lib/auth/server-auth';
+import { cachedSessionGroupedFeed, serverMyBoards } from '../lib/graphql/server-cached-client';
+import type { SessionFeedResult, UserBoard } from '@boardsesh/shared-schema';
+
+export type FeedTab = 'sessions' | 'proposals' | 'comments';
+export const VALID_FEED_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
+
+export type FeedSSRData = {
+  tab: FeedTab;
+  boardUuid: string | undefined;
+  isAuthenticatedSSR: boolean;
+  initialFeedResult: SessionFeedResult | null;
+  initialMyBoards: UserBoard[] | null;
+};
+
+export async function loadFeedSSR(searchParams: Record<string, string | string[] | undefined>): Promise<FeedSSRData> {
+  const tab = (VALID_FEED_TABS.includes(searchParams.tab as FeedTab) ? searchParams.tab : 'sessions') as FeedTab;
+  const boardUuid = typeof searchParams.board === 'string' ? searchParams.board : undefined;
+
+  const authToken = await getServerAuthToken();
+  const isAuthenticatedSSR = !!authToken;
+
+  let initialFeedResult: SessionFeedResult | null = null;
+  let initialMyBoards: UserBoard[] | null = null;
+
+  if (authToken) {
+    const feedPromise =
+      tab === 'sessions' ? cachedSessionGroupedFeed(boardUuid, true).catch(() => null) : Promise.resolve(null);
+    const boardsPromise = serverMyBoards(authToken);
+    const [feedResult, boardsResult] = await Promise.all([feedPromise, boardsPromise]);
+    initialFeedResult = feedResult;
+    initialMyBoards = boardsResult;
+  } else if (tab === 'sessions') {
+    try {
+      initialFeedResult = await cachedSessionGroupedFeed(boardUuid, false);
+    } catch {
+      // Feed fetch failed, client will retry
+    }
+  }
+
+  return { tab, boardUuid, isAuthenticatedSSR, initialFeedResult, initialMyBoards };
+}

--- a/packages/web/app/feed/page.tsx
+++ b/packages/web/app/feed/page.tsx
@@ -1,72 +1,17 @@
-import React from 'react';
-import { getServerAuthToken } from '../lib/auth/server-auth';
-import FeedPageContent from './feed-page-content';
-import { cachedSessionGroupedFeed, serverMyBoards } from '../lib/graphql/server-cached-client';
-import type { SessionFeedResult, UserBoard } from '@boardsesh/shared-schema';
-import { createPageMetadata } from '@/app/lib/seo/metadata';
-import { getServerTranslation } from '@/app/lib/i18n/server';
-import { getLocale } from '@/app/lib/i18n/get-locale';
-import I18nProvider from '@/app/components/providers/i18n-provider';
-
-export async function generateMetadata() {
-  const { t, locale } = await getServerTranslation('feed');
-  return createPageMetadata({
-    title: t('metadata.feed.title'),
-    description: t('metadata.feed.description'),
-    path: '/feed',
-    locale,
-  });
-}
-
-type FeedTab = 'sessions' | 'proposals' | 'comments';
-const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
+import { permanentRedirect } from 'next/navigation';
 
 type FeedProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+// /feed has been folded into /you as a sub-tab. Preserve old links via 308.
 export default async function FeedPage({ searchParams }: FeedProps) {
   const params = await searchParams;
-
-  // Parse URL state
-  const tab = (VALID_TABS.includes(params.tab as FeedTab) ? params.tab : 'sessions') as FeedTab;
-  const boardUuid = typeof params.board === 'string' ? params.board : undefined;
-
-  // Read auth cookie to determine if user is authenticated at SSR time
-  const authToken = await getServerAuthToken();
-  const isAuthenticatedSSR = !!authToken;
-
-  // SSR: fetch boards + feed in parallel
-  let initialFeedResult: SessionFeedResult | null = null;
-  let initialMyBoards: UserBoard[] | null = null;
-
-  if (authToken) {
-    const feedPromise =
-      tab === 'sessions' ? cachedSessionGroupedFeed(boardUuid, true).catch(() => null) : Promise.resolve(null);
-    const boardsPromise = serverMyBoards(authToken);
-
-    const [feedResult, boardsResult] = await Promise.all([feedPromise, boardsPromise]);
-    initialFeedResult = feedResult;
-    initialMyBoards = boardsResult;
-  } else if (tab === 'sessions') {
-    try {
-      initialFeedResult = await cachedSessionGroupedFeed(boardUuid, false);
-    } catch {
-      // Feed fetch failed, client will retry
-    }
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string') qs.set(key, value);
+    else if (Array.isArray(value)) for (const v of value) qs.append(key, v);
   }
-
-  const locale = await getLocale();
-
-  return (
-    <I18nProvider locale={locale} namespaces={['feed']}>
-      <FeedPageContent
-        initialTab={tab}
-        initialBoardUuid={boardUuid}
-        initialFeedResult={initialFeedResult}
-        isAuthenticatedSSR={isAuthenticatedSSR}
-        initialMyBoards={initialMyBoards}
-      />
-    </I18nProvider>
-  );
+  const target = qs.toString() ? `/you/feed?${qs.toString()}` : '/you/feed';
+  permanentRedirect(target);
 }

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -540,7 +540,7 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
             <Typography variant="body2" sx={{ color: 'var(--neutral-400)', mb: 1 }}>
               {t('home.feed.callout')}
             </Typography>
-            <Button variant="text" size="small" onClick={() => router.push('/feed')} sx={{ textTransform: 'none' }}>
+            <Button variant="text" size="small" onClick={() => router.push('/you/feed')} sx={{ textTransform: 'none' }}>
               {t('home.feed.cta')}
             </Button>
           </Box>

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -187,6 +187,8 @@ export const themeTokens = {
 
   // Liquid-glass surface — translucent FAB / pill backdrops with backdrop-filter.
   // Light-mode values; dark-mode overrides live in darkTokens.glass below.
+  // Shared by the queue-control FAB cluster and the bottom-tab pill so glass
+  // surfaces read as one design language across the bottom region.
   glass: {
     /** Resting backdrop for glass FABs (light mode). */
     background: 'rgba(255, 255, 255, 0.42)',
@@ -200,6 +202,17 @@ export const themeTokens = {
     shadow: 'rgba(0, 0, 0, 0.18)',
     /** backdrop-filter / -webkit-backdrop-filter value. */
     filter: 'blur(20px) saturate(200%)',
+    /** Bottom-tab pill: backdrop-filter blur strengths. soft for light mode,
+     *  strong for dark (which needs more blur to keep contrast against busy
+     *  page content underneath). */
+    blur: { soft: '12px', strong: '24px' },
+    /** Bottom-tab pill: resting backdrop. Slightly more opaque than
+     *  `background` because the pill spans wider and reads better with
+     *  more body. */
+    surface: 'rgba(255, 255, 255, 0.55)',
+    /** Bottom-tab pill: top-edge highlight overlay (the 'lit edge' that
+     *  makes the surface read as glass and not just a frosted panel). */
+    highlight: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0) 35%)',
   },
 
   // Common pure-color tokens used as foreground colour against tinted surfaces
@@ -256,6 +269,7 @@ export const darkTokens = {
   },
 
   glass: {
+    // FAB tokens (PR 2010) — queue-control floating cluster.
     background: 'rgba(28, 28, 30, 0.42)',
     backgroundHover: 'rgba(28, 28, 30, 0.62)',
     /** Edge highlight is dimmer in dark mode — a 28% white border on a
@@ -272,6 +286,12 @@ export const darkTokens = {
      *  symmetric and consumers can read `glassTokens.filter`
      *  unconditionally. */
     filter: 'blur(20px) saturate(200%)',
+    // Bottom-tab pill tokens — `surface` and `highlight` are dark-mode
+    // overrides for the floating tab bar pill. Co-located with the FAB
+    // tokens so any glass surface that needs them in dark mode reads from
+    // one place. (`border` is shared with the FAB cluster above.)
+    surface: 'rgba(26, 26, 26, 0.55)',
+    highlight: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0) 35%)',
   },
 } as const;
 

--- a/packages/web/app/you/feed/page.tsx
+++ b/packages/web/app/you/feed/page.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import FeedPageContent from '../../feed/feed-page-content';
+import { loadFeedSSR } from '../../feed/feed-server-data';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+
+export async function generateMetadata() {
+  const { t, locale } = await getServerTranslation('feed');
+  return createNoIndexMetadata({
+    title: t('metadata.feed.title'),
+    description: t('metadata.feed.description'),
+    path: '/you/feed',
+    locale,
+  });
+}
+
+type YouFeedProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+// Auth gate is handled by you/layout.tsx (redirects unauthenticated users to /).
+// I18nProvider for the `feed` namespace is also set up in the parent layout.
+export default async function YouFeedPage({ searchParams }: YouFeedProps) {
+  const params = await searchParams;
+  const ssr = await loadFeedSSR(params);
+
+  return (
+    <FeedPageContent
+      basePath="/you/feed"
+      initialTab={ssr.tab}
+      initialBoardUuid={ssr.boardUuid}
+      initialFeedResult={ssr.initialFeedResult}
+      isAuthenticatedSSR={ssr.isAuthenticatedSSR}
+      initialMyBoards={ssr.initialMyBoards}
+    />
+  );
+}

--- a/packages/web/app/you/you-tab-bar.tsx
+++ b/packages/web/app/you/you-tab-bar.tsx
@@ -6,7 +6,7 @@ import Tab from '@mui/material/Tab';
 import { useTranslation } from 'react-i18next';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 
-type YouTab = 'progress' | 'sessions' | 'logbook';
+type YouTab = 'progress' | 'sessions' | 'logbook' | 'feed';
 
 export default function YouTabBar() {
   const { t } = useTranslation('you');
@@ -14,10 +14,12 @@ export default function YouTabBar() {
   const pathname = usePathnameWithoutLocale();
 
   let activeTab: YouTab;
-  if (pathname === '/you/sessions') {
+  if (pathname.startsWith('/you/sessions')) {
     activeTab = 'sessions';
-  } else if (pathname === '/you/logbook') {
+  } else if (pathname.startsWith('/you/logbook')) {
     activeTab = 'logbook';
+  } else if (pathname.startsWith('/you/feed')) {
+    activeTab = 'feed';
   } else {
     activeTab = 'progress';
   }
@@ -35,6 +37,7 @@ export default function YouTabBar() {
       <Tab label={t('tabs.progress')} value="progress" />
       <Tab label={t('tabs.sessions')} value="sessions" />
       <Tab label={t('tabs.logbook')} value="logbook" />
+      <Tab label={t('tabs.feed')} value="feed" />
     </Tabs>
   );
 }

--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -274,10 +274,11 @@ test.describe('Bottom Tab Bar - Queue Integration', () => {
     await expect(page).toHaveURL(/\/playlists/, { timeout: 15000 });
     await verifyBarsShowClimb();
 
-    // Navigate to Feed (Notifications tab was removed from the bottom bar;
-    // use Feed as a second public route to verify persistence).
-    await tabClickWithFallback('Feed', false, /\/feed/, '/feed');
-    await expect(page).toHaveURL(/\/feed/, { timeout: 15000 });
+    // Navigate back to Home as a second hop before returning to Climb.
+    // (The Feed tab was folded into /you/feed and removed from the bottom bar;
+    // /you requires auth so we use Home instead to verify multi-hop persistence.)
+    await tabClickWithFallback('Home', false, '/', '/');
+    await expect(page).toHaveURL('/', { timeout: 15000 });
     await verifyBarsShowClimb();
 
     // Navigate back to Climb. Fallback URL is the original board this test

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -223,7 +223,6 @@
     "home": "Home",
     "climb": "Climb",
     "discover": "Discover",
-    "feed": "Feed",
     "create": "Create",
     "you": "You",
     "youSignInTitle": "Sign in to see your progress",

--- a/packages/web/i18n/locales/en-US/you.json
+++ b/packages/web/i18n/locales/en-US/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progress",
     "sessions": "Sessions",
-    "logbook": "Logbook"
+    "logbook": "Logbook",
+    "feed": "Feed"
   },
   "progress": {
     "title": "Progress"

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -217,7 +217,6 @@
     "home": "Inicio",
     "climb": "Vías",
     "discover": "Descubre",
-    "feed": "Actividad",
     "create": "Crear",
     "you": "Tú",
     "youSignInTitle": "Inicia sesión para ver tu progreso",

--- a/packages/web/i18n/locales/es/you.json
+++ b/packages/web/i18n/locales/es/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progreso",
     "sessions": "Sesiones",
-    "logbook": "Historial"
+    "logbook": "Historial",
+    "feed": "Actividad"
   },
   "progress": {
     "title": "Progreso"

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -223,7 +223,6 @@
     "home": "Accueil",
     "climb": "Blocs",
     "discover": "Découvrir",
-    "feed": "Fil",
     "create": "Créer",
     "you": "Vous",
     "youSignInTitle": "Connectez-vous pour voir votre progression",

--- a/packages/web/i18n/locales/fr/you.json
+++ b/packages/web/i18n/locales/fr/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progression",
     "sessions": "Sessions",
-    "logbook": "Carnet"
+    "logbook": "Carnet",
+    "feed": "Activité"
   },
   "progress": {
     "title": "Progression"


### PR DESCRIPTION
## Summary

- **Bottom bar redesign**: edge-to-edge `BottomNavigation` → floating glass pill. Stronger backdrop blur (24px dark / 12px light) + saturate(180%), hairline border, top-edge highlight, soft shadow, full pill radius. New `glass.{surface,border,highlight,blur}` tokens in `theme-config.ts` so other surfaces can adopt the same treatment later.
- **Scroll-collapse**: scrolling down shrinks the pill Safari-chrome-style — height 28px, icons 14px, width 220px, opacity 0.7. Scroll-up or near-top restores it.
- **Feed moves into /you**: drops the Feed tab from the bottom bar (5 tabs now), adds Feed as a sub-tab in `YouTabBar` after Logbook, mounts the activity feed at `/you/feed`. `/feed` 308-redirects to `/you/feed` (preserving `?tab=` and `?board=` params). `FeedPageContent` gets a `basePath` prop so its internal navigation tracks the new URL. SSR loader is shared between `/feed` (now redirect-only) and `/you/feed`.
- **Native** (Capacitor) renders the same pill — no edge-to-edge fallback. Safe-area inset clears the iOS home indicator / Android nav-gesture area.

## Test plan

- [ ] Mobile viewport: pill is centered, glass blur visible behind it, all 5 tabs render (Home · Climb · Discover · Create · You) — no Feed icon.
- [ ] Scroll down a long page → pill collapses to small icons-only chrome; scroll up → re-expands.
- [ ] Within ~24px of top: always expanded.
- [ ] Tap **You** → `/you` (Progress default). `YouTabBar` shows Progress · Sessions · Logbook · Feed.
- [ ] Tap Feed sub-tab → loads `/you/feed`, activity feed renders, You tab on the bottom bar stays highlighted.
- [ ] Inner Feed tabs (Sessions / Proposals / Comments) keep URL on `/you/feed?tab=...`.
- [ ] Visit `/feed` directly → 308 to `/you/feed`, params preserved.
- [ ] Home page CTA "View feed" routes to `/you/feed`.
- [ ] Native shell: pill identical to web, clears home indicator.
- [ ] iOS Safari: no URL-bar grey-bleed; safe-area handled by the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)