### PR TITLE
Add backend user data export

### DIFF
--- a/packages/backend/src/handlers/user-data-export.ts
+++ b/packages/backend/src/handlers/user-data-export.ts
@@ -1,0 +1,112 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { applyCorsHeaders } from './cors';
+import { validateNextAuthToken } from '../middleware/auth';
+import { isAuroraBoardType } from '../services/user-data-export-format';
+import {
+  getDownloadableUserDataExport,
+  getUserDataExportStatus,
+  requestUserDataExport,
+  type UserDataExportStatus,
+} from '../services/user-data-export';
+
+function extractAuthTokenFromHeader(req: IncomingMessage): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return null;
+
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+async function authenticate(req: IncomingMessage, res: ServerResponse): Promise<string | null> {
+  const token = extractAuthTokenFromHeader(req);
+  if (!token) {
+    sendJson(res, 401, { error: 'Authentication required' });
+    return null;
+  }
+
+  const authResult = await validateNextAuthToken(token);
+  if (!authResult) {
+    sendJson(res, 401, { error: 'Invalid or expired token' });
+    return null;
+  }
+
+  return authResult.userId;
+}
+
+function parseBoardType(url: URL, res: ServerResponse) {
+  const boardType = url.searchParams.get('boardType');
+  if (!isAuroraBoardType(boardType)) {
+    sendJson(res, 400, { error: 'Invalid or missing boardType' });
+    return null;
+  }
+
+  return boardType;
+}
+
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(JSON.stringify(body));
+}
+
+function statusCodeForExportStatus(status: UserDataExportStatus['status']): number {
+  if (status === 'generating') return 202;
+  if (status === 'unavailable') return 501;
+  return 200;
+}
+
+export async function handleUserDataExport(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  const userId = await authenticate(req, res);
+  if (!userId) return;
+
+  const boardType = parseBoardType(url, res);
+  if (!boardType) return;
+
+  const status =
+    req.method === 'POST'
+      ? await requestUserDataExport(userId, boardType)
+      : await getUserDataExportStatus(userId, boardType);
+
+  sendJson(res, statusCodeForExportStatus(status.status), status);
+}
+
+export async function handleUserDataExportDownload(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'GET') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  const userId = await authenticate(req, res);
+  if (!userId) return;
+
+  const boardType = parseBoardType(url, res);
+  if (!boardType) return;
+
+  const file = await getDownloadableUserDataExport(userId, boardType);
+  if (!file) {
+    sendJson(res, 404, { error: 'Export is not ready' });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': file.contentType ?? 'application/json',
+    'Content-Disposition': `attachment; filename="${file.filename}"`,
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    ...(file.contentLength != null ? { 'Content-Length': String(file.contentLength) } : {}),
+  });
+
+  file.stream.pipe(res);
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -13,6 +13,7 @@ import { handleAvatarUpload } from './handlers/avatars';
 import { handleStaticAvatar, handleStaticBetaThumbnail } from './handlers/static';
 import { handleSyncCron } from './handlers/sync';
 import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
+import { handleUserDataExport, handleUserDataExportDownload } from './handlers/user-data-export';
 import { createYogaInstance } from './graphql/yoga';
 import { setupWebSocketServer } from './websocket/setup';
 import { warmPopularConfigsCache } from './graphql/resolvers/social/boards';
