### PR TITLE
fix(playlists): raise allUserPlaylists pageSize cap so picker can fetch

### DIFF
--- a/packages/backend/src/__tests__/all-user-playlists.test.ts
+++ b/packages/backend/src/__tests__/all-user-playlists.test.ts
@@ -361,4 +361,31 @@ describe('allUserPlaylists resolver', () => {
     expect(result.totalCount).toBe(30);
     expect(result.hasMore).toBe(true);
   });
+
+  // The climb-action "Add to playlist" picker fetches the user's full library
+  // in one round-trip with pageSize 200. If the schema cap drops below that,
+  // validation throws and the drawer renders an empty list (only newly created
+  // playlists appear via optimistic cache writes). Pin the contract here.
+  it('accepts pageSize 200 (used by the climb-action picker)', async () => {
+    const ctx = makeCtx();
+
+    const { chain: countTotalChain } = createMockChain([{ count: 1 }]);
+    mockDb.select.mockReturnValueOnce(countTotalChain);
+
+    const { chain: mainChain } = createMockChain([makePlaylistRow({ uuid: 'pl-1' })]);
+    mockDb.select.mockReturnValueOnce(mainChain);
+
+    const { chain: countChain } = createMockChain([{ playlistId: BigInt(1), count: 5 }]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: followerChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followerChain);
+
+    const { chain: followedChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(followedChain);
+
+    const result = await playlistQueries.allUserPlaylists(null, { input: { pageSize: 200 } }, ctx);
+
+    expect(result.playlists).toHaveLength(1);
+  });
 });

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -50,7 +50,10 @@ export const GetAllUserPlaylistsInputSchema = z.object({
   boardType: BoardNameSchema.optional(),
   layoutId: z.number().int().positive().optional(),
   page: z.number().int().min(0).optional(),
-  pageSize: z.number().int().min(1).max(100).optional(),
+  // Owned-data query, no abuse vector — the climb-action picker fetches the
+  // user's full library in one round-trip with pageSize 200, so the cap needs
+  // to comfortably exceed that.
+  pageSize: z.number().int().min(1).max(500).optional(),
 });
 
 export const PinPlaylistInputSchema = z.object({


### PR DESCRIPTION
## Summary

The "Add to playlist" drawer rendered an empty list of existing playlists. Creating a playlist from inside the drawer made it appear, but every other playlist the user owned stayed invisible.

**Root cause:** the climb-action picker (`use-climb-actions-data.tsx:167-169`) requests `pageSize: 200` ("200 covers any realistic user"), but the server schema capped `pageSize` at 100 (`packages/backend/src/validation/schemas/playlists.ts`). The Zod validator threw, React Query treated the field as errored and held `data` at the empty default. The only playlists the user saw were ones written into the cache by `createPlaylist`'s optimistic update — exactly the reported symptom.

The client and server were updated in the same commit (`04e1b20` "fix(playlists): pin grid + paginated scroll, fix #1592"), but the validation cap (100) and the new client request size (200) ended up out of sync.

## Fix

- Raise `GetAllUserPlaylistsInputSchema.pageSize` max from 100 → 500. This query returns the authenticated user's own data, so there's no abuse vector; 500 gives comfortable headroom over the picker's 200 for power users with many Aurora-synced circuits.
- Add a regression test (`accepts pageSize 200 (used by the climb-action picker)`) that pins the contract between picker and resolver so the next bump can't silently re-break it.

## Test plan

- [x] `vp run typecheck:backend` passes
- [x] `vp test --project backend run all-user-playlists` — 9/9 pass (including new regression case)
- [x] Edited files clean under `vp fmt --check`
- [ ] Manual QA: open `/<board>/...` view, click a climb's actions menu → "Add to playlist". Existing playlists should now render. Edge case: Aurora-synced circuits (`layoutId=null`) should also appear.

https://claude.ai/code/session_01KwFC2eTrZok4h6PKQYkXMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwFC2eTrZok4h6PKQYkXMK)_