### PR TITLE
perf(motion): silky-smooth pill collapse + FAB cluster motion

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -589,33 +589,36 @@ The queue drawer dynamically expands from partial to full height based on scroll
 
 ### 7. Bottom Tab Bar
 
-Mobile-only navigation bar with glassmorphism effect.
+Mobile primary navigation. A floating **liquid-glass pill** (not an edge-to-edge bar) anchored above the safe area, with five tabs: Home, Climbs, Discover, Create, You. (Feed is folded under `/you/feed` — there's no top-level Feed tab anymore.) The pill scroll-collapses into a small Safari-style chrome on downward scroll and re-expands on upward scroll or near-top.
 
-**Styling:**
+**Pill chrome:**
 
-```css
-background: rgba(255, 255, 255, 0.5);
--webkit-backdrop-filter: blur(10px);
-backdrop-filter: blur(10px);
-padding-top: 4px;
-padding-bottom: env(safe-area-inset-bottom, 0px);
-```
+- Shape: rounded pill (`border-radius: 9999px`), `max-width: min(560px, 100%)`, centered horizontally with a `var(--spacing-2)` bottom gap above the safe area.
+- Liquid glass: layered translucent surface + top-edge highlight gradient + 1px hairline border. Backdrop-filter strength differs per theme — light mode uses `blur(12px) saturate(180%)`, dark mode uses `blur(24px) saturate(180%)` to keep contrast over busy content. Tokens live under `themeTokens.glass.*` / `darkTokens.glass.*`.
+- The pill sits in a `position: fixed` wrapper at `z-index: 10`. The wrapper's `pointer-events: none` lets taps pass through gaps; the pill itself accepts events.
 
-**Tab items:**
+**Tab items (expanded):**
 
-- Layout: Flex column, centered
-- Padding: `6px 0 4px`
-- Icon size: `20px`
-- Label: `10px`, `margin-top: 2px`, `line-height: 1`
-- Active color: `var(--color-primary)` (`#8C4A52`)
-- Inactive color: `var(--neutral-400)` (`#9CA3AF`)
-- Transition: `color 150ms ease`
-- Touch handling: `-webkit-tap-highlight-color: transparent`, `touch-action: manipulation`
+- Layout: Flex row inside the pill (MUI `BottomNavigation` + `BottomNavigationAction`).
+- Icon size: `20px`. Label: shown via `showLabels`. Active color: `var(--color-primary)`. Inactive: `var(--neutral-400)`.
+- Touch handling: `-webkit-tap-highlight-color: transparent`, `touch-action: manipulation`.
+
+**Collapsed state (scroll-down or Safari-chrome shrink):**
+
+- Triggered by an RAF-coalesced scroll listener with asymmetric thresholds (8px down to collapse, top-of-page or 8px+ up to expand). State is published to `<html data-tab-bar-collapsed>` so the queue-control FAB cluster can subscribe via plain CSS — no shared React state, no measurement-based jitter.
+- Pill shrinks to ~`220px × 28px` at `opacity: 0.7`. Icons drop to `14px` and labels fade out (via `opacity` + `pointer-events: none` — never `display: none`, which kills the transition).
+- **First-tap-to-expand:** when collapsed, a tap on any tab expands the pill instead of navigating; the user can then aim properly and tap again to navigate. Mirrors how Safari's collapsed URL bar behaves — at 14px / 28px chrome, all icons are equally hard to hit, so the safety net applies uniformly.
+
+**Motion:**
+
+- Single shared transition family with the iOS decelerate curve: `transition: <props> 220ms cubic-bezier(0.32, 0.72, 0, 1)` (the `themeTokens.transitions.snappy` curve). The same curve is used by the queue-control FAB cluster's collapse-tracking and the queue-control bar's `cardWrapper` minimisation, so the bottom region reads as one motion family.
+- Layer-promote with `will-change: transform, opacity` and `contain: paint` so the backdrop-filter rasterization stays GPU-composited and doesn't bleed into sibling paint cost.
+- `prefers-reduced-motion: reduce` falls back to opacity-only fade — vertical motion is suppressed, dimensional changes snap.
 
 **Responsive:**
 
-- Hidden at `min-width: 768px` (desktop uses sidebar/header navigation)
-- Safe area insets for notched devices
+- Pill stays mobile-first; on `min-width: 768px` the wrapper still renders but desktop chrome (sidebar/header) handles primary navigation.
+- Safe-area insets honoured via `env(safe-area-inset-bottom, 0px)` and `var(--tab-bar-safe-area-padding)`.
 
 ---
 

--- a/packages/web/app/__tests__/robots.test.ts
+++ b/packages/web/app/__tests__/robots.test.ts
@@ -10,10 +10,10 @@ describe('robots', () => {
     });
   });
 