@@ -94,6 +95,20 @@ export async function startServer(): Promise<ServerResources> {
       // OCR test data upload endpoint (handle OPTIONS for CORS preflight)
       if (pathname === '/api/ocr-test-data' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleOcrTestDataUpload(req, res);
+        return;
+      }
+
+      // User data export endpoints (request/status + authenticated download)
+      if (
+        pathname === '/api/user-data-export' &&
+        (req.method === 'GET' || req.method === 'POST' || req.method === 'OPTIONS')
+      ) {
+        await handleUserDataExport(req, res, url);
+        return;
+      }
+
+      if (pathname === '/api/user-data-export/download' && (req.method === 'GET' || req.method === 'OPTIONS')) {
+        await handleUserDataExportDownload(req, res, url);
         return;
       }
 
@@ -184,6 +199,7 @@ export async function startServer(): Promise<ServerResources> {
     console.info(`  Avatar upload: ${httpScheme}://0.0.0.0:${PORT}/api/avatars`);
     console.info(`  Avatar files: ${httpScheme}://0.0.0.0:${PORT}/static/avatars/`);
     console.info(`  OCR test data: ${httpScheme}://0.0.0.0:${PORT}/api/ocr-test-data`);
+    console.info(`  User data export: ${httpScheme}://0.0.0.0:${PORT}/api/user-data-export`);
     console.info(`  Sync cron: ${httpScheme}://0.0.0.0:${PORT}/sync-cron`);
 
     // Warm up popular board configs cache in the background.

--- a/packages/backend/src/services/user-data-export-format.test.ts
+++ b/packages/backend/src/services/user-data-export-format.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildAuroraJsonExport,
+  getIsoWeekPeriod,
+  getUserDataExportFilename,
+  getUserDataExportS3Key,
+  isAuroraBoardType,
+} from './user-data-export-format';
+
+describe('user data export formatting', () => {
+  it('formats ticks, likes, circuits, and user metadata as Aurora JSON export data', () => {
+    const exportData = buildAuroraJsonExport({
+      boardType: 'kilter',
+      user: {
+        id: 'user-1',
+        name: 'Marco',
+        email: 'marco@example.com',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      },
+      ticks: [
+        {
+          climbName: 'Warm Up',
+          status: 'flash',
+          angle: 20,
+          attemptCount: 1,
+          quality: 4,
+          difficulty: 12,
+          difficultyName: 'V3',
+          climbedAt: '2026-05-01 14:00:00',
+          createdAt: '2026-05-01 14:00:05',
+        },
+        {
+          climbName: 'Project',
+          status: 'attempt',
+          angle: 40,
+          attemptCount: 5,
+          quality: null,
+          difficulty: null,
+          difficultyName: null,
+          climbedAt: '2026-05-01 15:00:00',
+          createdAt: '2026-05-01 15:00:05',
+        },
+      ],
+      favorites: [
+        { climbName: 'Warm Up', createdAt: new Date('2026-05-02T10:00:00Z') },
+        { climbName: 'Warm Up', createdAt: new Date('2026-05-03T10:00:00Z') },
+      ],
+      circuitRows: [
+        {
+          playlistId: 1,
+          name: 'Power',
+          color: '#00AAFF',
+          createdAt: new Date('2026-05-01T12:00:00Z'),
+          description: 'Limit climbs',
+          isPublic: false,
+          climbName: 'Warm Up',
+          position: 0,
+        },
+        {
+          playlistId: 1,
+          name: 'Power',
+          color: '#00AAFF',
+          createdAt: new Date('2026-05-01T12:00:00Z'),
+          description: 'Limit climbs',
+          isPublic: false,
+          climbName: 'Project',
+          position: 1,
+        },
+      ],
+      climbs: [],
+    });
+
+    expect(exportData.user).toEqual({
+      username: 'Marco',
+      email_address: 'marco@example.com',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    expect(exportData.ascents).toEqual([
+      {
+        climb: 'Warm Up',
+        angle: 20,
+        count: 1,
+        stars: 4,
+        climbed_at: '2026-05-01 14:00:00',
+        created_at: '2026-05-01 14:00:05',
+        grade: 'V3',
+      },
+    ]);
+    expect(exportData.attempts).toEqual([
+      {
+        climb: 'Project',
+        angle: 40,
+        count: 5,
+        climbed_at: '2026-05-01 15:00:00',
+        created_at: '2026-05-01 15:00:05',
+      },
+    ]);
+    expect(exportData.likes).toEqual([{ climb: 'Warm Up', created_at: '2026-05-02T10:00:00.000Z' }]);
+    expect(exportData.circuits).toEqual([
+      {
+        name: 'Power',
+        color: '00AAFF',
+        created_at: '2026-05-01T12:00:00.000Z',
+        description: 'Limit climbs',
+        is_private: true,
+        climbs: ['Warm Up', 'Project'],
+      },
+    ]);
+  });
+
+  it('uses ISO weeks for deterministic weekly object names', () => {
+    const date = new Date('2026-05-07T12:00:00Z');
+
+    expect(getIsoWeekPeriod(date)).toEqual({ year: 2026, week: 19, label: '2026-W19' });
+    expect(getUserDataExportS3Key('user-1', 'tension', date)).toBe('user-data-exports/user-1/tension/2026-W19.json');
+    expect(getUserDataExportFilename('tension', date)).toBe('boardsesh-tension-export-2026-W19.json');
+  });
+
+  it('recognizes only Aurora-backed boards', () => {
+    expect(isAuroraBoardType('kilter')).toBe(true);
+    expect(isAuroraBoardType('moonboard')).toBe(false);
+    expect(isAuroraBoardType(null)).toBe(false);
+  });
+});

--- a/packages/backend/src/services/user-data-export-format.ts
+++ b/packages/backend/src/services/user-data-export-format.ts
@@ -1,0 +1,308 @@
+import { HOLE_PLACEMENTS, LAYOUTS } from '@boardsesh/board-constants/product-sizes';
+import { convertLitUpHoldsStringToMap } from '@boardsesh/board-constants/hold-states';
+import { AURORA_BOARDS, type AuroraBoardName, type BoardName } from '@boardsesh/shared-schema';
+
+export type AuroraJsonExport = {
+  user: {
+    username: string;
+    email_address?: string;
+    created_at?: string;
+  };
+  ascents: Array<{
+    climb: string;
+    angle: number;
+    count: number;
+    stars: number;
+    climbed_at: string;
+    created_at: string;
+    grade: string;
+  }>;
+  attempts: Array<{
+    climb: string;
+    angle: number;
+    count: number;
+    climbed_at: string;
+    created_at: string;
+  }>;
+  circuits: Array<{
+    name: string;
+    color: string;
+    created_at: string;
+    description?: string;
+    is_private?: boolean;
+    climbs: string[];
+  }>;
+  climbs: Array<{
+    name: string;
+    layout: string;
+    created_at: string;
+    is_draft?: boolean | null;
+    holds: Array<{ x: number; y: number; role: string }>;
+    description?: string;
+  }>;
+  likes: Array<{ climb: string; created_at: string }>;
+};
+
+export type ExportUserRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  createdAt: Date | string | null;
+};
+
+export type ExportTickRow = {
+  climbName: string | null;
+  status: 'flash' | 'send' | 'attempt';
+  angle: number;
+  attemptCount: number | null;
+  quality: number | null;
+  difficulty: number | null;
+  difficultyName: string | null;
+  climbedAt: string | Date;
+  createdAt: string | Date;
+};
+
+export type ExportFavoriteRow = {
+  climbName: string | null;
+  createdAt: string | Date;
+};
+
+export type ExportCircuitRow = {
+  playlistId: bigint | number | string;
+  name: string;
+  color: string | null;
+  createdAt: string | Date;
+  description: string | null;
+  isPublic: boolean | null;
+  climbName: string | null;
+  position: number | null;
+};
+
+export type ExportClimbRow = {
+  uuid: string;
+  name: string | null;
+  layoutId: number;
+  frames: string | null;
+  createdAt: string | Date | null;
+  isDraft: boolean | null;
+  description: string | null;
+};
+
+export type IsoWeekPeriod = {
+  year: number;
+  week: number;
+  label: string;
+};
+
+const ROLE_BY_HOLD_STATE: Record<string, string> = {
+  STARTING: 'start',
+  HAND: 'middle',
+  FINISH: 'finish',
+  FOOT: 'foot',
+};
+
+export function isAuroraBoardType(value: string | null | undefined): value is AuroraBoardName {
+  return !!value && (AURORA_BOARDS as readonly string[]).includes(value);
+}
+
+export function getIsoWeekPeriod(date = new Date()): IsoWeekPeriod {
+  const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNumber = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+
+  const year = utcDate.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil(((utcDate.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+
+  return {
+    year,
+    week,
+    label: `${year}-W${String(week).padStart(2, '0')}`,
+  };
+}
+
+export function getUserDataExportS3Key(userId: string, boardType: AuroraBoardName, date = new Date()): string {
+  const period = getIsoWeekPeriod(date);
+  return `user-data-exports/${userId}/${boardType}/${period.label}.json`;
+}
+
+export function getUserDataExportFilename(boardType: AuroraBoardName, date = new Date()): string {
+  const period = getIsoWeekPeriod(date);
+  return `boardsesh-${boardType}-export-${period.label}.json`;
+}
+
+export function buildAuroraJsonExport(input: {
+  boardType: AuroraBoardName;
+  user: ExportUserRow | null;
+  ticks: ExportTickRow[];
+  favorites: ExportFavoriteRow[];
+  circuitRows: ExportCircuitRow[];
+  climbs: ExportClimbRow[];
+}): AuroraJsonExport {
+  const user = buildUserExport(input.user);
+  const ascents: AuroraJsonExport['ascents'] = [];
+  const attempts: AuroraJsonExport['attempts'] = [];
+
+  for (const tick of input.ticks) {
+    if (!tick.climbName) continue;
+
+    if (tick.status === 'attempt') {
+      attempts.push({
+        climb: tick.climbName,
+        angle: tick.angle,
+        count: tick.attemptCount ?? 1,
+        climbed_at: formatTimestamp(tick.climbedAt),
+        created_at: formatTimestamp(tick.createdAt),
+      });
+      continue;
+    }
+
+    ascents.push({
+      climb: tick.climbName,
+      angle: tick.angle,
+      count: tick.attemptCount ?? 1,
+      stars: tick.quality ?? 0,
+      climbed_at: formatTimestamp(tick.climbedAt),
+      created_at: formatTimestamp(tick.createdAt),
+      grade: tick.difficultyName ?? (tick.difficulty == null ? '' : String(tick.difficulty)),
+    });
+  }
+
+  return {
+    user,
+    ascents,
+    attempts,
+    circuits: buildCircuitExports(input.circuitRows),
+    climbs: buildClimbExports(input.boardType, input.climbs),
+    likes: buildLikeExports(input.favorites),
+  };
+}
+
+function buildUserExport(user: ExportUserRow | null): AuroraJsonExport['user'] {
+  if (!user) {
+    return { username: 'Boardsesh User' };
+  }
+
+  const username = user.name || user.email?.split('@')[0] || user.id;
+  return {
+    username,
+    ...(user.email ? { email_address: user.email } : {}),
+    ...(user.createdAt ? { created_at: formatTimestamp(user.createdAt) } : {}),
+  };
+}
+
+function buildLikeExports(favorites: ExportFavoriteRow[]): AuroraJsonExport['likes'] {
+  const seen = new Set<string>();
+  const likes: AuroraJsonExport['likes'] = [];
+
+  for (const favorite of favorites) {
+    if (!favorite.climbName || seen.has(favorite.climbName)) continue;
+    seen.add(favorite.climbName);
+    likes.push({
+      climb: favorite.climbName,
+      created_at: formatTimestamp(favorite.createdAt),
+    });
+  }
+
+  return likes;
+}
+
+function buildCircuitExports(rows: ExportCircuitRow[]): AuroraJsonExport['circuits'] {
+  const circuits = new Map<
+    string,
+    {
+      name: string;
+      color: string;
+      created_at: string;
+      description?: string;
+      is_private?: boolean;
+      climbs: string[];
+      climbNamesSeen: Set<string>;
+    }
+  >();
+
+  for (const row of rows) {
+    const key = String(row.playlistId);
+    let circuit = circuits.get(key);
+
+    if (!circuit) {
+      circuit = {
+        name: row.name,
+        color: (row.color ?? '').replace(/^#/, ''),
+        created_at: formatTimestamp(row.createdAt),
+        ...(row.description ? { description: row.description } : {}),
+        ...(row.isPublic == null ? {} : { is_private: !row.isPublic }),
+        climbs: [],
+        climbNamesSeen: new Set<string>(),
+      };
+      circuits.set(key, circuit);
+    }
+
+    if (row.climbName && !circuit.climbNamesSeen.has(row.climbName)) {
+      circuit.climbNamesSeen.add(row.climbName);
+      circuit.climbs.push(row.climbName);
+    }
+  }
+
+  return [...circuits.values()].map(({ climbNamesSeen: _climbNamesSeen, ...circuit }) => circuit);
+}
+
+function buildClimbExports(boardType: AuroraBoardName, climbs: ExportClimbRow[]): AuroraJsonExport['climbs'] {
+  return climbs.map((climb) => ({
+    name: climb.name ?? climb.uuid,
+    layout: getLayoutName(boardType, climb.layoutId),
+    created_at: climb.createdAt ? formatTimestamp(climb.createdAt) : new Date(0).toISOString(),
+    is_draft: climb.isDraft,
+    holds: framesToExportHolds(boardType, climb.layoutId, climb.frames),
+    ...(climb.description ? { description: climb.description } : {}),
+  }));
+}
+
+export function framesToExportHolds(
+  boardType: AuroraBoardName,
+  layoutId: number,
+  frames: string | null | undefined,
+): Array<{ x: number; y: number; role: string }> {
+  if (!frames) return [];
+
+  const placementCoordinates = buildPlacementCoordinateMap(boardType, layoutId);
+  const firstFrame = convertLitUpHoldsStringToMap(frames, boardType as BoardName)[0] ?? {};
+
+  return Object.entries(firstFrame)
+    .map(([holdId, hold]) => {
+      const coordinates = placementCoordinates.get(Number(holdId));
+      const role = ROLE_BY_HOLD_STATE[String(hold.state)];
+      if (!coordinates || !role) return null;
+      return { ...coordinates, role };
+    })
+    .filter((hold): hold is { x: number; y: number; role: string } => hold != null)
+    .sort((a, b) => a.y - b.y || a.x - b.x || a.role.localeCompare(b.role));
+}
+
+function buildPlacementCoordinateMap(
+  boardType: AuroraBoardName,
+  layoutId: number,
+): Map<number, { x: number; y: number }> {
+  const map = new Map<number, { x: number; y: number }>();
+  const placementsBySet = HOLE_PLACEMENTS[boardType as BoardName] ?? {};
+
+  for (const [key, placements] of Object.entries(placementsBySet)) {
+    if (!key.startsWith(`${layoutId}-`)) continue;
+
+    for (const [placementId, , x, y] of placements) {
+      if (!map.has(placementId)) {
+        map.set(placementId, { x, y });
+      }
+    }
+  }
+
+  return map;
+}
+
+function getLayoutName(boardType: AuroraBoardName, layoutId: number): string {
+  return LAYOUTS[boardType as BoardName]?.[layoutId]?.name ?? String(layoutId);
+}
+
+function formatTimestamp(value: string | Date): string {
+  return typeof value === 'string' ? value : value.toISOString();
+}

--- a/packages/backend/src/services/user-data-export.ts
+++ b/packages/backend/src/services/user-data-export.ts
@@ -1,0 +1,315 @@
+import { and, asc, eq } from 'drizzle-orm';
+import {
+  boardClimbs,
+  boardDifficultyGrades,
+  boardseshTicks,
+  playlistClimbs,
+  playlistOwnership,
+  playlists,
+  userFavorites,
+  users,
+} from '@boardsesh/db/schema';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { dbRead } from '../db/client';
+import { getFromS3, getS3ObjectMetadata, isS3Configured, uploadToS3 } from '../storage/s3';
+import {
+  buildAuroraJsonExport,
+  getIsoWeekPeriod,
+  getUserDataExportFilename,
+  getUserDataExportS3Key,
+  type AuroraJsonExport,
+} from './user-data-export-format';
+
+export type UserDataExportStatus = {
+  boardType: AuroraBoardName;
+  period: string;
+  status: 'not_requested' | 'generating' | 'ready' | 'failed' | 'unavailable';
+  requestedAt?: string;
+  completedAt?: string;
+  downloadUrl?: string;
+  fileSize?: number;
+  error?: string;
+};
+
+type ExportJob = UserDataExportStatus & {
+  userId: string;
+  key: string;
+  jobId: string;
+};
+
+export type DownloadableUserDataExport = {
+  key: string;
+  filename: string;
+  stream: NonNullable<Awaited<ReturnType<typeof getFromS3>>>['stream'];
+  contentType: string | undefined;
+  contentLength: number | undefined;
+};
+
+const exportJobs = new Map<string, ExportJob>();
+
+export async function getUserDataExportStatus(
+  userId: string,
+  boardType: AuroraBoardName,
+): Promise<UserDataExportStatus> {
+  const descriptor = getCurrentExportDescriptor(userId, boardType);
+  const existing = exportJobs.get(descriptor.jobId);
+  if (existing) return toPublicStatus(existing);
+
+  if (!isS3Configured()) {
+    return {
+      boardType,
+      period: descriptor.period,
+      status: 'unavailable',
+      error: 'S3 storage is not configured',
+    };
+  }
+
+  const metadata = await getS3ObjectMetadata(descriptor.key);
+  if (!metadata) {
+    return {
+      boardType,
+      period: descriptor.period,
+      status: 'not_requested',
+    };
+  }
+
+  const readyJob: ExportJob = {
+    userId,
+    key: descriptor.key,
+    jobId: descriptor.jobId,
+    boardType,
+    period: descriptor.period,
+    status: 'ready',
+    completedAt: metadata.lastModified?.toISOString(),
+    downloadUrl: descriptor.downloadUrl,
+    fileSize: metadata.contentLength,
+  };
+  exportJobs.set(descriptor.jobId, readyJob);
+  return toPublicStatus(readyJob);
+}
+
+export async function requestUserDataExport(userId: string, boardType: AuroraBoardName): Promise<UserDataExportStatus> {
+  const descriptor = getCurrentExportDescriptor(userId, boardType);
+  const existing = exportJobs.get(descriptor.jobId);
+
+  if (existing?.status === 'generating' || existing?.status === 'ready') {
+    return toPublicStatus(existing);
+  }
+
+  if (!isS3Configured()) {
+    return {
+      boardType,
+      period: descriptor.period,
+      status: 'unavailable',
+      error: 'S3 storage is not configured',
+    };
+  }
+
+  const metadata = await getS3ObjectMetadata(descriptor.key);
+  if (metadata) {
+    const readyJob: ExportJob = {
+      userId,
+      key: descriptor.key,
+      jobId: descriptor.jobId,
+      boardType,
+      period: descriptor.period,
+      status: 'ready',
+      completedAt: metadata.lastModified?.toISOString(),
+      downloadUrl: descriptor.downloadUrl,
+      fileSize: metadata.contentLength,
+    };
+    exportJobs.set(descriptor.jobId, readyJob);
+    return toPublicStatus(readyJob);
+  }
+
+  const generatingJob: ExportJob = {
+    userId,
+    key: descriptor.key,
+    jobId: descriptor.jobId,
+    boardType,
+    period: descriptor.period,
+    status: 'generating',
+    requestedAt: new Date().toISOString(),
+  };
+  exportJobs.set(descriptor.jobId, generatingJob);
+
+  void generateAndStoreUserDataExport(generatingJob, descriptor.downloadUrl);
+
+  return toPublicStatus(generatingJob);
+}
+
+export async function getDownloadableUserDataExport(
+  userId: string,
+  boardType: AuroraBoardName,
+): Promise<DownloadableUserDataExport | null> {
+  if (!isS3Configured()) return null;
+
+  const descriptor = getCurrentExportDescriptor(userId, boardType);
+  const file = await getFromS3(descriptor.key);
+  if (!file) return null;
+
+  return {
+    key: descriptor.key,
+    filename: getUserDataExportFilename(boardType),
+    stream: file.stream,
+    contentType: file.contentType,
+    contentLength: file.contentLength,
+  };
+}
+
+export async function buildUserAuroraJsonExport(userId: string, boardType: AuroraBoardName): Promise<AuroraJsonExport> {
+  const [userRows, tickRows, favoriteRows, circuitRows, climbRows] = await Promise.all([
+    dbRead
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1),
+    dbRead
+      .select({
+        climbName: boardClimbs.name,
+        status: boardseshTicks.status,
+        angle: boardseshTicks.angle,
+        attemptCount: boardseshTicks.attemptCount,
+        quality: boardseshTicks.quality,
+        difficulty: boardseshTicks.difficulty,
+        difficultyName: boardDifficultyGrades.boulderName,
+        climbedAt: boardseshTicks.climbedAt,
+        createdAt: boardseshTicks.createdAt,
+      })
+      .from(boardseshTicks)
+      .innerJoin(
+        boardClimbs,
+        and(eq(boardseshTicks.boardType, boardClimbs.boardType), eq(boardseshTicks.climbUuid, boardClimbs.uuid)),
+      )
+      .leftJoin(
+        boardDifficultyGrades,
+        and(
+          eq(boardseshTicks.boardType, boardDifficultyGrades.boardType),
+          eq(boardseshTicks.difficulty, boardDifficultyGrades.difficulty),
+        ),
+      )
+      .where(and(eq(boardseshTicks.userId, userId), eq(boardseshTicks.boardType, boardType)))
+      .orderBy(asc(boardseshTicks.climbedAt), asc(boardseshTicks.createdAt), asc(boardseshTicks.uuid)),
+    dbRead
+      .select({
+        climbName: boardClimbs.name,
+        createdAt: userFavorites.createdAt,
+      })
+      .from(userFavorites)
+      .innerJoin(
+        boardClimbs,
+        and(eq(userFavorites.boardName, boardClimbs.boardType), eq(userFavorites.climbUuid, boardClimbs.uuid)),
+      )
+      .where(and(eq(userFavorites.userId, userId), eq(userFavorites.boardName, boardType)))
+      .orderBy(asc(userFavorites.createdAt)),
+    dbRead
+      .select({
+        playlistId: playlists.id,
+        name: playlists.name,
+        color: playlists.color,
+        createdAt: playlists.createdAt,
+        description: playlists.description,
+        isPublic: playlists.isPublic,
+        climbName: boardClimbs.name,
+        position: playlistClimbs.position,
+      })
+      .from(playlists)
+      .innerJoin(
+        playlistOwnership,
+        and(eq(playlistOwnership.playlistId, playlists.id), eq(playlistOwnership.userId, userId)),
+      )
+      .leftJoin(playlistClimbs, eq(playlistClimbs.playlistId, playlists.id))
+      .leftJoin(
+        boardClimbs,
+        and(eq(playlists.boardType, boardClimbs.boardType), eq(playlistClimbs.climbUuid, boardClimbs.uuid)),
+      )
+      .where(and(eq(playlists.boardType, boardType), eq(playlistOwnership.role, 'owner')))
+      .orderBy(asc(playlists.createdAt), asc(playlistClimbs.position)),
+    dbRead
+      .select({
+        uuid: boardClimbs.uuid,
+        name: boardClimbs.name,
+        layoutId: boardClimbs.layoutId,
+        frames: boardClimbs.frames,
+        createdAt: boardClimbs.createdAt,
+        isDraft: boardClimbs.isDraft,
+        description: boardClimbs.description,
+      })
+      .from(boardClimbs)
+      .where(and(eq(boardClimbs.userId, userId), eq(boardClimbs.boardType, boardType)))
+      .orderBy(asc(boardClimbs.createdAt), asc(boardClimbs.uuid)),
+  ]);
+
+  return buildAuroraJsonExport({
+    boardType,
+    user: userRows[0] ?? null,
+    ticks: tickRows,
+    favorites: favoriteRows,
+    circuitRows,
+    climbs: climbRows,
+  });
+}
+
+async function generateAndStoreUserDataExport(job: ExportJob, downloadUrl: string): Promise<void> {
+  try {
+    const payload = await buildUserAuroraJsonExport(job.userId, job.boardType);
+    const buffer = Buffer.from(JSON.stringify(payload, null, 2));
+
+    await uploadToS3(buffer, job.key, 'application/json', {
+      cacheControl: 'private, no-store',
+      acl: null,
+    });
+
+    exportJobs.set(job.jobId, {
+      ...job,
+      status: 'ready',
+      completedAt: new Date().toISOString(),
+      downloadUrl,
+      fileSize: buffer.length,
+      error: undefined,
+    });
+  } catch (error) {
+    console.error('[User Data Export] Export generation failed:', error);
+    exportJobs.set(job.jobId, {
+      ...job,
+      status: 'failed',
+      error: error instanceof Error ? error.message : 'Export generation failed',
+    });
+  }
+}
+
+function getCurrentExportDescriptor(userId: string, boardType: AuroraBoardName) {
+  const period = getIsoWeekPeriod().label;
+  const key = getUserDataExportS3Key(userId, boardType);
+  const downloadUrl = `/api/user-data-export/download?boardType=${encodeURIComponent(boardType)}`;
+
+  return {
+    period,
+    key,
+    jobId: getJobId(userId, boardType),
+    downloadUrl,
+  };
+}
+
+function getJobId(userId: string, boardType: AuroraBoardName): string {
+  const period = getIsoWeekPeriod().label;
+  return `${userId}:${boardType}:${period}`;
+}
+
+function toPublicStatus(job: ExportJob): UserDataExportStatus {
+  return {
+    boardType: job.boardType,
+    period: job.period,
+    status: job.status,
+    requestedAt: job.requestedAt,
+    completedAt: job.completedAt,
+    downloadUrl: job.downloadUrl,
+    fileSize: job.fileSize,
+    error: job.error,
+  };
+}

--- a/packages/backend/src/storage/s3.test.ts
+++ b/packages/backend/src/storage/s3.test.ts
@@ -1,0 +1,142 @@
+import { Readable } from 'stream';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const awsMocks = vi.hoisted(() => ({
+  clientConfig: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockCommand {
+    input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  return {
+    S3Client: class S3Client {
+      constructor(config: unknown) {
+        awsMocks.clientConfig(config);
+      }
+
+      send(command: unknown) {
+        return awsMocks.send(command);
+      }
+    },
+    PutObjectCommand: class PutObjectCommand extends MockCommand {},
+    DeleteObjectCommand: class DeleteObjectCommand extends MockCommand {},
+    GetObjectCommand: class GetObjectCommand extends MockCommand {},
+    HeadObjectCommand: class HeadObjectCommand extends MockCommand {},
+  };
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('s3 storage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = {
+      ...ORIGINAL_ENV,
+      AWS_ACCESS_KEY_ID: 'test-access-key',
+      AWS_SECRET_ACCESS_KEY: 'test-secret-key',
+      AWS_DEFAULT_REGION: 'us-east-1',
+      AWS_ENDPOINT_URL: 'http://s3.test',
+      AWS_S3_BUCKET_NAME: 'boardsesh-test-bucket',
+    };
+    awsMocks.clientConfig.mockClear();
+    awsMocks.send.mockReset();
+  });
+
+  it('treats fake AWS environment variables as configured storage', async () => {
+    const { getPublicUrl, isS3Configured } = await import('./s3');
+
+    expect(isS3Configured()).toBe(true);
+    expect(getPublicUrl('user-data-exports/user-1/kilter/2026-W19.json')).toBe(
+      'http://s3.test/boardsesh-test-bucket/user-data-exports/user-1/kilter/2026-W19.json',
+    );
+  });
+
+  it('uploads private user exports to the fake bucket without a public ACL', async () => {
+    const { uploadToS3 } = await import('./s3');
+
+    awsMocks.send.mockResolvedValueOnce({});
+    const body = Buffer.from('{"ascents":[]}');
+    const key = 'user-data-exports/user-1/kilter/2026-W19.json';
+
+    await expect(
+      uploadToS3(body, key, 'application/json', {
+        cacheControl: 'private, no-store',
+        acl: null,
+      }),
+    ).resolves.toEqual({
+      key,
+      url: `http://s3.test/boardsesh-test-bucket/${key}`,
+    });
+
+    expect(awsMocks.clientConfig).toHaveBeenCalledWith({
+      endpoint: 'http://s3.test',
+      region: 'us-east-1',
+      credentials: {
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      },
+      forcePathStyle: true,
+    });
+    expect(awsMocks.send).toHaveBeenCalledTimes(1);
+    const command = awsMocks.send.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(command.input).toEqual({
+      Bucket: 'boardsesh-test-bucket',
+      Key: key,
+      Body: body,
+      ContentType: 'application/json',
+      CacheControl: 'private, no-store',
+    });
+    expect(command.input).not.toHaveProperty('ACL');
+  });
+
+  it('reads object metadata from the fake bucket with a HeadObject command', async () => {
+    const { getS3ObjectMetadata } = await import('./s3');
+
+    const lastModified = new Date('2026-05-07T12:00:00Z');
+    awsMocks.send.mockResolvedValueOnce({
+      ContentType: 'application/json',
+      ContentLength: 123,
+      LastModified: lastModified,
+    });
+
+    const metadata = await getS3ObjectMetadata('user-data-exports/user-1/kilter/2026-W19.json');
+
+    expect(metadata).toEqual({
+      contentType: 'application/json',
+      contentLength: 123,
+      lastModified,
+    });
+    const command = awsMocks.send.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(command.input).toEqual({
+      Bucket: 'boardsesh-test-bucket',
+      Key: 'user-data-exports/user-1/kilter/2026-W19.json',
+    });
+  });
+
+  it('downloads objects from the fake bucket and returns null when S3 misses', async () => {
+    const { getFromS3 } = await import('./s3');
+
+    const stream = Readable.from(['{}']);
+    awsMocks.send.mockResolvedValueOnce({
+      Body: stream,
+      ContentType: 'application/json',
+      ContentLength: 2,
+    });
+
+    await expect(getFromS3('user-data-exports/user-1/kilter/2026-W19.json')).resolves.toEqual({
+      stream,
+      contentType: 'application/json',
+      contentLength: 2,
+    });
+
+    awsMocks.send.mockRejectedValueOnce(new Error('not found'));
+    await expect(getFromS3('missing.json')).resolves.toBeNull();
+  });
+});

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -1,4 +1,12 @@
-import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  type ObjectCannedACL,
+  type PutObjectCommandInput,
+} from '@aws-sdk/client-s3';
 import type { Readable } from 'stream';
 
 let s3Client: S3Client | null = null;
@@ -80,20 +88,27 @@ export async function uploadToS3(
   buffer: Buffer,
   key: string,
   contentType: string,
+  options: {
+    cacheControl?: string;
+    acl?: ObjectCannedACL | null;
+  } = {},
 ): Promise<{ url: string; key: string }> {
   const client = getS3Client();
   const bucket = getBucketName();
 
-  await client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: buffer,
-      ContentType: contentType,
-      CacheControl: 'public, max-age=31536000, immutable',
-      ACL: 'public-read',
-    }),
-  );
+  const input: PutObjectCommandInput = {
+    Bucket: bucket,
+    Key: key,
+    Body: buffer,
+    ContentType: contentType,
+    CacheControl: options.cacheControl ?? 'public, max-age=31536000, immutable',
+  };
+
+  if (options.acl !== null) {
+    input.ACL = options.acl ?? 'public-read';
+  }
+
+  await client.send(new PutObjectCommand(input));
 
   const url = getPublicUrl(key);
   return { url, key };
@@ -144,6 +159,35 @@ export async function getFromS3(key: string): Promise<{
     };
   } catch {
     // Return null for not found or other errors
+    return null;
+  }
+}
+
+/**
+ * Get S3 object metadata without downloading the object body.
+ */
+export async function getS3ObjectMetadata(key: string): Promise<{
+  contentType: string | undefined;
+  contentLength: number | undefined;
+  lastModified: Date | undefined;
+} | null> {
+  const client = getS3Client();
+  const bucket = getBucketName();
+
+  try {
+    const response = await client.send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+
+    return {
+      contentType: response.ContentType,
+      contentLength: response.ContentLength,
+      lastModified: response.LastModified,
+    };
+  } catch {
     return null;
   }
 }

