### PR TITLE
Fix user data export follow-ups

### DIFF
--- a/packages/backend/src/services/user-data-export-format.test.ts
+++ b/packages/backend/src/services/user-data-export-format.test.ts
@@ -67,7 +67,17 @@ describe('user data export formatting', () => {
           position: 1,
         },
       ],
-      climbs: [],
+      climbs: [
+        {
+          uuid: 'climb-1',
+          name: 'My Draft',
+          layoutId: 1,
+          frames: 'p1464r45p1131r42p1233r43p1270r44',
+          createdAt: new Date('2026-05-04T09:30:00Z'),
+          isDraft: true,
+          description: 'Exported from Boardsesh',
+        },
+      ],
     });
 
     expect(exportData.user).toEqual({
@@ -104,6 +114,21 @@ describe('user data export formatting', () => {
         description: 'Limit climbs',
         is_private: true,
         climbs: ['Warm Up', 'Project'],
+      },
+    ]);
+    expect(exportData.climbs).toEqual([
+      {
+        name: 'My Draft',
+        layout: 'Kilter Board Original',
+        created_at: '2026-05-04T09:30:00.000Z',
+        is_draft: true,
+        description: 'Exported from Boardsesh',
+        holds: [
+          { x: 4, y: 4, role: 'foot' },
+          { x: 64, y: 32, role: 'start' },
+          { x: 64, y: 80, role: 'middle' },
+          { x: 88, y: 96, role: 'finish' },
+        ],
       },
     ]);
   });