-  it('disallows crawling /feed, /api/, /auth/, and /settings', () => {
+  it('disallows crawling /api/, /auth/, /settings, and /you', () => {
     const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules[0] : result.rules;
-    expect(rules.disallow).toEqual(expect.arrayContaining(['/feed', '/api/', '/auth/', '/settings']));
+    expect(rules.disallow).toEqual(expect.arrayContaining(['/api/', '/auth/', '/settings', '/you', '/you/*']));
   });
 
   it('includes a sitemap URL', () => {

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -29,6 +29,17 @@
   bottom: max(8px, env(safe-area-inset-bottom));
 }
 
+/* iOS WKWebView: drop the pill flush with the bottom of the screen so its
+   rounded bottom edges nest into the iPhone's curved screen corners. The
+   home-indicator clearance moves *inside* the pill via
+   --tab-bar-safe-area-padding instead of lifting the whole element off
+   the bottom. Android stays on .nativeApp because gesture-nav clearance
+   varies more and a flush placement risks gesture conflicts there. */
+.iosNativeApp {
+  --tab-bar-safe-area-padding: env(safe-area-inset-bottom);
+  bottom: 0;
+}
+
 /* On desktop the pill stays centered and capped; the wrapper itself spans full
    width but the BottomNavigation child sets max-width: min(560px, 100%). */
 @media (min-width: 768px) {

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -452,14 +452,16 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           boxShadow: glassShadow,
           borderRadius: `${themeTokens.borderRadius.full}px`,
           // Layer-promote: keep backdrop-filter rasterization on its own GPU
-          // layer so the blur cost doesn't bleed into sibling paint, and clip
-          // repaints to the pill's own bounding box.
+          // layer so the blur cost doesn't bleed into sibling paint. (No
+          // `contain: paint` — it clips MUI touch ripples at the pill edge.)
+          // Deliberately permanent: scroll constantly drives the
+          // collapse/expand transition, so the cost of toggling
+          // `will-change` per-transition would cause more layer-creation
+          // jank than the small fixed compositor-memory footprint we pay
+          // by leaving it on for a single ~560×64px element.
           willChange: 'transform, opacity',
-          contain: 'paint',
           // Single shared iOS-decel curve for everything the pill animates.
-          // 220ms reads as deliberate without lagging — the curve does most
-          // of the perceptual work.
-          transition: `min-height 220ms ${themeTokens.transitions.snappy}, padding 220ms ${themeTokens.transitions.snappy}, max-width 220ms ${themeTokens.transitions.snappy}, opacity 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
+          transition: `min-height ${themeTokens.transitions.snappy}, padding ${themeTokens.transitions.snappy}, max-width ${themeTokens.transitions.snappy}, opacity ${themeTokens.transitions.snappy}, transform ${themeTokens.transitions.snappy}`,
           pt: `${collapsed ? 0 : themeTokens.spacing[2]}px`,
           pb: `calc(${collapsed ? 0 : themeTokens.spacing[2]}px + var(--tab-bar-safe-area-padding, 0px))`,
           px: `${collapsed ? themeTokens.spacing[1] : themeTokens.spacing[2]}px`,
@@ -483,7 +485,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             maxWidth: collapsed ? 32 : undefined,
             padding: collapsed ? '0 2px' : undefined,
             minHeight: collapsed ? 24 : undefined,
-            transition: `min-width 220ms ${themeTokens.transitions.snappy}, padding 220ms ${themeTokens.transitions.snappy}`,
+            transition: `min-width ${themeTokens.transitions.snappy}, padding ${themeTokens.transitions.snappy}`,
           },
           // Labels fade via opacity + collapse to 0 font-size so the icon
           // sits in the vertical centre of the collapsed pill. Without the
@@ -496,32 +498,50 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           // centres the icon as the pill shrinks. Not display:none —
           // that can't animate and would hard-cut the fade at frame 0.
           '& .MuiBottomNavigationAction-label': {
-            transition: `opacity 220ms ${themeTokens.transitions.snappy}, font-size 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
+            transition: `opacity ${themeTokens.transitions.snappy}, font-size ${themeTokens.transitions.snappy}, transform ${themeTokens.transitions.snappy}`,
             opacity: collapsed ? 0 : 1,
             fontSize: collapsed ? 0 : undefined,
             pointerEvents: collapsed ? 'none' : 'auto',
           },
           '& .MuiSvgIcon-root': {
-            transition: `font-size 220ms ${themeTokens.transitions.snappy}`,
+            transition: `font-size ${themeTokens.transitions.snappy}`,
             fontSize: collapsed ? 14 : 20,
           },
         }}
       >
-        <BottomNavigationAction label={t('bottomTabBar.home')} icon={<HomeOutlined />} value="home" sx={actionSx} />
+        {/* Wrapping labels in an aria-hidden span when collapsed keeps the
+            zero-font-size text out of the screen-reader tree (the icons are
+            still announced via the action's aria-label / route semantics). */}
         <BottomNavigationAction
-          label={t('bottomTabBar.climb')}
+          label={<span aria-hidden={collapsed || undefined}>{t('bottomTabBar.home')}</span>}
+          icon={<HomeOutlined />}
+          value="home"
+          sx={actionSx}
+        />
+        <BottomNavigationAction
+          label={<span aria-hidden={collapsed || undefined}>{t('bottomTabBar.climb')}</span>}
           icon={<FormatListBulletedOutlined />}
           value="climbs"
           sx={actionSx}
         />
         <BottomNavigationAction
-          label={t('bottomTabBar.discover')}
+          label={<span aria-hidden={collapsed || undefined}>{t('bottomTabBar.discover')}</span>}
           icon={<LocalOfferOutlined />}
           value="library"
           sx={actionSx}
         />
-        <BottomNavigationAction label={t('bottomTabBar.create')} icon={<AddOutlined />} value="create" sx={actionSx} />
-        <BottomNavigationAction label={t('bottomTabBar.you')} icon={<PersonOutlined />} value="you" sx={actionSx} />
+        <BottomNavigationAction
+          label={<span aria-hidden={collapsed || undefined}>{t('bottomTabBar.create')}</span>}
+          icon={<AddOutlined />}
+          value="create"
+          sx={actionSx}
+        />
+        <BottomNavigationAction
+          label={<span aria-hidden={collapsed || undefined}>{t('bottomTabBar.you')}</span>}
+          icon={<PersonOutlined />}
+          value="you"
+          sx={actionSx}
+        />
       </BottomNavigation>
 
       {/* Board Selector Drawer */}

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -485,14 +485,20 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             minHeight: collapsed ? 24 : undefined,
             transition: `min-width 220ms ${themeTokens.transitions.snappy}, padding 220ms ${themeTokens.transitions.snappy}`,
           },
