### PR TITLE
feat(experiments): gate minimised queue-bar FAB behind opt-in toggle

### DIFF
--- a/packages/web/app/components/experiments/experiments-drawer.tsx
+++ b/packages/web/app/components/experiments/experiments-drawer.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import ScienceOutlined from '@mui/icons-material/ScienceOutlined';
+
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import { EXPERIMENTS, setExperiment, useExperiment, type ExperimentKey } from '@/app/lib/experiments';
+
+type ExperimentsDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  onTransitionEnd?: (open: boolean) => void;
+};
+
+type ExperimentRowProps = {
+  experimentKey: ExperimentKey;
+  labelKey: string;
+  descriptionKey: string;
+};
+
+const ExperimentRow: React.FC<ExperimentRowProps> = ({ experimentKey, labelKey, descriptionKey }) => {
+  const { t } = useTranslation('common');
+  const enabled = useExperiment(experimentKey);
+
+  const handleToggle = useCallback(
+    (_event: React.SyntheticEvent, checked: boolean) => {
+      void setExperiment(experimentKey, checked);
+    },
+    [experimentKey],
+  );
+
+  const labelId = `experiment-${experimentKey}-label`;
+  const descriptionId = `experiment-${experimentKey}-description`;
+
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      alignItems="flex-start"
+      sx={{
+        py: 1.5,
+        px: 0.5,
+        borderBottom: 1,
+        borderColor: 'divider',
+        '&:last-of-type': { borderBottom: 'none' },
+      }}
+    >
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography id={labelId} variant="body1" component="div" fontWeight={600}>
+          {t(labelKey)}
+        </Typography>
+        <Typography id={descriptionId} variant="body2" component="div" color="text.secondary" sx={{ mt: 0.25 }}>
+          {t(descriptionKey)}
+        </Typography>
+      </Box>
+      <Switch
+        checked={enabled}
+        onChange={handleToggle}
+        inputProps={{
+          'aria-labelledby': labelId,
+          'aria-describedby': descriptionId,
+        }}
+      />
+    </Stack>
+  );
+};
+
+const ExperimentsDrawer: React.FC<ExperimentsDrawerProps> = ({ open, onClose, onTransitionEnd }) => {
+  const { t } = useTranslation('common');
+
+  return (
+    <SwipeableDrawer
+      placement="left"
+      open={open}
+      onClose={onClose}
+      onTransitionEnd={onTransitionEnd}
+      width={320}
+      title={t('experiments.title')}
+    >
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Stack direction="row" spacing={1.5} alignItems="flex-start">
+          <ScienceOutlined sx={{ color: 'text.secondary', mt: 0.25 }} />
+          <Typography variant="body2" color="text.secondary">
+            {t('experiments.subtitle')}
+          </Typography>
+        </Stack>
+
+        <Box>
+          {EXPERIMENTS.map((experiment) => (
+            <ExperimentRow
+              key={experiment.key}
+              experimentKey={experiment.key}
+              labelKey={experiment.labelKey}
+              descriptionKey={experiment.descriptionKey}
+            />
+          ))}
+        </Box>
+      </Box>
+    </SwipeableDrawer>
+  );
+};
+
+export default ExperimentsDrawer;

