### PR TITLE
[codex] Add minimized queue control bar

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -275,7 +275,7 @@ describe('ClimbsList thumbnail vs row click', () => {
     lastVirtualizerOpts = null;
   });
 
-  it('row click activates the climb but does NOT open the play drawer', () => {
+  it('unselected row click activates the climb but does NOT open the play drawer', () => {
     const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
     const onClimbSelect = vi.fn();
     render(
@@ -296,6 +296,31 @@ describe('ClimbsList thumbnail vs row click', () => {
       ([event]) => event instanceof CustomEvent && event.type === 'boardsesh:open-play-drawer',
     );
     expect(dispatched).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it('selected row click activates the climb and opens the play drawer', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    const onClimbSelect = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 3)}
+        selectedClimbUuid="climb-0"
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onClimbSelect={onClimbSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('row-climb-0'));
+
+    expect(onClimbSelect).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-0' }));
+    const dispatched = dispatchSpy.mock.calls.some(
+      ([event]) => event instanceof CustomEvent && event.type === 'boardsesh:open-play-drawer',
+    );
+    expect(dispatched).toBe(true);
     dispatchSpy.mockRestore();
   });
 

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -392,12 +392,13 @@ const ClimbsList = ({
     isFetching,
   });
 
-  // Row click: activates the climb but does NOT open the play drawer.
-  // Only the thumbnail (list mode) or card cover (grid mode) opens the drawer.
+  // Row click: first tap activates the climb; tapping the already-active row opens the play drawer.
+  // The thumbnail (list mode) or card cover (grid mode) still activates and opens in one tap.
   const handleClimbClickByIndex = useCallback(
     (index: number) => {
       const climb = climbs[index];
       if (climb) {
+        const alreadySelected = selectedClimbUuid === climb.uuid;
         onClimbSelectRef.current?.(climb);
         // Explicit user-pick signal for the onboarding tour. Fires only while
         // the tour is on the climb-list step so it can advance without
@@ -405,11 +406,13 @@ const ClimbsList = ({
         // hydration can trip).
         if (tourStepRef.current === 'climb-list') {
           dispatchTourClimbListPick();
+        } else if (alreadySelected) {
+          dispatchOpenPlayDrawer();
         }
         track('Climb List Row Clicked', { climbUuid: climb.uuid });
       }
     },
-    [climbs],
+    [climbs, selectedClimbUuid],
   );
 
   // Thumbnail / card-cover click: activates the climb and opens the play drawer.

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -602,13 +602,13 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
 
         if (status.status === 'ready') return status;
         if (status.status === 'failed' || status.status === 'unavailable') {
-          throw new Error(status.error ?? 'Export generation failed');
+          throw new Error(status.error ?? t('logbook.feed.export.generationFailed'));
         }
       }
 
-      throw new Error('Export is still generating. Try again shortly.');
+      throw new Error(t('logbook.feed.export.stillGenerating'));
     },
-    [token],
+    [t, token],
   );
 
   const handleExportMenuOpen = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
@@ -625,12 +625,12 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
 
       const backendUrl = getBackendHttpUrl();
       if (!backendUrl) {
-        showMessage('Boardsesh could not find the export service URL.', 'error');
+        showMessage(t('logbook.feed.export.missingServiceUrl'), 'error');
         return;
       }
 
       if (!token) {
-        showMessage('Sign in again to export your logbook data.', 'error');
+        showMessage(t('logbook.feed.export.signInAgain'), 'error');
         return;
       }
 
@@ -647,23 +647,23 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
         let status = await parseExportResponse(response);
 
         if (status.status === 'generating') {
-          showMessage(`${boardLabel} export is being generated.`, 'info', undefined, 5000);
+          showMessage(t('logbook.feed.export.generating', { board: boardLabel }), 'info', undefined, 5000);
           status = await waitForExport(backendUrl, boardType);
         }
 
         if (status.status !== 'ready') {
-          throw new Error(status.error ?? 'Export is not ready yet');
+          throw new Error(status.error ?? t('logbook.feed.export.notReady'));
         }
 
         await downloadExport(backendUrl, boardType);
-        showMessage(`${boardLabel} export downloaded.`, 'success');
+        showMessage(t('logbook.feed.export.downloaded', { board: boardLabel }), 'success');
       } catch (error) {
-        showMessage(error instanceof Error ? error.message : 'Export failed', 'error');
+        showMessage(error instanceof Error ? error.message : t('logbook.feed.export.failed'), 'error');
       } finally {
         setExportingBoard(null);
       }
     },
-    [downloadExport, handleExportMenuClose, showMessage, token, waitForExport],
+    [downloadExport, handleExportMenuClose, showMessage, t, token, waitForExport],
   );
 
   const showBoardType = selectedBoards.length === 0 || selectedBoards.length > 1;
