### PR TITLE
Spare climb shape in disco; add LED color picker

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -270,7 +270,7 @@ describe('useBoardBluetooth', () => {
 
     expect(sendResult).toBe(true);
     expect(mockGetLedPlacements).toHaveBeenCalledWith('kilter', 1, 10);
-    expect(mockGetAuroraBluetoothPacket).toHaveBeenCalledWith('p4131r42', { 4131: 39 }, 'kilter', 3);
+    expect(mockGetAuroraBluetoothPacket).toHaveBeenCalledWith('p4131r42', { 4131: 39 }, 'kilter', 3, undefined);
     expect(mockGetMoonboardBluetoothPacket).not.toHaveBeenCalled();
     expect(mockAdapter.write).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]), undefined);
   });

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-aurora.ts
@@ -2,7 +2,14 @@ import type { LedPlacements } from '@/app/lib/types';
 import { HOLD_STATE_MAP } from '../board-renderer/types';
 import { AURORA_ADVERTISED_SERVICE_UUID, MESSAGE_BODY_MAX_LENGTH, UART_SERVICE_UUID } from './bluetooth-shared';
 import type { AuroraBoardName } from '@/app/lib/api-wrappers/aurora/types';
-import { AURORA_BOARDS } from '@boardsesh/shared-schema';
+import { AURORA_BOARDS, type HoldState } from '@boardsesh/shared-schema';
+
+/**
+ * Optional per-state hex colour overrides (`#rrggbb` or `rrggbb`). When a
+ * frame's role code maps to one of these states, the override replaces the
+ * canonical colour from `HOLD_STATE_MAP` for that LED only.
+ */
+export type LedColorOverrides = Partial<Record<HoldState, string>>;
 
 // --- API v3 command bytes (3 bytes per LED, 16-bit positions) ---
 const V3_PACKET_MIDDLE = 81; // 'Q'
@@ -185,6 +192,7 @@ export const getAuroraBluetoothPacket = (
   placementPositions: LedPlacements,
   boardName: AuroraBoardName,
   apiLevel: number = 3,
+  colorOverrides?: LedColorOverrides,
 ): BluetoothPacketResult => {
   const isV2 = apiLevel < 3;
   const cmds = isV2 ? V2_COMMANDS : V3_COMMANDS;
@@ -225,7 +233,9 @@ export const getAuroraBluetoothPacket = (
       return;
     }
 
-    const color = state.color.replace('#', '');
+    const overrideForState = colorOverrides?.[state.name];
+    const colorSource = overrideForState ?? state.color;
+    const color = colorSource.replace('#', '');
     ledEntries.push({ position: ledPosition, color });
   });
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -26,6 +26,7 @@ import { buildSwitchUrl, decidePickerSelection, type ResolvedBoardConfig } from 
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { DiscoveredDevice } from '@/app/lib/ble/types';
 import type { PickerState } from './use-board-bluetooth';