--- a/packages/web/app/components/experiments/experiments-drawer.tsx
+++ b/packages/web/app/components/experiments/experiments-drawer.tsx
@@ -28,7 +28,7 @@ const ExperimentRow: React.FC<ExperimentRowProps> = ({ experimentKey, labelKey, 
   const enabled = useExperiment(experimentKey);
 
   const handleToggle = useCallback(
-    (_event: React.SyntheticEvent, checked: boolean) => {
+    (_event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
       void setExperiment(experimentKey, checked);
     },
     [experimentKey],

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
@@ -350,6 +350,15 @@ const isFabVisible = () => {
   return !!cluster && cluster.getAttribute('aria-hidden') === 'false';
 };
 
+// The bar's collapsible wrapper (queue-control-bar.tsx line 1047) is the
+// direct child of the testid root that carries `aria-hidden`. Its value
+// is `false` only when `layoutState === 'expanded'`, so it's a faithful
+// signal for "the bar is showing its full content" — independent of
+// whether the FAB cluster happens to be rendered.
+const getBarWrapper = () =>
+  document.querySelector('[data-testid="queue-control-bar"] > [aria-hidden]') as HTMLElement | null;
+const isBarExpanded = () => getBarWrapper()?.getAttribute('aria-hidden') === 'false';
+
 // Queries restricted to the FAB cluster so we don't collide with the
 // in-bar queue icon (which also uses aria-label="Open queue") that
 // stays mounted in the DOM under the collapsed wrapper.
@@ -617,21 +626,23 @@ describe('QueueControlBar with the FAB experiment off', () => {
     mockFabMinimisedEnabled = false;
   });
 
-  it('does not render the FAB cluster on a non-list page', async () => {
+  it('renders the bar expanded with no FAB cluster on a non-list page', async () => {
     await act(async () => {
       render(<QueueControlBar {...defaultProps} />);
     });
 
     expect(getFabCluster()).toBeNull();
+    expect(isBarExpanded()).toBe(true);
   });
 
-  it('does not render the FAB cluster on the climb list page', async () => {
+  it('renders the bar expanded with no FAB cluster on the climb list page', async () => {
     mockPathname = '/kilter/1/1/1/40/list';
     await act(async () => {
       render(<QueueControlBar {...defaultProps} />);
     });
 
     expect(getFabCluster()).toBeNull();
+    expect(isBarExpanded()).toBe(true);
   });
 
   it('passes enabled=false to the scroll-direction hook so it never collapses the bar', async () => {
@@ -640,9 +651,10 @@ describe('QueueControlBar with the FAB experiment off', () => {
     });
 
     expect(scrollHandlers.enabled).toBe(false);
+    expect(isBarExpanded()).toBe(true);
   });
 
-  it('does not peek when the current climb uuid changes (FAB DOM is gone)', async () => {
+  it('does not peek when the current climb uuid changes (bar stays expanded, FAB DOM is gone)', async () => {
     vi.useFakeTimers();
     try {
       const { rerender } = render(<QueueControlBar {...defaultProps} />);
@@ -661,21 +673,22 @@ describe('QueueControlBar with the FAB experiment off', () => {
 
       expect(document.querySelector('[class*="peekSnackbar"]')).toBeNull();
       expect(getFabCluster()).toBeNull();
+      expect(isBarExpanded()).toBe(true);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('keeps the queue drawer flow working without the FAB cluster', async () => {
+  it('keeps the bar fully expanded with the queue drawer closed', async () => {
     // The in-bar queue icon (not the FAB) is still wired up — sanity-check
-    // that closing the drawer leaves the bar in its always-expanded state.
+    // that the bar shows its full content and the queue drawer is closed
+    // until something user-driven opens it.
     await act(async () => {
       render(<QueueControlBar {...defaultProps} />);
     });
 
     expect(getFabCluster()).toBeNull();
-    // Queue drawer starts closed and stays so until user-driven flows open it
-    // — the FAB-driven open paths are gone, but the bar itself is rendered.
+    expect(isBarExpanded()).toBe(true);
     expect(queueDrawerOpenStates.at(-1)).toBe(false);
   });
 });

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-state-machine.test.tsx
@@ -27,6 +27,17 @@ vi.mock('@/app/lib/user-preferences-db', () => ({
   setGradeDisplayFormat: async () => {},
 }));
 
+// The minimised FAB experience is opt-in via the experiments drawer. The
+// existing state-machine tests below exercise the experiment-on path; the
+// dedicated "with the FAB experiment off" block at the bottom flips this
+// to false.
+let mockFabMinimisedEnabled = true;
+vi.mock('@/app/lib/experiments', () => ({
+  useExperiment: () => mockFabMinimisedEnabled,
+  setExperiment: vi.fn().mockResolvedValue(undefined),
+  EXPERIMENTS: [],
+}));
+
 let mockQueueContext: Record<string, unknown> = {};
 vi.mock('@/app/components/graphql-queue', () => ({
   useQueueContext: () => mockQueueContext,
@@ -100,11 +111,12 @@ vi.mock('@/app/hooks/use-color-mode', () => ({
 
 // useScrollDirection: pretend nothing scrolls. Tests that need a scroll
 // event override this via vi.mock factory call captures.
-const scrollHandlers: { onUp?: () => void; onDown?: () => void } = {};
+const scrollHandlers: { onUp?: () => void; onDown?: () => void; enabled?: boolean } = {};
 vi.mock('@/app/hooks/use-scroll-direction', () => ({
-  useScrollDirection: (opts: { onUp?: () => void; onDown?: () => void }) => {
+  useScrollDirection: (opts: { onUp?: () => void; onDown?: () => void; enabled?: boolean }) => {
     scrollHandlers.onUp = opts.onUp;
     scrollHandlers.onDown = opts.onDown;
+    scrollHandlers.enabled = opts.enabled;
   },
 }));
 
@@ -368,6 +380,8 @@ describe('QueueControlBar layout state machine', () => {
     queueDrawerOpenStates.length = 0;
     scrollHandlers.onUp = undefined;
     scrollHandlers.onDown = undefined;
+    scrollHandlers.enabled = undefined;
+    mockFabMinimisedEnabled = true;
   });
 
   it('starts minimised on a non-list page (FAB visible)', async () => {
@@ -585,5 +599,83 @@ describe('QueueControlBar layout state machine', () => {
 
     // Scroll down → minimised → FAB visible.
     expect(getFabCluster()?.getAttribute('aria-hidden')).toBe('false');
+  });
+});
+
+describe('QueueControlBar with the FAB experiment off', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = { ...baseQueueContext };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+    mockPathname = '/kilter/1/1/1/40/view/abc';
+    playDrawerOpenStates.length = 0;
+    queueDrawerOpenStates.length = 0;
+    scrollHandlers.onUp = undefined;
+    scrollHandlers.onDown = undefined;
+    scrollHandlers.enabled = undefined;
+    mockFabMinimisedEnabled = false;
+  });
+
+  it('does not render the FAB cluster on a non-list page', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(getFabCluster()).toBeNull();
+  });
+
+  it('does not render the FAB cluster on the climb list page', async () => {
+    mockPathname = '/kilter/1/1/1/40/list';
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(getFabCluster()).toBeNull();
+  });
+
+  it('passes enabled=false to the scroll-direction hook so it never collapses the bar', async () => {
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(scrollHandlers.enabled).toBe(false);
+  });
+
+  it('does not peek when the current climb uuid changes (FAB DOM is gone)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(<QueueControlBar {...defaultProps} />);
+      await act(async () => {});
+
+      const nextClimb = { ...mockClimb, uuid: 'climb-2', name: 'Different Climb' };
+      mockQueueContext = {
+        ...baseQueueContext,
+        queue: [{ uuid: 'item-2', climb: nextClimb, addedBy: 'user-1', suggested: false }],
+        currentClimbQueueItem: { uuid: 'item-2', climb: nextClimb, addedBy: 'user-1', suggested: false },
+        currentClimb: nextClimb,
+      };
+      await act(async () => {
+        rerender(<QueueControlBar {...propsWithFreshRef(defaultProps)} />);
+      });
+
+      expect(document.querySelector('[class*="peekSnackbar"]')).toBeNull();
+      expect(getFabCluster()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the queue drawer flow working without the FAB cluster', async () => {
+    // The in-bar queue icon (not the FAB) is still wired up — sanity-check
+    // that closing the drawer leaves the bar in its always-expanded state.
+    await act(async () => {
+      render(<QueueControlBar {...defaultProps} />);
+    });
+
+    expect(getFabCluster()).toBeNull();
+    // Queue drawer starts closed and stays so until user-driven flows open it
+    // — the FAB-driven open paths are gone, but the bar itself is rendered.
+    expect(queueDrawerOpenStates.at(-1)).toBe(false);
   });
 });

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -73,6 +73,7 @@ import IosShare from '@mui/icons-material/IosShare';
 import { QRCodeSVG } from 'qrcode.react';
 import { shareWithFallback } from '@/app/lib/share-utils';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { useExperiment } from '@/app/lib/experiments';
 import styles from './queue-control-bar.module.css';
 import { PLAY_DRAWER_EVENT as PLAY_DRAWER_EVENT_INTERNAL, dispatchOpenPlayDrawer } from './play-drawer-event';
 
@@ -145,9 +146,19 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const router = useLocaleRouter();
   const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
 
+  // The minimised/FAB experience is opt-in via the experiments drawer.
+  // While disabled the bar always renders expanded — no FAB cluster, no
+  // scroll-driven collapse, no peek snackbar. The hook returns the
+  // experiment default (false) on first render and lands the persisted
+  // value on the next tick, so users who haven't opted in pay nothing.
+  const fabMinimisedEnabled = useExperiment('queueBarFab');
+
   // Layout state: minimised by default, expanded on the climb list page.
   // Computed synchronously in useState so /list doesn't flash from minimised → expanded.
-  const [layoutState, setLayoutState] = useState<LayoutState>(() => (isClimbListPage ? 'expanded' : 'minimised'));
+  const [layoutState, setLayoutState] = useState<LayoutState>(() => {
+    if (!fabMinimisedEnabled) return 'expanded';
+    return isClimbListPage ? 'expanded' : 'minimised';
+  });
   const [openReason, setOpenReason] = useState<OpenReason>('default');
   const peekTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track the climb uuid we observed on first mount so the initial value
@@ -163,14 +174,14 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // from pathname — listing both is harmless but adds noise.
   useEffect(() => {
     setActiveDrawer('none');
-    setLayoutState(isClimbListPage ? 'expanded' : 'minimised');
+    setLayoutState(!fabMinimisedEnabled || isClimbListPage ? 'expanded' : 'minimised');
     setOpenReason('default');
     initialUuidRef.current = undefined;
     if (peekTimerRef.current) {
       clearTimeout(peekTimerRef.current);
       peekTimerRef.current = null;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname; fabMinimisedEnabled is stable per render
   }, [pathname]);
 
   // Cleanup timeouts on unmount
@@ -269,7 +280,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // Use event callbacks (not sticky state) so a stale direction can't
   // re-fire when unrelated state — e.g. a manual FAB tap — re-renders.
   useScrollDirection({
-    enabled: isClimbListPage || (layoutState === 'expanded' && openReason === 'userOpen'),
+    enabled: fabMinimisedEnabled && (isClimbListPage || (layoutState === 'expanded' && openReason === 'userOpen')),
     onDown: () => {
       if (layoutState !== 'expanded') return;
       if (isClimbListPage || openReason === 'userOpen') {
@@ -1518,17 +1529,21 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         </div>
       </div>
 
-      {/* FAB cluster — shown in minimised/peeking state */}
-      <QueueControlFab
-        mode={layoutState === 'expanded' ? 'hidden' : layoutState}
-        currentClimb={currentClimb}
-        boardDetails={boardDetails}
-        pathname={pathname}
-        onExpandFromGrade={handleFabExpand}
-        onOpenPlayView={handleFabPlayOpen}
-        onExpandFromTick={handleFabTickExpand}
-        onExpandFromQueue={handleFabQueueExpand}
-      />
+      {/* FAB cluster — shown in minimised/peeking state. Gated behind a
+          feature flag so we can flip back to the always-expanded bar without
+          paying for the FAB DOM, snackbar peek, or backdrop-filter when off. */}
+      {fabMinimisedEnabled && (
+        <QueueControlFab
+          mode={layoutState === 'expanded' ? 'hidden' : layoutState}
+          currentClimb={currentClimb}
+          boardDetails={boardDetails}
+          pathname={pathname}
+          onExpandFromGrade={handleFabExpand}
+          onOpenPlayView={handleFabPlayOpen}
+          onExpandFromTick={handleFabTickExpand}
+          onExpandFromQueue={handleFabQueueExpand}
+        />
+      )}
 
       <QueueDrawer open={activeDrawer === 'queue'} onClose={handleCloseDrawer} boardDetails={boardDetails} />
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -147,14 +147,19 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const enterFallbackRef = useRef<NodeJS.Timeout | null>(null);
 
   // The minimised/FAB experience is opt-in via the experiments drawer.
-  // While disabled the bar always renders expanded — no FAB cluster, no
-  // scroll-driven collapse, no peek snackbar. The hook returns the
-  // experiment default (false) on first render and lands the persisted
-  // value on the next tick, so users who haven't opted in pay nothing.
+  // `useExperiment` returns the registered default (false) on the first
+  // render and only lands the persisted IndexedDB value on the next tick —
+  // so users who opted in see a brief "expanded → minimised" snap on every
+  // page load. That's acceptable for an opt-in (the expanded bar is the
+  // documented default state) but it does mean the useState initialiser
+  // below cannot be the canonical source of truth: the runtime-flip effect
+  // further down reconciles `layoutState` whenever the flag value changes.
   const fabMinimisedEnabled = useExperiment('queueBarFab');
 
-  // Layout state: minimised by default, expanded on the climb list page.
-  // Computed synchronously in useState so /list doesn't flash from minimised → expanded.
+  // Layout state. The initialiser uses the synchronously-known flag value
+  // so the climb list and flag-off paths render in the right state on the
+  // first paint without an effect tick. The flag-change effect below takes
+  // over once IndexedDB hydrates or the user toggles the experiment live.
   const [layoutState, setLayoutState] = useState<LayoutState>(() => {
     if (!fabMinimisedEnabled) return 'expanded';
     return isClimbListPage ? 'expanded' : 'minimised';
@@ -181,8 +186,27 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       clearTimeout(peekTimerRef.current);
       peekTimerRef.current = null;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname; fabMinimisedEnabled is stable per render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname; the flag-change effect below handles fabMinimisedEnabled
   }, [pathname]);
+
+  // Runtime flag flip: react when `fabMinimisedEnabled` changes (IndexedDB
+  // hydration on mount, or a live toggle from the experiments drawer in
+  // this or another tab). The useState initialiser only runs once, so
+  // without this effect a flip never takes hold until the next route
+  // change — turning the experiment on would not visibly collapse the bar
+  // and turning it off would not bring it back. Drawer state is left
+  // alone here; the drawer-open effect already forces `expanded` while a
+  // drawer is mounted, so the only racing case (toggle while a drawer is
+  // open) self-corrects on the next render.
+  useEffect(() => {
+    setLayoutState(!fabMinimisedEnabled || isClimbListPage ? 'expanded' : 'minimised');
+    setOpenReason('default');
+    if (peekTimerRef.current) {
+      clearTimeout(peekTimerRef.current);
+      peekTimerRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isClimbListPage derives from pathname; pathname changes are handled by the route-reset effect above
+  }, [fabMinimisedEnabled]);
 
   // Cleanup timeouts on unmount
   useEffect(() => {

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -22,6 +22,7 @@ import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutl
 import GroupOutlined from '@mui/icons-material/GroupOutlined';
 import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
+import ScienceOutlined from '@mui/icons-material/ScienceOutlined';
 
 import { useSession, signOut } from 'next-auth/react';
 import { useColorMode } from '@/app/hooks/use-color-mode';
@@ -50,6 +51,7 @@ import { StoreReviewPromptDialog } from '../feedback/store-review-prompt-dialog'
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
+import ExperimentsDrawer from '../experiments/experiments-drawer';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
@@ -94,6 +96,8 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const [showRating, setShowRating] = useState(false);
   const [showBugReport, setShowBugReport] = useState(false);
   const [showStoreReviewPrompt, setShowStoreReviewPrompt] = useState(false);
+  const [showExperiments, setShowExperiments] = useState(false);
+  const [experimentsRendered, setExperimentsRendered] = useState(false);
 
   const { mode, toggleMode } = useColorMode();
   const isMoonboard = boardDetails?.board_name === 'moonboard';
@@ -124,6 +128,9 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   }, []);
   const handleMyBoardsTransitionEnd = useCallback((open: boolean) => {
     if (!open) setMyBoardsRendered(false);
+  }, []);
+  const handleExperimentsTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setExperimentsRendered(false);
   }, []);
 
   const handleChangeBoardClick = useCallback(
@@ -321,6 +328,21 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                 </span>
                 <span className={styles.menuItemLabel}>{t('ariaLabels.settings')}</span>
               </LocaleLink>
+
+              <button
+                type="button"
+                className={styles.menuItem}
+                onClick={() => {
+                  handleClose();
+                  setExperimentsRendered(true);
+                  setShowExperiments(true);
+                }}
+              >
+                <span className={styles.menuItemIcon}>
+                  <ScienceOutlined />
+                </span>
+                <span className={styles.menuItemLabel}>{t('userDrawer.experiments')}</span>
+              </button>
 
               {devUrlAvailable && (
                 <button
@@ -549,6 +571,14 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
       )}
 
       {devUrlAvailable && <DevUrlDialog open={showDevUrl} onClose={() => setShowDevUrl(false)} />}
+
+      {experimentsRendered && (
+        <ExperimentsDrawer
+          open={showExperiments}
+          onClose={() => setShowExperiments(false)}
+          onTransitionEnd={handleExperimentsTransitionEnd}
+        />
+      )}
 
       <FeedbackDialog
         open={showRating}

--- a/packages/web/app/lib/experiments.ts
+++ b/packages/web/app/lib/experiments.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getPreference, setPreference } from './user-preferences-db';
+
+/**
+ * User-toggleable experiments. Persisted to IndexedDB through
+ * `user-preferences-db` under the `experiment:*` key namespace, exposed
+ * via `useExperiment` for components and toggled from the experiments
+ * drawer.
+ *
+ * Adding a new experiment:
+ *   1. Add the key to `ExperimentKey` below.
+ *   2. Add the matching `experiment:<key>: boolean` entry to
+ *      `UserPreferenceKeyMap` in user-preferences-db.ts.
+ *   3. Append a definition to `EXPERIMENTS` with i18n label/description
+ *      keys (under the `common` namespace).
+ */
+
+export type ExperimentKey = 'queueBarFab';
+
+export type ExperimentDefinition = {
+  key: ExperimentKey;
+  /** i18n key under the `common` namespace. */
+  labelKey: string;
+  /** i18n key under the `common` namespace. */
+  descriptionKey: string;
+  default: boolean;
+};
+
+export const EXPERIMENTS: readonly ExperimentDefinition[] = [
+  {
+    key: 'queueBarFab',
+    labelKey: 'experiments.queueBarFab.label',
+    descriptionKey: 'experiments.queueBarFab.description',
+    default: false,
+  },
+] as const;
+
+const EXPERIMENT_CHANGE_EVENT = 'boardsesh:experiment-changed';
+
+type ExperimentPreferenceKey = `experiment:${ExperimentKey}`;
+
+const preferenceKey = (key: ExperimentKey): ExperimentPreferenceKey => `experiment:${key}`;
+
+const getDefault = (key: ExperimentKey): boolean =>
+  EXPERIMENTS.find((definition) => definition.key === key)?.default ?? false;
+
+type ExperimentChangeDetail = { key: ExperimentKey; value: boolean };
+
+const dispatchChange = (detail: ExperimentChangeDetail) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<ExperimentChangeDetail>(EXPERIMENT_CHANGE_EVENT, { detail }));
+};
+
+/**
+ * React hook returning the current value of an experiment.
+ *
+ * Initial render returns the registered default (so SSR and the first
+ * client paint stay in sync). The persisted IndexedDB value lands on the
+ * effect tick. Toggles dispatched through `setExperiment` notify every
+ * mounted consumer in the same tab via a window CustomEvent.
+ */
+export function useExperiment(key: ExperimentKey): boolean {
+  const [value, setValue] = useState<boolean>(() => getDefault(key));
+
+  useEffect(() => {
+    let cancelled = false;
+    void getPreference<boolean>(preferenceKey(key)).then((stored) => {
+      if (cancelled) return;
+      if (typeof stored === 'boolean') setValue(stored);
+    });
+
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<ExperimentChangeDetail>).detail;
+      if (detail?.key === key) setValue(detail.value);
+    };
+    window.addEventListener(EXPERIMENT_CHANGE_EVENT, onChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(EXPERIMENT_CHANGE_EVENT, onChange);
+    };
+  }, [key]);
+
+  return value;
+}
+
+/**
+ * Persist a new value for an experiment and broadcast it so every
+ * `useExperiment` consumer in the same tab re-renders.
+ */
+export async function setExperiment(key: ExperimentKey, value: boolean): Promise<void> {
+  await setPreference(preferenceKey(key), value);
+  dispatchChange({ key, value });
+}

--- a/packages/web/app/lib/experiments.ts
+++ b/packages/web/app/lib/experiments.ts
@@ -38,6 +38,7 @@ export const EXPERIMENTS: readonly ExperimentDefinition[] = [
 ] as const;
 
 const EXPERIMENT_CHANGE_EVENT = 'boardsesh:experiment-changed';
+const EXPERIMENT_CHANNEL_NAME = 'boardsesh:experiments';
 
 type ExperimentPreferenceKey = `experiment:${ExperimentKey}`;
 
@@ -48,9 +49,22 @@ const getDefault = (key: ExperimentKey): boolean =>
 
 type ExperimentChangeDetail = { key: ExperimentKey; value: boolean };
 
+// Lazy singleton: BroadcastChannel is only available in the browser and is
+// undefined in jsdom test environments, so guard both. Same-tab consumers
+// also need to hear about a flip — BroadcastChannel deliberately does NOT
+// deliver to the tab that posted, so we keep a window CustomEvent for the
+// in-tab path and the channel for cross-tab sync.
+let channelInstance: BroadcastChannel | null = null;
+const getChannel = (): BroadcastChannel | null => {
+  if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') return null;
+  if (!channelInstance) channelInstance = new BroadcastChannel(EXPERIMENT_CHANNEL_NAME);
+  return channelInstance;
+};
+
 const dispatchChange = (detail: ExperimentChangeDetail) => {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent<ExperimentChangeDetail>(EXPERIMENT_CHANGE_EVENT, { detail }));
+  getChannel()?.postMessage(detail);
 };
 
 /**
@@ -71,14 +85,19 @@ export function useExperiment(key: ExperimentKey): boolean {
       if (typeof stored === 'boolean') setValue(stored);
     });
 
-    const onChange = (event: Event) => {
-      const detail = (event as CustomEvent<ExperimentChangeDetail>).detail;
+    const applyChange = (detail: ExperimentChangeDetail | undefined) => {
       if (detail?.key === key) setValue(detail.value);
     };
-    window.addEventListener(EXPERIMENT_CHANGE_EVENT, onChange);
+    const onWindowEvent = (event: Event) => applyChange((event as CustomEvent<ExperimentChangeDetail>).detail);
+    const onChannelMessage = (event: MessageEvent<ExperimentChangeDetail>) => applyChange(event.data);
+
+    window.addEventListener(EXPERIMENT_CHANGE_EVENT, onWindowEvent);
+    const channel = getChannel();
+    channel?.addEventListener('message', onChannelMessage);
     return () => {
       cancelled = true;
-      window.removeEventListener(EXPERIMENT_CHANGE_EVENT, onChange);
+      window.removeEventListener(EXPERIMENT_CHANGE_EVENT, onWindowEvent);
+      channel?.removeEventListener('message', onChannelMessage);
     };
   }, [key]);
 

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -29,6 +29,11 @@ export type UserPreferenceKeyMap = {
   tickBarExpanded: boolean;
   'shakeToReport:dismissed': boolean;
   esp32Connections: Esp32Connection[];
+  // Experiment opt-ins exposed through the avatar → Experiments drawer.
+  // Keep the `experiment:` prefix so the IndexedDB store and any future
+  // bulk-clear path (e.g. a "reset all experiments" action) can match by
+  // prefix without enumerating every flag.
+  'experiment:queueBarFab': boolean;
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -30,9 +30,6 @@ export type UserPreferenceKeyMap = {
   'shakeToReport:dismissed': boolean;
   esp32Connections: Esp32Connection[];
   // Experiment opt-ins exposed through the avatar → Experiments drawer.
-  // Keep the `experiment:` prefix so the IndexedDB store and any future
-  // bulk-clear path (e.g. a "reset all experiments" action) can match by
-  // prefix without enumerating every flag.
   'experiment:queueBarFab': boolean;
 };
 

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -100,7 +100,16 @@
     "about": "About",
     "rateBoardsesh": "Rate Boardsesh",
     "reportBug": "Report a bug",
-    "logout": "Log out"
+    "logout": "Log out",
+    "experiments": "Experiments"
+  },
+  "experiments": {
+    "title": "Experiments",
+    "subtitle": "Try out features that aren't ready for everyone yet. Toggle anytime — no restart needed.",
+    "queueBarFab": {
+      "label": "Compact queue bar",
+      "description": "Collapses the queue bar to a floating button cluster on most pages, with a brief peek when the climb changes."
+    }
   },
   "loading": {
     "messages": [

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -100,7 +100,16 @@
     "about": "À propos",
     "rateBoardsesh": "Noter Boardsesh",
     "reportBug": "Signaler un bug",
-    "logout": "Se déconnecter"
+    "logout": "Se déconnecter",
+    "experiments": "Expériences"
+  },
+  "experiments": {
+    "title": "Expériences",
+    "subtitle": "Essayez des fonctionnalités encore en cours de finition. Activables et désactivables à la volée — aucun redémarrage requis.",
+    "queueBarFab": {
+      "label": "Barre de file compacte",
+      "description": "Réduit la barre de file en un groupe de boutons flottants sur la plupart des pages, avec un aperçu bref lors du changement de voie."
+    }
   },
   "loading": {
     "messages": [


### PR DESCRIPTION
## Summary
- Roll back the minimised FAB queue-control bar to always-expanded for everyone by default; keep the FAB code in place behind an opt-in.
- Introduce a tiny experiments registry (`packages/web/app/lib/experiments.ts`) with a `useExperiment` hook + `setExperiment` writer, persisted to IndexedDB through the existing `user-preferences-db` and broadcast in-tab via a `boardsesh:experiment-changed` window event.
- Add an Experiments drawer (left placement, slides in from the avatar drawer) with one MUI `Switch` per registered experiment. First entry is **Compact queue bar**, defaulting to off.
- In `queue-control-bar.tsx`, gate the initial `layoutState`, the route-reset effect default, `useScrollDirection.enabled`, and the `<QueueControlFab>` render on `useExperiment('queueBarFab')`. With the experiment off, the bar skips the state machine, the scroll listener, the peek timer, and the FAB DOM entirely.

## Why
Product wants the original always-expanded bar back as the default while keeping the FAB experience available for A/B-style opt-in. A user-facing toggle is the cheapest path to that — no remote flag client to wire up — and the existing IndexedDB preference store already gives us per-user persistence.

## Test plan
- [ ] Default (experiment off): on `/.../view/...` the bar renders fully expanded from first paint, no FAB cluster, no peek snackbar on next/previous climb, no collapse on scroll on `/list`.
- [ ] Avatar (top-left) → drawer shows **Experiments** between *Settings* and *Dev URL* (flask icon). Tapping it closes the avatar drawer and opens the experiments drawer.
- [ ] Toggling **Compact queue bar** flips the bar to FAB mode immediately without reload; toggling off reverts.
- [ ] Reload preserves toggle state (IndexedDB).
- [ ] DevTools → Performance: 5s scroll on `/list` with experiment off shows no React renders triggered by scroll and no scroll-listener work.
- [ ] `vp check`, `vp run typecheck:web`, and `vp test --project web` all pass (the existing 229 queue-control tests + 6 new flag-off tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)