### PR TITLE
[codex] fix iOS zone filter dragging

### DIFF
--- a/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
@@ -323,6 +323,49 @@ describe('ClimbSearchForm — drag handles', () => {
     expect(back.y).toBeCloseTo(31);
   });
 
+  it('marks zone handles as swipe-blocked so drawer gestures ignore zone drags', () => {
+    const startZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
+    mockUISearchParams = {
+      ...DEFAULT_SEARCH_PARAMS,
+      zoneBox: startZone,
+    };
+    render(<ClimbSearchForm boardDetails={boardDetails} />);
+
+    const seHandle = screen.getByTestId('zone-handle-se');
+    const moveHandle = screen.getByTestId('zone-handle-move');
+
+    expect(screen.getByTestId('zone-board-container').closest('[data-swipe-blocked]')).toBe(
+      screen.getByTestId('zone-board-container'),
+    );
+    expect(seHandle.closest('[data-swipe-blocked]')).toBe(seHandle);
+    expect(moveHandle.closest('[data-swipe-blocked]')).toBe(moveHandle);
+  });
+
+  it('renders larger invisible hit targets around zone handles', () => {
+    const startZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
+    mockUISearchParams = {
+      ...DEFAULT_SEARCH_PARAMS,
+      zoneBox: startZone,
+    };
+    render(<ClimbSearchForm boardDetails={boardDetails} />);
+
+    const seHandleRadius = Number(screen.getByTestId('zone-handle-se').getAttribute('r'));
+    const seHitRadius = Number(screen.getByTestId('zone-hit-se').getAttribute('r'));
+    const moveHandleRadius = Number(screen.getByTestId('zone-handle-move').getAttribute('r'));
+    const moveHitRadius = Number(screen.getByTestId('zone-hit-move').getAttribute('r'));
+    const moveBorderHitTarget = screen.getByTestId('zone-hit-move-border');
+
+    expect(seHitRadius).toBeGreaterThan(seHandleRadius * 2);
+    expect(moveHitRadius).toBeGreaterThan(moveHandleRadius * 2);
+    expect(Number(moveBorderHitTarget.getAttribute('stroke-width'))).toBe(seHitRadius);
+    expect(moveBorderHitTarget.getAttribute('pointer-events')).toBe('stroke');
+    expect(screen.getByTestId('zone-hit-se').closest('[data-swipe-blocked]')).toBe(screen.getByTestId('zone-hit-se'));
+    expect(screen.getByTestId('zone-hit-move').closest('[data-swipe-blocked]')).toBe(
+      screen.getByTestId('zone-hit-move'),
+    );
+    expect(moveBorderHitTarget.closest('[data-swipe-blocked]')).toBe(moveBorderHitTarget);
+  });
+
   it('dragging the SE corner shrinks the zone and prunes holds outside the new box', () => {
     const startZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
     mockUISearchParams = {
@@ -350,6 +393,29 @@ describe('ClimbSearchForm — drag handles', () => {
     // Hold 101 at grid (60, 80) is inside the new box; the other two are
     // dropped. Critical check: a regression that removed pruneHoldsToZone
     // from endDrag (while keeping it in handleEnable) would fail here.
+    expect(dragCall?.holdsFilter).toEqual({ 101: { STARTING: 'include' } });
+  });
+
+  it('persists the latest valid drag box when iOS cancels with bogus coordinates', () => {
+    const startZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
+    mockUISearchParams = {
+      ...DEFAULT_SEARCH_PARAMS,
+      holdsFilter: filterAllThreeHolds,
+      zoneBox: startZone,
+    };
+    render(<ClimbSearchForm boardDetails={boardDetails} />);
+
+    const seHandle = screen.getByTestId('zone-handle-se');
+
+    fireEvent.pointerDown(seHandle, { clientX: 862.5, clientY: 937.5, pointerId: 1 });
+    fireEvent.pointerMove(seHandle, { clientX: 525, clientY: 600, pointerId: 1 });
+    fireEvent.pointerCancel(seHandle, { clientX: 0, clientY: 1170, pointerId: 1 });
+
+    const dragCall = mockUpdateFilters.mock.calls.at(-1)?.[0] as
+      | { zoneBox: ZoneBox; holdsFilter: HoldsFilter }
+      | undefined;
+    expect(dragCall).toBeDefined();
+    expect(dragCall?.zoneBox).toEqual({ edgeLeft: 29, edgeRight: 70, edgeBottom: 76, edgeTop: 125 });
     expect(dragCall?.holdsFilter).toEqual({ 101: { STARTING: 'include' } });
   });
 

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -107,6 +107,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
 
   const defaultZone = useMemo(() => buildDefaultZone(dims), [dims]);
   const handleRadius = useMemo(() => computeHandleRadius(dims), [dims]);
+  const handleHitRadius = handleRadius * 2.25;
 
   // Local zone mirrors the URL param so dragging stays smooth without
   // hammering the search debounce on every pointermove.
@@ -124,6 +125,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
     startGridX: number;
     startGridY: number;
     startBox: ZoneBox;
+    latestBox: ZoneBox;
   } | null>(null);
 
   const svgPointToGrid = useCallback(
@@ -255,6 +257,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
         startGridX: grid.x,
         startGridY: grid.y,
         startBox: localZone,
+        latestBox: localZone,
       };
     },
     [localZone, svgPointToGrid],
@@ -264,17 +267,42 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
     (event: React.PointerEvent<SVGElement>) => {
       const drag = dragStateRef.current;
       if (!drag || event.pointerId !== drag.pointerId) return;
+      event.preventDefault();
+      event.stopPropagation();
       const grid = svgPointToGrid(event.clientX, event.clientY);
       if (!grid) return;
-      setLocalZone(applyDrag(drag.startBox, drag.mode, grid.x - drag.startGridX, grid.y - drag.startGridY, dims));
+      const nextZone = applyDrag(
+        drag.startBox,
+        drag.mode,
+        grid.x - drag.startGridX,
+        grid.y - drag.startGridY,
+        dims,
+      );
+      drag.latestBox = nextZone;
+      setLocalZone(nextZone);
     },
     [dims, svgPointToGrid],
   );
 