--- a/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createTestQueryClient } from '@/app/test-utils/test-providers';
@@ -23,6 +23,10 @@ const mockRequest = vi.fn();
 const getPreferenceMock = vi.fn().mockResolvedValue(null);
 const searchFormSpy = vi.fn();
 const showMessageSpy = vi.fn();
+const fetchMock = vi.fn();
+const createObjectURLMock = vi.fn();
+const revokeObjectURLMock = vi.fn();
+const anchorClickMock = vi.fn();
 
 // --- Mocks (must come before component import) ---
 
@@ -35,6 +39,10 @@ vi.mock('@/app/components/activity-feed/ascents-feed.module.css', () => ({
 
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/backend-url', () => ({
+  getBackendHttpUrl: () => 'http://backend.test',
 }));
 
 vi.mock('@/app/lib/graphql/operations/ticks', async () => {
@@ -169,10 +177,30 @@ beforeEach(() => {
   mockRequest.mockResolvedValue({
     userAscentsFeed: { items: [], hasMore: false },
   });
+  fetchMock.mockReset();
+  createObjectURLMock.mockReset();
+  createObjectURLMock.mockReturnValue('blob:export');
+  revokeObjectURLMock.mockReset();
+  anchorClickMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: createObjectURLMock,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: revokeObjectURLMock,
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(anchorClickMock);
   searchFormSpy.mockClear();
   getPreferenceMock.mockClear();
   showMessageSpy.mockClear();
   mockSearchParams.current = new URLSearchParams();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 function lastSelectedBoards(): Array<{ uuid: string }> {
@@ -291,5 +319,58 @@ describe('LogbookFeed — boards URL round-trip', () => {
         .map((b) => b.uuid)
         .sort(),
     ).toEqual(['logbook-kilter-1', 'logbook-tension-9']);
+  });
+
+  it('requests and downloads an Aurora JSON export for a logbook board', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ status: 'ready', downloadUrl: '/api/user-data-export/download?boardType=kilter' }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Disposition': 'attachment; filename="boardsesh-kilter-export-2026-W19.json"',
+          },
+        }),
+      );
+
+    renderFeed(false, [makeLayoutStats('kilter', 1)]);
+
+    fireEvent.click(await screen.findByRole('button', { name: /export/i }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Kilter JSON' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(fetchMock.mock.calls[0]).toEqual([
+      'http://backend.test/api/user-data-export?boardType=kilter',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      },
+    ]);
+    expect(fetchMock.mock.calls[1]).toEqual([
+      'http://backend.test/api/user-data-export/download?boardType=kilter',
+      {
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      },
+    ]);
+    expect(createObjectURLMock).toHaveBeenCalled();
+    expect(anchorClickMock).toHaveBeenCalled();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:export');
+    expect(showMessageSpy).toHaveBeenCalledWith('Kilter export downloaded.', 'success');
   });
 });

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -3,10 +3,13 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
-import { HistoryOutlined } from '@mui/icons-material';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import { FileDownloadOutlined, HistoryOutlined } from '@mui/icons-material';
 import {
   DEFAULT_FILTERS,
   DEFAULT_SORT,
@@ -17,6 +20,7 @@ import {
 } from '@/app/lib/logbook-preferences';
 import { readFiltersFromQuery, readSortFromQuery, filtersToQueryParams } from '@/app/lib/logbook-url-utils';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { getBackendHttpUrl } from '@/app/lib/backend-url';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
@@ -45,6 +49,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { isInstagramPostingSupported } from '@/app/lib/instagram-posting';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { AURORA_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
 import LogbookFeedItem from './logbook-feed-item';
 import LogbookSwipeHintOrchestrator from './logbook-swipe-hint-orchestrator';
 import LogbookSearchForm from './logbook-search-form';
@@ -54,6 +59,41 @@ import feedStyles from '@/app/components/activity-feed/ascents-feed.module.css';
 
 const PAGE_SIZE = 20;
 type StatusMode = 'both' | 'send' | 'attempt';
+
+type UserDataExportStatus = {
+  status: 'not_requested' | 'generating' | 'ready' | 'failed' | 'unavailable';
+  downloadUrl?: string;
+  error?: string;
+};
+
+function isAuroraBoardType(value: string): value is AuroraBoardName {
+  return (AURORA_BOARDS as readonly string[]).includes(value);
+}
+
+function formatBoardTypeLabel(boardType: string): string {
+  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+}
+
+function getExportFilename(response: Response, boardType: AuroraBoardName): string {
+  const disposition = response.headers.get('Content-Disposition') ?? '';
+  const match = disposition.match(/filename="([^"]+)"/);
+  return match?.[1] ?? `boardsesh-${boardType}-export.json`;
+}
+
+async function parseExportResponse(response: Response): Promise<UserDataExportStatus> {
+  const body = (await response.json().catch(() => null)) as (UserDataExportStatus & { error?: string }) | null;
+  if (!response.ok) {
+    throw new Error(body?.error ?? `Export request failed (${response.status})`);
+  }
+  if (!body) {
+    throw new Error('Export request returned an empty response');
+  }
+  return body;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // ---------- Component ----------
 
@@ -147,6 +187,8 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   const [editingItemUuid, setEditingItemUuid] = useState<string | null>(null);
   const [preferencesLoaded, setPreferencesLoaded] = useState(false);
   const [boardsInitialized, setBoardsInitialized] = useState(() => !searchParams.get('boards'));
+  const [exportMenuAnchor, setExportMenuAnchor] = useState<HTMLElement | null>(null);
+  const [exportingBoard, setExportingBoard] = useState<AuroraBoardName | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Debounced search text
@@ -293,6 +335,11 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     const types = [...new Set(selectedBoards.map((b) => b.boardType))];
     return types;
   }, [selectedBoards]);