--- a/packages/backend/src/services/user-data-export.test.ts
+++ b/packages/backend/src/services/user-data-export.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const storageMocks = vi.hoisted(() => ({
+  getFromS3: vi.fn(),
+  getS3ObjectMetadata: vi.fn(),
+  isS3Configured: vi.fn(),
+  uploadToS3: vi.fn(),
+}));
+
+const dbMocks = vi.hoisted(() => ({
+  dbRead: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../storage/s3', () => storageMocks);
+vi.mock('../db/client', () => dbMocks);
+
+describe('user data export service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    storageMocks.getFromS3.mockReset();
+    storageMocks.getS3ObjectMetadata.mockReset();
+    storageMocks.isS3Configured.mockReset();
+    storageMocks.uploadToS3.mockReset();
+    dbMocks.dbRead.select.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('returns a generic public error when export storage is unavailable', async () => {
+    storageMocks.isS3Configured.mockReturnValue(false);
+
+    const { getUserDataExportStatus } = await import('./user-data-export');
+
+    await expect(getUserDataExportStatus('user-1', 'kilter')).resolves.toMatchObject({
+      status: 'unavailable',
+      error: 'Export service is temporarily unavailable.',
+    });
+  });
+
+  it('does not expose raw generation errors in public export status', async () => {
+    storageMocks.isS3Configured.mockReturnValue(true);
+    storageMocks.getS3ObjectMetadata.mockResolvedValue(null);
+    dbMocks.dbRead.select.mockImplementation(() => {
+      throw new Error('database password leaked in stack trace');
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { getUserDataExportStatus, requestUserDataExport } = await import('./user-data-export');
+
+    await expect(requestUserDataExport('user-2', 'kilter')).resolves.toMatchObject({
+      status: 'generating',
+    });
+
+    await vi.waitFor(async () => {
+      await expect(getUserDataExportStatus('user-2', 'kilter')).resolves.toMatchObject({
+        status: 'failed',
+        error: 'Export generation failed. Try again later.',
+      });
+    });
+    await expect(getUserDataExportStatus('user-2', 'kilter')).resolves.not.toMatchObject({
+      error: expect.stringContaining('database password'),
+    });
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('evicts stale cached export jobs before serving status', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(0);
+    storageMocks.isS3Configured.mockReturnValue(true);
+    storageMocks.getS3ObjectMetadata
+      .mockResolvedValueOnce({
+        lastModified: new Date('2026-05-01T00:00:00Z'),
+        contentLength: 123,
+      })
+      .mockResolvedValue(null);
+
+    const { getUserDataExportStatus } = await import('./user-data-export');
+
+    await expect(getUserDataExportStatus('user-3', 'kilter')).resolves.toMatchObject({
+      status: 'ready',
+      fileSize: 123,
+    });
+
+    nowSpy.mockReturnValue(8 * 24 * 60 * 60 * 1000 + 1);
+
+    await expect(getUserDataExportStatus('user-3', 'kilter')).resolves.toMatchObject({
+      status: 'not_requested',
+    });
+    expect(storageMocks.getS3ObjectMetadata).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/services/user-data-export.ts
+++ b/packages/backend/src/services/user-data-export.ts
@@ -37,6 +37,10 @@ type ExportJob = UserDataExportStatus & {
   jobId: string;
 };
 
+type CachedExportJob = ExportJob & {
+  updatedAtMs: number;
+};
+
 export type DownloadableUserDataExport = {
   key: string;
   filename: string;
@@ -45,12 +49,26 @@ export type DownloadableUserDataExport = {
   contentLength: number | undefined;
 };
 
-const exportJobs = new Map<string, ExportJob>();
+const exportJobs = new Map<string, CachedExportJob>();
+const PUBLIC_EXPORT_FAILURE_MESSAGE = 'Export generation failed. Try again later.';
+const PUBLIC_EXPORT_UNAVAILABLE_MESSAGE = 'Export service is temporarily unavailable.';
+const EXPORT_JOB_CACHE_TTL_MS = 8 * 24 * 60 * 60 * 1000;
+const EXPORT_JOB_CACHE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+const exportJobCleanupInterval = setInterval(() => {
+  evictStaleExportJobs();
+}, EXPORT_JOB_CACHE_SWEEP_INTERVAL_MS);
+
+if (typeof exportJobCleanupInterval.unref === 'function') {
+  exportJobCleanupInterval.unref();
+}
 
 export async function getUserDataExportStatus(
   userId: string,
   boardType: AuroraBoardName,
 ): Promise<UserDataExportStatus> {
+  evictStaleExportJobs();
+
   const descriptor = getCurrentExportDescriptor(userId, boardType);
   const existing = exportJobs.get(descriptor.jobId);
   if (existing) return toPublicStatus(existing);
@@ -60,7 +78,7 @@ export async function getUserDataExportStatus(
       boardType,
       period: descriptor.period,
       status: 'unavailable',
-      error: 'S3 storage is not configured',
+      error: PUBLIC_EXPORT_UNAVAILABLE_MESSAGE,
     };
   }
 
@@ -84,11 +102,13 @@ export async function getUserDataExportStatus(
     downloadUrl: descriptor.downloadUrl,
     fileSize: metadata.contentLength,
   };
-  exportJobs.set(descriptor.jobId, readyJob);
+  storeExportJob(readyJob);
   return toPublicStatus(readyJob);
 }
 
 export async function requestUserDataExport(userId: string, boardType: AuroraBoardName): Promise<UserDataExportStatus> {
+  evictStaleExportJobs();
+
   const descriptor = getCurrentExportDescriptor(userId, boardType);
   const existing = exportJobs.get(descriptor.jobId);
 
@@ -101,7 +121,7 @@ export async function requestUserDataExport(userId: string, boardType: AuroraBoa
       boardType,
       period: descriptor.period,
       status: 'unavailable',
-      error: 'S3 storage is not configured',
+      error: PUBLIC_EXPORT_UNAVAILABLE_MESSAGE,
     };
   }
 
@@ -118,7 +138,7 @@ export async function requestUserDataExport(userId: string, boardType: AuroraBoa
       downloadUrl: descriptor.downloadUrl,
       fileSize: metadata.contentLength,
     };
-    exportJobs.set(descriptor.jobId, readyJob);
+    storeExportJob(readyJob);
     return toPublicStatus(readyJob);
   }
 
@@ -131,7 +151,7 @@ export async function requestUserDataExport(userId: string, boardType: AuroraBoa
     status: 'generating',
     requestedAt: new Date().toISOString(),
   };
-  exportJobs.set(descriptor.jobId, generatingJob);
+  storeExportJob(generatingJob);
 
   void generateAndStoreUserDataExport(generatingJob, descriptor.downloadUrl);
 
@@ -265,7 +285,7 @@ async function generateAndStoreUserDataExport(job: ExportJob, downloadUrl: strin
       acl: null,
     });
 
-    exportJobs.set(job.jobId, {
+    storeExportJob({
       ...job,
       status: 'ready',
       completedAt: new Date().toISOString(),
@@ -275,10 +295,10 @@ async function generateAndStoreUserDataExport(job: ExportJob, downloadUrl: strin
     });
   } catch (error) {
     console.error('[User Data Export] Export generation failed:', error);
-    exportJobs.set(job.jobId, {
+    storeExportJob({
       ...job,
       status: 'failed',
-      error: error instanceof Error ? error.message : 'Export generation failed',
+      error: PUBLIC_EXPORT_FAILURE_MESSAGE,
     });
   }
 }
@@ -299,6 +319,22 @@ function getCurrentExportDescriptor(userId: string, boardType: AuroraBoardName) 
 function getJobId(userId: string, boardType: AuroraBoardName): string {
   const period = getIsoWeekPeriod().label;
   return `${userId}:${boardType}:${period}`;
+}
+
+function storeExportJob(job: ExportJob): CachedExportJob {
+  const exportJob = { ...job, updatedAtMs: Date.now() };
+  exportJobs.set(exportJob.jobId, exportJob);
+  return exportJob;
+}
+
+function evictStaleExportJobs(now = Date.now()): void {
+  const staleBefore = now - EXPORT_JOB_CACHE_TTL_MS;
+
+  for (const [jobId, job] of exportJobs) {
+    if (job.updatedAtMs <= staleBefore) {
+      exportJobs.delete(jobId);
+    }
+  }
 }
 
 function toPublicStatus(job: ExportJob): UserDataExportStatus {

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
@@ -51,8 +51,19 @@ vi.mock('@/app/lib/board-constants', () => ({
     tension: {
       9: { id: 9, name: 'Original Layout', productId: 4 },
     },
+    decoy: {
+      2: { id: 2, name: 'Decoy Board', productId: 1 },
+    },
+    touchstone: {
+      1: { id: 1, name: 'Touchstone Board', productId: 1 },
+    },
+    grasshopper: {
+      1: { id: 1, name: 'Grasshopper Board', productId: 1 },
+    },
+    soill: {
+      1: { id: 1, name: 'So iLL Board', productId: 1 },
+    },
     moonboard: {},
-    // decoy, touchstone, grasshopper intentionally absent to exercise null-guard
   },
   HOLE_PLACEMENTS: {
     kilter: {
@@ -67,8 +78,31 @@ vi.mock('@/app/lib/board-constants', () => ({
       ],
     },
     tension: {},
+    decoy: {
+      '2-1': [
+        [2001, null, 10, 10],
+        [2002, null, 20, 20],
+      ],
+    },
+    touchstone: {
+      '1-1': [
+        [3001, null, 10, 10],
+        [3002, null, 20, 20],
+      ],
+    },
+    grasshopper: {
+      '1-1': [
+        [4001, null, 10, 10],
+        [4002, null, 20, 20],
+      ],
+    },
+    soill: {
+      '1-1': [
+        [5001, null, 10, 10],
+        [5002, null, 20, 20],
+      ],
+    },
     moonboard: {},
-    // decoy, touchstone, grasshopper intentionally absent to exercise null-guard
   },
 }));
 
@@ -342,6 +376,13 @@ describe('resolveLayoutName', () => {
 
   it('resolves Tension Original Layout to layout ID 9', () => {
     expect(resolveLayoutName('tension', 'Original Layout')).toBe(9);
+  });
+
+  it('resolves Aurora board layouts for imported draft climbs', () => {
+    expect(resolveLayoutName('decoy', 'Decoy Board')).toBe(2);
+    expect(resolveLayoutName('touchstone', 'Touchstone Board')).toBe(1);
+    expect(resolveLayoutName('grasshopper', 'Grasshopper Board')).toBe(1);
+    expect(resolveLayoutName('soill', 'So iLL Board')).toBe(1);
   });
 
   it('returns null for unknown layout name', () => {
@@ -645,40 +686,37 @@ describe('auroraExportSchema - climb validation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// New-board paths: boards without HOLE_PLACEMENTS or ROLE_TO_CODE entries
+// New Aurora board draft-climb import support
 // ---------------------------------------------------------------------------
 
-describe('buildCoordinateMap for unsupported boards', () => {
-  it('returns an empty map for a board with no HOLE_PLACEMENTS entry', () => {
-    const coordMap = buildCoordinateMap('decoy', 2);
-    expect(coordMap.size).toBe(0);
-  });
-
-  it('returns an empty map for touchstone', () => {
-    expect(buildCoordinateMap('touchstone', 1).size).toBe(0);
-  });
-
-  it('returns an empty map for grasshopper', () => {
-    expect(buildCoordinateMap('grasshopper', 1).size).toBe(0);
+describe('buildCoordinateMap for new Aurora boards', () => {
+  it('builds coordinate maps for newly supported Aurora boards', () => {
+    expect(buildCoordinateMap('decoy', 2).get('10,10')).toBe(2001);
+    expect(buildCoordinateMap('touchstone', 1).get('10,10')).toBe(3001);
+    expect(buildCoordinateMap('grasshopper', 1).get('10,10')).toBe(4001);
+    expect(buildCoordinateMap('soill', 1).get('10,10')).toBe(5001);
   });
 });
 
-describe('convertHoldsToFrames for boards without role codes', () => {
-  it('returns null for decoy (no ROLE_TO_CODE entry)', () => {
-    const coordMap = new Map([['10,10', 1]]);
-    const holds = [{ x: 10, y: 10, role: 'start' }];
-    expect(convertHoldsToFrames(holds, coordMap, 'decoy')).toBeNull();
-  });
+describe('convertHoldsToFrames for new Aurora boards', () => {
+  const tensionStyleBoards = ['decoy', 'touchstone', 'grasshopper', 'soill'] as const;
 
-  it('returns null for touchstone (no ROLE_TO_CODE entry)', () => {
-    const coordMap = new Map([['10,10', 1]]);
-    const holds = [{ x: 10, y: 10, role: 'start' }];
-    expect(convertHoldsToFrames(holds, coordMap, 'touchstone')).toBeNull();
-  });
+  for (const boardType of tensionStyleBoards) {
+    it(`uses Tension-style role codes for ${boardType}`, () => {
+      const coordMap = new Map([
+        ['10,10', 1],
+        ['20,20', 2],
+        ['30,30', 3],
+        ['40,40', 4],
+      ]);
+      const holds = [
+        { x: 10, y: 10, role: 'start' },
+        { x: 20, y: 20, role: 'middle' },
+        { x: 30, y: 30, role: 'finish' },
+        { x: 40, y: 40, role: 'foot' },
+      ];
 
-  it('returns null for grasshopper (no ROLE_TO_CODE entry)', () => {
-    const coordMap = new Map([['10,10', 1]]);
-    const holds = [{ x: 10, y: 10, role: 'start' }];
-    expect(convertHoldsToFrames(holds, coordMap, 'grasshopper')).toBeNull();
-  });
+      expect(convertHoldsToFrames(holds, coordMap, boardType)).toBe('p1r1p2r2p3r3p4r4');
+    });
+  }
 });

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -158,12 +158,14 @@ export function generateJsonImportAuroraId(
 // Climb draft import helpers
 // ---------------------------------------------------------------------------
 
-/** Map export role names to board-specific hold state codes.
- * Only boards with known codes are listed — absent entries mean climb draft
- * import is not supported for that board (ascents/attempts still import fine). */
+/** Map export role names to board-specific hold state codes. */
 const ROLE_TO_CODE: Partial<Record<AuroraBoardName, Record<string, number>>> = {
   kilter: { start: 42, middle: 43, finish: 44, foot: 45 },
   tension: { start: 1, middle: 2, finish: 3, foot: 4 },
+  decoy: { start: 1, middle: 2, finish: 3, foot: 4 },
+  touchstone: { start: 1, middle: 2, finish: 3, foot: 4 },
+  grasshopper: { start: 1, middle: 2, finish: 3, foot: 4 },
+  soill: { start: 1, middle: 2, finish: 3, foot: 4 },
 };
 
 /** Resolve a layout name (e.g. "Kilter Board Original") to a layout ID. */


### PR DESCRIPTION
## Summary
- Extend Aurora JSON import draft-climb role mappings for Decoy, Touchstone, Grasshopper, and So iLL boards
- Sanitize public user data export errors and add TTL cleanup for the in-memory export job cache
- Add backend export format coverage for exported user-created climbs
- Add service coverage for sanitized errors and stale job eviction

Closes #2026

## Tests
- `vp test run packages/backend/src/services/user-data-export.test.ts packages/backend/src/services/user-data-export-format.test.ts`
- `vp test run packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts`
- `bun run --filter=boardsesh-backend typecheck`

## Notes
- `bun run --filter=@boardsesh/web typecheck` is currently blocked by existing generated `.next/types/validator.ts` reference to missing `../../app/you/feed/page.js`.