### PR TITLE
feat(bottom-tab-bar): lift pill 12px for concentric screen-corner alignment

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,16 +1,20 @@
-/* Floating liquid-glass pill. The wrapper sits at a flat 12px above the
-   screen bottom — that's the geometric gap (screen_radius − pill_radius)
-   that makes the pill's rounded corners concentric with the iPhone's
-   curved screen corners. The 12px lift plus the pill's intrinsic height
-   keeps interactive content well above the iOS home-indicator gesture
-   zone (~34px on modern iPhones), so we don't need to pile additional
-   safe-area padding inside the pill — that path made the pill look
-   bottom-heavy. */
+/* Floating liquid-glass pill. The wrapper anchors against
+   --bottom-tab-bar-bottom-offset (defined in components/index.css) so the
+   wrapper, the FAB cluster, and the peek snackbar all track the same per-
+   platform line without re-deriving it. The variable resolves to:
+
+   - iOS Safari + Capacitor → flat 12px (concentric with the iPhone screen-
+     corner radius on iPhone 17 Pro; older iPhones get a tasteful floating-
+     pill gap with no gesture conflict).
+   - Android Capacitor → max(12px, env(safe-area-inset-bottom)) so the
+     gesture-nav inset (24–48px on modern Android) is respected.
+   - Android Chromium web → 12px floor (env reports 0).
+   - Desktop ≥768px → 8px (no inset, narrow centred pill). */
 .bottomBarWrapper {
   --tab-bar-safe-area-padding: 0px;
   --tab-bar-bottom-extension: 0px;
   position: fixed;
-  bottom: 12px;
+  bottom: var(--bottom-tab-bar-bottom-offset);
   left: 0;
   right: 0;
   padding-inline: 12px;
@@ -24,11 +28,10 @@
   pointer-events: auto;
 }
 
-/* On desktop the pill stays centered and capped; the wrapper itself spans full
-   width but the BottomNavigation child sets max-width: min(560px, 100%). */
+/* Desktop padding-inline tightens the gutter; the bottom offset is handled
+   by the :root override in components/index.css. */
 @media (min-width: 768px) {
   .bottomBarWrapper {
-    bottom: 8px;
     padding-inline: 24px;
   }
 }

--- a/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
+++ b/packages/web/app/components/bottom-tab-bar/bottom-bar-wrapper.module.css
@@ -1,12 +1,16 @@
-/* Floating liquid-glass pill. Centered, lifted off the bottom, with safe-area
-   clearance so it doesn't collide with the iOS home indicator or Android
-   gesture-nav area. Native (Capacitor) and web both render the pill — no
-   edge-to-edge fallback. */
+/* Floating liquid-glass pill. The wrapper sits at a flat 12px above the
+   screen bottom — that's the geometric gap (screen_radius − pill_radius)
+   that makes the pill's rounded corners concentric with the iPhone's
+   curved screen corners. The 12px lift plus the pill's intrinsic height
+   keeps interactive content well above the iOS home-indicator gesture
+   zone (~34px on modern iPhones), so we don't need to pile additional
+   safe-area padding inside the pill — that path made the pill look
+   bottom-heavy. */
 .bottomBarWrapper {
   --tab-bar-safe-area-padding: 0px;
   --tab-bar-bottom-extension: 0px;
   position: fixed;
-  bottom: max(4px, env(safe-area-inset-bottom));
+  bottom: 12px;
   left: 0;
   right: 0;
   padding-inline: 12px;
@@ -18,26 +22,6 @@
 /* Children (BottomNavigation, QueueControlBar, banners) handle their own taps. */
 .bottomBarWrapper > * {
   pointer-events: auto;
-}
-
-/* Native shells get the same pill but a slightly larger lift on Android, where
-   the gesture-nav area can be 24-48px above the WebView bottom. The
-   @capacitor-community/safe-area plugin populates env(safe-area-inset-bottom)
-   on Android via passed insets (Chromium 140+) or decorView padding (older);
-   on iOS WKWebView env() reports the home-indicator inset natively. */
-.nativeApp {
-  bottom: max(8px, env(safe-area-inset-bottom));
-}
-
-/* iOS WKWebView: drop the pill flush with the bottom of the screen so its
-   rounded bottom edges nest into the iPhone's curved screen corners. The
-   home-indicator clearance moves *inside* the pill via
-   --tab-bar-safe-area-padding instead of lifting the whole element off
-   the bottom. Android stays on .nativeApp because gesture-nav clearance
-   varies more and a flush placement risks gesture conflicts there. */
-.iosNativeApp {
-  --tab-bar-safe-area-padding: env(safe-area-inset-bottom);
-  bottom: 0;
 }
 
 /* On desktop the pill stays centered and capped; the wrapper itself spans full

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -131,6 +131,18 @@
      The tab bar publishes `data-tab-bar-collapsed` on <html>; consumers (FAB
      cluster, peek snackbar) override their `bottom` against this value. */
   --bottom-tab-bar-height-collapsed: 28px;
+  /* Distance from the screen bottom to the tab-bar wrapper's bottom edge.
+     Single source of truth so the wrapper, the FAB cluster, and the peek
+     snackbar all stay anchored to the same line without re-deriving the
+     value. Default is `max(12px, env(safe-area-inset-bottom))`, which
+     covers Android Capacitor (gesture-nav inset 24–48px) and Android
+     Chromium web (inset 0, 12px floor). The iOS override below pins it
+     to a flat 12px so the pill's rounded bottom corners align
+     concentrically with the iPhone screen-corner radius — accepting that
+     interactive content sits inside the home-indicator zone, since the
+     pill's intrinsic 64px height keeps tap targets clear of the
+     indicator gesture region in practice. */
+  --bottom-tab-bar-bottom-offset: max(12px, env(safe-area-inset-bottom));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;
@@ -144,6 +156,25 @@
      `text.brandPrimaryLight` / `text.brandMutedLight` — keep in sync. */
   --bs-text-brand-primary: #2a1f1f;
   --bs-text-brand-muted: #6b5b54;
+}
+
+/* iOS Safari + WKWebView (Capacitor) override: pin the tab-bar offset to a
+   flat 12px so the pill's rounded bottom corners align concentrically with
+   the iPhone screen-corner radius. `-webkit-touch-callout: none` is
+   supported by every WebKit-based engine and absent from Chromium, so this
+   selector reliably picks iOS without needing a JS-set class on <html>. */
+@supports (-webkit-touch-callout: none) {
+  :root {
+    --bottom-tab-bar-bottom-offset: 12px;
+  }
+}
+
+/* Desktop: tighter 8px lift since there's no home-indicator or gesture-nav
+   to clear and the pill is centred and width-capped at min(560px, 100%). */
+@media (min-width: 768px) {
+  :root {
+    --bottom-tab-bar-bottom-offset: 8px;
+  }
 }
 
 /* Dark mode overrides */

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -26,7 +26,6 @@ import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { SearchDrawerBridgeProvider } from '../search-drawer/search-drawer-bridge-context';
 import { StatsFilterBridgeProvider } from '../stats-filter-bridge/stats-filter-bridge-context';
 import { ProfileHeaderShareProvider } from '../profile-header-bridge/profile-header-bridge-context';