+
+  const exportableBoardTypes = useMemo(() => {
+    const sourceBoards = selectedBoards.length > 0 ? selectedBoards : logbookBoards;
+    return [...new Set(sourceBoards.map((board) => board.boardType))].filter(isAuroraBoardType);
+  }, [logbookBoards, selectedBoards]);
 
   const selectedLayoutIds = useMemo(() => {
     if (selectedBoards.length === 0) return undefined;
@@ -515,6 +562,110 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     setEditingItemUuid(null);
   }, []);
 
+  const downloadExport = useCallback(
+    async (backendUrl: string, boardType: AuroraBoardName) => {
+      const response = await fetch(`${backendUrl}/api/user-data-export/download?boardType=${boardType}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `Export download failed (${response.status})`);
+      }
+
+      const blob = await response.blob();
+      const filename = getExportFilename(response, boardType);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    },
+    [token],
+  );
+
+  const waitForExport = useCallback(
+    async (backendUrl: string, boardType: AuroraBoardName) => {
+      for (let i = 0; i < 30; i++) {
+        await wait(2000);
+        const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const status = await parseExportResponse(response);
+
+        if (status.status === 'ready') return status;
+        if (status.status === 'failed' || status.status === 'unavailable') {
+          throw new Error(status.error ?? 'Export generation failed');
+        }
+      }
+
+      throw new Error('Export is still generating. Try again shortly.');
+    },
+    [token],
+  );
+
+  const handleExportMenuOpen = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    setExportMenuAnchor(event.currentTarget);
+  }, []);
+
+  const handleExportMenuClose = useCallback(() => {
+    setExportMenuAnchor(null);
+  }, []);
+
+  const handleExportBoard = useCallback(
+    async (boardType: AuroraBoardName) => {
+      handleExportMenuClose();
+
+      const backendUrl = getBackendHttpUrl();
+      if (!backendUrl) {
+        showMessage('Boardsesh could not find the export service URL.', 'error');
+        return;
+      }
+
+      if (!token) {
+        showMessage('Sign in again to export your logbook data.', 'error');
+        return;
+      }
+
+      setExportingBoard(boardType);
+      const boardLabel = formatBoardTypeLabel(boardType);
+
+      try {
+        const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        let status = await parseExportResponse(response);
+
+        if (status.status === 'generating') {
+          showMessage(`${boardLabel} export is being generated.`, 'info', undefined, 5000);
+          status = await waitForExport(backendUrl, boardType);
+        }
+
+        if (status.status !== 'ready') {
+          throw new Error(status.error ?? 'Export is not ready yet');
+        }
+
+        await downloadExport(backendUrl, boardType);
+        showMessage(`${boardLabel} export downloaded.`, 'success');
+      } catch (error) {
+        showMessage(error instanceof Error ? error.message : 'Export failed', 'error');
+      } finally {
+        setExportingBoard(null);
+      }
+    },
+    [downloadExport, handleExportMenuClose, showMessage, token, waitForExport],
+  );
+
   const showBoardType = selectedBoards.length === 0 || selectedBoards.length > 1;
   const hasFilters =
     selectedBoards.length > 0 ||
@@ -564,10 +715,32 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     />
   );
 
+  const exportControls = exportableBoardTypes.length > 0 && (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1.5 }}>
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={exportingBoard ? <CircularProgress size={16} /> : <FileDownloadOutlined fontSize="small" />}
+        onClick={handleExportMenuOpen}
+        disabled={authLoading || !token || !!exportingBoard}
+      >
+        Export
+      </Button>
+      <Menu anchorEl={exportMenuAnchor} open={!!exportMenuAnchor} onClose={handleExportMenuClose}>
+        {exportableBoardTypes.map((boardType) => (
+          <MenuItem key={boardType} onClick={() => void handleExportBoard(boardType)}>
+            {formatBoardTypeLabel(boardType)} JSON
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+
   if (isLoading) {
     return (
       <>
         {searchForm}
+        {exportControls}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
           {Array.from({ length: 5 }).map((_, i) => (
             <LogbookItemSkeleton key={i} />
@@ -598,6 +771,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     return (
       <>
         {searchForm}
+        {exportControls}
         {userId && !authLoading && !token && (
           <Alert severity="warning" sx={{ mb: 2 }}>
             {authError
@@ -621,6 +795,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   return (
     <>
       {searchForm}
+      {exportControls}
       <LogbookSwipeHintOrchestrator />
       <div className={feedStyles.feed}>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>


### PR DESCRIPTION
Fixes #1784

## Summary

- adds authenticated backend endpoints to request, check status, and download user data exports
- builds Aurora-importer-shaped JSON exports from backend DB queries
- stores generated exports in S3 under a weekly user/board key and reuses the ready weekly file
- adds a `/you/logbook` export menu with one JSON export option per Aurora-backed board in the user's logbook

## Notes

This implementation generates exports on demand in a backend async job and stores one export object per user, board, and ISO week. It does not add a separate global scheduler that pre-generates every user's export weekly.

The export is board-scoped because the existing Aurora JSON importer is board-scoped: a mixed-board file cannot be imported back through the current importer without extra wrapper metadata.

## Testing

- `SKIP_TEST_INFRA=1 vp test run src/services/user-data-export-format.test.ts` from `packages/backend`
- `SKIP_TEST_INFRA=1 vp test run src/storage/s3.test.ts` from `packages/backend`
- `vp test run packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx`
- `bun run --filter=boardsesh-backend typecheck`
- `bun run --filter=@boardsesh/web typecheck`
- `vp fmt --check packages/backend/src/server.ts packages/backend/src/storage/s3.ts packages/backend/src/storage/s3.test.ts packages/backend/src/handlers/user-data-export.ts packages/backend/src/services/user-data-export.ts packages/backend/src/services/user-data-export-format.ts packages/backend/src/services/user-data-export-format.test.ts packages/web/app/components/library/logbook-feed.tsx packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx`
- `git diff --check`