+import { useLedColorOverrides, type LedColorOverrides } from '@/app/lib/led-color-overrides-db';
 
 type BluetoothContextValue = {
   isConnected: boolean;
@@ -49,6 +50,11 @@ type BluetoothContextValue = {
    * current climb's holds through random role colours. */
   partyMode: 'off' | 'glyphs' | 'disco';
   setPartyMode: (mode: 'off' | 'glyphs' | 'disco') => void;
+  /** Per-state hex colour overrides for HAND/FOOT/FINISH LEDs. Persisted in
+   * IndexedDB; consumers update via setLedColorOverrides which re-renders
+   * the auto-sender so the current climb repaints. */
+  ledColorOverrides: LedColorOverrides;
+  setLedColorOverrides: (next: LedColorOverrides) => void;
   isBluetoothSupported: boolean;
   isIOS: boolean;
 };
@@ -136,9 +142,12 @@ export function BluetoothProvider({
   boardUuid?: string;
   children: React.ReactNode;
 }) {
+  const [ledColorOverrides, setLedColorOverrides] = useLedColorOverrides();
+
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } = useBoardBluetooth({
     boardDetails,
     boardUuid,
+    ledColorOverrides,
   });
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
@@ -351,6 +360,8 @@ export function BluetoothProvider({
       boardDetails,
       partyMode,
       setPartyMode,
+      ledColorOverrides,
+      setLedColorOverrides,
       isBluetoothSupported,
       isIOS,
     }),
@@ -364,6 +375,8 @@ export function BluetoothProvider({
       boardDetails,
       partyMode,
       setPartyMode,
+      ledColorOverrides,
+      setLedColorOverrides,
       isBluetoothSupported,
       isIOS,
     ],

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -5,7 +5,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { track } from '@vercel/analytics';
 import * as Sentry from '@sentry/nextjs';
 import type { BoardDetails } from '@/app/lib/types';
-import { getAuroraBluetoothPacket, parseApiLevel, parseSerialNumber } from './bluetooth-aurora';
+import { getAuroraBluetoothPacket, parseApiLevel, parseSerialNumber, type LedColorOverrides } from './bluetooth-aurora';
 import { getMoonboardBluetoothPacket } from './bluetooth-moonboard';
 import type { HoldRenderData } from '../board-renderer/types';
 import { useWakeLock } from './use-wake-lock';
@@ -55,6 +55,10 @@ type UseBoardBluetoothOptions = {
   /** Saved board UUID when on a /b/{slug}/... route — used to link the recorded serial mapping. */
   boardUuid?: string;
   onConnectionChange?: (connected: boolean) => void;
+  /** Per-state hex colour overrides applied at packet build time. Changing
+   * this re-creates `sendFramesToBoard` so the auto-sender repaints the
+   * current climb with the new colours. */
+  ledColorOverrides?: LedColorOverrides;
 };
 
 /**
@@ -85,7 +89,12 @@ function recordBoardSerial(serialNumber: string, boardDetails: BoardDetails, boa
   }).catch(() => {});
 }
 
-export function useBoardBluetooth({ boardDetails, boardUuid, onConnectionChange }: UseBoardBluetoothOptions) {
+export function useBoardBluetooth({
+  boardDetails,
+  boardUuid,
+  onConnectionChange,
+  ledColorOverrides,
+}: UseBoardBluetoothOptions) {
   const { showMessage } = useSnackbar();
   const [loading, setLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
@@ -203,6 +212,7 @@ export function useBoardBluetooth({ boardDetails, boardUuid, onConnectionChange 
           placementPositions,
           boardDetails.board_name,
           apiLevelRef.current,
+          ledColorOverrides,
         );
 
         const skippedCount = result.skippedPositionCount + result.skippedRoleCount;
@@ -260,7 +270,7 @@ export function useBoardBluetooth({ boardDetails, boardUuid, onConnectionChange 
         return false;
       }
     },
-    [boardDetails, showMessage],
+    [boardDetails, showMessage, ledColorOverrides],
   );
 
   // Handle connection initiation

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -1,21 +1,32 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import Celebration from '@mui/icons-material/Celebration';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
 import AutoAwesome from '@mui/icons-material/AutoAwesome';
+import Palette from '@mui/icons-material/Palette';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { useCurrentClimb } from '../graphql-queue';
-import { STATE_TO_PRIMARY_CODE } from '../board-renderer/types';
+import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '../board-renderer/types';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { GLYPHS, PARTY_LETTERS, buildPartyFrames, mapGlyphToHolds } from './party-glyphs';
+import { CUSTOMISABLE_LED_ROLES, type CustomisableLedRole } from '@/app/lib/led-color-overrides-db';
+import type { BoardName } from '@boardsesh/shared-schema';
 
 const PARTY_TICK_MS = 600;
 const DISCO_TICK_MS = 450;
@@ -26,32 +37,59 @@ type LightControlDrawerProps = {
 };
 
 /**
- * Pull just the placement IDs out of a frame string like "p123r42p55r43".
- * Empty / malformed frames return [], so the disco effect no-ops gracefully
- * when the climb has no lit holds.
+ * Pull just the HAND-role placement IDs out of a frame string. Disco strobes
+ * only the regular hand-hold (the "blue" holds in climbing convention) so
+ * START/FOOT/FINISH stay at their canonical colours throughout — those are
+ * the cues climbers actually rely on while sending the route.
  */
-function extractPlacementIds(frames: string): number[] {
+function extractHandPlacementIds(frames: string, boardName: BoardName): number[] {
   if (!frames) return [];
+  const stateMap = HOLD_STATE_MAP[boardName];
+  if (!stateMap) return [];
   const ids: number[] = [];
   for (const segment of frames.split('p')) {
     if (!segment) continue;
-    const placementStr = segment.split('r')[0];
+    const [placementStr, roleStr] = segment.split('r');
     const placementId = Number(placementStr);
-    if (Number.isFinite(placementId)) ids.push(placementId);
+    const roleCode = Number(roleStr);
+    if (!Number.isFinite(placementId) || !Number.isFinite(roleCode)) continue;
+    if (stateMap[roleCode]?.name === 'HAND') ids.push(placementId);
   }
   return ids;
+}
+
+/**
+ * Default hex shown in the colour picker when the user hasn't customised this
+ * role yet — the canonical role colour for the active board so the swatch
+ * starts on whatever the LEDs are actually emitting.
+ */
+function getDefaultRoleColor(role: CustomisableLedRole, boardName: BoardName): string {
+  const code = STATE_TO_PRIMARY_CODE[boardName]?.[role];
+  if (code == null) return '#0000ff';
+  return HOLD_STATE_MAP[boardName]?.[code]?.color ?? '#0000ff';
 }
 
 export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, onClose }) => {
   const { t } = useTranslation('common');
   const { showMessage } = useSnackbar();
-  const { isConnected, sendFramesToBoard, clearBoard, boardDetails, partyMode, setPartyMode } = useBluetoothContext();
+  const {
+    isConnected,
+    sendFramesToBoard,
+    clearBoard,
+    boardDetails,
+    partyMode,
+    setPartyMode,
+    ledColorOverrides,
+    setLedColorOverrides,
+  } = useBluetoothContext();
   const { currentClimbQueueItem } = useCurrentClimb();
 
   const isMoonboard = boardDetails.board_name === 'moonboard';
   const climbFrames = currentClimbQueueItem?.climb.frames ?? '';
   const climbMirrored = !!currentClimbQueueItem?.climb.mirrored;
   const hasClimbLoaded = climbFrames.length > 0;
+
+  const [colorDialogOpen, setColorDialogOpen] = useState(false);
 
   // Pre-snap each unique letter's bitmap to hold IDs once per board config —
   // the snap is deterministic so we don't need to re-run it every tick.
@@ -89,10 +127,11 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     return () => window.clearInterval(intervalId);
   }, [partyMode, isConnected, isMoonboard, boardDetails.board_name, lettersToHoldIds, sendFramesToBoard]);
 