-          // Labels fade via opacity (was display:none, which can't animate —
-          // hard-cut at frame 0). pointer-events:none keeps the invisible
-          // label area from intercepting taps. MUI's showLabels={!collapsed}
-          // already collapses the label's vertical space via translateY, so
-          // we don't need display:none to claim the space back.
+          // Labels fade via opacity + collapse to 0 font-size so the icon
+          // sits in the vertical centre of the collapsed pill. Without the
+          // font-size shrink, the label's line-height keeps reserving
+          // vertical space inside MuiBottomNavigationAction's flex column
+          // (`flex-direction: column; justify-content: center`), so the
+          // icon ends up at the *top* of an icon-plus-empty-label group
+          // instead of centred. Animating font-size 12→0 in lockstep with
+          // the opacity fade collapses the label box smoothly and re-
+          // centres the icon as the pill shrinks. Not display:none —
+          // that can't animate and would hard-cut the fade at frame 0.
           '& .MuiBottomNavigationAction-label': {
-            transition: `opacity 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
+            transition: `opacity 220ms ${themeTokens.transitions.snappy}, font-size 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
             opacity: collapsed ? 0 : 1,
+            fontSize: collapsed ? 0 : undefined,
             pointerEvents: collapsed ? 'none' : 'auto',
           },
           '& .MuiSvgIcon-root': {

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -451,8 +451,15 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           border: `1px solid ${glassBorder}`,
           boxShadow: glassShadow,
           borderRadius: `${themeTokens.borderRadius.full}px`,
-          // Smoothly animate every collapse property at once.
-          transition: `min-height ${themeTokens.transitions.normal}, padding ${themeTokens.transitions.normal}, max-width ${themeTokens.transitions.normal}, opacity ${themeTokens.transitions.normal}, transform ${themeTokens.transitions.normal}`,
+          // Layer-promote: keep backdrop-filter rasterization on its own GPU
+          // layer so the blur cost doesn't bleed into sibling paint, and clip
+          // repaints to the pill's own bounding box.
+          willChange: 'transform, opacity',
+          contain: 'paint',
+          // Single shared iOS-decel curve for everything the pill animates.
+          // 220ms reads as deliberate without lagging — the curve does most
+          // of the perceptual work.
+          transition: `min-height 220ms ${themeTokens.transitions.snappy}, padding 220ms ${themeTokens.transitions.snappy}, max-width 220ms ${themeTokens.transitions.snappy}, opacity 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
           pt: `${collapsed ? 0 : themeTokens.spacing[2]}px`,
           pb: `calc(${collapsed ? 0 : themeTokens.spacing[2]}px + var(--tab-bar-safe-area-padding, 0px))`,
           px: `${collapsed ? themeTokens.spacing[1] : themeTokens.spacing[2]}px`,
@@ -465,20 +472,31 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           // mirrors the Safari chrome shrink so the user knows it's still
           // there but is out of the way.
           opacity: collapsed ? themeTokens.opacity.subtle : 1,
+          '@media (prefers-reduced-motion: reduce)': {
+            transition: `opacity 180ms ease-out`,
+            '& .MuiBottomNavigationAction-root, & .MuiBottomNavigationAction-label, & .MuiSvgIcon-root': {
+              transition: 'none',
+            },
+          },
           '& .MuiBottomNavigationAction-root': {
             minWidth: collapsed ? 32 : 'auto',
             maxWidth: collapsed ? 32 : undefined,
             padding: collapsed ? '0 2px' : undefined,
             minHeight: collapsed ? 24 : undefined,
-            transition: `min-width ${themeTokens.transitions.normal}, padding ${themeTokens.transitions.normal}`,
+            transition: `min-width 220ms ${themeTokens.transitions.snappy}, padding 220ms ${themeTokens.transitions.snappy}`,
           },
+          // Labels fade via opacity (was display:none, which can't animate —
+          // hard-cut at frame 0). pointer-events:none keeps the invisible
+          // label area from intercepting taps. MUI's showLabels={!collapsed}
+          // already collapses the label's vertical space via translateY, so
+          // we don't need display:none to claim the space back.
           '& .MuiBottomNavigationAction-label': {
-            transition: `opacity ${themeTokens.transitions.normal}`,
+            transition: `opacity 220ms ${themeTokens.transitions.snappy}, transform 220ms ${themeTokens.transitions.snappy}`,
             opacity: collapsed ? 0 : 1,
-            display: collapsed ? 'none' : undefined,
+            pointerEvents: collapsed ? 'none' : 'auto',
           },
           '& .MuiSvgIcon-root': {
-            transition: `font-size ${themeTokens.transitions.normal}`,
+            transition: `font-size 220ms ${themeTokens.transitions.snappy}`,
             fontSize: collapsed ? 14 : 20,
           },
         }}

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -26,7 +26,7 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
@@ -144,6 +144,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathnameWithoutLocale();
   const isNative = isNativeApp();
+  const isIOSNative = isNative && getPlatform() === 'ios';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
@@ -179,7 +180,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   return (
     <div
       ref={wrapperRef}
-      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''}`}
+      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''} ${isIOSNative ? bottomBarStyles.iosNativeApp : ''}`}
       data-testid="bottom-bar-wrapper"
     >
       <FeedbackPromptBanner />

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
@@ -373,7 +373,7 @@ describe('QueueControlBar queue button', () => {
     expect(screen.getByTestId('queue-drawer').getAttribute('data-open')).toBe('true');
   });
 
-  it('badge shows the queue count when items are queued', async () => {
+  it('does not render a queue-count badge on the open-queue button', async () => {
     mockQueueContext = {
       ...baseQueueContext,
       queue: [makeQueueItem('item-1'), makeQueueItem('item-2'), makeQueueItem('item-3')],
@@ -383,23 +383,9 @@ describe('QueueControlBar queue button', () => {
       render(<QueueControlBar {...defaultProps} />);
     });
 
+    // The count is visible inside the drawer; the button itself stays uncluttered.
     const badge = queryInBar().getByLabelText('Open queue').querySelector('.MuiBadge-badge');
-    expect(badge).toBeTruthy();
-    expect(badge!.textContent).toBe('3');
-  });
-
-  it('badge content is 0 (and rendered invisible) when queue is empty', async () => {
-    mockQueueContext = { ...baseQueueContext, queue: [] };
-
-    await act(async () => {
-      render(<QueueControlBar {...defaultProps} />);
-    });
-
-    const badge = queryInBar().getByLabelText('Open queue').querySelector('.MuiBadge-badge');
-    expect(badge).toBeTruthy();
-    // MUI renders `badgeContent={0}` literally; `invisible={true}` hides it via CSS
-    // (no public class name in v6+), so we assert on the bound count, not visibility.
-    expect(badge!.textContent).toBe('0');
+    expect(badge).toBeNull();
   });
 
   it('mini bar collapses (loses sessionHeaderExpanded) when tick mode activates', async () => {

--- a/packages/web/app/components/queue-control/__tests__/queue-control-fab.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-fab.test.tsx
@@ -280,7 +280,8 @@ describe('QueueControlFab', () => {
       // Minimised → no snackbar.
       expect(screen.queryByText('Test Climb')).toBeNull();
 
-      // Switch to peeking → snackbar mounts with name + setter byline.
+      // Switch to peeking → snackbar mounts with the climb name only
+      // (no setter byline — the peek stays uncluttered).
       rerender(
         <QueueControlFab
           mode="peeking"
@@ -291,7 +292,7 @@ describe('QueueControlFab', () => {
         />,
       );
       expect(screen.getByText('Test Climb')).toBeTruthy();
-      expect(screen.getByText(/setter1/)).toBeTruthy();
+      expect(screen.queryByText(/setter1/)).toBeNull();
 
       // Returning to minimised: the snackbar stays mounted (exit animation),
       // then unmounts after the SNACKBAR_EXIT_MS (200ms) timeout.
@@ -315,22 +316,5 @@ describe('QueueControlFab', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it('omits the byline when the climb has no setter username', () => {
-    const handlers = makeHandlers();
-    const climbWithoutSetter = { ...mockClimb, setter_username: '' };
-    render(
-      <QueueControlFab
-        mode="peeking"
-        currentClimb={climbWithoutSetter}
-        boardDetails={baseBoardDetails}
-        pathname="/kilter/1/1/1/40/view/abc"
-        {...handlers}
-      />,
-    );
-
-    expect(screen.getByText('Test Climb')).toBeTruthy();
-    expect(screen.queryByText(/By /)).toBeNull();
   });
 });

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -521,14 +521,15 @@
    the tick row and session header wrapper above. Opacity and grid-row
    share the same 220ms duration so the bar doesn't go invisible while
    still occupying ~20% of its height (which used to read as a layout jump
-   at the 180/220ms split). */
+   at the 180/220ms split). iOS-decel curve matches the FAB cluster's
+   transition so the swap reads as one coordinated motion. */
 .cardWrapper {
   display: grid;
   grid-template-rows: 1fr;
   opacity: 1;
   transition:
-    grid-template-rows 220ms ease-out,
-    opacity 220ms ease-out;
+    grid-template-rows 220ms cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 220ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .cardWrapperHidden {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -88,8 +88,6 @@ const PEEK_DURATION_MS = 3000;
 // light for callsites that only need the dispatch helper.
 export { PLAY_DRAWER_EVENT, dispatchOpenPlayDrawer } from './play-drawer-event';
 
-const QUEUE_BADGE_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
-
 const TICK_BADGE_SX = {
   '& .MuiBadge-badge': {
     backgroundColor: themeTokens.colors.success,
@@ -459,19 +457,11 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         aria-label={t('common:ariaLabels.openQueue')}
       >
         <IconButton size="small" component="span" tabIndex={-1} sx={{ p: 0.25 }}>
-          <Badge
-            badgeContent={queue.length}
-            max={99}
-            color="primary"
-            invisible={queue.length === 0}
-            sx={QUEUE_BADGE_SX}
-          >
-            <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
-          </Badge>
+          <FormatListBulletedOutlined sx={{ fontSize: 18 }} />
         </IconButton>
       </div>
     ),
-    [openQueueDrawer, queue.length, t],
+    [openQueueDrawer, t],
   );
   const shouldNavigate = isViewPage || isPlayPage;
 

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -212,15 +212,6 @@
   white-space: nowrap;
 }
 
-.peekByline {
-  font-size: 12px;
-  opacity: 0.75;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @keyframes peekSnackbarIn {
   from {
     opacity: 0;

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -6,12 +6,28 @@
    grid-row collapse into visible jitter — abandoned that approach
    intentionally). Instead, we react to a binary signal: the bottom tab
    bar publishes its collapsed state as `data-tab-bar-collapsed` on
-   <html>, and we override `bottom` via a single CSS rule below. One
-   200ms transition matches the tab-bar pill's own animation.
+   <html>, which sets a `--fab-collapse-offset` custom property on :root.
+   The cluster picks that up via `transform: translateY(...)` —
+   compositor-only, no reflow. One 220ms snappy transition matches the
+   tab-bar pill's animation family.
 
    The cluster's opacity is also a fade in/out: the bar visibly slides
    away above it to reveal the FABs already in place. The 80ms delay on
    the entrance keeps it from crossfading with the bar's exit. */
+
+/* When the tab bar collapses, drop the peek snackbar DOWN by the height
+   delta (~+31px). The snackbar is opaque (no backdrop-filter children)
+   so its anchor wrapper can use a transform safely.
+
+   The FAB cluster CANNOT use this — its children (5 FABs) all rely on
+   backdrop-filter for the liquid-glass effect, and putting transform on
+   their ancestor creates a containing block that breaks backdrop-filter
+   sampling (the FABs would blur their own empty parent instead of the
+   page behind). So .fabRoot stays on a `bottom` swap below. */
+:root[data-tab-bar-collapsed='true'] {
+  --fab-collapse-offset: calc(var(--bottom-tab-bar-height) - var(--bottom-tab-bar-height-collapsed));
+}
+
 .fabRoot {
   position: fixed;
   left: 0;
@@ -24,7 +40,15 @@
      fixed reference is the only way to keep the FAB perfectly stationary
      while the bar slides away. The custom property is the single source of
      truth so a tab-bar height change here propagates without grepping for
-     magic numbers. */
+     magic numbers.
+
+     The collapse animation rides on `bottom` rather than `transform` on
+     purpose: putting `transform` on this element would create a containing
+     block that breaks backdrop-filter sampling on every FAB child (they'd
+     blur the empty parent instead of the page behind). A `bottom` reflow
+     fires only on the binary tab-bar-collapsed toggle, on a single
+     fixed-positioned box with no descendants depending on its layout —
+     cheap, and it keeps the liquid-glass intact. */
   bottom: calc(var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2));
   z-index: 8;
   padding: 0 12px;
@@ -35,14 +59,10 @@
   pointer-events: none;
   opacity: 0;
   transition:
-    opacity 220ms ease-out 80ms,
-    bottom 200ms ease;
+    opacity 220ms cubic-bezier(0.32, 0.72, 0, 1) 80ms,
+    bottom 220ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-/* Tab bar collapsed: pill shrinks to --bottom-tab-bar-height-collapsed, so the
-   FAB cluster drops with it and reclaims the space the labels used to occupy.
-   Single transition on `bottom` (declared above) matches the bar's own
-   collapse timing. */
 :root[data-tab-bar-collapsed='true'] .fabRoot {
   bottom: calc(var(--bottom-tab-bar-height-collapsed) + env(safe-area-inset-bottom, 0px) + var(--spacing-2));
 }
@@ -54,7 +74,9 @@
 /* On the way out, drop the entrance delay so the cluster fades immediately
    and the bar takes its place underneath. */
 .fabRoot:not(.fabRootVisible) {
-  transition: opacity 180ms ease-in;
+  transition:
+    opacity 180ms cubic-bezier(0.4, 0, 1, 1),
+    bottom 220ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .thumbnailFab,
@@ -125,38 +147,47 @@
   pointer-events: auto;
 }
 
-/* Peek snackbar: pill-shaped overlay above the smaller FABs that surfaces
-   the current climb's title + byline when the climb changes. Sibling of
-   fabRoot in the portal (not nested inside) so Safari's flex +
-   absolute-position quirks can't hide it. Anchored to the bottom-bar
-   height + small-FAB height so it sits just above the right cluster.
+/* Peek snackbar wrapper: owns the fixed positioning + tab-bar-collapse
+   tracking (transform: translateY → compositor-only). Sibling of fabRoot
+   in the portal so Safari's flex + absolute-position quirks can't hide
+   it. Two-layer pattern: anchor handles position, inner snackbar handles
+   its own keyframes — no transform composition headaches. */
+.peekSnackbarAnchor {
+  position: fixed;
+  left: 0;
+  right: 0;
+  /* Anchored above the small-FAB row + gap. Same expanded-state bottom as
+     the FAB cluster (--bottom-tab-bar-height + safe-area + --spacing-2),
+     stacked with the small-FAB row (46px = SMALL_FAB_SIZE in
+     queue-control-fab.tsx) and a --spacing-3 visual gap above it.
+     Collapse follows via --fab-collapse-offset (translateY) — compositor-
+     only, and safe here because the snackbar is opaque (no backdrop-filter
+     children to break). */
+  bottom: calc(
+    var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px + var(--spacing-3)
+  );
+  z-index: 8;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  transform: translateY(var(--fab-collapse-offset, 0px));
+  transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  will-change: transform;
+}
 
-   Per UX review: the snackbar is opaque (no backdrop blur) so it reads as
+/* Per UX review: the snackbar is opaque (no backdrop blur) so it reads as
    a tooltip *for* the FAB rather than a fifth glass surface in the same
    region. */
 .peekSnackbar {
-  position: fixed;
-  left: 50%;
-  /* Same fixed anchor as the FAB cluster (above the small-FAB row + gap).
-     46px = small FAB diameter (mirrored from SMALL_FAB_SIZE in
-     queue-control-fab.tsx); --spacing-3 is the visual gap between the
-     small-FAB row and the snackbar pill above it. A
-     `:root[data-tab-bar-collapsed='true']` rule below tracks the bar
-     when it collapses, animated by the existing `transition: bottom`. */
-  bottom: calc(
-    var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px +
-      var(--spacing-3)
-  );
   max-width: calc(100vw - 32px);
-  z-index: 8;
   border-radius: 9999px;
   pointer-events: none;
   box-shadow:
     0 8px 24px rgba(0, 0, 0, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.28);
   border: 1px solid rgba(0, 0, 0, 0.08);
-  /* `forwards` keeps the centering translate after the animation finishes. */
-  animation: peekSnackbarIn 220ms ease-out forwards;
+  /* `forwards` locks the entrance state after the animation finishes. */
+  animation: peekSnackbarIn 220ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
@@ -166,18 +197,11 @@
   text-align: center;
 }
 
-:root[data-tab-bar-collapsed='true'] .peekSnackbar {
-  bottom: calc(
-    var(--bottom-tab-bar-height-collapsed) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px +
-      var(--spacing-3)
-  );
-}
-
-/* Exit phase: paired ease-in animation (incoming items decelerate, outgoing
-   items accelerate). The element stays mounted for the full 200ms exit
-   before unmounting in JS so the user sees a fade rather than a snap. */
+/* Exit phase: paired ease-in (incoming decelerates, outgoing accelerates).
+   The element stays mounted for the full 200ms exit before unmounting in
+   JS so the user sees a fade rather than a snap. */
 .peekSnackbarExiting {
-  animation: peekSnackbarOut 180ms ease-in forwards;
+  animation: peekSnackbarOut 180ms cubic-bezier(0.4, 0, 1, 1) forwards;
 }
 
 .peekName {
@@ -200,22 +224,22 @@
 @keyframes peekSnackbarIn {
   from {
     opacity: 0;
-    transform: translate(-50%, 6px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
 }
 
 @keyframes peekSnackbarOut {
   from {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
   to {
     opacity: 0;
-    transform: translate(-50%, 6px);
+    transform: translateY(6px);
   }
 }
 
@@ -224,15 +248,26 @@
    not the motion) but the transform component is removed so users with
    vestibular sensitivity don't get screen movement. */
 @media (prefers-reduced-motion: reduce) {
+  /* Disable the snackbar's tab-bar-collapse slide — it still appears/
+     disappears via opacity, just without the vertical motion. The FAB
+     cluster's bottom value still swaps when the tab bar collapses, but
+     without a transition it snaps instantly (intended). */
+  :root[data-tab-bar-collapsed='true'] {
+    --fab-collapse-offset: 0px;
+  }
+
   .fabRoot,
   .fabRoot:not(.fabRootVisible) {
     transition: opacity 180ms ease-out;
   }
 
+  .peekSnackbarAnchor {
+    transform: none;
+    transition: none;
+  }
+
   .peekSnackbar {
     animation: peekSnackbarFadeIn 180ms ease-out forwards;
-    transform: translateX(-50%);
-    transition: none;
   }
 
   .peekSnackbarExiting {
@@ -242,22 +277,18 @@
   @keyframes peekSnackbarFadeIn {
     from {
       opacity: 0;
-      transform: translateX(-50%);
     }
     to {
       opacity: 1;
-      transform: translateX(-50%);
     }
   }
 
   @keyframes peekSnackbarFadeOut {
     from {
       opacity: 1;
-      transform: translateX(-50%);
     }
     to {
       opacity: 0;
-      transform: translateX(-50%);
     }
   }
 }

--- a/packages/web/app/components/queue-control/queue-control-fab.tsx
+++ b/packages/web/app/components/queue-control/queue-control-fab.tsx
@@ -261,21 +261,32 @@ const QueueControlFab: React.FC<QueueControlFabProps> = ({
           snackbarMounted so the exit animation can run before unmount.
           role="status" + aria-live="polite" so screen readers announce
           the climb change in party mode without preempting other speech.
-          Rendered as MUI Box so we can pass the dynamic grade tint via
-          sx (project convention prefers sx over the style prop). */}
+          Rendered as MUI Box so we can pass the dynamic grade tint via sx
+          (project convention prefers sx over the style prop).
+
+          Wrapped in `peekSnackbarAnchor` (a plain div) so the outer layer
+          owns the fixed positioning + tab-bar-collapse translateY tracking,
+          while the inner Box owns its entrance/exit keyframes. Two layers,
+          two transforms, no composition headaches. Safe to put a transform
+          on the wrapper because the snackbar is opaque — no backdrop-filter
+          children for the transformed-ancestor containing-block to break. */}
       {snackbarMounted && (
-        <Box
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className={`${styles.peekSnackbar} ${snackbarExiting ? styles.peekSnackbarExiting : ''}`}
-          sx={{ backgroundColor: fabBackground }}
-        >
-          <span className={styles.peekName}>{currentClimb.name}</span>
-          {currentClimb.setter_username && (
-            <span className={styles.peekByline}>{t('queueBar.byline', { setter: currentClimb.setter_username })}</span>
-          )}
-        </Box>
+        <div className={styles.peekSnackbarAnchor}>
+          <Box
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className={`${styles.peekSnackbar} ${snackbarExiting ? styles.peekSnackbarExiting : ''}`}
+            sx={{ backgroundColor: fabBackground }}
+          >
+            <span className={styles.peekName}>{currentClimb.name}</span>
+            {currentClimb.setter_username && (
+              <span className={styles.peekByline}>
+                {t('queueBar.byline', { setter: currentClimb.setter_username })}
+              </span>
+            )}
+          </Box>
+        </div>
       )}
     </>,
     document.body,

--- a/packages/web/app/components/queue-control/queue-control-fab.tsx
+++ b/packages/web/app/components/queue-control/queue-control-fab.tsx
@@ -280,11 +280,6 @@ const QueueControlFab: React.FC<QueueControlFabProps> = ({
             sx={{ backgroundColor: fabBackground }}
           >
             <span className={styles.peekName}>{currentClimb.name}</span>
-            {currentClimb.setter_username && (
-              <span className={styles.peekByline}>
-                {t('queueBar.byline', { setter: currentClimb.setter_username })}
-              </span>
-            )}
           </Box>
         </div>
       )}

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/feed', '/api/', '/auth/', '/settings', '/you', '/you/*'],
+      disallow: ['/api/', '/auth/', '/settings', '/you', '/you/*'],
     },
     sitemap: absoluteUrl('/sitemap.xml'),
   };

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -148,8 +148,8 @@ export const themeTokens = {
     fast: '150ms ease',
     normal: '200ms ease',
     slow: '300ms ease',
-    /** iOS-style decelerate curve. Curve only — pair with a duration. */
-    snappy: 'cubic-bezier(0.32, 0.72, 0, 1)',
+    /** iOS-style decelerate — 220ms reads as deliberate without lagging. */
+    snappy: '220ms cubic-bezier(0.32, 0.72, 0, 1)',
   },
 
   // Z-index scale

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -148,6 +148,8 @@ export const themeTokens = {
     fast: '150ms ease',
     normal: '200ms ease',
     slow: '300ms ease',
+    /** iOS-style decelerate curve. Curve only — pair with a duration. */
+    snappy: 'cubic-bezier(0.32, 0.72, 0, 1)',
   },
 
   // Z-index scale

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -238,8 +238,7 @@
       "connectToBoard": "Connect to board",
       "openQueue": "Open queue",
       "saveTick": "Save tick"
-    },
-    "byline": "By {{setter}}"
+    }
   },
   "queueDrawer": {
     "title": "Queue",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -238,8 +238,7 @@
       "connectToBoard": "Conectar al panel",
       "openQueue": "Abrir cola",
       "saveTick": "Guardar marca"
-    },
-    "byline": "Por {{setter}}"
+    }
   },
   "queueDrawer": {
     "title": "Cola",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -238,8 +238,7 @@
       "connectToBoard": "Se connecter au panneau",
       "openQueue": "Ouvrir la file d'attente",
       "saveTick": "Enregistrer le tick"
-    },
-    "byline": "Par {{setter}}"
+    }
   },
   "queueDrawer": {
     "title": "File d'attente",


### PR DESCRIPTION
## Summary

Tunes the bottom tab bar pill and queue-control FAB cluster animations from generic-`ease`-with-overlapping-transitions to a single-curve, layer-promoted, iOS-style decelerate. On top of the motion polish, this branch makes a few small visible changes (called out below) and an iOS-only safe-area refinement.

- **Bottom tab bar pill** — layer-promote (`will-change: transform, opacity`) so backdrop-filter rasterization stays on its own GPU layer; drop the per-element compound transitions that competed with the pill's own motion; replace `display: none` on labels with `opacity: 0 + pointer-events: none` so the fade can actually play instead of hard-cutting at frame 0; iOS decel curve `cubic-bezier(0.32, 0.72, 0, 1)` at 220ms baked into the `transitions.snappy` token (matches the shape of the other `transitions.*` tokens). `aria-hidden` on labels when collapsed so screen readers don't announce the zero-font-size text.
- **iOS native shell** — pill drops flush with the bottom of the screen so its rounded bottom edges nest into the iPhone's curved screen corners. Home-indicator clearance moves *inside* the pill via `--tab-bar-safe-area-padding`. Android keeps the existing 8px lift because gesture-nav clearance is more variable.
- **FAB cluster** — kept on the `bottom`-swap pattern (a `transform` on `.fabRoot` would create a containing block that breaks backdrop-filter sampling on every FAB child — they'd blur the empty parent instead of the page behind). Matched the snappy curve so it moves in lockstep with the pill.
- **Peek snackbar** — wrapped in a `.peekSnackbarAnchor` that owns the collapse-tracking `translateY(var(--fab-collapse-offset))` (compositor-only). The snackbar is opaque, so transform on the ancestor is safe. Inner snackbar keeps its entrance/exit keyframes — two layers, one transform each.
- **`cardWrapper`** — easing-token swap so the queue-control bar's minimisation reads as one motion family with the FABs.
- **Reduced-motion** — vertical slide disabled, opacity fades retained as the cue. Vestibular-sensitive users see no movement.

### Visible behavioral changes

- **Queue-count badge dropped from the session mini bar's open-queue button.** The list-icon already opens the drawer where the count is visible — the badge added visual noise without telling the user anything new. (commit 5b42589eb)
- **Setter byline removed from the climb-change peek snackbar.** The peek now shows only the climb name; the byline crowded the snackbar without earning its space.

No new components, hooks, or external animation library. Blur strength preserved (12px / 24px).

## Test plan

- [ ] On `/<board>/.../list`, scroll the climbs list — the pill should collapse and re-expand without visible step transitions or label hard-cut.
- [ ] Tap a collapsed pill once — first tap expands instead of navigating (existing behaviour, kept intact).
- [ ] On a queue-bar page, minimise the bar (scroll-collapse) so the FAB cluster appears, then collapse the tab bar — FAB cluster should glide down with the pill and stay frosted (no transparent-window regression).
- [ ] Trigger a peek by changing the current climb — snackbar should slide up showing only the climb name, sit ~3s, slide down. If the tab bar collapses while the snackbar is up, it should track the bar smoothly.
- [ ] DevTools → rendering → `Emulate CSS prefers-reduced-motion: reduce`. Re-trigger collapses — should fall back to plain opacity fades, no slide.
- [ ] DevTools Performance — record a 5s scroll session crossing the pill collapse/expand threshold a couple of times. Frame rate should stay near 60fps.
- [ ] On the iOS Capacitor app, confirm the pill's bottom curves visually nest into the iPhone's screen corners (no gap to the bottom edge) and the home-indicator gesture still works.
- [ ] Confirm the queue-icon button in the session mini bar no longer renders a count badge; opening the drawer still shows the queued items.
- [ ] Confirm the climb-change peek snackbar shows only the climb name (no "By <setter>" line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)