-  const endDrag = useCallback(
+  const persistDraggedZone = useCallback(
+    (finalZone: ZoneBox) => {
+      setLocalZone(finalZone);
+      updateFilters({ zoneBox: finalZone, holdsFilter: pruneHoldsToZone(finalZone) });
+      track('Search Zone Updated', {
+        boardLayout: boardDetails.layout_name || '',
+        width: finalZone.edgeRight - finalZone.edgeLeft,
+        height: finalZone.edgeTop - finalZone.edgeBottom,
+      });
+    },
+    [boardDetails.layout_name, pruneHoldsToZone, updateFilters],
+  );
+
+  const handlePointerUp = useCallback(
     (event: React.PointerEvent<SVGElement>) => {
       const drag = dragStateRef.current;
       if (!drag || event.pointerId !== drag.pointerId) return;
+      event.preventDefault();
+      event.stopPropagation();
       dragStateRef.current = null;
       (event.target as Element).releasePointerCapture?.(event.pointerId);
       // Compute the final zone directly from the drag start state plus the
@@ -287,16 +315,26 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
       const grid = svgPointToGrid(event.clientX, event.clientY);
       const finalZone = grid
         ? applyDrag(drag.startBox, drag.mode, grid.x - drag.startGridX, grid.y - drag.startGridY, dims)
-        : drag.startBox;
-      setLocalZone(finalZone);
-      updateFilters({ zoneBox: finalZone, holdsFilter: pruneHoldsToZone(finalZone) });
-      track('Search Zone Updated', {
-        boardLayout: boardDetails.layout_name || '',
-        width: finalZone.edgeRight - finalZone.edgeLeft,
-        height: finalZone.edgeTop - finalZone.edgeBottom,
-      });
+        : drag.latestBox;
+      persistDraggedZone(finalZone);
     },
-    [boardDetails.layout_name, dims, pruneHoldsToZone, svgPointToGrid, updateFilters],
+    [dims, persistDraggedZone, svgPointToGrid],
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: React.PointerEvent<SVGElement>) => {
+      const drag = dragStateRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragStateRef.current = null;
+      (event.target as Element).releasePointerCapture?.(event.pointerId);
+      // iOS can cancel pointer streams with coordinates unrelated to the
+      // user's last finger position. Persist the last valid move instead of
+      // recalculating from the cancel event.
+      persistDraggedZone(drag.latestBox);
+    },
+    [persistDraggedZone],
   );
 
   // Drag pointer handlers attach to each interactive handle directly