-  // Disco mode: keep the current climb's lit holds, but reroll each hold's
-  // colour every tick. The placement IDs come straight from the climb's
-  // frames string so swapping climbs while the disco is running picks up
-  // the new holds on the next tick.
+  // Disco mode: keep the START/FOOT/FINISH holds at their canonical colours
+  // (so the climb stays readable) and re-roll only the HAND holds' colours
+  // every tick. Placement IDs come straight from the climb's frames so
+  // swapping climbs while the disco is running picks up the new holds on
+  // the next tick.
   useEffect(() => {
     if (partyMode !== 'disco' || !isConnected) return;
 
@@ -101,14 +140,31 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     );
     if (stateCodes.length === 0) return;
 
-    const placementIds = extractPlacementIds(climbFrames);
-    if (placementIds.length === 0) return;
+    const handPlacementIds = extractHandPlacementIds(climbFrames, boardDetails.board_name);
+    if (handPlacementIds.length === 0) return;
+
+    // Preserve the original frames for non-HAND holds — strip out only the
+    // HAND segments and append fresh randomised role codes for them. Built
+    // once per disco activation; the random roll happens inside the tick.
+    const baseSegments: string[] = [];
+    const stateMap = HOLD_STATE_MAP[boardDetails.board_name];
+    if (stateMap) {
+      for (const segment of climbFrames.split('p')) {
+        if (!segment) continue;
+        const [placementStr, roleStr] = segment.split('r');
+        const roleCode = Number(roleStr);
+        if (!Number.isFinite(roleCode)) continue;
+        if (stateMap[roleCode]?.name === 'HAND') continue;
+        baseSegments.push(`p${placementStr}r${roleStr}`);
+      }
+    }
+    const baseFrames = baseSegments.join('');
 
     const sendDiscoFrame = () => {
-      const frames = placementIds
+      const handFrames = handPlacementIds
         .map((id) => `p${id}r${stateCodes[Math.floor(Math.random() * stateCodes.length)]}`)
         .join('');
-      void sendFramesToBoard(frames, climbMirrored);
+      void sendFramesToBoard(`${baseFrames}${handFrames}`, climbMirrored);
     };
     sendDiscoFrame();
     const intervalId = window.setInterval(sendDiscoFrame, DISCO_TICK_MS);
@@ -156,30 +212,91 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     setPartyMode(partyMode === 'disco' ? 'off' : 'disco');
   };
 
