### PR TITLE
Fix climb list scroll on new search

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -267,6 +267,29 @@ describe('ClimbsList virtualization', () => {
     const items = screen.getAllByTestId('climb-list-item');
     expect(items).toHaveLength(5);
   });
+
+  it('scrolls to the top when a new search replaces the climb list', () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    const props = {
+      boardDetails: makeBoardDetails(),
+      isFetching: false,
+      hasMore: false,
+      onLoadMore: vi.fn(),
+    };
+
+    const { rerender } = render(<ClimbsList {...props} climbs={allClimbs.slice(0, 3)} />);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    rerender(<ClimbsList {...props} climbs={allClimbs.slice(50, 53)} />);
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' });
+  });
 });
 
 describe('ClimbsList thumbnail vs row click', () => {

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -1,6 +1,5 @@
 'use client';
-import React, { useMemo, useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
+import React, { useMemo, useRef } from 'react';
 import type { Climb, ParsedBoardRouteParameters, BoardDetails } from '@/app/lib/types';
 import { useQueueActions, useCurrentClimb, useSearchData } from '../graphql-queue';
 import ClimbsList from './climbs-list';
@@ -25,16 +24,6 @@ const BoardPageClimbsList = ({
   const { currentClimb } = useCurrentClimb();
   const { climbSearchResults, hasMoreResults, hasDoneFirstFetch, isFetchingClimbs } = useSearchData();
   const { setCurrentClimb, addToQueue, fetchMoreClimbs } = useQueueActions();
-
-  const searchParams = useSearchParams();
-  const page = searchParams.get('page');
-
-  // Scroll to top when search params reset to page 0
-  useEffect(() => {
-    if (page === '0' && hasDoneFirstFetch && isFetchingClimbs) {
-      window.scrollTo({ top: 0, behavior: 'instant' });
-    }
-  }, [page, hasDoneFirstFetch, isFetchingClimbs]);
 
   // Queue Context provider uses React Query infinite to fetch results, which can only happen clientside.
   // That data equals null at the start, so when its null we use the initialClimbs array which we

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -317,6 +317,7 @@ const ClimbsList = ({
   const INITIAL_BATCH = 6;
   const [visibleCount, setVisibleCount] = useState(climbs.length);
   const prevClimbsRef = useRef(climbs);
+  const shouldScrollToTopRef = useRef(false);
 
   if (climbs !== prevClimbsRef.current) {
     const prevClimbs = prevClimbsRef.current;
@@ -327,10 +328,19 @@ const ClimbsList = ({
     if (changeType === 'append' || changeType === 'same') {
       // Show all items immediately — no batching for appended pages or unchanged data
       setVisibleCount(climbs.length);
-    } else if (climbs.length > INITIAL_BATCH) {
-      setVisibleCount(INITIAL_BATCH);
+    } else {
+      shouldScrollToTopRef.current = true;
+      if (climbs.length > INITIAL_BATCH) {
+        setVisibleCount(INITIAL_BATCH);
+      }
     }
   }
+
+  useEffect(() => {
+    if (!shouldScrollToTopRef.current) return;
+    shouldScrollToTopRef.current = false;
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [climbs]);
 
   useEffect(() => {
     if (visibleCount < climbs.length) {


### PR DESCRIPTION
Fixes #1583

## Summary

- move new-search scroll reset into the shared climb list replacement path
- remove the narrower `page=0` URL-param scroll hook from `BoardPageClimbsList`
- add a regression test that verifies replacing the climb list scrolls back to the top

## Notes

The previous hook only reacted when the URL explicitly contained `page=0`, but the default page is commonly omitted from the query string. This instead treats a replaced climb list as the primitive for a new search, while preserving the existing no-scroll behavior for appended infinite-scroll results.

## Testing

- `vp test run packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx`
- `vp fmt --check packages/web/app/components/board-page/climbs-list.tsx packages/web/app/components/board-page/board-page-climbs-list.tsx packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx`
- `bun run --filter=@boardsesh/web typecheck`
- `git diff --check`