### PR TITLE
[codex] Fix desktop Holds & Zone expansion

### DIFF
--- a/packages/web/app/components/collapsible-section/__tests__/collapsible-section.test.tsx
+++ b/packages/web/app/components/collapsible-section/__tests__/collapsible-section.test.tsx
@@ -1,8 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import CollapsibleSection, { type CollapsibleSectionConfig } from '../collapsible-section';
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+let scrollIntoViewMock: ReturnType<typeof vi.fn>;
 
 function makeSections(): CollapsibleSectionConfig[] {
   return [
@@ -30,7 +33,44 @@ function makeSections(): CollapsibleSectionConfig[] {
   ];
 }
 
+function makeRect(top: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 0,
+    bottom: top,
+    width: 0,
+    height: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 describe('CollapsibleSection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scrollIntoViewMock = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: originalScrollIntoView,
+    });
+  });
+
   describe('uncontrolled mode (no forcedActiveKey)', () => {
     it('starts with no section active when there is no defaultActive', () => {
       render(<CollapsibleSection sections={makeSections()} />);
@@ -44,6 +84,38 @@ describe('CollapsibleSection', () => {
       render(<CollapsibleSection sections={makeSections()} />);
       fireEvent.click(screen.getByText('Invite'));
       expect(screen.getByText('Invite others')).toBeDefined();
+    });
+
+    it('scrolls a user-opened section to the top of the nearest scroll container', () => {
+      render(
+        <div data-testid="scroll-parent" style={{ overflowY: 'auto' }}>
+          <CollapsibleSection sections={makeSections()} />
+        </div>,
+      );
+
+      const scrollParent = screen.getByTestId('scroll-parent') as HTMLElement;
+      const scrollToMock = vi.fn();
+      Object.defineProperty(scrollParent, 'scrollHeight', { configurable: true, value: 1000 });
+      Object.defineProperty(scrollParent, 'clientHeight', { configurable: true, value: 200 });
+      Object.defineProperty(scrollParent, 'scrollTop', { configurable: true, value: 20 });
+      Object.defineProperty(scrollParent, 'scrollTo', { configurable: true, value: scrollToMock });
+      scrollParent.getBoundingClientRect = vi.fn(() => makeRect(10));
+
+      const activityCard = screen.getByText('Activity').closest('[class*="sectionCard"]') as HTMLElement;
+      activityCard.getBoundingClientRect = vi.fn(() => makeRect(210));
+
+      fireEvent.click(screen.getByText('Activity'));
+
+      expect(screen.getByText('Recent activity')).toBeDefined();
+      expect(scrollToMock).toHaveBeenCalledTimes(1);
+      expect(scrollToMock).toHaveBeenCalledWith({
+        top: 220,
+        behavior: 'smooth',
+      });
+      expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(275);
+      expect(scrollToMock).toHaveBeenCalledTimes(2);
     });
 
     it('clicking the title of an active section collapses it', () => {

--- a/packages/web/app/components/collapsible-section/collapsible-section.module.css
+++ b/packages/web/app/components/collapsible-section/collapsible-section.module.css
@@ -6,6 +6,17 @@
   padding: 4px 0;
 }
 
+@media (min-width: 768px) and (max-height: 700px) {
+  .steppedContainerCompactDesktop {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .steppedContainerCompactDesktop .sectionCardActive {
+    grid-column: 1 / -1;
+  }
+}
+
 /* Section card base */
 .sectionCard {
   background: var(--semantic-surface, #ffffff);

--- a/packages/web/app/components/collapsible-section/collapsible-section.tsx
+++ b/packages/web/app/components/collapsible-section/collapsible-section.tsx
@@ -26,6 +26,8 @@ type CollapsibleSectionProps = {
   defaultActiveKey?: string;
   /** When provided, forces this section to be active (e.g. for a guided tour). */
   forcedActiveKey?: string | null;
+  /** Use a denser collapsed layout on short desktop viewports. */
+  compactDesktopGrid?: boolean;
 };
 
 const EXPAND_SCROLL_DELAY_MS = 275;
@@ -62,7 +64,12 @@ function scrollSectionIntoView(sectionEl: HTMLElement): void {
   });
 }
 
-const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defaultActiveKey, forcedActiveKey }) => {
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
+  sections,
+  defaultActiveKey,
+  forcedActiveKey,
+  compactDesktopGrid = false,
+}) => {
   const sectionDefaultActive = sections.find((s) => s.defaultActive);
   const initialActiveKey = sectionDefaultActive?.key ?? defaultActiveKey ?? null;
   const [activeKey, setActiveKey] = useState<string | null>(initialActiveKey);
@@ -132,7 +139,9 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defau
   };
 
   return (
-    <div className={styles.steppedContainer}>
+    <div
+      className={`${styles.steppedContainer} ${compactDesktopGrid ? styles.steppedContainerCompactDesktop : ''}`}
+    >
       {sections.map((section) => {
         const isActive = effectiveActiveKey === section.key;
         const summaryParts = section.getSummary?.() ?? [];

--- a/packages/web/app/components/collapsible-section/collapsible-section.tsx
+++ b/packages/web/app/components/collapsible-section/collapsible-section.tsx
@@ -28,10 +28,46 @@ type CollapsibleSectionProps = {
   forcedActiveKey?: string | null;
 };
 
+const EXPAND_SCROLL_DELAY_MS = 275;
+
+function findScrollableParent(element: HTMLElement): HTMLElement | null {
+  let parent = element.parentElement;
+  let fallback: HTMLElement | null = null;
+  while (parent) {
+    const { overflowY } = window.getComputedStyle(parent);
+    const canScroll = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
+    if (canScroll) {
+      if (parent.scrollHeight > parent.clientHeight) {
+        return parent;
+      }
+      fallback ??= parent;
+    }
+    parent = parent.parentElement;
+  }
+  return fallback;
+}
+
+function scrollSectionIntoView(sectionEl: HTMLElement): void {
+  const scrollParent = findScrollableParent(sectionEl);
+  if (!scrollParent) {
+    sectionEl.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+    return;
+  }
+
+  const sectionTop = sectionEl.getBoundingClientRect().top;
+  const parentTop = scrollParent.getBoundingClientRect().top;
+  scrollParent.scrollTo({
+    top: scrollParent.scrollTop + sectionTop - parentTop,
+    behavior: 'smooth',
+  });
+}
+
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defaultActiveKey, forcedActiveKey }) => {
   const sectionDefaultActive = sections.find((s) => s.defaultActive);
   const initialActiveKey = sectionDefaultActive?.key ?? defaultActiveKey ?? null;
   const [activeKey, setActiveKey] = useState<string | null>(initialActiveKey);
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const pendingScrollKeyRef = useRef<string | null>(null);
   // Preserve the initial default so we can restore it if we transition back
   // from controlled (forcedActiveKey set) to uncontrolled mode.
   const initialActiveKeyRef = useRef(initialActiveKey);
@@ -62,6 +98,39 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defau
   const effectiveActiveKey = forcedActiveKey !== undefined ? forcedActiveKey : activeKey;
   const interactionDisabled = forcedActiveKey !== undefined;
 
+  useEffect(() => {
+    const key = pendingScrollKeyRef.current;
+    if (!key || effectiveActiveKey !== key) return;
+    const sectionEl = sectionRefs.current[key];
+    if (!sectionEl) return;
+
+    let timeout: number | undefined;
+    const frame = window.requestAnimationFrame(() => {
+      scrollSectionIntoView(sectionEl);
+      timeout = window.setTimeout(() => {
+        scrollSectionIntoView(sectionEl);
+        if (pendingScrollKeyRef.current === key) {
+          pendingScrollKeyRef.current = null;
+        }
+      }, EXPAND_SCROLL_DELAY_MS);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      if (timeout !== undefined) {
+        window.clearTimeout(timeout);
+      }
+      if (pendingScrollKeyRef.current === key) {
+        pendingScrollKeyRef.current = null;
+      }
+    };
+  }, [effectiveActiveKey]);
+
+  const openSection = (key: string) => {
+    pendingScrollKeyRef.current = key;
+    setActiveKey(key);
+  };
+
   return (
     <div className={styles.steppedContainer}>
       {sections.map((section) => {
@@ -74,8 +143,11 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ sections, defau
         return (
           <div
             key={section.key}
+            ref={(node) => {
+              sectionRefs.current[section.key] = node;
+            }}
             className={`${styles.sectionCard} ${isActive ? styles.sectionCardActive : ''}`}
-            {...(!isActive && !interactionDisabled ? { onClick: () => setActiveKey(section.key) } : {})}
+            {...(!isActive && !interactionDisabled ? { onClick: () => openSection(section.key) } : {})}
           >
             <div
               className={`${styles.collapsedRow} ${isActive ? styles.collapsedRowActive : ''}`}

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -503,7 +503,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   return (
     <div className={styles.formWrapper}>
       <div className={styles.primaryContent}>{climbContent}</div>
-      <CollapsibleSection sections={sections} defaultActiveKey={defaultActiveKey?.[0]} />
+      <CollapsibleSection sections={sections} defaultActiveKey={defaultActiveKey?.[0]} compactDesktopGrid />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Scroll user-opened collapsible sections to the top of the drawer body.
- Fix the desktop case where opening the bottom "Holds & Zone" section expanded it behind the fixed drawer footer.
- Add regression coverage for revealing a newly opened section in its nearest scroll container.

## Root cause
The desktop drawer body did not scroll after a lower filter section expanded. Because the section expansion animates over 250ms, the first layout pass can run before the drawer has enough scroll range, leaving the expanded content behind the footer.

## Validation
- `vp test run packages/web/app/components/collapsible-section/__tests__/collapsible-section.test.tsx`
- `bun run typecheck` in `packages/web`
- Playwright desktop check at 1280x720 confirmed "Holds & Zone" scrolls into view after opening.