@@ -724,12 +724,12 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
         onClick={handleExportMenuOpen}
         disabled={authLoading || !token || !!exportingBoard}
       >
-        Export
+        {t('logbook.feed.export.action')}
       </Button>
       <Menu anchorEl={exportMenuAnchor} open={!!exportMenuAnchor} onClose={handleExportMenuClose}>
         {exportableBoardTypes.map((boardType) => (
           <MenuItem key={boardType} onClick={() => void handleExportBoard(boardType)}>
-            {formatBoardTypeLabel(boardType)} JSON
+            {t('logbook.feed.export.jsonMenuItem', { board: formatBoardTypeLabel(boardType) })}
           </MenuItem>
         ))}
       </Menu>

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-collapsed.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-collapsed.test.tsx
@@ -1,0 +1,510 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import QueueControlBar from '../queue-control-bar';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockGetPreference = vi.fn();
+const mockSetPreference = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+}));
+
+let mockPathname = '/kilter/1/1/1/40/list';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useParams: () => ({
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '1',
+    set_ids: '1',
+    angle: '40',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', props, children),
+}));
+
+vi.mock('@vercel/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
+  useCardSwipeNavigation: () => ({
+    swipeHandlers: {},
+    swipeOffset: 0,
+    isAnimating: false,
+    navigateToNext: vi.fn(),
+    navigateToPrev: vi.fn(),
+    peekIsNext: true,
+    exitOffset: 0,
+    enterDirection: null,
+    clearEnterAnimation: vi.fn(),
+  }),
+  EXIT_DURATION: 300,
+  SNAP_BACK_DURATION: 200,
+  ENTER_ANIMATION_DURATION: 300,
+}));
+
+vi.mock('@/app/hooks/use-color-mode', () => ({
+  useColorMode: () => ({ mode: 'light' }),
+}));
+
+vi.mock('@/app/lib/grade-colors', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getGradeTintColor: () => null,
+  };
+});
+
+vi.mock('@/app/components/climb-card/climb-thumbnail', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-thumbnail' }),
+}));
+
+vi.mock('@/app/components/climb-card/climb-title', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-title' }),
+}));
+
+vi.mock('@/app/components/queue-control/queue-list', () => ({
+  default: React.forwardRef(() => React.createElement('div', { 'data-testid': 'queue-list' })),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'queue-drawer', 'data-open': open ? 'true' : 'false' }, children),
+}));
+
+vi.mock('@/app/components/queue-control/next-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'next-climb' }),
+}));
+
+vi.mock('@/app/components/queue-control/previous-climb-button', () => ({
+  default: () => React.createElement('button', { 'data-testid': 'prev-climb' }),
+}));
+
+vi.mock('@/app/components/logbook/tick-button', () => ({
+  TickButton: (props: { onActivateTickBar?: () => void; tickBarActive?: boolean }) =>
+    React.createElement(
+      'button',
+      {
+        'data-testid': 'tick-button',
+        onClick: props.onActivateTickBar,
+        'data-tick-active': props.tickBarActive,
+      },
+      'tick',
+    ),
+}));
+
+vi.mock('@/app/components/board-page/share-button', () => ({
+  ShareBoardButton: () => null,
+}));
+
+vi.mock('@/app/components/play-view/play-view-drawer', () => ({
+  default: ({
+    activeDrawer,
+    setActiveDrawer,
+  }: {
+    activeDrawer: string;
+    setActiveDrawer: (drawer: 'none' | 'play' | 'queue' | 'tick') => void;
+  }) =>
+    activeDrawer === 'play'
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'play-drawer' },
+          React.createElement(
+            'button',
+            {
+              'data-testid': 'close-play-drawer',
+              onClick: () => setActiveDrawer('none'),
+            },
+            'close',
+          ),
+        )
+      : null,
+}));
+
+vi.mock('@/app/components/onboarding/onboarding-tour-events', () => ({
+  TOUR_CLOSE_PLAY_VIEW_EVENT: 'onboarding:close-play-view',
+}));
+
+vi.mock('@/app/components/ui/confirm-popover', () => ({
+  ConfirmPopover: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+let mockPersistentSessionState: Record<string, unknown> = {
+  activeSession: null,
+  localBoardDetails: null,
+  localCurrentClimbQueueItem: null,
+  session: null,
+  users: [],
+};
+vi.mock('@/app/components/persistent-session/persistent-session-context', () => ({
+  usePersistentSessionState: () => mockPersistentSessionState,
+}));
+
+vi.mock('@/app/components/board-bluetooth-control/bluetooth-context', () => ({
+  useBluetoothContext: () => ({
+    isConnected: false,
+    isConnecting: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    sendLedUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ logbook: [] }),
+}));
+
+type QuickTickBarMockHandle = {
+  save: (element?: HTMLElement | null) => void;
+  saveAttempt: (element?: HTMLElement | null) => void;
+};
+
+vi.mock('@/app/components/logbook/quick-tick-bar', () => ({
+  QuickTickBar: React.forwardRef<QuickTickBarMockHandle, { onSave?: () => void }>((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      save: vi.fn(),
+      saveAttempt: vi.fn(),
+    }));
+    return React.createElement(
+      'div',
+      { 'data-testid': 'quick-tick-bar' },
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'save-tick',
+          onClick: props.onSave,
+        },
+        'save',
+      ),
+    );
+  }),
+}));
+
+vi.mock('@/app/hooks/use-tick-save', () => ({
+  hasPriorHistoryForClimb: () => false,
+}));
+
+vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/sesh-settings/sesh-settings-drawer-event', () => ({
+  dispatchOpenSeshSettingsDrawer: vi.fn(),
+}));
+
+vi.mock('@/app/lib/session-utils', () => ({
+  generateSessionName: () => 'Test Session',
+}));
+
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: () => null,
+}));
+
+vi.mock('@/app/lib/share-utils', () => ({
+  shareWithFallback: vi.fn(),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const mockClimb = {
+  uuid: 'climb-1',
+  setter_username: 'setter1',
+  name: 'Test Climb',
+  description: '',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: 'V7',
+  quality_average: '3.5',
+  stars: 3,
+  difficulty_error: '',
+  mirrored: false,
+  benchmark_difficulty: null,
+  userAscents: 0,
+  userAttempts: 0,
+};
+
+const baseQueueContext = {
+  queue: [{ uuid: 'item-1', climb: mockClimb, addedBy: 'user-1', suggested: false }],
+  currentClimbQueueItem: { uuid: 'item-1', climb: mockClimb, addedBy: 'user-1', suggested: false },
+  currentClimb: mockClimb,
+  climbSearchResults: [],
+  suggestedClimbs: [],
+  isFetchingClimbs: false,
+  isFetchingNextPage: false,
+  hasDoneFirstFetch: true,
+  viewOnlyMode: false,
+  parsedParams: { board_name: 'kilter', layout_id: '1', size_id: '1', set_ids: ['1'], angle: '40' },
+  connectionState: 'connected',
+  sessionId: 'session-1',
+  canMutate: true,
+  isDisconnected: false,
+  users: [],
+  endSession: vi.fn(),
+  disconnect: vi.fn(),
+  addToQueue: vi.fn(),
+  removeFromQueue: vi.fn(),
+  setCurrentClimb: vi.fn(),
+  setCurrentClimbQueueItem: vi.fn(),
+  setClimbSearchParams: vi.fn(),
+  setCountSearchParams: vi.fn(),
+  mirrorClimb: vi.fn(),
+  fetchMoreClimbs: vi.fn(),
+  getNextClimbQueueItem: vi.fn().mockReturnValue(null),
+  getPreviousClimbQueueItem: vi.fn().mockReturnValue(null),
+  setQueue: vi.fn(),
+};
+
+let mockQueueContext: Record<string, unknown> = {};
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueContext: () => mockQueueContext,
+  useQueueData: () => mockQueueContext,
+  useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({
+    currentClimb: mockQueueContext.currentClimb,
+  }),
+  useQueueList: () => ({
+    queue: mockQueueContext.queue,
+    suggestedClimbs: [],
+  }),
+  useSessionData: () => ({
+    viewOnlyMode: mockQueueContext.viewOnlyMode ?? false,
+    isSessionActive: !!mockQueueContext.sessionId,
+    sessionId: mockQueueContext.sessionId ?? null,
+    sessionSummary: null,
+    sessionGoal: null,
+    connectionState: mockQueueContext.connectionState ?? 'idle',
+    canMutate: mockQueueContext.canMutate ?? true,
+    isDisconnected: mockQueueContext.isDisconnected ?? false,
+    users: mockQueueContext.users ?? [],
+    clientId: 'client-1',
+    isLeader: true,
+    isBackendMode: false,
+    hasConnected: true,
+    connectionError: null,
+  }),
+}));
+
+const defaultProps = {
+  angle: '40' as unknown as number,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+};
+
+const swipeVertically = (element: Element, startY: number, endY: number) => {
+  fireEvent.touchStart(element, { touches: [{ clientX: 10, clientY: startY }] });
+  fireEvent.touchMove(element, { touches: [{ clientX: 10, clientY: endY }] });
+  fireEvent.touchEnd(element, { changedTouches: [{ clientX: 10, clientY: endY }] });
+};
+
+const renderQueueControlBar = async () => {
+  await act(async () => {
+    render(<QueueControlBar {...defaultProps} />);
+  });
+};
+
+describe('QueueControlBar collapsed mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/kilter/1/1/1/40/list';
+    mockQueueContext = { ...baseQueueContext };
+    mockPersistentSessionState = {
+      activeSession: null,
+      localBoardDetails: null,
+      localCurrentClimbQueueItem: null,
+      session: null,
+      users: [],
+    };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('loads the shared collapsed preference on normal routes', async () => {
+    mockGetPreference.mockImplementation((key: string) =>
+      Promise.resolve(key === 'queueControlBar:collapsed' ? true : null),
+    );
+
+    await renderQueueControlBar();
+
+    await waitFor(() => expect(screen.getByTestId('queue-control-bar-collapsed')).toBeTruthy());
+    expect(mockGetPreference).toHaveBeenCalledWith('queueControlBar:collapsed');
+  });
+
+  it('defaults create-climb routes to collapsed and persists the create preference when expanded', async () => {
+    mockPathname = '/kilter/1/1/1/40/create';
+
+    await renderQueueControlBar();
+
+    const miniBar = await screen.findByTestId('queue-control-bar-collapsed');
+    await act(async () => {
+      swipeVertically(miniBar, 120, 20);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId('queue-control-bar-collapsed')).toBeNull());
+    expect(mockGetPreference).toHaveBeenCalledWith('queueControlBar:createCollapsed');
+    expect(mockSetPreference).toHaveBeenCalledWith('queueControlBar:createCollapsed', false);
+  });
+
+  it('persists collapsed state when the expanded handle is dragged down', async () => {
+    await renderQueueControlBar();
+
+    const handle = screen.getByTestId('queue-collapse-handle');
+    expect(handle.closest('[data-tour-anchor="session-mini-bar"]')).toBeTruthy();
+
+    await act(async () => {
+      swipeVertically(handle, 20, 120);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('queue-control-bar-collapsed')).toBeTruthy());
+    expect(mockSetPreference).toHaveBeenCalledWith('queueControlBar:collapsed', true);
+  });
+
+  it('persists expanded state when the collapsed mini bar is dragged up', async () => {
+    mockGetPreference.mockImplementation((key: string) =>
+      Promise.resolve(key === 'queueControlBar:collapsed' ? true : null),
+    );
+
+    await renderQueueControlBar();
+
+    const miniBar = await screen.findByTestId('queue-control-bar-collapsed');
+    await act(async () => {
+      swipeVertically(miniBar, 120, 20);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId('queue-control-bar-collapsed')).toBeNull());
+    expect(mockSetPreference).toHaveBeenCalledWith('queueControlBar:collapsed', false);
+  });
+
+  it('temporarily expands for climb details and returns to collapsed after close', async () => {
+    mockGetPreference.mockImplementation((key: string) =>
+      Promise.resolve(key === 'queueControlBar:collapsed' ? true : null),
+    );
+
+    await renderQueueControlBar();
+
+    await act(async () => {
+      fireEvent.click(await screen.findByLabelText('Open climb details'));
+    });
+
+    expect(screen.queryByTestId('queue-control-bar-collapsed')).toBeNull();
+    expect(screen.getByTestId('play-drawer')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('close-play-drawer'));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('queue-control-bar-collapsed')).toBeTruthy());
+    expect(mockSetPreference).not.toHaveBeenCalledWith('queueControlBar:collapsed', false);
+  });
+
+  it('temporarily expands for collapsed tick mode and returns to collapsed after save', async () => {
+    mockGetPreference.mockImplementation((key: string) =>
+      Promise.resolve(key === 'queueControlBar:collapsed' ? true : null),
+    );
+
+    await renderQueueControlBar();
+    await screen.findByTestId('queue-control-bar-collapsed');
+    mockSetPreference.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('tick-button'));
+    });
+
+    expect(screen.queryByTestId('queue-control-bar-collapsed')).toBeNull();
+    expect(screen.getByTestId('quick-tick-bar')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-tick'));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('queue-control-bar-collapsed')).toBeTruthy());
+    expect(mockSetPreference).not.toHaveBeenCalledWith('queueControlBar:collapsed', false);
+    expect(mockSetPreference).not.toHaveBeenCalledWith('queueControlBar:collapsed', true);
+  });
+
+  it('temporarily expands for collapsed participant avatars and returns after closing them', async () => {
+    mockPersistentSessionState = {
+      activeSession: {
+        sessionId: 'session-1',
+        sessionName: 'Test Session',
+        startedAt: new Date('2025-01-01').toISOString(),
+      },
+      localBoardDetails: null,
+      localCurrentClimbQueueItem: null,
+      session: { id: 'session-1', name: 'Test Session', startedAt: new Date('2025-01-01').toISOString() },
+      users: [
+        { id: 'client-1', userId: 'user-1', username: 'Marco' },
+        { id: 'client-2', userId: 'user-2', username: 'Alex' },
+      ],
+    };
+    mockGetPreference.mockImplementation((key: string) =>
+      Promise.resolve(key === 'queueControlBar:collapsed' ? true : null),
+    );
+
+    await renderQueueControlBar();
+    await screen.findByTestId('queue-control-bar-collapsed');
+    mockSetPreference.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Show participants'));
+    });
+
+    expect(screen.queryByTestId('queue-control-bar-collapsed')).toBeNull();
+    expect(screen.getByLabelText('Hide participants')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Hide participants'));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('queue-control-bar-collapsed')).toBeTruthy());
+    expect(mockSetPreference).not.toHaveBeenCalledWith('queueControlBar:collapsed', false);
+    expect(mockSetPreference).not.toHaveBeenCalledWith('queueControlBar:collapsed', true);
+  });
+});

