### PR TITLE
[codex] Fix zone selector overlay

### DIFF
--- a/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx
@@ -204,6 +204,39 @@ describe('ClimbSearchForm — zone changes prune out-of-zone holds', () => {
     expect(screen.getByText('1 included')).toBeTruthy();
   });
 
+  it('renders the selected zone as transparent with dimmed excluded regions', () => {
+    const persistedZone: ZoneBox = { edgeLeft: 29, edgeRight: 115, edgeBottom: 31, edgeTop: 125 };
+    mockUISearchParams = {
+      ...DEFAULT_SEARCH_PARAMS,
+      zoneBox: persistedZone,
+    };
+    render(<ClimbSearchForm boardDetails={boardDetails} />);
+
+    const expectAttrs = (testId: string, attrs: Record<string, string>) => {
+      const node = screen.getByTestId(testId);
+      for (const [name, value] of Object.entries(attrs)) {
+        expect(node.getAttribute(name)).toBe(value);
+      }
+      expect(node.getAttribute('fill')).toBe('#111827');
+      expect(node.getAttribute('fill-opacity')).toBe('0.42');
+      expect(node.getAttribute('pointer-events')).toBe('none');
+    };
+
+    expectAttrs('zone-exclusion-top', { x: '0', y: '0', width: '1080', height: '232.5' });
+    expectAttrs('zone-exclusion-bottom', { x: '0', y: '937.5', width: '1080', height: '232.5' });
+    expectAttrs('zone-exclusion-left', { x: '0', y: '232.5', width: '217.5', height: '705' });
+    expectAttrs('zone-exclusion-right', { x: '862.5', y: '232.5', width: '217.5', height: '705' });
+
+    const outline = screen.getByTestId('zone-selection-outline');
+    expect(outline.getAttribute('x')).toBe('217.5');
+    expect(outline.getAttribute('y')).toBe('232.5');
+    expect(outline.getAttribute('width')).toBe('645');
+    expect(outline.getAttribute('height')).toBe('705');
+    expect(outline.getAttribute('fill')).toBe('none');
+    expect(outline.getAttribute('stroke')).toBe('#8C4A52');
+    expect(outline.getAttribute('pointer-events')).toBe('none');
+  });
+
   it('drawing a zone twice (e.g. user clears and redraws) prunes again from current holdsFilter', () => {
     mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS, holdsFilter: filterAllThreeHolds };
     const { rerender } = render(<ClimbSearchForm boardDetails={boardDetails} />);

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -54,7 +54,7 @@ const getAngleFromPath = (pathname: string): number => {
 };
 
 const HANDLE_OPACITY = 0.95;
-const RECT_FILL_OPACITY = 0.18;
+const ZONE_EXCLUSION_OPACITY = 0.42;
 const RECT_STROKE_OPACITY = 0.9;
 
 // Stable empty fallback so the ref-syncing effect doesn't re-run every
@@ -471,12 +471,52 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
               {...dragHandlers}
             />
             <rect
+              data-testid="zone-exclusion-top"
+              x={0}
+              y={0}
+              width={boardWidth}
+              height={rectSvg.y}
+              fill={themeTokens.neutral[900]}
+              fillOpacity={ZONE_EXCLUSION_OPACITY}
+              pointerEvents="none"
+            />
+            <rect
+              data-testid="zone-exclusion-bottom"
+              x={0}
+              y={rectSvg.y + rectSvg.height}
+              width={boardWidth}
+              height={Math.max(0, boardHeight - (rectSvg.y + rectSvg.height))}
+              fill={themeTokens.neutral[900]}
+              fillOpacity={ZONE_EXCLUSION_OPACITY}
+              pointerEvents="none"
+            />
+            <rect
+              data-testid="zone-exclusion-left"
+              x={0}
+              y={rectSvg.y}
+              width={rectSvg.x}
+              height={rectSvg.height}
+              fill={themeTokens.neutral[900]}
+              fillOpacity={ZONE_EXCLUSION_OPACITY}
+              pointerEvents="none"
+            />
+            <rect
+              data-testid="zone-exclusion-right"
+              x={rectSvg.x + rectSvg.width}
+              y={rectSvg.y}
+              width={Math.max(0, boardWidth - (rectSvg.x + rectSvg.width))}
+              height={rectSvg.height}
+              fill={themeTokens.neutral[900]}
+              fillOpacity={ZONE_EXCLUSION_OPACITY}
+              pointerEvents="none"
+            />
+            <rect
+              data-testid="zone-selection-outline"
               x={rectSvg.x}
               y={rectSvg.y}
               width={rectSvg.width}
               height={rectSvg.height}
-              fill={themeTokens.colors.primary}
-              fillOpacity={RECT_FILL_OPACITY}
+              fill="none"
               stroke={themeTokens.colors.primary}
               strokeOpacity={RECT_STROKE_OPACITY}
               strokeWidth={Math.max(boardWidth, boardHeight) * 0.005}

--- a/packages/web/scripts/dev-with-tailscale.ts
+++ b/packages/web/scripts/dev-with-tailscale.ts
@@ -132,7 +132,12 @@ function main(): void {
     console.info('[dev] TLS: serving via Next.js --experimental-https with Tailscale cert');
   }
 
-  const nextArgs = ['dev', '--hostname', '0.0.0.0', '--turbopack'];
+  // In TLS mode the cert is issued for the Tailscale MagicDNS hostname, not
+  // localhost. Binding Next to that hostname keeps its printed URL aligned
+  // with the certificate and avoids users opening https://localhost:<port>,
+  // which will always fail certificate validation.
+  const bindHostname = tlsEnabled ? resolution.hostname : '0.0.0.0';
+  const nextArgs = ['dev', '--hostname', bindHostname, '--turbopack'];
   if (tlsEnabled) {
     // Next.js requires --experimental-https to switch the dev server into
     // HTTPS mode; the cert+key flags then point at the files to use instead


### PR DESCRIPTION
## Summary
- Change the climb search zone selector so the selected region stays transparent.
- Dim the four excluded board regions around the selected zone instead of tinting the selected zone itself.
- Add a regression test for the overlay geometry and transparent selected-zone outline.
- Fix local HTTPS dev startup so Next binds to the Tailscale MagicDNS hostname when using a Tailscale cert, avoiding the invalid `https://localhost:<port>` certificate path.

## Why
The previous overlay made the selected region harder to inspect by placing a translucent fill over the exact board area the user cares about. This makes the UI read as an inclusion window with the non-matching board regions visually de-emphasized.

The dev-server fix keeps the advertised HTTPS URL aligned with the certificate subject so local testing through Tailscale does not fail certificate validation.

Fixes #2022.

## Validation
- `vp test run packages/web/app/components/search-drawer/__tests__/climb-search-form.test.tsx packages/web/app/components/search-drawer/__tests__/climb-zone-math.test.ts`
- `bun run typecheck` from `packages/web`
- `curl -I --max-time 10 https://vibetunnel-2.tailedd9d5.ts.net:3003` returned `HTTP/1.1 200 OK` with normal certificate validation