@@ -308,8 +346,8 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
   // capture self-contained.
   const dragHandlers = {
     onPointerMove: handlePointerMove,
-    onPointerUp: endDrag,
-    onPointerCancel: endDrag,
+    onPointerUp: handlePointerUp,
+    onPointerCancel: handlePointerCancel,
   };
 
   const rectSvg = useMemo(() => {
@@ -387,7 +425,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
         </Stack>
       </div>
 
-      <div className={styles.boardContainer}>
+      <div className={styles.boardContainer} data-testid="zone-board-container" data-swipe-blocked="">
         <BoardRenderer
           boardDetails={tightenedBoardDetails}
           litUpHoldsMap={{}}
@@ -417,6 +455,22 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
             className={styles.zoneOverlaySvg}
           >
             <rect
+              data-testid="zone-hit-move-border"
+              x={rectSvg.x}
+              y={rectSvg.y}
+              width={rectSvg.width}
+              height={rectSvg.height}
+              fill="none"
+              stroke="transparent"
+              strokeWidth={handleHitRadius}
+              onPointerDown={beginDrag('move')}
+              className={styles.zoneDragTarget}
+              data-swipe-blocked=""
+              cursor="move"
+              pointerEvents="stroke"
+              {...dragHandlers}
+            />
+            <rect
               x={rectSvg.x}
               y={rectSvg.y}
               width={rectSvg.width}
@@ -432,6 +486,19 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
                 under the zone fill stay tappable. Sized to match the corner
                 handles so it's a proper touch target on mobile. */}
             <circle
+              data-testid="zone-hit-move"
+              cx={rectSvg.centerX}
+              cy={rectSvg.centerY}
+              r={handleHitRadius}
+              fill="transparent"
+              onPointerDown={beginDrag('move')}
+              className={styles.zoneDragTarget}
+              data-swipe-blocked=""
+              cursor="move"
+              pointerEvents="all"
+              {...dragHandlers}
+            />
+            <circle
               data-testid="zone-handle-move"
               cx={rectSvg.centerX}
               cy={rectSvg.centerY}
@@ -441,6 +508,8 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
               stroke={themeTokens.neutral[50]}
               strokeWidth={handleRadius * 0.25}
               onPointerDown={beginDrag('move')}
+              className={styles.zoneDragHandle}
+              data-swipe-blocked=""
               cursor="move"
               pointerEvents="auto"
               {...dragHandlers}
@@ -451,21 +520,37 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
               const handlePos = gridToSvg(handleX, handleY, dims);
               const cursor = corner === 'nw' || corner === 'se' ? 'nwse-resize' : 'nesw-resize';
               return (
-                <circle
-                  key={corner}
-                  data-testid={`zone-handle-${corner}`}
-                  cx={handlePos.x}
-                  cy={handlePos.y}
-                  r={handleRadius}
-                  fill={themeTokens.colors.primary}
-                  fillOpacity={HANDLE_OPACITY}
-                  stroke={themeTokens.neutral[50]}
-                  strokeWidth={handleRadius * 0.25}
-                  onPointerDown={beginDrag(corner)}
-                  cursor={cursor}
-                  pointerEvents="auto"
-                  {...dragHandlers}
-                />
+                <React.Fragment key={corner}>
+                  <circle
+                    data-testid={`zone-hit-${corner}`}
+                    cx={handlePos.x}
+                    cy={handlePos.y}
+                    r={handleHitRadius}
+                    fill="transparent"
+                    onPointerDown={beginDrag(corner)}
+                    className={styles.zoneDragTarget}
+                    data-swipe-blocked=""
+                    cursor={cursor}
+                    pointerEvents="all"
+                    {...dragHandlers}
+                  />
+                  <circle
+                    data-testid={`zone-handle-${corner}`}
+                    cx={handlePos.x}
+                    cy={handlePos.y}
+                    r={handleRadius}
+                    fill={themeTokens.colors.primary}
+                    fillOpacity={HANDLE_OPACITY}
+                    stroke={themeTokens.neutral[50]}
+                    strokeWidth={handleRadius * 0.25}
+                    onPointerDown={beginDrag(corner)}
+                    className={styles.zoneDragHandle}
+                    data-swipe-blocked=""
+                    cursor={cursor}
+                    pointerEvents="auto"
+                    {...dragHandlers}
+                  />
+                </React.Fragment>
               );
             })}
           </svg>

--- a/packages/web/app/components/search-drawer/search-form.module.css
+++ b/packages/web/app/components/search-drawer/search-form.module.css
@@ -136,6 +136,8 @@
      heatmap overlay are positioned absolutely on top, so we need this
      container to be the positioning ancestor. */
   position: relative;
+  touch-action: none;
+  overscroll-behavior: contain;
 }
 
 .zoneSvg {
@@ -157,6 +159,15 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+  touch-action: none;
+}
+
+.zoneDragHandle {
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.zoneDragTarget {
   touch-action: none;
 }
 


### PR DESCRIPTION
## Summary

Fixes #2021 by making climb zone filter drags behave as local zone-editor gestures on iOS instead of leaking into the surrounding drawer/body scroll handling.

## What changed

- Marked the filter board surface and zone drag targets with `data-swipe-blocked` so drawer swipe-to-close ignores board editing gestures.
- Disabled touch scrolling on the filter board surface while it is being touched.
- Added larger invisible hit targets around the center/corner markers and a wide invisible zone-border move target, so users can move the zone without landing exactly on a small dot.
- Split pointer-up and pointer-cancel handling so cancelled iOS pointer streams persist the latest valid zone box instead of recalculating from unreliable cancel coordinates.
- Added regression coverage for the swipe-blocked surface/handles, enlarged hit targets, and bogus-coordinate pointer cancellation path.

## Validation

- `vp test run --project web --reporter=agent packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx`
- `vp test run --project web --reporter=agent packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx`
- `vp run typecheck:web`