### PR TITLE
fix(motion): tighten peek snackbar coupling, reduced-motion, iOS test gap

### DIFF
--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -12,6 +12,15 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
+// Capacitor utils are mocked so each test can dial the runtime platform
+// without poking window.Capacitor.
+let mockIsNativeApp = false;
+let mockPlatform: 'ios' | 'android' | 'web' = 'web';
+vi.mock('@/app/lib/ble/capacitor-utils', () => ({
+  isNativeApp: () => mockIsNativeApp,
+  getPlatform: () => mockPlatform,
+}));
+
 let mockPathname = '/';
 let mockQueueBridgeBoardInfo = {
   boardDetails: null as Record<string, unknown> | null,
@@ -132,6 +141,8 @@ describe('RootBottomBar', () => {
       queue: [],
       currentClimb: null,
     };
+    mockIsNativeApp = false;
+    mockPlatform = 'web';
   });
 
   it('renders the empty queue shell on board routes before queue bridge hydration completes', () => {
@@ -210,6 +221,43 @@ describe('RootBottomBar', () => {
     expect(screen.queryByTestId('queue-control-bar')).toBeNull();
     expect(screen.queryByTestId('queue-control-bar-shell')).toBeNull();
     expect(screen.getByTestId('bottom-tab-bar')).toBeTruthy();
+  });
+
+  // Platform-specific safe-area class. iOS gets `iosNativeApp` so the pill
+  // drops flush with the bottom of the screen and nests into the iPhone's
+  // curved corners; Android keeps the `nativeApp` lift only because gesture-
+  // nav clearance varies more.
+  it('applies the iosNativeApp class only on iOS native', () => {
+    mockIsNativeApp = true;
+    mockPlatform = 'ios';
+
+    render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
+
+    const wrapper = screen.getByTestId('bottom-bar-wrapper');
+    expect(wrapper.className).toMatch(/nativeApp/);
+    expect(wrapper.className).toMatch(/iosNativeApp/);
+  });
+
+  it('does not apply the iosNativeApp class on Android native', () => {
+    mockIsNativeApp = true;
+    mockPlatform = 'android';
+
+    render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
+
+    const wrapper = screen.getByTestId('bottom-bar-wrapper');
+    expect(wrapper.className).toMatch(/nativeApp/);
+    expect(wrapper.className).not.toMatch(/iosNativeApp/);
+  });
+
+  it('does not apply native or iosNativeApp classes on web', () => {
+    mockIsNativeApp = false;
+    mockPlatform = 'web';
+
+    render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
+
+    const wrapper = screen.getByTestId('bottom-bar-wrapper');
+    expect(wrapper.className).not.toMatch(/nativeApp/);
+    expect(wrapper.className).not.toMatch(/iosNativeApp/);
   });
 });
 

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -158,13 +158,15 @@
   right: 0;
   /* Anchored above the small-FAB row + gap. Same expanded-state bottom as
      the FAB cluster (--bottom-tab-bar-height + safe-area + --spacing-2),
-     stacked with the small-FAB row (46px = SMALL_FAB_SIZE in
-     queue-control-fab.tsx) and a --spacing-3 visual gap above it.
-     Collapse follows via --fab-collapse-offset (translateY) — compositor-
-     only, and safe here because the snackbar is opaque (no backdrop-filter
-     children to break). */
+     stacked with the small-FAB row (--small-fab-size, set inline from
+     SMALL_FAB_SIZE in queue-control-fab.tsx so this stays in sync) and a
+     --spacing-3 visual gap above it. Collapse follows via
+     --fab-collapse-offset (translateY) — compositor-only, and safe here
+     because the snackbar is opaque (no backdrop-filter children to
+     break). */
   bottom: calc(
-    var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px + var(--spacing-3)
+    var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + var(--small-fab-size, 46px) +
+      var(--spacing-3)
   );
   z-index: 8;
   display: flex;
@@ -255,6 +257,9 @@
   .peekSnackbarAnchor {
     transform: none;
     transition: none;
+    /* Without `will-change: auto` we'd keep the GPU layer promoted for
+       users who explicitly opted out of motion — pointless cost. */
+    will-change: auto;
   }
 
   .peekSnackbar {

--- a/packages/web/app/components/queue-control/queue-control-fab.tsx
+++ b/packages/web/app/components/queue-control/queue-control-fab.tsx
@@ -271,7 +271,13 @@ const QueueControlFab: React.FC<QueueControlFabProps> = ({
           on the wrapper because the snackbar is opaque — no backdrop-filter
           children for the transformed-ancestor containing-block to break. */}
       {snackbarMounted && (
-        <div className={styles.peekSnackbarAnchor}>
+        // `style` is used (rather than sx) purely to bridge SMALL_FAB_SIZE
+        // into the stylesheet as --small-fab-size, so the anchor's bottom
+        // calc stays in sync with the JS constant instead of hardcoding it.
+        <div
+          className={styles.peekSnackbarAnchor}
+          style={{ ['--small-fab-size' as string]: `${SMALL_FAB_SIZE}px` } as React.CSSProperties}
+        >
           <Box
             role="status"
             aria-live="polite"


### PR DESCRIPTION
## Summary

Three follow-up fixes from review on the now-merged #2012:

- **Peek snackbar's bottom calc no longer hardcodes `46px`.** `SMALL_FAB_SIZE` is bridged into the stylesheet as `--small-fab-size` via an inline style on the anchor div, so if the FAB size ever changes the snackbar's vertical anchor follows automatically instead of silently drifting.
- **`will-change: transform` is cleared under `prefers-reduced-motion`.** The peek anchor previously held a GPU layer even after the transform/transition were disabled for users who opted out of motion — pointless cost. Added `will-change: auto` to that media block.
- **Test coverage for the iOS-native branch.** New cases in `persistent-session-wrapper.test.tsx` lock in: iOS native applies both `nativeApp` and `iosNativeApp`, Android native applies only `nativeApp`, web applies neither. Mocks `isNativeApp` and `getPlatform` from `capacitor-utils`.

## Test plan

- [ ] `vp run typecheck:web` passes
- [ ] `vp test run --project web app/components/providers/__tests__/persistent-session-wrapper.test.tsx` — 8 tests pass (3 new platform cases)
- [ ] `vp test run --project web app/components/queue-control/__tests__/queue-control-fab.test.tsx` — peek snackbar still mounts/unmounts correctly with the inline-style change
- [ ] Manual: trigger a climb-change peek, then DevTools → rendering → emulate `prefers-reduced-motion: reduce` and re-trigger — the snackbar should appear/disappear via opacity only and Layers panel should show no peek-anchor compositor layer
- [ ] Manual: bump `SMALL_FAB_SIZE` to a different value locally (e.g. 50) and confirm the peek snackbar's vertical position tracks without any CSS edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)