### PR TITLE
feat(queue-control): peek snackbar only for remote climb changes, sticks until tap

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -73,6 +73,12 @@ export const CurrentClimbContext = createContext<CurrentClimbDataType | undefine
 // Components that only need to know *which* climb is current (not the full object)
 // can subscribe here and avoid re-renders when unrelated fields change.
 export const CurrentClimbUuidContext = createContext<string | null>(null);
+// Ultra-narrow context: monotonic counter of non-echo remote climb changes.
+// The peek snackbar in the queue-control bar subscribes here so it only
+// surfaces remote (party-mode partner) climb changes, not the local
+// user's own. Splitting from CurrentClimbContext keeps consumers of
+// either signal from re-rendering when only the other one changes.
+export const RemoteClimbChangeCountContext = createContext<number>(0);
 export const QueueListContext = createContext<QueueListDataType | undefined>(undefined);
 export const SearchContext = createContext<SearchDataType | undefined>(undefined);
 export const SessionContext = createContext<SessionDataType | undefined>(undefined);
@@ -703,6 +709,7 @@ export const GraphQLQueueProvider = ({
 
   // --- Fine-grained context values (each only changes when its specific fields change) ---
   const currentClimbUuid = state.currentClimbQueueItem?.uuid ?? null;
+  const remoteClimbChangeCount = state.remoteClimbChangeCount;
 
   const currentClimbValue: CurrentClimbDataType = useMemo(
     () => ({
@@ -785,16 +792,18 @@ export const GraphQLQueueProvider = ({
         <QueueContext.Provider value={contextValue}>
           <CurrentClimbContext.Provider value={currentClimbValue}>
             <CurrentClimbUuidContext.Provider value={currentClimbUuid}>
-              <QueueListContext.Provider value={queueListValue}>
-                <SearchContext.Provider value={searchValue}>
-                  <SessionContext.Provider value={sessionValue}>
-                    <FavoritesProvider {...favoritesProviderProps}>
-                      <PlaylistsProvider {...playlistsProviderProps}>{children}</PlaylistsProvider>
-                    </FavoritesProvider>
-                    <SessionSummaryDialog summary={sessionSummary} onDismiss={stableDismissSessionSummary} />
-                  </SessionContext.Provider>
-                </SearchContext.Provider>
-              </QueueListContext.Provider>
+              <RemoteClimbChangeCountContext.Provider value={remoteClimbChangeCount}>
+                <QueueListContext.Provider value={queueListValue}>
+                  <SearchContext.Provider value={searchValue}>
+                    <SessionContext.Provider value={sessionValue}>
+                      <FavoritesProvider {...favoritesProviderProps}>
+                        <PlaylistsProvider {...playlistsProviderProps}>{children}</PlaylistsProvider>
+                      </FavoritesProvider>
+                      <SessionSummaryDialog summary={sessionSummary} onDismiss={stableDismissSessionSummary} />
+                    </SessionContext.Provider>
+                  </SearchContext.Provider>
+                </QueueListContext.Provider>
+              </RemoteClimbChangeCountContext.Provider>
             </CurrentClimbUuidContext.Provider>
           </CurrentClimbContext.Provider>
         </QueueContext.Provider>
@@ -865,6 +874,16 @@ export const useOptionalCurrentClimb = (): CurrentClimbDataType | null => {
  *  without subscribing to the full CurrentClimbContext object. */
 export const useCurrentClimbUuid = (): string | null => {
   return useContext(CurrentClimbUuidContext);
+};
+
+/** Ultra-narrow hook: returns a counter that increments only when the
+ *  reducer applies a non-echo remote DELTA_UPDATE_CURRENT_CLIMB with a
+ *  non-null item — i.e. when *another* party-mode participant changes
+ *  the current climb. Subscribers re-render only on that signal, not
+ *  on every currentClimb update. Used by the peek snackbar so it
+ *  surfaces only remote-originated changes, not the local user's own. */
+export const useRemoteClimbChangeCount = (): number => {
+  return useContext(RemoteClimbChangeCountContext);
 };
 
 export const useQueueList = (): QueueListDataType => {

--- a/packages/web/app/components/graphql-queue/__tests__/set-current-climb-mutation.test.ts
+++ b/packages/web/app/components/graphql-queue/__tests__/set-current-climb-mutation.test.ts
@@ -63,6 +63,7 @@ const initialState: QueueState = {
   lastReceivedSequence: null,
   lastReceivedStateHash: null,
   needsResync: false,
+  remoteClimbChangeCount: 0,
 };
 
 describe('SET_CURRENT_CLIMB mutation optimization', () => {

--- a/packages/web/app/components/graphql-queue/index.ts
+++ b/packages/web/app/components/graphql-queue/index.ts
@@ -18,6 +18,7 @@ export {
   useCurrentClimb,
   useOptionalCurrentClimb,
   useCurrentClimbUuid,
+  useRemoteClimbChangeCount,
   useQueueList,
   useSearchData,
   useSessionData,
@@ -25,6 +26,7 @@ export {
   // Fine-grained context objects
   CurrentClimbContext,
   CurrentClimbUuidContext,
+  RemoteClimbChangeCountContext,
   QueueListContext,
   SearchContext,
   SessionContext,

--- a/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/pending-updates-integration.test.ts
@@ -56,6 +56,7 @@ const initialState: QueueState = {
   lastReceivedSequence: null,
   lastReceivedStateHash: null,
   needsResync: false,
+  remoteClimbChangeCount: 0,
 };
 
 describe('Pending Updates - Integration Tests', () => {

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-offline.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@/app/components/graphql-queue', () => ({
     currentClimb: mockQueueContext.currentClimb,
   }),
   useCurrentClimbUuid: () => (mockQueueContext.currentClimb as { uuid?: string } | undefined)?.uuid ?? null,
+  useRemoteClimbChangeCount: () => (mockQueueContext.remoteClimbChangeCount as number | undefined) ?? 0,
   useQueueList: () => ({
     queue: mockQueueContext.queue,
     suggestedClimbs: [],

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/app/components/graphql-queue', () => ({
     currentClimb: mockQueueContext.currentClimb,
   }),
   useCurrentClimbUuid: () => (mockQueueContext.currentClimb as { uuid?: string } | undefined)?.uuid ?? null,
+  useRemoteClimbChangeCount: () => (mockQueueContext.remoteClimbChangeCount as number | undefined) ?? 0,
   useQueueList: () => ({
     queue: mockQueueContext.queue,
     suggestedClimbs: [],

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/app/components/graphql-queue', () => ({
     currentClimb: mockQueueContext.currentClimb,
   }),
   useCurrentClimbUuid: () => (mockQueueContext.currentClimb as { uuid?: string } | undefined)?.uuid ?? null,
+  useRemoteClimbChangeCount: () => (mockQueueContext.remoteClimbChangeCount as number | undefined) ?? 0,
   useQueueList: () => ({
     queue: mockQueueContext.queue,
     suggestedClimbs: [],
@@ -477,24 +478,27 @@ describe('QueueControlBar layout state machine', () => {
     expect(getFabCluster()?.getAttribute('aria-hidden')).toBe('false');
   });
 
-  it('peeks the snackbar when the current climb uuid changes while minimised', async () => {
+  it('peeks the snackbar when a remote climb change arrives while minimised', async () => {
     vi.useFakeTimers();
     try {
       const { rerender } = render(<QueueControlBar {...defaultProps} />);
       await act(async () => {});
 
-      // No snackbar at first mount — initialUuidRef is set on first run.
+      // No snackbar at first mount — lastPeekedCountRef is captured on
+      // first run so the initial counter doesn't trigger a peek.
       expect(document.querySelector('[class*="peekSnackbar"]')).toBeNull();
 
-      // Swap the current climb to trigger the peek path. The bar is
-      // wrapped in React.memo, so we have to rotate the prop reference
-      // to force a re-render with the new mocked climb.
+      // Bump the remote-change counter (simulates a remote
+      // DELTA_UPDATE_CURRENT_CLIMB applying through the reducer). The
+      // bar is wrapped in React.memo, so rotate the prop reference to
+      // force a re-render that picks up the new context value.
       const nextClimb = { ...mockClimb, uuid: 'climb-2', name: 'Different Climb' };
       mockQueueContext = {
         ...baseQueueContext,
         queue: [{ uuid: 'item-2', climb: nextClimb, addedBy: 'user-1', suggested: false }],
         currentClimbQueueItem: { uuid: 'item-2', climb: nextClimb, addedBy: 'user-1', suggested: false },
         currentClimb: nextClimb,
+        remoteClimbChangeCount: 1,
       };
       await act(async () => {
         rerender(<QueueControlBar {...propsWithFreshRef(defaultProps)} />);
@@ -505,13 +509,22 @@ describe('QueueControlBar layout state machine', () => {
       expect(snackbar).toBeTruthy();
       expect(snackbar?.textContent).toMatch(/Different Climb/);
 
-      // After the 3s peek window the bar returns to minimised. That
-      // triggers the snackbar's separate 200ms exit timer (registered
-      // in a fresh effect after the layoutState change), so we need
-      // a second advance to let that fire too.
+      // The peek is now sticky — no auto-dismiss timer. Advance way
+      // past the old 3s window and confirm it's still up.
       await act(async () => {
-        vi.advanceTimersByTime(3100);
+        vi.advanceTimersByTime(10_000);
       });
+      expect(document.querySelector('[class*="peekSnackbar"]')).toBeTruthy();
+
+      // After the 300ms grace window, a user interaction dismisses it.
+      await act(async () => {
+        vi.advanceTimersByTime(350);
+      });
+      await act(async () => {
+        document.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+      });
+      // Snackbar exit animation is gated by an additional ~200ms unmount
+      // delay in the FAB component — give it time to finish.
       await act(async () => {
         vi.advanceTimersByTime(300);
       });
@@ -521,7 +534,28 @@ describe('QueueControlBar layout state machine', () => {
     }
   });
 
-  it('queues a peek when the climb changes while expanded and fires it on collapse', async () => {
+  it('does not peek for local-only climb changes (counter unchanged)', async () => {
+    const { rerender } = render(<QueueControlBar {...defaultProps} />);
+    await act(async () => {});
+
+    // Swap the current climb without bumping remoteClimbChangeCount —
+    // simulates a local user-initiated change. The peek must NOT fire.
+    const nextClimb = { ...mockClimb, uuid: 'climb-local', name: 'Local Climb' };
+    mockQueueContext = {
+      ...baseQueueContext,
+      queue: [{ uuid: 'item-local', climb: nextClimb, addedBy: 'user-1', suggested: false }],
+      currentClimbQueueItem: { uuid: 'item-local', climb: nextClimb, addedBy: 'user-1', suggested: false },
+      currentClimb: nextClimb,
+      // remoteClimbChangeCount unchanged (still 0)
+    };
+    await act(async () => {
+      rerender(<QueueControlBar {...propsWithFreshRef(defaultProps)} />);
+    });
+
+    expect(document.querySelector('[class*="peekSnackbar"]')).toBeNull();
+  });
+
+  it('queues a peek when a remote change arrives while expanded and fires it on collapse', async () => {
     // Party-mode scenario: user has the tick drawer open (bar expanded)
     // when another participant advances the queue. The peek must be
     // deferred until the drawer closes — otherwise the climb-change
@@ -538,15 +572,16 @@ describe('QueueControlBar layout state machine', () => {
       expect(screen.getByTestId('quick-tick-bar')).toBeTruthy();
       expect(getFabCluster()?.getAttribute('aria-hidden')).toBe('true');
 
-      // Climb changes while drawer is open. Snackbar must NOT appear
-      // yet — the peek effect early-returns because layoutState is
-      // 'expanded'.
+      // Remote change arrives while drawer is open. Snackbar must NOT
+      // appear yet — the trigger effect early-returns because
+      // layoutState is 'expanded'.
       const nextClimb = { ...mockClimb, uuid: 'climb-99', name: 'Party Climb' };
       mockQueueContext = {
         ...baseQueueContext,
         queue: [{ uuid: 'item-99', climb: nextClimb, addedBy: 'user-1', suggested: false }],
         currentClimbQueueItem: { uuid: 'item-99', climb: nextClimb, addedBy: 'user-1', suggested: false },
         currentClimb: nextClimb,
+        remoteClimbChangeCount: 1,
       };
       await act(async () => {
         rerender(<QueueControlBar {...propsWithFreshRef(defaultProps)} />);
@@ -554,8 +589,8 @@ describe('QueueControlBar layout state machine', () => {
       expect(document.querySelector('[class*="peekSnackbar"]')).toBeNull();
 
       // Close the drawer via the tick overlay (production close path).
-      // Bar collapses to minimised → peek effect re-runs because
-      // layoutState changed → fires the queued peek for the latest uuid.
+      // Bar collapses to minimised → trigger effect re-runs because
+      // layoutState changed → fires the queued peek for the latest climb.
       const overlay = document.querySelector('[data-testid="tick-backdrop-overlay"]') as HTMLElement | null;
       expect(overlay).toBeTruthy();
       await act(async () => {

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/app/components/graphql-queue', () => ({
     currentClimb: mockQueueContext.currentClimb,
   }),
   useCurrentClimbUuid: () => (mockQueueContext.currentClimb as { uuid?: string } | undefined)?.uuid ?? null,
+  useRemoteClimbChangeCount: () => (mockQueueContext.remoteClimbChangeCount as number | undefined) ?? 0,
   useQueueList: () => ({
     queue: mockQueueContext.queue,
     suggestedClimbs: [],

--- a/packages/web/app/components/queue-control/__tests__/queue-list-active.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-active.test.tsx
@@ -73,6 +73,7 @@ const mockQueueItems: ClimbQueueItem[] = [
 // Mock graphql-queue hooks
 vi.mock('../../graphql-queue', () => ({
   useCurrentClimbUuid: () => null,
+  useRemoteClimbChangeCount: () => 0,
   useQueueList: () => ({
     queue: mockQueueItems,
     suggestedClimbs: mockSuggestedClimbs,

--- a/packages/web/app/components/queue-control/__tests__/queue-list-virtualization.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-virtualization.test.tsx
@@ -79,6 +79,7 @@ let mockCurrentClimbUuid: string | null = null;
 
 vi.mock('../../graphql-queue', () => ({
   useCurrentClimbUuid: () => mockCurrentClimbUuid,
+  useRemoteClimbChangeCount: () => 0,
   useQueueList: () => ({
     queue: mockQueueItems,
     suggestedClimbs,

--- a/packages/web/app/components/queue-control/__tests__/reducer.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/reducer.test.ts
@@ -63,6 +63,7 @@ const initialState: QueueState = {
   lastReceivedSequence: null,
   lastReceivedStateHash: null,
   needsResync: false,
+  remoteClimbChangeCount: 0,
 };
 
 describe('queueReducer', () => {
@@ -1226,6 +1227,135 @@ describe('queueReducer', () => {
 
       expect(state4.currentClimbQueueItem).toEqual(itemC);
       expect(state4.pendingCurrentClimbUpdates).toHaveLength(0);
+    });
+  });
+
+  describe('DELTA_UPDATE_CURRENT_CLIMB - remoteClimbChangeCount', () => {
+    it('starts at 0', () => {
+      expect(initialState.remoteClimbChangeCount).toBe(0);
+    });
+
+    it('does not increment for local dispatch (no isServerEvent)', () => {
+      const action: QueueAction = {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: { item: mockClimbQueueItem, shouldAddToQueue: false },
+      };
+      const result = queueReducer(initialState, action);
+      expect(result.remoteClimbChangeCount).toBe(0);
+    });
+
+    it('increments for non-echo remote dispatch with non-null item', () => {
+      const action: QueueAction = {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: mockClimbQueueItem,
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          eventClientId: 'other-client',
+          myClientId: 'me',
+        },
+      };
+      const result = queueReducer(initialState, action);
+      expect(result.remoteClimbChangeCount).toBe(1);
+    });
+
+    it('does not increment for an echoed remote (correlation match)', () => {
+      const stateWithPending: QueueState = {
+        ...initialState,
+        pendingCurrentClimbUpdates: ['corr-1'],
+      };
+      const action: QueueAction = {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: mockClimbQueueItem,
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          serverCorrelationId: 'corr-1',
+        },
+      };
+      const result = queueReducer(stateWithPending, action);
+      expect(result.remoteClimbChangeCount).toBe(0);
+    });
+
+    it('does not increment for an echoed remote (own clientId)', () => {
+      const action: QueueAction = {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: mockClimbQueueItem,
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          eventClientId: 'me',
+          myClientId: 'me',
+        },
+      };
+      const result = queueReducer(initialState, action);
+      expect(result.remoteClimbChangeCount).toBe(0);
+    });
+
+    it('does not increment for a remote clear (item: null)', () => {
+      const stateWithPriorRemote: QueueState = {
+        ...initialState,
+        currentClimbQueueItem: mockClimbQueueItem,
+        remoteClimbChangeCount: 5,
+      };
+      const action: QueueAction = {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: null,
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          eventClientId: 'other-client',
+          myClientId: 'me',
+        },
+      };
+      const result = queueReducer(stateWithPriorRemote, action);
+      // Counter unchanged — no climb to surface in a peek
+      expect(result.remoteClimbChangeCount).toBe(5);
+      expect(result.currentClimbQueueItem).toBeNull();
+    });
+
+    it('preserves the counter across local actions that write currentClimbQueueItem', () => {
+      // Bump the counter via a remote event first.
+      const afterRemote = queueReducer(initialState, {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: mockClimbQueueItem,
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          eventClientId: 'other-client',
+          myClientId: 'me',
+        },
+      });
+      expect(afterRemote.remoteClimbChangeCount).toBe(1);
+
+      // SET_CURRENT_CLIMB (local) should leave the counter alone — the peek
+      // effect keys on the counter, not the climb item, so this is the
+      // critical guarantee.
+      const afterLocalSet = queueReducer(afterRemote, {
+        type: 'SET_CURRENT_CLIMB',
+        payload: { ...mockClimbQueueItem, uuid: 'different-uuid' },
+      });
+      expect(afterLocalSet.remoteClimbChangeCount).toBe(1);
+
+      // SET_CURRENT_CLIMB_QUEUE_ITEM (local) — same.
+      const afterLocalSetQueueItem = queueReducer(afterLocalSet, {
+        type: 'SET_CURRENT_CLIMB_QUEUE_ITEM',
+        payload: { ...mockClimbQueueItem, uuid: 'another-uuid' },
+      });
+      expect(afterLocalSetQueueItem.remoteClimbChangeCount).toBe(1);
+
+      // A subsequent non-echo remote bumps to 2.
+      const afterSecondRemote = queueReducer(afterLocalSetQueueItem, {
+        type: 'DELTA_UPDATE_CURRENT_CLIMB',
+        payload: {
+          item: { ...mockClimbQueueItem, uuid: 'remote-2' },
+          shouldAddToQueue: false,
+          isServerEvent: true,
+          eventClientId: 'other-client',
+          myClientId: 'me',
+        },
+      });
+      expect(afterSecondRemote.remoteClimbChangeCount).toBe(2);
     });
   });
 });

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -15,7 +15,13 @@ import CloudOffOutlined from '@mui/icons-material/CloudOffOutlined';
 import OpenInFullOutlined from '@mui/icons-material/OpenInFullOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import { track } from '@vercel/analytics';
-import { useQueueActions, useCurrentClimb, useCurrentClimbUuid, useQueueList, useSessionData } from '../graphql-queue';
+import {
+  useQueueActions,
+  useCurrentClimb,
+  useQueueList,
+  useRemoteClimbChangeCount,
+  useSessionData,
+} from '../graphql-queue';
 import { useScrollDirection } from '@/app/hooks/use-scroll-direction';
 import QueueControlFab from './queue-control-fab';
 import NextClimbButton from './next-climb-button';
@@ -81,7 +87,12 @@ export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
 type LayoutState = 'minimised' | 'expanded' | 'peeking';
 type OpenReason = 'userOpen' | 'tickOpen' | 'queueOpen' | 'playOpen' | 'scrollOpen' | 'default';
 
-const PEEK_DURATION_MS = 3000;
+/** Delay after entering 'peeking' before the dismiss listeners are armed.
+ *  Filters out the gesture that *caused* the peek (e.g. a tap on a FAB
+ *  that closed the drawer and let the trigger fire) and any in-flight
+ *  scroll momentum, so the peek doesn't dismiss before the user has
+ *  even had a chance to see it. */
+const PEEK_DISMISS_GRACE_MS = 300;
 
 // Re-export the window event so existing imports from this file keep working.
 // The actual definition lives in ./play-drawer-event to keep the import graph
@@ -149,27 +160,26 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // Computed synchronously in useState so /list doesn't flash from minimised → expanded.
   const [layoutState, setLayoutState] = useState<LayoutState>(() => (isClimbListPage ? 'expanded' : 'minimised'));
   const [openReason, setOpenReason] = useState<OpenReason>('default');
-  const peekTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Track the climb uuid we observed on first mount so the initial value
-  // doesn't trigger a peek (the bar mounts with a current climb already set).
-  const initialUuidRef = useRef<string | null | undefined>(undefined);
+  // Tracks the remote-climb-change counter we last fired a peek for. `null`
+  // means "not yet armed" — the next render captures the current count as
+  // baseline (so initial hydration doesn't peek). Bumped to the latest
+  // count whenever a peek fires *or* gets dismissed, so a counter advance
+  // that arrived during an active peek (which only updated snackbar text
+  // in place) doesn't re-trigger the same content right after dismiss.
+  const lastPeekedCountRef = useRef<number | null>(null);
 
   // Reset activeDrawer + layout state on navigation. Also re-arm the peek
-  // gate so the next climb-uuid change is treated as a *first observation*
-  // on the new route — without this, navigating to a climb that differs
-  // from the one we were viewing fires a peek that announces the climb
-  // we just navigated to (a duplicate cue, since the user just clicked).
+  // gate (lastPeekedCountRef → null) so the next render captures the
+  // current counter as baseline — without this, a remote counter that
+  // advanced just before navigation could fire a peek that announces the
+  // climb the user just navigated to (a duplicate cue).
   // isClimbListPage is omitted from deps because it's derived synchronously
   // from pathname — listing both is harmless but adds noise.
   useEffect(() => {
     setActiveDrawer('none');
     setLayoutState(isClimbListPage ? 'expanded' : 'minimised');
     setOpenReason('default');
-    initialUuidRef.current = undefined;
-    if (peekTimerRef.current) {
-      clearTimeout(peekTimerRef.current);
-      peekTimerRef.current = null;
-    }
+    lastPeekedCountRef.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname
   }, [pathname]);
 
@@ -200,67 +210,84 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   }, []);
 
   // While any drawer is open, the bar must stay expanded — drawers can't
-  // render meaningfully over a FAB. Cancel any in-flight peek timer too,
-  // otherwise it would fire setLayoutState('minimised') under the open
-  // drawer (and immediately get force-expanded again on the next render).
+  // render meaningfully over a FAB.
   useEffect(() => {
-    if (activeDrawer !== 'none') {
-      if (peekTimerRef.current) {
-        clearTimeout(peekTimerRef.current);
-        peekTimerRef.current = null;
-      }
-      if (layoutState !== 'expanded') {
-        setLayoutState('expanded');
-      }
+    if (activeDrawer !== 'none' && layoutState !== 'expanded') {
+      setLayoutState('expanded');
     }
   }, [activeDrawer, layoutState]);
 
-  // Peek-on-climb-change: when the current climb uuid changes (locally or
-  // from a party-mode WebSocket event), briefly surface the new climb's
-  // name in a snackbar above the FAB cluster.
+  // Peek-on-remote-climb-change. Two effects, separated by responsibility
+  // so neither does double duty:
   //
-  // The ref tracks the last uuid we *actually peeked for* — not the
-  // latest seen — and we only peek while layoutState === 'minimised'.
-  // The effect is keyed on both currentClimbUuid AND layoutState, so a
-  // climb change that happens while the bar is expanded is queued: the
-  // ref stays put, and when the bar later returns to minimised the
-  // effect re-fires (layoutState dep changed) and peeks for the latest
-  // uuid. If multiple climb changes happen while expanded, only the
-  // most recent one is announced on collapse — by design, so a long
-  // queue session doesn't bombard the user with stale peeks when they
-  // close a drawer.
-  const currentClimbUuid = useCurrentClimbUuid();
+  //   A) Trigger: fire setLayoutState('peeking') when the remote-change
+  //      counter advances past the last-peeked count *and* the bar is
+  //      currently minimised. Self-initiated changes never increment the
+  //      counter (that's the reducer's job — see DELTA_UPDATE_CURRENT_CLIMB),
+  //      so this effect cannot fire for the local user's own navigation.
+  //   B) Dismiss: while the snackbar is up, listen for any user
+  //      interaction (pointerdown / keydown / scroll) and dismiss on the
+  //      first one. No auto-dismiss timer — climbers' hands are on the
+  //      wall, not the phone, and a 3s auto-fade was too short.
+  //
+  // If the counter advances while the bar is in a drawer ('expanded') the
+  // peek is *queued*: the ref stays put, and the next return to
+  // 'minimised' re-evaluates and peeks for whichever climb is current
+  // then. Only the latest climb is announced on collapse — by design, so
+  // a long drawer session doesn't bombard the user with stale peeks.
+  //
+  // If the counter advances *during* a peek, the snackbar's text reads
+  // currentClimb from useCurrentClimb (already subscribed below) so it
+  // updates in place — no re-mount, no re-entrance animation. The peek
+  // stays continuous; only the content refreshes. lastPeekedCountRef is
+  // caught up to the latest count by the dismiss handler so the user
+  // doesn't get a redundant peek for the same climb after dismissing.
+  const remoteClimbChangeCount = useRemoteClimbChangeCount();
   useEffect(() => {
-    if (initialUuidRef.current === undefined) {
-      // First mount: record the current climb so the initial value doesn't
-      // immediately trigger a peek.
-      initialUuidRef.current = currentClimbUuid;
+    if (lastPeekedCountRef.current === null) {
+      // Re-arm: capture the current counter as baseline so initial
+      // hydration (or post-navigation re-render) doesn't trigger a peek.
+      lastPeekedCountRef.current = remoteClimbChangeCount;
       return;
     }
-    if (!currentClimbUuid) return;
-    if (currentClimbUuid === initialUuidRef.current) return;
-    // Bar isn't free to peek right now — leave the ref untouched so the
-    // next layoutState change re-evaluates against the latest uuid.
+    if (remoteClimbChangeCount === lastPeekedCountRef.current) return;
+    // Drawer is open or already peeking — leave the ref untouched so the
+    // next layoutState change re-evaluates against the latest counter.
     if (layoutState !== 'minimised') return;
-    initialUuidRef.current = currentClimbUuid;
-    if (peekTimerRef.current) clearTimeout(peekTimerRef.current);
+    lastPeekedCountRef.current = remoteClimbChangeCount;
     setLayoutState('peeking');
-    peekTimerRef.current = setTimeout(() => {
-      setLayoutState('minimised');
-      peekTimerRef.current = null;
-    }, PEEK_DURATION_MS);
-  }, [currentClimbUuid, layoutState]);
+  }, [remoteClimbChangeCount, layoutState]);
 
-  // Cleanup peek timer on unmount
-  useEffect(
-    () => () => {
-      if (peekTimerRef.current) {
-        clearTimeout(peekTimerRef.current);
-        peekTimerRef.current = null;
-      }
-    },
-    [],
-  );
+  // Dismiss-on-interaction. Listens at document/window level (capture
+  // phase for pointer/keyboard so we register dismiss before any child
+  // swallows the event — e.g. tapping a FAB still dismisses the peek as
+  // it opens the drawer). The snackbar itself has pointer-events: none
+  // so taps over it pass through to the page; this means tap-anywhere
+  // dismisses naturally.
+  useEffect(() => {
+    if (layoutState !== 'peeking') return;
+
+    const dismiss = () => {
+      // Catch the ref up to the latest count — otherwise a counter advance
+      // that happened during this peek (and only updated snackbar text in
+      // place) would re-fire trigger Effect A immediately on dismiss.
+      lastPeekedCountRef.current = remoteClimbChangeCount;
+      setLayoutState('minimised');
+    };
+
+    const armTimer = setTimeout(() => {
+      document.addEventListener('pointerdown', dismiss, { capture: true });
+      document.addEventListener('keydown', dismiss, { capture: true });
+      window.addEventListener('scroll', dismiss, { passive: true });
+    }, PEEK_DISMISS_GRACE_MS);
+
+    return () => {
+      clearTimeout(armTimer);
+      document.removeEventListener('pointerdown', dismiss, { capture: true });
+      document.removeEventListener('keydown', dismiss, { capture: true });
+      window.removeEventListener('scroll', dismiss);
+    };
+  }, [layoutState, remoteClimbChangeCount]);
 
   // Window scroll drives auto-collapse/expand:
   //  - climb list page: scroll down → collapse, scroll up → expand
@@ -286,39 +313,23 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   });
 
   const handleFabExpand = useCallback(() => {
-    if (peekTimerRef.current) {
-      clearTimeout(peekTimerRef.current);
-      peekTimerRef.current = null;
-    }
     setLayoutState('expanded');
     setOpenReason('userOpen');
   }, []);
 
   const handleFabTickExpand = useCallback(() => {
-    if (peekTimerRef.current) {
-      clearTimeout(peekTimerRef.current);
-      peekTimerRef.current = null;
-    }
     setLayoutState('expanded');
     setOpenReason('tickOpen');
     setActiveDrawer('tick');
   }, []);
 
   const handleFabQueueExpand = useCallback(() => {
-    if (peekTimerRef.current) {
-      clearTimeout(peekTimerRef.current);
-      peekTimerRef.current = null;
-    }
     setLayoutState('expanded');
     setOpenReason('queueOpen');
     setActiveDrawer('queue');
   }, []);
 
   const handleFabPlayOpen = useCallback(() => {
-    if (peekTimerRef.current) {
-      clearTimeout(peekTimerRef.current);
-      peekTimerRef.current = null;
-    }
     setLayoutState('expanded');
     setOpenReason('playOpen');
     setActiveDrawer('play');

--- a/packages/web/app/components/queue-control/reducer.ts
+++ b/packages/web/app/components/queue-control/reducer.ts
@@ -13,6 +13,7 @@ const initialState = (initialSearchParams: SearchRequestPagination): QueueState 
   lastReceivedSequence: null,
   lastReceivedStateHash: null,
   needsResync: false,
+  remoteClimbChangeCount: 0,
 });
 
 export function queueReducer(state: QueueState, action: QueueAction): QueueState {
@@ -252,6 +253,12 @@ export function queueReducer(state: QueueState, action: QueueAction): QueueState
         queue: newQueue,
         currentClimbQueueItem: item,
         pendingCurrentClimbUpdates: pendingUpdates,
+        // Bump only for non-echo remote events with a non-null item. A
+        // remote "clear" (item: null) doesn't peek — no climb to surface.
+        // Local events (no isServerEvent) leave the counter unchanged
+        // so the peek effect ignores them. Echoes returned earlier and
+        // never reach this branch, so they preserve the counter via state.
+        remoteClimbChangeCount: isServerEvent && item ? state.remoteClimbChangeCount + 1 : state.remoteClimbChangeCount,
       };
     }
 

--- a/packages/web/app/components/queue-control/types.ts
+++ b/packages/web/app/components/queue-control/types.ts
@@ -36,6 +36,13 @@ export type QueueState = {
   lastReceivedStateHash: string | null;
   // Flag to indicate corrupted data was filtered and a resync is needed
   needsResync: boolean;
+  /** Monotonic counter that increments only when the reducer applies a
+   *  non-echo remote DELTA_UPDATE_CURRENT_CLIMB with a non-null item.
+   *  The peek snackbar in the queue-control bar keys on this so it
+   *  surfaces only changes made by other party-mode participants —
+   *  not the local user's own navigation. Local actions and initial
+   *  hydration leave this untouched. */
+  remoteClimbChangeCount: number;
 };
 
 export type QueueAction =


### PR DESCRIPTION
## Summary

Two coupled changes to the peek snackbar (the pill that announces the new climb's name when the current climb changes):

- **Source filter** — peek now fires only when *another* party-mode participant changes the climb. Local user-initiated changes update the bar silently. Implemented via a monotonic `remoteClimbChangeCount` counter in reducer state that increments only on the apply path of non-echo remote `DELTA_UPDATE_CURRENT_CLIMB` with a non-null item. The reducer's existing echo filtering (correlation-ID match, own-clientId match) means non-bump cases never reach the apply path, so the counter is the cleanest possible "another user just did this" signal.
- **Stickiness** — peek no longer auto-dismisses after 3s. It stays visible until the user touches the screen (`pointerdown` / `keydown` / `scroll`), with a 300ms grace window so the gesture that triggered the peek (e.g. closing a drawer) doesn't dismiss it instantly. If another remote change arrives while the peek is up, the snackbar text updates in place — no re-mount, no re-entrance animation.

## Why a counter, not a boolean

`currentClimbQueueItem` is written by six reducer cases. Tracking origin with a `lastClimbChangeFromRemote` boolean would mean every one of those six writes has to remember to reset the flag, or a stale `true` from a prior remote event would falsely peek for the next local change. A counter that only ever increments — and only on the one apply path — is single-source-of-truth: every other case spreads `...state` and carries the counter forward unchanged, so future contributors can't accidentally trigger a peek by adding a new `currentClimbQueueItem` writer.

## Architecture

- New ultra-narrow context `RemoteClimbChangeCountContext` + hook `useRemoteClimbChangeCount()`. Mirrors the existing `useCurrentClimbUuid` pattern so consumers don't pay re-render cost for unrelated currentClimb updates.
- The bar's peek effect is split into two single-purpose effects:
  - **Effect A — trigger:** fires `setLayoutState('peeking')` when the counter advances past `lastPeekedCountRef.current` *and* `layoutState === 'minimised'`. If the bar is in a drawer, the peek is queued (the next return to `'minimised'` re-evaluates and peeks for whichever climb is current then).
  - **Effect B — dismiss:** while `'peeking'`, attaches document-level capture-phase listeners after a 300ms delay; first user interaction dismisses. Catches the ref up to the latest count on dismiss so a counter advance that arrived during the peek (which only updated text in place) doesn't re-fire as soon as we flip back to `'minimised'`.

## Test plan

- [ ] Two browsers signed in to the same party session. Window A picks a climb → A's bar updates silently, B's bar peeks with the new climb name.
- [ ] B doesn't tap → peek stays visible indefinitely (try waiting 30+ seconds).
- [ ] B taps anywhere → peek dismisses (after the 300ms grace).
- [ ] A picks again while B's peek is still up → B's snackbar text updates in place, no re-bounce.
- [ ] Solo user changes climbs (no party session) → no peek ever fires.
- [ ] B opens the queue drawer, A picks a new climb, B closes the drawer → peek fires for the latest climb on collapse.
- [ ] Reload B mid-session → no peek on first paint (counter baseline captured by `lastPeekedCountRef`).
- [ ] `vp check`, `vp run typecheck:web`, `vp test --project web` — all pass (1 pre-existing French i18n failure unrelated).
- [ ] DevTools `prefers-reduced-motion: reduce` — peek still fires; CSS already disables transform on the FAB cluster, so motion is opacity-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)