+  const handleColorChange = (role: CustomisableLedRole, hex: string) => {
+    setLedColorOverrides({ ...ledColorOverrides, [role]: hex });
+  };
+
+  const handleColorReset = () => {
+    setLedColorOverrides({});
+  };
+
   return (
-    <SwipeableDrawer placement="bottom" open={open} onClose={onClose} title={t('lightControl.title')} height="auto">
-      <List disablePadding>
-        <ListItemButton onClick={handleClearAll} disabled={!isConnected}>
-          <ListItemIcon>
-            <LightbulbOutlined />
-          </ListItemIcon>
-          <ListItemText primary={t('lightControl.turnOffAll')} />
-        </ListItemButton>
-        <ListItemButton onClick={handleDiscoToggle} disabled={!isConnected || !hasClimbLoaded}>
-          <ListItemIcon>{partyMode === 'disco' ? <StopCircleOutlined /> : <AutoAwesome />}</ListItemIcon>
-          <ListItemText
-            primary={partyMode === 'disco' ? t('lightControl.stopDisco') : t('lightControl.discoMode')}
-            secondary={!hasClimbLoaded ? t('lightControl.discoNeedsClimb') : undefined}
-          />
-        </ListItemButton>
-        <ListItemButton onClick={handlePartyToggle} disabled={!isConnected || isMoonboard}>
-          <ListItemIcon>{partyMode === 'glyphs' ? <StopCircleOutlined /> : <Celebration />}</ListItemIcon>
-          <ListItemText
-            primary={partyMode === 'glyphs' ? t('lightControl.stopParty') : t('lightControl.partyMode')}
-            secondary={isMoonboard ? t('lightControl.partyUnsupported') : undefined}
-          />
-        </ListItemButton>
-      </List>
-    </SwipeableDrawer>
+    <>
+      <SwipeableDrawer placement="bottom" open={open} onClose={onClose} title={t('lightControl.title')} height="auto">
+        <List disablePadding>
+          <ListItemButton onClick={handleClearAll} disabled={!isConnected}>
+            <ListItemIcon>
+              <LightbulbOutlined />
+            </ListItemIcon>
+            <ListItemText primary={t('lightControl.turnOffAll')} />
+          </ListItemButton>
+          <ListItemButton onClick={handleDiscoToggle} disabled={!isConnected || !hasClimbLoaded}>
+            <ListItemIcon>{partyMode === 'disco' ? <StopCircleOutlined /> : <AutoAwesome />}</ListItemIcon>
+            <ListItemText
+              primary={partyMode === 'disco' ? t('lightControl.stopDisco') : t('lightControl.discoMode')}
+              secondary={!hasClimbLoaded ? t('lightControl.discoNeedsClimb') : undefined}
+            />
+          </ListItemButton>
+          <ListItemButton onClick={handlePartyToggle} disabled={!isConnected || isMoonboard}>
+            <ListItemIcon>{partyMode === 'glyphs' ? <StopCircleOutlined /> : <Celebration />}</ListItemIcon>
+            <ListItemText
+              primary={partyMode === 'glyphs' ? t('lightControl.stopParty') : t('lightControl.partyMode')}
+              secondary={isMoonboard ? t('lightControl.partyUnsupported') : undefined}
+            />
+          </ListItemButton>
+          <ListItemButton onClick={() => setColorDialogOpen(true)} disabled={isMoonboard}>
+            <ListItemIcon>
+              <Palette />
+            </ListItemIcon>
+            <ListItemText
+              primary={t('lightControl.customizeColors')}
+              secondary={isMoonboard ? t('lightControl.customizeColorsUnsupported') : undefined}
+            />
+          </ListItemButton>
+        </List>
+      </SwipeableDrawer>
+      <Dialog open={colorDialogOpen} onClose={() => setColorDialogOpen(false)} fullWidth maxWidth="xs">
+        <DialogTitle>{t('lightControl.customizeColorsTitle')}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {t('lightControl.customizeColorsHelp')}
+          </Typography>
+          <Stack spacing={2}>
+            {CUSTOMISABLE_LED_ROLES.map((role) => {
+              const fallback = getDefaultRoleColor(role, boardDetails.board_name);
+              const value = ledColorOverrides[role] ?? fallback;
+              return (
+                <Box key={role} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
+                  <Typography variant="body1">{t(`lightControl.role.${role}`)}</Typography>
+                  <Box
+                    component="input"
+                    type="color"
+                    value={value}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                      handleColorChange(role, event.target.value)
+                    }
+                    sx={{
+                      width: 56,
+                      height: 40,
+                      border: 'none',
+                      padding: 0,
+                      background: 'transparent',
+                      cursor: 'pointer',
+                    }}
+                    aria-label={t(`lightControl.role.${role}`)}
+                  />
+                </Box>
+              );
+            })}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleColorReset}>{t('lightControl.resetColors')}</Button>
+          <Button onClick={() => setColorDialogOpen(false)} variant="contained">
+            {t('actions.done')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };

--- a/packages/web/app/lib/led-color-overrides-db.ts
+++ b/packages/web/app/lib/led-color-overrides-db.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { openDB, type IDBPDatabase } from 'idb';
+import type { HoldState } from '@boardsesh/shared-schema';
+
+/**
+ * User-configurable hex colour overrides for LED roles. Only HAND/FOOT/FINISH
+ * are user-customisable; STARTING stays the canonical green so first-look
+ * climbing convention isn't broken.
+ *
+ * Values are stored as `#rrggbb` strings (lowercase, with leading `#`). A
+ * missing key falls back to the board's canonical role colour at packet
+ * build time — so an unset override is functionally equivalent to "default".
+ */
+export type LedColorOverrides = Partial<Record<Extract<HoldState, 'HAND' | 'FOOT' | 'FINISH'>, string>>;
+
+export const CUSTOMISABLE_LED_ROLES = ['HAND', 'FOOT', 'FINISH'] as const;
+export type CustomisableLedRole = (typeof CUSTOMISABLE_LED_ROLES)[number];
+
+const DB_NAME = 'boardsesh-led-colors';
+const STORE_NAME = 'overrides';
+const RECORD_KEY = 'current';
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+
+function getDb(): Promise<IDBPDatabase> | null {
+  // jsdom-based test environments expose `window` but lack `indexedDB`, so a
+  // bare `typeof window` check would still let `openDB` blow up. The narrower
+  // guard keeps SSR + tests + private-mode browsers all on the no-op path.
+  if (typeof window === 'undefined' || typeof indexedDB === 'undefined') return null;
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      },
+    }).catch((error) => {
+      console.error('Failed to open LED color overrides DB:', error);
+      // Reset so a later call can retry — but return a never-resolving stub
+      // for this call so the caller's awaits don't reject. The reset must
+      // happen *after* returning the rejected promise, so callers above
+      // see a single rejection and we stop retrying within the same tick.
+      dbPromise = null;
+      throw error;
+    });
+  }
+  return dbPromise;
+}
+
+export async function getLedColorOverrides(): Promise<LedColorOverrides> {
+  const dbReq = getDb();
+  if (!dbReq) return {};
+  try {
+    const db = await dbReq;
+    const value = await db.get(STORE_NAME, RECORD_KEY);
+    return (value as LedColorOverrides | undefined) ?? {};
+  } catch (error) {
+    console.error('Failed to read LED color overrides:', error);
+    return {};
+  }
+}
+
+export async function setLedColorOverrides(overrides: LedColorOverrides): Promise<void> {
+  const dbReq = getDb();
+  if (!dbReq) return;
+  try {
+    const db = await dbReq;
+    await db.put(STORE_NAME, overrides, RECORD_KEY);
+    notify(overrides);
+  } catch (error) {
+    console.error('Failed to write LED color overrides:', error);
+  }
+}
+
+// In-process pub-sub so multiple components in the same tab stay in sync
+// without each having to round-trip through IndexedDB on every change.
+const listeners = new Set<(overrides: LedColorOverrides) => void>();
+
+function notify(overrides: LedColorOverrides) {
+  for (const listener of listeners) listener(overrides);
+}
+
+/**
+ * Subscribe to LED colour-override changes. Returns the current value plus a
+ * setter that persists to IndexedDB and notifies all live subscribers.
+ */
+export function useLedColorOverrides(): [LedColorOverrides, (next: LedColorOverrides) => void] {
+  const [overrides, setOverrides] = useState<LedColorOverrides>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    getLedColorOverrides()
+      .then((value) => {
+        if (!cancelled) setOverrides(value);
+      })
+      .catch(() => {
+        // getLedColorOverrides already logs — swallow here so React doesn't
+        // surface an unhandled rejection in environments without IndexedDB.
+      });
+    const listener = (value: LedColorOverrides) => setOverrides(value);
+    listeners.add(listener);
+    return () => {
+      cancelled = true;
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const update = (next: LedColorOverrides) => {
+    setOverrides(next);
+    void setLedColorOverrides(next);
+  };
+
+  return [overrides, update];
+}

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -17,7 +17,17 @@
     "discoMode": "Disco the climb",
     "stopDisco": "Stop disco",
     "discoNeedsClimb": "Load a climb to start the disco",
-    "clearFailed": "Couldn't clear the board"
+    "clearFailed": "Couldn't clear the board",
+    "customizeColors": "Customize LED colors",
+    "customizeColorsUnsupported": "Custom colors aren't available on this board",
+    "customizeColorsTitle": "LED colors",
+    "customizeColorsHelp": "Pick the colors your board lights up for hands, feet, and the finish hold. Start holds keep their default green.",
+    "resetColors": "Reset",
+    "role": {
+      "HAND": "Hands",
+      "FOOT": "Feet",
+      "FINISH": "Finish"
+    }
   },
   "actions": {
     "yes": "Yes",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -17,7 +17,17 @@
     "discoMode": "Disco sur le bloc",
     "stopDisco": "Arrêter le disco",
     "discoNeedsClimb": "Chargez un bloc pour lancer le disco",
-    "clearFailed": "Impossible d'éteindre le board"
+    "clearFailed": "Impossible d'éteindre le board",
+    "customizeColors": "Personnaliser les couleurs LED",
+    "customizeColorsUnsupported": "Couleurs personnalisées indisponibles sur ce board",
+    "customizeColorsTitle": "Couleurs des LED",
+    "customizeColorsHelp": "Choisissez les couleurs des prises pour les mains, les pieds et l'arrivée. Les prises de départ gardent leur vert par défaut.",
+    "resetColors": "Réinitialiser",
+    "role": {
+      "HAND": "Mains",
+      "FOOT": "Pieds",
+      "FINISH": "Arrivée"
+    }
   },
   "actions": {
     "yes": "Oui",


### PR DESCRIPTION
## Summary

- Disco mode now re-rolls colours only on HAND placements; STARTING/FOOT/FINISH keep their canonical role colours every tick so the route's shape stays readable while the hands strobe
- New "Customize LED colors" entry in the lights drawer opens a dialog with HAND / FOOT / FINISH colour swatches that persist in IndexedDB and are applied at BLE packet build time
- STARTING stays at the board's canonical green (climbing convention — first-look cue)
- Threads an optional \`colorOverrides\` map through \`getAuroraBluetoothPacket\` keyed by \`HoldState\`; falls back to \`HOLD_STATE_MAP\` when a state isn't overridden. MoonBoard's separate packet path doesn't share this lookup, so the entry is disabled there

## Test plan

- [ ] Pair a Kilter or Tension board, load any climb, hit **Disco the climb** — only HAND holds flicker; START/FOOT/FINISH stay at their canonical colours
- [ ] **Customize LED colors** → pick custom hex for Hands, Feet, Finish → send a climb → verify BLE LEDs render the chosen colours; reload page → values persist
- [ ] **Reset** clears all overrides; the climb re-renders with defaults
- [ ] Toggle disco while a custom hand colour is set — disco's random palette shows during the show; on stop, the climb returns with the custom hand colour applied
- [ ] MoonBoard: customize entry is disabled with the "isn't available" subtitle
- [ ] No climb loaded: disco button stays disabled with the existing prompt

## Notes

- The SVG board renderer still uses the canonical role colours; only the physical BLE LEDs honour overrides. SVG palette rewiring is a much larger surface and intentionally out of scope here
- French \`common.json\` was missing the disco keys from the prior commit — added the new \`customizeColors\` keys plus backfilled the prior gap so the i18n catalog completeness test for \`fr/common.json\` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)