-import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import dynamic from 'next/dynamic';
 import { SESH_SETTINGS_DRAWER_EVENT } from '../sesh-settings/sesh-settings-drawer-event';
 import { BoardSwitchConfirmProvider } from '../board-lock/board-switch-confirm-provider';
@@ -143,8 +142,6 @@ const HIDE_TAB_BAR_PAGES = ['/aurora-migration'];
 export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData }) {
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathnameWithoutLocale();
-  const isNative = isNativeApp();
-  const isIOSNative = isNative && getPlatform() === 'ios';
 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
@@ -178,11 +175,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   }, []);
 
   return (
-    <div
-      ref={wrapperRef}
-      className={`${bottomBarStyles.bottomBarWrapper} ${isNative ? bottomBarStyles.nativeApp : ''} ${isIOSNative ? bottomBarStyles.iosNativeApp : ''}`}
-      data-testid="bottom-bar-wrapper"
-    >
+    <div ref={wrapperRef} className={bottomBarStyles.bottomBarWrapper} data-testid="bottom-bar-wrapper">
       <FeedbackPromptBanner />
       {hasActiveQueue && boardDetails && (
         <ErrorBoundary>

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -49,7 +49,7 @@
      fires only on the binary tab-bar-collapsed toggle, on a single
      fixed-positioned box with no descendants depending on its layout —
      cheap, and it keeps the liquid-glass intact. */
-  bottom: calc(var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2));
+  bottom: calc(12px + var(--bottom-tab-bar-height) + var(--spacing-2));
   z-index: 8;
   padding: 0 12px;
   display: flex;
@@ -63,8 +63,10 @@
     bottom 220ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
+/* Collapsed state hugs the small pill — tighten the spacing to spacing-1
+   so the FAB cluster sits ~4px above the collapsed pill. */
 :root[data-tab-bar-collapsed='true'] .fabRoot {
-  bottom: calc(var(--bottom-tab-bar-height-collapsed) + env(safe-area-inset-bottom, 0px) + var(--spacing-2));
+  bottom: calc(12px + var(--bottom-tab-bar-height-collapsed) + var(--spacing-1));
 }
 
 .fabRootVisible {
@@ -157,15 +159,13 @@
   left: 0;
   right: 0;
   /* Anchored above the small-FAB row + gap. Same expanded-state bottom as
-     the FAB cluster (--bottom-tab-bar-height + safe-area + --spacing-2),
+     the FAB cluster (12px lift + --bottom-tab-bar-height + --spacing-2),
      stacked with the small-FAB row (46px = SMALL_FAB_SIZE in
      queue-control-fab.tsx) and a --spacing-3 visual gap above it.
      Collapse follows via --fab-collapse-offset (translateY) — compositor-
      only, and safe here because the snackbar is opaque (no backdrop-filter
      children to break). */
-  bottom: calc(
-    var(--bottom-tab-bar-height) + env(safe-area-inset-bottom, 0px) + var(--spacing-2) + 46px + var(--spacing-3)
-  );
+  bottom: calc(12px + var(--bottom-tab-bar-height) + var(--spacing-2) + 46px + var(--spacing-3));
   z-index: 8;
   display: flex;
   justify-content: center;

--- a/packages/web/app/components/queue-control/queue-control-fab.module.css
+++ b/packages/web/app/components/queue-control/queue-control-fab.module.css
@@ -49,7 +49,7 @@
      fires only on the binary tab-bar-collapsed toggle, on a single
      fixed-positioned box with no descendants depending on its layout —
      cheap, and it keeps the liquid-glass intact. */
-  bottom: calc(12px + var(--bottom-tab-bar-height) + var(--spacing-2));
+  bottom: calc(var(--bottom-tab-bar-bottom-offset) + var(--bottom-tab-bar-height) + var(--spacing-2));
   z-index: 8;
   padding: 0 12px;
   display: flex;
@@ -66,7 +66,7 @@
 /* Collapsed state hugs the small pill — tighten the spacing to spacing-1
    so the FAB cluster sits ~4px above the collapsed pill. */
 :root[data-tab-bar-collapsed='true'] .fabRoot {
-  bottom: calc(12px + var(--bottom-tab-bar-height-collapsed) + var(--spacing-1));
+  bottom: calc(var(--bottom-tab-bar-bottom-offset) + var(--bottom-tab-bar-height-collapsed) + var(--spacing-1));
 }
 
 .fabRootVisible {
@@ -159,13 +159,15 @@
   left: 0;
   right: 0;
   /* Anchored above the small-FAB row + gap. Same expanded-state bottom as
-     the FAB cluster (12px lift + --bottom-tab-bar-height + --spacing-2),
-     stacked with the small-FAB row (46px = SMALL_FAB_SIZE in
-     queue-control-fab.tsx) and a --spacing-3 visual gap above it.
+     the FAB cluster (--bottom-tab-bar-bottom-offset + --bottom-tab-bar-height
+     + --spacing-2), stacked with the small-FAB row (46px = SMALL_FAB_SIZE
+     in queue-control-fab.tsx) and a --spacing-3 visual gap above it.
      Collapse follows via --fab-collapse-offset (translateY) — compositor-
      only, and safe here because the snackbar is opaque (no backdrop-filter
      children to break). */
-  bottom: calc(12px + var(--bottom-tab-bar-height) + var(--spacing-2) + 46px + var(--spacing-3));
+  bottom: calc(
+    var(--bottom-tab-bar-bottom-offset) + var(--bottom-tab-bar-height) + var(--spacing-2) + 46px + var(--spacing-3)
+  );
   z-index: 8;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary

- Bottom tab bar wrapper now sits at a flat `bottom: 12px` instead of `max(4px, env(safe-area-inset-bottom))`. On iPhone 17 Pro that 12px gap equals `screen_radius − pill_radius`, so the pill's rounded bottom corners trace concentrically with the curved screen corners.
- Drops the safe-area math from both the wrapper position and the FAB / peek snackbar anchors. The 12px lift plus the pill's intrinsic 64px height keeps interactive content clear of the home-indicator gesture zone without internal padding inflating the pill.
- FAB cluster gains the same 12px lift; collapsed-state spacing tightens to `--spacing-1` so the FABs hug the small pill in scroll-collapsed mode instead of floating detached above it.
- Removes now-unused `.nativeApp` / `.iosNativeApp` class branches and the platform-detection imports in `persistent-session-wrapper.tsx` — the base wrapper rule covers web, iOS native (Capacitor), and Android native uniformly.

## Test plan

- [ ] Load on iPhone 17 Pro (Safari and Capacitor build): confirm the pill's bottom-corner curves visibly trace the screen's corner curves
- [ ] Scroll down to trigger the collapse animation: confirm the FAB cluster hugs the small pill (~4px gap) without overlapping
- [ ] Scroll back up: confirm the FAB cluster fades and the pill expands smoothly
- [ ] Smoke-check on web (desktop and mobile Safari): pill renders at 12px (mobile) / 8px (desktop ≥768px), no platform regressions
- [ ] Smoke-check on Android native: pill at 12px, FAB cluster anchors correctly above it, no gesture-nav conflict
- [ ] Trigger peek mode: confirm the peek snackbar still sits one small-FAB row + spacing above the FAB cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)