--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -28,6 +28,111 @@
   background-color: var(--semantic-surface);
 }
 
+.collapsedCard {
+  overflow: hidden;
+}
+
+.queueCollapseHandleRegion {
+  position: absolute;
+  left: 50%;
+  top: 18px;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 24px;
+  border-radius: 9999px;
+  color: var(--neutral-600);
+  cursor: ns-resize;
+  touch-action: none;
+  z-index: 1;
+}
+
+.queueCollapseHandle {
+  width: 36px;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: currentColor;
+  opacity: 0.45;
+}
+
+.queueCollapseHandleRegion:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.collapsedMiniBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+  box-sizing: border-box;
+  height: 44px;
+  min-height: 44px;
+  padding: var(--space-1, 4px) var(--space-2, 8px);
+  touch-action: none;
+}
+
+.collapsedClimbButton {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-2, 8px);
+  min-height: 36px;
+  border-radius: 4px;
+  color: var(--neutral-900);
+  text-align: left;
+}
+
+.collapsedThumbnail {
+  width: 22px;
+  max-height: 32px;
+  overflow: hidden;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.collapsedGrade {
+  flex-shrink: 0;
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.collapsedName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 600;
+}
+
+.collapsedAvatarButton,
+.collapsedTickButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.collapsedAvatarButton {
+  min-width: 34px;
+  min-height: 36px;
+  border-radius: 9999px;
+}
+
+:global(html[data-theme='dark']) .queueCollapseHandleRegion {
+  color: var(--neutral-300);
+}
+
+:global(html[data-theme='dark']) .collapsedClimbButton {
+  color: var(--neutral-100);
+}
+
 @media (min-width: 768px) {
   .queueBar {
     background-color: transparent;
@@ -142,6 +247,7 @@
 
 /* Session header strip — sits above the swipe container inside the card */
 .sessionHeader {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import MuiButton from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
 import IconButton from '@mui/material/IconButton';
 import MuiCard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -59,7 +60,7 @@ import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Badge from '@mui/material/Badge';
 import Typography from '@mui/material/Typography';
-import { getGradeTintColor } from '@/app/lib/grade-colors';
+import { formatGrade, getGradeTintColor, getSoftGradeColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { usePersistentSessionState } from '../persistent-session/persistent-session-context';
@@ -94,6 +95,13 @@ const TICK_BADGE_SX = {
     border: '2px solid transparent',
   },
 } as const;
+
+const QUEUE_CONTROL_BAR_COLLAPSED_PREFERENCE_KEY = 'queueControlBar:collapsed';
+const QUEUE_CONTROL_BAR_CREATE_COLLAPSED_PREFERENCE_KEY = 'queueControlBar:createCollapsed';
+
+type QueueControlTemporaryExpansion = 'details' | 'tick' | 'participants' | null;
+
+const isCreateClimbPath = (pathname: string): boolean => pathname.split('/').includes('create');
 
 function TickBadgeAvatar({
   user,
@@ -222,10 +230,32 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // Keep the tick row mounted during the close animation so it can collapse.
   const [tickRowVisible, setTickRowVisible] = useState(false);
   const [participantsExpanded, setParticipantsExpanded] = useState(false);
+  const isCreateClimbRoute = useMemo(() => isCreateClimbPath(pathname), [pathname]);
+  const queueControlBarPreferenceKey = isCreateClimbRoute
+    ? QUEUE_CONTROL_BAR_CREATE_COLLAPSED_PREFERENCE_KEY
+    : QUEUE_CONTROL_BAR_COLLAPSED_PREFERENCE_KEY;
+  const [queueBarCollapsed, setQueueBarCollapsed] = useState(() => isCreateClimbPath(pathname));
+  const [temporaryExpandedReason, setTemporaryExpandedReason] = useState<QueueControlTemporaryExpansion>(null);
 
   const sessionShareUrl = activeSession?.sessionId
     ? `${typeof window !== 'undefined' ? window.location.origin : ''}/join/${activeSession.sessionId}`
     : '';
+
+  useEffect(() => {
+    let cancelled = false;
+    const defaultCollapsed = isCreateClimbRoute;
+    setTemporaryExpandedReason(null);
+    setParticipantsExpanded(false);
+
+    void getPreference<boolean>(queueControlBarPreferenceKey).then((persistedCollapsed) => {
+      if (cancelled) return;
+      setQueueBarCollapsed(persistedCollapsed ?? defaultCollapsed);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isCreateClimbRoute, queueControlBarPreferenceKey]);
 
   const handleInviteShare = useCallback(async () => {
     if (!sessionShareUrl) return;
@@ -443,6 +473,14 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     () => getGradeTintColor(displayedClimb?.difficulty, 'session', isDark),
     [displayedClimb?.difficulty, isDark],
   );
+  const collapsedGrade = useMemo(
+    () => formatGrade(displayedClimb?.difficulty, 'v-grade') ?? displayedClimb?.difficulty,
+    [displayedClimb?.difficulty],
+  );
+  const collapsedGradeColor = useMemo(
+    () => getSoftGradeColor(displayedClimb?.difficulty, isDark),
+    [displayedClimb?.difficulty, isDark],
+  );
 
   // Deduplicate session users by userId (stable DB UUID).
   // When userId is absent (unauthenticated), fall back to connection id
@@ -477,6 +515,14 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     }
     return set;
   }, [queue, currentClimb?.uuid, myUserId, localTickedClimbs]);
+
+  const isQueueBarCollapsed =
+    queueBarCollapsed &&
+    temporaryExpandedReason === null &&
+    activeDrawer === 'none' &&
+    !tickRowVisible &&
+    !participantsExpanded &&
+    !!displayedClimb;
 
   // Reset local tick cache when the active session changes
   useEffect(() => {
@@ -593,6 +639,18 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       return () => clearTimeout(timer);
     }
   }, [tickBarActive]);
+
+  useEffect(() => {
+    if (activeDrawer === 'none' && temporaryExpandedReason !== null && temporaryExpandedReason !== 'participants') {
+      setTemporaryExpandedReason(null);
+    }
+  }, [activeDrawer, temporaryExpandedReason]);
+
+  useEffect(() => {
+    if (!participantsExpanded && temporaryExpandedReason === 'participants') {
+      setTemporaryExpandedReason(null);
+    }
+  }, [participantsExpanded, temporaryExpandedReason]);
 
   const tickSwipeEnabled = tickBarActive && !tickCommentFocused;
 
@@ -720,6 +778,93 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       source: 'bar_tap',
     });
   }, [currentClimb, boardDetails.layout_name]);
+
+  const persistQueueBarCollapsed = useCallback(
+    (collapsed: boolean) => {
+      setQueueBarCollapsed(collapsed);
+      setTemporaryExpandedReason(null);
+      if (collapsed) {
+        setParticipantsExpanded(false);
+        setActiveDrawer('none');
+      }
+      void setPreference(queueControlBarPreferenceKey, collapsed);
+    },
+    [queueControlBarPreferenceKey],
+  );
+
+  const handleCollapsedClimbInfoClick = useCallback(() => {
+    if (!currentClimb) return;
+    setTemporaryExpandedReason('details');
+    setActiveDrawer('play');
+    track('Play Drawer Opened', {
+      boardLayout: boardDetails.layout_name || '',
+      source: 'collapsed_bar_tap',
+    });
+  }, [currentClimb, boardDetails.layout_name]);
+
+  const handleTickBarActivate = useCallback(() => setActiveDrawer('tick'), []);
+
+  const handleCollapsedTickActivate = useCallback(() => {
+    setTemporaryExpandedReason('tick');
+    setActiveDrawer('tick');
+  }, []);
+
+  const handleCollapsedParticipantsClick = useCallback(() => {
+    setTemporaryExpandedReason('participants');
+    setParticipantsExpanded(true);
+  }, []);
+
+  const handleParticipantToggle = useCallback(() => {
+    setParticipantsExpanded((prev) => !prev);
+  }, []);
+
+  const collapseHandleSwipeHandlers = useSwipeable({
+    onSwipedDown: (eventData) => {
+      if (Math.abs(eventData.deltaY) >= 40 || eventData.velocity > 0.25) {
+        persistQueueBarCollapsed(true);
+      }
+    },
+    trackMouse: true,
+    preventScrollOnSwipe: false,
+    delta: 10,
+  });
+
+  const collapsedMiniBarSwipeHandlers = useSwipeable({
+    onSwipedUp: (eventData) => {
+      if (Math.abs(eventData.deltaY) >= 40 || eventData.velocity > 0.25) {
+        persistQueueBarCollapsed(false);
+      }
+    },
+    trackMouse: true,
+    preventScrollOnSwipe: false,
+    delta: 10,
+  });
+
+  const handleCollapseHandleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        event.stopPropagation();
+        persistQueueBarCollapsed(true);
+      }
+    },
+    [persistQueueBarCollapsed],
+  );
+
+  const queueCollapseHandle = !tickBarActive && !tickRowVisible && (
+    <div
+      {...collapseHandleSwipeHandlers}
+      className={styles.queueCollapseHandleRegion}
+      role="button"
+      tabIndex={0}
+      aria-label={t('queueBar.ariaLabels.collapseControlBar')}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={handleCollapseHandleKeyDown}
+      data-testid="queue-collapse-handle"
+    >
+      <span className={styles.queueCollapseHandle} />
+    </div>
+  );
 
   // Transition style shared by current and peek text
   const getTextTransitionStyle = () => {
@@ -855,6 +1000,84 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     );
   }
 
+  if (isQueueBarCollapsed && displayedClimb) {
+    return (
+      <div id="onboarding-queue-bar" className={`queue-bar-shadow ${styles.queueBar}`} data-testid="queue-control-bar">
+        <MuiCard variant="outlined" className={`${styles.card} ${styles.collapsedCard}`} sx={{ border: 'none' }}>
+          <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <div
+              {...collapsedMiniBarSwipeHandlers}
+              className={styles.collapsedMiniBar}
+              data-testid="queue-control-bar-collapsed"
+              style={{
+                backgroundColor: gradeTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
+              }}
+            >
+              <ButtonBase
+                className={styles.collapsedClimbButton}
+                onClick={handleCollapsedClimbInfoClick}
+                aria-label={t('queueBar.ariaLabels.openClimbDetails')}
+              >
+                <span className={styles.collapsedThumbnail}>
+                  <ClimbThumbnail
+                    boardDetails={boardDetails}
+                    currentClimb={displayedClimb}
+                    pathname={pathname}
+                    maxHeight="32px"
+                  />
+                </span>
+                <span className={styles.collapsedName}>{displayedClimb.name}</span>
+                {collapsedGrade && (
+                  <span className={styles.collapsedGrade} style={{ color: collapsedGradeColor }}>
+                    {collapsedGrade}
+                  </span>
+                )}
+              </ButtonBase>
+              {activeSession && uniqueSessionUsers.length > 0 && (
+                <ButtonBase
+                  className={styles.collapsedAvatarButton}
+                  onClick={handleCollapsedParticipantsClick}
+                  aria-label={t('queueBar.ariaLabels.showParticipants')}
+                >
+                  <AvatarGroup
+                    max={3}
+                    sx={{
+                      '& .MuiAvatar-root': {
+                        width: 28,
+                        height: 28,
+                        fontSize: 11,
+                        border: '2px solid transparent',
+                      },
+                    }}
+                  >
+                    {uniqueSessionUsers.map((user) => (
+                      <TickBadgeAvatar
+                        key={user.id}
+                        user={user}
+                        hasTicked={tickedBySet.has(user.id) || (user.userId != null && tickedBySet.has(user.userId))}
+                      />
+                    ))}
+                  </AvatarGroup>
+                </ButtonBase>
+              )}
+              <div className={styles.collapsedTickButton}>
+                <TickButton
+                  currentClimb={displayedClimb}
+                  angle={angle}
+                  boardDetails={boardDetails}
+                  onActivateTickBar={handleCollapsedTickActivate}
+                  onTickSave={(el) => quickTickBarRef.current?.save(el)}
+                  tickBarActive={false}
+                  isFlash={isFlash}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </MuiCard>
+      </div>
+    );
+  }
+
   let offlineBannerText: string;
   if (!sessionId) {
     offlineBannerText = 'Offline';
@@ -876,6 +1099,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
             className={`${styles.sessionHeaderWrapper} ${!tickBarActive && !tickRowVisible ? styles.sessionHeaderExpanded : ''}`}
           >
             <div className={styles.sessionHeaderInner} data-tour-anchor="session-mini-bar">
+              {queueCollapseHandle}
               {/* Offline overlay on session header */}
               {isDisconnected && !dismissedDisconnect && (
                 <div
@@ -921,15 +1145,19 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       className={styles.avatarToggle}
                       onClick={(e) => {
                         e.stopPropagation();
-                        setParticipantsExpanded((prev) => !prev);
+                        handleParticipantToggle();
                       }}
                       role="button"
                       tabIndex={0}
-                      aria-label={participantsExpanded ? 'Hide participants' : 'Show participants'}
+                      aria-label={
+                        participantsExpanded
+                          ? t('queueBar.ariaLabels.hideParticipants')
+                          : t('queueBar.ariaLabels.showParticipants')
+                      }
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.stopPropagation();
-                          setParticipantsExpanded((prev) => !prev);
+                          handleParticipantToggle();
                         }
                       }}
                     >
@@ -1320,7 +1548,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                       currentClimb={displayedClimb}
                       angle={angle}
                       boardDetails={boardDetails}
-                      onActivateTickBar={() => setActiveDrawer('tick')}
+                      onActivateTickBar={handleTickBarActivate}
                       onTickSave={(el) => quickTickBarRef.current?.save(el)}
                       tickBarActive={tickBarActive}
                       isFlash={isFlash}

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -26,6 +26,8 @@ export type UserPreferenceKeyMap = {
   'swipeHint:climbListSeen': boolean;
   'swipeHint:queueBarSeen': boolean;
   'swipeHint:logbookSeen': boolean;
+  'queueControlBar:collapsed': boolean;
+  'queueControlBar:createCollapsed': boolean;
   tickBarExpanded: boolean;
   'shakeToReport:dismissed': boolean;
   esp32Connections: Esp32Connection[];

--- a/packages/web/i18n/locales/en-US/profile.json
+++ b/packages/web/i18n/locales/en-US/profile.json
@@ -138,6 +138,18 @@
         "deleteFailed": "Failed to delete tick",
         "tickDeleted": "Tick deleted",
         "undo": "Undo"
+      },
+      "export": {
+        "action": "Export",
+        "jsonMenuItem": "{{board}} JSON",
+        "missingServiceUrl": "Boardsesh could not find the export service URL.",
+        "signInAgain": "Sign in again to export your logbook data.",
+        "generating": "{{board}} export is being generated.",
+        "generationFailed": "Export generation failed",
+        "stillGenerating": "Export is still generating. Try again shortly.",
+        "notReady": "Export is not ready yet",
+        "downloaded": "{{board}} export downloaded.",
+        "failed": "Export failed"
       }
     },
     "search": {

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -232,7 +232,11 @@
       "shareSessionLink": "Share session link",
       "closeTickBar": "Close tick bar",
       "enterPlayMode": "Enter play mode",
-      "logAttempt": "Log attempt"
+      "logAttempt": "Log attempt",
+      "collapseControlBar": "Collapse queue control bar",
+      "openClimbDetails": "Open climb details",
+      "showParticipants": "Show participants",
+      "hideParticipants": "Hide participants"
     }
   },
   "queueDrawer": {


### PR DESCRIPTION
## What changed

- Added a persisted collapsed mode for the root-mounted queue control bar.
- Stores separate IndexedDB preferences for regular routes and create-climb routes.
- Renders a compact queue mini bar with grade, climb name, tick action, and active-session avatars.
- Temporarily expands from compact mode for climb details, tick logging, and participant controls without changing the saved collapsed preference.
- Opens the play drawer when tapping an already selected climb row.
- Moved the new logbook export strings into i18n so the repository i18n scan passes.

Fixes #1584.

## Validation

- `vp test run packages/web/app/components/queue-control/__tests__/queue-control-bar-collapsed.test.tsx packages/web/app/components/queue-control/__tests__/queue-control-bar-tick-overlay.test.tsx packages/web/app/components/queue-control/__tests__/queue-control-bar-queue-button.test.tsx packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx --reporter=agent`
- `vp run check:i18n`
- `vp run typecheck:web`
- `vp check --fix` on the changed files

Full `vp check` still reports existing unrelated formatting/lint backlog in files outside this PR, so I did not bulk-format or refactor those files.

## Manual QA

Dev server started at `https://localhost:43003` and `https://vibetunnel-2.tailedd9d5.ts.net:43003`.

- Select a climb on a board list route and drag the queue bar handle down; the compact mini bar should appear.
- Drag the compact mini bar up; the full queue bar should return and persist after refresh.
- Visit a create-climb route; the queue bar should default to compact until expanded.
- From compact mode, tap climb name/grade, tick, and active-session avatars; each should temporarily expand and collapse again after close/save.
- Tap an unselected climb row, then tap the selected row again; the first tap selects, the second opens the climb drawer.